### PR TITLE
Report unknown connection speeds rather than the assumed high value.

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -103,7 +103,7 @@ define(['common', 'modules/detect', 'modules/analytics/optimizely'], function(co
 
             s.prop47    = config.page.edition || '';
 
-            s.prop48    = detect.getConnectionSpeed(w.performance);
+            s.prop48    = detect.getConnectionSpeed(w.performance, null, true);
 
             if (config.switches.optimizely === true) {
                 s.prop51    = optimizely.readTests();

--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -60,7 +60,7 @@ define(function () {
         return total_time;
     }
 
-    function getConnectionSpeed(performance, connection) {
+    function getConnectionSpeed(performance, connection, reportUnknown) {
 
         connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
 
@@ -72,19 +72,23 @@ define(function () {
             return 'low';
         }
 
-        var load_time = getPageSpeed(performance);
+        var loadTime = getPageSpeed(performance);
 
-        // Assume high speed for non supporting browsers.
+        // Assume high speed for non supporting browsers
         var speed = "high";
+        if (reportUnknown) {
+            speed = "unknown";
+        }
 
-        if (load_time) {
-            if (load_time > 1000) { // One second
+        if (loadTime) {
+            if (loadTime > 1000) { // One second
                 speed = 'medium';
-                if (load_time > 3000) { // Three seconds
+                if (loadTime > 3000) { // Three seconds
                     speed = 'low';
                 }
             }
         }
+
         
         return speed;
 

--- a/common/test/assets/javascripts/spec/Detect.spec.js
+++ b/common/test/assets/javascripts/spec/Detect.spec.js
@@ -33,17 +33,25 @@ define(['modules/detect'], function(detect) {
 
         });
 
-        it("if mobile connection type can be determined speed should default to low", function() {
+        it("should return low if CELL connection can be determined", function() {
 
             expect(detect.getConnectionSpeed(null, { type: 3} )).toBe('low'); // type 3 is CELL_2G
 
-            expect(detect.getConnectionSpeed(null, { type: 4} )).toBe('low'); // type 3 is CELL_3G
+            expect(detect.getConnectionSpeed(null, { type: 4} )).toBe('low'); // type 4 is CELL_3G
 
-            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 1000 } }, { type: 4} )).toBe('low');
+            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 750 } }, { type: 4} )).toBe('low');
 
             expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 8000 } }, { type: 6} )).toBe('low');
 
             expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 750 } }, { type: 6} )).toBe('high');
+
+        });
+
+        it("should return high or unknown if the speed can't be determined", function() {
+
+            expect(detect.getConnectionSpeed(null, null)).toBe('high');
+
+            expect(detect.getConnectionSpeed(null, null, true)).toBe('unknown');
 
         });
     });


### PR DESCRIPTION
Slowly getting to the bottom of this weird reporting. We weren't explicitly showing users who don't support the nav timing API or the connection API. This will be a nice (if disappointing) metric to understand.

This change allows getConnectionSpeed to optionally report unknown speeds so Omniture can query this.
