### PR TITLE
Delay font test

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -117,6 +117,14 @@ define([
                 s.prop51  = testData;
                 s.eVar51  = testData;
                 s.events = s.apl(s.events,'event58',',');
+            } else {
+                // If no other tests running try and collect AB font rendering test results.
+                var fonttest = localStorage.getItem('gu.webfontrendertest');
+                if(fonttest) {
+                    s.prop51  = fonttest;
+                    s.eVar51  = fonttest;
+                    s.events = s.apl(s.events,'event58',',');
+                }
             }
 
             s.prop56    = 'Javascript';

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -6,7 +6,6 @@ html {
 	font-family: $serif;
 }
 
-.delay-font-render,
 .delay-font-render {
     h1, h2, h3, h4, h5, h6, p, ul, ol, dl, blockquote, table {
         visibility: hidden;

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -6,6 +6,14 @@ html {
 	font-family: $serif;
 }
 
+.delay-font-render,
+.delay-font-render {
+    h1, h2, h3, h4, h5, h6, p, ul, ol, dl, blockquote, table {
+        visibility: hidden;
+    }
+}
+
+
 //Bump font-size back upto 16px
 body {
 	font-size: 100%;

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -22,6 +22,10 @@ object CommonSwitches {
     "If this is switched on then the custom Guardian web font will load.",
     initiallyOn = true)
 
+  val FontDelaySwitch = DefaultSwitch("web-fonts-delay",
+    "If this is switched on then web fonts will pause for 2 seconds before rendering.",
+    initiallyOn = false)
+
   val AudienceScienceSwitch = DefaultSwitch("audience-science",
     "If this switch is on the Audience Science will be enabled.",
     initiallyOn = true)
@@ -95,7 +99,7 @@ object CommonSwitches {
     initiallyOn = false)
   
   val all: Seq[Switchable] = Seq(
-    FontSwitch, AutoRefreshSwitch, AudienceScienceSwitch, DoubleCacheTimesSwitch,
+    FontSwitch, FontDelaySwitch, AutoRefreshSwitch, AudienceScienceSwitch, DoubleCacheTimesSwitch,
     RelatedContentSwitch, NetworkFrontAppealSwitch,
     ExperimentStoryModule01Switch, StoryVersionBSwitch, StoryFrontTrails, SocialSwitch,
     SearchSwitch, QuantcastSwitch, HomescreenSwitch, AdvertSwitch,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -23,7 +23,7 @@ object CommonSwitches {
     initiallyOn = true)
 
   val FontDelaySwitch = DefaultSwitch("web-fonts-delay",
-    "If this is switched on then web fonts will pause for 2 seconds before rendering.",
+    "If this is switched on an AB test runs to measure the impact of not showing fallback fonts while fonts download.",
     initiallyOn = false)
 
   val AudienceScienceSwitch = DefaultSwitch("audience-science",

--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -7,6 +7,6 @@
     .is-updating { background-image: url(@Static("images/auto-update-activity.gif")); }
 </style>
 
-<style class="initial" data-cache-name="WebEgyptial" data-cache-file-woff="@Static("fonts/WebEgyptian.woff.js")" data-cache-file-ttf="@Static("fonts/WebEgyptian.ttf.js")"></style>
+<style class="initial" data-cache-name="WebEgyptian" data-cache-file-woff="@Static("fonts/WebEgyptian.woff.js")" data-cache-file-ttf="@Static("fonts/WebEgyptian.ttf.js")"></style>
 
 <style class="initial" data-cache-name="WebEgyptianNav" data-cache-file-woff="@Static("fonts/WebEgyptianNav.woff.js")" data-cache-file-ttf="@Static("fonts/WebEgyptianNav.ttf.js")" data-min-width="300"></style>

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -1,6 +1,7 @@
 @(item: MetaData, bootstrapJsModule: String, switches: Seq[com.gu.management.Switchable])(implicit request: RequestHeader)
 
 @import CommonSwitches.FontSwitch
+@import CommonSwitches.FontDelaySwitch
 
 <script id="gu">
     // we want this to happen ASAP to avoid FOUC
@@ -39,7 +40,34 @@
             showFonts = false;
         }
 
+        function removeFallbackFont() {
+            document.documentElement.className += ' delay-font-render';
+            setTimeout(function() {
+                document.documentElement.className = document.documentElement.className.replace('delay-font-render', '');
+            }, 3000);
+        }
+
         if (showFonts) {
+            
+            // This sledgehammers an AB test into localStorage for Omniture to pick up later.
+            @if(FontDelaySwitch.isSwitchedOn) {
+                var test = localStorage.getItem('gu.webfontrendertest');
+                if (test) {
+                    if (test.indexOf('| nofallback') > 0) {
+                        removeFallbackFont();
+                    }
+                } else {
+                    if (Math.random() < 0.1) {
+                        localStorage.setItem('gu.webfontrendertest', 'AB | WebFontFallback | nofallback');
+                        removeFallbackFont();
+                    } else {
+                        localStorage.setItem('gu.webfontrendertest', 'AB | WebFontFallback | control');
+                    }
+                }
+            } else {
+                localStorage.removeItem('gu.webfontrendertest');
+            }   
+
             var start = (new Date().getTime());
             var styleNodes = document.querySelectorAll('[data-cache-name]');
             for (var i = 0, j = styleNodes.length; i<j; ++i) {
@@ -47,9 +75,12 @@
                     nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff\.(.*)\.js$/),
                     cachedCss = localStorage.getItem('gu.fonts.' + nameAndCacheKey[1] + '.' + nameAndCacheKey[2]);
                 if (cachedCss) {
+                    @if(FontDelaySwitch.isSwitchedOn) {
+                        document.documentElement.className = document.documentElement.className.replace('delay-font-render', '');
+                    }
                     style.innerHTML = cachedCss;
                     style.setAttribute('data-cache-full', 'true');
-                    document.querySelector('html').className += ' font-' + name + '-loaded';
+                    document.querySelector('html').className += ' font-' + nameAndCacheKey[1] + '-loaded';
                 }
             }
             var fontTime = (new Date().getTime()) - start;


### PR DESCRIPTION
cc @phamann 

Very crudely set up an AB test that sets 10% of audience to not show fallback font while waiting for webfont to load (with 3 second timeout) - then report it to Omniture if no 'real' AB tests are running.
