### PR TITLE
Report 'can swipe' devices

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -119,6 +119,9 @@ define([
                 s.prop51  = testData;
                 s.eVar51  = testData;
                 s.events = s.apl(s.events,'event58',',');
+            } else if (detect.canSwipe()) {
+                s.prop51  = 'can swipe';
+                s.eVar51  = 'can swipe';
             }
 
             s.prop56    = 'Javascript';


### PR DESCRIPTION
But only if no test is running. i.e. it's a kludge that reuses the same prop51/evar51 that tests use.
