### PR TITLE
Added a link to the desktop site (articles only for now).

### DIFF
--- a/article/app/views/article.scala.html
+++ b/article/app/views/article.scala.html
@@ -47,7 +47,7 @@
                 </div>
 
             </article>
-
+            @fragments.mainSiteLink(article, Configuration)
         </div>
 
         <div class="unit lastUnit">

--- a/article/app/views/article.scala.html
+++ b/article/app/views/article.scala.html
@@ -37,6 +37,7 @@
             )
         </div>
     </article>
+    @fragments.mainSiteLink(article, Configuration)
 
     @if(storyPackage.nonEmpty && ABTest(request).isA) {
         @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 5)

--- a/article/conf/env/DEV.properties
+++ b/article/conf/env/DEV.properties
@@ -3,7 +3,7 @@
 #
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/article/conf/env/GUDEV.properties
+++ b/article/conf/env/GUDEV.properties
@@ -6,8 +6,7 @@
 
 static.path=/assets/
 
-
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -32,11 +32,23 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
 
     scenario("Navigate to www.guardian.co.uk (desktop site)") {
       given("I'm on article entitled 'We must capitalise on a low-carbon future'")
+      and("I am using the UK edition")
       HtmlUnit("/environment/2012/feb/22/capitalise-low-carbon-future") { browser =>
         import browser._
-  
+
         then("I should see a link to the corresponding desktop article")
         findFirst("#main-site").getAttribute("href") should be("http://www.guardian.co.uk/environment/2012/feb/22/capitalise-low-carbon-future?mobile-redirect=false")
+      }
+    }
+
+    scenario("Navigate to www.guardiannews.com (desktop site)") {
+      given("I'm on article entitled 'We must capitalise on a low-carbon future'")
+      and("I am using the US edition")
+      HtmlUnit.US("/environment/2012/feb/22/capitalise-low-carbon-future") { browser =>
+        import browser._
+
+        then("I should see a link to the corresponding desktop article")
+        findFirst("#main-site").getAttribute("href") should be("http://www.guardiannews.com/environment/2012/feb/22/capitalise-low-carbon-future?mobile-redirect=false")
       }
     }
   }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -29,5 +29,18 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         adPlaceholder.getAttribute("data-link-name") should be("ad slot top-banner-ad")
       }
     }
+
+    scenario("navigate to guardian.co.uk") {
+      given("the user is viewing an article")
+      HtmlUnit("/environment/2012/feb/22/capitalise-low-carbon-future") { browser =>
+        import browser._
+
+        when("the user clicks the 'main site' link")
+        $("#main-site").click()
+
+        then("the user navigates to the same article on guardian.co.uk")
+        browser.url should be("http://www.guardian.co.uk/environment/2012/feb/22/capitalise-low-carbon-future?mobile-redirect=false")
+      }
+    }
   }
 }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -4,7 +4,7 @@ import test.`package`._
 
 class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
 
-  feature("rendering an article") {
+  feature("Article") {
 
     scenario("correct placeholder for ad is rendered") {
 
@@ -30,16 +30,13 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
       }
     }
 
-    scenario("navigate to guardian.co.uk") {
-      given("the user is viewing an article")
+    scenario("Navigate to www.guardian.co.uk (desktop site)") {
+      given("I'm on article entitled 'We must capitalise on a low-carbon future'")
       HtmlUnit("/environment/2012/feb/22/capitalise-low-carbon-future") { browser =>
         import browser._
-
-        when("the user clicks the 'main site' link")
-        $("#main-site").click()
-
-        then("the user navigates to the same article on guardian.co.uk")
-        browser.url should be("http://www.guardian.co.uk/environment/2012/feb/22/capitalise-low-carbon-future?mobile-redirect=false")
+  
+        then("I should see a link to the corresponding desktop article")
+        findFirst("#main-site").getAttribute("href") should be("http://www.guardian.co.uk/environment/2012/feb/22/capitalise-low-carbon-future?mobile-redirect=false")
       }
     }
   }

--- a/article/test/ArticleTemplateTest.scala
+++ b/article/test/ArticleTemplateTest.scala
@@ -6,6 +6,9 @@ import org.scalatest.FlatSpec
 import org.fluentlenium.core.domain.{ FluentWebElement, FluentList }
 
 class ArticleTemplateTest extends FlatSpec with ShouldMatchers {
+
+  implicit val config = conf.Configuration
+
   "Article Template" should "render article metadata" in HtmlUnit("/environment/2012/feb/22/capitalise-low-carbon-future") { browser =>
     import browser._
 
@@ -49,7 +52,6 @@ class ArticleTemplateTest extends FlatSpec with ShouldMatchers {
     val linkUrls = $("a").getAttributes("href")
 
     linkNames should contain("David Cameron defends windfarm plans to Tory MPs")
-    linkUrls should contain("http://localhost:3333/environment/2012/feb/21/cameron-defends-wind-farm-mps")
+    linkUrls should contain(WithHost("/environment/2012/feb/21/cameron-defends-wind-farm-mps"))
   }
-
 }

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -1,27 +1,9 @@
 package test
 
-import play.api.test._
-import play.api.test.Helpers._
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
+import conf.Configuration
 
 object `package` {
 
-  /**
-   * Executes a block of code in a running server, with a test HtmlUnit browser.
-   */
-  def HtmlUnit[T](path: String)(block: TestBrowser => T): T = {
-    running(TestServer(3333), HTMLUNIT) {
-      browser =>
-        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
-        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
+  object HtmlUnit extends EditionalisedHtmlUnit(Configuration)
 
-        browser.goTo("http://localhost:3333" + path)
-        block(browser)
-    }
-  }
-
-  /**
-   * Executes a block of code in a FakeApplication.
-   */
-  def Fake[T](block: => T): T = running(FakeApplication()) { block }
 }

--- a/common/app/views/fragments/mainSiteLink.scala.html
+++ b/common/app/views/fragments/mainSiteLink.scala.html
@@ -1,0 +1,11 @@
+@(item: MetaData, config: common.GuardianConfiguration)(implicit request: RequestHeader)
+
+<div>
+@defining(Edition(request, config)){ edition =>
+    @if(edition == "US") {
+        <a id="main-site" href="http://www.guardiannews.com/@item.id?mobile-redirect=false" data-link-name="US">Desktop site</a>
+    } else {
+        <a id="main-site" href="http://www.guardian.co.uk/@item.id?mobile-redirect=false" data-link-name="UK">Desktop site</a>
+    }
+}
+</div>

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,0 +1,52 @@
+package test
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.openqa.selenium.htmlunit.HtmlUnitDriver
+import common.GuardianConfiguration
+
+/**
+ * Executes a block of code in a running server, with a test HtmlUnit browser.
+ */
+class EditionalisedHtmlUnit(config: GuardianConfiguration) {
+
+  import config.edition._
+
+  val Port = """.*:(\d*)$""".r
+
+  def apply[T](path: String)(block: TestBrowser => T): T = UK(path)(block)
+
+  def UK[T](path: String)(block: TestBrowser => T): T = goTo(path, "http://" + ukHost)(block)
+
+  def US[T](path: String)(block: TestBrowser => T): T = goTo(path, "http://" + usHost)(block)
+
+  private def goTo[T](path: String, host: String)(block: TestBrowser => T): T = {
+
+    val port = host match {
+      case Port(p) => p.toInt
+      case _ => 9000
+    }
+
+    running(TestServer(port), HTMLUNIT) {
+      browser =>
+        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
+        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
+
+        browser.goTo(host + path)
+        block(browser)
+    }
+  }
+}
+
+object WithHost {
+  def apply(path: String)(implicit config: GuardianConfiguration): String = UK(path)(config)
+  def UK(path: String)(implicit config: GuardianConfiguration): String = "http://" + config.edition.ukHost + path
+  def US(path: String)(implicit config: GuardianConfiguration): String = "http://" + config.edition.usHost + path
+}
+
+/**
+ * Executes a block of code in a FakeApplication.
+ */
+object Fake {
+  def apply[T](block: => T): T = running(FakeApplication()) { block }
+}

--- a/core-navigation/conf/env/DEV.properties
+++ b/core-navigation/conf/env/DEV.properties
@@ -5,7 +5,7 @@ plugins.location=http://guardian-scripted.appspot.com/code/plugins.js
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/core-navigation/conf/env/GUDEV.properties
+++ b/core-navigation/conf/env/GUDEV.properties
@@ -8,7 +8,7 @@ plugins.location=http://guardian-scripted.appspot.com/code/plugins.js
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/core-navigation/test/package.scala
+++ b/core-navigation/test/package.scala
@@ -1,27 +1,9 @@
 package test
 
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
-import play.api.test._
-import play.api.test.Helpers._
+import conf.Configuration
 
 object `package` {
 
-  /**
-   * Executes a block of code in a running server, with a test HtmlUnit browser.
-   */
-  def HtmlUnit[T](path: String)(block: TestBrowser => T): T = {
-    running(TestServer(3333), HTMLUNIT) {
-      browser =>
-        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
-        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
+  object HtmlUnit extends EditionalisedHtmlUnit(Configuration)
 
-        browser.goTo("http://localhost:3333" + path)
-        block(browser)
-    }
-  }
-
-  /**
-   * Executes a block of code in a FakeApplication.
-   */
-  def Fake[T](block: => T): T = running(FakeApplication()) { block }
 }

--- a/front/conf/env/DEV.properties
+++ b/front/conf/env/DEV.properties
@@ -4,7 +4,7 @@
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/front/conf/env/GUDEV.properties
+++ b/front/conf/env/GUDEV.properties
@@ -6,7 +6,7 @@
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/front/test/package.scala
+++ b/front/test/package.scala
@@ -1,27 +1,9 @@
 package test
 
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
-import play.api.test._
-import play.api.test.Helpers._
+import conf.Configuration
 
 object `package` {
 
-  /**
-   * Executes a block of code in a running server, with a test HtmlUnit browser.
-   */
-  def HtmlUnit[T](path: String)(block: TestBrowser => T): T = {
-    running(TestServer(3333), HTMLUNIT) {
-      browser =>
-        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
-        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
+  object HtmlUnit extends EditionalisedHtmlUnit(Configuration)
 
-        browser.goTo("http://localhost:3333" + path)
-        block(browser)
-    }
-  }
-
-  /**
-   * Executes a block of code in a FakeApplication.
-   */
-  def Fake[T](block: => T): T = running(FakeApplication()) { block }
 }

--- a/gallery/conf/env/DEV.properties
+++ b/gallery/conf/env/DEV.properties
@@ -4,7 +4,7 @@
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/gallery/conf/env/GUDEV.properties
+++ b/gallery/conf/env/GUDEV.properties
@@ -6,7 +6,7 @@
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/gallery/test/GalleryTemplateTest.scala
+++ b/gallery/test/GalleryTemplateTest.scala
@@ -3,8 +3,15 @@ package test
 import org.scalatest.matchers.ShouldMatchers
 import collection.JavaConversions._
 import org.scalatest.FlatSpec
+import conf.Configuration
+import common.GuardianConfiguration
 
 class GalleryTemplateTest extends FlatSpec with ShouldMatchers {
+
+  implicit val config = Configuration
+
+  private val host = "http://" + Configuration.edition.ukHost
+
   "Gallery Template" should "render article metadata" in HtmlUnit("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") {
     browser =>
       import browser._
@@ -28,7 +35,7 @@ class GalleryTemplateTest extends FlatSpec with ShouldMatchers {
     val linkUrls = $("a").getAttributes("href")
 
     linkNames should contain("Big Noise orchestra's classical music proves instrumental in social change")
-    linkUrls should contain("http://localhost:3333/music/2012/jun/24/simon-bolivar-dudamel-review")
+    linkUrls should contain(WithHost("/music/2012/jun/24/simon-bolivar-dudamel-review"))
   }
 
   it should "render caption and navigation on first image page" in HtmlUnit("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") { browser =>
@@ -40,7 +47,7 @@ class GalleryTemplateTest extends FlatSpec with ShouldMatchers {
     $("p.nav a#js-gallery-prev").getAttributes("href").toList should be(List("javascript:")) // and this is how it's hidden
 
     $("p.nav a#js-gallery-next").getTexts.toList should be(List("Next"))
-    $("p.nav a#js-gallery-next").getAttributes("href").toList should be(List("http://localhost:3333/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=2"))
+    $("p.nav a#js-gallery-next").getAttributes("href").toList should be(List(WithHost("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=2")))
   }
 
   it should "render caption and navigation on second image page" in HtmlUnit("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=2") { browser =>
@@ -49,10 +56,10 @@ class GalleryTemplateTest extends FlatSpec with ShouldMatchers {
     $("p.caption").getTexts.firstNonEmpty.get should include("Socialist Party supporters watch live TV debate as their presidential")
 
     $("p.nav a#js-gallery-prev").getTexts.toList should be(List("Previous"))
-    $("p.nav a#js-gallery-prev").getAttributes("href").toList should be(List("http://localhost:3333/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=1"))
+    $("p.nav a#js-gallery-prev").getAttributes("href").toList should be(List(WithHost("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=1")))
 
     $("p.nav a#js-gallery-next").getTexts.toList should be(List("Next"))
-    $("p.nav a#js-gallery-next").getAttributes("href").toList should be(List("http://localhost:3333/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=3"))
+    $("p.nav a#js-gallery-next").getAttributes("href").toList should be(List(WithHost("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=3")))
   }
 
   it should "render caption and navigation on last image page" in HtmlUnit("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=22") { browser =>
@@ -61,10 +68,10 @@ class GalleryTemplateTest extends FlatSpec with ShouldMatchers {
     $("p.caption").getTexts.firstNonEmpty.get should include("This little scout has been taking part in a parade")
 
     $("p.nav a#js-gallery-prev").getTexts.toList should be(List("Previous"))
-    $("p.nav a#js-gallery-prev").getAttributes("href").toList should be(List("http://localhost:3333/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=21"))
+    $("p.nav a#js-gallery-prev").getAttributes("href").toList should be(List(WithHost("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?index=21")))
 
     $("p.nav a#js-gallery-next").getTexts.toList should be(List("Next"))
-    $("p.nav a#js-gallery-next").getAttributes("href").toList should be(List("http://localhost:3333/news/gallery/2012/may/02/picture-desk-live-kabul-burma?trail=true"))
+    $("p.nav a#js-gallery-next").getAttributes("href").toList should be(List(WithHost("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?trail=true")))
   }
 
   it should "render caption and navigation on trail page" in HtmlUnit("/news/gallery/2012/may/02/picture-desk-live-kabul-burma?trail=true") { browser =>

--- a/gallery/test/package.scala
+++ b/gallery/test/package.scala
@@ -1,33 +1,15 @@
 package test
 
+import conf.Configuration
 import java.util.{ List => JList }
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
-import play.api.test._
-import play.api.test.Helpers._
-import scala.collection.JavaConversions._
+import collection.JavaConversions._
 
 object `package` {
 
-  /**
-   * Executes a block of code in a running server, with a test HtmlUnit browser.
-   */
-  def HtmlUnit[T](path: String)(block: TestBrowser => T): T = {
-    running(TestServer(3333), HTMLUNIT) {
-      browser =>
-        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
-        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
-
-        browser.goTo("http://localhost:3333" + path)
-        block(browser)
-    }
-  }
-
-  /**
-   * Executes a block of code in a FakeApplication.
-   */
-  def Fake[T](block: => T): T = running(FakeApplication()) { block }
+  object HtmlUnit extends EditionalisedHtmlUnit(Configuration)
 
   implicit def listString2FirstNonEmpty(list: JList[String]) = new {
     lazy val firstNonEmpty: Option[String] = list find { !_.isEmpty }
   }
+
 }

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -103,7 +103,7 @@ trait Prototypes {
       "com.gu" %% "management-play" % "5.13",
       "com.gu" %% "management-logback" % "5.13",
       "com.gu" %% "configuration" % "3.6",
-      "com.gu.openplatform" %% "content-api-client" % "1.16.2",
+      "com.gu.openplatform" %% "content-api-client" % "1.16.3",
 
       "com.typesafe.akka" % "akka-agent" % "2.0.2",
       "org.scala-tools.time" % "time_2.9.1" % "0.5",

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -14,15 +14,17 @@ object Frontend extends Build with Prototypes {
 
   val common = library("common")
 
-  val article = application("article").dependsOn(common)
-  val gallery = application("gallery").dependsOn(common)
+  val commonWithTests = common % "test->test;compile->compile"
 
-  val tag = application("tag").dependsOn(common)
-  val section = application("section").dependsOn(common)
-  val front = application("front").dependsOn(common)
-  val coreNavigation = application("core-navigation").dependsOn(common)
+  val article = application("article").dependsOn(commonWithTests)
+  val gallery = application("gallery").dependsOn(commonWithTests)
 
-  val video = application("video").dependsOn(common)
+  val tag = application("tag").dependsOn(commonWithTests)
+  val section = application("section").dependsOn(commonWithTests)
+  val front = application("front").dependsOn(commonWithTests)
+  val coreNavigation = application("core-navigation").dependsOn(commonWithTests)
+
+  val video = application("video").dependsOn(commonWithTests)
 
   val main = root().aggregate(
     common, article, gallery, tag, section, front, video, coreNavigation

--- a/section/conf/env/DEV.properties
+++ b/section/conf/env/DEV.properties
@@ -4,7 +4,7 @@
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/section/conf/env/GUDEV.properties
+++ b/section/conf/env/GUDEV.properties
@@ -6,7 +6,7 @@
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/section/test/package.scala
+++ b/section/test/package.scala
@@ -1,27 +1,9 @@
 package test
 
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
-import play.api.test._
-import play.api.test.Helpers._
+import conf.Configuration
 
 object `package` {
 
-  /**
-   * Executes a block of code in a running server, with a test HtmlUnit browser.
-   */
-  def HtmlUnit[T](path: String)(block: TestBrowser => T): T = {
-    running(TestServer(3333), HTMLUNIT) {
-      browser =>
-        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
-        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
+  object HtmlUnit extends EditionalisedHtmlUnit(Configuration)
 
-        browser.goTo("http://localhost:3333" + path)
-        block(browser)
-    }
-  }
-
-  /**
-   * Executes a block of code in a FakeApplication.
-   */
-  def Fake[T](block: => T): T = running(FakeApplication()) { block }
 }

--- a/tag/conf/env/DEV.properties
+++ b/tag/conf/env/DEV.properties
@@ -5,7 +5,7 @@ plugins.location=http://guardian-scripted.appspot.com/code/plugins.js
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/tag/conf/env/GUDEV.properties
+++ b/tag/conf/env/GUDEV.properties
@@ -8,7 +8,7 @@ plugins.location=http://guardian-scripted.appspot.com/code/plugins.js
 
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/tag/test/package.scala
+++ b/tag/test/package.scala
@@ -1,27 +1,9 @@
 package test
 
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
-import play.api.test._
-import play.api.test.Helpers._
+import conf.Configuration
 
 object `package` {
 
-  /**
-   * Executes a block of code in a running server, with a test HtmlUnit browser.
-   */
-  def HtmlUnit[T](path: String)(block: TestBrowser => T): T = {
-    running(TestServer(3333), HTMLUNIT) {
-      browser =>
-        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
-        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
+  object HtmlUnit extends EditionalisedHtmlUnit(Configuration)
 
-        browser.goTo("http://localhost:3333" + path)
-        block(browser)
-    }
-  }
-
-  /**
-   * Executes a block of code in a FakeApplication.
-   */
-  def Fake[T](block: => T): T = running(FakeApplication()) { block }
 }

--- a/video/conf/env/DEV.properties
+++ b/video/conf/env/DEV.properties
@@ -3,7 +3,7 @@
 #
 static.path=/assets/
 
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/video/conf/env/GUDEV.properties
+++ b/video/conf/env/GUDEV.properties
@@ -6,8 +6,7 @@
 
 static.path=/assets/
 
-
-edition.host.us=localhostcom:9000
+edition.host.us=127.0.0.1:9000
 edition.host.uk=localhost:9000
 
 #properties that start with guardian.page will be exposed via JavaScript

--- a/video/test/package.scala
+++ b/video/test/package.scala
@@ -1,27 +1,9 @@
 package test
 
-import play.api.test._
-import play.api.test.Helpers._
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
+import conf.Configuration
 
 object `package` {
 
-  /**
-   * Executes a block of code in a running server, with a test HtmlUnit browser.
-   */
-  def HtmlUnit[T](path: String)(block: TestBrowser => T): T = {
-    running(TestServer(3333), HTMLUNIT) {
-      browser =>
-        // http://stackoverflow.com/questions/7628243/intrincate-sites-using-htmlunit
-        browser.webDriver.asInstanceOf[HtmlUnitDriver] setJavascriptEnabled false
+  object HtmlUnit extends EditionalisedHtmlUnit(Configuration)
 
-        browser.goTo("http://localhost:3333" + path)
-        block(browser)
-    }
-  }
-
-  /**
-   * Executes a block of code in a FakeApplication.
-   */
-  def Fake[T](block: => T): T = running(FakeApplication()) { block }
 }


### PR DESCRIPTION
The mobile-redirect=false parameter is added to the url.

It will link to guardian.co.uk or guardiannews.com depending on what edition you are on (but note that R2 will ultimately decided on redirects)
