### PR TITLE
Changed all /px.gif to point to new beacon domain

### DIFF
--- a/common/app/assets/javascripts/modules/errors.js
+++ b/common/app/assets/javascripts/modules/errors.js
@@ -2,7 +2,8 @@ define(['common'], function (common) {
 
     var Errors = function (w) {
 
-        var path = '/px.gif',
+        var url = "http://beacon." + window.location.hostname,
+            path = '/px.gif',
             win = w || window,
             body = document.body,
             createImage = function(url) {
@@ -13,7 +14,7 @@ define(['common'], function (common) {
                 body.appendChild(image);
             },
             makeUrl = function(properties) {
-                return path + '?js/' + encodeURIComponent(properties.join(','));
+                return url + path + '?js/' + encodeURIComponent(properties.join(','));
             },
             log = function(message, filename, lineno) {
                 var url = makeUrl([message, filename, lineno]);

--- a/common/app/assets/javascripts/modules/errors.js
+++ b/common/app/assets/javascripts/modules/errors.js
@@ -2,7 +2,7 @@ define(['common'], function (common) {
 
     var Errors = function (w) {
 
-        var url = "http://beacon." + window.location.hostname,
+        var url = "//beacon." + window.location.hostname,
             path = '/px.gif',
             win = w || window,
             body = document.body,

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -48,7 +48,7 @@
             if (fontTime > 50) {
                 var img = document.createElement("img");
                 img.style = "display: none";
-                img.src = "http://beacon." + window.location.hostname +  "/px.gif?fonts/&fonttime=" + fontTime;
+                img.src = "//beacon." + window.location.hostname +  "/px.gif?fonts/&fonttime=" + fontTime;
                 document.getElementsByTagName("head")[0].appendChild(img);
             }
         }

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -48,7 +48,7 @@
             if (fontTime > 50) {
                 var img = document.createElement("img");
                 img.style = "display: none";
-                img.src = "/px.gif?fonts/&fonttime=" + fontTime;
+                img.src = "http://beacon." + window.location.hostname +  "/px.gif?fonts/&fonttime=" + fontTime;
                 document.getElementsByTagName("head")[0].appendChild(img);
             }
         }

--- a/common/test/assets/javascripts/spec/Errors.spec.js
+++ b/common/test/assets/javascripts/spec/Errors.spec.js
@@ -20,7 +20,7 @@ define(['common', 'modules/errors'], function(common, Errors) {
         it("should log javascript errors with the error message, line number and file", function(){
             var fakeError = { 'message': 'foo', lineno: 1, filename: 'foo.js' }
             e.log(fakeError.message, fakeError.lineno, fakeError.filename);
-            expect(document.getElementById('js-err').getAttribute('src')).toBe('/px.gif?js/foo%2C1%2Cfoo.js');
+            expect(document.getElementById('js-err').getAttribute('src')).toContain('/px.gif?js/foo%2C1%2Cfoo.js');
         });
 
     });


### PR DESCRIPTION
Need to wait for @daithiocrualaoich opinion on the remaining references to /px.gif in the metrics gathering:

https://github.com/guardian/frontend/blob/master/diagnostics/app/conf/context.scala#L13
https://github.com/guardian/frontend/blob/master/diagnostics/app/metrics/NginxLog.scala#L2
