### PR TITLE
chrome as optional driver

### DIFF
--- a/integration-tests/src/test/java/com/gu/test/DriverFactory.java
+++ b/integration-tests/src/test/java/com/gu/test/DriverFactory.java
@@ -1,10 +1,12 @@
 package com.gu.test;
 
+import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.net.MalformedURLException;
@@ -26,7 +28,17 @@ public class DriverFactory {
 			driver = new HtmlUnitDriver(capabilities);
 		}
         else if (type.equals("chrome")){
-         driver = new ChromeDriver();
+            if (!httpProxy.isEmpty()){
+                Proxy proxy = new Proxy();
+            proxy.setHttpProxy(httpProxy);
+                DesiredCapabilities dc = DesiredCapabilities.chrome();
+                dc.setCapability(CapabilityType.PROXY,proxy);
+                driver = new ChromeDriver(dc);
+            }
+            else{
+            driver = new ChromeDriver();
+            }
+            return driver;
 
         }
         else {

--- a/integration-tests/src/test/java/com/gu/test/DriverFactory.java
+++ b/integration-tests/src/test/java/com/gu/test/DriverFactory.java
@@ -1,14 +1,15 @@
 package com.gu.test;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.logging.Level;
-
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
 
 public class DriverFactory {
 	
@@ -23,7 +24,12 @@ public class DriverFactory {
 			capabilities.setJavascriptEnabled(true);
 			
 			driver = new HtmlUnitDriver(capabilities);
-		} else {
+		}
+        else if (type.equals("chrome")){
+         driver = new ChromeDriver();
+
+        }
+        else {
 
 			FirefoxProfile profile = new FirefoxProfile();
 			

--- a/integration-tests/src/test/java/com/gu/test/SharedDriver.java
+++ b/integration-tests/src/test/java/com/gu/test/SharedDriver.java
@@ -1,13 +1,7 @@
 package com.gu.test;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.List;
-import java.util.Properties;
-
+import cucumber.annotation.Before;
 import junit.framework.Assert;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -15,7 +9,11 @@ import org.openqa.selenium.support.events.EventFiringWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import cucumber.annotation.Before;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.Properties;
 
 public class SharedDriver extends EventFiringWebDriver {
 	
@@ -58,8 +56,10 @@ public class SharedDriver extends EventFiringWebDriver {
 
 	public void clearLocalStorage() {
 		// only execute on a page
-		if (!getCurrentUrl().equals("about:blank")) {
-			executeScript("window.localStorage.clear();");						
+		if (!getCurrentUrl().equals("about:blank") && System.getProperty("driver")==("firefox")) {
+            //this doesn't work in Chrome (throws an exception see http://code.google.com/p/chromedriver/issues/detail?id=153)
+	executeScript("window.localStorage.clear();");
+
 		}
 	}
 

--- a/integration-tests/src/test/java/com/gu/test/SharedDriver.java
+++ b/integration-tests/src/test/java/com/gu/test/SharedDriver.java
@@ -57,8 +57,6 @@ public class SharedDriver extends EventFiringWebDriver {
 
 	public void clearLocalStorage() {
 		// only execute on a page
-        String driver = System.getProperty("driver");
-        System.out.println(driver);
         if (!getCurrentUrl().equals("about:blank") && REAL_DRIVER instanceof FirefoxDriver) {
             //this doesn't work in Chrome (throws an exception see http://code.google.com/p/chromedriver/issues/detail?id=153)
 		executeScript("window.localStorage.clear();");

--- a/integration-tests/src/test/java/com/gu/test/SharedDriver.java
+++ b/integration-tests/src/test/java/com/gu/test/SharedDriver.java
@@ -5,6 +5,7 @@ import junit.framework.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -56,9 +57,11 @@ public class SharedDriver extends EventFiringWebDriver {
 
 	public void clearLocalStorage() {
 		// only execute on a page
-		if (!getCurrentUrl().equals("about:blank") && System.getProperty("driver")==("firefox")) {
+        String driver = System.getProperty("driver");
+        System.out.println(driver);
+        if (!getCurrentUrl().equals("about:blank") && REAL_DRIVER instanceof FirefoxDriver) {
             //this doesn't work in Chrome (throws an exception see http://code.google.com/p/chromedriver/issues/detail?id=153)
-	executeScript("window.localStorage.clear();");
+		executeScript("window.localStorage.clear();");
 
 		}
 	}


### PR DESCRIPTION
Adds the ability to run tests in chrome using the property -Ddriver=chrome

_Gotchas_
To run this locally you will need Chromedriver in your PATH https://code.google.com/p/chromedriver/
For this to work in teamcity, chrome and chromedriver will need to be in the PATH (I am talking to websys about the best way to do this)
clearing local storage does not appear to work in Chrome, this is http://code.google.com/p/chromedriver/issues/detail?id=153 to stop it throwing an exception I've had to put some conditional logic around running this, this causes a few tests to fail which rely on clearing local storage. I couldn't find a workaround for this.
