### PR TITLE
Fixed bug in parsing dates.

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -22,10 +22,7 @@ define('bootstraps/app', [
     pageConfig
 ) {
 
-    DateUtilities.init();
-
     var routes = function(rawConfig) {
-
         var config = pageConfig(rawConfig);
 
         domReady(function() {

--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -1,4 +1,5 @@
 define('bootstraps/app', [
+    "modules/dateUtilities",
     "domReady",
     "modules/router",
     "bootstraps/common",
@@ -9,6 +10,7 @@ define('bootstraps/app', [
     "bootstraps/gallery",
     "modules/pageconfig"
 ], function (
+    DateUtilities,
     domReady,
     Router,
     Common,
@@ -19,6 +21,8 @@ define('bootstraps/app', [
     Gallery,
     pageConfig
 ) {
+
+    DateUtilities.init();
 
     var routes = function(rawConfig) {
 

--- a/common/app/assets/javascripts/modules/dateUtilities.js
+++ b/common/app/assets/javascripts/modules/dateUtilities.js
@@ -1,0 +1,41 @@
+define(function () {
+
+    var init = function () {
+        // turns out Date.parse has problems cross browser, so thank you
+        // http://stackoverflow.com/questions/5802461/javascript-which-browsers-support-parsing-of-iso-8601-date-string-with-date-par#answer-5805595
+        Date.fromISO = (function () {
+            if (Date.parse && (Date.parse('2011-04-26T13:16:50Z') === 1303823810000)) {
+                return function (s) {
+                    return new Date(Date.parse(s));
+                }
+            } else {
+                return function (s) {
+                    var day, tz,
+                        rx = /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
+                        p = rx.exec(s) || [];
+                    if (p[1]) {
+                        day = p[1].split(/\D/).map(function (itm) {
+                            return parseInt(itm, 10) || 0;
+                        });
+                        day[1] -= 1;
+                        day = new Date(Date.UTC.apply(Date, day));
+                        if (!day.getDate()) return NaN;
+                        if (p[5]) {
+                            tz = parseInt(p[5], 10) * 60;
+                            if (p[6]) tz += parseInt(p[6], 10);
+                            if (p[4] == "+") tz *= -1;
+                            if (tz) day.setUTCMinutes(day.getUTCMinutes() + tz);
+                        }
+                        return day;
+                    }
+                    return NaN;
+                }
+            }
+        })();
+    };
+
+    return {
+        init: init
+    }
+
+});

--- a/common/app/assets/javascripts/modules/dateUtilities.js
+++ b/common/app/assets/javascripts/modules/dateUtilities.js
@@ -3,39 +3,40 @@ define(function () {
     var init = function () {
         // turns out Date.parse has problems cross browser, so thank you
         // http://stackoverflow.com/questions/5802461/javascript-which-browsers-support-parsing-of-iso-8601-date-string-with-date-par#answer-5805595
-        Date.fromISO = (function () {
-            if (Date.parse && (Date.parse('2011-04-26T13:16:50Z') === 1303823810000)) {
-                return function (s) {
+        Date.fromISO= (function(){
+            var diso= Date.parse('2011-04-26T13:16:50Z');
+            if (diso === 1303823810000) {
+                return function(s){
                     return new Date(Date.parse(s));
-                }
+                };
             } else {
-                return function (s) {
+                return function(s){
                     var day, tz,
-                        rx = /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
-                        p = rx.exec(s) || [];
+                        rx= /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
+                        p= rx.exec(s) || [];
                     if (p[1]) {
-                        day = p[1].split(/\D/).map(function (itm) {
+                        day= p[1].split(/\D/).map(function(itm){
                             return parseInt(itm, 10) || 0;
                         });
-                        day[1] -= 1;
-                        day = new Date(Date.UTC.apply(Date, day));
-                        if (!day.getDate()) return NaN;
+                        day[1]-= 1;
+                        day= new Date(Date.UTC.apply(Date, day));
+                        if (!day.getDate()) { return NaN; }
                         if (p[5]) {
-                            tz = parseInt(p[5], 10) * 60;
-                            if (p[6]) tz += parseInt(p[6], 10);
-                            if (p[4] == "+") tz *= -1;
-                            if (tz) day.setUTCMinutes(day.getUTCMinutes() + tz);
+                            tz = parseInt(p[5], 10)*60;
+                            if (p[6]) { tz += parseInt(p[6], 10); }
+                            if (p[4] === "+") { tz*= -1; }
+                            if (tz) { day.setUTCMinutes(day.getUTCMinutes()+ tz); }
                         }
                         return day;
                     }
                     return NaN;
-                }
+                };
             }
-        })();
+        }());
     };
 
     return {
         init: init
-    }
+    };
 
 });

--- a/common/app/assets/javascripts/modules/dateUtilities.js
+++ b/common/app/assets/javascripts/modules/dateUtilities.js
@@ -1,8 +1,8 @@
-define(function () {
+define((function () {
 
     if (!Date.parse || Date.parse("2012-01-01T01:01:01") !== 1325379661000) {
        
-        // fix inconsistent Date.parse implementations 
+        // fix inconsistent Date.parse implementations
         Date.prototype.parse = function (s) {
             var day, tz,
                 rx= /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
@@ -26,4 +26,4 @@ define(function () {
         };
 
     }
-}());
+}()));

--- a/common/app/assets/javascripts/modules/dateUtilities.js
+++ b/common/app/assets/javascripts/modules/dateUtilities.js
@@ -1,42 +1,29 @@
 define(function () {
 
-    var init = function () {
-        // turns out Date.parse has problems cross browser, so thank you
-        // http://stackoverflow.com/questions/5802461/javascript-which-browsers-support-parsing-of-iso-8601-date-string-with-date-par#answer-5805595
-        Date.fromISO= (function(){
-            var diso= Date.parse('2011-04-26T13:16:50Z');
-            if (diso === 1303823810000) {
-                return function(s){
-                    return new Date(Date.parse(s));
-                };
-            } else {
-                return function(s){
-                    var day, tz,
-                        rx= /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
-                        p= rx.exec(s) || [];
-                    if (p[1]) {
-                        day= p[1].split(/\D/).map(function(itm){
-                            return parseInt(itm, 10) || 0;
-                        });
-                        day[1]-= 1;
-                        day= new Date(Date.UTC.apply(Date, day));
-                        if (!day.getDate()) { return NaN; }
-                        if (p[5]) {
-                            tz = parseInt(p[5], 10)*60;
-                            if (p[6]) { tz += parseInt(p[6], 10); }
-                            if (p[4] === "+") { tz*= -1; }
-                            if (tz) { day.setUTCMinutes(day.getUTCMinutes()+ tz); }
-                        }
-                        return day;
-                    }
-                    return NaN;
-                };
+    if (!Date.parse || Date.parse("2012-01-01T01:01:01") !== 1325379661000) {
+        
+        // fix inconsistent Date.parse implementations 
+        Date.prototype.parse = function (s) {
+            var day, tz,
+                rx= /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
+                p= rx.exec(s) || [];
+            if (p[1]) {
+                day= p[1].split(/\D/).map(function(itm){
+                    return parseInt(itm, 10) || 0;
+                });
+                day[1]-= 1;
+                day= new Date(Date.UTC.apply(Date, day));
+                if (!day.getDate()) { return NaN; }
+                if (p[5]) {
+                    tz = parseInt(p[5], 10)*60;
+                    if (p[6]) { tz += parseInt(p[6], 10); }
+                    if (p[4] === "+") { tz*= -1; }
+                    if (tz) { day.setUTCMinutes(day.getUTCMinutes()+ tz); }
+                }
+                return day;
             }
-        }());
-    };
+            return NaN;
+        };
 
-    return {
-        init: init
-    };
-
+    }
 });

--- a/common/app/assets/javascripts/modules/dateUtilities.js
+++ b/common/app/assets/javascripts/modules/dateUtilities.js
@@ -1,7 +1,7 @@
 define(function () {
 
     if (!Date.parse || Date.parse("2012-01-01T01:01:01") !== 1325379661000) {
-        
+       
         // fix inconsistent Date.parse implementations 
         Date.prototype.parse = function (s) {
             var day, tz,
@@ -22,8 +22,8 @@ define(function () {
                 }
                 return day;
             }
-            return NaN;
+            return ""; // best to fail silently here
         };
 
     }
-});
+}());

--- a/common/app/assets/javascripts/modules/pageconfig.js
+++ b/common/app/assets/javascripts/modules/pageconfig.js
@@ -5,35 +5,6 @@
  */
 define(['modules/pad', "common"], function (pad, common) {
 
-    // turns out Date.parse has problems cross browser, so thank you
-    // http://stackoverflow.com/questions/5802461/javascript-which-browsers-support-parsing-of-iso-8601-date-string-with-date-par#answer-5805595
-    function parseDate(d) {
-        var diso= Date.parse('2011-04-26T13:16:50Z');
-        if(diso === 1303823810000){
-            return new Date(Date.parse(d));
-        } else {
-            var day, tz,
-                rx= /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
-                p= rx.exec(d) || [];
-            if(p[1]){
-                day= p[1].split(/\D/).map(function(itm){
-                    return parseInt(itm, 10) || 0;
-                });
-                day[1]-= 1;
-                day= new Date(Date.UTC.apply(Date, day));
-                if(!day.getDate()) return NaN;
-                if(p[5]){
-                    tz= parseInt(p[5], 10)*60;
-                    if(p[6]) tz += parseInt(p[6], 10);
-                    if(p[4]== "+") tz*= -1;
-                    if(tz) day.setUTCMinutes(day.getUTCMinutes()+ tz);
-                }
-                return day;
-            }
-            return NaN;
-        }
-    }
-
     return function(config){
         return common.extend(
             {
@@ -53,7 +24,7 @@ define(['modules/pad', "common"], function (pad, common) {
                     // assumes an 'internet' date such as 2012-12-23T22:30:00.000Z
                     // http://www.ietf.org/rfc/rfc3339.txt
                     if(config.page.webPublicationDate){
-                        return parseDate(config.page.webPublicationDate)
+                        return Date.fromISO(config.page.webPublicationDate);
                     }
                 },
 

--- a/common/app/assets/javascripts/modules/pageconfig.js
+++ b/common/app/assets/javascripts/modules/pageconfig.js
@@ -24,7 +24,7 @@ define(['modules/pad', "common"], function (pad, common) {
                     // assumes an 'internet' date such as 2012-12-23T22:30:00.000Z
                     // http://www.ietf.org/rfc/rfc3339.txt
                     if(config.page.webPublicationDate){
-                        return Date.parse(config.page.webPublicationDate);
+                        return (new Date().parse(config.page.webPublicationDate));
                     }
                 },
 

--- a/common/app/assets/javascripts/modules/pageconfig.js
+++ b/common/app/assets/javascripts/modules/pageconfig.js
@@ -9,7 +9,7 @@ define(['modules/pad', "common"], function (pad, common) {
     // http://stackoverflow.com/questions/5802461/javascript-which-browsers-support-parsing-of-iso-8601-date-string-with-date-par#answer-5805595
     function parseDate(d) {
         var diso= Date.parse('2011-04-26T13:16:50Z');
-        if(diso === 1303823810000 && false){
+        if(diso === 1303823810000){
             return new Date(Date.parse(d));
         } else {
             var day, tz,

--- a/common/app/assets/javascripts/modules/pageconfig.js
+++ b/common/app/assets/javascripts/modules/pageconfig.js
@@ -4,6 +4,36 @@
     Common functions to simplify access to page data
  */
 define(['modules/pad', "common"], function (pad, common) {
+
+    // turns out Date.parse has problems cross browser, so thank you
+    // http://stackoverflow.com/questions/5802461/javascript-which-browsers-support-parsing-of-iso-8601-date-string-with-date-par#answer-5805595
+    function parseDate(d) {
+        var diso= Date.parse('2011-04-26T13:16:50Z');
+        if(diso === 1303823810000 && false){
+            return new Date(Date.parse(d));
+        } else {
+            var day, tz,
+                rx= /^(\d{4}\-\d\d\-\d\d([tT][\d:\.]*)?)([zZ]|([+\-])(\d\d):(\d\d))?$/,
+                p= rx.exec(d) || [];
+            if(p[1]){
+                day= p[1].split(/\D/).map(function(itm){
+                    return parseInt(itm, 10) || 0;
+                });
+                day[1]-= 1;
+                day= new Date(Date.UTC.apply(Date, day));
+                if(!day.getDate()) return NaN;
+                if(p[5]){
+                    tz= parseInt(p[5], 10)*60;
+                    if(p[6]) tz += parseInt(p[6], 10);
+                    if(p[4]== "+") tz*= -1;
+                    if(tz) day.setUTCMinutes(day.getUTCMinutes()+ tz);
+                }
+                return day;
+            }
+            return NaN;
+        }
+    }
+
     return function(config){
         return common.extend(
             {
@@ -23,7 +53,7 @@ define(['modules/pad', "common"], function (pad, common) {
                     // assumes an 'internet' date such as 2012-12-23T22:30:00.000Z
                     // http://www.ietf.org/rfc/rfc3339.txt
                     if(config.page.webPublicationDate){
-                        return new Date(Date.parse(config.page.webPublicationDate));
+                        return parseDate(config.page.webPublicationDate)
                     }
                 },
 

--- a/common/app/assets/javascripts/modules/pageconfig.js
+++ b/common/app/assets/javascripts/modules/pageconfig.js
@@ -24,7 +24,7 @@ define(['modules/pad', "common"], function (pad, common) {
                     // assumes an 'internet' date such as 2012-12-23T22:30:00.000Z
                     // http://www.ietf.org/rfc/rfc3339.txt
                     if(config.page.webPublicationDate){
-                        return Date.fromISO(config.page.webPublicationDate);
+                        return Date.parse(config.page.webPublicationDate);
                     }
                 },
 


### PR DESCRIPTION
Turns out that Date.parse is not exactly cross browser compatible, and was causing error spikes.

Quick Copy n Paste job from Stackoverflow sorted it.

Here is a graph of the error spikes on Football server...
![football_errors](https://f.cloud.github.com/assets/76709/152569/ace14bce-75cb-11e2-9a9c-f8eb8a628721.png)
