### PR TITLE
Escape html in titles

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -8,7 +8,7 @@
         data-full-width="@mainPicture.width"
         itemprop="contentURL"
         alt="@Html(mainPicture.altText.getOrElse(""))"
-        title="@StripAndEscapeHtmlTags(mainPicture.caption.getOrElse(""))" />
+        title="@StripHtmlTagsAndUnescapeEntities(mainPicture.caption.getOrElse(""))" />
     @if(smallCrop.caption.headOption.getOrElse("").trim != "") {
     <figcaption class="main-caption" itemprop="description">@Html(smallCrop.caption.getOrElse(""))</figcaption>
     }

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -8,7 +8,7 @@
         data-full-width="@mainPicture.width"
         itemprop="contentURL"
         alt="@StripHtmlTags(mainPicture.altText.getOrElse(""))"
-        title="@StripHtmlTags(mainPicture.caption.getOrElse(""))" />
+        title="@StripAndEscapeHtmlTags(mainPicture.caption.getOrElse(""))" />
     @if(smallCrop.caption.headOption.getOrElse("").trim != "") {
     <figcaption class="main-caption" itemprop="description">@Html(smallCrop.caption.getOrElse(""))</figcaption>
     }

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -7,7 +7,7 @@
         data-fullsrc="@mainPicture.path"
         data-full-width="@mainPicture.width"
         itemprop="contentURL"
-        alt="@StripHtmlTags(mainPicture.altText.getOrElse(""))"
+        alt="@StripAndEscapeHtmlTags(mainPicture.altText.getOrElse(""))"
         title="@StripAndEscapeHtmlTags(mainPicture.caption.getOrElse(""))" />
     @if(smallCrop.caption.headOption.getOrElse("").trim != "") {
     <figcaption class="main-caption" itemprop="description">@Html(smallCrop.caption.getOrElse(""))</figcaption>

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -7,7 +7,7 @@
         data-fullsrc="@mainPicture.path"
         data-full-width="@mainPicture.width"
         itemprop="contentURL"
-        alt="@StripAndEscapeHtmlTags(mainPicture.altText.getOrElse(""))"
+        alt="@Html(mainPicture.altText.getOrElse(""))"
         title="@StripAndEscapeHtmlTags(mainPicture.caption.getOrElse(""))" />
     @if(smallCrop.caption.headOption.getOrElse("").trim != "") {
     <figcaption class="main-caption" itemprop="description">@Html(smallCrop.caption.getOrElse(""))</figcaption>

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -23,7 +23,7 @@
                     data-full-width="@largeCrop.width"
                 }
                 itemprop="contentURL"
-                alt="@StripHtmlTags(smallCrop.altText.getOrElse(""))"
+                alt="@StripAndEscapeHtmlTags(smallCrop.altText.getOrElse(""))"
                 title="@StripAndEscapeHtmlTags(smallCrop.caption.getOrElse(""))"
             />
         </a>

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -24,7 +24,7 @@
                 }
                 itemprop="contentURL"
                 alt="@StripHtmlTags(smallCrop.altText.getOrElse(""))"
-                title="@StripHtmlTags(smallCrop.caption.getOrElse(""))"
+                title="@StripAndEscapeHtmlTags(smallCrop.caption.getOrElse(""))"
             />
         </a>
     }

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -23,7 +23,7 @@
                     data-full-width="@largeCrop.width"
                 }
                 itemprop="contentURL"
-                alt="@StripAndEscapeHtmlTags(smallCrop.altText.getOrElse(""))"
+                alt="@Html(smallCrop.altText.getOrElse(""))"
                 title="@StripAndEscapeHtmlTags(smallCrop.caption.getOrElse(""))"
             />
         </a>

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -24,7 +24,7 @@
                 }
                 itemprop="contentURL"
                 alt="@Html(smallCrop.altText.getOrElse(""))"
-                title="@StripAndEscapeHtmlTags(smallCrop.caption.getOrElse(""))"
+                title="@StripHtmlTagsAndUnescapeEntities(smallCrop.caption.getOrElse(""))"
             />
         </a>
     }

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -13,8 +13,8 @@
                         @trail.mainPicture(width=220).map { largeCrop =>
                             data-fullsrc="@largeCrop.path"
                             data-full-width="@largeCrop.width"
-                            alt="@StripHtmlTags(largeCrop.altText.getOrElse(""))"
-                            title="@StripHtmlTags(largeCrop.caption.getOrElse(""))"
+                            alt="@StripAndEscapeHtmlTags(largeCrop.altText.getOrElse(""))"
+                            title="@StripAndEscapeHtmlTags(largeCrop.caption.getOrElse(""))"
                         }
                         itemprop="contentURL"
                     />

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -13,7 +13,7 @@
                         @trail.mainPicture(width=220).map { largeCrop =>
                             data-fullsrc="@largeCrop.path"
                             data-full-width="@largeCrop.width"
-                            alt="@StripAndEscapeHtmlTags(largeCrop.altText.getOrElse(""))"
+                            alt="@Html(largeCrop.altText.getOrElse(""))"
                             title="@StripAndEscapeHtmlTags(largeCrop.caption.getOrElse(""))"
                         }
                         itemprop="contentURL"

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -14,7 +14,7 @@
                             data-fullsrc="@largeCrop.path"
                             data-full-width="@largeCrop.width"
                             alt="@Html(largeCrop.altText.getOrElse(""))"
-                            title="@StripAndEscapeHtmlTags(largeCrop.caption.getOrElse(""))"
+                            title="@StripHtmlTagsAndUnescapeEntities(largeCrop.caption.getOrElse(""))"
                         }
                         itemprop="contentURL"
                     />

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -340,7 +340,7 @@ object StripHtmlTagsAndUnescapeEntities{
   val stripped = doc.body.html
   val unescaped = StringEscapeUtils.unescapeHtml(stripped)
   unescaped.replace("\"","&#34;")   //double quotes will break HTML attributes
-      }
+  }
 }
 
 object Head {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -336,10 +336,10 @@ object StripHtmlTags {
 
 object StripHtmlTagsAndUnescapeEntities{
   def apply( html: String) : String = {
-  val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
-  val stripped = doc.body.html
-  val unescaped = StringEscapeUtils.unescapeHtml(stripped)
-  unescaped.replace("\"","&#34;")   //double quotes will break HTML attributes
+    val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
+    val stripped = doc.body.html
+    val unescaped = StringEscapeUtils.unescapeHtml(stripped)
+    unescaped.replace("\"","&#34;")   //double quotes will break HTML attributes
   }
 }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -334,11 +334,10 @@ object StripHtmlTags {
 }
 
 object StripAndEscapeHtmlTags{
-   def apply( html: String) : String = {
- 
-val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
-doc.outputSettings().escapeMode(EscapeMode.xhtml)
-doc.body().html()
+  def apply( html: String) : String = {
+  val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
+  doc.outputSettings().escapeMode(EscapeMode.xhtml).charset("UTF-8");
+  doc.body().html() 
    }
 }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -6,12 +6,12 @@ import model._
 import org.jsoup.nodes.{ Element, Document }
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
+import org.jsoup.safety.Cleaner
 import org.jboss.dna.common.text.Inflector
 import play.api.libs.json.Writes
 import play.api.libs.json.Json._
 import play.api.templates.Html
 import scala.collection.JavaConversions._
-
 import scala.Some
 import play.api.mvc.RequestHeader
 import org.joda.time.{ DateTimeZone, DateTime }
@@ -19,6 +19,7 @@ import org.joda.time.format.DateTimeFormat
 import conf.Configuration
 import com.gu.openplatform.contentapi.model.MediaAsset
 import play.Play
+import org.jsoup.nodes.Entities.EscapeMode
 
 sealed trait Style {
   val className: String
@@ -330,6 +331,15 @@ object cleanTrailText {
 
 object StripHtmlTags {
   def apply(html: String): String = Jsoup.clean(html, Whitelist.none())
+}
+
+object StripAndEscapeHtmlTags{
+   def apply( html: String) : String = {
+ 
+val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
+doc.outputSettings().escapeMode(EscapeMode.xhtml)
+doc.body().html()
+   }
 }
 
 object Head {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -336,8 +336,8 @@ object StripHtmlTags {
 object StripAndEscapeHtmlTags{
   def apply( html: String) : String = {
   val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
-  doc.outputSettings().escapeMode(EscapeMode.xhtml).charset("UTF-8");
-  doc.body().html()
+  doc.outputSettings().escapeMode(EscapeMode.xhtml).charset("UTF-8")
+  doc.body.html
    }
 }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -20,6 +20,7 @@ import conf.Configuration
 import com.gu.openplatform.contentapi.model.MediaAsset
 import play.Play
 import org.jsoup.nodes.Entities.EscapeMode
+import org.apache.commons.lang.StringEscapeUtils
 
 sealed trait Style {
   val className: String
@@ -336,9 +337,10 @@ object StripHtmlTags {
 object StripAndEscapeHtmlTags{
   def apply( html: String) : String = {
   val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
-  doc.outputSettings().escapeMode(EscapeMode.xhtml).charset("UTF-8")
-  doc.body.html
-   }
+  val stripped = doc.body.html
+  val unescaped = StringEscapeUtils.unescapeHtml(stripped)
+  unescaped.replace("\"","&#34;")   //double quotes will break HTML attributes
+      }
 }
 
 object Head {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -337,7 +337,7 @@ object StripAndEscapeHtmlTags{
   def apply( html: String) : String = {
   val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
   doc.outputSettings().escapeMode(EscapeMode.xhtml).charset("UTF-8");
-  doc.body().html() 
+  doc.body().html()
    }
 }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -334,7 +334,7 @@ object StripHtmlTags {
   def apply(html: String): String = Jsoup.clean(html, Whitelist.none())
 }
 
-object StripAndEscapeHtmlTags{
+object StripHtmlTagsAndUnescapeEntities{
   def apply( html: String) : String = {
   val doc = new Cleaner(Whitelist.none()).clean(Jsoup.parse(html))
   val stripped = doc.body.html

--- a/common/test/common/StripHtmlTagsAndUnescapeEntitiesTest.scala
+++ b/common/test/common/StripHtmlTagsAndUnescapeEntitiesTest.scala
@@ -2,15 +2,13 @@ package common
 
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
-import views.support.{StripAndEscapeHtmlTags}
+import views.support.{StripHtmlTagsAndUnescapeEntities}
 
-class UnescapeHtmlInAttributesTest extends FlatSpec with ShouldMatchers {
+class StripHtmlTagsAndUnescapeEntitiesTest extends FlatSpec with ShouldMatchers {
 
-  "Unescape HTML in attributes" should "unescape entities" in {
+  "Strip HTML tags and unescape entities" should "unescape entities" in {
 
-
-
-    val html: String = StripAndEscapeHtmlTags(
+    val html: String = StripHtmlTagsAndUnescapeEntities(
     "Wigan Athletic have appointed Owen Coyle, the former Burnley and Bolton manager, to succeed Roberto Mart&iacute;nez. Photograph: Carl Recine/Action Images")
 
     html should equal ("Wigan Athletic have appointed Owen Coyle, the former Burnley and Bolton manager, to succeed Roberto Martínez. Photograph: Carl Recine/Action Images")
@@ -18,13 +16,13 @@ class UnescapeHtmlInAttributesTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "strip out HTML" in {
-    val html: String = StripAndEscapeHtmlTags(
+    val html: String = StripHtmlTagsAndUnescapeEntities(
     "<a href=\"https://www.facebook.com/pages/Jacob-Everett/295006103859003\">Jacob Everett </a> has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at <a href=\"http://www.jacobeverett.com/\">jacobeverett.com</a>. Recommended by Guardian reader <a href=\"http://discussion.guardian.co.uk/comment-permalink/23575543\">Adamki</a>.")
     html should equal ("Jacob Everett  has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at jacobeverett.com. Recommended by Guardian reader Adamki.")
   }
 
   it should "escape double quotes" in {
-    val html: String = StripAndEscapeHtmlTags("\"quoted text\"")
+    val html: String = StripHtmlTagsAndUnescapeEntities("\"quoted text\"")
     html should equal ("&#34;quoted text&#34;")
   }
 

--- a/common/test/common/UnescapeHtmlInAttributesTest.scala
+++ b/common/test/common/UnescapeHtmlInAttributesTest.scala
@@ -1,0 +1,20 @@
+package common
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import views.support.{StripAndEscapeHtmlTags, HtmlCleaner}
+
+class UnescapeHtmlInAttributesTest extends FlatSpec with ShouldMatchers {
+
+  "Unescape HTML in attributes" should "remove strip HTML and unescape entities" in {
+
+
+
+    val html: String = StripAndEscapeHtmlTags(
+      "Wigan Athletic have appointed Owen Coyle, the former Burnley and Bolton manager, to succeed Roberto Mart&iacute;nez. Photograph: Carl Recine/Action Images")
+    html should equal ("Wigan Athletic have appointed Owen Coyle, the former Burnley and Bolton manager, to succeed Roberto Martínez. Photograph: Carl Recine/Action Images")
+  }
+
+
+
+}

--- a/common/test/common/UnescapeHtmlInAttributesTest.scala
+++ b/common/test/common/UnescapeHtmlInAttributesTest.scala
@@ -2,17 +2,31 @@ package common
 
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
-import views.support.{StripAndEscapeHtmlTags, HtmlCleaner}
+import views.support.{StripAndEscapeHtmlTags}
 
 class UnescapeHtmlInAttributesTest extends FlatSpec with ShouldMatchers {
 
-  "Unescape HTML in attributes" should "remove strip HTML and unescape entities" in {
+  "Unescape HTML in attributes" should "unescape entities" in {
 
 
 
     val html: String = StripAndEscapeHtmlTags(
-      "Wigan Athletic have appointed Owen Coyle, the former Burnley and Bolton manager, to succeed Roberto Mart&iacute;nez. Photograph: Carl Recine/Action Images")
+    "Wigan Athletic have appointed Owen Coyle, the former Burnley and Bolton manager, to succeed Roberto Mart&iacute;nez. Photograph: Carl Recine/Action Images")
+
     html should equal ("Wigan Athletic have appointed Owen Coyle, the former Burnley and Bolton manager, to succeed Roberto Martínez. Photograph: Carl Recine/Action Images")
+
+  }
+
+  it should "strip out HTML" in {
+    val html: String = StripAndEscapeHtmlTags(
+     "<a href=\"https://www.facebook.com/pages/Jacob-Everett/295006103859003\">Jacob Everett </a> has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at <a href=\"http://www.jacobeverett.com/\">jacobeverett.com</a>. Recommended by Guardian reader <a href=\"http://discussion.guardian.co.uk/comment-permalink/23575543\">Adamki</a>.")
+      html should equal ("Jacob Everett  has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at jacobeverett.com. Recommended by Guardian reader Adamki.")
+  }
+
+   it should "escape quote marks" in {
+    val html: String = StripAndEscapeHtmlTags(
+      "\"quoted text\"")
+    html should equal ("&quot;quoted text&quot;")
   }
 
 

--- a/common/test/common/UnescapeHtmlInAttributesTest.scala
+++ b/common/test/common/UnescapeHtmlInAttributesTest.scala
@@ -19,14 +19,13 @@ class UnescapeHtmlInAttributesTest extends FlatSpec with ShouldMatchers {
 
   it should "strip out HTML" in {
     val html: String = StripAndEscapeHtmlTags(
-     "<a href=\"https://www.facebook.com/pages/Jacob-Everett/295006103859003\">Jacob Everett </a> has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at <a href=\"http://www.jacobeverett.com/\">jacobeverett.com</a>. Recommended by Guardian reader <a href=\"http://discussion.guardian.co.uk/comment-permalink/23575543\">Adamki</a>.")
-      html should equal ("Jacob Everett  has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at jacobeverett.com. Recommended by Guardian reader Adamki.")
+    "<a href=\"https://www.facebook.com/pages/Jacob-Everett/295006103859003\">Jacob Everett </a> has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at <a href=\"http://www.jacobeverett.com/\">jacobeverett.com</a>. Recommended by Guardian reader <a href=\"http://discussion.guardian.co.uk/comment-permalink/23575543\">Adamki</a>.")
+    html should equal ("Jacob Everett  has a simple idea, but one that he carries out beautifully: the head of a famous person imposed on shoulders made from a map of the area they are associated with. This one of Groucho Marx and a map of New York from 1939 is available to buy at jacobeverett.com. Recommended by Guardian reader Adamki.")
   }
 
-   it should "escape quote marks" in {
-    val html: String = StripAndEscapeHtmlTags(
-      "\"quoted text\"")
-    html should equal ("&quot;quoted text&quot;")
+  it should "escape double quotes" in {
+    val html: String = StripAndEscapeHtmlTags("\"quoted text\"")
+    html should equal ("&#34;quoted text&#34;")
   }
 
 


### PR DESCRIPTION
Fix for a bug @kaelig spotted where title attributes are not escaped e.g. http://m.guardian.co.uk/football/2013/jun/14/owen-coyle-wigan-athletic-manager

Aside: Found out whilst doing this that we do not seem to get the alt text from the content API instead using the caption as the alt text, but I can't work out why from looking at the code.
