### PR TITLE
HTML entities are escaped in discussion's article title

### DIFF
--- a/discussion/app/views/comments.scala.html
+++ b/discussion/app/views/comments.scala.html
@@ -8,7 +8,7 @@
         <div class="article-body">
             <header class="article__head">
                 <h1 class="article-headline">
-                    <a href="@page.contentUrl">@page.title</a>
+                    <a href="@page.contentUrl">@Html(page.title)</a>
                 </h1>
             </header>
         


### PR DESCRIPTION
In some instances HTML entities would appear in the code, like in this discussion: http://m.guardian.co.uk/discussion//p/3gjpx

`Hari Kunzru's Memory Palace creates a 'walk-in' graphic novel at the V&amp;A`

![double backflip](http://www.stupidgifs.com/images/full/844.gif)
