### PR TITLE
Configured trailblock

### DIFF
--- a/front/app/controllers/front/ConfiguredEdition.scala
+++ b/front/app/controllers/front/ConfiguredEdition.scala
@@ -78,7 +78,7 @@ class ConfiguredEdition(edition: String, descriptions: Seq[TrailblockDescription
         toId((block \ "id").as[String]),
         (block \ "title").as[String],
         (block \ "numItems").as[Int],
-        showMore = (block \ "showMore").as[Boolean]
+        showMore = (block \ "showMore").asOpt[Boolean].getOrElse(false)
       )
     }
   }

--- a/front/test/ConfiguredEditionFeatureTest.scala
+++ b/front/test/ConfiguredEditionFeatureTest.scala
@@ -40,7 +40,7 @@ class ConfiguredEditionFeatureTest extends FeatureSpec with GivenWhenThen with S
         front.warmup()
 
         then("I should see the configured feature trailblock")
-        front.configuredTrailblocks.map(_.description) should be(Seq(TrailblockDescription("world/iraq", "Iraq", 3)))
+        front.configuredTrailblocks.map(_.description) should be(Seq(TrailblockDescription("world/iraq", "Iraq", 3, showMore = true)))
       }
     }
 


### PR DESCRIPTION
Fixing test to handle the fact the json config mightn't have the `showMore` property set
