### PR TITLE
Related links

### DIFF
--- a/common/app/assets/stylesheets/module/module.less
+++ b/common/app/assets/stylesheets/module/module.less
@@ -127,9 +127,10 @@
 }
 
 .trailtext {
+    font-family: helvetica, arial, sans-serif;
     font-size: 14px;
     line-height: 18px;
-    color: #999999; 
+    color: #262626; 
 }
 
 .trailblock .img img {

--- a/common/app/assets/stylesheets/module/module.less
+++ b/common/app/assets/stylesheets/module/module.less
@@ -60,9 +60,6 @@
 /* nicole sullivan's media object */
 
 /* ====== media ====== */
-.media { 
-    margin: 10px 0;
-}
 
 .media, .bd {
     overflow: hidden; 
@@ -103,47 +100,40 @@
 }
 
 
-
-.trailblock-shaded {
-    margin: 0px 0px 10px 0px;
-    padding: 10px 2% 10px 2%;
-    background: #eeeeee;    
+.trailblock {
+    margin-top: 26px;
 }
 
+.trailblock > li {
+    margin-bottom: 9px;
 
+}
 
 .trailblock h3 {
-    font: bold 15px/20px helvetica, arial, sans-serif;
-    margin: 0px 0px 10px 0px;
+    font-size: 15px;
+    line-height: 20px;
+    padding-top: 3px; 
+    margin-bottom: 12px;
 }
 
-.trailblock li {
-    margin: 10px 0px 0px 0px;
-    padding: 0;
+.trailblock-shaded {
+    padding: 0 5px 12px 5px; 
+    background-color: #ededed;
 }
 
-.trailblock li:first-of-type .media {
-  margin: 0;
-  padding: 0;
-  border: none;
+.trail-headline {
+    font-size: 15px;
+    line-height: 20px;
 }
 
-.trailblock a {
-    font: normal 15px/20px georgia, serif;
-}
-
-.trailblock p {
-  margin: 0;
-  padding: 0;
+.trailtext {
+    font-size: 14px;
+    line-height: 18px;
+    color: #999999; 
 }
 
 .trailblock .img img {
-    width: 60px;
-}
-
-.trailblock .trailtext {
-    color: #333;
-    font-weight: normal;
+    width: 145px; /** less variable */
 }
 
 

--- a/common/app/assets/stylesheets/theme/theme.less
+++ b/common/app/assets/stylesheets/theme/theme.less
@@ -7,6 +7,17 @@
     border-bottom: 1px solid #bebebe;
     margin-bottom: 3px;
 }
+
+.b2 {
+    border-top: 1px dotted #999999;
+    padding-top: 3px;
+}
+
+.b2b {
+    border-bottom: 1px dotted #999999;
+    margin-bottom: 3px;
+}
+
 /*
 
 .b2 {

--- a/common/app/assets/stylesheets/theme/typography.less
+++ b/common/app/assets/stylesheets/theme/typography.less
@@ -86,3 +86,12 @@ h2 i b,
     font-family: "wt1-bolditalic", georgia;
     font-weight: normal;
 }
+
+.trailblock h3,
+.trail-headline {
+    font-family: "wt1-bold", georgia, serif;
+    font-weight: normal;
+}
+
+
+

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -11,6 +11,6 @@ object JsonComponent extends Results {
 
     request.getQueryString("callback").map { callback =>
       Ok("%s(%s);" format (callback, json)).as("application/javascript")
-    } getOrElse (Ok(json).as("application/json"))
+    } getOrElse (Ok(html))
   }
 }

--- a/common/app/views/fragments/debugInfo.scala.html
+++ b/common/app/views/fragments/debugInfo.scala.html
@@ -1,24 +1,5 @@
 @(config: common.GuardianConfiguration)
 
-@if(config.debug.enabled) {
-     <div id="debug">
-        <strong>debug info</strong>
-        <ul>
-            <li>Screen height: <span id="screenHeight"></span></li>
-            <li>Screen width: <span id="screenWidth"></span></li>
-            <li>Window height: <span id="windowHeight"></span></li>
-            <li>Window width: <span id="windowWidth"></span></li>
-            <li>Layout mode: <span id="layout"></span></li>
-            <li>Connection Speed: <span id="bandwidth"></span></li>
-            <li>Battery: <span id="battery"></span></li>
-            <li>Pixel Ratio: <span id="pixelratio"></span></li>
-            <li>Retina display: <span id="retina"></span></li>
-        </ul>
-    </div>
-}
-
-
-
 @*
   We are currently getting a lot of stale content served. Trying to figure out exactly how old.
   Cannot view page source or headers easily on a mobile so putting this data at bottom of page.

--- a/common/app/views/fragments/formatTrail.scala.html
+++ b/common/app/views/fragments/formatTrail.scala.html
@@ -1,13 +1,13 @@
 @(trail: Trail)
 
-<div class="media b1">
+<div class="media b2">
     @trail.thumbnail.map{ imageUrl =>
     <a href="@trail.url" class="img" data-link-name="trail image">
         <img class="maxed" src="@imageUrl" alt='@Html(trail.linkText)' title="@Html(trail.linkText)" />
     </a>
     }
     <div class="bd">
-        <p><a href="@trail.url" data-link-name="link text">@RemoveOuterParaHtml(trail.linkText)</a></p>
+        <p><a href="@trail.url" class="trail-headline" data-link-name="link text">@RemoveOuterParaHtml(trail.linkText)</a></p>
         @trail.trailText.map { text => <p class="gt-base trailtext">@RemoveOuterParaHtml(text)</p> }
     </div>
 </div>

--- a/common/app/views/fragments/relatedTrails.scala.html
+++ b/common/app/views/fragments/relatedTrails.scala.html
@@ -5,14 +5,10 @@
         <h3>@Html(heading)</h3>
         
         <ul class="plain">
-        @* extra trails are hidden by css, up to a maximum of 10 *@
+        @* extra trails are hidden by css, up to a maximum of n *@
         @trails.map{ trail =>
             <li>@formatTrail(trail)</li>
         }
         </ul>
-
-        @if(numTrails > visibleTrails) {
-            <h3 class="b1 b1b expander"><a class="js-expand-trailblock" href="javascript://">More</a> <span class="count">@(numTrails - visibleTrails)</span></h3>
-        }
     </div>
 }

--- a/common/app/views/fragments/relatedTrails.scala.html
+++ b/common/app/views/fragments/relatedTrails.scala.html
@@ -1,10 +1,10 @@
 @(trails: Seq[Trail], heading: String, visibleTrails: Int)
 
 @defining(trails.length){ numTrails =>
-    <div class="trailblock-shaded show-@{visibleTrails}" id="related-trails" data-link-name="related : separate : @heading">
-        <h3>@Html(heading)</h3>
+    <div class="zone-border trailblock trailblock-shaded show-@{visibleTrails}" id="related-trails" data-link-name="related : separate : @heading">
+        <h3 class="zone-color">@Html(heading)</h3>
         
-        <ul class="plain">
+        <ul class="unstyled">
         @* extra trails are hidden by css, up to a maximum of n *@
         @trails.map{ trail =>
             <li>@formatTrail(trail)</li>

--- a/core-navigation/app/controllers/RelatedController.scala.scala
+++ b/core-navigation/app/controllers/RelatedController.scala.scala
@@ -26,7 +26,7 @@ object RelatedController extends Controller with Logging {
       .response
 
     val heading = "Related content"
-    val related = response.relatedContent map { new Content(_) } take (10)
+    val related = response.relatedContent map { new Content(_) }
 
     Some(Related(heading, related))
   }

--- a/core-navigation/test/RelatedControllerTest.scala
+++ b/core-navigation/test/RelatedControllerTest.scala
@@ -1,0 +1,32 @@
+package test
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.FlatSpec
+
+class RelatedControllerTest extends FlatSpec with ShouldMatchers {
+
+  "Related Controller" should "serve the correct headers when the article exists" in Fake {
+    val result = controllers.RelatedController.render("UK", "uk/2012/aug/07/woman-torture-burglary-waterboard-surrey")(FakeRequest())
+    status(result) should be(200)
+    contentType(result).get should be("text/html")
+    charset(result).get should be("utf-8")
+    header("Cache-Control", result).get should be("must-revalidate, max-age=900")
+  }
+  
+  it should "serve the correct headers when given a callback parameter" in Fake {
+    val request = FakeRequest(GET, "/related/UK/uk/2012/aug/07/woman-torture-burglary-waterboard-surrey?callback=foo")
+    val Some(result) = routeAndCall(request)
+
+    status(result) should be(200)
+    contentType(result).get should be("application/javascript")
+    contentAsString(result) should startWith ("foo({\"html\"") // the callback
+  }
+  
+  it should "404 when article does not exist" in Fake {
+    val result = controllers.RelatedController.render("UK", "related/i/am/not/here")(FakeRequest())
+    status(result) should be(404)
+  }
+
+}

--- a/core-navigation/test/RelatedFeatureTest.scala
+++ b/core-navigation/test/RelatedFeatureTest.scala
@@ -18,14 +18,6 @@ class RelatedFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
       }
     }
 
-/*
-   Scenario: If has no Story Package, then show Related Links
-   Scenario: Each item in the list should contain a relative date stamp - Eg, 'published 1 minute/hour/day ago' 
-   Scenario: Links in the story package should *not* contain the current article (deduplicated)
-   Scenario: 404
-   Scenario: 5xx 
-*/
-
     scenario("Shows article metadata for each related link") {
 
       given("there is an article 'Woman tortured during burglary tells of waterboarding ordeal'")
@@ -35,18 +27,20 @@ class RelatedFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         then("I should see the headline, trail text for each related link")
 
         val article = findFirst("li")
-        article.findFirst("a").getAttribute("href") should include ("/uk/2009/oct/22/robbery-burglary-theft-rise-crime")
+        article.findFirst("a").getAttribute("href") should include("/uk/2009/oct/22/robbery-burglary-theft-rise-crime")
         article.findFirst("p").getText should be("Crime falls by 4%, latest figures show")
         article.findFirst(".trailtext").getText should be("Knife murders down by a third, but burglaries and robberies on the rise")
 
         and("I should see the pictures where they exist")
         article.findFirst("img").getAttribute("src") should be("http://static.guim.co.uk/sys-images/Money/Pix/pictures/2007/09/26/Burglar84.jpg")
-        
+
         val articleWithNoPicture = find("li", 3)
         articleWithNoPicture.find("img") should have length 0
 
       }
     }
+
+    scenario("Related links should *not* contain the current article")(pending)
 
   }
 }

--- a/core-navigation/test/RelatedFeatureTest.scala
+++ b/core-navigation/test/RelatedFeatureTest.scala
@@ -18,12 +18,7 @@ class RelatedFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
       }
     }
 
-    /*
-   Scenario: Should have (optional) picture, link text, trail text
-   Scenario: Hidden links should only have headline, trail text
-   Scenario: Expanders should 'show more', then 'show less'
-   Scenario: Number of 'more' items should be represented by a number
-   Scenario: Appear *after* the comments 
+/*
    Scenario: If has no Story Package, then show Related Links
    Scenario: Each item in the list should contain a relative date stamp - Eg, 'published 1 minute/hour/day ago' 
    Scenario: Links in the story package should *not* contain the current article (deduplicated)
@@ -37,12 +32,18 @@ class RelatedFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
       HtmlUnit("/related/UK/uk/2012/aug/07/woman-torture-burglary-waterboard-surrey") { browser =>
         import browser._
 
-        then("I should see the headline, trail text and pictures for each related link")
+        then("I should see the headline, trail text for each related link")
 
         val article = findFirst("li")
-        article.findFirst("img").getAttribute("src") should be("http://static.guim.co.uk/sys-images/Money/Pix/pictures/2007/09/26/Burglar84.jpg")
+        article.findFirst("a").getAttribute("href") should include ("/uk/2009/oct/22/robbery-burglary-theft-rise-crime")
         article.findFirst("p").getText should be("Crime falls by 4%, latest figures show")
         article.findFirst(".trailtext").getText should be("Knife murders down by a third, but burglaries and robberies on the rise")
+
+        and("I should see the pictures where they exist")
+        article.findFirst("img").getAttribute("src") should be("http://static.guim.co.uk/sys-images/Money/Pix/pictures/2007/09/26/Burglar84.jpg")
+        
+        val articleWithNoPicture = find("li", 3)
+        articleWithNoPicture.find("img") should have length 0
 
       }
     }

--- a/core-navigation/test/RelatedFeatureTest.scala
+++ b/core-navigation/test/RelatedFeatureTest.scala
@@ -1,0 +1,52 @@
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{ GivenWhenThen, FeatureSpec }
+import test.`package`._
+
+class RelatedFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
+
+  feature("Related links") {
+
+    scenario("Shows related links") {
+
+      given("there is an article 'Woman tortured during burglary tells of waterboarding ordeal'")
+      HtmlUnit("/related/UK/uk/2012/aug/07/woman-torture-burglary-waterboard-surrey") { browser =>
+        import browser._
+
+        then("I should see the related links")
+        $("li") should have length 10
+
+      }
+    }
+
+    /*
+   Scenario: Should have (optional) picture, link text, trail text
+   Scenario: Hidden links should only have headline, trail text
+   Scenario: Expanders should 'show more', then 'show less'
+   Scenario: Number of 'more' items should be represented by a number
+   Scenario: Appear *after* the comments 
+   Scenario: If has no Story Package, then show Related Links
+   Scenario: Each item in the list should contain a relative date stamp - Eg, 'published 1 minute/hour/day ago' 
+   Scenario: Links in the story package should *not* contain the current article (deduplicated)
+   Scenario: 404
+   Scenario: 5xx 
+*/
+
+    scenario("Shows article metadata for each related link") {
+
+      given("there is an article 'Woman tortured during burglary tells of waterboarding ordeal'")
+      HtmlUnit("/related/UK/uk/2012/aug/07/woman-torture-burglary-waterboard-surrey") { browser =>
+        import browser._
+
+        then("I should see the headline, trail text and pictures for each related link")
+
+        val article = findFirst("li")
+        article.findFirst("img").getAttribute("src") should be("http://static.guim.co.uk/sys-images/Money/Pix/pictures/2007/09/26/Burglar84.jpg")
+        article.findFirst("p").getText should be("Crime falls by 4%, latest figures show")
+        article.findFirst(".trailtext").getText should be("Knife murders down by a third, but burglaries and robberies on the rise")
+
+      }
+    }
+
+  }
+}
+


### PR DESCRIPTION
- BDD tests around related links 
- Applied CSS from Ben's style-guide

TODO
- Merge with 'related' branch
- Controller tests for content-type, status codes etc.
- Javascript layer to cover :-
  
  Scenario: Maximum of 10 related links - show 5, hide 5 - 'show more'
  Scenario: Expanders should 'show more', then 'show less'
  Scenario: Number of 'more' items should be represented by a number 
  Scenario: If has no Story Package, then show Related Links
  Scenario: Each item in the list should contain a relative date stamp - Eg, 'published 1 minute/hour/day ago'
