### PR TITLE
Compiled domReady with the rest of our AMD modules

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -3,10 +3,12 @@ define(['common', 'modules/related', 'modules/images', 'modules/popular',
     'modules/relativedates', 'modules/analytics/clickstream',
     'modules/analytics/omniture', 'modules/tabs', 'modules/fonts', 'qwery',
     'modules/detect', 'modules/navigation/top-stories.js',
-    'modules/navigation/controls.js'],
+    'modules/navigation/controls.js',
+    'vendor/domReady'
+    ],
     function (common, Related, Images, Popular, Expandable, Orientation, RelativeDates,
                 Clickstream, Omniture, Tabs, Fonts, qwery, detect,
-                TopStories, NavigationControls) {
+                TopStories, NavigationControls, domReady) {
 
         var modules = {
 
@@ -79,8 +81,7 @@ define(['common', 'modules/related', 'modules/images', 'modules/popular',
          
         };
 
-    return {
-        init: function(config, userPrefs) {
+    var bootstrap = function (config, userPrefs) {
             modules.upgradeImages();
             modules.transcludeRelated(config.page.coreNavigationUrl, config.page.pageId);
             modules.transcludeMostPopular(config.page.coreNavigationUrl, config.page.section);
@@ -90,6 +91,17 @@ define(['common', 'modules/related', 'modules/images', 'modules/popular',
             modules.loadOmnitureAnalytics(config);
             modules.loadFonts(config, navigator.userAgent, userPrefs);
             modules.loadOphanAnalytics(config);
-        }
+        };
+
+    // domReady proxy for bootstrap
+    var domReadyBootstrap = function (config, userPrefs) {
+            domReady(function () {
+                bootstrap(config, userPrefs);
+                });
+            };
+
+    return {
+        go: domReadyBootstrap
     };
+
 });

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -11,8 +11,7 @@
         baseUrl: '@{config.static.path}javascripts',
         paths: {
             'bootstraps/@bootstrapJsModule': '@static("javascripts/bootstraps/%s.js".format(bootstrapJsModule)).asModulePath',
-            omniture: '@static("javascripts/vendor/omniture.js").asModulePath',
-            'domReady': '@static("javascripts/vendor/domReady.js").asModulePath'
+            omniture: '@static("javascripts/vendor/omniture.js").asModulePath'
         }
     };
 
@@ -120,12 +119,8 @@
                 };
             })
 
-            require(['config', 'bootstraps/@bootstrapJsModule', 'domReady'], function(config, bootstrap, domReady) {
-
-                domReady(function (){
-                    bootstrap.init(config, guardian.userPrefs);
-                });
-
+            require(['config', 'bootstraps/@bootstrapJsModule'], function(config, bootstrap) {
+                bootstrap.go(config, guardian.userPrefs);
             });
         };
 


### PR DESCRIPTION
- Added domReady proxy to bootstrap
- Bootstrap interface is now bootstrap.go(), which is cooler than
  bootstrap.init()*

@mattandrews @phamann improvement? 
- really it made sense to have private methods called init & domReadyInit, then hide which one is being called from the public interface.
