### PR TITLE
copied tag to section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Running
 
 Assuming you have checked out this project, open a console and change directory into the root of the project.
 
-Start Simple Build Tool (sbt) by running `./sbt012 --no-proxy`
+Start Simple Build Tool (sbt) by running `./sbt012`
 
 Once sbt is running (it may take a while first time) then compile the project by typing `compile` (also can take a while first time)
 
@@ -120,11 +120,6 @@ typically include:
 Deploying
 ---------
 Deployment uses the [Magenta][magenta] library.
-
-
-No Proxy Build
---------------
-Invoke `sbt012` with a `--no-proxy` parameter to directly download artifacts.
 
 
 Additional Documentation

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -65,7 +65,6 @@ object Frontend extends Build with Prototypes with Testing {
     .dependsOn(front)
     .dependsOn(article)
     .dependsOn(section)
-    .dependsOn(tag)
     .dependsOn(video)
     .dependsOn(gallery)
     .dependsOn(football)

--- a/section/app/controllers/TagController.scala
+++ b/section/app/controllers/TagController.scala
@@ -1,0 +1,74 @@
+package controllers
+
+import com.gu.openplatform.contentapi.model.ItemResponse
+import common._
+import conf._
+import model._
+import play.api.mvc.{ Result, RequestHeader, Controller, Action }
+import org.joda.time.DateTime
+import org.scala_tools.time.Implicits._
+
+import concurrent.Future
+
+case class TagAndTrails(tag: Tag, trails: Seq[Trail], leadContent: Seq[Trail])
+
+object TagController extends Controller with Logging with JsonTrails with ExecutionContexts with implicits.Collections {
+
+  def render(path: String) = Action { implicit request =>
+    val promiseOfTag = lookup(path)
+    Async {
+      promiseOfTag.map {
+        case Left(model) => renderTag(model)
+        case Right(notFound) => notFound
+      }
+    }
+  }
+
+  def renderTrails(path: String) = Action { implicit request =>
+    val promiseOfTag = lookup(path)
+    Async {
+      promiseOfTag.map {
+        case Left(model) => renderTrailsFragment(model)
+        case Right(notFound) => notFound
+      }
+    }
+  }
+
+  private def lookup(path: String)(implicit request: RequestHeader) = {
+    val edition = Edition(request)
+    log.info(s"Fetching tag: $path for edition $edition")
+
+    ContentApi.item(path, edition).showEditorsPicks(true).pageSize(20).response.map{ response: ItemResponse =>
+
+      val tag = response.tag map { new Tag(_) }
+
+      val leadContentCutOff = DateTime.now - 7.days
+      val editorsPicks: Seq[Content] = response.editorsPicks.map(new Content(_))
+
+      val leadContent: Seq[Content] = if (editorsPicks.isEmpty)
+        response.leadContent.take(1).map { new Content(_) }.filter(_.webPublicationDate > leadContentCutOff)
+      else
+        Nil
+
+      val latest: Seq[Content] = response.results.map(new Content(_)).filterNot(c => leadContent.map(_.id).exists(_ == c.id))
+
+      val allTrails = (editorsPicks ++ latest).distinctBy(_.id).take(20)
+
+      val model = tag map { TagAndTrails(_, allTrails, leadContent) }
+      ModelOrResult(model, response)
+
+    }.recover{suppressApiNotFound}
+  }
+
+  private def renderTag(model: TagAndTrails)(implicit request: RequestHeader) = {
+    val htmlResponse = () => views.html.tag(model.tag, model.trails, model.leadContent)
+    val jsonResponse = () => views.html.fragments.tagBody(model.tag, model.trails, model.leadContent)
+    renderFormat(htmlResponse, jsonResponse, model.tag, Switches.all)
+  }
+  
+  private def renderTrailsFragment(model: TagAndTrails)(implicit request: RequestHeader) = {
+    val response = () => views.html.fragments.trailblocks.headline(model.trails, numItemsVisible = model.trails.size)
+    renderFormat(response, response, model.tag)
+  }
+  
+}

--- a/section/app/views/fragments/tagBody.scala.html
+++ b/section/app/views/fragments/tagBody.scala.html
@@ -1,0 +1,47 @@
+@(tag: Tag, trails: Seq[Trail], leadContent: Seq[Trail])(implicit request: RequestHeader)
+
+<section class="front-section zone-@tag.section" data-link-name="@tag.section" role="main">
+
+    @fragments.headers.sectionHead(tag.name)
+
+    @if(tag.isContributor) {
+        <div class="profile media">
+            @tag.contributorImagePath.map { url =>
+                <div class="profile-img media-img">
+                    <img src="@url" alt="@tag.name" />
+                </div>
+            }
+            @if(tag.bio) {
+                <p class="type-7 profile-bio">
+                    @RemoveOuterParaHtml(tag.bio)
+                </p>
+            }
+        </div>
+
+        <h2 class="type-2 article-zone b1">Latest</h2>
+    }
+
+
+    @if(leadContent.nonEmpty) {
+        @leadContent.zipWithRowInfo.map{ case (trail, info) =>
+            <div class="box-indent lead-content @if(info.rowNum == 1 && trail.mainPicture) {has-image}" data-link-name="lead content">
+                @fragments.trails.featured(trail, info.rowNum)
+            </div>
+        }
+    }
+
+    <div class="trailblock" data-count="@trails.length" data-link-name="Tag:block:@tag.section">
+        @fragments.trailblocks.section(trails, trails.size)
+    </div>
+
+</section>
+
+@if(tag.section == "football") {
+    @if(tag.isFootballCompetition) {
+        @fragments.footballNav("/" + tag.id, Some(tag.webTitle), Some("/" + tag.id))
+    } else {
+        @fragments.footballNav("/football")
+    }
+}
+
+@fragments.mostPopularPlaceholder(tag.section)

--- a/section/app/views/tag.scala.html
+++ b/section/app/views/tag.scala.html
@@ -1,0 +1,7 @@
+@(tag: Tag, trails: Seq[Trail], leadContent: Seq[Trail])(implicit request: RequestHeader)
+
+@main(tag, Switches.all){  }{
+
+    @fragments.tagBody(tag, trails, leadContent)
+
+}

--- a/section/conf/routes
+++ b/section/conf/routes
@@ -8,6 +8,12 @@ GET     /assets/*file                              controllers.Assets.at(path="/
 
 GET		/sections					               controllers.SectionsController.render()
 
+
+GET     /$path<[\w\d-]*/[\w\d-]*>                     controllers.TagController.render(path)
+GET     /$path<[\w\d-]*/[\w\d-]*>/trails              controllers.TagController.renderTrails(path)
+GET     /$path<[\w\d-]*/[\w\d-]*/[\w\d-]*>            controllers.TagController.render(path)
+GET     /$path<[\w\d-]*/[\w\d-]*/[\w\d-]*>/trails     controllers.TagController.renderTrails(path)
+
 # culture and sport sections now live in front
 GET    /$path<(?!culture|sport)[\w\d-]*>           controllers.SectionController.render(path)
 GET    /$path<(?!culture|sport)[\w\d-]*>/trails    controllers.SectionController.renderTrails(path)

--- a/section/test/TagControllerTest.scala
+++ b/section/test/TagControllerTest.scala
@@ -1,0 +1,30 @@
+package test
+
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.FlatSpec
+import play.api.test._
+import play.api.test.Helpers._
+import controllers.TagController
+
+class TagControllerTest extends FlatSpec with ShouldMatchers {
+  
+  val tagUrl = "/world/turkey"
+
+  "Tag Controller" should "200 when content type is tag" in Fake {
+    val result = TagController.render(tagUrl)(TestRequest())
+    status(result) should be(200)
+  }
+
+  it should "return JSONP when callback is supplied" in Fake {
+    val fakeRequest = FakeRequest(GET, tagUrl + "?callback=foo").withHeaders("host" -> "localhost:9000")
+    val result = TagController.render(tagUrl)(fakeRequest)
+    status(result) should be(200)
+    header("Content-Type", result).get should be("application/javascript")
+  }
+
+  it should "internal redirect when content type is not tag" in Fake {
+    val result = TagController.render("world/video/2012/feb/10/inside-tibet-heart-protest-video")(TestRequest())
+    status(result) should be(200)
+    header("X-Accel-Redirect", result).get should be("/type/video/world/video/2012/feb/10/inside-tibet-heart-protest-video")
+  }
+}

--- a/section/test/TagFeatureTest.scala
+++ b/section/test/TagFeatureTest.scala
@@ -1,0 +1,89 @@
+package test
+
+import org.scalatest.{ FeatureSpec, GivenWhenThen }
+import org.scalatest.matchers.ShouldMatchers
+import collection.JavaConversions._
+import conf.{CommonSwitches, Configuration}
+
+class TagFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatchers {
+
+  feature("Tag Pages trail size") {
+
+    scenario("Tag pages should show at least 20 trails (includes  leadContent if present)") {
+
+      Given("I visit a tag page")
+
+      HtmlUnit("/technology/askjack") { browser =>
+        import browser._
+        val trails = $(".trailblock .trail, .lead-content")
+        trails.length should be(20)
+      }
+
+    }
+
+  }
+  
+  feature("Contributor pages") {
+
+    scenario("Should display the profile images") {
+
+      Given("I visit the 'Jemima Kiss' contributor page")
+      CommonSwitches.ImageServerSwitch.switchOn()
+
+      HtmlUnit("/profile/jemimakiss") { browser =>
+        import browser._
+        Then("I should see her profile image")
+        val profileImage = findFirst(".profile-img img")
+        profileImage.getAttribute("src") should be(s"${Configuration.images.path}/c/sys-images/Guardian/Pix/contributor/2007/09/28/jemima_kiss_140x140.jpg")
+      }
+    }
+
+    scenario("Should not not display profiles where they don't exist") {
+      Given("I visit the 'Sam Jones' contributor page")
+      HtmlUnit("/profile/samjones") { browser =>
+        import browser._
+        Then("I should not see her profile image")
+        val profileImages = find(".profile-img img")
+        profileImages.length should be(0) 
+      }
+
+    }
+  }
+
+  feature("Tag Pages Football Nav") {
+
+    scenario("Tags that are football compeitions that have teams, link to that place on the teams page") {
+
+      Given("I visit the 'Premier League' tag page")
+
+      HtmlUnit("/football/premierleague") { browser =>
+        import browser._
+        val teamsPageLink = findFirst("ul.nav a[data-link-name='teams']")
+        teamsPageLink.getAttribute("href") should endWith("/football/teams#premierleague")
+      }
+
+    }
+
+    scenario("Tags that are football compeitions but don't have teams don't link to the teams page") {
+
+      Given("I visit the 'Capital One Cup' tag page")
+
+      HtmlUnit("/football/capital-one-cup") { browser =>
+        import browser._
+        val teamsPageLinks = $("ul.nav a[data-link-name='teams']")
+        teamsPageLinks.length should be(0)
+      }
+
+      Given("I visit the 'Scottish League Cup' tag page")
+
+      HtmlUnit("/football/cis-insurance-cup") { browser =>
+        import browser._
+        val teamsPageLinks = $("ul.nav a[data-link-name='teams']")
+        teamsPageLinks.length should be(0)
+      }
+
+    }
+
+  }
+
+}

--- a/section/test/TagTemplateTest.scala
+++ b/section/test/TagTemplateTest.scala
@@ -1,0 +1,14 @@
+package test
+
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.FlatSpec
+import scala.collection.JavaConversions._
+
+class TagTemplateTest extends FlatSpec with ShouldMatchers {
+
+  it should "render tag headline" in HtmlUnit("/world/turkey") { browser =>
+    import browser._
+
+    $("h1").first.getText should be("Turkey")
+  }
+}


### PR DESCRIPTION
The first stage in modifying swimlanes for Frontend. I've copied all the tag functionality into section, so that we can soon change the routing for tags. Then, we can remove the old tag project, and rename section to something more general.
