### PR TITLE
Added s-maxage, remove public

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -24,7 +24,7 @@ object Cached extends Results {
 
     // see http://tools.ietf.org/html/rfc5861 for definitions of these headers
     result.withHeaders(
-      "Cache-Control" -> s"public, max-age=$maxAge, stale-while-revalidate=$maxAge, stale-if-error=345600",
+      "Cache-Control" -> s"max-age=$maxAge, s-maxage=$maxAge, stale-while-revalidate=$maxAge, stale-if-error=345600",
       "Expires" -> expiresTime.toHttpDateTimeString,
       "Date" -> now.toHttpDateTimeString
     )

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -21,7 +21,7 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("public, max-age=5, stale-while-revalidate=5, stale-if-error=345600")
+    headers("Cache-Control") should be("max-age=5, s-maxage=5, stale-while-revalidate=5, stale-if-error=345600")
   }
 
   it should "cache content less than 24 hours old for 1 minute" in {
@@ -33,7 +33,7 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("public, max-age=60, stale-while-revalidate=60, stale-if-error=345600")
+    headers("Cache-Control") should be("max-age=60, s-maxage=60, stale-while-revalidate=60, stale-if-error=345600")
   }
 
   it should "cache older content for 15 minutes" in {
@@ -45,7 +45,7 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("public, max-age=900, stale-while-revalidate=900, stale-if-error=345600")
+    headers("Cache-Control") should be("max-age=900, s-maxage=900, stale-while-revalidate=900, stale-if-error=345600")
   }
 
   it should "cache other things for 1 minute" in {
@@ -66,7 +66,7 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     val result = Cached(page)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("public, max-age=60, stale-while-revalidate=60, stale-if-error=345600")
+    headers("Cache-Control") should be("max-age=60, s-maxage=60, stale-while-revalidate=60, stale-if-error=345600")
   }
 
   it should "double the cache time if DoubleCacheTimesSwitch is switched on" in {
@@ -78,7 +78,7 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("public, max-age=120, stale-while-revalidate=120, stale-if-error=345600")
+    headers("Cache-Control") should be("max-age=120, s-maxage=120, stale-while-revalidate=120, stale-if-error=345600")
   }
 
   private def content(lastModified: DateTime, live: Boolean): Content = {


### PR DESCRIPTION
i. Our CDNs will use 's-maxage' to cache the resources.

ii. The clients will use the 'max-age' value.

iii. When we switch to Varnish (on a single domain) we either need to remove 's-maxage' on outbound requests or add the 'private' declaration.

In this regard I thinking the 'public' declaration is spurious.

@gklopper as discussed
