### PR TITLE
renderFormat now takes () => Html instead of just plain Html.

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -48,8 +48,8 @@ object ArticleController extends Controller with Logging with ExecutionContexts 
   }
 
   private def renderArticle(model: ArticlePage)(implicit request: RequestHeader): Result = {
-    val htmlResponse = views.html.article(model.article, model.storyPackage)
-    val jsonResponse = views.html.fragments.articleBody(model.article, model.storyPackage)
+    val htmlResponse = () => views.html.article(model.article, model.storyPackage)
+    val jsonResponse = () => views.html.fragments.articleBody(model.article, model.storyPackage)
     renderFormat(htmlResponse, jsonResponse, model.article, Switches.all)
   }
   

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -50,26 +50,32 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
       log.error(s"Failing quietly on: ${e.getMessage}", e)
       default
   }
-  
-  def renderFormat(htmlResponse: Html, jsonResponse: Html, metaData: model.MetaData)(implicit request: RequestHeader) = Cached(metaData) {
+
+
+  /*
+    NOTE: The htmlResponse & jsonResponse are () => Html functions so that you do not do all the rendering twice.
+          Only the once you actually render is used
+   */
+
+  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, metaData: model.MetaData)(implicit request: RequestHeader) = Cached(metaData) {
     if (request.isJson)
-      JsonComponent(jsonResponse)
+      JsonComponent(jsonResponse())
     else
-      Ok(htmlResponse)
+      Ok(htmlResponse())
   }
   
-  def renderFormat(htmlResponse: Html, jsonResponse: Html, metaData: model.MetaData, switches: Seq[Switchable])(implicit request: RequestHeader) = Cached(metaData) {
+  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, metaData: model.MetaData, switches: Seq[Switchable])(implicit request: RequestHeader) = Cached(metaData) {
     if (request.isJson)
-      JsonComponent(metaData, switches, jsonResponse)
+      JsonComponent(metaData, switches, jsonResponse())
     else
-      Ok(htmlResponse)
+      Ok(htmlResponse())
   }
   
-  def renderFormat(htmlResponse: Html, jsonResponse: Html, cacheTime: Integer)(implicit request: RequestHeader) = Cached(cacheTime) {
+  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, cacheTime: Integer)(implicit request: RequestHeader) = Cached(cacheTime) {
     if (request.isJson)
-      JsonComponent(jsonResponse)
+      JsonComponent(jsonResponse())
     else
-      Ok(htmlResponse)
+      Ok(htmlResponse())
   }
 }
 

--- a/core-navigation/app/controllers/MostPopularController.scala
+++ b/core-navigation/app/controllers/MostPopularController.scala
@@ -29,8 +29,8 @@ object MostPopularController extends Controller with Logging with ExecutionConte
           (sectionPopular ++ globalPopular) match {
             case Nil => NotFound
             case popular => {
-              val htmlResponse = views.html.mostPopular(page, popular)
-              val jsonResponse = views.html.fragments.mostPopular(popular, 5)
+              val htmlResponse = () => views.html.mostPopular(page, popular)
+              val jsonResponse = () => views.html.fragments.mostPopular(popular, 5)
               renderFormat(htmlResponse, jsonResponse, 900)
             }
           }

--- a/core-navigation/app/controllers/RelatedController.scala
+++ b/core-navigation/app/controllers/RelatedController.scala
@@ -39,7 +39,7 @@ object RelatedController extends Controller with Logging with ExecutionContexts 
   }
 
   private def renderRelated(model: Related)(implicit request: RequestHeader) = {
-    val html = views.html.fragments.relatedTrails(model.trails, model.heading, 5)
+    val html = () => views.html.fragments.relatedTrails(model.trails, model.heading, 5)
     renderFormat(html, html, 900)
   }
 }

--- a/core-navigation/app/controllers/TopStoriesController.scala
+++ b/core-navigation/app/controllers/TopStoriesController.scala
@@ -51,17 +51,17 @@ object TopStoriesController extends Controller with Logging with Paging with Jso
       "Top Stories",
       "GFE:Top Stories"
     )
-    val htmlResponse = views.html.topStories(page, trails)
-    val jsonResponse = views.html.fragments.topStoriesBody(trails)
+    val htmlResponse = () => views.html.topStories(page, trails)
+    val jsonResponse = () => views.html.fragments.topStoriesBody(trails)
     renderFormat(htmlResponse, jsonResponse, 900)
   }
 
   private def renderTopStoriesTrails(trails: Seq[Trail])(implicit request: RequestHeader) = {
     val trailsLength = request.getQueryString("page-size").map{ _.toInt }.getOrElse(trails.size)
     val response = if (request.getQueryString("view") == Some("link")) 
-      views.html.fragments.trailblocks.link(trails, trailsLength)
+      () => views.html.fragments.trailblocks.link(trails, trailsLength)
     else
-      views.html.fragments.trailblocks.headline(trails, trailsLength)
+      () => views.html.fragments.trailblocks.headline(trails, trailsLength)
       
     renderFormat(response, response, 900)
   }

--- a/event/app/controllers/StoryController.scala
+++ b/event/app/controllers/StoryController.scala
@@ -34,8 +34,8 @@ object StoryController extends Controller with Logging with ExecutionContexts {
           val storyId = request.getQueryString("storyId").getOrElse("0")
           val filteredStories = stories.filterNot(_.id.equals(storyId))
           
-          val htmlResponse = views.html.latest(StoriesPage(filteredStories))
-          val jsonResponse = views.html.fragments.latestBody(StoriesPage(filteredStories))
+          val htmlResponse = () => views.html.latest(StoriesPage(filteredStories))
+          val jsonResponse = () => views.html.fragments.latestBody(StoriesPage(filteredStories))
           renderFormat(htmlResponse, jsonResponse, StoriesPage(filteredStories), Switches.all)
         } else {
           JsonNotFound()
@@ -69,8 +69,8 @@ object StoryController extends Controller with Logging with ExecutionContexts {
       Async {
         promiseOfStory.map { storyOption =>
           storyOption.map { story =>
-            val htmlResponse = views.html.story(StoryPage(story))
-            val jsonResponse = views.html.fragments.storyBody(StoryPage(story))
+            val htmlResponse = () => views.html.story(StoryPage(story))
+            val jsonResponse = () => views.html.fragments.storyBody(StoryPage(story))
             renderFormat(htmlResponse, jsonResponse, StoryPage(story), Switches.all)
           }.getOrElse(JsonNotFound())
         }

--- a/football/app/controllers/CompetitionListController.scala
+++ b/football/app/controllers/CompetitionListController.scala
@@ -20,8 +20,8 @@ object CompetitionListController extends Controller with CompetitionListFilters 
       "Rest of world"
     )
     
-    val htmlResponse = views.html.competitions(filters, page, competitionList)
-    val jsonResponse = views.html.fragments.competitionsBody(filters, page, competitionList)
+    val htmlResponse = () => views.html.competitions(filters, page, competitionList)
+    val jsonResponse = () => views.html.fragments.competitionsBody(filters, page, competitionList)
     renderFormat(htmlResponse, jsonResponse, page, Switches.all)
     
   }

--- a/football/app/controllers/CompetitionTablesController.scala
+++ b/football/app/controllers/CompetitionTablesController.scala
@@ -25,7 +25,7 @@ object CompetitionTablesController extends Controller with Logging with Competit
 
     competitionId.map { id =>
       loadTable(id).map { table =>
-        val html = views.html.fragments.frontTableBlock(table)
+        val html = () => views.html.fragments.frontTableBlock(table)
         renderFormat(html, html, 60)
       }.getOrElse(Cached(600)(NoContent))
     } getOrElse (BadRequest("need a competition id"))
@@ -33,7 +33,7 @@ object CompetitionTablesController extends Controller with Logging with Competit
 
   def renderTeam(teamId: String) = Action { implicit request =>
     loadTableWithTeam(teamId).map { table =>
-      val html = views.html.fragments.frontTableBlock(table, Some(teamId))
+      val html = () => views.html.fragments.frontTableBlock(table, Some(teamId))
       renderFormat(html, html, 60)
     }.getOrElse(Cached(600)(NoContent))
   }

--- a/football/app/controllers/FixturesController.scala
+++ b/football/app/controllers/FixturesController.scala
@@ -165,7 +165,7 @@ object TeamFixturesController extends Controller with Logging with CompetitionFi
       val upcomingFixtures = fixtures.filter(_.fixture.date >= startDate).take(2)
       
     
-      val html = views.html.fragments.teamFixtures(team, previousResult, upcomingFixtures)
+      val html = () => views.html.fragments.teamFixtures(team, previousResult, upcomingFixtures)
       renderFormat(html, html, 60)
     }.getOrElse(NotFound)
   }

--- a/football/app/controllers/FrontScoresController.scala
+++ b/football/app/controllers/FrontScoresController.scala
@@ -25,7 +25,7 @@ object FrontScoresController extends Controller with implicits.Football with Log
     )
 
     competition.map { comp =>
-      val html = views.html.fragments.frontMatchBlock(comp, numVisible, isCompetitionPage)
+      val html = () => views.html.fragments.frontMatchBlock(comp, numVisible, isCompetitionPage)
       renderFormat(html, html, 60)
     } getOrElse (NoContent)
   }

--- a/football/app/controllers/LeagueTableController.scala
+++ b/football/app/controllers/LeagueTableController.scala
@@ -41,8 +41,8 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
       }
     }
     
-    val htmlResponse = views.html.tables(TablesPage(page, groups, "/football", filters, None))
-    val jsonResponse = views.html.fragments.tablesBody(TablesPage(page, groups, "/football", filters, None))
+    val htmlResponse = () => views.html.tables(TablesPage(page, groups, "/football", filters, None))
+    val jsonResponse = () => views.html.fragments.tablesBody(TablesPage(page, groups, "/football", filters, None))
     renderFormat(htmlResponse, jsonResponse, page, Switches.all)
 
   }
@@ -63,8 +63,8 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
 
     val comps = Competitions.competitions.filter(_.showInTeamsList).filter(_.hasTeams)
     
-    val htmlResponse = views.html.teamlist(TablesPage(page, groups, "/football", filters, None), comps)
-    val jsonResponse = views.html.fragments.teamlistBody(TablesPage(page, groups, "/football", filters, None), comps)
+    val htmlResponse = () => views.html.teamlist(TablesPage(page, groups, "/football", filters, None), comps)
+    val jsonResponse = () => views.html.fragments.teamlistBody(TablesPage(page, groups, "/football", filters, None), comps)
     renderFormat(htmlResponse, jsonResponse, page, Switches.all)
 
   }
@@ -80,8 +80,8 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
         "GFE:Football:automatic:competition tables"
       )
     
-      val htmlResponse = views.html.tables(TablesPage(page, Seq(table), table.competition.url, filters, Some(table.competition)))
-      val jsonResponse = views.html.fragments.tablesBody(TablesPage(page, Seq(table), table.competition.url, filters, Some(table.competition)))
+      val htmlResponse = () => views.html.tables(TablesPage(page, Seq(table), table.competition.url, filters, Some(table.competition)))
+      val jsonResponse = () => views.html.fragments.tablesBody(TablesPage(page, Seq(table), table.competition.url, filters, Some(table.competition)))
       renderFormat(htmlResponse, jsonResponse, page, Switches.all)
     }.getOrElse(Redirect("/football/tables"))
   }

--- a/football/app/controllers/LiveMatchesController.scala
+++ b/football/app/controllers/LiveMatchesController.scala
@@ -42,8 +42,8 @@ object LiveMatchesController extends Controller with CompetitionLiveFilters with
       comp = competition
     )
     
-    val htmlResponse = views.html.matches(livePage)
-    val jsonResponse = views.html.fragments.matchesBody(livePage)
+    val htmlResponse = () => views.html.matches(livePage)
+    val jsonResponse = () => views.html.fragments.matchesBody(livePage)
     renderFormat(htmlResponse, jsonResponse, page, Switches.all)
   }
 

--- a/football/app/controllers/MatchController.scala
+++ b/football/app/controllers/MatchController.scala
@@ -58,8 +58,8 @@ object MatchController extends Controller with Football with Requests with Loggi
       Async {
         promiseOfLineup.map { lineUp =>
           val page = MatchPage(theMatch, lineUp)
-          val htmlResponse = views.html.footballMatch(page)
-          val jsonResponse = views.html.fragments.footballMatchBody(page)
+          val htmlResponse = () => views.html.footballMatch(page)
+          val jsonResponse = () => views.html.fragments.footballMatchBody(page)
           renderFormat(htmlResponse, jsonResponse, page, Switches.all)
         }
       }

--- a/football/app/controllers/ResultsController.scala
+++ b/football/app/controllers/ResultsController.scala
@@ -148,8 +148,8 @@ object TeamResultsController extends Controller with Logging with CompetitionRes
         "GFE:Football:automatic:team results"
       )
       
-      val htmlResponse = views.html.teamFixtures(page, filters, upcomingFixtures)
-      val jsonResponse = views.html.fragments.teamFixturesBody(page, filters, upcomingFixtures)
+      val htmlResponse = () => views.html.teamFixtures(page, filters, upcomingFixtures)
+      val jsonResponse = () => views.html.fragments.teamFixturesBody(page, filters, upcomingFixtures)
       renderFormat(htmlResponse, jsonResponse, page, Switches.all)
     }.getOrElse(NotFound)
   }

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -103,8 +103,8 @@ class FrontController extends Controller with Logging with JsonTrails with Execu
     else if (trailblocks.isEmpty) {
       InternalServerError
     } else {
-      val htmlResponse = views.html.front(frontPage, trailblocks)
-      val jsonResponse = views.html.fragments.frontBody(frontPage, trailblocks)
+      val htmlResponse = () => views.html.front(frontPage, trailblocks)
+      val jsonResponse = () => views.html.fragments.frontBody(frontPage, trailblocks)
       renderFormat(htmlResponse, jsonResponse, frontPage, Switches.all)
     }
   }
@@ -130,7 +130,7 @@ class FrontController extends Controller with Logging with JsonTrails with Execu
       InternalServerError
     } else {
       val trails: Seq[Trail] = trailblock.get.trails
-      val response = views.html.fragments.trailblocks.headline(trails, numItemsVisible = trails.size)
+      val response = () => views.html.fragments.trailblocks.headline(trails, numItemsVisible = trails.size)
       renderFormat(response, response, frontPage)
     }
   }

--- a/gallery/app/controllers/GalleryController.scala
+++ b/gallery/app/controllers/GalleryController.scala
@@ -50,8 +50,8 @@ object GalleryController extends Controller with Logging with ExecutionContexts 
   }
 
   private def renderGallery(model: GalleryPage)(implicit request: RequestHeader) = {
-    val htmlResponse = views.html.gallery(model.gallery, model.storyPackage, model.index, model.trail)
-    val jsonResponse = views.html.fragments.galleryBody(model.gallery, model.storyPackage, model.index, model.trail)
+    val htmlResponse = () => views.html.gallery(model.gallery, model.storyPackage, model.index, model.trail)
+    val jsonResponse = () => views.html.fragments.galleryBody(model.gallery, model.storyPackage, model.index, model.trail)
     renderFormat(htmlResponse, jsonResponse, model.gallery, Switches.all)
   }
     

--- a/section/app/controllers/SectionController.scala
+++ b/section/app/controllers/SectionController.scala
@@ -52,14 +52,14 @@ object SectionController extends Controller with Logging with Paging with JsonTr
   }
 
   private def renderSectionFront(model: SectionFrontPage)(implicit request: RequestHeader) = {
-    val htmlResponse = views.html.section(model.section, model.editorsPicks, model.latestContent)
-    val jsonResponse = views.html.fragments.sectionBody(model.section, model.editorsPicks, model.latestContent)
+    val htmlResponse = () => views.html.section(model.section, model.editorsPicks, model.latestContent)
+    val jsonResponse = () => views.html.fragments.sectionBody(model.section, model.editorsPicks, model.latestContent)
     renderFormat(htmlResponse, jsonResponse, model.section, Switches.all)
   }
   
   private def renderTrailsFragment(model: SectionFrontPage)(implicit request: RequestHeader) = {
     val trails: Seq[Trail] = model.editorsPicks ++ model.latestContent
-    val response = views.html.fragments.trailblocks.headline(trails, numItemsVisible = trails.size)
+    val response = () => views.html.fragments.trailblocks.headline(trails, numItemsVisible = trails.size)
     renderFormat(response, response, model.section)
   }
   

--- a/section/app/controllers/SectionsController.scala
+++ b/section/app/controllers/SectionsController.scala
@@ -10,8 +10,8 @@ object SectionsController extends Controller with Logging {
   val page = Page(canonicalUrl = None, "sections", "sections", "All sections", "GFE:All sections")
 
   def render = Action { implicit request =>
-    val htmlResponse = views.html.sections(page)
-    val jsonResponse = views.html.fragments.sectionsBody(page)
+    val htmlResponse = () => views.html.sections(page)
+    val jsonResponse = () => views.html.fragments.sectionsBody(page)
     renderFormat(htmlResponse, jsonResponse, page, Switches.all)
   }
 

--- a/tag/app/controllers/TagController.scala
+++ b/tag/app/controllers/TagController.scala
@@ -61,13 +61,13 @@ object TagController extends Controller with Logging with JsonTrails with Execut
   }
 
   private def renderTag(model: TagAndTrails)(implicit request: RequestHeader) = {
-    val htmlResponse = views.html.tag(model.tag, model.trails, model.leadContent)
-    val jsonResponse = views.html.fragments.tagBody(model.tag, model.trails, model.leadContent)
+    val htmlResponse = () => views.html.tag(model.tag, model.trails, model.leadContent)
+    val jsonResponse = () => views.html.fragments.tagBody(model.tag, model.trails, model.leadContent)
     renderFormat(htmlResponse, jsonResponse, model.tag, Switches.all)
   }
   
   private def renderTrailsFragment(model: TagAndTrails)(implicit request: RequestHeader) = {
-    val response = views.html.fragments.trailblocks.headline(model.trails, numItemsVisible = model.trails.size)
+    val response = () => views.html.fragments.trailblocks.headline(model.trails, numItemsVisible = model.trails.size)
     renderFormat(response, response, model.tag)
   }
   

--- a/video/app/controllers/VideoController.scala
+++ b/video/app/controllers/VideoController.scala
@@ -39,8 +39,8 @@ object VideoController extends Controller with Logging with ExecutionContexts {
   }
 
   private def renderVideo(model: VideoPage)(implicit request: RequestHeader): Result = {
-    val htmlResponse = views.html.video(model)
-    val jsonResponse = views.html.fragments.videoBody(model)
+    val htmlResponse = () => views.html.video(model)
+    val jsonResponse = () => views.html.fragments.videoBody(model)
     renderFormat(htmlResponse, jsonResponse, model.video, Switches.all)
   }
 


### PR DESCRIPTION
This is so that only the one you are going to use is rendered, currently we are doubling up all our rendering and parsing article bodies is the most expensive thing we do.
