### PR TITLE
Fixed competition table page

### DIFF
--- a/football/app/controllers/LeagueTableController.scala
+++ b/football/app/controllers/LeagueTableController.scala
@@ -67,7 +67,7 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
   }
 
   def renderCompetition(competition: String) = Action { implicit request =>
-    loadTables.find(_.competition.url.endsWith(s"/competition")).map { table =>
+    loadTables.find(_.competition.url.endsWith(s"/$competition")).map { table =>
 
       val page = new Page(
         Some(s"http://www.guardian.co.uk/football/$competition/tables"),

--- a/football/test/LeagueTablesFeatureTest.scala
+++ b/football/test/LeagueTablesFeatureTest.scala
@@ -44,6 +44,7 @@ class LeagueTablesFeatureTest extends FeatureSpec with GivenWhenThen with Should
       HtmlUnit("/football/premierleague/table") { browser =>
         import browser._
 
+        $("h1").getTexts should contain("Premier League table")
         $(".table-football-body td").getTexts should contain("Arsenal")
       }
 


### PR DESCRIPTION
Competition tables now work again. By some blind (bad) luck the tests were still passing due to a redirect. I have fixed the test so that it will actually fail if this happens again.
