### PR TITLE
Track content api timeouts

### DIFF
--- a/common/app/common/ContentApiClient.scala
+++ b/common/app/common/ContentApiClient.scala
@@ -79,7 +79,7 @@ class ContentApiClient(configuration: GuardianConfiguration) extends Api with Ap
           throw e
       }
     }
-  } //java.net.ConnectException
+  }
 
   object metrics {
     object ContentApiHttpTimingMetric extends TimingMetric(

--- a/common/app/common/ContentApiClient.scala
+++ b/common/app/common/ContentApiClient.scala
@@ -74,12 +74,16 @@ class ContentApiClient(configuration: GuardianConfiguration) extends Api with Ap
 
     metrics.ContentApiHttpTimingMetric.measure {
       try { super.fetch(url, parameters + ("user-tier" -> "internal")) } catch {
-        case e: Throwable if e.getCause.getClass == classOf[TimeoutException] =>
+        case e: Throwable if isTimeout(e) =>
           metrics.ContentApiHttpTimeoutCountMetric.increment()
           throw e
       }
     }
   }
+
+  private def isTimeout(e: Throwable): Boolean = Option(e.getCause)
+    .map(_.getClass == classOf[TimeoutException])
+    .getOrElse(false)
 
   object metrics {
     object ContentApiHttpTimingMetric extends TimingMetric(


### PR DESCRIPTION
It feels like we are getting a lot of these lately, Have added a metric to count them.
