### PR TITLE
Jasmine sbt

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -53,11 +53,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 			<artifactId>selenium-java</artifactId>
 			<version>2.24.1</version>
 		</dependency>
-        <dependency>
-            <groupId>com.novocode</groupId>
-            <artifactId>junit-interface</artifactId>
-            <version>0.10-M1</version>
-        </dependency>
 	</dependencies>
 
 	<build>
@@ -78,6 +73,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	                    <property>
                             <name>cucumber.options</name>
                             <value>${cucumber.options}</value>
+	                    </property>
+	                    <property>
+	                       <name>frontend.root.dir</name>
+	                       <value>${basedir}/..</value>
 	                    </property>
 					</systemProperties>
 				</configuration>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -53,6 +53,11 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 			<artifactId>selenium-java</artifactId>
 			<version>2.24.1</version>
 		</dependency>
+        <dependency>
+            <groupId>com.novocode</groupId>
+            <artifactId>junit-interface</artifactId>
+            <version>0.10-M1</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
+++ b/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
@@ -1,18 +1,11 @@
 package com.gu.test;
 
-import cucumber.junit.Cucumber;
-
-import org.junit.AfterClass;
 import org.junit.runner.RunWith;
+
+import cucumber.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @Cucumber.Options(tags = "~@ignore", format = {"pretty", "html:target/cucumber-html-report"})
 
-public class RunCukesTest {
-	
-	@AfterClass
-	public static void tearDown() {
-		SharedDriver.REAL_DRIVER.close();
-	}
-	
+public class RunCukesTest {	
 }

--- a/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
+++ b/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
@@ -1,10 +1,18 @@
 package com.gu.test;
 
 import cucumber.junit.Cucumber;
+
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @Cucumber.Options(tags = "~@ignore", format = {"pretty", "html:target/cucumber-html-report"})
 
 public class RunCukesTest {
+	
+	@AfterClass
+	public static void tearDown() {
+		SharedDriver.REAL_DRIVER.close();
+	}
+	
 }

--- a/integration-tests/src/test/java/com/gu/test/SharedDriver.java
+++ b/integration-tests/src/test/java/com/gu/test/SharedDriver.java
@@ -19,7 +19,14 @@ import cucumber.annotation.Before;
 
 public class SharedDriver extends EventFiringWebDriver {
 	
-    public static final WebDriver REAL_DRIVER;
+    private static final WebDriver REAL_DRIVER;
+    
+    private static final Thread CLOSE_THREAD = new Thread() {
+        @Override
+        public void run() {
+            REAL_DRIVER.close();
+        }
+    };
     
     protected EventListener eventListener;
     
@@ -40,6 +47,8 @@ public class SharedDriver extends EventFiringWebDriver {
 			}
 		}
 		REAL_DRIVER = new FirefoxDriver(profile);
+		
+		Runtime.getRuntime().addShutdownHook(CLOSE_THREAD);
     }
 
     public SharedDriver() {

--- a/integration-tests/src/test/java/com/gu/test/SharedDriver.java
+++ b/integration-tests/src/test/java/com/gu/test/SharedDriver.java
@@ -19,17 +19,10 @@ import cucumber.annotation.Before;
 
 public class SharedDriver extends EventFiringWebDriver {
 	
-    private static final WebDriver REAL_DRIVER;
+    public static final WebDriver REAL_DRIVER;
     
     protected EventListener eventListener;
     
-    private static final Thread CLOSE_THREAD = new Thread() {
-        @Override
-        public void run() {
-            REAL_DRIVER.close();
-        }
-    };
-
     static {
 		FirefoxProfile profile = new FirefoxProfile();
 		// if http_proxy system variable, set proxy in profile
@@ -47,8 +40,6 @@ public class SharedDriver extends EventFiringWebDriver {
 			}
 		}
 		REAL_DRIVER = new FirefoxDriver(profile);
-    	
-        Runtime.getRuntime().addShutdownHook(CLOSE_THREAD);
     }
 
     public SharedDriver() {
@@ -57,14 +48,6 @@ public class SharedDriver extends EventFiringWebDriver {
         // add an event listener to the driver
         eventListener = new EventListener();
     	register(eventListener);
-    }
-
-    @Override
-    public void close() {
-        if(Thread.currentThread() != CLOSE_THREAD) {
-            throw new UnsupportedOperationException("You shouldn't close this WebDriver. It's shared and will close when the JVM exits.");
-        }
-        super.close();
     }
 
     @Before

--- a/integration-tests/src/test/java/com/gu/test/Steps.java
+++ b/integration-tests/src/test/java/com/gu/test/Steps.java
@@ -54,11 +54,14 @@ public class Steps {
 	
 	@When("^I visit the (.*) jasmine test runner$")
 	public void I_visit_the_jasmine_test_runner(String project) throws Throwable {
-		File currentDir = new File(".");
-		System.out.println(currentDir.getCanonicalPath());
-		// open the appropriate runner 
+		// get the frontend project root, if there's a system prop, otherwise assume
+		String frontendRoot = (System.getProperty("frontend.dir") != null) 
+			? System.getProperty("frontend.dir")
+			: System.getProperty("user.dir") + "/..";
+			
+		// open the appropriate runner
 		webDriver.get(
-			"file:///" + currentDir.getCanonicalPath() + "/../" + project + "/test/assets/javascripts/runner.html"
+			"file:///" + frontendRoot + "/" + project + "/test/assets/javascripts/runner.html"
 		);
 		// confirm we're on the correct page
 		Assert.assertTrue(webDriver.getTitle().contains("Jasmine Spec Runner"));

--- a/integration-tests/src/test/java/com/gu/test/Steps.java
+++ b/integration-tests/src/test/java/com/gu/test/Steps.java
@@ -54,9 +54,10 @@ public class Steps {
 	@When("^I visit the (.*) jasmine test runner$")
 	public void I_visit_the_jasmine_test_runner(String project) throws Throwable {
 		// get the frontend project root, if there's a system prop, otherwise assume
-		String frontendRoot = (System.getProperty("frontend.dir") != null) 
-			? System.getProperty("frontend.dir")
-			: System.getProperty("user.dir") + "/..";
+		// we're there already
+		String frontendRoot = (System.getProperty("frontend.root.dir") != null) 
+			? System.getProperty("frontend.root.dir")
+			: System.getProperty("user.dir");
 			
 		// open the appropriate runner
 		webDriver.get(

--- a/integration-tests/src/test/java/com/gu/test/Steps.java
+++ b/integration-tests/src/test/java/com/gu/test/Steps.java
@@ -1,6 +1,5 @@
 package com.gu.test;
 
-import java.io.File;
 import java.util.List;
 
 import junit.framework.Assert;

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -12,11 +12,25 @@ import com.gu.RequireJS._
 import com.gu.RequireJS
 import com.gu.SbtJshintPlugin
 import com.gu.SbtJshintPlugin._
+import templemore.xsbt.cucumber.CucumberPlugin
+import templemore.xsbt.cucumber.CucumberPlugin._
 
 object Frontend extends Build with Prototypes {
 
   val version = "1-SNAPSHOT"
-
+    
+  // jasmine project
+  val jasmine = Project("jasmine", file("integration-tests"),
+      settings = Defaults.defaultSettings ++ CucumberPlugin.cucumberSettings ++ 
+      Seq (
+        CucumberPlugin.cucumberFeaturesDir := new File("./integration-tests/src/test/resources/com/gu/test/common.feature")
+      )
+    )
+  	.settings(
+      // use pom for dependency management
+  	  externalPom()
+  	)
+  	
   val common = library("common")
 
   val commonWithTests = common % "test->test;compile->compile"
@@ -37,18 +51,6 @@ object Frontend extends Build with Prototypes {
     .dependsOn(section)
     .dependsOn(gallery)
     .dependsOn(coreNavigation)
-
-  lazy val jasmine = Project(id = "jasmine", base = file("integration-tests"))
-  	.settings(
-      // use pom for dependency management
-  	  externalPom(),
-  	  testOptions += Tests.Argument(
-		  TestFrameworks.JUnit, "-q", "-v", 
-		  "-Dcucumber.options=integration-tests/src/test/resources --tags @jasmine --tags ~@ignore --glue com/gu/test --format pretty",
-		  "-Dfrontend.dir=" + System.getProperty("user.dir")
-		  
-	  )
-  	)
     
   val main = root().aggregate(
     common, article, gallery, tag, section, front, video, coreNavigation, dev, jasmine
@@ -150,7 +152,7 @@ trait Prototypes {
       },
 
       (test in Test) <<= (test in Test) dependsOn (jshint),
-
+      
       templatesImport ++= Seq(
         "common._",
         "model._",

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -28,7 +28,7 @@ object Frontend extends Build with Prototypes {
   val front = application("front").dependsOn(commonWithTests)
   val coreNavigation = application("core-navigation").dependsOn(commonWithTests)
   val video = application("video").dependsOn(commonWithTests)
-
+  
   val dev = application("dev-build")
     .dependsOn(front)
     .dependsOn(article)
@@ -38,9 +38,22 @@ object Frontend extends Build with Prototypes {
     .dependsOn(gallery)
     .dependsOn(coreNavigation)
 
+  lazy val jasmine = Project(id = "jasmine", base = file("integration-tests"))
+  	.settings(
+      // use pom for dependency management
+  	  externalPom(),
+  	  testOptions += Tests.Argument(
+		  TestFrameworks.JUnit, "-q", "-v", 
+		  "-Dcucumber.options=integration-tests/src/test/resources --tags @jasmine --tags ~@ignore --glue com/gu/test --format pretty",
+		  "-Dfrontend.dir=" + System.getProperty("user.dir")
+		  
+	  )
+  	)
+    
   val main = root().aggregate(
-    common, article, gallery, tag, section, front, video, coreNavigation, dev
+    common, article, gallery, tag, section, front, video, coreNavigation, dev, jasmine
   )
+  
 }
 
 trait Prototypes {

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -27,12 +27,20 @@ object Frontend extends Build with Prototypes {
       )
     )
   	.settings(
-      // use pom for dependency management
-  	  externalPom()
+  	  libraryDependencies ++= Seq(
+		  "junit" % "junit" % "4.10",
+	      "org.seleniumhq.selenium" % "selenium-java" % "2.24.1",
+	      "info.cukes" % "cucumber-core" % "1.0.14",
+	      "info.cukes" % "cucumber-java" % "1.0.14",
+	      "info.cukes" % "cucumber-junit" % "1.0.14",
+	      "info.cukes" % "cucumber-picocontainer" % "1.0.14"
+	  )
+  	  // TODO - doesn't work - cucumber is an input task
+  	  // (test in Test) <<= (test in Test) dependsOn (cucumber)
   	)
   	
-  val common = library("common")
-
+  val common = library("common").dependsOn(jasmine % "test->test")
+  
   val commonWithTests = common % "test->test;compile->compile"
 
   val article = application("article").dependsOn(commonWithTests)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,9 +3,12 @@ logLevel := Level.Warn
 
 resolvers ++= Seq(
   "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
+  "Templemore Repository" at "http://templemore.co.uk/repo",
   Classpaths.typesafeResolver
 )
 
 addSbtPlugin("play" % "sbt-plugin" % "2.1-06142012")
 
 addSbtPlugin("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.4.0")
+
+addSbtPlugin("templemore" %% "xsbt-cucumber-plugin" % "0.5.0")


### PR DESCRIPTION
Added a Jasmine subproject, that runs the jasmine spec runner

To run

```
$ project jasmine
$ cucumber
```

We want to run this as part of the standard test task though, but I'm buggered if I can work out how. The `cucumber` task is an input task, so looks you can't depend on it. Guess we need a standard task wrapper around it 
