### PR TITLE
Log the state as soon as the article has been read.

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/reading.js
+++ b/common/app/assets/javascripts/modules/analytics/reading.js
@@ -12,8 +12,10 @@ define(['common'], function (common) {
             PATH = "/px.gif",
             START = new Date().getTime(),
             WORDCOUNT = config.wordCount,
-            WPM = 200; //Average words onsole.log(config);per minute
-
+            WPM = 200,
+            READ_THRESHOLD = 80; // Ie. 80% 
+            logCount = 0; // Average words 
+ 
         this.viewportPercentage = 0;
 
         this.timer = {
@@ -49,7 +51,10 @@ define(['common'], function (common) {
 
         this.logElementPosition = function(el) {
             var current = parseInt(this.getPercentageInViewPort(el), 10);
-            return this.viewportPercentage = (current > this.viewportPercentage) ? current : this.viewportPercentage;
+            this.viewportPercentage = (current > this.viewportPercentage) ? current : this.viewportPercentage;
+            if (this.viewportPercentage > READ_THRESHOLD) {
+                this.log();    
+            }
         };
 
         this.articleIsInViewport = function(el) {
@@ -95,6 +100,12 @@ define(['common'], function (common) {
         },
 
         this.log = function() {
+           
+            // Prevent multiple entries p/page 
+            if (logCount >= 1) {
+                return false;
+            }
+
             var data = {
                 "id" : id,
                 "timeOnPage"        : this.timeOnPage(),
@@ -105,6 +116,7 @@ define(['common'], function (common) {
                 "percentageViewport": this.viewportPercentage
             };
 
+            logCount++;
             var url = this.makeUrl(data);
             this.createImage(url);
         };


### PR DESCRIPTION
This captures people who come to us (views) and read the article in full and who do not create an onwards journey.

As per discussion,
- Tracking using this technique we'll probably will lose some data from 3g/2g connections.
- We'll capture data from people who view a single article and read it, but not from people who view an article and don't read it.
- We'll accidentally capture data from people who read an article, visit another, then click back and visit another. So we are only interested in the first entry per user id + url
