### PR TITLE
Tabs refactor + stickness

### DIFF
--- a/common/app/assets/javascripts/modules/tabs.js
+++ b/common/app/assets/javascripts/modules/tabs.js
@@ -62,7 +62,7 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
                 bean.add(tabSet, 'click', function (e) {
                     var targetElm = e.target;
                     // if we use tabSet instead of this, it sets all tabs to use the last set in the loop
-                    var tabContainer = targetElm.parentNode.parentNode.parentNode; // Horrible!
+                    var tabContainer = targetElm.parentNode.parentNode;
                     // verify they clicked an <a> element
                     if (targetElm.nodeName.toLowerCase() === "a") {
                         vHeight = view.showTab(tabContainer, targetElm, e);
@@ -84,10 +84,10 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
                             vScroll = window.pageYOffset || document.documentElement.scrollTop;
 
                             if( !vFixed && vScroll >= vPos && vScroll <= vPos+vHeight ) {
-                                bonzo(tabSet).addClass('tabs-fix');
+                                bonzo(tabSet).addClass('tabs-fixed');
                                 vFixed = true;
                             } else if( vFixed && (vScroll < vPos || vScroll > vPos+vHeight)) {
-                                bonzo(tabSet).removeClass('tabs-fix');
+                                bonzo(tabSet).removeClass('tabs-fixed');
                                 vFixed = false;
                             }
                         });

--- a/common/app/assets/javascripts/modules/tabs.js
+++ b/common/app/assets/javascripts/modules/tabs.js
@@ -36,8 +36,6 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
 
                 // only do this if we know the href was a tab ID, not a URL
                 originalEvent.preventDefault();
-
-                return bonzo(paneToShow).offset().height;
             }
         };
 
@@ -46,47 +44,52 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
             var ols = common.$g('.tabs-container').each(function (container) {
 
                 var tabSet = common.$g('ol.js-tabs', container)[0],
-                    vPos = bonzo(tabSet).offset().top,
-                    vFixed = false,
+                    tabSetHeight = 0,
+                    vPos = 0,
                     vHeight = 0,
-                    vScroll = 0;
+                    vScroll = 0,
+                    vFixed = false;
 
-                window.console.log(container);
-                window.console.log(tabSet);
+                if(tabSet) {
 
-                if(tabSet.getAttribute('data-is-bound') === true) {
-                    return false;
-                }
-
-                bean.add(tabSet, 'click', function (e) {
-                    var targetElm = e.target;
-                    // verify they clicked an <a> element
-                    if (targetElm.nodeName.toLowerCase() === "a") {
-                        vHeight = view.showTab(container, targetElm, e);
+                    if(tabSet.getAttribute('data-is-bound') === true) {
+                        return false;
                     }
-                    if (vScroll > vPos) {
-                        window.scrollTo(0, vPos);
-                    }
-                });
 
-                if (bonzo(container).hasClass('tabs-fixable')) {
+                    tabSetHeight = bonzo(tabSet).offset().height;
+                    vPos = bonzo(tabSet).offset().top;
 
-                    vHeight = bonzo(container).offset().height;
-
-                    bean.add(window, 'scroll', function (e) {
-                        vScroll = window.pageYOffset || document.documentElement.scrollTop;
-
-                        if( !vFixed && vScroll >= vPos && vScroll <= vPos+vHeight ) {
-                            bonzo(tabSet).addClass('tabs-fixed');
-                            vFixed = true;
-                        } else if( vFixed && (vScroll < vPos || vScroll > vPos+vHeight)) {
-                            bonzo(tabSet).removeClass('tabs-fixed');
-                            vFixed = false;
+                    bean.add(tabSet, 'click', function (e) {
+                        var targetElm = e.target;
+                        // verify they clicked an <a> element
+                        if (targetElm.nodeName.toLowerCase() === "a") {
+                            view.showTab(container, targetElm, e);
+                            vHeight = bonzo(container).offset().height - tabSetHeight;
+                            if (vScroll > vPos) {
+                                window.scrollTo(0, vPos);
+                            }
                         }
                     });
+
+                    if (bonzo(container).hasClass('tabs-fixable')) {
+
+                        vHeight = bonzo(container).offset().height - tabSetHeight;
+
+                        bean.add(window, 'scroll', function (e) {
+                            vScroll = window.pageYOffset || document.documentElement.scrollTop;
+
+                            if( !vFixed && vScroll >= vPos && vScroll <= vPos + vHeight ) {
+                                bonzo(tabSet).addClass('tabs-fixed');
+                                vFixed = true;
+                            } else if( vFixed && (vScroll < vPos || vScroll > vPos + vHeight)) {
+                                bonzo(tabSet).removeClass('tabs-fixed');
+                                vFixed = false;
+                            }
+                        });
+                    }
+        
+                    tabSet.setAttribute('data-is-bound', true);
                 }
-    
-                tabSet.setAttribute('data-is-bound', true);
             });
         };
 

--- a/common/app/assets/javascripts/modules/tabs.js
+++ b/common/app/assets/javascripts/modules/tabs.js
@@ -19,14 +19,14 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
 
         var view = {
 
-            showTab: function (tabSet, clickedTab, originalEvent) {
+            showTab: function (container, clickedTab, originalEvent) {
 
                 // find the active tab in the set. returns an array of 1 item, hence [0]
-                var currentTab = common.$g('.tabs-selected a', tabSet)[0];
+                var currentTab = common.$g('.tabs-selected a', container)[0];
 
                 // trim the leading # and find the matching panel element
-                var paneToShow = document.getElementById(clickedTab.getAttribute('href').substring(1));
-                var paneToHide = document.getElementById(currentTab.getAttribute('href').substring(1));
+                var paneToShow = container.querySelector('#' + clickedTab.getAttribute('href').substring(1));
+                var paneToHide = container.querySelector('#' + currentTab.getAttribute('href').substring(1));
 
                 // show hide stuff
                 bonzo(currentTab.parentNode).removeClass('tabs-selected');
@@ -42,15 +42,17 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
         };
 
         this.init = function () {
-            var tabSelector = 'ol.js-tabs';
 
-            var ols = common.$g(tabSelector).each(function (tabSet) {
+            var ols = common.$g('.tabs-container').each(function (container) {
 
-                var vPos = bonzo(tabSet).offset().top,
+                var tabSet = common.$g('ol.js-tabs', container)[0],
+                    vPos = bonzo(tabSet).offset().top,
                     vFixed = false,
                     vHeight = 0,
-                    vScroll = 0,
-                    containerEl;
+                    vScroll = 0;
+
+                window.console.log(container);
+                window.console.log(tabSet);
 
                 if(tabSet.getAttribute('data-is-bound') === true) {
                     return false;
@@ -58,37 +60,30 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
 
                 bean.add(tabSet, 'click', function (e) {
                     var targetElm = e.target;
-                    // if we use tabSet instead of this, it sets all tabs to use the last set in the loop
-                    var tabContainer = targetElm.parentNode.parentNode;
                     // verify they clicked an <a> element
                     if (targetElm.nodeName.toLowerCase() === "a") {
-                        vHeight = view.showTab(tabContainer, targetElm, e);
+                        vHeight = view.showTab(container, targetElm, e);
                     }
                     if (vScroll > vPos) {
                         window.scrollTo(0, vPos);
                     }
                 });
 
-                if (bonzo(tabSet.parentNode).hasClass('tabs-fixable')) {
+                if (bonzo(container).hasClass('tabs-fixable')) {
 
-                    // Assumes 1st visible tab pane is associated with this tabset. So doesn't yet support pages with multiple tabs
-                    containerEl = document.querySelector('.tabs-pane:not(.js-hidden)');
+                    vHeight = bonzo(container).offset().height;
 
-                    if (containerEl) {
-                        vHeight = bonzo(containerEl).offset().height;
+                    bean.add(window, 'scroll', function (e) {
+                        vScroll = window.pageYOffset || document.documentElement.scrollTop;
 
-                        bean.add(window, 'scroll', function (e) {
-                            vScroll = window.pageYOffset || document.documentElement.scrollTop;
-
-                            if( !vFixed && vScroll >= vPos && vScroll <= vPos+vHeight ) {
-                                bonzo(tabSet).addClass('tabs-fixed');
-                                vFixed = true;
-                            } else if( vFixed && (vScroll < vPos || vScroll > vPos+vHeight)) {
-                                bonzo(tabSet).removeClass('tabs-fixed');
-                                vFixed = false;
-                            }
-                        });
-                    }
+                        if( !vFixed && vScroll >= vPos && vScroll <= vPos+vHeight ) {
+                            bonzo(tabSet).addClass('tabs-fixed');
+                            vFixed = true;
+                        } else if( vFixed && (vScroll < vPos || vScroll > vPos+vHeight)) {
+                            bonzo(tabSet).removeClass('tabs-fixed');
+                            vFixed = false;
+                        }
+                    });
                 }
     
                 tabSet.setAttribute('data-is-bound', true);

--- a/common/app/assets/javascripts/modules/tabs.js
+++ b/common/app/assets/javascripts/modules/tabs.js
@@ -41,11 +41,8 @@ define(['common', 'bean', 'bonzo', 'qwery'], function (common, bean, bonzo, qwer
             }
         };
 
-        this.init = function (tabSelector) {
-
-            if (!tabSelector) {
-                tabSelector = 'ol.js-tabs';
-            }
+        this.init = function () {
+            var tabSelector = 'ol.js-tabs';
 
             var ols = common.$g(tabSelector).each(function (tabSet) {
 

--- a/common/app/assets/stylesheets/module/_tabs.less
+++ b/common/app/assets/stylesheets/module/_tabs.less
@@ -78,28 +78,29 @@
     border-left: none;
 }
 
-.tabs-fixable {
-    position: relative;
-}
+@media (max-width: 640px) {
 
-.tabs-fixable .tabs {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 42px;
-    padding: 0px @gutter;
-}
+    .tabs-fixable {
+        position: relative;
+    }
 
-.tabs-fixable .tabs.tabs-fixed {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 2;
-    .box-shadow(0 8px 6px -6px #999);
-} 
+    .tabs-fixable .tabs {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 42px;
+        padding: 0px @gutter;
+        z-index: 2;
+    }
 
-.tabs-fixable .tabs-content {
-    padding-top: 42px;  
+    .tabs-fixable .tabs.tabs-fixed {
+        position: fixed;
+        .box-shadow(0 8px 6px -6px #999);
+    }
+
+    .tabs-fixable .tabs-content {
+        padding-top: 42px;  
+    }
+
 }

--- a/common/app/assets/stylesheets/module/_tabs.less
+++ b/common/app/assets/stylesheets/module/_tabs.less
@@ -1,12 +1,14 @@
 @tabBorderWidth: 2px;
 
+.tabs-container {
+    padding: 0 @gutter;
+}
+
 .tabs {
-    border: @tabBorderWidth solid @mushroom;
-    margin: @baseline @gutter 0 @gutter;
+    margin: 0;
+    padding: 0;
     border-bottom: none;
-    padding: 0px;
     list-style-type: none;
-    background: @mushroom;
     overflow: hidden;
 }
 
@@ -14,12 +16,13 @@
     width: 50%;
     float: left;
     margin: 0px;
-    padding: 0px;
-}
+    background: @mushroom;
+ }
 
 .tabs a {
     text-align: center;
     color: #545454;
+    margin: @tabBorderWidth @tabBorderWidth 0 @tabBorderWidth;
     padding: @baseline*2;
     display: block;
     font-weight: normal;
@@ -49,7 +52,6 @@
 
 .tabs-content {
     clear: both;
-    margin: 0px @gutter;
     border: @tabBorderWidth solid @mushroom;
     border-top: none;
 }
@@ -76,16 +78,28 @@
     border-left: none;
 }
 
-.tabs-fixable .tabs-content {
-    margin-top: height: 42px;  
+.tabs-fixable {
+    position: relative;
 }
 
-.tabs.tabs-fixed  {
-  position: fixed;
-  top: 0;
-  width: 100%;
-  margin: 0 0 0 -16px;
-  padding: 0 0 0 16px;
-  z-index: 2;
-  .box-shadow(0 8px 6px -6px #999);
+.tabs-fixable .tabs {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 42px;
+    padding: 0px @gutter;
+}
+
+.tabs-fixable .tabs.tabs-fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 2;
+    .box-shadow(0 8px 6px -6px #999);
 } 
+
+.tabs-fixable .tabs-content {
+    padding-top: 42px;  
+}

--- a/common/app/assets/stylesheets/module/_tabs.less
+++ b/common/app/assets/stylesheets/module/_tabs.less
@@ -10,6 +10,7 @@
     border-bottom: none;
     list-style-type: none;
     overflow: hidden;
+    background: #ffffff;
 }
 
 .tabs li {
@@ -97,6 +98,10 @@
     .tabs-fixable .tabs.tabs-fixed {
         position: fixed;
         .box-shadow(0 8px 6px -6px #999);
+    }
+
+    .tabs-fixable .tabs li {
+        height: 42px;
     }
 
     .tabs-fixable .tabs-content {

--- a/common/app/assets/stylesheets/module/_tabs.less
+++ b/common/app/assets/stylesheets/module/_tabs.less
@@ -75,3 +75,17 @@
 .tabs-multiple li:last-child {
     border-left: none;
 }
+
+.tabs-fixable .tabs-content {
+    margin-top: height: 42px;  
+}
+
+.tabs.tabs-fixed  {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  margin: 0 0 0 -16px;
+  padding: 0 0 0 16px;
+  z-index: 2;
+  .box-shadow(0 8px 6px -6px #999);
+} 

--- a/common/app/assets/stylesheets/module/_tabs.less
+++ b/common/app/assets/stylesheets/module/_tabs.less
@@ -30,9 +30,10 @@
     text-decoration: none;
 }
 
-@media screen and (max-width: 300px) {
+@media screen and (max-width: 18.75em) {
     .tabs li a {
         font-size: 14px;
+        font-size: 1.4rem;
     }
 }
 
@@ -69,7 +70,7 @@
 
 .tabs-multiple li {
     display: table-cell;
-    border-left: 2px solid #ffffff;
+    border-left: @tabBorderWidth solid #ffffff;
     width: auto;
     float: none;
 }
@@ -79,7 +80,7 @@
     border-left: none;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 40em) {
 
     .tabs-fixable {
         position: relative;

--- a/common/app/assets/stylesheets/module/experiments/_story.less
+++ b/common/app/assets/stylesheets/module/experiments/_story.less
@@ -113,16 +113,3 @@ a.trail-story-title {
   color: @newsRed;
 }
 
-.tabs-fixable {
-  height: 42px;
-}
-
-.tabs.tabs-fix  {
-  position: fixed;
-  top: 0;
-  width: 100%;
-  margin: 0 0 0 -16px;
-  padding: 0 0 0 16px;
-  z-index: 2;
-  .box-shadow(0 8px 6px -6px #999);
-} 

--- a/common/test/assets/javascripts/runner.html
+++ b/common/test/assets/javascripts/runner.html
@@ -254,26 +254,29 @@
         <!-- Tabs.spec -->
         <p id="tabs-test">
 
-          <ol class="tabs js-tabs">
-              <li class="tabs-selected"><a id="tab1" href="#tab1panel">Foo</a></li>
-              <li><a id="tab2" href="#tab2panel">Bar</a></li>
-          </ol>
+          <div class="tabs-container">
+            <ol class="tabs js-tabs">
+                <li class="tabs-selected"><a id="tab1" href="#tab1panel">Foo</a></li>
+                <li><a id="tab2" href="#tab2panel">Bar</a></li>
+            </ol>
 
-          <div class="tabs-content">
-               <div class="tabs-pane" id="tab1panel">foo</div>
-               <div class="tabs-pane js-hidden" id="tab2panel">bar</div>
+            <div class="tabs-content">
+                 <div class="tabs-pane" id="tab1panel">foo</div>
+                 <div class="tabs-pane js-hidden" id="tab2panel">bar</div>
+            </div>
           </div>
 
+          <div class="tabs-container">
+            <ol class="tabs">
+                <li class="tabs-selected"><a id="tab1_2" href="#tab1panel_2">Foo</a></li>
+                <li><a id="tab2_2" href="#tab2panel_2">Bar</a></li>
+                <li><a id="fake-tab" href="http://www.google.com">Google (fake tab)</a></li>
+            </ol>
 
-          <ol class="tabs">
-              <li class="tabs-selected"><a id="tab1_2" href="#tab1panel_2">Foo</a></li>
-              <li><a id="tab2_2" href="#tab2panel_2">Bar</a></li>
-              <li><a id="fake-tab" href="http://www.google.com">Google (fake tab)</a></li>
-          </ol>
-
-          <div class="tabs-content">
-               <div class="tabs-pane" id="tab1panel_2">foo</div>
-               <div class="tabs-pane js-hidden" id="tab2panel_2">bar</div>
+            <div class="tabs-content">
+                 <div class="tabs-pane" id="tab1panel_2">foo</div>
+                 <div class="tabs-pane js-hidden" id="tab2panel_2">bar</div>
+            </div>
           </div>
 
         </p>

--- a/core-navigation/app/views/fragments/mostPopular.scala.html
+++ b/core-navigation/app/views/fragments/mostPopular.scala.html
@@ -7,30 +7,35 @@
         <h2 class="type-2 article-zone">Most read</h2>
 
         @if(isTabbed) {
-            <ol class="tabs js-tabs" id="js-popular-tabs">
-                @popular.zipWithRowInfo.map{ case (section, info) =>
-                    <li@if(info.isFirst){ class="tabs-selected"}>
-                        <a href="#tabs-popular-@info.rowNum" class="type-6" data-link-name="tab @info.rowNum @section.heading">@Html(section.heading)</a>
-                    </li>
-                }
-            </ol>
+            <div class="tabs-container">
+                <ol class="tabs js-tabs" id="js-popular-tabs">
+                    @popular.zipWithRowInfo.map{ case (section, info) =>
+                        <li@if(info.isFirst){ class="tabs-selected"}>
+                            <a href="#tabs-popular-@info.rowNum" class="type-6" data-link-name="tab @info.rowNum @section.heading">@Html(section.heading)</a>
+                        </li>
+                    }
+                </ol>
+                <div class="tabs-content">
         }
 
-        @if(isTabbed) {<div class="tabs-content">}
-            @popular.zipWithRowInfo.map{ case (section, info) =>
-                <div id="tabs-popular-@info.rowNum"
-                    class="@if(isTabbed){tabs-pane @if(!info.isFirst){ js-hidden}} headline-list"
-                    data-link-name="@section.heading">
+        @popular.zipWithRowInfo.map{ case (section, info) =>
+            <div id="tabs-popular-@info.rowNum"
+                class="@if(isTabbed){tabs-pane @if(!info.isFirst){ js-hidden}} headline-list"
+                data-link-name="@section.heading">
 
-                    <ul class="unstyled">
-                        @section.trails.zipWithRowInfo.map{ case (trail, info) =>
-                            <li><span class="count">@info.rowNum</span> @linkText(trail, info)</li>
-                        }
-                    </ul>
+                <ul class="unstyled">
+                    @section.trails.zipWithRowInfo.map{ case (trail, info) =>
+                        <li><span class="count">@info.rowNum</span> @linkText(trail, info)</li>
+                    }
+                </ul>
 
+            </div>
+        }
+
+        @if(isTabbed) {
                 </div>
-            }
-        @if(isTabbed) {</div>}
+            </div>
+        }
 
     </div>
 }

--- a/core-navigation/test/MostPopularFeatureTest.scala
+++ b/core-navigation/test/MostPopularFeatureTest.scala
@@ -27,7 +27,7 @@ class MostPopularFeatureTest extends FeatureSpec with GivenWhenThen with ShouldM
         import browser._
 
         Then("I should see a list of 'world' content")
-        findFirst(".zone-world").findFirst("h1").getText should be("Most read: World news")
+        findFirst(".zone-world").findFirst("h2").getText should be("Most read: World news")
         And("it should contain world news")
         $(".zone-world li").size should be > (0)
 
@@ -41,7 +41,7 @@ class MostPopularFeatureTest extends FeatureSpec with GivenWhenThen with ShouldM
         import browser._
 
         Then("I should see the site wide most read")
-        $("h1")(1).getText should be("Most read: The Guardian")
+        $("h2")(1).getText should be("Most read: The Guardian")
       }
     }
 

--- a/event/app/views/fragments/analysis.scala.html
+++ b/event/app/views/fragments/analysis.scala.html
@@ -1,37 +1,39 @@
 @(story: Story, edition: String)
 
-<ol class="tabs js-tabs" id="js-story-tabs">
-    <li class="tabs-selected"><a href="#tabs-story-1" class="type-6" data-link-name="tab 1 analysis">Analysis</a></li>
-    <li><a href="#tabs-story-2" class="type-6" data-link-name="tab 2 background">Background</a></li>
-</ol>
+<div class="tabs-container">
+    <ol class="tabs js-tabs" id="js-story-tabs">
+        <li class="tabs-selected"><a href="#tabs-story-1" class="type-6" data-link-name="tab 1 analysis">Analysis</a></li>
+        <li><a href="#tabs-story-2" class="type-6" data-link-name="tab 2 background">Background</a></li>
+    </ol>
 
-<div class="tabs-content">
+    <div class="tabs-content">
 
-    <div id="tabs-story-1" class="tabs-pane" data-link-name="analysis">
-        <ul class="unstyled">
-            @story.contentByAnalysis.zipWithRowInfo.map{ case(c, info) =>
-                @{
-                    c match {
-                        case a: Article => {
-                            fragments.storyArticle(a, edition)
+        <div id="tabs-story-1" class="tabs-pane" data-link-name="analysis">
+            <ul class="unstyled">
+                @story.contentByAnalysis.zipWithRowInfo.map{ case(c, info) =>
+                    @{
+                        c match {
+                            case a: Article => {
+                                fragments.storyArticle(a, edition)
+                            }
                         }
                     }
-                }
 
-                @if(story.hasQuotes) {
-                    @story.contentWithQuotes.drop(info.rowNum-1).headOption.map{ quote =>
-                        <li class="story-article">@fragments.quote(story, info.rowNum-1)</li>
+                    @if(story.hasQuotes) {
+                        @story.contentWithQuotes.drop(info.rowNum-1).headOption.map{ quote =>
+                            <li class="story-article">@fragments.quote(story, info.rowNum-1)</li>
+                        }
                     }
+
                 }
+            </ul>
+            <p class="box-indent"><a class="back-to-top" href="#top">Back to top</a></p>
+        </div>
 
-            }
-        </ul>
-        <p class="box-indent"><a class="back-to-top" href="#top">Back to top</a></p>
-    </div>
+        <div id="tabs-story-2" class="tabs-pane js-hidden" data-link-name="background">
+            @fragments.explainer(story)
 
-    <div id="tabs-story-2" class="tabs-pane js-hidden" data-link-name="background">
-        @fragments.explainer(story)
-
-        @fragments.agents(story)
+            @fragments.agents(story)
+        </div>
     </div>
 </div>

--- a/event/app/views/storyVersionB.scala.html
+++ b/event/app/views/storyVersionB.scala.html
@@ -8,41 +8,40 @@
 
         @fragments.latest(story, page.edition, 2)
 
-        <div class="tabs-fixable">
+        <div class="tabs-container tabs-fixable">
             <ol class="tabs js-tabs" id="js-story-tabs">
                 <li class="tabs-selected"><a href="#tabs-story-1" class="type-6" data-link-name="tab 1 analysis">Analysis</a></li>
                 <li><a href="#tabs-story-2" class="type-6" data-link-name="tab 2 background">Background</a></li>
             </ol>
-        </div>
+            <div class="tabs-content">
 
-        <div class="tabs-content">
-
-            <div id="tabs-story-1" class="tabs-pane" data-link-name="analysis">
-                <ul class="unstyled">
-                    @story.contentByAnalysis.zipWithRowInfo.map{ case(c, info) =>
-                        @{
-                            c match {
-                                case a: Article => {
-                                    fragments.storyArticle(a, page.edition)
+                <div id="tabs-story-1" class="tabs-pane" data-link-name="analysis">
+                    <ul class="unstyled">
+                        @story.contentByAnalysis.zipWithRowInfo.map{ case(c, info) =>
+                            @{
+                                c match {
+                                    case a: Article => {
+                                        fragments.storyArticle(a, page.edition)
+                                    }
                                 }
                             }
-                        }
 
-                        @if(story.hasQuotes) {
-                            @story.contentWithQuotes.drop(info.rowNum-1).headOption.map{ quote =>
-                                <li class="story-article">@fragments.quote(story, info.rowNum-1)</li>
+                            @if(story.hasQuotes) {
+                                @story.contentWithQuotes.drop(info.rowNum-1).headOption.map{ quote =>
+                                    <li class="story-article">@fragments.quote(story, info.rowNum-1)</li>
+                                }
                             }
+
                         }
+                    </ul>
+                    <p class="box-indent"><a class="back-to-top" href="#top">Back to top</a></p>
+                </div>
 
-                    }
-                </ul>
-                <p class="box-indent"><a class="back-to-top" href="#top">Back to top</a></p>
-            </div>
+                <div id="tabs-story-2" class="tabs-pane js-hidden" data-link-name="background">
+                    @fragments.explainer(story)
 
-            <div id="tabs-story-2" class="tabs-pane js-hidden" data-link-name="background">
-                @fragments.explainer(story)
-
-                @fragments.agents(story)
+                    @fragments.agents(story)
+                </div>
             </div>
         </div>
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -17,7 +17,7 @@ To run all features (except `@ignore` and `@scala-test`)
 
 To run a particular tagged feature (e.g.`@network-front`)
 
-	$ mvn test -Dcucumber.options="--tags @network-front"
+	$ mvn test -Dtags="--tags @network-front"
 
 Running on a different host (i.e. not `http://localhost:9000`)
 
@@ -37,4 +37,4 @@ Running in Chrome will trigger a profile ignoring all tests tagged `@brokeninchr
      	
 To run the jasmine tests
 
-	$ mvn test -Dcucumber.options="--tags @jasmine"
+	$ mvn test -Dtags="--tags @jasmine"

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -15,9 +15,9 @@ To run all features (except `@ignore` and `@scala-test`)
 
 	$ mvn test
 
-To run a particular tagged feature (e.g.`@network-front`, but not `@ignore` or `@scala-test`)
+To run a particular tagged feature (e.g.`@network-front`)
 
-	$ mvn test -Dtags="--tags @network-front"
+	$ mvn test -Dcucumber.options="--tags @network-front"
 
 Running on a different host (i.e. not `http://localhost:9000`)
 
@@ -37,4 +37,4 @@ Running in Chrome will trigger a profile ignoring all tests tagged `@brokeninchr
      	
 To run the jasmine tests
 
-	$ mvn test -Dtags="--tags @jasmine"
+	$ mvn test -Dcucumber.options="--tags @jasmine"

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -11,6 +11,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<properties>
 	   <cucumber.version>1.1.3</cucumber.version>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+       <tags>--tags ~@nothing</tags>
 	</properties>
     <profiles>
         <profile>
@@ -18,6 +19,9 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <properties>
+                <cucumber.options>${tags} --tags ~@ignore --tags ~@scala-test</cucumber.options>
+            </properties>
         </profile>
         <profile>
             <id>chrome</id>
@@ -29,8 +33,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
                 </property>
             </activation>
             <properties>
-                <tags>--tags ~@nothing</tags>
-                <cucumber.options>${tags} --tags ~@brokeninchrome --tags ~@ignore --tags ~@scala-test</cucumber.options>
+                <cucumber.options>${tags} --tags ~@ignore --tags ~@scala-test --tags ~@brokeninchrome</cucumber.options>
             </properties>
         </profile>
     </profiles>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -18,10 +18,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <tags>--tags ~@nothing</tags>
-		        <cucumber.options>src/test/resources ${tags} --tags ~@ignore --tags ~@scala-test --glue com/gu/test --format pretty --format html:target/cucumber-html-report</cucumber.options>
-	        </properties>
         </profile>
         <profile>
             <id>chrome</id>
@@ -33,8 +29,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
                 </property>
             </activation>
             <properties>
-                <tags>--tags ~@brokeninchrome</tags>
-                <cucumber.options>src/test/resources ${tags} --tags ~@ignore --tags ~@scala-test --glue com/gu/test --format pretty --format html:target/cucumber-html-report</cucumber.options>
+                <tags>--tags ~@nothing</tags>
+                <cucumber.options>${tags} --tags ~@brokeninchrome --tags ~@ignore --tags ~@scala-test</cucumber.options>
             </properties>
         </profile>
     </profiles>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -72,6 +72,11 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 			<artifactId>selenium-java</artifactId>
 			<version>2.30.0</version>
 		</dependency>
+		<dependency>
+		    <groupId>xerces</groupId>
+		    <artifactId>xercesImpl</artifactId>
+		    <version>2.10.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -8,6 +8,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<packaging>jar</packaging>
 	<name>integration-tests</name>
 	<url>http://maven.apache.org</url>
+	<properties>
+	   <cucumber.version>1.1.3</cucumber.version>
+       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
     <profiles>
         <profile>
             <id>integration-tests</id>
@@ -15,13 +19,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tags>--tags ~@nothing</tags>
-		<cucumber.version>1.0.14</cucumber.version>
-		<cucumber.options>src/test/resources ${tags} --tags ~@ignore --tags ~@scala-test --glue com/gu/test --format pretty --format html:target/cucumber-html-report</cucumber.options>
-	</properties>
+                <tags>--tags ~@nothing</tags>
+		        <cucumber.options>src/test/resources ${tags} --tags ~@ignore --tags ~@scala-test --glue com/gu/test --format pretty --format html:target/cucumber-html-report</cucumber.options>
+	        </properties>
         </profile>
-
         <profile>
             <id>chrome</id>
             <activation>
@@ -32,9 +33,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
                 </property>
             </activation>
             <properties>
-                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                 <tags>--tags ~@brokeninchrome</tags>
-                <cucumber.version>1.0.14</cucumber.version>
                 <cucumber.options>src/test/resources ${tags} --tags ~@ignore --tags ~@scala-test --glue com/gu/test --format pretty --format html:target/cucumber-html-report</cucumber.options>
             </properties>
         </profile>
@@ -44,7 +43,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.10</version>
+			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -52,11 +51,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	        <artifactId>junit-addons</artifactId>
 	        <version>1.4</version>
         </dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
-		</dependency>
 		<dependency>
 			<groupId>info.cukes</groupId>
 			<artifactId>cucumber-core</artifactId>

--- a/integration-tests/src/test/java/com/gu/test/ArticleSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/ArticleSteps.java
@@ -3,16 +3,16 @@ package com.gu.test;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 import junitx.framework.StringAssert;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
-import cucumber.annotation.en.Given;
-import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 
 
 public class ArticleSteps {
@@ -79,7 +79,7 @@ public class ArticleSteps {
 	@Then("^\"([^\"]*)\" is displayed$")
 	public void is_displayed(String headerText) throws Throwable {
 		WebElement relatedHeader = webDriver.waitForElement(By.cssSelector("#js-related h3"));
-		Assert.assertEquals(headerText, relatedHeader.getText());
+		assertEquals(headerText, relatedHeader.getText());
 	}
 
 	@Then("^\"([^\"]*)\" \"([^\"]*)\" displayed$")
@@ -99,12 +99,12 @@ public class ArticleSteps {
 
 	@Then("^I can see a list of the most popular stories on guardian.co.uk for the section I am in$")
 	public void I_can_see_list_popular_stories_on_guardian_for_the_section_i_am_in() throws Throwable {
-		Assert.assertEquals("block", webDriver.getElementCssValue(By.id("tabs-popular-2"), "display"));
+		assertEquals("block", webDriver.getElementCssValue(By.id("tabs-popular-2"), "display"));
 	}
 
 	@Then("^I can see a list of the most popular stories on guardian.co.uk for the whole guardian site$")
 	public void I_can_see_a_list_of_the_most_popular_stories_on_guardian_co_uk_for_the_whole_guardian_site() throws Throwable {
-		Assert.assertEquals("block", webDriver.getElementCssValue(By.id("tabs-popular-1"), "display"));
+		assertEquals("block", webDriver.getElementCssValue(By.id("tabs-popular-1"), "display"));
 	}
 	
 	@When("^\"([^\"]*)\" is unavailable$")
@@ -114,12 +114,12 @@ public class ArticleSteps {
 
 	@Then("^\"([^\"]*)\" is not displayed$")
 	public void is_not_displayed(String arg1) throws Throwable {
-		Assert.assertTrue(webDriver.findElements(By.id("related-trails")).size() == 0);
+		assertTrue(webDriver.findElements(By.id("related-trails")).size() == 0);
 	}
 
 	@Then("^\"([^\"]*)\" section tab show read \"([^\"]*)\"$")
 	public void section_tab_show_read(String arg1, String arg2) throws Throwable {
-		Assert.assertTrue(webDriver.isTextPresentByElement(By.className("tabs-selected"), arg2));
+		assertTrue(webDriver.isTextPresentByElement(By.className("tabs-selected"), arg2));
 	}
 
 	@When("^I click \"([^\"]*)\" tab at the top of the page$")
@@ -130,7 +130,7 @@ public class ArticleSteps {
 	@Then("^a list of \"([^\"]*)\" opens$")
 	public void a_list_of_opens(String arg1) throws Throwable {
 		// wait for top stories panel to open
-		Assert.assertTrue(webDriver.waitForCss(By.id("topstories-header"), "display", "block"));
+		assertTrue(webDriver.waitForCss(By.id("topstories-header"), "display", "block"));
 	}
 
 	@Then("^another click on \"([^\"]*)\" closes the list.$")
@@ -140,7 +140,7 @@ public class ArticleSteps {
 		// click the tab
 		webDriver.findElement(By.linkText(linkText)).click();
 		// wait for top stories tab to close
-		Assert.assertTrue(webDriver.waitForCss(By.id("topstories-header"), "display", "none"));
+		assertTrue(webDriver.waitForCss(By.id("topstories-header"), "display", "none"));
 	}
 
 	@When("^I click \"([^\"]*)\" tab at the foot of the page$")
@@ -150,13 +150,13 @@ public class ArticleSteps {
 
 	@Then("^a list of the footer \"([^\"]*)\" opens$")
 	public void a_list_of_the_footer_opens(String arg1) throws Throwable {
-		Assert.assertEquals("block", webDriver.getElementCssValue(By.id("topstories-footer"), "display"));
+		assertEquals("block", webDriver.getElementCssValue(By.id("topstories-footer"), "display"));
 	}
 
 	@Then("^another click on the footer \"([^\"]*)\" closes the list.$")
 	public void another_click_on_the_footer_closes_the_list(String arg1) throws Throwable {
 		webDriver.findElement(By.id("topstories-control-footer")).click();
-		Assert.assertEquals("none", webDriver.getElementCssValue(By.id("topstories-footer"), "display"));
+		assertEquals("none", webDriver.getElementCssValue(By.id("topstories-footer"), "display"));
 	}
 
 	@When("^I select the sections navigation button$")
@@ -166,13 +166,13 @@ public class ArticleSteps {
 
 	@Then("^it should show me a list of sections$")
 	public void it_should_show_a_list_of_sections() throws Throwable {
-		Assert.assertEquals("block", webDriver.getElementCssValue(By.id("sections-header"), "display"));
+		assertEquals("block", webDriver.getElementCssValue(By.id("sections-header"), "display"));
 	}
 
 	@Then("^another click on the \"([^\"]*)\" \"([^\"]*)\" tab closes the list$")
 	public void another_click_on_the_tab_closes_the_list(String arg1, String arg2) throws Throwable {
 		webDriver.findElement(By.id("sections-control-" + arg1)).click();
-		Assert.assertEquals("none", webDriver.getElementCssValue(By.id("sections-" + arg1), "display"));
+		assertEquals("none", webDriver.getElementCssValue(By.id("sections-" + arg1), "display"));
 	}
 
 	@Given("^I have a fast connection speed$")
@@ -184,7 +184,7 @@ public class ArticleSteps {
 	@Then("^the high resolution version of the image is displayed$")
 	public void article_high_resolution_image_and_caption_is_displayed() throws Throwable {
 		WebElement highResImage = webDriver.findElement(By.className("image-high"));
-		Assert.assertTrue(highResImage != null);
+		assertTrue(highResImage != null);
 	}
 
 
@@ -196,7 +196,7 @@ public class ArticleSteps {
 		
 		String expectedTrailblockHeight = (sectionState.equals("expand")) ? "none" : "0";
 		// sections are hidden with css max-height
-		Assert.assertTrue(webDriver.waitForCss(By.cssSelector("#related-trails .panel"), "max-height", expectedTrailblockHeight));
+		assertTrue(webDriver.waitForCss(By.cssSelector("#related-trails .panel"), "max-height", expectedTrailblockHeight));
 	}
 
 	@When("^Back to top is selected$")
@@ -208,7 +208,7 @@ public class ArticleSteps {
 	public void article_page_scrolls_to_the_top() throws Throwable {
 		//get href value of the element (back to the top) to locate for example "top" div is show above the container as a way for confirming the Back to the top will work
 		String var = webDriver.findElement(By.linkText("Back to top")).getAttribute("href");
-		Assert.assertTrue(webDriver.findElements(By.id(var.substring(var.indexOf("#")+1))).size() > 0);
+		assertTrue(webDriver.findElements(By.id(var.substring(var.indexOf("#")+1))).size() > 0);
 	}
 
 	@When("^I click footer links \\(Desktop version, Help, Contact us, Feedback, T&C's and Pricacy policy\\)$")

--- a/integration-tests/src/test/java/com/gu/test/DisplayAdvertsSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/DisplayAdvertsSteps.java
@@ -1,10 +1,10 @@
 package com.gu.test;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 import org.openqa.selenium.By;
 
-import cucumber.annotation.en.Then;
+import cucumber.api.java.en.Then;
 
 
 public class DisplayAdvertsSteps {
@@ -18,12 +18,12 @@ public class DisplayAdvertsSteps {
 	
 	@Then("^an advert will be at the top of the page$")
 	public void an_Advert_will_be_at_the_top_of_the_page() throws Throwable {
-		Assert.assertTrue(webDriver.waitForElement(By.cssSelector("#ad-slot-top-banner-ad iframe.ad")) != null);
+		assertTrue(webDriver.waitForElement(By.cssSelector("#ad-slot-top-banner-ad iframe.ad")) != null);
 	}
 
 	@Then("^an advert will not be at the foot of the page$")
 	public void an_advert_will_not_be_at_the_foot_of_the_page() throws Throwable {
-		Assert.assertFalse(webDriver.waitForElement(By.cssSelector("#ad-slot-bottom-banner-ad iframe.ad")) != null);
+		assertFalse(webDriver.waitForElement(By.cssSelector("#ad-slot-bottom-banner-ad iframe.ad")) != null);
 	}
 
 }

--- a/integration-tests/src/test/java/com/gu/test/FootballSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/FootballSteps.java
@@ -4,14 +4,14 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import cucumber.annotation.en.Given;
-import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 
 public class FootballSteps {
 
@@ -59,12 +59,12 @@ public class FootballSteps {
 	@Then("^the competition filter list opens$")
 	public void the_competition_filter_list_opens() throws Throwable {
 		WebElement leagueList = webDriver.waitForVisible(By.id("js-football-league-list"));
-	    Assert.assertTrue(leagueList != null);
+	    assertTrue(leagueList != null);
 	}
 
 	@Then("^the competition filter list closes$")
 	public void the_competition_filter_list_closes() throws Throwable {
-	    Assert.assertTrue(webDriver.waitForHidden(By.id("js-football-league-list")));
+	    assertTrue(webDriver.waitForHidden(By.id("js-football-league-list")));
 	}
 	
 	@When("^I click \"(.+)\"$")
@@ -76,7 +76,7 @@ public class FootballSteps {
 	public void I_should_see_the_following_days_worth_of(int numOfDays, String matchesType) throws Throwable {
 		// should now have twice as many days worth of results
 		List<WebElement> competitions = webDriver.findElements(By.className("competitions"));
-		Assert.assertEquals(numOfDays, competitions.size() - numOfDays);
+		assertEquals(numOfDays, competitions.size() - numOfDays);
 	}
 	
 	@Then("^there should be an auto-update component$")
@@ -88,7 +88,7 @@ public class FootballSteps {
 	public void auto_update_should_be_on() throws Throwable {
 		WebElement autoUpdate = webDriver.findElement(By.className("update"));
 	    WebElement selectedButton = autoUpdate.findElement(By.cssSelector("button.is-active"));
-	    Assert.assertEquals("on", selectedButton.getAttribute("data-action"));
+	    assertEquals("on", selectedButton.getAttribute("data-action"));
 	}
 
 	@Then("^the matches should update every (\\d+) seconds$")
@@ -110,7 +110,7 @@ public class FootballSteps {
 	@Then("^auto-update should be off$")
 	public void auto_update_should_be_off() throws Throwable {
 	    WebElement offButton = webDriver.findElement(By.cssSelector(".update button[data-action='off']"));
-	    Assert.assertTrue(offButton.getAttribute("class").contains("is-active"));
+	    assertTrue(offButton.getAttribute("class").contains("is-active"));
 	}
 
 	@Given("^I visit any Football league and/or Domestic competition tag page$")
@@ -126,7 +126,7 @@ public class FootballSteps {
 	@Then("^table should show the top (\\d+) teams$")
 	public void table_should_show_the_top_teams(int teams) throws Throwable {
 	    List<WebElement> rows = webDriver.findElements(By.cssSelector(".table-football-body tr"));
-		Assert.assertEquals(teams, rows.size());
+		assertEquals(teams, rows.size());
 	}
 
 	@Then("^there should be a link to \"([^\"]*)\"$")
@@ -148,21 +148,21 @@ public class FootballSteps {
 	public void the_team_s_upcoming_fixtures_are_shown(int matchCount) throws Throwable {
 	    WebElement fixturesContainer = webDriver.waitForElement(By.cssSelector(".team-fixtures"));
 	    List<WebElement> matches = fixturesContainer.findElements(By.className("match"));
-	    Assert.assertEquals(matchCount, matches.size());
+	    assertEquals(matchCount, matches.size());
 	}
 
 	@Then("^the previous result is shown$")
 	public void the_previous_result_is_shown() throws Throwable {
 		WebElement fixturesContainer = webDriver.waitForElement(By.cssSelector(".team-results"));
 	    List<WebElement> matches = fixturesContainer.findElements(By.className("match"));
-	    Assert.assertEquals(1, matches.size());
+	    assertEquals(1, matches.size());
 	}
 
 	@Then("^table will show the teams current position within (\\d+) rows$")
 	public void table_will_show_the_teams_current_position_within_rows(int rowsCount) throws Throwable {
 	    WebElement table = webDriver.waitForElement(By.className("table-football"));
 	    List<WebElement> rows = table.findElements(By.cssSelector("tbody tr"));
-	    Assert.assertEquals(rowsCount, rows.size());
+	    assertEquals(rowsCount, rows.size());
 	}
 
 	@Then("^the teams row should be highlighted$")

--- a/integration-tests/src/test/java/com/gu/test/FrontSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/FrontSteps.java
@@ -1,8 +1,6 @@
 package com.gu.test;
 
-import java.util.List;
-
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -51,7 +49,7 @@ public class FrontSteps {
   	public void the_section_will_be_toggled(String sectionState) throws Throwable {
     		String expectedTrailblockHeight = (sectionState.equals("shown")) ? "none" : "0";
     		// sections are hidden with css max-height
-    		Assert.assertTrue(webDriver.waitForCss(
+    		assertTrue(webDriver.waitForCss(
     		    By.xpath(trailblockXpath), "max-height", expectedTrailblockHeight)
     		);
   	}
@@ -62,10 +60,30 @@ public class FrontSteps {
         String trailblockXpath = "//section[.//h1/descendant-or-self::*[contains(text(), '" + section + "')]]/div[contains(@class, 'trailblock')]";
         WebElement trailblock = webDriver.findElement(By.xpath(trailblockXpath));
         WebElement cta = trailblock.findElement(By.cssSelector("button.cta"));
-        Assert.assertEquals(ctaText, cta.getText());
+        assertEquals(ctaText, cta.getText());
         cta.click();
         // wait for second list of top stories to load in
         webDriver.waitForElement(By.xpath("//div[@id='" +  trailblock.getAttribute("id") + "']/ul[2]"));
+    }
+    
+    @When("^there are no more trails to show$")
+    public void there_are_no_more_trails_to_show() throws Throwable {
+      // get the first cta
+      WebElement showMoreCta = webDriver.waitForElement(By.cssSelector("section .trailblock button.cta"));
+      // NOTE: assuming there won't be more that 10 clicks
+      int counter = 10;
+      while(counter-- > 0) {
+        showMoreCta.click();
+      }
+      if (showMoreCta.isDisplayed()) {
+        fail("CTA still visible");
+      }
+    }
+
+    @Then("^the '([^']*)' CTA should disappear$")
+    public void the_CTA_should_disappear(String ctaText) throws Throwable {
+      WebElement section = webDriver.findElement(By.cssSelector("section"));
+      assertEquals(0, section.findElements(By.xpath("div[contains(@class, 'trailblock')]/button[text()='" + ctaText + "']")).size());
     }
 	
 }

--- a/integration-tests/src/test/java/com/gu/test/FrontSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/FrontSteps.java
@@ -65,25 +65,5 @@ public class FrontSteps {
         // wait for second list of top stories to load in
         webDriver.waitForElement(By.xpath("//div[@id='" +  trailblock.getAttribute("id") + "']/ul[2]"));
     }
-    
-    @When("^there are no more trails to show$")
-    public void there_are_no_more_trails_to_show() throws Throwable {
-      // get the first cta
-      WebElement showMoreCta = webDriver.waitForElement(By.cssSelector("section .trailblock button.cta"));
-      // NOTE: assuming there won't be more that 10 clicks
-      int counter = 10;
-      while(counter-- > 0) {
-        showMoreCta.click();
-      }
-      if (showMoreCta.isDisplayed()) {
-        fail("CTA still visible");
-      }
-    }
-
-    @Then("^the '([^']*)' CTA should disappear$")
-    public void the_CTA_should_disappear(String ctaText) throws Throwable {
-      WebElement section = webDriver.findElement(By.cssSelector("section"));
-      assertEquals(0, section.findElements(By.xpath("div[contains(@class, 'trailblock')]/button[text()='" + ctaText + "']")).size());
-    }
 	
 }

--- a/integration-tests/src/test/java/com/gu/test/FrontSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/FrontSteps.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.*;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import cucumber.annotation.en.Given;
-import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 
 public class FrontSteps {
 

--- a/integration-tests/src/test/java/com/gu/test/NavigationSteps.java
+++ b/integration-tests/src/test/java/com/gu/test/NavigationSteps.java
@@ -1,13 +1,13 @@
 package com.gu.test;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import cucumber.annotation.en.Given;
-import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 
 public class NavigationSteps {
 
@@ -30,9 +30,9 @@ public class NavigationSteps {
     public void Im_shown_the_top_stories_from_the_Guardian_site(int numOfTopStories) throws Throwable {
     	// assert stories are displayed
     	WebElement topStories = webDriver.findElement(By.id("topstories-header"));
-    	Assert.assertTrue(topStories.isDisplayed());
+    	assertTrue(topStories.isDisplayed());
     	// assert it has the correct number of stories
-    	Assert.assertEquals(numOfTopStories, topStories.findElements(By.tagName("li")).size());
+    	assertEquals(numOfTopStories, topStories.findElements(By.tagName("li")).size());
     }
 
     @Then("^the \"(Top stories|Sections)\" menu should (open|close)$")
@@ -67,7 +67,7 @@ public class NavigationSteps {
     @Then("^the top story link should have a (.*) of (.*)$")
     public void the_top_story_link_should_have_a_of(String cssProperty, String expectedColor) throws Throwable {
         // confirm it has the correct css color
-    	Assert.assertEquals(expectedColor, webDriver.getElementCssValue(By.cssSelector("#topstories-header li a"), cssProperty));
+    	assertEquals(expectedColor, webDriver.getElementCssValue(By.cssSelector("#topstories-header li a"), cssProperty));
     }
     
 }

--- a/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
+++ b/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
@@ -4,6 +4,6 @@ import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@Cucumber.Options(format = {"progress", "html:target/cucumber-html-report"}, tags = {"~@ignore", "~@scala-test"})
+@Cucumber.Options(format = {"progress", "html:target/cucumber-html-report"})
 public class RunCukesTest {
 }

--- a/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
+++ b/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
@@ -1,10 +1,9 @@
 package com.gu.test;
 
+import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
-import cucumber.api.junit.Cucumber;
-
 @RunWith(Cucumber.class)
-
+@Cucumber.Options(format = {"progress", "html:target/cucumber-html-report"}, tags = {"~@ignore", "~@scala-test"})
 public class RunCukesTest {
 }

--- a/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
+++ b/integration-tests/src/test/java/com/gu/test/RunCukesTest.java
@@ -2,7 +2,7 @@ package com.gu.test;
 
 import org.junit.runner.RunWith;
 
-import cucumber.junit.Cucumber;
+import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 

--- a/integration-tests/src/test/java/com/gu/test/SharedDriver.java
+++ b/integration-tests/src/test/java/com/gu/test/SharedDriver.java
@@ -1,7 +1,7 @@
 package com.gu.test;
 
-import cucumber.annotation.Before;
-import junit.framework.Assert;
+import cucumber.api.java.Before;
+import static org.junit.Assert.*;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -148,7 +148,7 @@ public class SharedDriver extends EventFiringWebDriver {
 
 		for (WebElement footerLink : footerLinks) {
 			// checks if the page is 200 - errors if it finds another type of page eg 404, 502
-			Assert.assertEquals(200, checkURLReturns(footerLink.getAttribute("href")));
+			assertEquals(200, checkURLReturns(footerLink.getAttribute("href")));
 		}
 	}
 

--- a/integration-tests/src/test/java/com/gu/test/Steps.java
+++ b/integration-tests/src/test/java/com/gu/test/Steps.java
@@ -2,14 +2,14 @@ package com.gu.test;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import static org.junit.Assert.*;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import cucumber.annotation.en.Given;
-import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 
 public class Steps {
 
@@ -54,7 +54,7 @@ public class Steps {
 		String tabId = tabName.toLowerCase().replace(" ", "") + "-control-header";
 	    WebElement tab = webDriver.findElement(By.id(tabId));
 	    // confirm element is shown/hidden
-	    Assert.assertEquals(tabState.equals("shown"), tab.isDisplayed());
+	    assertEquals(tabState.equals("shown"), tab.isDisplayed());
 	}
 	
 	@When("^I visit the (.*) jasmine test runner$")
@@ -70,7 +70,7 @@ public class Steps {
 			"file:///" + frontendRoot + "/" + project + "/test/assets/javascripts/runner.html"
 		);
 		// confirm we're on the correct page
-		Assert.assertTrue(webDriver.getTitle().contains("Jasmine Spec Runner"));
+		assertTrue(webDriver.getTitle().contains("Jasmine Spec Runner"));
 	}
 
 	@Then("^all the jasmine tests pass$")
@@ -99,7 +99,7 @@ public class Steps {
 			}
 		}
 		
-		Assert.assertFalse(testFailure);
+		assertFalse(testFailure);
 	}
 	
 }

--- a/integration-tests/src/test/java/com/gu/test/StorySteps.java
+++ b/integration-tests/src/test/java/com/gu/test/StorySteps.java
@@ -2,15 +2,13 @@ package com.gu.test;
 
 import java.util.List;
 
-import junit.framework.Assert;
-import junitx.framework.StringAssert;
+import static org.junit.Assert.*;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import cucumber.annotation.en.Given;
-import cucumber.annotation.en.Then;
-import cucumber.annotation.en.When;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
 
 
 public class StorySteps {
@@ -23,15 +21,10 @@ public class StorySteps {
         this.webDriver = webDriver;
     }
 
-    @Given("^I am on an story$")
-    public void I_am_on_an_article() throws Throwable {
-        webDriver.open(story);
-    }
-
     @Then("^Latest developments is displayed$")
     public void Latest_developments_is_displayed() throws Throwable {
         WebElement heading = webDriver.findElement(By.cssSelector(".story-latest .article-headline"));
-        Assert.assertTrue(heading.getText().equals("Latest developments"));
+        assertTrue(heading.getText().equals("Latest developments"));
     }
 
     @Then("^Latest stories is displayed$")
@@ -42,7 +35,7 @@ public class StorySteps {
     @Then("^the first (\\d+) blocks from article is shown$")
     public void the_first_blocks_from_article_is_shown(int stories) throws Throwable {
         List<WebElement> s = webDriver.findElements(By.cssSelector(".story-latest .article-body > *"));
-        Assert.assertEquals((s.size() - 2), stories);
+        assertEquals((s.size() - 2), stories);
     }
 
     @Then("^a \"([^\"]*)\" of events is displayed$")

--- a/integration-tests/src/test/java/com/gu/test/StorySteps.java
+++ b/integration-tests/src/test/java/com/gu/test/StorySteps.java
@@ -20,6 +20,11 @@ public class StorySteps {
     public StorySteps(SharedDriver webDriver) {
         this.webDriver = webDriver;
     }
+    
+    @Given("^I am on an story$")
+    public void I_am_on_an_article() throws Throwable {
+        webDriver.open(story);
+    }
 
     @Then("^Latest developments is displayed$")
     public void Latest_developments_is_displayed() throws Throwable {

--- a/integration-tests/src/test/java/com/gu/test/TypographySteps.java
+++ b/integration-tests/src/test/java/com/gu/test/TypographySteps.java
@@ -1,9 +1,9 @@
 package com.gu.test;
 
-import org.junit.Assert;
+import static org.junit.Assert.*;
 import org.openqa.selenium.By;
 
-import cucumber.annotation.en.Then;
+import cucumber.api.java.en.Then;
 
 public class TypographySteps {
 
@@ -16,6 +16,6 @@ public class TypographySteps {
 	@Then("^the typeface should be rendered as \"([^\"]*)\"$")
 	public void the_typeface_should_be_rendered_as(String fontName) throws Throwable {
 		//check the font family for header contains the fontName
-		 Assert.assertTrue(webDriver.getElementCssValue(By.cssSelector("h1"), "font-family").contains(fontName));
+		 assertTrue(webDriver.getElementCssValue(By.cssSelector("h1"), "font-family").contains(fontName));
 	}
 }

--- a/integration-tests/src/test/resources/com/gu/test/network-front.feature
+++ b/integration-tests/src/test/resources/com/gu/test/network-front.feature
@@ -10,12 +10,6 @@ Feature: Network front
             | Sport           |
             | Comment is free |
             | Culture         |
-        
-    @foo    
-    Scenario: The 'Show more' CTA disappears if there are no more trails to show
-        Given I visit the network front
-        When there are no more trails to show
-        Then the 'Show more' CTA should disappear
          
     Scenario: Users can hide sections
         Given I visit the network front 

--- a/integration-tests/src/test/resources/com/gu/test/network-front.feature
+++ b/integration-tests/src/test/resources/com/gu/test/network-front.feature
@@ -10,6 +10,12 @@ Feature: Network front
             | Sport           |
             | Comment is free |
             | Culture         |
+        
+    @foo    
+    Scenario: The 'Show more' CTA disappears if there are no more trails to show
+        Given I visit the network front
+        When there are no more trails to show
+        Then the 'Show more' CTA should disappear
          
     Scenario: Users can hide sections
         Given I visit the network front 

--- a/sbt012
+++ b/sbt012
@@ -48,7 +48,7 @@ done
 #MaxPermSize specifies the the maximum size for the permanent generation heap,
 # a heap that holds objects such as classes and methods. Xmx is the heap size.
 
-java -Xmx4096M -XX:MaxPermSize=2048m \
+java -Xmx1024M -XX:MaxPermSize=1024m \
   -XX:ReservedCodeCacheSize=128m \
 	-Dsbt.boot.directory=$SBT_BOOT_DIR \
   -Dhttp.proxyHost=devproxy.gul3.gnl\

--- a/sbt012
+++ b/sbt012
@@ -48,7 +48,7 @@ done
 #MaxPermSize specifies the the maximum size for the permanent generation heap,
 # a heap that holds objects such as classes and methods. Xmx is the heap size.
 
-java -Xmx1024M -XX:MaxPermSize=1024m \
+java -Xmx4096M -XX:MaxPermSize=2048m \
   -XX:ReservedCodeCacheSize=128m \
 	-Dsbt.boot.directory=$SBT_BOOT_DIR \
   -Dhttp.proxyHost=devproxy.gul3.gnl\

--- a/sbt012-tc
+++ b/sbt012-tc
@@ -34,15 +34,9 @@ fi
 
 
 # Ivy configuration
-IVY_PARAMS=""
-for arg in "$@"
-do
-    if [ "$arg" == "--directory-ivy-cache" ]; then
-      echo "setting ivy cache dir"
-      IVY_PARAMS="-Dsbt.ivy.home=.ivy -Divy.home=.ivy"
-      shift
-    fi
-done
+echo "setting ivy cache dir"
+IVY_PARAMS="-Dsbt.ivy.home=$HOME/.ivy2-frontend -Divy.home=$HOME/.ivy2-frontend"
+echo $IVY_PARAMS
 
 # proxy that Play uses
 export proxy_host=devproxy.gul3.gnl

--- a/style-guide/app/views/styleGuide/fragments/module.scala.html
+++ b/style-guide/app/views/styleGuide/fragments/module.scala.html
@@ -6,17 +6,19 @@
         <p class="box-indent type-7">@Html(notes)</p>
     }
 
-    <ol class="tabs js-tabs">
-        <li class="tabs-selected"><a href="#modules-@id-output">Output</a></li>
-        <li><a href="#modules-@id-code">Source code</a></li>
-    </ol>
+    <div class="tabs-container">
+        <ol class="tabs js-tabs">
+            <li class="tabs-selected"><a href="#modules-@id-output">Output</a></li>
+            <li><a href="#modules-@id-code">Source code</a></li>
+        </ol>
 
-    <div class="tabs-content">
-         <div class="tabs-pane" id="modules-@id-output">
-            @Html(html)
-         </div>
-         <div class="tabs-pane js-hidden" id="modules-@id-code">
-            <pre class="prettyprint">@html.toString().trim()</pre>
-         </div>
+        <div class="tabs-content">
+             <div class="tabs-pane" id="modules-@id-output">
+                @Html(html)
+             </div>
+             <div class="tabs-pane js-hidden" id="modules-@id-code">
+                <pre class="prettyprint">@html.toString().trim()</pre>
+             </div>
+        </div>
     </div>
 </div>

--- a/style-guide/app/views/styleGuide/modules.scala.html
+++ b/style-guide/app/views/styleGuide/modules.scala.html
@@ -57,36 +57,38 @@
                 <h2 class="type-5 zone-color box-indent">Tweet</h2>
                 <p class="box-indent type-7">A tweet block</p>
 
-                <ol class="tabs js-tabs">
-                    <li class="tabs-selected"><a href="#modules-tweet-output">Output</a></li>
-                    <li><a href="#modules-tweet-code">Source code</a></li>
-                </ol>
+                <div class="tabs-container">
+                    <ol class="tabs js-tabs">
+                        <li class="tabs-selected"><a href="#modules-tweet-output">Output</a></li>
+                        <li><a href="#modules-tweet-code">Source code</a></li>
+                    </ol>
 
-                <div class="tabs-content">
-                     <div class="tabs-pane from-content-api" id="modules-tweet-output">
-                        <blockquote class="tweet">
-                                <span class="tweet-user">— Angelique Chrisafis (@Html("@achrisafis"))</span>
-                                <a href="https://twitter.com/achrisafis/status/282088154050203648" data-datetime="2012-12-21T11:40:31+00:00"
-                                    data-link-name="in body link" class="tweet-date">December 21, 2012</a>
-                                <p class="tweet-body">Baffled local builder said he kept getting filmed. "Workman walks down street, must be very exciting"
-                                    <a href="https://twitter.com/search/%23bugarach" data-link-name="in body link">#bugarach</a>
-                                    <a href="https://twitter.com/search/%23endoftheworld" data-link-name="in body link">#endoftheworld</a>
-                                </p>
-                            </blockquote>
-                     </div>
-                     <div class="tabs-pane js-hidden" id="modules-tweet-code">
-                        <pre class="prettyprint">
-&lt;blockquote class="tweet">
-    &lt;span class="tweet-user">— Angelique Chrisafis (@Html("@achrisafis"))&lt;/span>
-    &lt;a href="https://twitter.com/achrisafis/status/282088154050203648" data-datetime="2012-12-21T11:40:31+00:00"
-        data-link-name="in body link" class="tweet-date">December 21, 2012&lt;/a>
-    &lt;p class="tweet-body">Baffled local builder said he kept getting filmed. "Workman walks down street, must be very exciting"
-        &lt;a href="https://twitter.com/search/%23bugarach" data-link-name="in body link">#bugarach&lt;/a>
-        &lt;a href="https://twitter.com/search/%23endoftheworld" data-link-name="in body link">#endoftheworld&lt;/a>
-    &lt;/p>
-&lt;/blockquote>
-                        </pre>
-                     </div>
+                    <div class="tabs-content">
+                         <div class="tabs-pane from-content-api" id="modules-tweet-output">
+                            <blockquote class="tweet">
+                                    <span class="tweet-user">— Angelique Chrisafis (@Html("@achrisafis"))</span>
+                                    <a href="https://twitter.com/achrisafis/status/282088154050203648" data-datetime="2012-12-21T11:40:31+00:00"
+                                        data-link-name="in body link" class="tweet-date">December 21, 2012</a>
+                                    <p class="tweet-body">Baffled local builder said he kept getting filmed. "Workman walks down street, must be very exciting"
+                                        <a href="https://twitter.com/search/%23bugarach" data-link-name="in body link">#bugarach</a>
+                                        <a href="https://twitter.com/search/%23endoftheworld" data-link-name="in body link">#endoftheworld</a>
+                                    </p>
+                                </blockquote>
+                         </div>
+                         <div class="tabs-pane js-hidden" id="modules-tweet-code">
+                            <pre class="prettyprint">
+    &lt;blockquote class="tweet">
+        &lt;span class="tweet-user">— Angelique Chrisafis (@Html("@achrisafis"))&lt;/span>
+        &lt;a href="https://twitter.com/achrisafis/status/282088154050203648" data-datetime="2012-12-21T11:40:31+00:00"
+            data-link-name="in body link" class="tweet-date">December 21, 2012&lt;/a>
+        &lt;p class="tweet-body">Baffled local builder said he kept getting filmed. "Workman walks down street, must be very exciting"
+            &lt;a href="https://twitter.com/search/%23bugarach" data-link-name="in body link">#bugarach&lt;/a>
+            &lt;a href="https://twitter.com/search/%23endoftheworld" data-link-name="in body link">#endoftheworld&lt;/a>
+        &lt;/p>
+    &lt;/blockquote>
+                            </pre>
+                         </div>
+                    </div>
                 </div>
             </div>
 
@@ -96,30 +98,32 @@
                 <p class="box-indent type-7">A quote.<br/><br/>
                 N.B. This currently relies on a parent HTML class of <code>.block</code></p>
 
-                <ol class="tabs js-tabs">
-                    <li class="tabs-selected"><a href="#modules-quote-output">Output</a></li>
-                    <li><a href="#modules-quote-code">Source code</a></li>
-                </ol>
+                <div class="tabs-container">
+                    <ol class="tabs js-tabs">
+                        <li class="tabs-selected"><a href="#modules-quote-output">Output</a></li>
+                        <li><a href="#modules-quote-code">Source code</a></li>
+                    </ol>
 
-                <div class="tabs-content">
-                     <div class="tabs-pane block" id="modules-quote-output">
-                        <blockquote>
-                            <p>In all the excitement over the discovery of a
-                            <a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link">
-                            Higgs-like particle</a> at Cern this year, physicists at the lab were probably not thinking about
-                            the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part
-                            and which describes fundamental particles and forces of nature – hides a terrifying secret: a
-                            theoretical composite particle that is so stable it can transform any other particle of matter
-                            into a copy of itself.</p>
-                        </blockquote>
-                     </div>
-                     <div class="tabs-pane js-hidden" id="modules-quote-code">
-                        <pre class="prettyprint">
-&lt;blockquote &gt;
-    &lt;p&gt;In all the excitement over the discovery of a &lt;a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link"&gt;Higgs-like particle&lt;/a&gt; at Cern this year, physicists at the lab were probably not thinking about the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part and which describes fundamental particles and forces of nature – hides a terrifying secret: a theoretical composite particle that is so stable it can transform any other particle of matter into a copy of itself.&lt;/p&gt;
-&lt;/blockquote&gt;
-                        </pre>
-                     </div>
+                    <div class="tabs-content">
+                         <div class="tabs-pane block" id="modules-quote-output">
+                            <blockquote>
+                                <p>In all the excitement over the discovery of a
+                                <a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link">
+                                Higgs-like particle</a> at Cern this year, physicists at the lab were probably not thinking about
+                                the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part
+                                and which describes fundamental particles and forces of nature – hides a terrifying secret: a
+                                theoretical composite particle that is so stable it can transform any other particle of matter
+                                into a copy of itself.</p>
+                            </blockquote>
+                         </div>
+                         <div class="tabs-pane js-hidden" id="modules-quote-code">
+                            <pre class="prettyprint">
+    &lt;blockquote &gt;
+        &lt;p&gt;In all the excitement over the discovery of a &lt;a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link"&gt;Higgs-like particle&lt;/a&gt; at Cern this year, physicists at the lab were probably not thinking about the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part and which describes fundamental particles and forces of nature – hides a terrifying secret: a theoretical composite particle that is so stable it can transform any other particle of matter into a copy of itself.&lt;/p&gt;
+    &lt;/blockquote&gt;
+                            </pre>
+                         </div>
+                    </div>
                 </div>
 
             </div>
@@ -130,32 +134,34 @@
                 <p class="box-indent type-7">A pull quote<br/><br/>
                 N.B. This currently relies on a parent HTML class of <code>.from-content-api</code></p>
 
-                <ol class="tabs js-tabs">
-                    <li class="tabs-selected"><a href="#modules-pull-quote-output">Output</a></li>
-                    <li><a href="#modules-pull-quote-code">Source code</a></li>
-                </ol>
+                <div class="tabs-container">
+                    <ol class="tabs js-tabs">
+                        <li class="tabs-selected"><a href="#modules-pull-quote-output">Output</a></li>
+                        <li><a href="#modules-pull-quote-code">Source code</a></li>
+                    </ol>
 
-                <div class="tabs-content">
-                     <div class="tabs-pane from-content-api" id="modules-pull-quote-output">
-                        <blockquote class="quoted">
-                            <p>In all the excitement over the discovery of a
-                            <a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link">
-                            Higgs-like particle</a> at Cern this year, physicists at the lab were probably not thinking about
-                            the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part
-                            and which describes fundamental particles and forces of nature – hides a terrifying secret: a
-                            theoretical composite particle that is so stable it can transform any other particle of matter
-                            into a copy of itself.</p>
-                        </blockquote>
-                     </div>
-                     <div class="tabs-pane js-hidden" id="modules-pull-quote-code">
-                        <pre class="prettyprint">
-&lt;blockquote class="quoted"&gt;
-    &lt;p&gt;In all the excitement over the discovery of a &lt;a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link"&gt;Higgs-like particle&lt;/a&gt; at Cern this year, physicists at the lab were probably not thinking about the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part and which describes fundamental particles and forces of nature – hides a terrifying secret: a theoretical composite particle that is so stable it can transform any other particle of matter into a copy of itself.&lt;/p&gt;
-&lt;/blockquote&gt;
-                        </pre>
-                     </div>
+                    <div class="tabs-content">
+                         <div class="tabs-pane from-content-api" id="modules-pull-quote-output">
+                            <blockquote class="quoted">
+                                <p>In all the excitement over the discovery of a
+                                <a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link">
+                                Higgs-like particle</a> at Cern this year, physicists at the lab were probably not thinking about
+                                the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part
+                                and which describes fundamental particles and forces of nature – hides a terrifying secret: a
+                                theoretical composite particle that is so stable it can transform any other particle of matter
+                                into a copy of itself.</p>
+                            </blockquote>
+                         </div>
+                         <div class="tabs-pane js-hidden" id="modules-pull-quote-code">
+                            <pre class="prettyprint">
+    &lt;blockquote class="quoted"&gt;
+        &lt;p&gt;In all the excitement over the discovery of a &lt;a href="/science/2012/jul/04/higgs-boson-cern-scientists-discover" data-link-name="in body link"&gt;Higgs-like particle&lt;/a&gt; at Cern this year, physicists at the lab were probably not thinking about the end of the world. But the Standard Model of particle physics – of which the Higgs boson is part and which describes fundamental particles and forces of nature – hides a terrifying secret: a theoretical composite particle that is so stable it can transform any other particle of matter into a copy of itself.&lt;/p&gt;
+    &lt;/blockquote&gt;
+                            </pre>
+                         </div>
+                    </div>
                 </div>
-
+                
             </div>
 
         </section>

--- a/style-guide/app/views/styleGuide/zones.scala.html
+++ b/style-guide/app/views/styleGuide/zones.scala.html
@@ -19,24 +19,26 @@
 
             <p class="box-indent type-7">Change the text colour of the text in any element to the appropriate zone colour, by adding a class value of <code>.zone-color</code>.</p>
 
-            <ol class="tabs js-tabs">
-                <li class="tabs-selected"><a href="#zone-colour-output">Output</a></li>
-                <li><a href="#zone-colour-code">Source code</a></li>
-            </ol>
+            <div class="tabs-container">
+                <ol class="tabs js-tabs">
+                    <li class="tabs-selected"><a href="#zone-colour-output">Output</a></li>
+                    <li><a href="#zone-colour-code">Source code</a></li>
+                </ol>
 
-            <div class="tabs-content">
-                 <div class="tabs-pane" id="zone-colour-output">
-                    <div class="zone-environment">
-                        <p class="zone-color">I'm an environmental paragraph</p>
-                    </div>
-                 </div>
-                 <div class="tabs-pane js-hidden" id="zone-colour-code">
-                    <pre class="prettyprint">
-&lt;div class="zone-environment"&gt;
-    &lt;p class="zone-color"&gt;I'm an environmental paragraph&lt;/p&gt;
-&lt;/div&gt;
-                    </pre>
-                 </div>
+                <div class="tabs-content">
+                     <div class="tabs-pane" id="zone-colour-output">
+                        <div class="zone-environment">
+                            <p class="zone-color">I'm an environmental paragraph</p>
+                        </div>
+                     </div>
+                     <div class="tabs-pane js-hidden" id="zone-colour-code">
+                        <pre class="prettyprint">
+    &lt;div class="zone-environment"&gt;
+        &lt;p class="zone-color"&gt;I'm an environmental paragraph&lt;/p&gt;
+    &lt;/div&gt;
+                        </pre>
+                     </div>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
Tab modules are now wrapped with `<div class="tabs-container">...</div>` to scope the selectors to content within that module. 

Tabs can be made sticky to the viewport top when width is 640 or less by adding the `tabs-fixable` class to the above wrapper element. The tabs only stick while the top scroll position is within the tab module.
