### PR TITLE
General omnitrue tracking tweaks

### DIFF
--- a/common/app/assets/javascripts/modules/trailblocktoggle.js
+++ b/common/app/assets/javascripts/modules/trailblocktoggle.js
@@ -53,9 +53,10 @@ define([
                 trailblock = document.getElementById(trailblock);
                 bonzo(trailblock).toggleClass(classesToToggle);
 
-                var hideTrailblock = (trigger.text() === "Hide") ? "Show" : "Hide";
-                trigger.text(hideTrailblock);
-                trigger.attr('data-link-name', hideTrailblock);
+                var text = trigger.text();
+                trigger.text((text === "Hide") ? "Show" : "Hide");
+                //This is backwards as executes before omniture call
+                trigger.attr('data-link-name', (text === "Hide") ? "Hide" : "Show");
                 
                 if (!manualTrigger) { // don't add it to prefs since we're reading from them
                     var shouldHideSection = true;

--- a/common/app/assets/stylesheets/module/_matches.less
+++ b/common/app/assets/stylesheets/module/_matches.less
@@ -333,7 +333,12 @@ a.competition-title {
     border-bottom: none;
 }
 
-.football-filter span {    
+//For omniture tracking
+.football-filter > span {
+    display: block;
+}
+
+.football-filter-arrow {    
     background: @sportMid;
     height: 100%;
     width: 48px;

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -1,40 +1,44 @@
-@(page: MetaData, config: common.GuardianConfiguration)
+@(page: MetaData, config: common.GuardianConfiguration)( implicit request:RequestHeader)
 @import conf.CommonSwitches._
 
-@defining(
-("http://hits.guardian.co.uk/b/ss/%s/1/H.24.2/?%s".format(
-    config.javascript.pageData("guardian.page.omnitureAccount"),
-    OmnitureAnalyticsData(page, "No Javascript")), config.javascript.pageData("guardian.page.omnitureAccount"))
-){ case (omnitureCall, omnitureAccount) =>
-        <noscript id="omnitureNoScript">
-            <div>
-                <img id="omnitureNoScriptImage" alt=""
-                     src='@omnitureCall' width="1" height="1" class="h" />
-            </div>
-        </noscript>
+@defining(request.host + request.path) { path =>
 
-    @if(OmnitureVerificationSwitch.isSwitchedOn){
-        <img id="omnitureVerificationScriptImage" alt=""
-            src='@omnitureCall.replace(omnitureAccount, "guardiangu-frontend-dev")' width="1" height="1" class="h" />
+    @defining(
+    ("http://hits.guardian.co.uk/b/ss/%s/1/H.24.2/?%s".format(
+        config.javascript.pageData("guardian.page.omnitureAccount"),
+        OmnitureAnalyticsData(page, "No Javascript", path)), config.javascript.pageData("guardian.page.omnitureAccount"))
+    ){ case (omnitureCall, omnitureAccount) =>
+            <noscript id="omnitureNoScript">
+                <div>
+                    <img id="omnitureNoScriptImage" alt=""
+                         src="@omnitureCall" width="1" height="1" class="h" />
+                </div>
+            </noscript>
+
+        @if(OmnitureVerificationSwitch.isSwitchedOn){
+            <img id="omnitureVerificationScriptImage" alt=""
+                src='@omnitureCall.replace(omnitureAccount, "guardiangu-frontend-dev")' width="1" height="1" class="h" />
+        }
     }
-}
 
-@defining(
-"http://hits.guardian.co.uk/b/ss/%s/1/H.24.2/?%s".format(
-    config.javascript.pageData("guardian.page.omnitureAccount"),
-    OmnitureAnalyticsData(page, "Partial Javascript"))
-){ omnitureCall =>
-        <script>
-            @*
-            //    we do not run our javascript on some browsers, hence analytics will not run.
-            //    this does a minimal tracking for those devices
-             *@
-            if (!guardian.isModernBrowser) {
-                var analyticsImage = document.createElement("img");
-                analyticsImage.src = "@omnitureCall";
-                analyticsImage.width = "1";
-                analyticsImage.height = "1";
-                document.body.appendChild(analyticsImage);
-            }
-        </script>
+    @defining(
+    "http://hits.guardian.co.uk/b/ss/%s/1/H.24.2/?%s".format(
+        config.javascript.pageData("guardian.page.omnitureAccount"),
+        OmnitureAnalyticsData(page, "Partial Javascript", path))
+    ){ omnitureCall =>
+            <script>
+                @*
+                //    we do not run our javascript on some browsers, hence analytics will not run.
+                //    this does a minimal tracking for those devices
+                 *@
+                if (!guardian.isModernBrowser) {
+                    var analyticsImage = document.createElement("img");
+                    analyticsImage.src = "@omnitureCall";
+                    analyticsImage.width = "1";
+                    analyticsImage.height = "1";
+                    document.body.appendChild(analyticsImage);
+                }
+            </script>
+    }
+
 }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -195,7 +195,7 @@ object ContributorLinks {
 }
 
 object OmnitureAnalyticsData {
-  def apply(page: MetaData, jsSupport: String): Html = {
+  def apply(page: MetaData, jsSupport: String, path: String): Html = {
 
     val data = page.metaData.map { case (key, value) => key -> value.toString }
     val pageCode = data.get("page-code").getOrElse("")
@@ -211,6 +211,7 @@ object OmnitureAnalyticsData {
 
     val pageName = page.analyticsName
     val analyticsData = Map(
+      "g" -> path,
       "ns" -> "guardian",
       "pageName" -> pageName,
       "v7" -> pageName,

--- a/football/app/views/fragments/filterBar.scala.html
+++ b/football/app/views/fragments/filterBar.scala.html
@@ -1,0 +1,6 @@
+@(title: String)
+<h1 class="type-4 js-collapsible collapsible box-indent football-filter" data-toggle-panel="js-football-league-list">
+    <span data-link-name="Football | @title | filter">
+        @title <span class="football-filter-arrow"><i class="i-filter-arrow-down js-visible"></i></span>
+    </span>
+</h1>

--- a/football/app/views/matches.scala.html
+++ b/football/app/views/matches.scala.html
@@ -19,7 +19,7 @@
         <div class="update update-live-matches" data-link-name="autoupdate"></div>
     }
 
-    <h1 class="type-4 js-collapsible collapsible box-indent football-filter" data-toggle-panel="js-football-league-list">@model.page.webTitle <span><i class="i-filter-arrow-down js-visible"></i></span></h1>
+    @fragments.filterBar(model.page.webTitle)
 
     @fragments.filters(model.filters, model.page, model.pageType)
     

--- a/football/app/views/tables.scala.html
+++ b/football/app/views/tables.scala.html
@@ -13,7 +13,7 @@
         <p class="dateline"><i class="i-date"></i> <span>Last updated: a minute ago</span></p>
     </div>
 
-    <h1 class="type-3 js-collapsible collapsible box-indent football-filter" data-toggle-panel="js-football-league-list">@model.page.webTitle <span><i class="i-filter-arrow-down js-visible"></i></span></h1>
+    @fragments.filterBar(model.page.webTitle)
 
     @fragments.filters(model.filters, model.page, "tables")
 

--- a/football/app/views/teamFixtures.scala.html
+++ b/football/app/views/teamFixtures.scala.html
@@ -8,7 +8,7 @@
         <a class="zone-color" data-link-name="article section" href="/football">Football</a>
     </h2>
 
-    <h1 class="type-4 js-collapsible collapsible box-indent football-filter" data-toggle-panel="js-football-league-list">@page.webTitle <span><i class="i-filter-arrow-down js-visible"></i></span></h1>
+    @fragments.filterBar(page.webTitle)
 
     @fragments.filters(filters, page, "fixtures")
     

--- a/front/app/views/fragments/frontBlock.scala.html
+++ b/front/app/views/fragments/frontBlock.scala.html
@@ -1,6 +1,6 @@
 @(block: Trailblock, edition: String)(implicit request: RequestHeader)
 
-<section class="front-section zone-@block.description.section" data-link-name="Front | block | @block.description.name">
+<section class="front-section zone-@block.description.section" data-link-name="block | @block.description.name">
 
     @if(block.description.id != "") {
 	    @if("/" + block.description.id == request.path) {

--- a/front/app/views/fragments/frontBlock.scala.html
+++ b/front/app/views/fragments/frontBlock.scala.html
@@ -1,13 +1,13 @@
 @(block: Trailblock, edition: String)(implicit request: RequestHeader)
 
-<section class="front-section zone-@block.description.section">
+<section class="front-section zone-@block.description.section" data-link-name="Front | block | @block.description.name">
 
     @if(block.description.id != "") {
 	    @if("/" + block.description.id == request.path) {
 	        @fragments.headline(block.description.name, List("article-zone", "zone-color", "type-0"))
 	    } else {
 	        <div class="@if(request.path == "/"){front-section-head zone-background} else {sub-section-head}">
-	            <a @if(request.path != ""){class="zone-color"} data-link-name="heading link" href="/@block.description.id">
+	            <a @if(request.path != ""){class="zone-color"} data-link-name="section link" href="/@block.description.id">
                     @fragments.headline(block.description.name, List("type-1"))
                 </a>
 		        <button class="initially-off js-toggle-trailblock toggle-trailblock" data-zone-name="@edition.toLowerCase()"
@@ -20,8 +20,7 @@
 
     <div class="trailblock js-front-trailblock rolled-out"
         id="front-trailblock-@SafeName(block.description)"
-        data-count="@{block.trails.length - block.description.numItemsVisible}"
-        data-link-name="Front | block | @block.description.name">
+        data-count="@{block.trails.length - block.description.numItemsVisible}">
 
         @block.description.style match {
             case Some(Thumbnail) => { @trailblocks.thumbnail(block.trails, block.description.numItemsVisible) } 

--- a/front/app/views/front.scala.html
+++ b/front/app/views/front.scala.html
@@ -2,7 +2,7 @@
 
 @main(front, Static, Configuration, Switches.all){
 }{
-    <div id="front-container" class="cf">
+    <div id="front-container" class="cf" data-link-name="Front">
         @trailblocks.map{ block =>
             @fragments.frontBlock(block, Edition(request, Configuration))
         }


### PR DESCRIPTION
- Added full URL to non-js omniture calls to hopefully banish "The others"
- Corrected show/hide tracking on fronts due to JS event binding execution order
- Corrected section title tracking on fronts
- Adde tracking to filter dropdown on football pages
