### PR TITLE
Section fronts

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -39,6 +39,7 @@ GET     /football/:competition/table                        controllers.LeagueTa
 GET     /_warmup                              controllers.FrontController.warmup()
 GET     /_up                                  controllers.FrontController.isUp()
 GET     /                                     controllers.FrontController.render()
+GET     /$path<culture|sport>                 controllers.FrontController.renderFor(path)
 
 
 #Video

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -37,14 +37,18 @@ class FrontController extends Controller with Logging {
 
   def isUp() = Action { Ok("Ok") }
 
-  def render() = Action { implicit request =>
+  def render() = renderFor("front")
+
+
+  //todo 404 on not found
+  def renderFor(path: String) = Action { implicit request =>
     //in this case lookup has no blocking IO - so not Async here
-    lookup() map { renderFront } getOrElse { NotFound }
+    lookup(path) map { renderFront } getOrElse { NotFound }
   }
 
-  private def lookup()(implicit request: RequestHeader): Option[FrontPage] = {
+  private def lookup(path: String)(implicit request: RequestHeader): Option[FrontPage] = {
     val edition = Edition(request, Configuration)
-    Some(front(edition))
+    Some(front(path, edition))
   }
 
   private def renderFront(model: FrontPage)(implicit request: RequestHeader) = model match {

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -35,14 +35,18 @@ class FrontController extends Controller with Logging {
 
   def isUp() = Action { Ok("Ok") }
 
-  def render() = Action { implicit request =>
+  def render() = renderFor("front")
+
+
+  //todo 404 on not found
+  def renderFor(path: String) = Action { implicit request =>
     //in this case lookup has no blocking IO - so not Async here
-    lookup() map { renderFront } getOrElse { NotFound }
+    lookup(path) map { renderFront } getOrElse { NotFound }
   }
 
-  private def lookup()(implicit request: RequestHeader): Option[FrontPage] = {
+  private def lookup(path: String)(implicit request: RequestHeader): Option[FrontPage] = {
     val edition = Edition(request, Configuration)
-    Some(front(edition))
+    Some(front(path, edition))
   }
 
   private def renderFront(model: FrontPage)(implicit request: RequestHeader) = model match {

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -37,7 +37,6 @@ class FrontController extends Controller with Logging {
 
   def render() = renderFor("front")
 
-
   //todo 404 on not found
   def renderFor(path: String) = Action { implicit request =>
     //in this case lookup has no blocking IO - so not Async here

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -39,7 +39,6 @@ class FrontController extends Controller with Logging {
 
   def render() = renderFor("front")
 
-
   //todo 404 on not found
   def renderFor(path: String) = Action { implicit request =>
     //in this case lookup has no blocking IO - so not Async here

--- a/front/app/controllers/front/ConfiguredEdition.scala
+++ b/front/app/controllers/front/ConfiguredEdition.scala
@@ -27,7 +27,7 @@ class ConfiguredEdition(edition: String, descriptions: Seq[TrailblockDescription
       case head :: Nil => head :: configuredTrailblocks
       case head :: tail => head :: configuredTrailblocks ::: tail
     }
-    super.apply()
+    dedupe(trailblocks)
   }
 
   override def refresh() = {

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -16,37 +16,55 @@ class Front extends AkkaSupport with Logging {
 
   private var refreshSchedule: Option[Cancellable] = None
 
-  val uk = new FrontEdition("UK", Seq(
-    TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),
-    TrailblockDescription("sport", "Sport", numItemsVisible = 5, numLargeImages = 1),
-    TrailblockDescription("commentisfree", "Comment is free", numItemsVisible = 3),
-    TrailblockDescription("culture", "Culture", numItemsVisible = 1),
-    TrailblockDescription("business", "Business", numItemsVisible = 1),
-    TrailblockDescription("lifeandstyle", "Life and style", numItemsVisible = 1),
-    TrailblockDescription("money", "Money", numItemsVisible = 1),
-    TrailblockDescription("travel", "Travel", numItemsVisible = 1)
-  ))
+  private val ukEditions = Map(
 
-  val us = new FrontEdition("US", Seq(
-    TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),
-    TrailblockDescription("sport", "Sports", numItemsVisible = 5, numLargeImages = 1),
-    TrailblockDescription("commentisfree", "Comment is free", numItemsVisible = 3),
-    TrailblockDescription("culture", "Culture", numItemsVisible = 1),
-    TrailblockDescription("business", "Business", numItemsVisible = 1),
-    TrailblockDescription("lifeandstyle", "Life and style", numItemsVisible = 1),
-    TrailblockDescription("money", "Money", numItemsVisible = 1),
-    TrailblockDescription("travel", "Travel", numItemsVisible = 1)
-  ))
+    "front" -> new FrontEdition("UK", Seq(
+      TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),
+      TrailblockDescription("sport", "Sport", numItemsVisible = 5, numLargeImages = 1),
+      TrailblockDescription("commentisfree", "Comment is free", numItemsVisible = 3),
+      TrailblockDescription("culture", "Culture", numItemsVisible = 1),
+      TrailblockDescription("business", "Business", numItemsVisible = 1),
+      TrailblockDescription("lifeandstyle", "Life and style", numItemsVisible = 1),
+      TrailblockDescription("money", "Money", numItemsVisible = 1),
+      TrailblockDescription("travel", "Travel", numItemsVisible = 1)
+    )),
+
+    "sport" -> new FrontEdition("UK", Seq(
+      TrailblockDescription("sport", "Sport", numItemsVisible = 5, numLargeImages = 1),
+      TrailblockDescription("sport/cycling", "Cycling", numItemsVisible = 3),
+      TrailblockDescription("sport/rugby-union", "Rugby", numItemsVisible = 1)
+    ))
+  )
+
+  private val usEditions = Map(
+
+    "front" -> new FrontEdition("US", Seq(
+      TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),
+      TrailblockDescription("sport", "Sports", numItemsVisible = 5, numLargeImages = 1),
+      TrailblockDescription("commentisfree", "Comment is free", numItemsVisible = 3),
+      TrailblockDescription("culture", "Culture", numItemsVisible = 1),
+      TrailblockDescription("business", "Business", numItemsVisible = 1),
+      TrailblockDescription("lifeandstyle", "Life and style", numItemsVisible = 1),
+      TrailblockDescription("money", "Money", numItemsVisible = 1),
+      TrailblockDescription("travel", "Travel", numItemsVisible = 1)
+    )),
+
+    "sport" -> new FrontEdition("US", Seq(
+      TrailblockDescription("sport", "Sports", numItemsVisible = 5, numLargeImages = 1),
+      TrailblockDescription("sport/cycling", "Cycling", numItemsVisible = 3),
+      TrailblockDescription("sport/nfl", "NFL", numItemsVisible = 1)
+    ))
+  )
+
+  private def allFronts = ukEditions.toSeq ++ usEditions.toSeq
 
   def refresh() {
-    uk.refresh()
-    us.refresh()
+    allFronts.foreach { case (name, front) => front.refresh() }
   }
 
   def shutdown() {
     refreshSchedule foreach { _.cancel() }
-    uk.shutDown()
-    us.shutDown()
+    allFronts.foreach { case (name, front) => front.shutDown() }
   }
 
   def startup() {
@@ -56,15 +74,14 @@ class Front extends AkkaSupport with Logging {
     })
   }
 
-  def apply(edition: String): FrontPage = edition match {
-    case "US" => FrontPage(us())
-    case anythingElse => FrontPage(uk())
+  def apply(path: String, edition: String): FrontPage = edition match {
+    case "US" => FrontPage(usEditions(path)())
+    case anythingElse => FrontPage(ukEditions(path)())
   }
 
   def warmup() {
     refresh()
-    uk.warmup()
-    us.warmup()
+    allFronts.foreach { case (name, front) => front.warmup() }
   }
 }
 

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -16,7 +16,7 @@ class Front extends AkkaSupport with Logging {
 
   private var refreshSchedule: Option[Cancellable] = None
 
-  private val ukEditions = Map(
+  val ukEditions = Map(
 
     "front" -> new ConfiguredEdition("UK", Seq(
       TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),
@@ -30,13 +30,22 @@ class Front extends AkkaSupport with Logging {
     )),
 
     "sport" -> new FrontEdition("UK", Seq(
-      TrailblockDescription("sport", "Sport", numItemsVisible = 5, numLargeImages = 1),
-      TrailblockDescription("sport/cycling", "Cycling", numItemsVisible = 3),
-      TrailblockDescription("sport/rugby-union", "Rugby", numItemsVisible = 1)
+      TrailblockDescription("sport", "Sport", numItemsVisible = 5),
+      TrailblockDescription("football", "Football", numItemsVisible = 3),
+      TrailblockDescription("sport/cricket", "Cricket", numItemsVisible = 1),
+      TrailblockDescription("sport/rugby-union", "Rugby Union", numItemsVisible = 1),
+      TrailblockDescription("sport/motorsports", "Motor Sport", numItemsVisible = 1),
+      TrailblockDescription("sport/tennis", "Tennis", numItemsVisible = 1),
+      TrailblockDescription("sport/golf", "Golf", numItemsVisible = 1),
+      TrailblockDescription("sport/horse-racing", "Horse Racing", numItemsVisible = 1),
+      TrailblockDescription("sport/rugbyleague", "Rugby League", numItemsVisible = 1),
+      TrailblockDescription("sport/us-sport", "US Sport", numItemsVisible = 1),
+      TrailblockDescription("sport/boxing", "Boxing", numItemsVisible = 1),
+      TrailblockDescription("sport/cycling", "Cycling", numItemsVisible = 1)
     ))
   )
 
-  private val usEditions = Map(
+  val usEditions = Map(
 
     "front" -> new ConfiguredEdition("US", Seq(
       TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -42,6 +42,17 @@ class Front extends AkkaSupport with Logging {
       TrailblockDescription("sport/us-sport", "US Sport", numItemsVisible = 1),
       TrailblockDescription("sport/boxing", "Boxing", numItemsVisible = 1),
       TrailblockDescription("sport/cycling", "Cycling", numItemsVisible = 1)
+    )),
+
+    "culture" -> new FrontEdition("UK", Seq(
+      TrailblockDescription("culture", "Culture", numItemsVisible = 5),
+      TrailblockDescription("tv-and-radio", "TV & Radio", numItemsVisible = 1),
+      TrailblockDescription("film", "Film", numItemsVisible = 1),
+      TrailblockDescription("music", "Music", numItemsVisible = 1),
+      TrailblockDescription("stage", "Stage", numItemsVisible = 1),
+      TrailblockDescription("books", "Books", numItemsVisible = 1),
+      TrailblockDescription("artanddesign", "Art & Design", numItemsVisible = 1),
+      TrailblockDescription("technology/games", "Games", numItemsVisible = 1)
     ))
   )
 
@@ -60,7 +71,28 @@ class Front extends AkkaSupport with Logging {
 
     "sport" -> new FrontEdition("US", Seq(
       TrailblockDescription("sport", "Sports", numItemsVisible = 5),
-      TrailblockDescription("sport/nfl", "NFL", numItemsVisible = 1)
+      TrailblockDescription("football", "Football", numItemsVisible = 3),
+      TrailblockDescription("sport/cricket", "Cricket", numItemsVisible = 1),
+      TrailblockDescription("sport/rugby-union", "Rugby Union", numItemsVisible = 1),
+      TrailblockDescription("sport/motorsports", "Motor Sport", numItemsVisible = 1),
+      TrailblockDescription("sport/tennis", "Tennis", numItemsVisible = 1),
+      TrailblockDescription("sport/golf", "Golf", numItemsVisible = 1),
+      TrailblockDescription("sport/horse-racing", "Horse Racing", numItemsVisible = 1),
+      TrailblockDescription("sport/rugbyleague", "Rugby League", numItemsVisible = 1),
+      TrailblockDescription("sport/us-sport", "US Sport", numItemsVisible = 1),
+      TrailblockDescription("sport/boxing", "Boxing", numItemsVisible = 1),
+      TrailblockDescription("sport/cycling", "Cycling", numItemsVisible = 1)
+    )),
+
+    "culture" -> new FrontEdition("US", Seq(
+      TrailblockDescription("culture", "Culture", numItemsVisible = 5),
+      TrailblockDescription("tv-and-radio", "TV & Radio", numItemsVisible = 1),
+      TrailblockDescription("film", "Film", numItemsVisible = 1),
+      TrailblockDescription("music", "Music", numItemsVisible = 1),
+      TrailblockDescription("stage", "Stage", numItemsVisible = 1),
+      TrailblockDescription("books", "Books", numItemsVisible = 1),
+      TrailblockDescription("artanddesign", "Art & Design", numItemsVisible = 1),
+      TrailblockDescription("technology/games", "Games", numItemsVisible = 1)
     ))
 
   )

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -59,10 +59,10 @@ class Front extends AkkaSupport with Logging {
     )),
 
     "sport" -> new FrontEdition("US", Seq(
-      TrailblockDescription("sport", "Sports", numItemsVisible = 5, numLargeImages = 1),
-      TrailblockDescription("sport/cycling", "Cycling", numItemsVisible = 3),
+      TrailblockDescription("sport", "Sports", numItemsVisible = 5),
       TrailblockDescription("sport/nfl", "NFL", numItemsVisible = 1)
     ))
+
   )
 
   private def allFronts = ukEditions.toSeq ++ usEditions.toSeq

--- a/front/app/controllers/front/Front.scala
+++ b/front/app/controllers/front/Front.scala
@@ -18,7 +18,7 @@ class Front extends AkkaSupport with Logging {
 
   private val ukEditions = Map(
 
-    "front" -> new FrontEdition("UK", Seq(
+    "front" -> new ConfiguredEdition("UK", Seq(
       TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),
       TrailblockDescription("sport", "Sport", numItemsVisible = 5, numLargeImages = 1),
       TrailblockDescription("commentisfree", "Comment is free", numItemsVisible = 3),
@@ -38,7 +38,7 @@ class Front extends AkkaSupport with Logging {
 
   private val usEditions = Map(
 
-    "front" -> new FrontEdition("US", Seq(
+    "front" -> new ConfiguredEdition("US", Seq(
       TrailblockDescription("", "News", numItemsVisible = 5, numLargeImages = 2),
       TrailblockDescription("sport", "Sports", numItemsVisible = 5, numLargeImages = 1),
       TrailblockDescription("commentisfree", "Comment is free", numItemsVisible = 3),

--- a/front/app/controllers/front/FrontEdition.scala
+++ b/front/app/controllers/front/FrontEdition.scala
@@ -8,7 +8,7 @@ import model.Trailblock
   Responsible for handling the blocks of the front for an edition
   Responsibilites include de-duping
  */
-class FrontEdition(val edition: String, val descriptions: Seq[TrailblockDescription]) extends ConfiguredEdition {
+class FrontEdition(val edition: String, val descriptions: Seq[TrailblockDescription]) {
 
   val manualAgents = descriptions.map(TrailblockAgent(_, edition))
 
@@ -16,13 +16,7 @@ class FrontEdition(val edition: String, val descriptions: Seq[TrailblockDescript
 
     var usedTrails = List.empty[String]
 
-    val trailblocks = manualAgents.flatMap(_.trailblock).toList match {
-      case Nil => configuredTrailblocks
-      case head :: Nil => head :: configuredTrailblocks
-      case head :: tail => head :: configuredTrailblocks ::: tail
-    }
-
-    trailblocks.map {
+    manualAgents.flatMap(_.trailblock).map {
       trailblock =>
         val deDupedTrails = trailblock.trails.flatMap {
           trail =>
@@ -45,18 +39,10 @@ class FrontEdition(val edition: String, val descriptions: Seq[TrailblockDescript
     }
   }
 
-  override def refresh() = {
-    super.refresh()
-    manualAgents.foreach(_.refresh())
-  }
+  def refresh() = manualAgents.foreach(_.refresh())
 
-  override def shutDown() = {
-    super.shutDown()
-    manualAgents.foreach(_.close())
-  }
+  def shutDown() = manualAgents.foreach(_.close())
 
-  override def warmup() {
-    manualAgents.foreach(_.warmup())
-    super.warmup()
-  }
+  def warmup() = manualAgents.foreach(_.warmup())
+
 }

--- a/front/app/controllers/front/FrontEdition.scala
+++ b/front/app/controllers/front/FrontEdition.scala
@@ -12,11 +12,13 @@ class FrontEdition(val edition: String, val descriptions: Seq[TrailblockDescript
 
   val manualAgents = descriptions.map(TrailblockAgent(_, edition))
 
-  def apply(): Seq[Trailblock] = {
+  def apply(): Seq[Trailblock] = dedupe(manualAgents.flatMap(_.trailblock))
+
+  protected def dedupe(trailblocks: Seq[Trailblock]): Seq[Trailblock] = {
 
     var usedTrails = List.empty[String]
 
-    manualAgents.flatMap(_.trailblock).map {
+    trailblocks.map {
       trailblock =>
         val deDupedTrails = trailblock.trails.flatMap {
           trail =>

--- a/front/app/controllers/front/TrailblockAgent.scala
+++ b/front/app/controllers/front/TrailblockAgent.scala
@@ -18,9 +18,7 @@ class TrailblockAgent(val description: TrailblockDescription, val edition: Strin
 
   private lazy val agent = play_akka.agent[Option[Trailblock]](None)
 
-  def refresh() = agent.sendOff {
-    old => Some(Trailblock(description, loadTrails(description.id)))
-  }
+  def refresh() = agent.sendOff { old => Some(Trailblock(description, loadTrails(description.id))) }
 
   def close() = agent.close()
 

--- a/front/conf/env/DEV.properties
+++ b/front/conf/env/DEV.properties
@@ -13,4 +13,4 @@ guardian.page.omnitureAccount=guardiangu-mobiledev
 guardian.page.optimizelyId=64744925
 guardian.page.coreNavigationUrl=http://localhost:9001
 
-front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/DEV/config/front.json
+front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/PROD/config/front.json

--- a/front/conf/env/DEV.properties
+++ b/front/conf/env/DEV.properties
@@ -15,4 +15,4 @@ guardian.page.coreNavigationUrl=http://localhost:9001
 guardian.page.oasUrl=http://oas.guardian.co.uk/RealMedia/ads/
 guardian.page.oasSiteId=beta.guardian.co.uk/oas.html
 
-front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/PROD/config/front.json
+front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/DEV/config/front.json

--- a/front/conf/env/DEV.properties
+++ b/front/conf/env/DEV.properties
@@ -15,4 +15,4 @@ guardian.page.coreNavigationUrl=http://localhost:9001
 guardian.page.oasUrl=http://oas.guardian.co.uk/RealMedia/ads/
 guardian.page.oasSiteId=beta.guardian.co.uk/oas.html
 
-front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/DEV/config/front.json
+front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/PROD/config/front.json

--- a/front/conf/routes
+++ b/front/conf/routes
@@ -10,6 +10,6 @@ GET     /_warmup                    controllers.FrontController.warmup()
 
 GET     /_up                        controllers.FrontController.isUp()
 
-GET     /:path                      controllers.FrontController.renderFor(path)
+GET     /$path<culture|sport>       controllers.FrontController.renderFor(path)
 
 GET     /                           controllers.FrontController.render()

--- a/front/conf/routes
+++ b/front/conf/routes
@@ -10,4 +10,6 @@ GET     /_warmup                    controllers.FrontController.warmup()
 
 GET     /_up                        controllers.FrontController.isUp()
 
+GET     /:path                      controllers.FrontController.renderFor(path)
+
 GET     /                           controllers.FrontController.render()

--- a/front/test/ConfiguredEditionFeatureTest.scala
+++ b/front/test/ConfiguredEditionFeatureTest.scala
@@ -15,8 +15,7 @@ class ConfiguredEditionFeatureTest extends FeatureSpec with GivenWhenThen with S
       given("I visit the Network Front")
       and("I am on the UK edition")
       Fake {
-        val front = new ConfiguredEdition {
-          override def edition = "UK"
+        val front = new ConfiguredEdition("UK", Nil) {
           override val configUrl = "http://s3-eu-west-1.amazonaws.com/aws-frontend-store/TMC/config/front-test.json"
         }
 
@@ -33,8 +32,7 @@ class ConfiguredEditionFeatureTest extends FeatureSpec with GivenWhenThen with S
       given("I visit the Network Front")
       and("I am on the US edition")
       Fake {
-        val front = new ConfiguredEdition {
-          override def edition = "US"
+        val front = new ConfiguredEdition("US", Nil) {
           override val configUrl = "http://s3-eu-west-1.amazonaws.com/aws-frontend-store/TMC/config/front-test.json"
         }
 
@@ -51,8 +49,7 @@ class ConfiguredEditionFeatureTest extends FeatureSpec with GivenWhenThen with S
       given("I visit the Network Front")
       and("the feature trailblock has broken confiuration")
       Fake {
-        val front = new ConfiguredEdition {
-          override def edition = "US"
+        val front = new ConfiguredEdition("US", Nil) {
           override val configUrl = "http://s3-eu-west-1.amazonaws.com/aws-frontend-store/TMC/config/front-bad-does-not-exist.json"
         }
 

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -148,153 +148,153 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
       }
     }
 
-    //    scenario("load different content for UK and US front") {
-    //      given("I visit the Network Front")
-    //
-    //      Fake {
-    //
-    //        //in real life these will always be editors picks only (content api does not do latest for front)
-    //        val ukAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "UK")
-    //        val usAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "US")
-    //
-    //        ukAgent.refresh()
-    //        usAgent.refresh()
-    //
-    //        ukAgent.warmup()
-    //        usAgent.warmup()
-    //
-    //        val ukTrails = ukAgent.trailblock.get.trails
-    //        val usTrails = usAgent.trailblock.get.trails
-    //
-    //        then("I should see UK Top Stories if I am in the UK edition")
-    //        and("I should see US Top Stories if I am in the US edition")
-    //
-    //        ukTrails should not equal (usTrails)
-    //      }
-    //    }
-    //
-    //    scenario("de-duplicate visible trails") {
-    //
-    //      given("I am on the Network Front and I have not expanded any blocks")
-    //
-    //      Fake {
-    //        val duplicateStory = StubTrail("http://www.gu.com/1234")
-    //
-    //        val description = TrailblockDescription("", "Name", 5)
-    //
-    //        val topStoriesBlock = new TrailblockAgent(description, "UK") {
-    //          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("world", 9)))
-    //        }
-    //
-    //        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
-    //          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
-    //        }
-    //
-    //        val front = new FrontEdition("UK", Nil) {
-    //          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
-    //        }
-    //
-    //        then("I should not see a link to the same piece of content twice")
-    //
-    //        val topStories = front()(0)
-    //        val sport = front()(1)
-    //
-    //        topStories.trails.contains(duplicateStory) should be(true)
-    //
-    //        sport.trails.contains(duplicateStory) should be(false)
-    //        sport.trails should have length (9)
-    //      }
-    //    }
-    //
-    //    scenario("do not de-duplicate from hidden trails") {
-    //
-    //      given("I am on the Network Front and I have not expanded any blocks")
-    //
-    //      Fake {
-    //        val duplicateStory = StubTrail("http://www.gu.com/1234")
-    //
-    //        val description = TrailblockDescription("", "Name", 5)
-    //        //duplicate trail is hidden behind "more" button
-    //        val topTrails = createTrails("news", 5) ::: duplicateStory :: createTrails("world", 4)
-    //
-    //        val topStoriesBlock = new TrailblockAgent(description, "UK") {
-    //          override lazy val trailblock = Some(Trailblock(description, topTrails))
-    //        }
-    //
-    //        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
-    //          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
-    //        }
-    //
-    //        val front = new FrontEdition("UK", Nil) {
-    //          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
-    //        }
-    //
-    //        then("I should see a link that is a duplicate of a link that is hidden")
-    //
-    //        val topStories = front()(0)
-    //        val sport = front()(1)
-    //
-    //        topStories.trails.contains(duplicateStory) should be(true)
-    //
-    //        sport.trails.contains(duplicateStory) should be(true)
-    //        sport.trails should have length (10)
-    //      }
-    //    }
-    //
-    //    scenario("Default front trailblock configuration") {
-    //
-    //      given("I visit the network front")
-    //
-    //      then("I should see 10 (5 of whch are hidden) Top stories")
-    //      Front.uk.descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
-    //      Front.us.descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
-    //
-    //      and("I should see 10 (5 of which are hidden) Sport (Sports in US) stories")
-    //      Front.uk.descriptions(1) should be(TrailblockDescription("sport", "Sport", 5, 1))
-    //      Front.us.descriptions(1) should be(TrailblockDescription("sport", "Sports", 5, 1))
-    //
-    //      and("I should see 6 (3 of which are hidden) Comment is Free stories")
-    //      Front.uk.descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
-    //      Front.us.descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
-    //
-    //      and("I should see 1 Culture story")
-    //      Front.uk.descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
-    //      Front.us.descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
-    //
-    //      and("I should see 1 Business story")
-    //      Front.uk.descriptions(4) should be(TrailblockDescription("business", "Business", 1))
-    //      Front.us.descriptions(4) should be(TrailblockDescription("business", "Business", 1))
-    //
-    //      and("I should see 1 Life and Style story")
-    //      Front.uk.descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
-    //      Front.us.descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
-    //
-    //      and("I should see 1 Money story")
-    //      Front.uk.descriptions(6) should be(TrailblockDescription("money", "Money", 1))
-    //      Front.us.descriptions(6) should be(TrailblockDescription("money", "Money", 1))
-    //
-    //      and("I should see 1 Travel story")
-    //      Front.uk.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
-    //      Front.us.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
-    //    }
-    //
-    //    //this is so that the load balancer knows this server has a problem
-    //    scenario("Return error if front is empty") {
-    //
-    //      given("I visit the network front")
-    //      and("it is empty")
-    //
-    //      Fake {
-    //        val controller = new FrontController {
-    //          override val front = new Front() {
-    //            override def apply(edition: String) = FrontPage(Seq.empty)
-    //          }
-    //        }
-    //
-    //        then("I should see an internal server error")
-    //        controller.render()(FakeRequest()).asInstanceOf[SimpleResult[AnyContent]].header.status should be(500)
-    //      }
-    //    }
+    scenario("load different content for UK and US front") {
+      given("I visit the Network Front")
+
+      Fake {
+
+        //in real life these will always be editors picks only (content api does not do latest for front)
+        val ukAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "UK")
+        val usAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "US")
+
+        ukAgent.refresh()
+        usAgent.refresh()
+
+        ukAgent.warmup()
+        usAgent.warmup()
+
+        val ukTrails = ukAgent.trailblock.get.trails
+        val usTrails = usAgent.trailblock.get.trails
+
+        then("I should see UK Top Stories if I am in the UK edition")
+        and("I should see US Top Stories if I am in the US edition")
+
+        ukTrails should not equal (usTrails)
+      }
+    }
+
+    scenario("de-duplicate visible trails") {
+
+      given("I am on the Network Front and I have not expanded any blocks")
+
+      Fake {
+        val duplicateStory = StubTrail("http://www.gu.com/1234")
+
+        val description = TrailblockDescription("", "Name", 5)
+
+        val topStoriesBlock = new TrailblockAgent(description, "UK") {
+          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("world", 9)))
+        }
+
+        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
+          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
+        }
+
+        val front = new FrontEdition("UK", Nil) {
+          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
+        }
+
+        then("I should not see a link to the same piece of content twice")
+
+        val topStories = front()(0)
+        val sport = front()(1)
+
+        topStories.trails.contains(duplicateStory) should be(true)
+
+        sport.trails.contains(duplicateStory) should be(false)
+        sport.trails should have length (9)
+      }
+    }
+
+    scenario("do not de-duplicate from hidden trails") {
+
+      given("I am on the Network Front and I have not expanded any blocks")
+
+      Fake {
+        val duplicateStory = StubTrail("http://www.gu.com/1234")
+
+        val description = TrailblockDescription("", "Name", 5)
+        //duplicate trail is hidden behind "more" button
+        val topTrails = createTrails("news", 5) ::: duplicateStory :: createTrails("world", 4)
+
+        val topStoriesBlock = new TrailblockAgent(description, "UK") {
+          override lazy val trailblock = Some(Trailblock(description, topTrails))
+        }
+
+        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
+          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
+        }
+
+        val front = new FrontEdition("UK", Nil) {
+          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
+        }
+
+        then("I should see a link that is a duplicate of a link that is hidden")
+
+        val topStories = front()(0)
+        val sport = front()(1)
+
+        topStories.trails.contains(duplicateStory) should be(true)
+
+        sport.trails.contains(duplicateStory) should be(true)
+        sport.trails should have length (10)
+      }
+    }
+
+    scenario("Default front trailblock configuration") {
+
+      given("I visit the network front")
+
+      then("I should see 10 (5 of whch are hidden) Top stories")
+      Front.ukEditions("front").descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
+      Front.usEditions("front").descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
+
+      and("I should see 10 (5 of which are hidden) Sport (Sports in US) stories")
+      Front.ukEditions("front").descriptions(1) should be(TrailblockDescription("sport", "Sport", 5, 1))
+      Front.usEditions("front").descriptions(1) should be(TrailblockDescription("sport", "Sports", 5, 1))
+
+      and("I should see 6 (3 of which are hidden) Comment is Free stories")
+      Front.ukEditions("front").descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
+      Front.usEditions("front").descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
+
+      and("I should see 1 Culture story")
+      Front.ukEditions("front").descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
+      Front.usEditions("front").descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
+
+      and("I should see 1 Business story")
+      Front.ukEditions("front").descriptions(4) should be(TrailblockDescription("business", "Business", 1))
+      Front.usEditions("front").descriptions(4) should be(TrailblockDescription("business", "Business", 1))
+
+      and("I should see 1 Life and Style story")
+      Front.ukEditions("front").descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
+      Front.usEditions("front").descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
+
+      and("I should see 1 Money story")
+      Front.ukEditions("front").descriptions(6) should be(TrailblockDescription("money", "Money", 1))
+      Front.usEditions("front").descriptions(6) should be(TrailblockDescription("money", "Money", 1))
+
+      and("I should see 1 Travel story")
+      Front.ukEditions("front").descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
+      Front.usEditions("front").descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
+    }
+
+    //this is so that the load balancer knows this server has a problem
+    scenario("Return error if front is empty") {
+
+      given("I visit the network front")
+      and("it is empty")
+
+      Fake {
+        val controller = new FrontController {
+          override val front = new Front() {
+            override def apply(path: String, edition: String) = FrontPage(Seq.empty)
+          }
+        }
+
+        then("I should see an internal server error")
+        controller.render()(FakeRequest()).asInstanceOf[SimpleResult[AnyContent]].header.status should be(500)
+      }
+    }
   }
 
   private def createTrails(section: String, numTrails: Int) = (1 to numTrails).toList map {

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -278,6 +278,56 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
       Front.usEditions("front").descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
     }
 
+    /**
+     * Football section front
+     */
+    scenario("Footbll section front contains the top 10 stories across sport") {
+
+      given("I am on the 'sport' section front")
+
+      then("I should see the top 10 stories across sport")
+      Front.ukEditions("sport").descriptions(0) should be(TrailblockDescription("sport", "Sport", 5))
+      Front.usEditions("sport").descriptions(0) should be(TrailblockDescription("sport", "Sports", 5))
+    }
+
+    scenario("Sub-sections on the Sport section front show a number of top stories") {
+
+      given("I am on the 'sport' section front")
+
+      then("the 'Football' should contain up to 6 stories")
+      Front.ukEditions("sport").descriptions(1) should be(TrailblockDescription("football", "Football", 3))
+
+      and("the 'Cricket' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(2) should be(TrailblockDescription("sport/cricket", "Cricket", 1))
+
+      and("the 'Rugby Union' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(3) should be(TrailblockDescription("sport/rugby-union", "Rugby Union", 1))
+
+      and("the 'Motor Sport' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(4) should be(TrailblockDescription("sport/motorsports", "Motor Sport", 1))
+
+      and("the 'Tennis' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(5) should be(TrailblockDescription("sport/tennis", "Tennis", 1))
+
+      and("the 'Golf' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(6) should be(TrailblockDescription("sport/golf", "Golf", 1))
+
+      and("the 'Horse Racing' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(7) should be(TrailblockDescription("sport/horse-racing", "Horse Racing", 1))
+
+      and("the 'Rugby League' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(8) should be(TrailblockDescription("sport/rugbyleague", "Rugby League", 1))
+
+      and("the 'US Sport' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(9) should be(TrailblockDescription("sport/us-sport", "US Sport", 1))
+
+      and("the 'Boxing' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(10) should be(TrailblockDescription("sport/boxing", "Boxing", 1))
+
+      and("the 'Cycling' should contain up to 1 story")
+      Front.ukEditions("sport").descriptions(11) should be(TrailblockDescription("sport/cycling", "Cycling", 1))
+    }
+
     //this is so that the load balancer knows this server has a problem
     scenario("Return error if front is empty") {
 

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -294,38 +294,94 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
 
       given("I am on the 'sport' section front")
 
-      then("the 'Football' should contain up to 6 stories")
+      then("the 'Football' sub-section should contain up to 6 stories")
       Front.ukEditions("sport").descriptions(1) should be(TrailblockDescription("football", "Football", 3))
+      Front.usEditions("sport").descriptions(1) should be(TrailblockDescription("football", "Football", 3))
 
-      and("the 'Cricket' should contain up to 1 story")
+      and("the 'Cricket' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(2) should be(TrailblockDescription("sport/cricket", "Cricket", 1))
+      Front.usEditions("sport").descriptions(1) should be(TrailblockDescription("football", "Football", 3))
 
-      and("the 'Rugby Union' should contain up to 1 story")
+      and("the 'Rugby Union' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(3) should be(TrailblockDescription("sport/rugby-union", "Rugby Union", 1))
+      Front.usEditions("sport").descriptions(3) should be(TrailblockDescription("sport/rugby-union", "Rugby Union", 1))
 
-      and("the 'Motor Sport' should contain up to 1 story")
+      and("the 'Motor Sport' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(4) should be(TrailblockDescription("sport/motorsports", "Motor Sport", 1))
+      Front.usEditions("sport").descriptions(3) should be(TrailblockDescription("sport/rugby-union", "Rugby Union", 1))
 
-      and("the 'Tennis' should contain up to 1 story")
+      and("the 'Tennis' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(5) should be(TrailblockDescription("sport/tennis", "Tennis", 1))
+      Front.usEditions("sport").descriptions(3) should be(TrailblockDescription("sport/rugby-union", "Rugby Union", 1))
 
-      and("the 'Golf' should contain up to 1 story")
+      and("the 'Golf' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(6) should be(TrailblockDescription("sport/golf", "Golf", 1))
+      Front.usEditions("sport").descriptions(6) should be(TrailblockDescription("sport/golf", "Golf", 1))
 
-      and("the 'Horse Racing' should contain up to 1 story")
+      and("the 'Horse Racing' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(7) should be(TrailblockDescription("sport/horse-racing", "Horse Racing", 1))
+      Front.usEditions("sport").descriptions(6) should be(TrailblockDescription("sport/golf", "Golf", 1))
 
-      and("the 'Rugby League' should contain up to 1 story")
+      and("the 'Rugby League' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(8) should be(TrailblockDescription("sport/rugbyleague", "Rugby League", 1))
+      Front.usEditions("sport").descriptions(8) should be(TrailblockDescription("sport/rugbyleague", "Rugby League", 1))
 
-      and("the 'US Sport' should contain up to 1 story")
+      and("the 'US Sport' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(9) should be(TrailblockDescription("sport/us-sport", "US Sport", 1))
+      Front.usEditions("sport").descriptions(9) should be(TrailblockDescription("sport/us-sport", "US Sport", 1))
 
-      and("the 'Boxing' should contain up to 1 story")
+      and("the 'Boxing' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(10) should be(TrailblockDescription("sport/boxing", "Boxing", 1))
+      Front.usEditions("sport").descriptions(11) should be(TrailblockDescription("sport/cycling", "Cycling", 1))
 
-      and("the 'Cycling' should contain up to 1 story")
+      and("the 'Cycling' sub-section should contain up to 1 story")
       Front.ukEditions("sport").descriptions(11) should be(TrailblockDescription("sport/cycling", "Cycling", 1))
+      Front.usEditions("sport").descriptions(11) should be(TrailblockDescription("sport/cycling", "Cycling", 1))
+    }
+
+    /**
+     * Culture section front
+     */
+    scenario("Culture section front contains the top 10 stories across culture") {
+
+      given("I am on the 'culture' section front")
+
+      then("I should see the top 10 stories across culture")
+      Front.ukEditions("culture").descriptions(0) should be(TrailblockDescription("culture", "Culture", 5))
+      Front.usEditions("culture").descriptions(0) should be(TrailblockDescription("culture", "Culture", 5))
+    }
+
+    scenario("Sub-sections on the Culture section front show a number of top stories") {
+
+      given("I am on the 'culture' section front")
+
+      then("the 'TV & Radio' sub-section should contain up to 1 story")
+      Front.ukEditions("culture").descriptions(1) should be(TrailblockDescription("tv-and-radio", "TV & Radio", 1))
+      Front.usEditions("culture").descriptions(1) should be(TrailblockDescription("tv-and-radio", "TV & Radio", 1))
+
+      then("the 'Film' sub-section should contain up to 1 story")
+      Front.ukEditions("culture").descriptions(2) should be(TrailblockDescription("film", "Film", 1))
+      Front.usEditions("culture").descriptions(2) should be(TrailblockDescription("film", "Film", 1))
+
+      then("the 'Music' sub-section should contain up to 1 story")
+      Front.ukEditions("culture").descriptions(3) should be(TrailblockDescription("music", "Music", 1))
+      Front.usEditions("culture").descriptions(3) should be(TrailblockDescription("music", "Music", 1))
+
+      then("the 'Stage' sub-section should contain up to 1 story")
+      Front.ukEditions("culture").descriptions(4) should be(TrailblockDescription("stage", "Stage", 1))
+      Front.usEditions("culture").descriptions(4) should be(TrailblockDescription("stage", "Stage", 1))
+
+      then("the 'Books' sub-section should contain up to 1 story")
+      Front.ukEditions("culture").descriptions(5) should be(TrailblockDescription("books", "Books", 1))
+      Front.usEditions("culture").descriptions(5) should be(TrailblockDescription("books", "Books", 1))
+
+      then("the 'Art & Design' sub-section should contain up to 1 story")
+      Front.ukEditions("culture").descriptions(6) should be(TrailblockDescription("artanddesign", "Art & Design", 1))
+      Front.usEditions("culture").descriptions(6) should be(TrailblockDescription("artanddesign", "Art & Design", 1))
+
+      then("the 'Games' sub-section should contain up to 1 story")
+      Front.ukEditions("culture").descriptions(7) should be(TrailblockDescription("technology/games", "Games", 1))
+      Front.usEditions("culture").descriptions(7) should be(TrailblockDescription("technology/games", "Games", 1))
     }
 
     //this is so that the load balancer knows this server has a problem

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -148,153 +148,153 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
       }
     }
 
-    scenario("load different content for UK and US front") {
-      given("I visit the Network Front")
-
-      Fake {
-
-        //in real life these will always be editors picks only (content api does not do latest for front)
-        val ukAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "UK")
-        val usAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "US")
-
-        ukAgent.refresh()
-        usAgent.refresh()
-
-        ukAgent.warmup()
-        usAgent.warmup()
-
-        val ukTrails = ukAgent.trailblock.get.trails
-        val usTrails = usAgent.trailblock.get.trails
-
-        then("I should see UK Top Stories if I am in the UK edition")
-        and("I should see US Top Stories if I am in the US edition")
-
-        ukTrails should not equal (usTrails)
-      }
-    }
-
-    scenario("de-duplicate visible trails") {
-
-      given("I am on the Network Front and I have not expanded any blocks")
-
-      Fake {
-        val duplicateStory = StubTrail("http://www.gu.com/1234")
-
-        val description = TrailblockDescription("", "Name", 5)
-
-        val topStoriesBlock = new TrailblockAgent(description, "UK") {
-          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("world", 9)))
-        }
-
-        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
-          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
-        }
-
-        val front = new FrontEdition("UK", Nil) {
-          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
-        }
-
-        then("I should not see a link to the same piece of content twice")
-
-        val topStories = front()(0)
-        val sport = front()(1)
-
-        topStories.trails.contains(duplicateStory) should be(true)
-
-        sport.trails.contains(duplicateStory) should be(false)
-        sport.trails should have length (9)
-      }
-    }
-
-    scenario("do not de-duplicate from hidden trails") {
-
-      given("I am on the Network Front and I have not expanded any blocks")
-
-      Fake {
-        val duplicateStory = StubTrail("http://www.gu.com/1234")
-
-        val description = TrailblockDescription("", "Name", 5)
-        //duplicate trail is hidden behind "more" button
-        val topTrails = createTrails("news", 5) ::: duplicateStory :: createTrails("world", 4)
-
-        val topStoriesBlock = new TrailblockAgent(description, "UK") {
-          override lazy val trailblock = Some(Trailblock(description, topTrails))
-        }
-
-        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
-          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
-        }
-
-        val front = new FrontEdition("UK", Nil) {
-          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
-        }
-
-        then("I should see a link that is a duplicate of a link that is hidden")
-
-        val topStories = front()(0)
-        val sport = front()(1)
-
-        topStories.trails.contains(duplicateStory) should be(true)
-
-        sport.trails.contains(duplicateStory) should be(true)
-        sport.trails should have length (10)
-      }
-    }
-
-    scenario("Default front trailblock configuration") {
-
-      given("I visit the network front")
-
-      then("I should see 10 (5 of whch are hidden) Top stories")
-      Front.uk.descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
-      Front.us.descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
-
-      and("I should see 10 (5 of which are hidden) Sport (Sports in US) stories")
-      Front.uk.descriptions(1) should be(TrailblockDescription("sport", "Sport", 5, 1))
-      Front.us.descriptions(1) should be(TrailblockDescription("sport", "Sports", 5, 1))
-
-      and("I should see 6 (3 of which are hidden) Comment is Free stories")
-      Front.uk.descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
-      Front.us.descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
-
-      and("I should see 1 Culture story")
-      Front.uk.descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
-      Front.us.descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
-
-      and("I should see 1 Business story")
-      Front.uk.descriptions(4) should be(TrailblockDescription("business", "Business", 1))
-      Front.us.descriptions(4) should be(TrailblockDescription("business", "Business", 1))
-
-      and("I should see 1 Life and Style story")
-      Front.uk.descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
-      Front.us.descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
-
-      and("I should see 1 Money story")
-      Front.uk.descriptions(6) should be(TrailblockDescription("money", "Money", 1))
-      Front.us.descriptions(6) should be(TrailblockDescription("money", "Money", 1))
-
-      and("I should see 1 Travel story")
-      Front.uk.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
-      Front.us.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
-    }
-
-    //this is so that the load balancer knows this server has a problem
-    scenario("Return error if front is empty") {
-
-      given("I visit the network front")
-      and("it is empty")
-
-      Fake {
-        val controller = new FrontController {
-          override val front = new Front() {
-            override def apply(edition: String) = FrontPage(Seq.empty)
-          }
-        }
-
-        then("I should see an internal server error")
-        controller.render()(FakeRequest()).asInstanceOf[SimpleResult[AnyContent]].header.status should be(500)
-      }
-    }
+    //    scenario("load different content for UK and US front") {
+    //      given("I visit the Network Front")
+    //
+    //      Fake {
+    //
+    //        //in real life these will always be editors picks only (content api does not do latest for front)
+    //        val ukAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "UK")
+    //        val usAgent = TrailblockAgent(TrailblockDescription("", "Top Stories", 5), "US")
+    //
+    //        ukAgent.refresh()
+    //        usAgent.refresh()
+    //
+    //        ukAgent.warmup()
+    //        usAgent.warmup()
+    //
+    //        val ukTrails = ukAgent.trailblock.get.trails
+    //        val usTrails = usAgent.trailblock.get.trails
+    //
+    //        then("I should see UK Top Stories if I am in the UK edition")
+    //        and("I should see US Top Stories if I am in the US edition")
+    //
+    //        ukTrails should not equal (usTrails)
+    //      }
+    //    }
+    //
+    //    scenario("de-duplicate visible trails") {
+    //
+    //      given("I am on the Network Front and I have not expanded any blocks")
+    //
+    //      Fake {
+    //        val duplicateStory = StubTrail("http://www.gu.com/1234")
+    //
+    //        val description = TrailblockDescription("", "Name", 5)
+    //
+    //        val topStoriesBlock = new TrailblockAgent(description, "UK") {
+    //          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("world", 9)))
+    //        }
+    //
+    //        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
+    //          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
+    //        }
+    //
+    //        val front = new FrontEdition("UK", Nil) {
+    //          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
+    //        }
+    //
+    //        then("I should not see a link to the same piece of content twice")
+    //
+    //        val topStories = front()(0)
+    //        val sport = front()(1)
+    //
+    //        topStories.trails.contains(duplicateStory) should be(true)
+    //
+    //        sport.trails.contains(duplicateStory) should be(false)
+    //        sport.trails should have length (9)
+    //      }
+    //    }
+    //
+    //    scenario("do not de-duplicate from hidden trails") {
+    //
+    //      given("I am on the Network Front and I have not expanded any blocks")
+    //
+    //      Fake {
+    //        val duplicateStory = StubTrail("http://www.gu.com/1234")
+    //
+    //        val description = TrailblockDescription("", "Name", 5)
+    //        //duplicate trail is hidden behind "more" button
+    //        val topTrails = createTrails("news", 5) ::: duplicateStory :: createTrails("world", 4)
+    //
+    //        val topStoriesBlock = new TrailblockAgent(description, "UK") {
+    //          override lazy val trailblock = Some(Trailblock(description, topTrails))
+    //        }
+    //
+    //        val sportStoriesBlock = new TrailblockAgent(description, "UK") {
+    //          override lazy val trailblock = Some(Trailblock(description, duplicateStory :: createTrails("sport", 9)))
+    //        }
+    //
+    //        val front = new FrontEdition("UK", Nil) {
+    //          override val manualAgents = Seq(topStoriesBlock, sportStoriesBlock)
+    //        }
+    //
+    //        then("I should see a link that is a duplicate of a link that is hidden")
+    //
+    //        val topStories = front()(0)
+    //        val sport = front()(1)
+    //
+    //        topStories.trails.contains(duplicateStory) should be(true)
+    //
+    //        sport.trails.contains(duplicateStory) should be(true)
+    //        sport.trails should have length (10)
+    //      }
+    //    }
+    //
+    //    scenario("Default front trailblock configuration") {
+    //
+    //      given("I visit the network front")
+    //
+    //      then("I should see 10 (5 of whch are hidden) Top stories")
+    //      Front.uk.descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
+    //      Front.us.descriptions(0) should be(TrailblockDescription("", "News", 5, 2))
+    //
+    //      and("I should see 10 (5 of which are hidden) Sport (Sports in US) stories")
+    //      Front.uk.descriptions(1) should be(TrailblockDescription("sport", "Sport", 5, 1))
+    //      Front.us.descriptions(1) should be(TrailblockDescription("sport", "Sports", 5, 1))
+    //
+    //      and("I should see 6 (3 of which are hidden) Comment is Free stories")
+    //      Front.uk.descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
+    //      Front.us.descriptions(2) should be(TrailblockDescription("commentisfree", "Comment is free", 3, 0))
+    //
+    //      and("I should see 1 Culture story")
+    //      Front.uk.descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
+    //      Front.us.descriptions(3) should be(TrailblockDescription("culture", "Culture", 1))
+    //
+    //      and("I should see 1 Business story")
+    //      Front.uk.descriptions(4) should be(TrailblockDescription("business", "Business", 1))
+    //      Front.us.descriptions(4) should be(TrailblockDescription("business", "Business", 1))
+    //
+    //      and("I should see 1 Life and Style story")
+    //      Front.uk.descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
+    //      Front.us.descriptions(5) should be(TrailblockDescription("lifeandstyle", "Life and style", 1))
+    //
+    //      and("I should see 1 Money story")
+    //      Front.uk.descriptions(6) should be(TrailblockDescription("money", "Money", 1))
+    //      Front.us.descriptions(6) should be(TrailblockDescription("money", "Money", 1))
+    //
+    //      and("I should see 1 Travel story")
+    //      Front.uk.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
+    //      Front.us.descriptions(7) should be(TrailblockDescription("travel", "Travel", 1))
+    //    }
+    //
+    //    //this is so that the load balancer knows this server has a problem
+    //    scenario("Return error if front is empty") {
+    //
+    //      given("I visit the network front")
+    //      and("it is empty")
+    //
+    //      Fake {
+    //        val controller = new FrontController {
+    //          override val front = new Front() {
+    //            override def apply(edition: String) = FrontPage(Seq.empty)
+    //          }
+    //        }
+    //
+    //        then("I should see an internal server error")
+    //        controller.render()(FakeRequest()).asInstanceOf[SimpleResult[AnyContent]].header.status should be(500)
+    //      }
+    //    }
   }
 
   private def createTrails(section: String, numTrails: Int) = (1 to numTrails).toList map {

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -6,7 +6,7 @@ Set-up
 
 For use with Eclipse
 
-    $ mvn eclispe:eclipse
+    $ mvn eclipse:eclipse
 
 Usage
 -----

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,6 +1,15 @@
-# Integration Tests
+Integration Tests
+=================
 
-## Usage
+Set-up
+------
+
+For use with Eclipse
+
+    $ mvn eclispe:eclipse
+
+Usage
+-----
 
 To run all features (except `@ignore` and `@scala-test`)
 

--- a/integration-tests/build.sbt
+++ b/integration-tests/build.sbt
@@ -1,0 +1,1 @@
+EclipseKeys.skipProject := true

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,10 +3,10 @@
 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gu</groupId>
-	<artifactId>frontend-integration-tests</artifactId>
+	<artifactId>integration-tests</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
-	<name>frontend-integration-tests</name>
+	<name>integration-tests</name>
 	<url>http://maven.apache.org</url>
 
 	<properties>

--- a/integration-tests/src/test/java/com/gu/test/DisplayAdvertsTestSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/DisplayAdvertsTestSteps.java
@@ -4,7 +4,6 @@ import junit.framework.Assert;
 
 import org.openqa.selenium.By;
 
-import cucumber.annotation.en.Given;
 import cucumber.annotation.en.Then;
 
 

--- a/integration-tests/src/test/java/com/gu/test/SectionFrontsSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/SectionFrontsSteps.java
@@ -1,5 +1,12 @@
 package com.gu.test;
 
+import java.util.List;
+
+import org.junit.Assert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ByChained;
+
 import cucumber.annotation.en.Given;
 
 public class SectionFrontsSteps {
@@ -13,6 +20,25 @@ public class SectionFrontsSteps {
 	@Given("^I am on the '(.*)' section front$")
 	public void I_am_on_a_section_front(String sectionFront) throws Throwable {
 		webDriver.open("/" + sectionFront);
+	}
+	
+	@Given("^I should see up to (\\d+) '([^']*)' top stories$")
+	public void I_should_see_up_to_top_stories(int numOfTopStories, String subSectionTitle) throws Throwable {
+		WebElement subSectionLink = webDriver.findElement(
+			new ByChained(By.id("front-container"), By.linkText(subSectionTitle))
+		);
+		// get the associated (visible) trails
+		List<WebElement> trails = subSectionLink.findElements(By.xpath("../following-sibling::div/ul[1]/li"));
+		Assert.assertTrue(trails.size() <= numOfTopStories);
+	}
+	@Given("^any more than (\\d+) '([^']*)' top stories should be hidden$")
+	public void any_more_than_top_stories_should_be_hidden(int numOfTopStories, String subSectionTitle) throws Throwable {
+		WebElement subSectionLink = webDriver.findElement(
+			new ByChained(By.id("front-container"), By.linkText(subSectionTitle))
+		);
+		// get the associated (invisible) trails
+		List<WebElement> trails = subSectionLink.findElements(By.xpath("../following-sibling::div/ul[2]/li"));
+		Assert.assertTrue(trails.size() <= numOfTopStories);
 	}
 	
 }

--- a/integration-tests/src/test/java/com/gu/test/SectionFrontsSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/SectionFrontsSteps.java
@@ -1,0 +1,18 @@
+package com.gu.test;
+
+import cucumber.annotation.en.Given;
+
+public class SectionFrontsSteps {
+
+	private final SharedDriver webDriver;
+
+	public SectionFrontsSteps(SharedDriver webDriver) {
+		this.webDriver = webDriver;
+	}
+
+	@Given("^I am on the '(.*)' section front$")
+	public void I_am_on_a_section_front(String sectionFront) throws Throwable {
+		webDriver.open("/" + sectionFront);
+	}
+	
+}

--- a/integration-tests/src/test/java/com/gu/test/SharedSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/SharedSteps.java
@@ -1,15 +1,6 @@
 package com.gu.test;
 
-import java.util.List;
-
-import junit.framework.Assert;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-
 import cucumber.annotation.en.Given;
-import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
 
 public class SharedSteps {
 

--- a/integration-tests/src/test/java/com/gu/test/TypographySteps.java
+++ b/integration-tests/src/test/java/com/gu/test/TypographySteps.java
@@ -3,9 +3,7 @@ package com.gu.test;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 
-import cucumber.annotation.en.Given;
 import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
 
 public class TypographySteps {
 

--- a/integration-tests/src/test/resources/com/gu/test/section-fronts-culture.feature
+++ b/integration-tests/src/test/resources/com/gu/test/section-fronts-culture.feature
@@ -1,4 +1,3 @@
-@section-fronts
 Feature: Section Fronts - Culture
     As a Guardian user
     I want to get a further break-down of sections on the culture section front
@@ -7,12 +6,12 @@ Feature: Section Fronts - Culture
     @scala-test
     Scenario: Page contains the top 10 stories across culture
        Given I am on the 'culture' section front
-       Then I the page should contains the top 10 stories across culture
+       Then I should see the top 10 stories across culture
        
     Scenario: Culture top stories should display 5 and hide the rest
         Given I am on the 'culture' section front
-        Then up to 5 top stories should be displayed
-            And more than 5 top stories should be hidden
+        Then I should see up to 5 'Culture' top stories
+            And any more than 5 'Culture' top stories should be hidden
        
     @scala-test
     Scenario Outline: Sub-sections show a number of top stories, and be of the correct visual 'level'
@@ -33,8 +32,6 @@ Feature: Section Fronts - Culture
        
     Scenario: User can hide and show the sections
         Given I am on the 'culture' section front
-        When I click the 'hide' section button
-        Then the section should collapse
-        When I click the 'show' section button
-        Then the section should expand
+        Then I can click "Hide" to collapse a section
+            And I can click "Show" to expand a section
             

--- a/integration-tests/src/test/resources/com/gu/test/section-fronts-culture.feature
+++ b/integration-tests/src/test/resources/com/gu/test/section-fronts-culture.feature
@@ -1,0 +1,40 @@
+@section-fronts
+Feature: Section Fronts - Culture
+    As a Guardian user
+    I want to get a further break-down of sections on the culture section front
+    So that I can navigate content easier
+    
+    @scala-test
+    Scenario: Page contains the top 10 stories across culture
+       Given I am on the 'culture' section front
+       Then I the page should contains the top 10 stories across culture
+       
+    Scenario: Culture top stories should display 5 and hide the rest
+        Given I am on the 'culture' section front
+        Then up to 5 top stories should be displayed
+            And more than 5 top stories should be hidden
+       
+    @scala-test
+    Scenario Outline: Sub-sections show a number of top stories, and be of the correct visual 'level'
+        Give I am on the 'culture' section front
+        Then there should be a '<sub-section>' section
+            And the '<sub-section>' should contain up to <num-of-stories> stories
+            And the '<sub-section>' should be a visual level <level>
+        
+        Examples:
+            | sub-section  | num-of-stories | level |
+            | TV & Radio   | 1              | 2     |
+            | Film         | 1              | 2     |
+            | Music        | 1              | 2     |
+            | Stage        | 1              | 2     |
+            | Books        | 1              | 3     |
+            | Art & Design | 1              | 3     |
+            | Games        | 1              | 3     |
+       
+    Scenario: User can hide and show the sections
+        Given I am on the 'culture' section front
+        When I click the 'hide' section button
+        Then the section should collapse
+        When I click the 'show' section button
+        Then the section should expand
+            

--- a/integration-tests/src/test/resources/com/gu/test/section-fronts-culture.feature
+++ b/integration-tests/src/test/resources/com/gu/test/section-fronts-culture.feature
@@ -1,3 +1,4 @@
+@section-fronts
 Feature: Section Fronts - Culture
     As a Guardian user
     I want to get a further break-down of sections on the culture section front
@@ -17,8 +18,8 @@ Feature: Section Fronts - Culture
     Scenario Outline: Sub-sections show a number of top stories, and be of the correct visual 'level'
         Give I am on the 'culture' section front
         Then there should be a '<sub-section>' section
-            And the '<sub-section>' should contain up to <num-of-stories> stories
-            And the '<sub-section>' should be a visual level <level>
+            And the '<sub-section>' sub-section should contain up to <num-of-stories> stories
+            And the '<sub-section>' sub-section should be a visual level <level>
         
         Examples:
             | sub-section  | num-of-stories | level |

--- a/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
+++ b/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
@@ -7,7 +7,7 @@ Feature: Section Fronts - Sport
 	@scala-test
 	Scenario: Page contains the top 10 stories across sport
 	   Given I am on the 'sport' section front
-	   Then I the page should contains the top 10 stories across sport
+	   Then I should see the top 10 stories across sport
 	   
     Scenario: Sport top stories should display 5 and hide the rest
         Given I am on the 'sport' section front

--- a/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
+++ b/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
@@ -8,11 +8,11 @@ Feature: Section Fronts - Sport
 	Scenario: Page contains the top 10 stories across sport
 	   Given I am on the 'sport' section front
 	   Then I should see the top 10 stories across sport
-	   
+
     Scenario: Sport top stories should display 5 and hide the rest
         Given I am on the 'sport' section front
-        Then up to 5 top stories should be displayed
-            And more than 5 top stories should be hidden
+        Then I should see up to 5 'Sport' top stories
+            And any more than 5 'Sport' top stories should be hidden
        
     @scala-test
     Scenario Outline: Sub-sections show a number of top stories, and be of the correct visual 'level'
@@ -35,16 +35,13 @@ Feature: Section Fronts - Sport
             | Boxing       | 1              | 3     |
             | Cycling      | 1              | 3     |
             
-       
     Scenario: Football top stories should display 3 and hide the rest
         Given I am on the 'sport' section front
-        Then up to 3 top stories for football should be displayed
-            And any more than 3 top stories for football should be hidden
-            
+        Then I should see up to 3 'Football' top stories
+            And any more than 3 'Football' top stories should be hidden
+
     Scenario: User can hide and show the sections
         Given I am on the 'sport' section front
-        When I click the 'hide' section button
-        Then the section should collapse
-        When I click the 'show' section button
-        Then the section should expand
+        Then I can click "Hide" to collapse a section
+            And I can click "Show" to expand a section
             

--- a/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
+++ b/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
@@ -18,8 +18,8 @@ Feature: Section Fronts - Sport
     Scenario Outline: Sub-sections show a number of top stories, and be of the correct visual 'level'
         Give I am on the 'sport' section front
         Then there should be a '<sub-section>' section
-            And the '<sub-section>' should contain up to <num-of-stories> stories
-            And the '<sub-section>' should be a visual level <level>
+            And the '<sub-section>' sub-section should contain up to <num-of-stories> stories
+            And the '<sub-section>' sub-section should be a visual level <level>
         
         Examples:
             | sub-section  | num-of-stories | level |

--- a/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
+++ b/integration-tests/src/test/resources/com/gu/test/section-fronts-sport.feature
@@ -1,0 +1,50 @@
+@section-fronts
+Feature: Section Fronts - Sport
+	As a Guardian user
+	I want to get a further break-down of sections on the sport section front
+	So that I can navigate content easier
+	
+	@scala-test
+	Scenario: Page contains the top 10 stories across sport
+	   Given I am on the 'sport' section front
+	   Then I the page should contains the top 10 stories across sport
+	   
+    Scenario: Sport top stories should display 5 and hide the rest
+        Given I am on the 'sport' section front
+        Then up to 5 top stories should be displayed
+            And more than 5 top stories should be hidden
+       
+    @scala-test
+    Scenario Outline: Sub-sections show a number of top stories, and be of the correct visual 'level'
+        Give I am on the 'sport' section front
+        Then there should be a '<sub-section>' section
+            And the '<sub-section>' should contain up to <num-of-stories> stories
+            And the '<sub-section>' should be a visual level <level>
+        
+        Examples:
+            | sub-section  | num-of-stories | level |
+            | Football     | 6              | 1     |
+            | Cricket      | 1              | 2     |
+            | Rugby Union  | 1              | 2     |
+            | Motor Sport  | 1              | 2     |
+            | Tennis       | 1              | 2     |
+            | Golf         | 1              | 2     |
+            | Horse Racing | 1              | 3     |
+            | Rugby League | 1              | 3     |
+            | US Sport     | 1              | 3     |
+            | Boxing       | 1              | 3     |
+            | Cycling      | 1              | 3     |
+            
+       
+    Scenario: Football top stories should display 3 and hide the rest
+        Given I am on the 'sport' section front
+        Then up to 3 top stories for football should be displayed
+            And any more than 3 top stories for football should be hidden
+            
+    Scenario: User can hide and show the sections
+        Given I am on the 'sport' section front
+        When I click the 'hide' section button
+        Then the section should collapse
+        When I click the 'show' section button
+        Then the section should expand
+            

--- a/section/conf/routes
+++ b/section/conf/routes
@@ -4,8 +4,9 @@
 
 
 # For dev machines
-GET     /assets/*file               controllers.Assets.at(path="/public", file)
+GET     /assets/*file                     controllers.Assets.at(path="/public", file)
 
-GET		/sections					controllers.SectionsController.render()
+GET		/sections					      controllers.SectionsController.render()
 
-GET     /*path                      controllers.SectionController.render(path)
+# culture and sport sections now live in front
+GET     /$path<(?!culture|sport)[\w\d-]*> controllers.SectionController.render(path)


### PR DESCRIPTION
Culture and Sport section fronts now contain sub-sections, à la the network front

Re-wrote the `FrontEdition` class so it's not forced to use `ConfiguredEdition`. Tests pass, @daithiocrualaoich, could you take a look to make sure it's sane
