### PR TITLE
fixing top stories nav for non-JS users

### DIFF
--- a/common/app/views/fragments/navigation.scala.html
+++ b/common/app/views/fragments/navigation.scala.html
@@ -13,8 +13,8 @@
 
 @if(!isFooter){
     <div id="navigation-header" data-link-name="global navigation: header">
-        <a href="#topstories-footer" data-is-ajax="1" data-link-name="Top stories" id="topstories-control-header"
-        class="topstories-control is-off">
+        <a href="/top-stories" data-is-ajax="1" data-link-name="Top stories" id="topstories-control-header"
+        class="topstories-control">
             <i class="i i-nav-divider"></i>
             <span>Top stories</span>
             <i class="i i-arrow-small-down"></i>


### PR DESCRIPTION
this fixes two earlier bugs (probably accidental merge overwrite) -- we now no longer hide the top-stories link for non-JS users, and this link is now fixed to go to the correct page.
