### PR TITLE
Front stories improvements

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/local-election-story.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/local-election-story.js
@@ -1,6 +1,8 @@
 define(['modules/story/frontstories'], function (FrontStories) {
 
     var LocalElectionStory = function () {
+        
+        var storyId = '881908';
 
         this.id = 'LocalElectionStoryV2';
         this.audience = 1;
@@ -19,7 +21,7 @@ define(['modules/story/frontstories'], function (FrontStories) {
             {
                 id: 'swap',
                 test: function () {
-                    new FrontStories().init();
+                    new FrontStories({ storyId: storyId }).init();
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/story/frontstories.js
+++ b/common/app/assets/javascripts/modules/story/frontstories.js
@@ -69,7 +69,7 @@ define([
                         $trail.replaceWith(firstStory);
                     }
                 } else {
-                    // otherwise bung in second position
+                    // otherwise bung in last position
                     bonzo(document.querySelector('.trail:last-child')).after(firstStory);
                 }
             }

--- a/common/app/assets/javascripts/modules/story/frontstories.js
+++ b/common/app/assets/javascripts/modules/story/frontstories.js
@@ -11,9 +11,11 @@ define([
     storage
 ) {
 
-    function FrontStories() {
-
-        var override = storage.get('gu.storyfronttrails') === 'on',
+    function FrontStories(options) {
+        
+        var opts = options || {},
+            storyId = opts.storyId,
+            override = storage.get('gu.storyfronttrails') === 'on',
             self = this;
 
         this.init = function () {
@@ -25,56 +27,61 @@ define([
         // View
         this.view = {
             render: function (json) {
-                // NOTE: hard-coded to replace first trail tagged with 'politics/local-elections' - REMOVE ME AFTER TEST
-                var trail = document.querySelector('section:first-child .trail[data-trail-tags*="politics/local-elections"]'),
-                    firstStory = bonzo.create(json.html)[0];
-                if (firstStory) {
-                    if (trail) {
-                        var $trail = bonzo(trail);
-                        // if this is the featured trail (i.e. the first one), need to keep it featured
-                        // NOTE: hacky, endpoint should return 'featured' version
-                        if ($trail.previous().length === 0) {
-                            // update title
-                            common.$g('h2 a', trail).text(
-                                common.$g('h2 a', firstStory).text()
-                            );
-                            // update links
-                            common.$g('a', trail).attr(
-                                'href', common.$g('a', firstStory).attr('href')
-                            );
-                            // update text
-                            common.$g('.trail-text', trail).text(
-                                common.$g('.trail-text', firstStory).text()
-                            );
-                            // update image
-                            var $img = common.$g('img', firstStory);
-                            common.$g('img', trail).attr({
-                                'src': $img.attr('src'),
-                                'alt': $img.attr('alt'),
-                            });
-                            // update timestamp
-                            common.$g('.relative-timestamp', trail).replaceWith(
-                                common.$g('.relative-timestamp', firstStory)
-                            );
-                            // add story title
-                            common.$g('h2', trail).before(
-                                common.$g('.trail-story-title', firstStory)
-                            );
-                        } else {
-                            // otherwise a straight replace
-                            $trail.replaceWith(firstStory);
-                        }
+                var firstStory = bonzo.create(json.html)[0];
+                if (!firstStory) {
+                    return;
+                }
+                // should we replace a trail (should have data-link-name front-story)?
+                var trail = document.querySelector('section:first-child .trail[data-link-name*="front-story"]');
+                if (trail) {
+                    var $trail = bonzo(trail);
+                    // if this is the featured trail (i.e. the first one), need to keep it featured
+                    // NOTE: hacky, endpoint should return 'featured' version
+                    if ($trail.previous().length === 0) {
+                        // update title
+                        common.$g('h2 a', trail).text(
+                            common.$g('h2 a', firstStory).text()
+                        );
+                        // update links
+                        common.$g('a', trail).attr(
+                            'href', common.$g('a', firstStory).attr('href')
+                        );
+                        // update text
+                        common.$g('.trail-text', trail).text(
+                            common.$g('.trail-text', firstStory).text()
+                        );
+                        // update image
+                        var $img = common.$g('img', firstStory);
+                        common.$g('img', trail).attr({
+                            'src': $img.attr('src'),
+                            'alt': $img.attr('alt'),
+                        });
+                        // update timestamp
+                        common.$g('.relative-timestamp', trail).replaceWith(
+                            common.$g('.relative-timestamp', firstStory)
+                        );
+                        // add story title
+                        common.$g('h2', trail).before(
+                            common.$g('.trail-story-title', firstStory)
+                        );
                     } else {
-                        // otherwise bung in second position
-                        bonzo(document.querySelector('.trail:last-child')).after(firstStory);
+                        // otherwise a straight replace
+                        $trail.replaceWith(firstStory);
                     }
+                } else {
+                    // otherwise bung in second position
+                    bonzo(document.querySelector('.trail:last-child')).after(firstStory);
                 }
             }
         };
 
         this.load = function () {
+            var url = '/stories/articles';
+            if (storyId) {
+                url += '?storyId=' + storyId;
+            }
             return ajax({
-                url: '/stories/articles',
+                url: url,
                 type: 'jsonp',
                 jsonpCallback: 'callback',
                 jsonpCallbackName: 'showStoryTrails',

--- a/common/app/views/fragments/trailblocks/featured.scala.html
+++ b/common/app/views/fragments/trailblocks/featured.scala.html
@@ -3,7 +3,7 @@
 <ul class="unstyled">
     @trails.take(numItemsVisible).zipWithRowInfo.map{ case (trail, info) =>
         <li class="trail @if(info.rowNum == 1 && trail.mainPicture(width=220)) { has-image }"
-            data-link-name="trail@if(trail.tags.filter(_.id == "politics/local-elections").nonEmpty){ | local-elections}"
+            data-link-name="trail@if(trail.tags.filter(_.id == "politics/local-elections").nonEmpty){ | front-story}"
             data-trail-tags="@trail.tags.map(_.id).mkString(",")">
             @if(info.rowNum == 1) {
                 @fragments.trails.featured(trail, info.rowNum, related)

--- a/common/app/views/fragments/trailblocks/thumbnail.scala.html
+++ b/common/app/views/fragments/trailblocks/thumbnail.scala.html
@@ -3,7 +3,7 @@
 <ul class="unstyled">
     @trails.take(numItemsVisible).zipWithRowInfo.map{ case (trail, info) =>
         <li class="trail"
-            data-link-name="trail@if(trail.tags.filter(_.id == "politics/local-elections").nonEmpty){ | local-elections}"
+            data-link-name="trail@if(trail.tags.filter(_.id == "politics/local-elections").nonEmpty){ | front-story}"
             data-trail-tags="@trail.tags.map(_.id).mkString(",")">
             @fragments.trails.thumbnail(trail, info.rowNum, related, showThumbnail = (info.rowNum <= numThumbnails), headingLevel = headingLevel)
         </li>

--- a/event/app/controllers/StoryController.scala
+++ b/event/app/controllers/StoryController.scala
@@ -50,12 +50,12 @@ object StoryController extends Controller with Logging {
   }
 
   def latestWithContent() = Action { implicit request =>
-    val promiseOfStories = Future(Story.mongo.latestWithContent())
+    val promiseOfStories = Future(Story.mongo.latestWithContent(request.getQueryString("storyId")))
 
     Async {
       promiseOfStories.map { stories =>
         if (stories.nonEmpty) {
-          Cached(60) {
+          Cached(300) {
             val html = views.html.fragments.latestWithContent(stories)
             JsonComponent(html)
           }

--- a/event/app/model/story.scala
+++ b/event/app/model/story.scala
@@ -143,8 +143,11 @@ object Story {
       }
     }
 
-    def latestWithContent(): Seq[Story] = {
-      measure(Stories.find(DBObject.empty).map(grater[ParsedStory].asObject(_))).toSeq.reverse.map(loadContent(_))
+    def latestWithContent(storyId: Option[String] = None): Seq[Story] = {
+      val query = storyId.map{ storyId =>
+        DBObject("id" -> storyId)
+      } getOrElse(DBObject.empty)
+      measure(Stories.find(query).map(grater[ParsedStory].asObject(_))).toSeq.reverse.map(loadContent(_))
     }
 
     def latest(): Seq[Story] = {


### PR DESCRIPTION
- allow passing in a story id to `stories/articles`
- made more agnostic (still need the tag of the story to replace added to the trailblock template though)
