### PR TITLE
Better decided on low/medium/high connection speed.

### DIFF
--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -78,9 +78,9 @@ define(function () {
         var speed = "high";
 
         if (load_time) {
-            if (load_time > 750) { // One second
+            if (load_time > 750) { // .75 second
                 speed = 'medium';
-                if (load_time > 3000) { // Four seconds
+                if (load_time > 3000) { // Three seconds
                     speed = 'low';
                 }
             }

--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -78,9 +78,9 @@ define(function () {
         var speed = "high";
 
         if (load_time) {
-            if (load_time > 1000) { // One second
+            if (load_time > 750) { // One second
                 speed = 'medium';
-                if (load_time > 4000) { // Four seconds
+                if (load_time > 3000) { // Four seconds
                     speed = 'low';
                 }
             }

--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -60,7 +60,17 @@ define(function () {
         return total_time;
     }
 
-    function getConnectionSpeed(performance) {
+    function getConnectionSpeed(performance, connection) {
+
+        var connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
+
+        var isMobileNetwork = connection.type == 3 // connection.CELL_2G 
+                  || connection.type == 4 // connection.CELL_3G
+                  || /^[23]g$/.test( connection.type ); // string value in new spec
+
+        if (isMobileNetwork) {
+            return 'low';
+        }
 
         var load_time = getPageSpeed(performance);
 

--- a/common/test/assets/javascripts/spec/Detect.spec.js
+++ b/common/test/assets/javascripts/spec/Detect.spec.js
@@ -16,7 +16,7 @@ define(['modules/detect'], function(detect) {
 
     });
 
-   describe("Connection speed", function() {
+    describe("Connection speed", function() {
    
         it("should default to 'high' speed", function(){
             window.performance = null; 
@@ -30,11 +30,25 @@ define(['modules/detect'], function(detect) {
             expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseStart: 3000 } })).toBe('medium');
             
             expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseStart: 1000 } })).toBe('high');
-        
-        }); 
-   });
 
-   describe("Font support", function() {
+        });
+
+        it("if mobile connection type can be determined speed should default to low", function() {
+
+            expect(detect.getConnectionSpeed(null, { type: 3} )).toBe('low'); // type 3 is CELL_2G
+
+            expect(detect.getConnectionSpeed(null, { type: 4} )).toBe('low'); // type 3 is CELL_3G
+
+            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseStart: 1000 } }, { type: 4} )).toBe('low');
+
+            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseStart: 8000 } }, { type: 6} )).toBe('low');
+
+            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseStart: 1000 } }, { type: 6} )).toBe('high');
+
+        });
+    });
+
+    describe("Font support", function() {
    
         var ttfUserAgents = [
             'Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) ...'


### PR DESCRIPTION
This adds support for navigator.connection.type to determine 2g/3g/wifi on Android devices. Fallsback to 'low' connection speed behaviour if on 2g/3g.

This should reduce the number of people getting the full bandwidth experience which appears unreasonably high currently.

@phamann @commuterjoy - You probably still want to adjust the page load timings that determine low/medium/high when this API is not supported.
