### PR TITLE
Switcher for frontend experiments

### DIFF
--- a/article/app/views/article.scala.html
+++ b/article/app/views/article.scala.html
@@ -35,13 +35,14 @@
             itemprop="@if(article.isReview){reviewBody} else {articleBody}">
 		      @fragments.articleBody(article)
         </div>
+
     </article>
 
     @if(storyPackage.nonEmpty) {
         @fragments.relatedTrails(storyPackage, heading = "Related content", visibleTrails = 5)
-    } else {
-        <div id="js-related"></div>
     }
+    
+    <aside id="js-related"></aside>
 
-    @fragments.mostPopularPlaceholder(article.section)
+    <div id="js-popular"></div>
 }

--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -62,8 +62,8 @@ define([
 
         if (!experimentName) {
             for (var key in config.switches) {
-                if (config.switches[key] && key.match(/experiment(\w+)/)) {
-                    experimentName = key.match(/experiment(\w+)/)[1];
+                if (config.switches[key] && key.match(/^experiment(\w+)/)) {
+                    experimentName = key.match(/^experiment(\w+)/)[1];
                     break;
                 }
             }

--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -5,14 +5,14 @@ define([
     "modules/autoupdate",
     "modules/matchnav",
     "modules/analytics/reading",
-    "modules/story-package"
+    "modules/experiment"
 ], function (
     common,
     Expandable,
     AutoUpdate,
     MatchNav,
     Reading,
-    StoryPackage
+    Experiment
 ) {
 
     var modules = {
@@ -57,21 +57,22 @@ define([
     };
 
     var ready = function(config) {
-        var storyPackageName = localStorage.getItem('gu.storypackage') || '';
+        var experimentName = localStorage.getItem('gu.experiment') || '',
+            experiment;
 
-        if (!storyPackageName) {
+        if (!experimentName) {
             for (var key in config.switches) {
-                if (config.switches[key] && key.match(/storytelling(\w+)/)) {
-                    storyPackageName = key.match(/storytelling(\w+)/)[1];
+                if (config.switches[key] && key.match(/experiment(\w+)/)) {
+                    experimentName = key.match(/experiment(\w+)/)[1];
                     break;
                 }
             }
         }
-        storyPackageName = storyPackageName.toLowerCase();
+        experimentName = experimentName.toLowerCase();
 
-        if (storyPackageName) {
-            var story = new StoryPackage(config, storyPackageName).init();
-        } else if (!config.page.hasStoryPackage) {
+        if (experimentName) {
+            experiment = new Experiment(config, experimentName).init();
+        } else {
             common.mediator.emit("modules:related:load");
         }
 

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -85,13 +85,12 @@ define([
         transcludeRelated: function (config){
             common.mediator.on("modules:related:load", function(){
 
-                var hasStoryPackage = document.getElementById("related-trails") !== null,
-                    relatedExpandable = new Expandable({ id: 'related-trails', expanded: false }),
+                var relatedExpandable = new Expandable({ id: 'related-trails', expanded: false }),
                     host,
                     pageId,
                     url;
 
-                if (hasStoryPackage) {
+                if (config.page.hasStoryPackage) {
                     relatedExpandable.init();
                 } else {
                     host = config.page.coreNavigationUrl;

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -83,20 +83,24 @@ define([
         },
 
         transcludeRelated: function (config){
+            common.mediator.on("modules:related:load", function(){
 
-          common.mediator.on("modules:related:load", function(url){
+                var hasStoryPackage = document.getElementById("related-trails") !== null,
+                    relatedExpandable = new Expandable({ id: 'related-trails', expanded: false }),
+                    host,
+                    pageId,
+                    url;
 
-              var hasStoryPackage = document.getElementById("related-trails") !== null;
-
-              var relatedExpandable = new Expandable({ id: 'related-trails', expanded: false });
-
-              if (hasStoryPackage) {
-                  relatedExpandable.init();
-              } else {
-                  common.mediator.on('modules:related:render', relatedExpandable.init);
-                  new Related(document.getElementById('js-related'), config.switches).load(url[0]);
-              }
-          });
+                if (hasStoryPackage) {
+                    relatedExpandable.init();
+                } else {
+                    host = config.page.coreNavigationUrl;
+                    pageId = config.page.pageId;
+                    url =  host + '/related/' + pageId;
+                    common.mediator.on('modules:related:render', relatedExpandable.init);
+                    new Related(document.getElementById('js-related'), config.switches).load(url);
+                }
+            });
         },
 
         transcludeMostPopular: function (host, section, edition) {

--- a/common/app/assets/javascripts/modules/experiment.js
+++ b/common/app/assets/javascripts/modules/experiment.js
@@ -1,9 +1,9 @@
 define([
     'common',
-    'reqwest'
+    'ajax'
 ], function (
     common,
-    reqwest
+    ajax
 ) {
 
     function Experiment(config, experimentName) {
@@ -34,7 +34,7 @@ define([
         });
 
         this.load = function (url) {
-            reqwest({
+            return ajax({
                 url: url,
                 type: 'jsonp',
                 jsonpCallback: 'callback',

--- a/common/app/assets/javascripts/modules/experiment.js
+++ b/common/app/assets/javascripts/modules/experiment.js
@@ -9,19 +9,19 @@ define([
     Pad
 ) {
 
-    function StoryPackage(config, storyPackageName) {
+    function Experiment(config, experimentName) {
 
         var that = this;
 
         this.init = function () {
-            this.load('/story-package/' + storyPackageName + '/' + config.page.pageId);
+            this.load('/experiment/' + experimentName + '/' + config.page.pageId);
         };
 
         // View
         this.view = {
             render: function (html) {
                 document.getElementById('js-related').innerHTML = html;
-                common.mediator.emit('modules:story-package:render');
+                common.mediator.emit('modules:experiment:render');
                 // Remove the existing story package and its title
                 common.$g('#related-trails, h3.type-2.article-zone').remove();
             },
@@ -31,8 +31,8 @@ define([
         };
 
         // Bindings
-        common.mediator.on('modules:story-package:loaded', this.view.render);
-        common.mediator.on('modules:story-package:render', function() {
+        common.mediator.on('modules:experiment:loaded', this.view.render);
+        common.mediator.on('modules:experiment:render', function() {
             common.mediator.emit('modules:tabs:render');
         });
 
@@ -56,6 +56,6 @@ define([
         };
     }
     
-    return StoryPackage;
+    return Experiment;
 
 });

--- a/common/app/assets/javascripts/modules/experiment.js
+++ b/common/app/assets/javascripts/modules/experiment.js
@@ -1,12 +1,9 @@
 define([
-    'modules/expandable',
     'common',
     'reqwest'
 ], function (
-    Expandable,
     common,
-    reqwest,
-    Pad
+    reqwest
 ) {
 
     function Experiment(config, experimentName) {
@@ -39,12 +36,12 @@ define([
         this.load = function (url) {
             reqwest({
                 url: url,
-                type: 'html',
-                success: function (resp) {
-                    // 200: resp = body as a string
-                    // 404: resp = XHR object (the error callback isn't called, weirdly)
-                    if (typeof resp === 'string') {
-                        that.view.render(resp);
+                type: 'jsonp',
+                jsonpCallback: 'callback',
+                jsonpCallbackName: 'showExperiment',
+                success: function (json) {
+                    if (json.html) {
+                        that.view.render(json.html);
                     } else {
                         that.view.fallback();
                     }

--- a/common/app/assets/javascripts/modules/story-package.js
+++ b/common/app/assets/javascripts/modules/story-package.js
@@ -1,0 +1,61 @@
+define([
+    'modules/expandable',
+    'common',
+    'reqwest'
+], function (
+    Expandable,
+    common,
+    reqwest,
+    Pad
+) {
+
+    function StoryPackage(config, storyPackageName) {
+
+        var that = this;
+
+        this.init = function () {
+            this.load('/story-package/' + storyPackageName + '/' + config.page.pageId);
+        };
+
+        // View
+        this.view = {
+            render: function (html) {
+                document.getElementById('js-related').innerHTML = html;
+                common.mediator.emit('modules:story-package:render');
+                // Remove the existing story package and its title
+                common.$g('#related-trails, h3.type-2.article-zone').remove();
+            },
+            fallback: function () {
+                common.mediator.emit("modules:related:load");
+            }
+        };
+
+        // Bindings
+        common.mediator.on('modules:story-package:loaded', this.view.render);
+        common.mediator.on('modules:story-package:render', function() {
+            common.mediator.emit('modules:tabs:render');
+        });
+
+        this.load = function (url) {
+            reqwest({
+                url: url,
+                type: 'html',
+                success: function (resp) {
+                    // 200: resp = body as a string
+                    // 404: resp = XHR object (the error callback isn't called, weirdly)
+                    if (typeof resp === 'string') {
+                        that.view.render(resp);
+                    } else {
+                        that.view.fallback();
+                    }
+                },
+                error: function () {
+                    that.view.fallback();
+                }
+            });
+        };
+    }
+    
+    return StoryPackage;
+
+});

--- a/common/app/common/ContentApiClient.scala
+++ b/common/app/common/ContentApiClient.scala
@@ -10,7 +10,7 @@ trait ApiQueryDefaults { self: Api =>
   val supportedTypes = "type/gallery|type/article|type/video"
 
   //NOTE - do NOT add body to this list
-  val trailFields = "headline,trail-text,liveBloggingNow,thumbnail,showInRelatedContent,wordcount"
+  val trailFields = "headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount"
 
   val references = "pa-football-competition,pa-football-team"
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -61,7 +61,7 @@ class Content(delegate: ApiContent) extends Trail with Tags with MetaData {
     "series" -> series.map { _.name }.mkString(","),
     "blogs" -> blogs.map { _.name }.mkString(","),
     "commentable" -> fields.get("commentable").map(_ == "true").getOrElse(false),
-    "show-in-related" -> fields.get("showInRelatedContent").map(_.toBoolean).getOrElse(true),
+    "has-story-package" -> fields.get("hasStoryPackage").map(_.toBoolean).getOrElse(false),
     "page-code" -> fields("internalPageCode"),
     "isLive" -> isLive,
     "wordCount" -> wordCount


### PR DESCRIPTION
If an experiment is available for an article (e.g. if the article was added to an event in the admin tool), it will be ajax'd into that article to replace the story-package/related articles.

The admin switchboard activates experiments. If more than one is activated, the first wins. Experiments must have routes starting "/experiment/..", e.g. 
/experiment/foobar01/the/page/id/etc

To bypass the switch mechanism, set a localStorage key of "gu.experiment" in your browser to the name of an experiment, e.g. "foobar01"

To add a new experiment, add a route/controller/view and a switch in the admin switchboard.  The switch's name must begin with "experiment", e.g. "experiment-foobar-01"
