### PR TITLE
Gallery: Tap the image to advance the gallery

### DIFF
--- a/common/app/assets/javascripts/modules/gallery.js
+++ b/common/app/assets/javascripts/modules/gallery.js
@@ -9,6 +9,7 @@ define(["bean", "swipe", "common", "modules/detect", "modules/url", "bonzo"], fu
             galleryConfig: {
                 nextLink: document.getElementById('js-gallery-next'),
                 prevLink: document.getElementById('js-gallery-prev'),
+                image: document.getElementById('js-gallery-img'),
                 currentIndex: urlParams.index || 0,
                 currentSlideClassName: 'js-current-gallery-slide',
                 inSwipeMode: false,
@@ -75,6 +76,12 @@ define(["bean", "swipe", "common", "modules/detect", "modules/url", "bonzo"], fu
 
                     bean.add(view.galleryConfig.prevLink, 'click', function(e) {
                         view.galleryConfig.gallerySwipe.prev();
+                        e.preventDefault();
+                    });
+
+                    // bind an image tap/click to advance the gallery
+                    bean.add(view.galleryConfig.image, 'click', function(e) {
+                        view.galleryConfig.gallerySwipe.next();
                         e.preventDefault();
                     });
 


### PR DESCRIPTION
I can't test this due to incompatible gen-idea plugins but it aims to allow you to tap on the image to advance the gallery rather than having to scroll back up to the navigation buttons if the swipe isn't recognised (Firefox Beta for Android).
