### PR TITLE
Update static assets to have public cache of 10 years.

### DIFF
--- a/article/conf/deploy.json
+++ b/article/conf/deploy.json
@@ -16,7 +16,7 @@
             "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=2592000"
+                "cacheControl":"public, max-age=315360000"
             }
         }
     },

--- a/front/conf/deploy.json
+++ b/front/conf/deploy.json
@@ -16,7 +16,7 @@
             "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=2592000"
+                "cacheControl":"public, max-age=315360000"
             }
         }
     },

--- a/gallery/conf/deploy.json
+++ b/gallery/conf/deploy.json
@@ -16,7 +16,7 @@
             "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=2592000"
+                "cacheControl":"public, max-age=315360000"
             }
         }
     },

--- a/section/conf/deploy.json
+++ b/section/conf/deploy.json
@@ -16,7 +16,7 @@
             "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=2592000"
+                "cacheControl":"public, max-age=315360000"
             }
         }
     },

--- a/tag/conf/deploy.json
+++ b/tag/conf/deploy.json
@@ -16,7 +16,7 @@
             "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=2592000"
+                "cacheControl":"public, max-age=315360000"
             }
         }
     },

--- a/video/conf/deploy.json
+++ b/video/conf/deploy.json
@@ -16,7 +16,7 @@
             "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=2592000"
+                "cacheControl":"public, max-age=315360000"
             }
         }
     },


### PR DESCRIPTION
Gets rid of lots of warning flags in various performance monitoring tools.

@gklopper - Is there a deploy.json for football? I saw a compiled one, but no source?
