### PR TITLE
Toggle fix

### DIFF
--- a/common/app/assets/javascripts/modules/trailblocktoggle.js
+++ b/common/app/assets/javascripts/modules/trailblocktoggle.js
@@ -58,7 +58,11 @@ define([
                 trigger.attr('data-link-name', hideTrailblock);
                 
                 if (!manualTrigger) { // don't add it to prefs since we're reading from them
-                    model.logPreference(hideTrailblock, trailblockId);
+                    var shouldHideSection = true;
+                    if (hideTrailblock === "Hide") {
+                        shouldHideSection = false;
+                    }
+                    model.logPreference(shouldHideSection, trailblockId);
                 }
             },
 
@@ -82,7 +86,7 @@ define([
         var model = {
 
             logPreference: function (shouldHideSection, section) {
-                
+
                 if (window.localStorage) {
                     var existingPrefs = userPrefs.get(options.prefName);
                     


### PR DESCRIPTION
This fixes an issue: if you go to the NF and hide a trailblock and look in `localStorage` for `gu.prefs.front-trailblocks-UK`, you should see the ID of the trail. If you then show it again, it should duplicate its ID in `gu.prefs.front-trailblocks-UK` again.

This fix prevents this behaviour.

Problem was that I was passing through a string which always resolved to `true`, foolishly. Now I pass something with proper truthiness.
