### PR TITLE
Made blocks not overlap when live blogs have narrow pictures

### DIFF
--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -118,7 +118,3 @@
         padding-left: 40px;
         margin-bottom: $baseline*2;
     }
-
-.block {
-  overflow: hidden;
-}

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -118,3 +118,7 @@
         padding-left: 40px;
         margin-bottom: $baseline*2;
     }
+
+.block {
+  overflow: hidden;
+}

--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -41,6 +41,13 @@
     border-left: none;
 }
 
+//Blocks
+//---------------------------------------------
+
+.from-content-api .block {
+  overflow: hidden;
+}
+
 //Captions
 //---------------------------------------------
 .caption,


### PR DESCRIPTION
## Before

![picture-desk-before](https://f.cloud.github.com/assets/76709/290779/87964aac-92f1-11e2-9341-15479244788b.png)
## After

![picture-desk-after](https://f.cloud.github.com/assets/76709/290782/92ce4212-92f1-11e2-9cb5-b4e1d698e612.png)
