### PR TITLE
Send optimizely test data back to Omniture and Ophan.

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -55,13 +55,6 @@ define([
                 reader.init();
             }
         },
-        
-        addOptimizely: function(config) {
-            // pull in optimizely js
-            if(config.switches.optimizely === true) {
-                require(['js!' + config.page.optimizelyUrl]);
-            }
-        },
 
         initExperiments: function(config) {
             common.mediator.on('modules:experiment:render', function() {
@@ -93,7 +86,6 @@ define([
     var defer = function(config) {
         common.deferToLoadEvent(function() {
             modules.logReading(config);
-            modules.addOptimizely(config);
         });
     };
 

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -22,6 +22,7 @@ define([
     'modules/relativedates',
     'modules/analytics/clickstream',
     'modules/analytics/omniture',
+    'modules/analytics/optimizely',
     'modules/adverts/adverts',
     'modules/cookies',
     'modules/search',
@@ -49,6 +50,7 @@ define([
     RelativeDates,
     Clickstream,
     Omniture,
+    optimizely,
     Adverts,
     Cookies,
     Search,
@@ -169,7 +171,19 @@ define([
         },
 
         loadOphanAnalytics: function (config) {
-            require([config.page.ophanUrl], function (Ophan) {
+            var dependOn = [config.page.ophanUrl];
+            if (config.switches.optimizely === true) {
+                console.log("optimizely true");
+                dependOn.push('js!' + config.page.optimizelyUrl);
+            }
+            require(dependOn, function (Ophan) {
+                if (config.switches.optimizely === true) {
+                    Ophan.additionalViewData(function() {
+                        return {
+                            "optimizely": optimizely.readTests()
+                        };
+                    });
+                }
                 Ophan.startLog();
             });
         },

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -173,7 +173,6 @@ define([
         loadOphanAnalytics: function (config) {
             var dependOn = [config.page.ophanUrl];
             if (config.switches.optimizely === true) {
-                console.log("optimizely true");
                 dependOn.push('js!' + config.page.optimizelyUrl);
             }
             require(dependOn, function (Ophan) {

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -129,7 +129,7 @@ define(['common', 'modules/detect', 'modules/analytics/optimizely'], function(co
             this.logView();
             common.mediator.on('module:clickstream:click', this.logTag );
             common.mediator.emit('module:omniture:loaded');
-        }
+        };
 
         this.init = function() {
 

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -1,8 +1,8 @@
-define(['common', 'modules/detect'], function(common, detect) {
+define(['common', 'modules/detect', 'modules/analytics/optimizely'], function(common, detect, optimizely) {
 
     // https://developer.omniture.com/en_US/content_page/sitecatalyst-tagging/c-tagging-overview
 
-	/**
+    /**
      * @param Object w 'window' object, used for testing
      */
     function Omniture(s, config, w) {
@@ -68,7 +68,6 @@ define(['common', 'modules/detect'], function(common, detect) {
             s.tl(true, 'o', tagStr);
         };
 
-
         this.populatePageProperties = function() {
 
             // http://www.scribd.com/doc/42029685/15/cookieDomainPeriods
@@ -106,6 +105,10 @@ define(['common', 'modules/detect'], function(common, detect) {
 
             s.prop48    = detect.getConnectionSpeed(w.performance);
 
+            if (config.switches.optimizely === true) {
+                s.prop51    = optimizely.readTests();
+            }
+
             s.prop56    = 'Javascript';
 
             s.prop65    = config.page.headline || '';
@@ -121,6 +124,13 @@ define(['common', 'modules/detect'], function(common, detect) {
             }
         };
 
+        this.loaded = function() {
+            this.populatePageProperties();
+            this.logView();
+            common.mediator.on('module:clickstream:click', this.logTag );
+            common.mediator.emit('module:omniture:loaded');
+        }
+
         this.init = function() {
 
             // must be set before the Omniture file is parsed
@@ -132,17 +142,15 @@ define(['common', 'modules/detect'], function(common, detect) {
             // use the global 's' object
 
             if (s !== null) {
-                that.populatePageProperties();
-                that.logView();
-                common.mediator.on('module:clickstream:click', that.logTag );
-                common.mediator.emit('module:omniture:loaded');
+                that.loaded();
             } else {
-                require(['js!omniture'], function(placeholder){
+                var dependOn = ['js!omniture'];
+                if (config.switches.optimizely === true) {
+                    dependOn.push('js!' + config.page.optimizelyUrl);
+                }
+                require(dependOn, function(placeholder){
                     s = window.s;
-                    that.populatePageProperties();
-                    that.logView();
-                    common.mediator.on('module:clickstream:click', that.logTag );
-                    common.mediator.emit('module:omniture:loaded');
+                    that.loaded();
                 });
             }
 

--- a/common/app/assets/javascripts/modules/analytics/optimizely.js
+++ b/common/app/assets/javascripts/modules/analytics/optimizely.js
@@ -2,9 +2,9 @@ define(function() {
 
     function readTests(config) {
         var tests = [];
+        var prop = '';
         if (window.optimizely) {
             var optim = window.optimizely;
-            var prop = '';
             for (var i = 0, j = optim.activeExperiments.length; i<j; ++i) {
                 var experimentId = optim.activeExperiments[i];
                 var activeVariantId = optim.variationIdsMap[experimentId][0];
@@ -15,12 +15,11 @@ define(function() {
                 }
             }
         }
-        console.log(prop);
         return prop;
     }
 
     return {
         'readTests': readTests
-    }
+    };
 });
 

--- a/common/app/assets/javascripts/modules/analytics/optimizely.js
+++ b/common/app/assets/javascripts/modules/analytics/optimizely.js
@@ -9,13 +9,10 @@ define(function() {
                 var experimentId = optim.activeExperiments[i];
                 var activeVariantId = optim.variationIdsMap[experimentId][0];
                 prop += optim.allExperiments[experimentId].name + '#' + experimentId + '=';
-                prop += optim.allVariations[activeVariantId].name + '#' + activeVariantId;
-                if (i >= optim.activeExperiments.length) {
-                    prop += "|||";
-                }
+                prop += optim.allVariations[activeVariantId].name + '#' + activeVariantId + '|||'
             }
         }
-        return prop;
+        return prop.substring(0, prop.length-3);
     }
 
     return {

--- a/common/app/assets/javascripts/modules/analytics/optimizely.js
+++ b/common/app/assets/javascripts/modules/analytics/optimizely.js
@@ -1,0 +1,26 @@
+define(function() {
+
+    function readTests(config) {
+        var tests = [];
+        if (window.optimizely) {
+            var optim = window.optimizely;
+            var prop = '';
+            for (var i = 0, j = optim.activeExperiments.length; i<j; ++i) {
+                var experimentId = optim.activeExperiments[i];
+                var activeVariantId = optim.variationIdsMap[experimentId][0];
+                prop += optim.allExperiments[experimentId].name + '#' + experimentId + '=';
+                prop += optim.allVariations[activeVariantId].name + '#' + activeVariantId;
+                if (i >= optim.activeExperiments.length) {
+                    prop += "|||";
+                }
+            }
+        }
+        console.log(prop);
+        return prop;
+    }
+
+    return {
+        'readTests': readTests
+    }
+});
+


### PR DESCRIPTION
This is part of our push to 'get optimizely to do something useful quickly'. This logs the current test and current variant data back to Omniture and Ophan.

This is unfortunate because it means holding back Omniture and Ophan pings until Optimizely has loaded, hence the slightly ugly crunching of optimizely into the ophan and omniture inits. Very open to better ways of doing this, short or long term.

It's also unfortunate because it loads optimizely on every page, not just the article. :/

Longer term, these need to be sent to Ophan/Omniture as separate requests.

If you want to test, ensure optimizely switch is on in your environment, and then check Ophan ping for an 'optimizely' attr, and the Omniture ping for prop51.

Thoughts?
