### PR TITLE
Fixed gallery layout bug #814

### DIFF
--- a/common/app/assets/javascripts/components/swipe/swipe.js
+++ b/common/app/assets/javascripts/components/swipe/swipe.js
@@ -69,7 +69,7 @@
       this.container.style.visibility = 'hidden';
 
       // determine width of each slide
-      this.width = this.container.getBoundingClientRect().width - 40;
+      this.width = this.container.getBoundingClientRect().width;
 
       // dynamic css
       this.element.style.width = (this.slides.length * this.width) + 'px';


### PR DESCRIPTION
Fixes bug that I introduced last week with galleries showing 40px of the next image on the screen.

Lesson learnt: **Never hack the third-party library**
