### PR TITLE
DONT MERGE: Dev asset non-compilation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,7 @@ module.exports = function (grunt) {
     grunt.registerTask('test', ['test:common']);
 
     grunt.registerTask('compile:common', ['requirejs:common']);
-    grunt.registerTask('compile', ['compile:common']);
+    grunt.registerTask('compile', []);
 
     grunt.registerTask('default', ['test', 'compile']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,7 +185,7 @@ module.exports = function (grunt) {
     grunt.registerTask('compile:common:css', ['sass:common']);
     grunt.registerTask('compile:common:js', ['requirejs:common']);
 
-    grunt.registerTask('compile', ['compile:common:css']);
+    grunt.registerTask('compile', ['compile:common:css', 'compile:common:js']);
 
     grunt.registerTask('default', ['test', 'compile']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,7 +185,7 @@ module.exports = function (grunt) {
     grunt.registerTask('compile:common:css', ['sass:common']);
     grunt.registerTask('compile:common:js', ['requirejs:common']);
 
-    grunt.registerTask('compile', ['compile:common:css', 'compile:common:js']);
+    grunt.registerTask('compile', ['compile:common:css']);
 
     grunt.registerTask('default', ['test', 'compile']);
 

--- a/common/app/assets/javascripts/modules/fonts.js
+++ b/common/app/assets/javascripts/modules/fonts.js
@@ -74,13 +74,13 @@ define(['ajax', 'common'], function (ajax, common) {
             this.clearWithPrefix(storagePrefix + name);
             this.clearWithPrefix('_guFont:'); // Remove legacy non-cache-busted font.
         };
-        
+
         this.clearAllFontsFromStorage = function() {
             this.clearWithPrefix(storagePrefix);
         };
 
         function getNameAndCacheKey(style) {
-            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff\.(.*)\.js$/);
+            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(:?\.(.*))?\.js$/);
             nameAndCacheKey.shift();
             return nameAndCacheKey;
         }

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -76,12 +76,21 @@
                 }.mkString(","))}
             }
         };
+        
+        var script = document.createElement('script');
+        script.async = 'async';
+        script.src = '@Static("javascripts/components/curl/dist/curl-with-js-and-domReady/curl.js")';
+        document.getElementsByTagName("head")[0].appendChild(script);
 
         var script = document.createElement('script');
         script.async = 'async';
         script.src = '@Static("javascripts/bootstraps/app.js")';
+        document.getElementsByTagName("head")[0].appendChild(script);
 
-        document.getElementsByTagName("head")[0].appendChild(script); 
+        var script = document.createElement('script');
+        script.async = 'async';
+        script.src = '@Static("javascripts/bootstraps/go.js")';
+        document.getElementsByTagName("head")[0].appendChild(script);
     
     })(guardian.isModernBrowser);
 

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -14,7 +14,15 @@
                 apiName: 'require',
                 paths: {
                     omniture: '@Static("javascripts/vendor/omniture.js")',
-                    homescreen: '@Static("javascripts/vendor/add2home.js")' // Mofified version. Do not upgrade.
+                    homescreen: '@Static("javascripts/vendor/add2home.js")', // Mofified version. Do not upgrade.
+                    bean: '@Static("javascripts/components/bean/bean.js")',
+                    bonzo: '@Static("javascripts/components/bonzo/src/bonzo.js")',
+                    domReady: '@Static("javascripts/components/domready/ready.js")',
+                    EventEmitter: '@Static("javascripts/components/eventEmitter/EventEmitter.js")',
+                    qwery: '@Static("javascripts/components/qwery/mobile/qwery-mobile.js")',
+                    reqwest: '@Static("javascripts/components/reqwest/src/reqwest.js")',
+                    domwrite: '@Static("javascripts/components/dom-write/dom-write.js")',
+                    swipe: '@Static("javascripts/components/swipe/swipe.js")'
                 }
             };
 
@@ -36,7 +44,7 @@
             var styleNodes = document.querySelectorAll('[data-cache-name]');
             for (var i = 0, j = styleNodes.length; i<j; ++i) {
                 var style = styleNodes[i],
-                    nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff\.(.*)\.js$/),
+                    nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(:?\.(.*))?\.js$/),
                     cachedCss = localStorage.getItem('gu.fonts.' + nameAndCacheKey[1] + '.' + nameAndCacheKey[2]);
                 if (cachedCss) {
                     style.innerHTML = cachedCss;
@@ -79,20 +87,18 @@
             }
         };
         
-        var script = document.createElement('script');
-        script.async = 'async';
-        script.src = '@Static("javascripts/components/curl/dist/curl-with-js-and-domReady/curl.js")';
-        document.getElementsByTagName("head")[0].appendChild(script);
+        var curlScript = document.createElement('script');
+        curlScript.src = '@Static("javascripts/components/curl/dist/curl-with-js-and-domReady/curl.js")';
+        document.getElementsByTagName("head")[0].appendChild(curlScript);
 
-        var script = document.createElement('script');
-        script.async = 'async';
-        script.src = '@Static("javascripts/bootstraps/app.js")';
-        document.getElementsByTagName("head")[0].appendChild(script);
+        var appScript = document.createElement('script');
+        appScript.src = '@Static("javascripts/bootstraps/app.js")';
+        document.getElementsByTagName("head")[0].appendChild(appScript);
 
-        var script = document.createElement('script');
-        script.async = 'async';
-        script.src = '@Static("javascripts/bootstraps/go.js")';
-        document.getElementsByTagName("head")[0].appendChild(script);
+        var goScript = document.createElement('script');
+        goScript.async = 'async';
+        goScript.src = '@Static("javascripts/bootstraps/go.js")';
+        document.getElementsByTagName("head")[0].appendChild(goScript);
     
     })(guardian.isModernBrowser);
 

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -78,12 +78,21 @@
                 }.mkString(","))}
             }
         };
+        
+        var script = document.createElement('script');
+        script.async = 'async';
+        script.src = '@Static("javascripts/components/curl/dist/curl-with-js-and-domReady/curl.js")';
+        document.getElementsByTagName("head")[0].appendChild(script);
 
         var script = document.createElement('script');
         script.async = 'async';
         script.src = '@Static("javascripts/bootstraps/app.js")';
+        document.getElementsByTagName("head")[0].appendChild(script);
 
-        document.getElementsByTagName("head")[0].appendChild(script); 
+        var script = document.createElement('script');
+        script.async = 'async';
+        script.src = '@Static("javascripts/bootstraps/go.js")';
+        document.getElementsByTagName("head")[0].appendChild(script);
     
     })(guardian.isModernBrowser);
 

--- a/project/Assets.scala
+++ b/project/Assets.scala
@@ -18,7 +18,10 @@ case class Asset(absolute: File, base: File) {
     val Path = """(.*)\.([^\.]*)$""".r
     val Path(file, suffix) = debased
 
-    "%s.%s.%s".format(file, absolute.md5Hex, suffix)
+    // don't add MD5 hash - conditional on dev
+    // better to not run asset hashing at all on dev?
+//    "%s.%s.%s".format(file, absolute.md5Hex, suffix)
+    "%s.%s".format(file, suffix)
   }
 
   def toText: String = debased + "=" + debasedWithMD5Chunk

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -15,8 +15,8 @@ object Frontend extends Build with Prototypes with Testing {
 
   val common = library("common").settings(
     javascriptFiles <<= baseDirectory{ (baseDir) => baseDir \ "app" \ "assets" ** "*.js" },
-    (test in Test) <<= (test in Test) dependsOn (gruntTask("test")),
-    resources in Compile <<=  (resources in Compile) dependsOn (gruntTask("compile", javascriptFiles))
+    (test in Test) <<= (test in Test) dependsOn (gruntTask("test"))//,
+//    resources in Compile <<=  (resources in Compile) dependsOn (gruntTask("compile", javascriptFiles))
   )
 
   val commonWithTests = common % "test->test;compile->compile"

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -18,7 +18,7 @@ object Frontend extends Build with Prototypes with Testing {
     javascriptFiles <<= baseDirectory{ (baseDir) => baseDir \ "app" \ "assets" ** "*.js" },
     cssFiles <<= baseDirectory{ (baseDir) => baseDir \ "app" \ "assets" ** "*.scss" },
     (test in Test) <<= (test in Test) dependsOn (gruntTask("test")),
-    resources in Compile <<=  (resources in Compile) dependsOn (gruntTask("compile:common:js", javascriptFiles)),
+//    resources in Compile <<=  (resources in Compile) dependsOn (gruntTask("compile:common:js", javascriptFiles)),
     resources in Compile <<=  (resources in Compile) dependsOn (gruntTask("compile:common:css", cssFiles))
   )
 

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -18,6 +18,7 @@ object Frontend extends Build with Prototypes with Testing {
     javascriptFiles <<= baseDirectory{ (baseDir) => baseDir \ "app" \ "assets" ** "*.js" },
     cssFiles <<= baseDirectory{ (baseDir) => baseDir \ "app" \ "assets" ** "*.scss" },
     (test in Test) <<= (test in Test) dependsOn (gruntTask("test")),
+    // conditionally turn off compiliation on dev
 //    resources in Compile <<=  (resources in Compile) dependsOn (gruntTask("compile:common:js", javascriptFiles)),
     resources in Compile <<=  (resources in Compile) dependsOn (gruntTask("compile:common:css", cssFiles))
   )

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -63,7 +63,8 @@ trait Prototypes extends Testing {
         Seq(
           // don't copy across svg files (they're inline)
           (sourceDirectory / "assets" / "images") ** "*.png",
-          (sourceDirectory / "assets" / "javascripts" / "bootstraps") ** "app.js",
+//          (sourceDirectory / "assets" / "javascripts" / "bootstraps") ** "app.js",
+          (sourceDirectory / "assets" / "javascripts") ** "*.js",
           (sourceDirectory / "public") ** "*"
         )
       },

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -64,6 +64,8 @@ trait Prototypes extends Testing {
         Seq(
           // don't copy across svg files (they're inline)
           (sourceDirectory / "assets" / "images") ** "*.png",
+          // copy everything across on dev
+          // better, only copy across the files we need (tie into the curl config?)
 //          (sourceDirectory / "assets" / "javascripts" / "bootstraps") ** "app.js",
           (sourceDirectory / "assets" / "javascripts") ** "*.js",
           (sourceDirectory / "assets" / "stylesheets") ** "*.min.css",

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -64,7 +64,8 @@ trait Prototypes extends Testing {
         Seq(
           // don't copy across svg files (they're inline)
           (sourceDirectory / "assets" / "images") ** "*.png",
-          (sourceDirectory / "assets" / "javascripts" / "bootstraps") ** "app.js",
+//          (sourceDirectory / "assets" / "javascripts" / "bootstraps") ** "app.js",
+          (sourceDirectory / "assets" / "javascripts") ** "*.js",
           (sourceDirectory / "assets" / "stylesheets") ** "*.min.css",
           (sourceDirectory / "public") ** "*"
         )


### PR DESCRIPTION
Hacked about to get a proof-of-concept non-compilation of assets working, i.e. modules are pulled in when needed.

However, because we have so many modules, it's now actually slower as each module it pulled in. The upfront compilation, now we switched over to grunt, is now actually pretty quick. So after all this I'd say we should stick to compiling on dev. 

However, there are a couple of things we should do
- don't minify js - `"optimize"  : "none"`
- add source maps to js (http://requirejs.org/docs/optimization.html#sourcemaps) and sass
- look into tightening up the asset hashing - each request seems to set it off multiple times; it only needs to be created once, when a file changes
