### PR TITLE
Pre-commit hook that runs js-hint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
                 },
                 {
                   "font-family": "EgyptianText",
-                  "font-weight": "500", 
+                  "font-weight": "500",
                   "file": "resources/fonts/EgyptianText-Medium.woff",
                   "format": "woff"
                 },
@@ -106,7 +106,7 @@ module.exports = function (grunt) {
                 },
                 {
                   "font-family": "EgyptianText",
-                  "font-weight": "500", 
+                  "font-weight": "500",
                   "file": "resources/fonts/EgyptianText-Medium.ttf",
                   "format": "ttf"
                 },
@@ -152,7 +152,20 @@ module.exports = function (grunt) {
                 }
               ]
             }
-          },
+          }
+        },
+        // Clean stuff up
+        clean: {
+          // Clean any pre-commit hooks in .git/hooks directory
+          hooks: ['.git/hooks/pre-commit']
+        },
+
+        // Run shell commands
+        shell: {
+          hooks: {
+            // Copy the project's pre-commit hook into .git/hooks
+            command: 'cp git-hooks/pre-commit .git/hooks/'
+          }
         }
 
     });
@@ -162,6 +175,8 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-requirejs');
     grunt.loadNpmTasks('grunt-webfontjson');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-shell');
 
     // Standard tasks
     grunt.registerTask('test:common', ['jshint:common']);
@@ -173,4 +188,7 @@ module.exports = function (grunt) {
     grunt.registerTask('compile', ['compile:common:css', 'compile:common:js']);
 
     grunt.registerTask('default', ['test', 'compile']);
+
+    // Clean the .git/hooks/pre-commit file then copy in the latest version
+    grunt.registerTask('hookmeup', ['clean:hooks', 'shell:hooks']);
 };

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Pre-commit hooks
+
+# Lint stuff before commiting
+grunt jshint:common

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "grunt-contrib-requirejs": "~0.3.4",
     "grunt-webfontjson": "~0.0.2",
     "grunt-contrib-sass": "~0.2.2",
-    "svgo": "~0.2.3"
+    "svgo": "~0.2.3",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-shell": "~0.2.1"
+  },
+  "scripts": {
+    "postinstall": "grunt hookmeup"
   }
 }


### PR DESCRIPTION
Taken from https://coderwall.com/p/g1kqzg

On an `npm install`, hook is added to client's repo - think this is a seamless as we can make it, though does still involve an extra step
