### PR TITLE
Don't add trailing slash if there is no section, as it causes an unecess...

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -66,7 +66,7 @@ define([
         },
 
         transcludeMostPopular: function (host, section, edition) {
-            var url = host + '/most-popular/' + edition + '/' + section,
+            var url = host + '/most-popular/' + edition + (section ? '/' + section : ''),
                 domContainer = document.getElementById('js-popular'),
                 p = new Popular(domContainer).load(url);
 


### PR DESCRIPTION
If there is no section value, don't append trailing slash in calls to the /most-popular endpoint. It causes an unnecessary redirect, and the associated performance penalty.
