### PR TITLE
Match nav jsonp

### DIFF
--- a/common/app/assets/javascripts/modules/matchnav.js
+++ b/common/app/assets/javascripts/modules/matchnav.js
@@ -27,6 +27,9 @@ define(['common', 'ajax', 'modules/pad'], function (common, ajax, Pad) {
                         common.mediator('module:error', 'Failed to load match nav', 'matchnav.js');
                         return;
                     }
+                    if (json.status === 404) {
+                        return;
+                    }
                     that.view.render(json, context);
                     common.mediator.emit('modules:matchnav:loaded', json);
                 }

--- a/football/app/controllers/MoreOnMatchController.scala
+++ b/football/app/controllers/MoreOnMatchController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import model.{ Trail, Cached, Content }
 import play.api.mvc.{ RequestHeader, Action, Controller }
-import common.{ Site, JsonComponent, Logging }
+import common.{ Site, JsonComponent, Logging, JsonNotFound }
 import org.joda.time.format.DateTimeFormat
 import conf.ContentApi
 import feed.Competitions._
@@ -39,14 +39,14 @@ object MoreOnMatchController extends Controller with Football with Requests with
         // for our purposes here, we are only interested in content with exactly 2 team tags
         promiseOfRelated.map(_.filter(_.tags.filter(_.isFootballTeam).length == 2)).map { related =>
           related match {
-            case Nil => NotFound
+            case Nil => Cached(300)(JsonNotFound())
             case _ => Cached(300)(JsonComponent(
               "nav" -> views.html.fragments.matchNav(populateNavModel(theMatch, withExactlyTwoTeams(related))))
             )
           }
         }
       }
-    }.getOrElse(NotFound)
+    }.getOrElse(Cached(300)(JsonNotFound()))
   }
 
   def moreOn(matchId: String) = Action { implicit request =>
@@ -55,7 +55,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
       Async {
         promiseOfRelated.map { related =>
           related match {
-            case Nil => NotFound
+            case Nil => Cached(300)(JsonNotFound())
             case _ => Cached(300)(JsonComponent(
               ("nav" -> views.html.fragments.matchNav(populateNavModel(theMatch, withExactlyTwoTeams(related)))),
               ("related" -> views.html.fragments.relatedTrails(related, "More on this match", 5)))
@@ -63,7 +63,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
           }
         }
       }
-    }.getOrElse(NotFound)
+    }.getOrElse(Cached(300)(JsonNotFound()))
   }
 
   def loadMoreOn(request: RequestHeader, theMatch: FootballMatch): Future[Seq[Content]] = {

--- a/football/test/controllers/MoreOnMatchFeatureTest.scala
+++ b/football/test/controllers/MoreOnMatchFeatureTest.scala
@@ -10,14 +10,14 @@ class MoreOnMatchFeatureTest extends FeatureSpec with GivenWhenThen with ShouldM
 
   val theMatch =
 
-  feature("More on match") {
+  feature("Match Nav") {
 
     scenario("View content related to a match") {
 
       Given("I visit a match page")
 
       Fake {
-        val request = FakeRequest("GET", "/football/foo?callback=call").withHeaders("host" -> "localhost:9000")
+        val request = FakeRequest("GET", "/football/api/match-nav/2012/12/01/1006/65?callback=call").withHeaders("host" -> "localhost:9000")
 
         val result = MoreOnMatchController.matchNav("2012", "12", "01", "1006", "65")(request)
 
@@ -32,5 +32,66 @@ class MoreOnMatchFeatureTest extends FeatureSpec with GivenWhenThen with ShouldM
         body should include("/football/match/")
       }
     }
+
+    scenario("Non-existant match pages return jsonp with status property 404") {
+
+      Given("I visit a non-existant match page")
+
+      Fake {
+        val request = FakeRequest("GET", "football/api/match-nav/2010/01/01/1/2?callback=call").withHeaders("host" -> "localhost:9000")
+
+        val result = MoreOnMatchController.matchNav("2010", "01", "01", "1", "2")(request)
+
+        status(result) should be(200)
+
+        val body = contentAsString(result)
+
+        Then("I should see the status in the object with value 404")
+        body should include("\"status\":404")
+      }
+    }
+  }
+
+  feature("More on match") {
+
+    scenario("View content related to a match") {
+
+      Given("I visit a match page")
+
+      Fake {
+        val request = FakeRequest("GET", "/football/api/match-nav/1010?callback=call").withHeaders("host" -> "localhost:9000")
+
+        val result = MoreOnMatchController.moreOn("1010")(request)
+
+        status(result) should be(200)
+
+        val body = contentAsString(result)
+
+        Then("I should see the match report")
+        body should include("/football/2012/dec/02/arsenal-swansea-match-report-michu")
+
+        And("I should see the stats page")
+        body should include("/football/match/")
+      }
+    }
+
+    scenario("Non-existant match pages return jsonp with status property 404") {
+
+      Given("I visit a non-existant match page")
+
+      Fake {
+        val request = FakeRequest("GET", "/football/api/match-nav/bad-id?callback=call").withHeaders("host" -> "localhost:9000")
+
+        val result = MoreOnMatchController.moreOn("bad-id")(request)
+
+        status(result) should be(200)
+
+        val body = contentAsString(result)
+
+        Then("I should see the status in the object with value 404")
+        body should include("\"status\":404")
+      }
+    }
+    
   }
 }


### PR DESCRIPTION
Should always return a `200`, with the status code in the response object if technically a `404`
