### PR TITLE
Correct cache lookup in HTML head.

### DIFF
--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -35,9 +35,8 @@
             var styleNodes = document.querySelectorAll('[data-cache-name]');
             for (var i = 0, j = styleNodes.length; i<j; ++i) {
                 var style = styleNodes[i],
-                    name = style.getAttribute('data-cache-name'),
-                    cacheKey = style.getAttribute('data-cache-file-woff').split('.')[2],
-                    cachedCss = localStorage.getItem('gu.fonts.' + name + '.' + cacheKey);
+                    nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff\.(.*)\.js$/),
+                    cachedCss = localStorage.getItem('gu.fonts.' + nameAndCacheKey[1] + '.' + nameAndCacheKey[2]);
                 if (cachedCss) {
                     style.innerHTML = cachedCss;
                     style.setAttribute('data-cache-full', 'true');


### PR DESCRIPTION
Forgot to correct filename parsing in the non-AMD head.

We don't have an integration test that actually tests fonts are being rendered - an oversight due to it being quite hard to test, but it is doable. Will try and add something.
