### PR TITLE
Remove adslot for browsers with JS disabled

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -1,5 +1,7 @@
 .ad-slot {
-    display: block;
+    display: none;
+    .js-on & { display: block; }
+
     width: 100%;
     padding: 10px 0 0 0;
     text-align: center;


### PR DESCRIPTION
Since Ads will not load without JS, we should hide the slot they are supposed to fill if JS is disabled.

![feels good](http://www.stupidgifs.com/images/full/859.gif)
