### PR TITLE
Removes omniture delay on <button> clicks, removes CSS transition on tra...

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -29,7 +29,7 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
 
         // delegate, emit the derived tag
         bean.add(document.body, "click", function (event) {
-            var target, dataIsXhr, href, isXhr, isInternalAnchor;
+            var target, dataIsXhr, href, isXhr, isInternalAnchor, isUiControl;
 
             if (filterSource(event.target.tagName.toLowerCase()).length > 0) {
 
@@ -39,8 +39,9 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
 
                 isXhr = (dataIsXhr) ? true : false;
                 isInternalAnchor = (href && (href.indexOf('#') === 0)) ? true : false;
+                isUiControl = ('BUTTON' === target.nodeName);
 
-                common.mediator.emit('module:clickstream:click', [target, getTag(target, []), isXhr, isInternalAnchor]);
+                common.mediator.emit('module:clickstream:click', [target, getTag(target, []), isXhr, isInternalAnchor, isUiControl]);
             } else {
                 return false;
             }

--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -39,7 +39,7 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
 
                 isXhr = (dataIsXhr) ? true : false;
                 isInternalAnchor = (href && (href.indexOf('#') === 0)) ? true : false;
-                isUiControl = ('BUTTON' === target.nodeName);
+                isUiControl = ('button' === target.nodeName.toLowerCase());
 
                 common.mediator.emit('module:clickstream:click', [target, getTag(target, []), isXhr, isInternalAnchor, isUiControl]);
             } else {

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -27,10 +27,11 @@ define(['common', 'modules/detect', 'bean'], function(common, detect, bean) {
             var element = params[0],
                 tag = params[1],
                 isXhr = params[2],
-                isInternalAnchor = params[3];
+                isInternalAnchor = params[3],
+                isUiControl = params[4];
 
             // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
-            var delay = (isXhr || isInternalAnchor) ? true : element;
+            var delay = (isXhr || isInternalAnchor || isUiControl) ? true : element;
             that.populateEventProperties(tag);
 
             s.tl(delay, 'o', tag);

--- a/common/app/assets/stylesheets/state/_state.less
+++ b/common/app/assets/stylesheets/state/_state.less
@@ -43,8 +43,6 @@
 .trailblock .panel,
 .rolled-out {
      height: auto;
-     max-height: 9999px;
-     overflow: hidden;
      margin-bottom: 0px;
 }
 

--- a/common/app/assets/stylesheets/state/_state.less
+++ b/common/app/assets/stylesheets/state/_state.less
@@ -45,18 +45,25 @@
      height: auto;
      max-height: 9999px;
      overflow: hidden;
-     .transition(max-height 1s ease-in-out);
      margin-bottom: 0px;
+}
+
+.trailblock .panel {
+     .transition(max-height 1s ease-in-out);
 }
 
 .trailblock.shut > .panel,
 .competition-table.shut > .panel,
 .rolled-up {
-    .transition(max-height .5s ease-in-out);
     overflow: hidden;
     position: relative;
     max-height: 0;
     padding-top: 0;
+}
+
+.trailblock.shut > .panel,
+.competition-table.shut > .panel {
+    .transition(max-height .5s ease-in-out);
 }
 
 .trail-headline a:visited {

--- a/common/test/assets/javascripts/spec/Clickstream.spec.js
+++ b/common/test/assets/javascripts/spec/Clickstream.spec.js
@@ -36,7 +36,7 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
             bean.fire(el, 'click');
 
             runs(function(){
-                expect(spy.withArgs([el, 'outer div | the button', false, false])).toHaveBeenCalledOnce();
+                expect(spy.withArgs([el, 'outer div | the button', false, false, true])).toHaveBeenCalledOnce();
             });
 
         });
@@ -71,7 +71,7 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
             bean.fire(el, 'click');
 
             runs(function(){
-                expect(spy.withArgs([el, 'outer div | xhr link', true, false])).toHaveBeenCalledOnce();
+                expect(spy.withArgs([el, 'outer div | xhr link', true, false, false])).toHaveBeenCalledOnce();
                 expect(spy).toHaveBeenCalledOnce();
             });
         });
@@ -90,7 +90,7 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
             bean.fire(el, 'click');
 
             runs(function(){
-                expect(spy.withArgs([el, 'outer div | paragraph', false, true])).toHaveBeenCalledOnce();
+                expect(spy.withArgs([el, 'outer div | paragraph', false, true, false])).toHaveBeenCalledOnce();
                 expect(spy).toHaveBeenCalledOnce();
             });
         });


### PR DESCRIPTION
Adds another case for not having an Omniture pre-delay when the clicked element is a button - i.e. is an "internal" UI control such as trailblock roll-up/roll-out.

Removes CSS transitions from trailblock roll-up/roll-out. The max-height fix for the lack of explicit heights - as are required for the transition - causes the animation to be ineffectual.

My first pull request. 
Treat it with scepticism. 
(It passed all the tests though...)
