### PR TITLE
Hide Search button when switch is OFF

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_control.scss
+++ b/common/app/assets/stylesheets/module/nav/_control.scss
@@ -117,9 +117,15 @@ span.control__menu.i-menu {
             position: absolute;
             top: 0;
             right: 48px;
+
+            &.edge {
+                right: 0;
+            }
+
         }
     }
 }
+
 
 .control--topstories span {
     display: none;

--- a/common/app/assets/stylesheets/module/nav/_control.scss
+++ b/common/app/assets/stylesheets/module/nav/_control.scss
@@ -118,7 +118,7 @@ span.control__menu.i-menu {
             top: 0;
             right: 48px;
 
-            &.edge {
+            &.control--right {
                 right: 0;
             }
 

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,4 +1,5 @@
 @(page: MetaData)(implicit request: RequestHeader)
+@import CommonSwitches.SearchSwitch
 
 <header id="header" class="cf" role="banner" data-link-name="global navigation: header">
 
@@ -20,14 +21,17 @@
         <i class="i i-menu-active"></i>
     </a>
 
-    <a href="https://www.google.co.uk/advanced_search?q=site:www.guardian.co.uk" data-is-ajax data-link-name="Search icon" class="control control--search" data-control-for="nav-popup-search">
-        <i class="i i-nav-divider"></i>
-        <span class="h">Search</span>
-        <i class="i i-search"></i>
-    </a>
+
+    @if(SearchSwitch.isSwitchedOn) {
+        <a href="https://www.google.co.uk/advanced_search?q=site:www.guardian.co.uk" data-is-ajax data-link-name="Search icon" class="control control--search" data-control-for="nav-popup-search">
+            <i class="i i-nav-divider"></i>
+            <span class="h">Search</span>
+            <i class="i i-search"></i>
+        </a>
+    }
 
     <a href="/top-stories" data-is-ajax data-link-name="Top stories" data-control-for="nav-popup-topstories"
-        class="control control--topstories">
+        class="control control--topstories @if(SearchSwitch.isSwitchedOff) { edge }">
         <i class="i i-nav-divider"></i>
         <span>Top stories</span>
         <i class="i i-top-stories"></i>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -31,7 +31,7 @@
     }
 
     <a href="/top-stories" data-is-ajax data-link-name="Top stories" data-control-for="nav-popup-topstories"
-        class="control control--topstories @if(SearchSwitch.isSwitchedOff) { edge }">
+        class="control control--topstories @if(SearchSwitch.isSwitchedOff) { control--right }">
         <i class="i i-nav-divider"></i>
         <span>Top stories</span>
         <i class="i i-top-stories"></i>


### PR DESCRIPTION
This should fix an issue where the search button remains visible, even when the switch is turned off.
