### PR TITLE
Dev mode for grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function (grunt) {
 
     var isDev = (grunt.option('dev')) || process.env.GRUNT_ISDEV === '1';
     if (isDev) {
-        console.log("\n### Running Grunt in DEV mode ###\n");
+        grunt.log.subhead('Running Grunt in DEV mode');
     }
 
     // Project configuration.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,12 @@
 /* global module: false */
 module.exports = function (grunt) {
-    // Project configuration.
 
+    var isDev = (grunt.option('dev')) || process.env.GRUNT_ISDEV === '1';
+    if (isDev) {
+        console.log("\n### Running Grunt in DEV mode ###\n");
+    }
+
+    // Project configuration.
     grunt.initConfig({
         sass: {
             common: {
@@ -12,7 +17,8 @@ module.exports = function (grunt) {
                 options: {
                     check: false,
                     quiet: true,
-                    style: "compressed",
+                    debugInfo: (isDev) ? true : false,
+                    style: (isDev) ? 'nested' : 'compressed',
                     loadPath: [
                         'common/app/assets/stylesheets/components/pasteup/sass/layout',
                         'common/app/assets/stylesheets/components/normalize-scss'
@@ -41,7 +47,8 @@ module.exports = function (grunt) {
                         "startFile" : "common/app/assets/javascripts/components/curl/dist/curl-with-js-and-domReady/curl.js",
                         "endFile"   : "common/app/assets/javascripts/bootstraps/go.js"
                     },
-                    "optimize"  : "uglify2",
+                    optimize: (isDev) ? 'none' : 'uglify2',
+                    useSourceUrl:  (isDev) ? true : false,
                     "preserveLicenseComments" : false
                 }
             }

--- a/sbt012
+++ b/sbt012
@@ -45,6 +45,8 @@ do
     fi
 done
 
+# Grunt configuration
+export GRUNT_ISDEV=1
 
 #MaxPermSize specifies the the maximum size for the permanent generation heap,
 # a heap that holds objects such as classes and methods. Xmx is the heap size.


### PR DESCRIPTION
Added a dev mode to grunt. 

Currently doesn't minify css/js and adds source maps. Triggered by an env variable (`GRUNT_ISDEV`), which I've added to sbt012, or passing `--dev` when calling grunt, e.g.

```
grunt compile --dev
```
