### PR TITLE
Handle empty jsonp responses

### DIFF
--- a/common/app/assets/javascripts/modules/autoupdate.js
+++ b/common/app/assets/javascripts/modules/autoupdate.js
@@ -97,6 +97,10 @@ define([
                 jsonpCallback: 'callback',
                 jsonpCallbackName: 'autoUpdate',
                 success: function (response) {
+                    if (!response) {
+                        common.mediator('module:error', 'Failed to load auto-update: ' + options.path, 'autoupdate.js');
+                        return;
+                    }
                     if(response.refreshStatus === false) {
                         that.off();
                         that.view.destroy();
@@ -104,9 +108,6 @@ define([
                         that.view.render(response);
                         common.mediator.emit('modules:autoupdate:loaded', response);
                     }
-                },
-                error: function () {
-                    common.mediator('module:error', 'Failed to load auto-update:' + options.path, 'autoupdate.js');
                 }
             });
         };

--- a/common/app/assets/javascripts/modules/fonts.js
+++ b/common/app/assets/javascripts/modules/fonts.js
@@ -30,11 +30,12 @@ define(['ajax', 'common'], function (ajax, common) {
                         url: url + style.getAttribute('data-cache-file-' + fileFormat),
                         type: 'jsonp',
                         jsonpCallbackName: 'guFont',
-                        error: function () {
-                            common.mediator('module:error', 'Failed to load fonts', 'fonts.js');
-                        },
                         success: (function (style) {
                             return function (json) {
+                                if (!json) {
+                                    common.mediator('module:error', 'Failed to load fonts', 'fonts.js');
+                                    return;
+                                }
                                 if (typeof callback === 'function') {
                                     callback(style, json);
                                 }

--- a/common/app/assets/javascripts/modules/matchnav.js
+++ b/common/app/assets/javascripts/modules/matchnav.js
@@ -23,11 +23,12 @@ define(['common', 'ajax', 'modules/pad'], function (common, ajax, Pad) {
                 jsonpCallback: 'callback',
                 jsonpCallbackName: 'showMatchNav',
                 success: function (json) {
+                    if (!json) {
+                        common.mediator('module:error', 'Failed to load match nav', 'matchnav.js');
+                        return;
+                    }
                     that.view.render(json, context);
                     common.mediator.emit('modules:matchnav:loaded', json);
-                },
-                error: function () {
-                    common.mediator('module:error', 'Failed to load match nav', 'matchnav.js');
                 }
             });
         };


### PR DESCRIPTION
Seeing things like http://frontend-dashboard.herokuapp.com/occurrences?message=Unable%20to%20get%20value%20of%20the%20property%20'html':%20object%20is%20null%20or%20undefined in the log, which _seems_ to indicate an empty object is being passed to the jsonp callback. 

Which is weird
