### PR TITLE
Swipe on iPhone5 only

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -213,7 +213,7 @@ define([
         },
 
         initSwipe: function(config) {
-            if (detect.canSwipe() && (config.switches.swipeNav || userPrefs.isOn('swipe-nav'))) {
+            if ((config.switches.swipeNav && detect.canSwipe() && !userPrefs.isOff('swipe-nav')) || userPrefs.isOn('swipe-nav')) {
                 swipeNav(config);
             }
         }

--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -200,17 +200,17 @@ define(['modules/userPrefs'], function (userPrefs) {
 
     function canSwipe() {
         var os;
-        if (userPrefs.isOn('swipe-nav-force')) {
-            return true;
-        }
         if (!hasPushStateSupport()) {
             return false;
         }
         os = getMobileOS();
+        // iOS
         if (os.name === 'iOS' && os.version >= 6) {
-            return true;
+            // This'll be true only for iPhone5:
+            return window.devicePixelRatio >= 2 && screen.availHeight === 548;
         }
         /*
+        // Android
         if (os.name === 'Android' && os.version >= 4) {
             return true;
         }


### PR DESCRIPTION
Swipe can be forced on any device with userprefs `swipe-nav` and `swipe-nav-on-click`
