### PR TITLE
Added task to clean asset maps before dist

### DIFF
--- a/project/PlayAssetHash.scala
+++ b/project/PlayAssetHash.scala
@@ -54,7 +54,6 @@ object PlayAssetHash extends Plugin {
   def deleteAssetMaps = (streams, resourceManaged, target) map { (s, resources, target) =>
     val log = s.log
     val assetMapDir = target / "dist" / "assetmaps"
-    log.info(assetMapDir.getAbsolutePath)
     if (assetMapDir.exists()) {
       FileUtils.deleteDirectory(assetMapDir)
       log.info("Deleted assetmap dir " + assetMapDir)

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -117,8 +117,7 @@ trait Prototypes extends Testing {
         case s: String if s.endsWith("ServerWithStop.class") => MergeStrategy.first  // There is a scala trait and a Java interface
         case "README" => MergeStrategy.first
         case "CHANGELOG" => MergeStrategy.first
-        case x => println(x)
-          old(x)
+        case x => old(x)
       }
     }
   )


### PR DESCRIPTION
We have asset map collisions when assets change. This will delete old asset maps and allow us to skip the global 'clean' task in our builds.
