### PR TITLE
Fix 'most read' on profile pages 

### DIFF
--- a/common/app/assets/javascripts/modules/popular.js
+++ b/common/app/assets/javascripts/modules/popular.js
@@ -4,7 +4,8 @@ define(['common', 'modules/lazyload'], function (common, LazyLoad) {
         var container = context.querySelector('.js-popular');
 
         if (container) {
-            url = url || '/most-read' + (config.page && config.page.section ? '/' + config.page.section : '');
+            var hasSection = config.page && config.page.section && config.page.section !== 'global';
+            url = url || '/most-read' + (hasSection ? '/' + config.page.section : '');
             new LazyLoad({
                 url: url + '.json',
                 container: container,

--- a/common/app/assets/javascripts/modules/popular.js
+++ b/common/app/assets/javascripts/modules/popular.js
@@ -4,6 +4,7 @@ define(['common', 'modules/lazyload'], function (common, LazyLoad) {
         var container = context.querySelector('.js-popular');
 
         if (container) {
+            // some pages, e.g. profiles, are flagged as 'section: global', a non-existent section - this ignores those
             var hasSection = config.page && config.page.section && config.page.section !== 'global';
             url = url || '/most-read' + (hasSection ? '/' + config.page.section : '');
             new LazyLoad({

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -1,6 +1,6 @@
 @(section: String)
 
-@defining(Some(section).filter(_.nonEmpty).map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
+@defining(Some(section).filter{ section => section.nonEmpty && !section.equals("global")}.map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
     <div class="js-popular">
         <h2 class="type-2 article-zone">
             <a class="most-viewed-no-js" href="@url" data-link-name="Most viewed @section">Most read <i class="i i-filter-arrow-right"></i></a>

--- a/common/test/assets/javascripts/runner.html
+++ b/common/test/assets/javascripts/runner.html
@@ -187,9 +187,6 @@
         <!-- Related.spec -->
         <div class="js-related"></div>
 
-        <!-- Popular.spec -->
-        <div class="js-popular"></div>
-
         <!-- Expandables -->
         <style>
             ul.flex {

--- a/common/test/assets/javascripts/spec/Popular.spec.js
+++ b/common/test/assets/javascripts/spec/Popular.spec.js
@@ -44,8 +44,7 @@ define(['common', 'bonzo', 'ajax', 'modules/popular'], function(common, bonzo, a
             });
         });
 
-        // json test needs to be run asynchronously
-        it('should not pass section if section it "global"', function(){
+        it('should not pass section if section is "global"', function(){
 
             server.respondWith('/most-read.json?_edition=UK', [200, {}, '{ "html": "<b>popular</b>" }']);
 


### PR DESCRIPTION
See https://github.com/guardian/frontend/issues/952

Don't pull in most read, or link to it, if section is 'global'
