### PR TITLE
Front

### DIFF
--- a/common/app/common/AkkaSupport.scala
+++ b/common/app/common/AkkaSupport.scala
@@ -6,6 +6,7 @@ import akka.util.Duration
 import akka.util.duration._
 import play.api.libs.concurrent.{ Akka => PlayAkka }
 import play.api.Play
+import java.util.concurrent.{ Executors, TimeUnit }
 
 trait AkkaSupport {
   object play_akka {
@@ -32,3 +33,21 @@ trait AkkaSupport {
     def agent[T](value: T): Agent[T] = Agent(value)(play_akka.system())
   }
 }
+
+trait PlainOldScheduling {
+  //Akka sometimes deadlocks during startup if we try schedule things there
+  //so use this as a bootstrap mechanism
+  //https://groups.google.com/forum/?fromgroups=#!topic/play-framework/yO8GsBLzGGY
+  object executor {
+    def scheduleOnce(delay: Long, timeUnit: TimeUnit)(block: => Unit) {
+      val executor = Executors.newSingleThreadScheduledExecutor()
+      executor.schedule(new Runnable() {
+        override def run() {
+          block
+          executor.shutdown()
+        }
+      }, delay, timeUnit)
+    }
+  }
+}
+

--- a/features/network-front.feature
+++ b/features/network-front.feature
@@ -7,9 +7,14 @@ Feature: Network front
 	- Metric: 
 	- Metric: 
 
-	Scenario: Trailblocks
+ 
+
+    Scenario: Trailblocks
 		Given I visit the front page
-		Then I should see the following trailblocks <a, b, c, d, e>
+		Then I should see the following trailblocks <News(Top stories), Sport, Comment is free, Features, 
+                Culture, Business, Life style, Money and Travel>
+                And each block have minimum 1 story maximum 5 stories
+                And expanders for each block be maximum 5 stories
 
 	Scenario: Texture
 		Given a series of trailblocks network front 

--- a/front/app/Global.scala
+++ b/front/app/Global.scala
@@ -1,9 +1,9 @@
-import common.{ AkkaSupport, RequestMetrics }
+import common.RequestMetrics
 import com.gu.management.play.{ RequestTimer, StatusCounters }
 import controllers.front.Front
 import play.api.GlobalSettings
 
-object Global extends GlobalSettings with RequestTimer with StatusCounters with AkkaSupport {
+object Global extends GlobalSettings with RequestTimer with StatusCounters {
 
   import RequestMetrics._
 

--- a/front/app/Global.scala
+++ b/front/app/Global.scala
@@ -14,13 +14,7 @@ object Global extends GlobalSettings with RequestTimer with StatusCounters with 
   override val redirectCounter = Request30xs
 
   override def onStart(app: play.api.Application) {
-
     super.onStart(app)
-
-    //wait for Akka to fully startup to avoid deadlocks
-    //https://groups.google.com/forum/?fromgroups=#!topic/play-framework/yO8GsBLzGGY
-    while (play_akka.uptime() == 0) { Thread.`yield`() }
-
     Front.startup()
   }
 

--- a/front/app/conf/context.scala
+++ b/front/app/conf/context.scala
@@ -4,6 +4,7 @@ import common._
 import com.gu.management._
 import com.gu.management.play._
 import logback.LogbackLevelPage
+import java.net.{ HttpURLConnection, URL }
 
 object Configuration extends GuardianConfiguration("frontend-front", webappConfDirectory = "env")
 
@@ -23,12 +24,29 @@ object Metrics {
   val all: Seq[Metric] = ContentApi.metrics.all ++ CommonMetrics.all
 }
 
+object FrontHealthCheck extends ManagementPage {
+
+  val path = "/management/healthcheck"
+
+  def get(req: com.gu.management.HttpRequest) = {
+    val connectionToFront = new URL("http://localhost:9000").openConnection().asInstanceOf[HttpURLConnection]
+    try {
+      connectionToFront.getResponseCode match {
+        case 200 => PlainTextResponse("Ok")
+        case other => ErrorResponse(other, connectionToFront.getResponseMessage)
+      }
+    } finally {
+      connectionToFront.disconnect()
+    }
+  }
+}
+
 object Management extends Management {
   val applicationName = Configuration.application
 
   lazy val pages = List(
     new ManifestPage,
-    new HealthcheckManagementPage,
+    FrontHealthCheck,
     new Switchboard(Switches.all, applicationName),
     StatusPage(applicationName, Metrics.all),
     new PropertiesPage(Configuration.toString),

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -4,10 +4,11 @@ import common._
 import conf._
 import front.Front
 import model._
-import play.api.mvc.{ Result, RequestHeader, Controller, Action }
+import play.api.mvc._
 import play.api.libs.concurrent.Akka
-import play.api.Play
-import Play.current
+import play.api.Play.current
+import model.Trailblock
+import scala.Some
 
 case class FrontPage(trailblocks: Seq[Trailblock]) extends MetaData {
   override val canonicalUrl = "http://www.guardian.co.uk"
@@ -24,7 +25,9 @@ case class FrontPage(trailblocks: Seq[Trailblock]) extends MetaData {
   lazy val collapseEmptyBlocks: FrontPage = new FrontPage(trailblocks filterNot { _.trails.isEmpty })
 }
 
-object FrontController extends Controller with Logging {
+class FrontController extends Controller with Logging {
+
+  val front: Front = Front
 
   def warmup() = Action {
     log.info("warming up front")
@@ -44,11 +47,13 @@ object FrontController extends Controller with Logging {
 
   private def lookup()(implicit request: RequestHeader): Option[FrontPage] = {
     val edition = Edition(request, Configuration)
-    Some(Front(edition))
+    Some(front(edition))
   }
 
-  private def renderFront(model: FrontPage)(implicit request: RequestHeader): Result =
-    CachedOk(model) {
-      Compressed(views.html.front(model))
-    }
+  private def renderFront(model: FrontPage)(implicit request: RequestHeader) = model match {
+    case FrontPage(Nil) => InternalServerError
+    case m => CachedOk(m) { Compressed(views.html.front(model)) }
+  }
 }
+
+object FrontController extends FrontController

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -31,13 +31,8 @@ class FrontController extends Controller with Logging {
 
   def warmup() = Action {
     log.info("warming up front")
-    val promiseOfWarmup = Akka.future {
-      Front.startup()
-    }
-
-    Async {
-      promiseOfWarmup.map(warm => Ok("warm"))
-    }
+    val promiseOfWarmup = Akka.future(Front.warmup())
+    Async { promiseOfWarmup.map(warm => Ok("warm")) }
   }
 
   def render() = Action { implicit request =>

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -11,6 +11,7 @@ import common.{ PlainOldScheduling, Logging, AkkaSupport }
 import java.util.concurrent.TimeUnit
 
 //Responsible for holding the definition of the two editions
+//and bootstrapping the front (setting up the refresh schedule)
 class Front extends AkkaSupport with PlainOldScheduling with Logging {
 
   val refreshDuration = akka.util.Duration(60, SECONDS)

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -7,10 +7,11 @@ import akka.actor.Cancellable
 import play.api.Play
 import Play.current
 import org.joda.time.DateTime
-import common.{ Logging, AkkaSupport }
+import common.{ PlainOldScheduling, Logging, AkkaSupport }
+import java.util.concurrent.TimeUnit
 
 //Responsible for holding the definition of the two editions
-class Front extends AkkaSupport with Logging {
+class Front extends AkkaSupport with PlainOldScheduling with Logging {
 
   val refreshDuration = akka.util.Duration(60, SECONDS)
 
@@ -50,10 +51,12 @@ class Front extends AkkaSupport with Logging {
   }
 
   def startup() {
-    refreshSchedule = Some(play_akka.scheduler.every(refreshDuration) {
-      log.info("Refreshing Front")
-      Front.refresh()
-    })
+    executor.scheduleOnce(3, TimeUnit.SECONDS) {
+      refreshSchedule = Some(play_akka.scheduler.every(refreshDuration) {
+        log.info("Refreshing Front")
+        Front.refresh()
+      })
+    }
   }
 
   def apply(edition: String): FrontPage = edition match {
@@ -62,6 +65,7 @@ class Front extends AkkaSupport with Logging {
   }
 
   def warmup() {
+    refresh()
     uk.warmup()
     us.warmup()
   }

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -50,30 +50,20 @@ class Front extends AkkaSupport with Logging {
   }
 
   def startup() {
-    //There is a deadlock problem when running in dev/test mode.
-    //dev machines are quick enough that it hardly ever happens, but our teamcity agents are really slow
-    //and this causes many broken tests
-    //https://groups.google.com/forum/?fromgroups=#!topic/play-framework/yO8GsBLzGGY
-    if (!Play.isTest && !refreshSchedule.isDefined) {
-      refreshSchedule = Some(play_akka.scheduler.every(refreshDuration, initialDelay = refreshDuration) {
-        log.info("Refreshing Front")
-        Front.refresh()
-      })
-    }
-
-    //ensures the app comes up with data for the front
-    Front.refresh()
-    Front.warmup()
-  }
-
-  private def warmup() {
-    uk.warmup()
-    us.warmup()
+    refreshSchedule = Some(play_akka.scheduler.every(refreshDuration) {
+      log.info("Refreshing Front")
+      Front.refresh()
+    })
   }
 
   def apply(edition: String): FrontPage = edition match {
     case "US" => FrontPage(us())
     case anythingElse => FrontPage(uk())
+  }
+
+  def warmup() {
+    uk.warmup()
+    us.warmup()
   }
 }
 

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -6,11 +6,16 @@ import org.scalatest.matchers.ShouldMatchers
 import controllers.front.{ TrailblockAgent, FrontEdition, Front }
 import model._
 import org.joda.time.DateTime
-import model.Trailblock
-import model.TrailblockDescription
 import collection.JavaConversions._
+import controllers.{ FrontController }
+import play.api.test.FakeRequest
+import play.api.mvc._
+import model.Trailblock
+import scala.Some
+import controllers.FrontPage
+import model.TrailblockDescription
 
-class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
+class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatchers with Results {
 
   feature("Network Front") {
 
@@ -272,6 +277,22 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
       and("I should see 1 Travel story")
       Front.uk.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
       Front.us.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
+    }
+
+    //this is so that the load balancer knows this server has a problem
+    scenario("Return error if front is empty") {
+
+      given("I visit the network front")
+      and("it is empty")
+
+      val controller = new FrontController {
+        override val front = new Front() {
+          override def apply(edition: String) = FrontPage(Seq.empty)
+        }
+      }
+
+      then("I should see an internal server error")
+      controller.render()(FakeRequest()).asInstanceOf[SimpleResult[AnyContent]].header.status should be(500)
     }
   }
 


### PR DESCRIPTION
Added support for front for autoscaling.

Bootstrapping the front uses plain old executors for scheduling to avoid deadlock issue.

Front now returns a 500 if it is empty
