### PR TITLE
Renaming test so we can use story-front-trails switch

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -4,15 +4,15 @@ define([
 
     //Current tests
     'modules/experiments/tests/relatedContent',
-    'modules/experiments/tests/cleveland-story'
+    'modules/experiments/tests/story-front-trail'
 ], function (
     common,
     userPrefs,
     RelatedContent,
-    ClevelandStory) {
+    StoryFrontTrail) {
     
     var TESTS = {
-            ClevelandStory: new ClevelandStory()
+            StoryFrontTrail: new StoryFrontTrail()
         };
 
     var testKey = 'ab.current',

--- a/common/app/assets/javascripts/modules/experiments/tests/story-front-trail.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/story-front-trail.js
@@ -1,12 +1,12 @@
 define(['modules/story/frontstories'], function (FrontStories) {
 
-    var LocalElectionStory = function () {
+    var StoryFrontTrail = function () {
         
         var storyId = '680026';
 
-        this.id = 'ClevelandStory';
+        this.id = 'StoryFrontTrail';
         this.audience = 1;
-        this.description = 'Swap out the first cleveland tagged trail with the story component';
+        this.description = 'Swap out the first appropriately tagged trail with the story component';
         this.canRun = function(config) {
             // only run on network front
             return config.page.pageId === '';
@@ -27,6 +27,6 @@ define(['modules/story/frontstories'], function (FrontStories) {
         ];
     };
 
-    return LocalElectionStory;
+    return StoryFrontTrail;
 
 });

--- a/common/app/assets/javascripts/modules/story/frontstories.js
+++ b/common/app/assets/javascripts/modules/story/frontstories.js
@@ -19,7 +19,7 @@ define([
             self = this;
 
         this.init = function () {
-            if (guardian.config.switches.abClevelandStory || override) {
+            if (guardian.config.switches.storyFrontTrails || override) {
                 this.load();
             }
         };

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -90,8 +90,8 @@ object CommonSwitches {
     "If this switch is on the australia front will be available",
     initiallyOn = false)
 
-  val ClevelandStory = DefaultSwitch("ab-cleveland-story",
-    "If this switch is on cleveland story AB test will be enabled.",
+  val ABStoryFrontTrail = DefaultSwitch("ab-story-front-trail",
+    "If this switch is on story front trail AB test will be enabled.",
     initiallyOn = false)
   
   val ImageServerSwitch = DefaultSwitch("image-server",
@@ -103,7 +103,7 @@ object CommonSwitches {
     RelatedContentSwitch, NetworkFrontAppealSwitch,
     ExperimentStoryModule01Switch, StoryVersionBSwitch, StoryFrontTrails, SocialSwitch,
     SearchSwitch, QuantcastSwitch, HomescreenSwitch, OptimizelySwitch, AdvertSwitch,
-    VideoAdvertSwitch, ImageServerSwitch, ABRelatedContentV2, ClevelandStory,
+    VideoAdvertSwitch, ImageServerSwitch, ABRelatedContentV2, ABStoryFrontTrail,
     AustraliaFrontSwitch
   )
 }


### PR DESCRIPTION
Means we can leave test running, just flip the `story-front-trails` switch
