### PR TITLE
Added a social counts endpoint for a piece of content.

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -94,6 +94,10 @@ class GuardianConfiguration(
       .getOrElse(throw new RuntimeException("Front config url not set"))
   }
 
+  object google {
+    lazy val googlePlusApiKey: Option[String] = configuration.getStringProperty("google.plus.api.key")
+  }
+
   object pa {
     lazy val apiKey = configuration.getStringProperty("pa.api.key")
       .getOrElse(throw new RuntimeException("unable to load pa api key"))

--- a/core-navigation/app/controllers/SocialCountController.scala
+++ b/core-navigation/app/controllers/SocialCountController.scala
@@ -1,0 +1,92 @@
+package controllers
+
+import play.api.mvc.{ Action, Controller }
+import common.{ JsonComponent, Logging }
+import play.api.libs.ws.WS
+import java.net.URLEncoder.encode
+import play.api.libs.concurrent.Promise.sequence
+import model.Cached
+import java.net.URI
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+private case class Social(count: Int)
+
+object SocialCountController extends Controller with Logging {
+
+  import conf.Configuration.google.googlePlusApiKey
+
+  def render(url: String) = Action { implicit request =>
+    val encodedUrl = encode(url, "UTF-8")
+
+    val host = new URI(url).getHost
+
+    // we are not proxying share counts for the entire internet
+    if (!host.contains("guardian.co.uk") && !host.contains("guardiannews.com")) { Forbidden("Will only lookup Guardian pages") }
+    else {
+      val promiseOfTwitter = WS.url("http://urls.api.twitter.com/1/urls/count.json?url=%s".format(encodedUrl)).get()
+        .map { response => socialOrBust("twitter") { Social((response.json \ "count").as[Int]) }
+        }
+
+      val promiseOfFacebook = WS.url("http://api.ak.facebook.com/restserver.php?v=1.0&method=links.getStats&urls=%s&format=json".format(encodedUrl)).get()
+        .map { response => socialOrBust("facebook") { Social((response.json \\ "share_count")(0).as[Int]) }
+        }
+
+      val promiseOfReddit = WS.url("http://buttons.reddit.com/button_info.json?url=%s".format(encodedUrl)).get()
+        .map { response => socialOrBust("reddit") { Social((response.json \\ "ups")(0).as[Int]) }
+        }
+
+      val promiseOflinkedIn = WS.url("http://www.linkedin.com/countserv/count/share?url=%s&format=json".format(encodedUrl)).get()
+        .map { response => socialOrBust("linkedin") { Social((response.json \ "count").as[Int]) }
+        }
+
+      val promiseOfGooglePlus = googlePlusApiKey.map { key =>
+        WS.url("https://clients6.google.com/rpc?key=" + key).withHeaders("Content-Type" -> "application/json").post {
+          """
+            |[
+            | {
+            |   "method":"pos.plusones.get",
+            |   "id":"p",
+            |   "params":{
+            |     "nolog":true,
+            |     "id":"%s",
+            |     "source":"widget",
+            |     "userId":"@viewer",
+            |     "groupId":"@self"
+            |   },
+            |   "jsonrpc":"2.0",
+            |   "key":"p",
+            |   "apiVersion":"v1"
+            | }
+            |]
+          """.stripMargin.format(url)
+        }.map { response =>
+          socialOrBust("googleplus") {
+            Social(((response.json \\ "metadata")(0) \ "globalCounts" \ "count").as[Int])
+          }
+        }
+      }.toSeq
+
+      val countsWithTimeout =
+        (Seq(promiseOfFacebook, promiseOfTwitter, promiseOfReddit, promiseOflinkedIn) ++ promiseOfGooglePlus)
+          .map(_.orTimeout(None, 300, MILLISECONDS))
+
+      Async {
+        sequence(countsWithTimeout).map { _.map { _.left.getOrElse(None) } }
+          .map { social =>
+            Cached(900) {
+              JsonComponent(social.flatten: _*)
+            }
+          }
+      }
+    }
+  }
+
+  //make sure we do not crash out entire call just because we cannot parse one result
+  private def socialOrBust(name: String)(block: => Social): Option[(String, Social)] = try {
+    Some(name -> block)
+  } catch {
+    case e: Throwable =>
+      log.error("Error accessing " + name, e)
+      None
+  }
+}

--- a/core-navigation/conf/routes
+++ b/core-navigation/conf/routes
@@ -4,10 +4,12 @@
 
 # For dev machines
 GET    /assets/*file                    controllers.Assets.at(path="/public", file)
-GET    /most-read.json                controllers.MostPopularController.renderJson(path = "")
-GET    /most-read/*path.json          controllers.MostPopularController.renderJson(path)
-GET    /most-read                     controllers.MostPopularController.renderNoJavascript(path = "")
-GET    /most-read/*path               controllers.MostPopularController.renderNoJavascript(path)
+GET    /most-read.json                  controllers.MostPopularController.renderJson(path = "")
+GET    /most-read/*path.json            controllers.MostPopularController.renderJson(path)
+GET    /most-read                       controllers.MostPopularController.renderNoJavascript(path = "")
+GET    /most-read/*path                 controllers.MostPopularController.renderNoJavascript(path)
 GET    /top-stories                     controllers.TopStoriesController.render()
 GET    /top-stories.json                controllers.TopStoriesController.renderJson()
 GET    /related/*path                   controllers.RelatedController.render(path)
+
+GET    /social-counts                   controllers.SocialCountController.render(url: String)

--- a/core-navigation/conf/routes
+++ b/core-navigation/conf/routes
@@ -11,5 +11,4 @@ GET    /most-read/*path                 controllers.MostPopularController.render
 GET    /top-stories                     controllers.TopStoriesController.render()
 GET    /top-stories.json                controllers.TopStoriesController.renderJson()
 GET    /related/*path                   controllers.RelatedController.render(path)
-
 GET    /social-counts                   controllers.SocialCountController.render(url: String)

--- a/core-navigation/test/SocialCountControllerTest.scala
+++ b/core-navigation/test/SocialCountControllerTest.scala
@@ -1,0 +1,45 @@
+package test
+
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.FlatSpec
+import play.api.test.Helpers._
+import play.api.test.{ FakeHeaders, FakeRequest }
+import play.api.mvc.AnyContentAsEmpty
+
+class SocialCountControllerTest extends FlatSpec with ShouldMatchers {
+
+  implicit val request = new FakeRequest("GET", "http://localhost:9000", FakeHeaders(), AnyContentAsEmpty) {
+    override lazy val queryString = Map("callback" -> Seq("counts"))
+  }
+
+  "Social Count Controller" should "not proxy share counts for the entire internet" in Fake {
+    val result = controllers.SocialCountController.render("http://someoneelse.com")(request)
+    status(result) should be(403)
+  }
+
+  it should "provide share counts for guardian.co.uk" in {
+    Fake {
+      val result = controllers.SocialCountController.render("http://www.guardian.co.uk/commentisfree?")(request)
+
+      status(result) should be(200)
+
+      val body = contentAsString(result)
+
+      body.matches(""".*"facebook":\{"count":[0-9]+\}.*""") should be(true)
+      body.matches(""".*"twitter":\{"count":[0-9]+\}.*""") should be(true)
+    }
+  }
+
+  it should "provide share counts for guardiannews.com" in {
+    Fake {
+      val result = controllers.SocialCountController.render("http://www.guardiannews.com/commentisfree?")(request)
+
+      status(result) should be(200)
+
+      val body = contentAsString(result)
+
+      body.matches(""".*"facebook":\{"count":[0-9]+\}.*""") should be(true)
+      body.matches(""".*"twitter":\{"count":[0-9]+\}.*""") should be(true)
+    }
+  }
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -16,7 +16,8 @@ GET    /most-read                                           controllers.MostPopu
 GET    /most-read/*path                                     controllers.MostPopularController.renderNoJavascript(path)
 GET    /top-stories                                         controllers.TopStoriesController.render()
 GET    /top-stories.json                                    controllers.TopStoriesController.renderJson()
-GET     /related/*path                                      controllers.RelatedController.render(path)
+GET    /related/*path                                       controllers.RelatedController.render(path)
+GET    /social-counts                                       controllers.SocialCountController.render(url: String)
 
 #Stories
 GET    /stories                                             controllers.StoryController.latest()


### PR DESCRIPTION
Work in progress (counts are not actually being used yet), I just want to know if it is worth doing this ourselves (we control data format, quotas, cache times etc) or do we hit a 3rd party directly.

Simple controller that returns share counts for
Facebook, Twitter, Linkedin, Reddit, Google plus (requires api key)

You hit a url that looks like... `http://localhost:9000/social-counts?url=http://www.guardian.co.uk/commentisfree&callback=counts`

and you get back data that looks like...

```
counts({
  "linkedin":{"count":164},
  "facebook":{"count":64},
  "reddit":{"count":1},
  "refreshStatus":true,
  "googleplus":{"count":17},
  "twitter":{"count":799}
});
```
