### PR TITLE
Updated football static assets expiry times to match other apps.

### DIFF
--- a/football/conf/deploy.json
+++ b/football/conf/deploy.json
@@ -17,7 +17,7 @@
             "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=2592000"
+                "cacheControl":"public, max-age=315360000"
             }
         }
     },


### PR DESCRIPTION
To match other apps. 10 year expiry times for static assets as standard.
