### PR TITLE
Add URL to Google advanced search with site field prefilled.

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -20,7 +20,7 @@
         <i class="i i-menu-active"></i>
     </a>
 
-    <a href="#" data-link-name="Search icon" class="control control--search" data-control-for="nav-popup-search">
+    <a href="https://www.google.co.uk/advanced_search?q=site:www.guardian.co.uk" data-link-name="Search icon" class="control control--search" data-control-for="nav-popup-search">
         <i class="i i-nav-divider"></i>
         <span class="h">Search</span>
         <i class="i i-search"></i>


### PR DESCRIPTION
Good because fixes broken search button. Bad because site field is hardcoded to www.guardian.co.uk, which won't always be true.

Could always just hide the search link with no-js class value.
