### PR TITLE
Ensure container clears header to avoid h1 popping alongside logo.

### DIFF
--- a/common/app/assets/stylesheets/layout/_layout.less
+++ b/common/app/assets/stylesheets/layout/_layout.less
@@ -1,5 +1,6 @@
 #container {
     padding: 10px;
+    clear: both;
 }
 
 .component {

--- a/common/app/views/fragments/navigation.scala.html
+++ b/common/app/views/fragments/navigation.scala.html
@@ -1,5 +1,6 @@
 @(static: StaticAssets, config: GuardianConfiguration, page: MetaData, isFooter: Boolean=false)(implicit request: RequestHeader)
 @if(!isFooter){
+<div class="cf">
 	<a href="/" data-link-name="site logo" id="logo">
         The Guardian
 	</a>
@@ -17,6 +18,10 @@
 
     <a href="#sections-footer" data-is-ajax="1" data-link-name="sections" id="@if(!isFooter){sections-control-header} else {sections-control-footer}" class="sections-control@if(isFooter){ initially-off}"><span>Sections</span></a>
 </div>
+
+@if(!isFooter) {
+    </div>
+}
 
 <div id="@if(!isFooter){topstories-header} else {topstories-footer}" class="nav-popup top-stories initially-off"></div>
 

--- a/gallery/app/views/gallery.scala.html
+++ b/gallery/app/views/gallery.scala.html
@@ -32,63 +32,60 @@
         guardian.gallery = @JSON(gallery);
     </script>
 }{
-    <div id="container">
-        @fragments.headline(gallery.headline)
-        @fragments.standfirst(gallery)
+    @fragments.headline(gallery.headline)
+    @fragments.standfirst(gallery)
 
-        @fragments.byline(gallery.byline, gallery)
-        @fragments.dateline(gallery.webPublicationDate)
+    @fragments.byline(gallery.byline, gallery)
+    @fragments.dateline(gallery.webPublicationDate)
 
-        @if(trail) {
-            <p class="trail">Trail page here...</p>
-        } else {
-            <p class="nav">
+    @if(trail) {
+        <p class="trail">Trail page here...</p>
+    } else {
+        <p class="nav">
 
-                @*
-                  TODO: Standard CS navigation indexing functions in views.support.
-                *@
+            @*
+              TODO: Standard CS navigation indexing functions in views.support.
+            *@
 
-                @if(index > 1) {
-                    <a id="js-gallery-prev" data-link-name="Gallery Previous" data-is-ajax="true" href="?index=@(index - 1)">Previous</a>
-                } else {
-                    <a id="js-gallery-prev" data-link-name="Gallery Previous" data-is-ajax="true" class="initially-off" href="javascript://">Previous</a>
-                }
+            @if(index > 1) {
+                <a id="js-gallery-prev" data-link-name="Gallery Previous" data-is-ajax="true" href="?index=@(index - 1)">Previous</a>
+            } else {
+                <a id="js-gallery-prev" data-link-name="Gallery Previous" data-is-ajax="true" class="initially-off" href="javascript://">Previous</a>
+            }
 
-                Image <span id="js-gallery-index">@index</span> of @gallery.size
+            Image <span id="js-gallery-index">@index</span> of @gallery.size
 
-                @if(index < gallery.size) {
-                    <a id="js-gallery-next" data-link-name="Gallery Next" data-is-ajax="true" href="?index=@(index + 1)">Next</a>
-                } else {
-                    <a id="js-gallery-next" data-link-name="Gallery Next" data-is-ajax="true" data-next="trail" href="?trail=true">Next</a>
-                }
-            </p>
+            @if(index < gallery.size) {
+                <a id="js-gallery-next" data-link-name="Gallery Next" data-is-ajax="true" href="?index=@(index + 1)">Next</a>
+            } else {
+                <a id="js-gallery-next" data-link-name="Gallery Next" data-is-ajax="true" data-next="trail" href="?trail=true">Next</a>
+            }
+        </p>
 
-            <div class="gallery-container" id="js-gallery">
-                <ul class="unstyled">
-                    @gallery.images.zipWithRowInfo.map{ case(image, row) =>
-                        @if(row.rowNum == index) {
-                            <li id="js-gallery-item-@row.rowNum" class="js-current-gallery-slide" data-image="true" data-index="@row.rowNum" data-total="@gallery.size">
-                                <img class="maxed" src="@image.url" data-width="@image.width" />
-                        } else {
-                            <li id="js-gallery-item-@row.rowNum" class="initially-off" data-image="false" data-index="@row.rowNum" data-total="@gallery.size" data-src="@image.url" data-fullsrc='@image.url' data-width="@image.width">
-                        }
-                                @fragments.caption(image.caption.getOrElse(""))
-                                <p class="caption-credit"><strong>@image.credit</strong></p>
-                            </li>
-                        
+        <div class="gallery-container" id="js-gallery">
+            <ul class="unstyled">
+                @gallery.images.zipWithRowInfo.map{ case(image, row) =>
+                    @if(row.rowNum == index) {
+                        <li id="js-gallery-item-@row.rowNum" class="js-current-gallery-slide" data-image="true" data-index="@row.rowNum" data-total="@gallery.size">
+                            <img class="maxed" src="@image.url" data-width="@image.width" />
+                    } else {
+                        <li id="js-gallery-item-@row.rowNum" class="initially-off" data-image="false" data-index="@row.rowNum" data-total="@gallery.size" data-src="@image.url" data-fullsrc='@image.url' data-width="@image.width">
                     }
-                </ul>
-            </div>
+                            @fragments.caption(image.caption.getOrElse(""))
+                            <p class="caption-credit"><strong>@image.credit</strong></p>
+                        </li>
+                    
+                }
+            </ul>
+        </div>
 
-        }
-   
-        @if(storyPackage nonEmpty) {
-            @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 5)
-        } else {
-            <div id="related"></div>
-        }
+    }
 
+    @if(storyPackage nonEmpty) {
+        @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 5)
+    } else {
+        <div id="related"></div>
+    }
 
-        <div id="most-popular"></div>
-    </div>
+    <div id="most-popular"></div>
 }

--- a/section/app/views/section.scala.html
+++ b/section/app/views/section.scala.html
@@ -1,16 +1,14 @@
 @(section: Section, editorsPicks: Seq[Trail], latestContent: Seq[Trail])(implicit request: RequestHeader)
 
 @main(section, Static, Configuration, Switches.all){  }{
-    <div id="container">
-        @fragments.headline(section.name)
+    @fragments.headline(section.name)
 
-        @defining(math.max(editorsPicks.length, 15)){ numTrails =>
-            @defining((editorsPicks ++ latestContent).take(numTrails)){ trails =>
-                @trails.zipWithRowInfo.map{ case (trail, info) =>
-                    <div class="unit size1of2">@fragments.formatTrail(trail,info)</div>
-                }
+    @defining(math.max(editorsPicks.length, 15)){ numTrails =>
+        @defining((editorsPicks ++ latestContent).take(numTrails)){ trails =>
+            @trails.zipWithRowInfo.map{ case (trail, info) =>
+                <div class="unit size1of2">@fragments.formatTrail(trail,info)</div>
             }
         }
-        <div id="most-popular"></div>
-    </div>
+    }
+    <div id="most-popular"></div>
 }

--- a/tag/app/views/tag.scala.html
+++ b/tag/app/views/tag.scala.html
@@ -1,22 +1,20 @@
 @(tag: Tag, trails: Seq[Trail], leadContent: Seq[Trail])(implicit request: RequestHeader)
 
 @main(tag, Static, Configuration, Switches.all){  }{
-    <div id="container">
-        @fragments.headline(tag.name)
+    @fragments.headline(tag.name)
 
-        @if(leadContent nonEmpty) {
-            <div data-link-name="lead content">
-                @leadContent.zipWithRowInfo.map{ case (trail, info) =>
-                    @fragments.formatTrail(trail, info)
-                }
-            </div>
-        }
-
-        <div data-link-name="latest">
-            @trails.zipWithRowInfo.map{ case(trail, info) => @fragments.formatTrail(trail, info) }
+    @if(leadContent nonEmpty) {
+        <div data-link-name="lead content">
+            @leadContent.zipWithRowInfo.map{ case (trail, info) =>
+                @fragments.formatTrail(trail, info)
+            }
         </div>
+    }
 
-        <div id="most-popular"></div>
-        
+    <div data-link-name="latest">
+        @trails.zipWithRowInfo.map{ case(trail, info) => @fragments.formatTrail(trail, info) }
     </div>
+
+    <div id="most-popular"></div>
+
 }

--- a/video/app/views/video.scala.html
+++ b/video/app/views/video.scala.html
@@ -3,7 +3,6 @@
 @main(video, Static, Configuration, Switches.all){
     <link rel="stylesheet" type="text/css" href='@Static("stylesheets/video.min.css")' />
 }{
-<div id="container">
     @fragments.headline(video.headline)
 
     <div id="player">
@@ -23,5 +22,4 @@
         <div id="related"></div>
     }
     <div id="most-popular"></div>
-</div>
 }


### PR DESCRIPTION
@mattandrews I get this annoying render issue where a short section header pops up alongside the logo. I've fixed this by ensuring the container always clears any content above it. Should be safeish?
