### PR TITLE
removing 'new' from link

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -9,7 +9,7 @@
 
     <ul class="nav nav--stacked nav--top-border-off cf">
     	<li>@fragments.mainSiteLink(page)</li>
-    	<li><a data-link-name="about" href="/help/insideguardian/2012/nov/26/guardian-launches-new-mobile-site">About this new site</a></li>
+    	<li><a data-link-name="about" href="/help/insideguardian/2012/nov/26/guardian-launches-new-mobile-site">About this site</a></li>
         <li><a data-link-name="help" href="/help/2012/nov/26/guardian-mobile-site">Help</a></li>
     	<li><a data-link-name="contact" href="/help/contact-us">Contact us</a></li>
         <li><a data-link-name="feedback" target="_blank" href="http://survey.omniture.com/d1/hosted/815f9cfba1">Feedback</a></li>


### PR DESCRIPTION
After 6 months, I don't think this version of the site is 'new' anymore. Also I'm not a fan of time references like this, as they inevitably bit rot
