### PR TITLE
body background-colour set to white

### DIFF
--- a/common/app/assets/stylesheets/base/_base.scss
+++ b/common/app/assets/stylesheets/base/_base.scss
@@ -1,3 +1,7 @@
+body {
+    background-color: #ffffff;
+}
+
 .dateline {
     font-family: $sans-serif;
     margin: 0px 0px $baseline*2 0px;


### PR DESCRIPTION
Pull request of the century.
- phantomjs rasterises the page with a transparent background
- Also, probably, there's an accessibility reason for doing this (Eg. non-white default bg)
