### PR TITLE
Stop ads stacking

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -187,10 +187,11 @@ define([
 
         loadAdverts: function () {
             if (!userPrefs.isOff('adverts')){
+                var ads = Adverts;
                 common.mediator.on('page:common:deferred:loaded', function(config, context) {
                     if (config.switches && config.switches.adverts) {
-                        Adverts.init(config, context);
-                        common.mediator.on('modules:adverts:docwrite:loaded', Adverts.loadAds);
+                        ads.init(config, context);
+                        common.mediator.on('modules:adverts:docwrite:loaded', ads.loadAds);
                     }
                 });
             }


### PR DESCRIPTION
Sometimes happens if ads load slower than the user's swipe rate.
