### PR TITLE
stillImageUrl causing errors in PROD logs

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -14,10 +14,9 @@ class Content(delegate: ApiContent) extends Trail with Tags with MetaData {
 
   lazy val images: Seq[Image] = delegate.mediaAssets.filter { _.`type` == "picture" } map { Image(_) }
 
-  lazy val videoImages: Seq[Image] = delegate.mediaAssets.filter { _.`type` == "video" } map { videoAsset =>
-    val imageAsset = videoAsset.copy(file = Option(videoAsset.fields.get("stillImageUrl")))
-    Image(imageAsset)
-  }
+  lazy val videoImages: Seq[Image] = delegate.mediaAssets.filter(_.`type` == "video")
+    .filter(_.safeFields.isDefinedAt("stillImageUrl"))
+    .map { videoAsset => Image(videoAsset.copy(file = videoAsset.safeFields.get("stillImageUrl"))) }
 
   lazy val id: String = delegate.id
   lazy val sectionName: String = delegate.sectionName.getOrElse("")

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.openplatform.contentapi.model.{ Content => ApiContent }
+import com.gu.openplatform.contentapi.model.{ Content => ApiContent, MediaAsset }
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import scala.math.abs
@@ -15,6 +15,10 @@ object `package` {
     lazy val isArticle: Boolean = content.tags exists { _.id == "type/article" }
     lazy val isGallery: Boolean = content.tags exists { _.id == "type/gallery" }
     lazy val isVideo: Boolean = content.tags exists { _.id == "type/video" }
+  }
+
+  implicit def media2rich(a: MediaAsset) = new {
+    lazy val safeFields = a.fields.getOrElse(Map.empty)
   }
 
   implicit def any2In[A](a: A) = new {


### PR DESCRIPTION
Modified unsafe use of Option.get so we should have less errors in the logs.
