### PR TITLE
Football: fixing styling issues and JS loading

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -56,11 +56,6 @@ define([
 
         var modules = {
 
-            hideJsElements: function () {
-                var html = common.$g('body')[0];
-                bonzo(html).toggleClass('js-off js-on');
-            },
-
             attachGlobalErrorHandler: function () {
                 var e = new Errors(window);
                 e.init();
@@ -240,7 +235,6 @@ define([
         
         var isNetworkFront = (config.page.pageId === "");
 
-        modules.hideJsElements();
         modules.attachGlobalErrorHandler();
         modules.upgradeImages();
         modules.transcludeTopStories(config);

--- a/common/app/assets/stylesheets/module/_football-tables.less
+++ b/common/app/assets/stylesheets/module/_football-tables.less
@@ -74,8 +74,9 @@
 // overriding pasteup :(
 .table-football-body:hover tr,
 .table-football-body:hover tr:nth-child(even),
+.table-football-body tr:nth-child(even),
 .table-football-body:hover tr:hover,
 .table-football tr.highlighted-row,
 .table-football-body tr:last-child {
-    background-color: transparent;
+    background-color: transparent !important;
 }

--- a/common/app/assets/stylesheets/module/_headline-list.less
+++ b/common/app/assets/stylesheets/module/_headline-list.less
@@ -16,7 +16,7 @@
 .headline-list p {
     float: left;
     width: 82%;
-    padding-left: @baseline*3;
+    padding-left: @baseline*2;
 }
 
 .headline-list a {
@@ -30,9 +30,5 @@
 	.type-9;
     float:left;
     color: #777777;
-}
-
-// this feels a bit filthy. sorry (MA)
-.headline-list li:nth-child(10) .count {
-    padding-left: 0;
+    width: 12px;
 }

--- a/common/app/assets/stylesheets/module/_matches.less
+++ b/common/app/assets/stylesheets/module/_matches.less
@@ -141,6 +141,12 @@ a.competition-title {
     margin-bottom: @baseline;
 }
 
+// this overrides components when places on a front (to avoid gaps)
+.trailblock .matches,
+.trailblock .competitions {
+    margin-bottom: 0;
+}
+
 .matches {
     background-color: #f4f4ee;
 }

--- a/common/app/assets/stylesheets/module/_matches.less
+++ b/common/app/assets/stylesheets/module/_matches.less
@@ -69,7 +69,6 @@ a.competition-title {
     font-family: @sans-serif;
     overflow: hidden;
     margin-right: 36px; // offsets the FT/HT box
-    word-break: break-all; // fixes things for small screens
 }
 
 .match-team {

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -4,6 +4,9 @@
 
 <script id="gu">
 
+    // we want this to happen ASAP to avoid FOUC
+    document.documentElement.className = document.documentElement.className.replace(/\bjs-off\b/g, '') + ' js-on ';
+
     var guardian = {
         isModernBrowser: ('querySelector' in document && 'addEventListener' in window && 'localStorage' in window)
     },

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @(metaData: MetaData, static: StaticAssets, config: GuardianConfiguration, switches: Seq[com.gu.management.Switchable])(head: Html)(body: Html)(implicit request: RequestHeader)
 <!doctype html>
-<html>
+<html class="js-off">
 <head>
     <title>@metaData.webTitle</title>
     @fragments.metaData(metaData, config, static)
@@ -10,7 +10,7 @@
     @head
 
 </head>
-<body id="top" class="zone-@metaData.section js-off" itemscope itemtype="http://schema.org/WebPage">
+<body id="top" class="zone-@metaData.section" itemscope itemtype="http://schema.org/WebPage">
     
     <div id="container"> 
         @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="x54")


### PR DESCRIPTION
As discussed with @phamann, moved the `.js-off` toggle to happen almost immediately on every page rather than on DOMready (as we don't need to wait for it). This prevents long FOUC on the UI.

Also fixed some issues with hover states on tables and little gaps on fronts with football components on them.
