### PR TITLE
Do speed detection with responseEnd, so it's measuring more than just latency

### DIFF
--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -50,7 +50,7 @@ define(function () {
         
         if (perf && perf.timing) {
             start_time =  perf.timing.requestStart || perf.timing.fetchStart || perf.timing.navigationStart;
-            end_time = perf.timing.responseStart;
+            end_time = perf.timing.responseEnd;
 
             if (start_time && end_time) {
                 total_time = end_time - start_time;
@@ -78,7 +78,7 @@ define(function () {
         var speed = "high";
 
         if (load_time) {
-            if (load_time > 750) { // .75 second
+            if (load_time > 1000) { // One second
                 speed = 'medium';
                 if (load_time > 3000) { // Three seconds
                     speed = 'low';


### PR DESCRIPTION
This was measuring the latency of the request/response rather than any bandwidth.

Adjust this to include the time it takes to download HTML to see if this makes our graphs any more reasonable. Current graph:

![Screen Shot 2013-04-02 at 17 35 21](https://f.cloud.github.com/assets/30920/329467/1ba44dc8-9bb4-11e2-8d0d-112379a0a873.png)

cc @phamann 
