### PR TITLE
Better link tracking

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -123,7 +123,7 @@ define([
                 }
             });
 
-            var cs = new Clickstream({ filter: ["a", "span", "button"] }),
+            var cs = new Clickstream({filter: ["a", "button"]}),
                 o = new Omniture(null, config).init();
         },
 

--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -35,8 +35,13 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
         var getClickSpec = function (spec) {
             var el = spec.el,
                 elName = el.tagName.toLowerCase(),
-                dataLinkName,
+                dataLinkName = el.getAttribute('data-link-name'),
                 href;
+
+            if (dataLinkName) {
+                spec.tag = spec.tag || [];
+                spec.tag.push(dataLinkName);
+            }
 
             if (elName === 'body') {
                 if (spec.validTarget) {
@@ -62,12 +67,6 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
 
                     spec.sameHost = spec.samePage || compareHosts(href);
                 }
-            }
-
-            dataLinkName = el.getAttribute('data-link-name');
-            if (dataLinkName) {
-                spec.tag = spec.tag || [];
-                spec.tag.push(dataLinkName);
             }
 
             // Recurse

--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -44,7 +44,7 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
             }
 
             if (elName === 'body') {
-                if (spec.validTarget) {
+                if (spec.validTarget && spec.tag.length) {
                     spec.tag = [].concat(spec.tag).reverse().join(' | ');
                     delete spec.el;
                     delete spec.validTarget;

--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -35,7 +35,8 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
         var getClickSpec = function (spec) {
             var el = spec.el,
                 elName = el.tagName.toLowerCase(),
-                dataLinkName;
+                dataLinkName,
+                href;
 
             if (elName === 'body') {
                 if (spec.validTarget) {
@@ -53,8 +54,13 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
                 spec.validTarget = filterSource(el.tagName.toLowerCase()).length > 0;
                 if(spec.validTarget) {
                     spec.target = el;
-                    spec.samePage = (elName === 'button') || (' ' + el.className + ' ').indexOf(' control ') > -1;
-                    spec.sameHost = spec.samePage || compareHosts(el.getAttribute('href'));
+                    href = el.getAttribute('href');
+                    spec.samePage = href && href.indexOf('#') === 0
+                        || elName === 'button'
+                        || el.getAttribute('data-is-ajax')
+                        || ' '+el.className+' '.indexOf(' control ') > -1;
+
+                    spec.sameHost = spec.samePage || compareHosts(href);
                 }
             }
 

--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -11,7 +11,7 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
             });
         };
 
-        var hasSameHost = function(url) {
+        var compareHosts = function(url) {
             var urlHost,
                 urlProtocol,
                 host,
@@ -32,49 +32,48 @@ define(['common', 'modules/detect', 'bean'], function (common, detect, bean) {
             return !urlHost || (urlHost === host && urlProtocol === protocol);
         };
 
-        var getTag = function (element, tag, valid) {
+        var getClickSpec = function (spec) {
+            var el = spec.el,
+                elName = el.tagName.toLowerCase(),
+                dataLinkName;
 
-            var elementName = element.tagName.toLowerCase(),
-                dataLinkName = element.getAttribute('data-link-name');
-
-            valid = valid || filterSource(element.tagName.toLowerCase()).length > 0;
-
-            if (elementName === 'body') {
-                return valid ? tag.reverse().join(' | ') : false;
+            if (elName === 'body') {
+                if (spec.validTarget) {
+                    spec.tag = [].concat(spec.tag).reverse().join(' | ');
+                    delete spec.el;
+                    delete spec.validTarget;
+                    return spec;
+                }
+                else {
+                    return false;
+                }
             }
 
+            if(!spec.validTarget) {
+                spec.validTarget = filterSource(el.tagName.toLowerCase()).length > 0;
+                if(spec.validTarget) {
+                    spec.target = el;
+                    spec.samePage = (elName === 'button') || (' ' + el.className + ' ').indexOf(' control ') > -1;
+                    spec.sameHost = spec.samePage || compareHosts(el.getAttribute('href'));
+                }
+            }
+
+            dataLinkName = el.getAttribute('data-link-name');
             if (dataLinkName) {
-                tag.push(dataLinkName);
+                spec.tag = spec.tag || [];
+                spec.tag.push(dataLinkName);
             }
 
-            return getTag(element.parentNode, tag, valid);
+            // Recurse
+            spec.el = el.parentNode;
+            return getClickSpec(spec);
         };
 
         // delegate, emit the derived tag
         bean.add(document.body, 'click', function (event) {
-            var target = event.target,
-                tag    = getTag(target, [], false),
-                dataIsXhr,
-                href,
-                isSamePage,
-                isSameHost;
-
-            if (tag) {
-
-                dataIsXhr = target.getAttribute('data-is-ajax');
-                href = target.getAttribute('href');
-
-                isSamePage = (
-                    !!dataIsXhr ||                             // xhr
-                    (href && (href.indexOf('#') === 0)) ||     // internal anchor
-                    'button' === target.nodeName.toLowerCase() // UI button
-                );
-                isSameHost = hasSameHost(href);
-
-                common.mediator.emit('module:clickstream:click', [target, tag, isSamePage, isSameHost]);
-
-            } else {
-                return false;
+            var clickSpec = getClickSpec({el: event.target});
+            if (clickSpec) {
+                common.mediator.emit('module:clickstream:click', clickSpec);
             }
         });
 

--- a/common/app/assets/javascripts/modules/analytics/gallery.js
+++ b/common/app/assets/javascripts/modules/analytics/gallery.js
@@ -81,9 +81,8 @@ define([
                 that.logView.call(that);
             });
 
-            common.mediator.on('module:clickstream:click', function(params) {
-                var isSamePage = params[2];
-                if (!isSamePage && params[0].nodeName.toLowerCase() === 'a') {
+            common.mediator.on('module:clickstream:click', function(clickSpec) {
+                if (!clickSpec.samePage) {
                     that.log.call(that);
                 }
             });

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -33,29 +33,26 @@ define([
             s.tl(true,'o',"AutoUpdate Refresh");
         };
 
-        this.logTag = function(params) {
-            var element = params[0],
-                tag = params[1],
-                isSamePage = params[2],
-                isSameHost = params[3],
-                storeObj,
+        this.logTag = function(spec) {
+            var storeObj,
                 delay;
 
-            // Remove the 'false' clause once Omniture guys support the localStorage approach...
-            if (isSameHost && !isSamePage) {
-                // Came from a link to a new page on the same host.
-                // Do session storage rather than an omniture track.
+            if (!spec.tag) {
+                return;
+            } else if (spec.sameHost && !spec.samePage) {
+                // Came from a link to a new page on the same host,
+                // so do session storage rather than an omniture track.
                 storeObj = {
                     pageName: s.pageName,
-                    tag: tag,
+                    tag: spec.tag,
                     time: new Date().getTime()
                 };
                 localStorage.setItem(storagePrefix + 'referrerVars', JSON.stringify(storeObj));
             } else {
-                that.populateEventProperties(tag);
+                that.populateEventProperties(spec.tag);
                 // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
-                delay = isSamePage ? true : element;
-                s.tl(delay, 'o', tag);
+                delay = spec.samePage ? true : spec.target;
+                s.tl(delay, 'o', spec.tag);
             }
         };
 

--- a/common/app/assets/javascripts/modules/analytics/reading.js
+++ b/common/app/assets/javascripts/modules/analytics/reading.js
@@ -103,9 +103,8 @@ define([
             });
         };
 
-        common.mediator.on('module:clickstream:click', function(params) {
-            var isSamePage = params[2];
-            if (!isSamePage && params[0].nodeName.toLowerCase() === 'a') {
+        common.mediator.on('module:clickstream:click', function(clickSpec) {
+            if (!clickSpec.samePage) {
                 that.log.call(that);
             }
         });

--- a/common/app/assets/javascripts/modules/analytics/video.js
+++ b/common/app/assets/javascripts/modules/analytics/video.js
@@ -94,9 +94,8 @@ define([
             Bean.on(video, 'play', this.play);
             Bean.on(video, 'pause stop', this.stop);
 
-            common.mediator.on('module:clickstream:click', function(params) {
-                var isSamePage = params[2];
-                if (!isSamePage && params[0].nodeName.toLowerCase() === 'a') {
+            common.mediator.on('module:clickstream:click', function(clickSpec) {
+                if (!clickSpec.samePage) {
                     that.log.call(that);
                 }
             });

--- a/common/test/assets/javascripts/runner.html
+++ b/common/test/assets/javascripts/runner.html
@@ -309,6 +309,13 @@
     <div data-link-name="outer div">
         <p id="not-inside-a-link">
             <a href="/foo" id="click-me" data-link-name="the link">The link</a>
+            <a href="/foo" id="click-me-ancestor" data-link-name="the ancestor">
+              <span>
+                <span>
+                  <span id="click-me-descendant" data-link-name="the descendant">The link descendant</span>
+                </span>
+              </span>
+            </a>
             <a href="/foo" id="click-me-quick" data-is-ajax="true" data-link-name="xhr link">Xhr Link</a>
             <button id="click-me-button" data-link-name="the button">Span Link</button>
             <p href="#hello" id="click-me-slow" data-link-name="paragraph">Paragraph 'Link'</p>

--- a/common/test/assets/javascripts/spec/Clickstream.spec.js
+++ b/common/test/assets/javascripts/spec/Clickstream.spec.js
@@ -7,6 +7,14 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
             e.preventDefault();
         })
 
+        bean.add(document.getElementById('click-me-ancestor'), 'click', function(e) {
+            e.preventDefault();
+        })
+
+        bean.add(document.getElementById('click-me-descendant'), 'click', function(e) {
+            e.preventDefault();
+        })
+
         bean.add(document.getElementById('click-me-quick'), 'click', function(e) {
             e.preventDefault();
         })
@@ -34,17 +42,44 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
             var cs  = new Clickstream({ filter: ["button"] }),
                 object = { method: function (p) {} },
                 spy = sinon.spy(object, "method"),
-                el = document.getElementById('click-me-button');
-
-            spy.withArgs([el, 'outer div | the button', false, false]);
+                el = document.getElementById('click-me-button'),
+                clickSpec = {
+                    target: el,
+                    samePage: true,
+                    sameHost: true,
+                    tag: 'outer div | the button'
+                };
 
             common.mediator.on('module:clickstream:click', spy);
-            common.mediator.on('module:clickstream:click', function(){ console.log(arguments); });
 
             bean.fire(el, 'click');
 
             runs(function(){
-                expect(spy.withArgs([el, 'outer div | the button', true, true])).toHaveBeenCalledOnce();
+                expect(spy.withArgs(clickSpec)).toHaveBeenCalledOnce();
+            });
+
+        });
+
+        it("should report the ancestor 'clickable' element, not the element that actually received the click", function(){
+
+            var cs  = new Clickstream({ filter: ["a"] }),
+                object = { method: function (p) {} },
+                spy = sinon.spy(object, "method"),
+                el = document.getElementById('click-me-descendant'),
+                elAncestor = document.getElementById('click-me-ancestor'),
+                clickSpec = {
+                    target: elAncestor,
+                    samePage: false,
+                    sameHost: true,
+                    tag: 'outer div | the ancestor | the descendant'
+                };
+
+            common.mediator.on('module:clickstream:click', spy);
+
+            bean.fire(el, 'click');
+
+            runs(function(){
+                expect(spy.withArgs(clickSpec)).toHaveBeenCalledOnce();
             });
 
         });
@@ -65,41 +100,25 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
 
         });
 
-        it("should indicate if a click emanates from an XmlHttpRequest source", function(){
-
-            var cs  = new Clickstream({ filter: ["a"] }),
-                object = { method: function (p) {} },
-                spy = sinon.spy(object, "method"),
-                el = document.getElementById('click-me-quick');
-
-            spy.withArgs(["outer div | xhr link", true]);
-
-            common.mediator.on('module:clickstream:click', spy);
-
-            bean.fire(el, 'click');
-
-            runs(function(){
-                expect(spy.withArgs([el, 'outer div | xhr link', true, true])).toHaveBeenCalledOnce();
-                expect(spy).toHaveBeenCalledOnce();
-            });
-        });
-
         it("should indicate if a click emanates from a internal anchor", function(){
 
             var cs  = new Clickstream({ filter: ["p"] }),
                 object = { method: function (p) {} },
                 spy = sinon.spy(object, "method"),
-                el = document.getElementById('click-me-slow');
-
-            spy.withArgs(["outer div | parapraph", false, true]);
+                el = document.getElementById('click-me-slow'),
+                clickSpec = {
+                    target: el,
+                    samePage: true,
+                    sameHost: true,
+                    tag: 'outer div | paragraph'
+                };
 
             common.mediator.on('module:clickstream:click', spy);
 
             bean.fire(el, 'click');
 
             runs(function(){
-                expect(spy.withArgs([el, 'outer div | paragraph', true, true])).toHaveBeenCalledOnce();
-                expect(spy).toHaveBeenCalledOnce();
+                expect(spy.withArgs(clickSpec)).toHaveBeenCalledOnce();
             });
         });
 
@@ -108,17 +127,20 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
             var cs  = new Clickstream({ filter: ["a"] }),
                 object = { method: function (p) {} },
                 spy = sinon.spy(object, "method"),
-                el = document.getElementById('click-me-internal');
-
-            spy.withArgs(["outer div | internal link", false, true]);
+                el = document.getElementById('click-me-internal'),
+                clickSpec = {
+                    target: el,
+                    samePage: false,
+                    sameHost: true,
+                    tag: 'outer div | internal link'
+                };
 
             common.mediator.on('module:clickstream:click', spy);
 
             bean.fire(el, 'click');
 
             runs(function(){
-                expect(spy.withArgs([el, 'outer div | internal link', false, true])).toHaveBeenCalledOnce();
-                expect(spy).toHaveBeenCalledOnce();
+                expect(spy.withArgs(clickSpec)).toHaveBeenCalledOnce();
             });
         });
 
@@ -127,17 +149,20 @@ define(['analytics/clickstream', 'bean', 'common'], function(Clickstream, bean, 
             var cs  = new Clickstream({ filter: ["a"] }),
                 object = { method: function (p) {} },
                 spy = sinon.spy(object, "method"),
-                el = document.getElementById('click-me-external');
-
-            spy.withArgs(["outer div | external link", false, true]);
+                el = document.getElementById('click-me-external'),
+                clickSpec = {
+                    target: el,
+                    samePage: false,
+                    sameHost: false,
+                    tag: 'outer div | external link'
+                };
 
             common.mediator.on('module:clickstream:click', spy);
 
             bean.fire(el, 'click');
 
             runs(function(){
-                expect(spy.withArgs([el, 'outer div | external link', false, false])).toHaveBeenCalledOnce();
-                expect(spy).toHaveBeenCalledOnce();
+                expect(spy.withArgs(clickSpec)).toHaveBeenCalledOnce();
             });
         });
 


### PR DESCRIPTION
The `module:clickstream:click` event now emits an object: 
{
  target: [the `a` or `button` element ancestor of the actually clicked element], 
  samePage: [Boolean],
  sameHost: [Boolean],
  tag: ["the | link | name | string"],
}

To specify that an element has "same page" behaviour, you can add the class `control` it. This disambiguates things like `<a href="/top-stories">`, which despite looking like an off-page link is turned into a same-page controller by js.
