### PR TITLE
Individual servers can now pass back information to the router if they t...

### DIFF
--- a/common/app/common/ModelOrNotFound.scala
+++ b/common/app/common/ModelOrNotFound.scala
@@ -1,0 +1,26 @@
+package common
+
+import play.api.mvc.{ Result, Results }
+import com.gu.openplatform.contentapi.model.ItemResponse
+import model._
+
+// http://wiki.nginx.org/X-accel
+object ModelOrNotFound extends Results {
+  def apply[T](item: Option[T], response: ItemResponse): Either[T, Result] =
+    item.map(Left(_)).orElse {
+      response.content.map {
+        case a if a.isArticle => internalRedirect("type/article", a.id)
+        case v if v.isVideo => internalRedirect("type/video", v.id)
+        case g if g.isGallery => internalRedirect("type/gallery", g.id)
+
+        // TODO we could do something clever here, it means we know this exists but that we do not yet support it,
+        // maybe a page that says "want to see this on our main site?"
+        case _ => Right(NotFound)
+      }
+        .orElse(response.tag.map(t => internalRedirect("type/tag", t.id)))
+        .orElse(response.section.map(s => internalRedirect("type/section", s.id)))
+    }.getOrElse(Right(NotFound))
+
+  private def internalRedirect(base: String, id: String) =
+    Right(NotFound.withHeaders("X-Accel-Redirect" -> "/%s/%s".format(base, id)))
+}

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -2,8 +2,9 @@ package common
 
 import com.gu.openplatform.contentapi.ApiError
 import play.api.Logger
+import play.api.mvc.Result
 
-object `package` extends implicits.Strings with implicits.Requests {
+object `package` extends implicits.Strings with implicits.Requests with play.api.mvc.Results {
 
   def suppressApi404[T](block: => Option[T])(implicit log: Logger): Option[T] = {
     try {
@@ -12,6 +13,16 @@ object `package` extends implicits.Strings with implicits.Requests {
       case ApiError(404, message) =>
         log.info("Got a 404 while calling content api: " + message)
         None
+    }
+  }
+
+  def suppressApi404[T](block: => Either[T, Result])(implicit log: Logger): Either[T, Result] = {
+    try {
+      block
+    } catch {
+      case ApiError(404, message) =>
+        log.info("Got a 404 while calling content api: " + message)
+        Right(NotFound)
     }
   }
 

--- a/common/test/common/ModelOrNotFoundTest.scala
+++ b/common/test/common/ModelOrNotFoundTest.scala
@@ -1,0 +1,101 @@
+package common
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import com.gu.openplatform.contentapi.model.{ Section, ItemResponse, Tag, Content }
+import org.joda.time.DateTime
+import play.api.test._
+import play.api.test.Helpers._
+
+private object TestModel
+
+class ModelOrNotFoundTest extends FlatSpec with ShouldMatchers {
+
+  val testContent = new Content("the/id", None, None, new DateTime(), "the title", "http://foo.bar", "http://foo.bar")
+
+  val articleTag = new Tag("type/article", "type", webTitle = "the title", webUrl = "http://foo.bar", apiUrl = "http://foo.bar")
+  val galleryTag = articleTag.copy(id = "type/gallery")
+  val videoTag = articleTag.copy(id = "type/video")
+
+  val testArticle = testContent.copy(tags = List(articleTag))
+  val testGallery = testContent.copy(tags = List(galleryTag))
+  val testVideo = testContent.copy(tags = List(videoTag))
+
+  val testSection = new Section("water", "Water", "http://foo.bar", "http://foo.bar")
+
+  // FML
+  val stubResponse = new ItemResponse("ok", "top_tier", None, None, None, None, None, None, None, None, None, Nil, Nil, Nil, Nil, Nil, Nil)
+
+  "ModelOrNotFound" should "return the model if it exists" in {
+    ModelOrNotFound(
+      item = Some(TestModel),
+      response = stubResponse
+    ) should be(Left(TestModel))
+  }
+
+  it should "internal redirect to an article if it has shown up at the wrong server" in {
+
+    val notFound = ModelOrNotFound(
+      item = None,
+      response = stubResponse.copy(content = Some(testArticle))
+    ).right.get
+
+    status(notFound) should be(404)
+    headers(notFound)("X-Accel-Redirect") should be("/type/article/the/id")
+  }
+
+  it should "internal redirect to a video if it has shown up at the wrong server" in {
+
+    val notFound = ModelOrNotFound(
+      item = None,
+      response = stubResponse.copy(content = Some(testVideo))
+    ).right.get
+
+    status(notFound) should be(404)
+    headers(notFound)("X-Accel-Redirect") should be("/type/video/the/id")
+  }
+
+  it should "internal redirect to a gallery if it has shown up at the wrong server" in {
+
+    val notFound = ModelOrNotFound(
+      item = None,
+      response = stubResponse.copy(content = Some(testGallery))
+    ).right.get
+
+    status(notFound) should be(404)
+    headers(notFound)("X-Accel-Redirect") should be("/type/gallery/the/id")
+  }
+
+  it should "404 if it is an unsupported content type" in {
+
+    val notFound = ModelOrNotFound(
+      item = None,
+      response = stubResponse.copy(content = Some(testContent))
+    ).right.get
+
+    status(notFound) should be(404)
+    headers(notFound).get("X-Accel-Redirect") should be(None)
+  }
+
+  it should "internal redirect to a tag if it has shown up at the wrong server" in {
+
+    val notFound = ModelOrNotFound(
+      item = None,
+      response = stubResponse.copy(tag = Some(articleTag))
+    ).right.get
+
+    status(notFound) should be(404)
+    headers(notFound)("X-Accel-Redirect") should be("/type/tag/type/article")
+  }
+
+  it should "internal redirect to a section if it has shown up at the wrong server" in {
+
+    val notFound = ModelOrNotFound(
+      item = None,
+      response = stubResponse.copy(section = Some(testSection))
+    ).right.get
+
+    status(notFound) should be(404)
+    headers(notFound)("X-Accel-Redirect") should be("/type/section/water")
+  }
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -79,8 +79,8 @@ GET     /$path<[\w\d-]*/[\w\d-]*/[\w\d-]*>.:format    controllers.TagController.
 #Section
 GET		/sections							         controllers.SectionsController.render()
 # culture and sport sections now live in front
-GET     /$path<(?!culture|sport)[\w\d-]*>            controllers.SectionController.render(path, format = "html")
-GET     /$path<(?!culture|sport)[\w\d-]*>.:format    controllers.SectionController.render(path, format)
+GET    /$path<(?!culture|sport)[\w\d-]*>            controllers.SectionController.render(path)
+GET    /$path<(?!culture|sport)[\w\d-]*>.json       controllers.SectionController.renderJson(path)
 
 #Articles
 GET     /*path                                controllers.ArticleController.render(path)

--- a/gallery/app/controllers/GalleryController.scala
+++ b/gallery/app/controllers/GalleryController.scala
@@ -24,11 +24,14 @@ object GalleryController extends Controller with Logging {
     val promiseOfGalleryPage = Akka.future(lookup(path, index, isTrail))
 
     Async {
-      promiseOfGalleryPage.map(_.map { renderGallery } getOrElse { NotFound })
+      promiseOfGalleryPage.map {
+        case Left(model) => renderGallery(model)
+        case Right(notFound) => notFound
+      }
     }
   }
 
-  private def lookup(path: String, index: Int, isTrail: Boolean)(implicit request: RequestHeader): Option[GalleryPage] = suppressApi404 {
+  private def lookup(path: String, index: Int, isTrail: Boolean)(implicit request: RequestHeader) = suppressApi404 {
     val edition = Edition(request, Configuration)
     log.info("Fetching gallery: " + path + " for edition " + edition)
     val response: ItemResponse = ContentApi.item(path, edition)
@@ -38,7 +41,8 @@ object GalleryController extends Controller with Logging {
     val gallery = response.content.filter { _.isGallery } map { new Gallery(_) }
     val storyPackage = response.storyPackage map { new Content(_) }
 
-    gallery map { g => GalleryPage(g, storyPackage.filterNot(_.id == g.id), index, isTrail) }
+    val model = gallery map { g => GalleryPage(g, storyPackage.filterNot(_.id == g.id), index, isTrail) }
+    ModelOrNotFound(model, response)
   }
 
   private def renderGallery(model: GalleryPage)(implicit request: RequestHeader) =

--- a/section/app/controllers/SectionController.scala
+++ b/section/app/controllers/SectionController.scala
@@ -14,15 +14,30 @@ object SectionController extends Controller with Logging with Paging with Format
 
   val validFormats: Seq[String] = Seq("html", "json")
 
-  def render(path: String, format: String = "html") = Action { implicit request =>
+  def render(path: String) = Action { implicit request =>
     val promiseOfSection = Akka.future(lookup(path))
+
     // make sure a valid format has been requested
-    checkFormat(format).map { validFormat =>
-      Async(promiseOfSection.map(_.map { renderSectionFront(_, validFormat) } getOrElse { NotFound }))
-    } getOrElse (BadRequest)
+    Async {
+      promiseOfSection.map {
+        case Left(model) => renderSectionFront(model, "html")
+        case Right(notFound) => notFound
+      }
+    }
   }
 
-  private def lookup(path: String)(implicit request: RequestHeader): Option[SectionFrontPage] = suppressApi404 {
+  def renderJson(path: String) = Action { implicit request =>
+    val promiseOfSection = Akka.future(lookup(path))
+    // make sure a valid format has been requested
+    Async {
+      promiseOfSection.map {
+        case Left(model) => renderSectionFront(model, "json")
+        case Right(_) => NotFound //do not redirect json
+      }
+    }
+  }
+
+  private def lookup(path: String)(implicit request: RequestHeader) = suppressApi404 {
     val edition = Edition(request, Configuration)
     log.info("Fetching front: " + path + "for edition " + edition)
     val response: ItemResponse = ContentApi.item(path, edition)
@@ -40,7 +55,8 @@ object SectionController extends Controller with Logging with Paging with Format
       response.results map { new Content(_) } filterNot { c => editorsPicksIds contains (c.id) }
     )
 
-    section map { SectionFrontPage(_, editorsPicks, latestContent) }
+    val model = section map { SectionFrontPage(_, editorsPicks, latestContent) }
+    ModelOrNotFound(model, response)
   }
 
   private def renderSectionFront(model: SectionFrontPage, format: String)(implicit request: RequestHeader) = Cached(model.section) {

--- a/section/conf/routes
+++ b/section/conf/routes
@@ -9,5 +9,5 @@ GET     /assets/*file                     controllers.Assets.at(path="/public", 
 GET		/sections					      controllers.SectionsController.render()
 
 # culture and sport sections now live in front
-GET    /$path<(?!culture|sport)[\w\d-]*>            controllers.SectionController.render(path, format = "html")
-GET    /$path<(?!culture|sport)[\w\d-]*>.:format    controllers.SectionController.render(path, format)
+GET    /$path<(?!culture|sport)[\w\d-]*>            controllers.SectionController.render(path)
+GET    /$path<(?!culture|sport)[\w\d-]*>.json       controllers.SectionController.renderJson(path)

--- a/video/app/controllers/VideoController.scala
+++ b/video/app/controllers/VideoController.scala
@@ -15,11 +15,14 @@ object VideoController extends Controller with Logging {
   def render(path: String) = Action { implicit request =>
     val promiseOfVideo = Akka.future(lookup(path))
     Async {
-      promiseOfVideo.map(_.map { renderVideo }.getOrElse { NotFound })
+      promiseOfVideo.map {
+        case Left(model) => renderVideo(model)
+        case Right(notFound) => notFound
+      }
     }
   }
 
-  private def lookup(path: String)(implicit request: RequestHeader): Option[VideoPage] = suppressApi404 {
+  private def lookup(path: String)(implicit request: RequestHeader) = suppressApi404 {
     val edition = Edition(request, Configuration)
     log.info("Fetching video: " + path + " for edition " + edition)
     val response: ItemResponse = ContentApi.item(path, edition)
@@ -30,7 +33,8 @@ object VideoController extends Controller with Logging {
     val videoOption = response.content.filter { _.isVideo } map { new Video(_) }
     val storyPackage = response.storyPackage map { new Content(_) }
 
-    videoOption map { video => VideoPage(video, storyPackage.filterNot(_.id == video.id)) }
+    val model = videoOption map { video => VideoPage(video, storyPackage.filterNot(_.id == video.id)) }
+    ModelOrNotFound(model, response)
   }
 
   private def renderVideo(model: VideoPage)(implicit request: RequestHeader): Result =


### PR DESCRIPTION
...ry to serve the wrong page type

These are 'internal' and therefore cannot be hit directly. You can only hit them via the X-Accel method http://wiki.nginx.org/X-accel

The idea is that we have a small number amount of content whose urls do not pattern match properly. There are some articles whose URLs make them look like tag pages. 

by simply setting a header on the 404 we can bounce them to the correct proxy.
