### PR TITLE
Direct links

### DIFF
--- a/article/app/views/article.scala.html
+++ b/article/app/views/article.scala.html
@@ -33,9 +33,10 @@
         <div class="article-body" itemprop="@if(article.isReview){reviewBody} else {articleBody}">
             @* <!-- ordering of cleaners is important --> *@
             @withJsoup(article.body)(
-            PictureCleaner(article),
-            InBodyLinkCleaner,
-            InsertAfterParagraph(4){ fragments.inBodyPackage(storyPackage) }
+                PictureCleaner(article),
+                InBodyLinkCleaner,
+                BlockCleaner,
+                InsertAfterParagraph(4){ fragments.inBodyPackage(storyPackage) }
             )
         </div>
     </article>

--- a/article/app/views/article.scala.html
+++ b/article/app/views/article.scala.html
@@ -35,7 +35,7 @@
             @withJsoup(article.body)(
                 PictureCleaner(article),
                 InBodyLinkCleaner,
-                BlockCleaner,
+                BlockNumberCleaner,
                 InsertAfterParagraph(4){ fragments.inBodyPackage(storyPackage) }
             )
         </div>

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -209,6 +209,18 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
           be("http://static.guim.co.uk/sys-images/Business/Pix/pictures/2012/7/20/1342784451172/Chancellor-George-Osborne-003.jpg")
       }
     }
+
+    scenario("Direct link to paragraph") {
+
+      given("I have clicked a direct link to paragrah 16 on the article 'Eurozone crisis live: Fitch downgrades Greece on euro exit fears'")
+
+      HtmlUnit("/business/2012/may/17/eurozone-crisis-cameron-greece-euro-exit#block-16") { browser =>
+        import browser._
+
+        then("I should see paragraph 16")
+        findFirst("#block-16").getText should startWith("11.31am: Vince Cable, the business secretary")
+      }
+    }
   }
 
   private def hasLinkName(e: FluentWebElement, name: String) = e.getAttribute("data-link-name") == name

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -71,7 +71,7 @@ trait HtmlCleaner {
   def clean(d: Document): Document
 }
 
-object BlockCleaner extends HtmlCleaner {
+object BlockNumberCleaner extends HtmlCleaner {
 
   private val Block = """<!-- Block (\d*) -->""".r
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConversions._
 import scala.Some
 import play.api.mvc.RequestHeader
 import org.joda.time.{ DateTimeZone, DateTime }
-import org.joda.time.format.{ DateTimeFormat }
+import org.joda.time.format.DateTimeFormat
 
 object JSON {
   //we wrap the result in an Html so that play does not escape it as html
@@ -69,6 +69,26 @@ case class RowInfo(rowNum: Int, isLast: Boolean = false) {
 
 trait HtmlCleaner {
   def clean(d: Document): Document
+}
+
+object BlockCleaner extends HtmlCleaner {
+
+  private val Block = """<!-- Block (\d*) -->""".r
+
+  override def clean(document: Document): Document = {
+    document.getAllElements.foreach { element =>
+      val blockComments = element.childNodes.flatMap { node =>
+        node.toString.trim match {
+          case Block(num) =>
+            Option(node.nextSibling).foreach(_.attr("id", "block-" + num))
+            Some(node)
+          case _ => None
+        }
+      }
+      blockComments.foreach(_.remove())
+    }
+    document
+  }
 }
 
 case class PictureCleaner(imageHolder: Images) extends HtmlCleaner {

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -94,7 +94,7 @@ class TemplatesTest extends FlatSpec with ShouldMatchers {
 
   }
 
-  "BlockCleaner" should "insert ids in block minute by minnute blocks" in {
+  "BlockCleaner" should "insert block ids in minute by minute content" in {
 
     val body = withJsoup(bodyWithBLocks)(BlockNumberCleaner).text.trim
 

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -94,6 +94,14 @@ class TemplatesTest extends FlatSpec with ShouldMatchers {
 
   }
 
+  "BlockCleaner" should "insert ids in block minute by minnute blocks" in {
+
+    val body = withJsoup(bodyWithBLocks)(BlockCleaner).text.trim
+
+    body should include("""<span id="block-14">some heading</span>""")
+    body should include("""<p id="block-1">some more text</p>""")
+  }
+
   "RowInfo" should "add row info to a sequence" in {
 
     val items = Seq("a", "b", "c", "d")
@@ -149,5 +157,10 @@ class TemplatesTest extends FlatSpec with ShouldMatchers {
   val bodyTextWithLinks = """
     <p>bar <a href="http://www.guardiannews.com/section/2011/jan/01/words-for-url">the link</a></p>
   """
+
+  val bodyWithBLocks = """<body>
+      <!-- Block 14 --><span>some heading</span><p>some text</p>
+      <!-- Block 1 --><p>some more text</p>
+    </body>"""
 
 }

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -96,7 +96,7 @@ class TemplatesTest extends FlatSpec with ShouldMatchers {
 
   "BlockCleaner" should "insert ids in block minute by minnute blocks" in {
 
-    val body = withJsoup(bodyWithBLocks)(BlockCleaner).text.trim
+    val body = withJsoup(bodyWithBLocks)(BlockNumberCleaner).text.trim
 
     body should include("""<span id="block-14">some heading</span>""")
     body should include("""<p id="block-1">some more text</p>""")


### PR DESCRIPTION
Live blog bodies are now marked up with paragraph numbers

bug #GFE-34

The first element after a <!-- Block XX --> comment now gets an id="block-XX"

Thinking about it, these direct links are probably doubly important on mobile (not much screen real estate)
