### PR TITLE
Fastly control headers

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -28,6 +28,7 @@ object Cached extends Results {
       "Cache-Control" -> s"public, max-age=$maxAge, stale-while-revalidate=$maxAge, stale-if-error=345600",
       "X-Gu-Stale-While-Revalidate" -> s"$maxAge",
       "X-Gu-Stale-If-Error" -> "345600",
+      "X-Gu-Cache-Control" -> s"private, max-age=$maxAge", // Tells fastly to use this at it's response header
       "Expires" -> expiresTime.toHttpDateTimeString,
       "Date" -> now.toHttpDateTimeString
     )

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -26,6 +26,8 @@ object Cached extends Results {
     // see http://tools.ietf.org/html/rfc5861 for definitions of these headers
     result.withHeaders(
       "Cache-Control" -> s"public, max-age=$maxAge, stale-while-revalidate=$maxAge, stale-if-error=345600",
+      "X-Gu-Stale-While-Revalidate" -> s"$maxAge",
+      "X-Gu-Stale-If-Error" -> "345600",
       "Expires" -> expiresTime.toHttpDateTimeString,
       "Date" -> now.toHttpDateTimeString
     )

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -41,6 +41,17 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
 
     headers("Cache-Control") should be("public, max-age=900, stale-while-revalidate=900, stale-if-error=345600")
   }
+  
+  it should "send stale-while-revalidate and stale-if-error instructions to the CDN" in {
+    val modifiedLongAgo = DateTime.now - 25.hours
+    val liveContent = content(lastModified = modifiedLongAgo, live = false)
+
+    val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
+    val headers = result.header.headers
+
+    headers("X-Gu-Stale-While-Revalidate") should be("900")
+    headers("X-Gu-Stale-If-Error") should be("345600")
+  }
 
   it should "cache other things for 1 minute" in {
     val page = new MetaData {

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -52,6 +52,16 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     headers("X-Gu-Stale-While-Revalidate") should be("900")
     headers("X-Gu-Stale-If-Error") should be("345600")
   }
+  
+  it should "send the a cache-control instruction to the CDN" in {
+    val modifiedLongAgo = DateTime.now - 25.hours
+    val liveContent = content(lastModified = modifiedLongAgo, live = false)
+    
+    val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
+    val headers = result.header.headers
+
+    headers("X-Gu-Cache-Control") should be("private, max-age=900")
+  }
 
   it should "cache other things for 1 minute" in {
     val page = new MetaData {


### PR DESCRIPTION
- X-Gu-Stale-While-Revalidate - fastly emulation of stale-while-revalidate
- X-Gu-Stale-If-Error - fastly emulation of stale-if-error
- X-Gu-Cache-Control - the cache-control header fastly should send to the user

As discussed with @gklopper 
