### PR TITLE
Option to let errors bubble up to default handler

### DIFF
--- a/common/app/assets/javascripts/modules/errors.js
+++ b/common/app/assets/javascripts/modules/errors.js
@@ -1,4 +1,4 @@
-define(['userPrefs', 'common'], function (userPrefs, common) {
+define(['modules/userPrefs', 'common'], function (userPrefs, common) {
 
     var Errors = function (config) {
 

--- a/common/app/assets/javascripts/modules/errors.js
+++ b/common/app/assets/javascripts/modules/errors.js
@@ -1,4 +1,4 @@
-define(['common'], function (common) {
+define(['userPrefs', 'common'], function (userPrefs, common) {
 
     var Errors = function (config) {
 
@@ -25,7 +25,7 @@ define(['common'], function (common) {
                     var url = makeUrl([message, filename, lineno]);
                     createImage(url);
                 }
-                return true;
+                return (userPrefs.isOn('showErrors')) ? false : true;
             },
             init = function() {
                 win.onerror = log;


### PR DESCRIPTION
Append `?gu.prefs.switchOn=showErrors` to query
