### PR TITLE
Correct 'Desktop version' link for football pages

### DIFF
--- a/common/app/views/fragments/mainSiteLink.scala.html
+++ b/common/app/views/fragments/mainSiteLink.scala.html
@@ -1,9 +1,11 @@
 @(item: MetaData, config: common.GuardianConfiguration)(implicit request: RequestHeader)
 
-@defining(Edition(request, config)){ edition =>
-    @if(edition == "US") {
-        <a id="main-site" href="http://www.guardiannews.com/@item.id?mobile-redirect=false" data-link-name="US">Desktop version</a>
+@import java.net.URL
+
+@defining(new URL(item.canonicalUrl).getPath()){ canonicalPath =>
+    @if(Edition(request, config) == "US") {
+        <a id="main-site" href="http://www.guardiannews.com@canonicalPath?mobile-redirect=false" data-link-name="US">Desktop version</a>
     } else {
-        <a id="main-site" href="http://www.guardian.co.uk/@item.id?mobile-redirect=false" data-link-name="UK">Desktop version</a>
+        <a id="main-site" href="http://www.guardian.co.uk@canonicalPath?mobile-redirect=false" data-link-name="UK">Desktop version</a>
     }
 }

--- a/common/app/views/fragments/mainSiteLink.scala.html
+++ b/common/app/views/fragments/mainSiteLink.scala.html
@@ -1,8 +1,8 @@
 @(item: MetaData, config: common.GuardianConfiguration)(implicit request: RequestHeader)
 
-@import java.net.URL
+@import java.net.URI
 
-@defining(new URL(item.canonicalUrl).getPath()){ canonicalPath =>
+@defining(new URI(item.canonicalUrl).getPath()){ canonicalPath =>
     @if(Edition(request, config) == "US") {
         <a id="main-site" href="http://www.guardiannews.com@canonicalPath?mobile-redirect=false" data-link-name="US">Desktop version</a>
     } else {

--- a/football/test/FixturesFeatureTest.scala
+++ b/football/test/FixturesFeatureTest.scala
@@ -79,5 +79,28 @@ class FixturesFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatc
         }
       }
     }
+
+    scenario("The 'Desktop version' link points to the correct, equivalent desktop page") {
+
+      given("I visit the fixtures page")
+      and("I am on the 'UK' edition")
+      HtmlUnit("/football/fixtures") { browser =>
+        import browser._
+
+        then("the 'Desktop version' link should point to 'http://www.guardian.co.uk/football/matches?mobile-redirect=false'")
+        findFirst("#main-site").getAttribute("href") should be("http://www.guardian.co.uk/football/matches?mobile-redirect=false")
+      }
+
+      given("I visit the fixtures page")
+      and("I am on the 'US' edition")
+      HtmlUnit.US("/football/fixtures") { browser =>
+        import browser._
+
+        then("the 'Desktop version' link should point to 'http://www.guardiannews.com/football/matches?mobile-redirect=false'")
+        findFirst("#main-site").getAttribute("href") should be("http://www.guardiannews.com/football/matches?mobile-redirect=false")
+      }
+
+    }
+
   }
 }

--- a/football/test/ResultsFeatureTest.scala
+++ b/football/test/ResultsFeatureTest.scala
@@ -75,5 +75,28 @@ class ResultsFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         }
       }
     }
+
+    scenario("The 'Desktop version' link points to the correct, equivalent desktop page") {
+
+      given("I visit the results page")
+      and("I am on the 'UK' edition")
+      HtmlUnit("/football/results") { browser =>
+        import browser._
+
+        then("the 'Desktop version' link should point to 'http://www.guardian.co.uk/football/matches?mobile-redirect=false'")
+        findFirst("#main-site").getAttribute("href") should be("http://www.guardian.co.uk/football/matches?mobile-redirect=false")
+      }
+
+      given("I visit the results page")
+      and("I am on the 'US' edition")
+      HtmlUnit.US("/football/results") { browser =>
+        import browser._
+
+        then("the 'Desktop version' link should point to 'http://www.guardiannews.com/football/matches?mobile-redirect=false'")
+        findFirst("#main-site").getAttribute("href") should be("http://www.guardiannews.com/football/matches?mobile-redirect=false")
+      }
+
+    }
+
   }
 }

--- a/football/test/TablesFeatureTest.scala
+++ b/football/test/TablesFeatureTest.scala
@@ -3,43 +3,24 @@ package test
 import org.scalatest.{ FeatureSpec, GivenWhenThen }
 import org.scalatest.matchers.ShouldMatchers
 
-class LiveMatchesFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
+class TablesFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
 
-  // just checking these pages actually load
-
-  feature("Live Matches") {
-
-    scenario("Visit the live matches") {
-
-      given("I visit the live matches page")
-
-      HtmlUnit("/football/live") { browser =>
-        then("I should see todays live matches")
-      }
-    }
-
-    scenario("Competition fixtures filter") {
-
-      given("I am on the premier league live matches page")
-      HtmlUnit("/football/premierleague/live") { browser =>
-        then("I should see premier league live games")
-      }
-    }
+  feature("Tables") {
 
     scenario("The 'Desktop version' link points to the correct, equivalent desktop page") {
 
-      given("I visit the live page")
+      given("I visit the tables page")
       and("I am on the 'UK' edition")
-      HtmlUnit("/football/live") { browser =>
+      HtmlUnit("/football/tables") { browser =>
         import browser._
 
         then("the 'Desktop version' link should point to 'http://www.guardian.co.uk/football/matches?mobile-redirect=false'")
         findFirst("#main-site").getAttribute("href") should be("http://www.guardian.co.uk/football/matches?mobile-redirect=false")
       }
 
-      given("I visit the live page")
+      given("I visit the tables page")
       and("I am on the 'US' edition")
-      HtmlUnit.US("/football/live") { browser =>
+      HtmlUnit.US("/football/tables") { browser =>
         import browser._
 
         then("the 'Desktop version' link should point to 'http://www.guardiannews.com/football/matches?mobile-redirect=false'")

--- a/integration-tests/src/test/resources/com/gu/test/football.feature
+++ b/integration-tests/src/test/resources/com/gu/test/football.feature
@@ -102,4 +102,21 @@ Feature: Football fixtures
     @scala-test
     Scenario: User can see up to 28 days worth of results for a particular competition  
         Given I visit the "premierleague" results page
-        Then I should see 28 days of results  
+        Then I should see 28 days of results
+        
+    @scala-test
+    Scenario Outline: The 'Desktop version' link points to the correct, equivalent desktop page
+        Given I visit the '<page>' page
+            And I am on the '<edition>' edition
+        Then the 'Desktop version' link should point to '<url>'
+        
+        Examples:
+            | page     | edition | url                                                                |
+            | table    | UK      | http://www.guardian.co.uk/football/matches?mobile-redirect=false   |
+            | table    | US      | http://www.guardiannews.com/football/matches?mobile-redirect=false |
+            | live     | UK      | http://www.guardian.co.uk/football/matches?mobile-redirect=false   |
+            | live     | US      | http://www.guardiannews.com/football/matches?mobile-redirect=false |
+            | fixtures | UK      | http://www.guardian.co.uk/football/matches?mobile-redirect=false   |
+            | fixtures | US      | http://www.guardiannews.com/football/matches?mobile-redirect=false |
+            | results  | UK      | http://www.guardian.co.uk/football/matches?mobile-redirect=false   |
+            | results  | US      | http://www.guardiannews.com/football/matches?mobile-redirect=false |


### PR DESCRIPTION
Were using `id`, now using the `canonicalUrl` property of the `MetaPage` object to create the link to the desktop version of the page. Think this makes more sense, as `id` is basically the path of the current page 
