### PR TITLE
InBodyLink now understands editions

### DIFF
--- a/applications/app/views/fragments/sectionsBody.scala.html
+++ b/applications/app/views/fragments/sectionsBody.scala.html
@@ -10,7 +10,7 @@
 
         @if(zone.name.title != "News") {
         	<h1 class="article-zone type-2">
-                <a href="@zone.name.href" data-link-name="zone:text" class="zone-color">
+                <a href="@InBodyLink(zone.name.href)" data-link-name="zone:text" class="zone-color">
                     @HtmlFormat.raw(zone.name.title)
                 </a>
             </h1>
@@ -20,7 +20,7 @@
 
             @zone.sections.map{ section =>
                 <li class="nav__item">
-                    <a class="nav__link" href="@section.href" data-link-name="@section.linkName:text">
+                    <a class="nav__link" href="@InBodyLink(section.href)" data-link-name="@section.linkName:text">
                         @HtmlFormat.raw(section.title)
                     </a>
                 </li>

--- a/applications/app/views/fragments/sectionsBody.scala.html
+++ b/applications/app/views/fragments/sectionsBody.scala.html
@@ -10,7 +10,7 @@
 
         @if(zone.name.title != "News") {
         	<h1 class="article-zone type-2">
-                <a href="@InBodyLink(zone.name.href)" data-link-name="zone:text" class="zone-color">
+                <a href="@LinkTo(zone.name.href)" data-link-name="zone:text" class="zone-color">
                     @HtmlFormat.raw(zone.name.title)
                 </a>
             </h1>
@@ -20,7 +20,7 @@
 
             @zone.sections.map{ section =>
                 <li class="nav__item">
-                    <a class="nav__link" href="@InBodyLink(section.href)" data-link-name="@section.linkName:text">
+                    <a class="nav__link" href="@LinkTo(section.href)" data-link-name="@section.linkName:text">
                         @HtmlFormat.raw(section.title)
                     </a>
                 </li>

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -3,7 +3,7 @@
 @defining(page.video){ video =>
     <div class="monocolumn-wrapper">
         <h2 class="article-zone type-1">
-            <a class="zone-color" data-link-name="article section" href="/@InBodyLink(video.section)">@Html(video.sectionName)</a>
+            <a class="zone-color" data-link-name="article section" href="/@LinkTo(video.section)">@Html(video.sectionName)</a>
         </h2>
     
         <article id="article" class="article video @if(video.isLive){is-live}" itemprop="mainContentOfPage"

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -3,7 +3,7 @@
 @defining(page.video){ video =>
     <div class="monocolumn-wrapper">
         <h2 class="article-zone type-1">
-            <a class="zone-color" data-link-name="article section" href="/@video.section">@Html(video.sectionName)</a>
+            <a class="zone-color" data-link-name="article section" href="/@InBodyLink(video.section)">@Html(video.sectionName)</a>
         </h2>
     
         <article id="article" class="article video @if(video.isLive){is-live}" itemprop="mainContentOfPage"

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -4,7 +4,7 @@
 <div class="monocolumn-wrapper">
     
     <h2 class="article-zone type-1">
-        <a class="zone-color" data-link-name="article section" href="@InBodyLink{/@article.section}">@Html(article.sectionName)</a>
+        <a class="zone-color" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName)</a>
     </h2>
 
     <article id="article" class="article @if(article.isLive){is-live}"
@@ -61,7 +61,7 @@
     @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {
         <div class="article__discussion article-body"></div>
         <div class="d-show-cta-wrapper">    
-            <a class="d-show-cta js-show-discussion js-top" href="@InBodyLink{/discussion/@article.shortUrlId}"
+            <a class="d-show-cta js-show-discussion js-top" href="@LinkTo{/discussion/@article.shortUrlId}"
                data-is-ajax data-link-name="View all comments">
                 View all comments <span class="d-commentcount speech-bubble"><span class="js-commentcount__number"></span></span>
             </a>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -4,7 +4,7 @@
 <div class="monocolumn-wrapper">
     
     <h2 class="article-zone type-1">
-        <a class="zone-color" data-link-name="article section" href="/@article.section">@Html(article.sectionName)</a>
+        <a class="zone-color" data-link-name="article section" href="@InBodyLink{/@article.section}">@Html(article.sectionName)</a>
     </h2>
 
     <article id="article" class="article @if(article.isLive){is-live}"
@@ -41,7 +41,7 @@
              itemprop="@if(article.isReview){reviewBody} else {articleBody}">
                  @withJsoup(BulletCleaner(article.body))(
                      PictureCleaner(article),
-                     InBodyLinkCleaner("in body link"),
+                     InBodyLinkCleaner("in body link")(Edition(request)),
                      BlockNumberCleaner,
                      TweetCleaner,
                      WitnessCleaner,
@@ -61,7 +61,7 @@
     @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {
         <div class="article__discussion article-body"></div>
         <div class="d-show-cta-wrapper">    
-            <a class="d-show-cta js-show-discussion js-top" href="/discussion/@article.shortUrlId"
+            <a class="d-show-cta js-show-discussion js-top" href="@InBodyLink{/discussion/@article.shortUrlId}"
                data-is-ajax data-link-name="View all comments">
                 View all comments <span class="d-commentcount speech-bubble"><span class="js-commentcount__number"></span></span>
             </a>

--- a/article/app/views/fragments/witnessCallToAction.scala.html
+++ b/article/app/views/fragments/witnessCallToAction.scala.html
@@ -1,14 +1,14 @@
-@(content: model.Content)
+@(content: model.Content)(implicit request: RequestHeader)
 
 @if(content.allowUserGeneratedContent) {
     @content.witnessAssignment.map{ assignmentId =>
         @defining(s"https://witness.guardian.co.uk/assignment/$assignmentId#contribute"){ assignmentUrl =>
             <div class="witness-call-to-action">
-                <a href="@assignmentUrl" data-link-name="witness cta plus">
+                <a href="@InBodyLink{@assignmentUrl}" data-link-name="witness cta plus">
                     <i class="i i-ee-add-button"></i>
                  </a>
                     <div class="witness-call-to-action--box">
-                        <a href="@assignmentUrl" data-link-name="witness cta text">
+                        <a href="@InBodyLink{@assignmentUrl}" data-link-name="witness cta text">
                             <p>
                                 Contribute with <i class="i i-witness-logo" title="Guardian Witness"></i>
                             </p>

--- a/article/app/views/fragments/witnessCallToAction.scala.html
+++ b/article/app/views/fragments/witnessCallToAction.scala.html
@@ -4,11 +4,11 @@
     @content.witnessAssignment.map{ assignmentId =>
         @defining(s"https://witness.guardian.co.uk/assignment/$assignmentId#contribute"){ assignmentUrl =>
             <div class="witness-call-to-action">
-                <a href="@InBodyLink{@assignmentUrl}" data-link-name="witness cta plus">
+                <a href="@LinkTo{@assignmentUrl}" data-link-name="witness cta plus">
                     <i class="i i-ee-add-button"></i>
                  </a>
                     <div class="witness-call-to-action--box">
-                        <a href="@InBodyLink{@assignmentUrl}" data-link-name="witness cta text">
+                        <a href="@LinkTo{@assignmentUrl}" data-link-name="witness cta text">
                             <p>
                                 Contribute with <i class="i i-witness-logo" title="Guardian Witness"></i>
                             </p>

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -17,7 +17,11 @@ abstract class Edition(
 
 object Edition {
 
+  // gives templates an implicit edition
+  implicit def edition(implicit request: RequestHeader) = this(request)
+
   val defaultEdition = editions.Uk
+
   val all = Seq(
     editions.Uk,
     editions.Us

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -2,7 +2,7 @@ package common
 
 import play.api.templates.Html
 
-object InBodyLink extends Logging {
+object LinkTo extends Logging {
 
   //all content types except article (they do not have the word "article" in the url)
   val supportedContentTypes = Seq("gallery", "video")

--- a/common/app/views/fragments/commentCount.scala.html
+++ b/common/app/views/fragments/commentCount.scala.html
@@ -1,4 +1,4 @@
 @(url: String)(implicit request: RequestHeader)
 <span class="trail__comment-count">
-    <a class="trail__comment-count" href="@InBodyLink{@url#comments}" data-link-name="Comment count"></a>
+    <a class="trail__comment-count" href="@LinkTo{@url#comments}" data-link-name="Comment count"></a>
 </span>

--- a/common/app/views/fragments/commentCount.scala.html
+++ b/common/app/views/fragments/commentCount.scala.html
@@ -1,4 +1,4 @@
-@(url: String)
+@(url: String)(implicit request: RequestHeader)
 <span class="trail__comment-count">
-    <a class="trail__comment-count" href="@url#comments" data-link-name="Comment count"></a>
+    <a class="trail__comment-count" href="@InBodyLink{@url#comments}" data-link-name="Comment count"></a>
 </span>

--- a/common/app/views/fragments/expiredBody.scala.html
+++ b/common/app/views/fragments/expiredBody.scala.html
@@ -1,7 +1,7 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
 <h2 class="article-zone type-1">
-    <a class="zone-color" data-link-name="article section" href="/@content.section">@Html(content.sectionName)</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/@content.section}">@Html(content.sectionName)</a>
 </h2>
 
 <article id="article" class="article" itemprop="mainContentOfPage" itemscope itemtype="@content.schemaType">

--- a/common/app/views/fragments/expiredBody.scala.html
+++ b/common/app/views/fragments/expiredBody.scala.html
@@ -1,7 +1,7 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
 <h2 class="article-zone type-1">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/@content.section}">@Html(content.sectionName)</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/@content.section}">@Html(content.sectionName)</a>
 </h2>
 
 <article id="article" class="article" itemprop="mainContentOfPage" itemscope itemtype="@content.schemaType">

--- a/common/app/views/fragments/footballNav.scala.html
+++ b/common/app/views/fragments/footballNav.scala.html
@@ -2,7 +2,7 @@
 @import common._
 
 <h3 class="article-zone type-2">
-    <a class="zone-color" href="@InBodyLink{@competitionUrl.getOrElse("/football")}" data-link-name="football index">@competitionName.getOrElse("Football")</a>
+    <a class="zone-color" href="@LinkTo{@competitionUrl.getOrElse("/football")}" data-link-name="football index">@competitionName.getOrElse("Football")</a>
 </h3>
 <div class="box-indent">
     <div class="sections cf football-nav" data-link-name="football bottom nav">
@@ -38,7 +38,7 @@
 
             }) { links =>
                 @links.map{ l =>
-                    <li class="nav__item"><a class="nav__link" href="@InBodyLink{@l.url}" data-link-name="@l.linkName">@l.linkText</a></li>
+                    <li class="nav__item"><a class="nav__link" href="@LinkTo{@l.url}" data-link-name="@l.linkName">@l.linkText</a></li>
                 }
             }
         </ul>

--- a/common/app/views/fragments/footballNav.scala.html
+++ b/common/app/views/fragments/footballNav.scala.html
@@ -2,7 +2,7 @@
 @import common._
 
 <h3 class="article-zone type-2">
-    <a class="zone-color" href="@competitionUrl.getOrElse("/football")" data-link-name="football index">@competitionName.getOrElse("Football")</a>
+    <a class="zone-color" href="@InBodyLink{@competitionUrl.getOrElse("/football")}" data-link-name="football index">@competitionName.getOrElse("Football")</a>
 </h3>
 <div class="box-indent">
     <div class="sections cf football-nav" data-link-name="football bottom nav">
@@ -38,7 +38,7 @@
 
             }) { links =>
                 @links.map{ l =>
-                    <li class="nav__item"><a class="nav__link" href="@l.url" data-link-name="@l.linkName">@l.linkText</a></li>
+                    <li class="nav__item"><a class="nav__link" href="@InBodyLink{@l.url}" data-link-name="@l.linkName">@l.linkText</a></li>
                 }
             }
         </ul>

--- a/common/app/views/fragments/formatTags.scala.html
+++ b/common/app/views/fragments/formatTags.scala.html
@@ -1,3 +1,3 @@
-@(tag: Tag)
+@(tag: Tag)(implicit request: RequestHeader)
 
-<li class="b1"><a href="@tag.url">@Html(tag.name)</a></li>
+<li class="b1"><a href="@InBodyLink{@tag.url}">@Html(tag.name)</a></li>

--- a/common/app/views/fragments/formatTags.scala.html
+++ b/common/app/views/fragments/formatTags.scala.html
@@ -1,3 +1,3 @@
 @(tag: Tag)(implicit request: RequestHeader)
 
-<li class="b1"><a href="@InBodyLink{@tag.url}">@Html(tag.name)</a></li>
+<li class="b1"><a href="@LinkTo{@tag.url}">@Html(tag.name)</a></li>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -3,13 +3,14 @@
 
 <header id="header" role="banner" data-link-name="global navigation: header">
     <div class="header__inner gs-container cf">
-        <a href="/" id="logo" class="i i-guardian-logo" data-link-name="site logo">The Guardian</a>
+        <a @SiteOr{ site => href="/" }{ href="@InBodyLink{/}" } 
+            id="logo" class="i i-guardian-logo" data-link-name="site logo">The Guardian</a>
 
         <div class="nav-container">
             <ul class="nav nav--global" data-link-name="Sections">
                 @Edition(request).navigation(page).map{ nav =>
                     <li class="nav__item @if(nav.currentFor(page)){is-active}">
-                        <a href="@nav.name.href" class="nav__link" data-link-name="@nav.name.linkName">@nav.name.title</a>
+                        <a href="@InBodyLink{@nav.name.href}" class="nav__link" data-link-name="@nav.name.linkName">@nav.name.title</a>
                     </li>
                 }
             </ul>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -3,14 +3,14 @@
 
 <header id="header" role="banner" data-link-name="global navigation: header">
     <div class="header__inner gs-container cf">
-        <a @SiteOr{ site => href="/" }{ href="@InBodyLink{/}" } 
+        <a @SiteOr{ site => href="/" }{ href="@LinkTo{/}" }
             id="logo" class="i i-guardian-logo" data-link-name="site logo">The Guardian</a>
 
         <div class="nav-container">
             <ul class="nav nav--global" data-link-name="Sections">
                 @Edition(request).navigation(page).map{ nav =>
                     <li class="nav__item @if(nav.currentFor(page)){is-active}">
-                        <a href="@InBodyLink{@nav.name.href}" class="nav__link" data-link-name="@nav.name.linkName">@nav.name.title</a>
+                        <a href="@LinkTo{@nav.name.href}" class="nav__link" data-link-name="@nav.name.linkName">@nav.name.title</a>
                     </li>
                 }
             </ul>

--- a/common/app/views/fragments/headers/frontSectionHead.scala.html
+++ b/common/app/views/fragments/headers/frontSectionHead.scala.html
@@ -1,7 +1,7 @@
 @(description: TrailblockDescription,  edition: Option[Edition] = None)(implicit request: RequestHeader)
 <div class="@if(request.path == "/"){front-section-head zone-background} else {sub-section-head}">
     <h1>
-       <a @if(request.path != ""){class="zone-color"} data-link-name="section heading" href="/@description.id">
+       <a @if(request.path != ""){class="zone-color"} data-link-name="section heading" href="@InBodyLink{/@description.id}">
          @description.name
         </a>
     </h1>

--- a/common/app/views/fragments/headers/frontSectionHead.scala.html
+++ b/common/app/views/fragments/headers/frontSectionHead.scala.html
@@ -1,7 +1,7 @@
 @(description: TrailblockDescription,  edition: Option[Edition] = None)(implicit request: RequestHeader)
 <div class="@if(request.path == "/"){front-section-head zone-background} else {sub-section-head}">
     <h1>
-       <a @if(request.path != ""){class="zone-color"} data-link-name="section heading" href="@InBodyLink{/@description.id}">
+       <a @if(request.path != ""){class="zone-color"} data-link-name="section heading" href="@LinkTo{/@description.id}">
          @description.name
         </a>
     </h1>

--- a/common/app/views/fragments/linkText.scala.html
+++ b/common/app/views/fragments/linkText.scala.html
@@ -1,7 +1,7 @@
-@(trail: Trail, info: RowInfo)
+@(trail: Trail, info: RowInfo)(implicit request: RequestHeader)
 
 <p class="type-7">
-    <a href="@trail.url" data-link-name="@info.rowNum | text">
+    <a href="@InBodyLink{@trail.url}" data-link-name="@info.rowNum | text">
         @RemoveOuterParaHtml(trail.linkText)
     </a>
 </p>

--- a/common/app/views/fragments/linkText.scala.html
+++ b/common/app/views/fragments/linkText.scala.html
@@ -1,7 +1,7 @@
 @(trail: Trail, info: RowInfo)(implicit request: RequestHeader)
 
 <p class="type-7">
-    <a href="@InBodyLink{@trail.url}" data-link-name="@info.rowNum | text">
+    <a href="@LinkTo{@trail.url}" data-link-name="@info.rowNum | text">
         @RemoveOuterParaHtml(trail.linkText)
     </a>
 </p>

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -1,9 +1,9 @@
-@(section: String)
+@(section: String)(implicit request: RequestHeader)
 
 @defining(Some(section).filter{ section => section.nonEmpty && !section.equals("global")}.map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
     <div class="js-popular">
         <h2 class="type-2 article-zone">
-            <a class="most-viewed-no-js" href="@url" data-link-name="Most viewed @section">Most read <i class="i i-filter-arrow-right"></i></a>
+            <a class="most-viewed-no-js" href="@InBodyLink{@url}" data-link-name="Most viewed @section">Most read <i class="i i-filter-arrow-right"></i></a>
         </h2>
     </div>
 }

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -3,7 +3,7 @@
 @defining(Some(section).filter{ section => section.nonEmpty && !section.equals("global")}.map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
     <div class="js-popular">
         <h2 class="type-2 article-zone">
-            <a class="most-viewed-no-js" href="@InBodyLink{@url}" data-link-name="Most viewed @section">Most read <i class="i i-filter-arrow-right"></i></a>
+            <a class="most-viewed-no-js" href="@LinkTo{@url}" data-link-name="Most viewed @section">Most read <i class="i i-filter-arrow-right"></i></a>
         </h2>
     </div>
 }

--- a/common/app/views/fragments/sections.scala.html
+++ b/common/app/views/fragments/sections.scala.html
@@ -20,7 +20,7 @@
         }{
             @Edition(request).navigation(page).map{ section =>
                 <li class="nav__item@if(section.name.newWindow && !isFooter){ mobile-only}">
-                    <a href="@InBodyLink{@section.name.href}"
+                    <a href="@LinkTo{@section.name.href}"
                         data-link-name="@section.name.linkName"
                         class="nav__link@if("/" + page.id == section.name.href) { is-active}"
                         @if(section.name.newWindow){ target="_blank" }>
@@ -49,7 +49,7 @@
             <li class="nav__item"><a class="nav__link edition edition-au" data-link-name="switch to au edition" href="http://@site.ukHost/australia@if(site.isUsEdition){#gu.prefs.switchOn=australia-edition}">Australia edition</a></li>
         }{
             @Edition.others(request).map{ edition =>
-                <li class="nav__item"><a class="nav__link edition" data-edition="@edition.id" data-link-name="switch to @edition.id edition" href="@InBodyLink{/}(edition)">@edition.displayName</a></li>
+                <li class="nav__item"><a class="nav__link edition" data-edition="@edition.id" data-link-name="switch to @edition.id edition" href="@LinkTo{/}(edition)">@edition.displayName</a></li>
             }
         }
     </ul>

--- a/common/app/views/fragments/sections.scala.html
+++ b/common/app/views/fragments/sections.scala.html
@@ -5,16 +5,29 @@
     @if(isFooter){ data-link-name="global navigation: footer : sections"} else {
         data-link-name="global navigation: header : sections"}>
     <ul class="nav nav--columns nav--top-border-off @if(isFooter){nav--footer} cf">
-
-        @Edition(request).navigation(page).map{ section =>
-        <li class="nav__item@if(section.name.newWindow && !isFooter){ mobile-only}">
-            <a href="@section.name.href"
-                data-link-name="@section.name.linkName"
-                class="nav__link@if("/" + page.id == section.name.href) { is-active}"
+        @* <!-- TODO delete site after switch to single domain --> *@
+        @SiteOr{ site =>
+            @Edition(request).navigation(page).map{ section =>
+            <li class="nav__item@if(section.name.newWindow && !isFooter){ mobile-only}">
+                <a href="@section.name.href"
+                   data-link-name="@section.name.linkName"
+                   class="nav__link@if("/" + page.id == section.name.href) { is-active}"
                 @if(section.name.newWindow){ target="_blank" }>
-                    @HtmlFormat.raw(section.name.title)
-            </a>
-        </li>
+                @HtmlFormat.raw(section.name.title)
+                </a>
+            </li>
+            }
+        }{
+            @Edition(request).navigation(page).map{ section =>
+                <li class="nav__item@if(section.name.newWindow && !isFooter){ mobile-only}">
+                    <a href="@InBodyLink{@section.name.href}"
+                        data-link-name="@section.name.linkName"
+                        class="nav__link@if("/" + page.id == section.name.href) { is-active}"
+                        @if(section.name.newWindow){ target="_blank" }>
+                            @HtmlFormat.raw(section.name.title)
+                    </a>
+                </li>
+            }
         }
         <li class="nav__item @if(!isFooter){ mobile-only}"><a class="nav__link" data-link-name="all sections" href="/sections">All sections</a></li>
     </ul>
@@ -36,7 +49,7 @@
             <li class="nav__item"><a class="nav__link edition edition-au" data-link-name="switch to au edition" href="http://@site.ukHost/australia@if(site.isUsEdition){#gu.prefs.switchOn=australia-edition}">Australia edition</a></li>
         }{
             @Edition.others(request).map{ edition =>
-                <li class="nav__item"><a class="nav__link edition" data-edition="@edition.id" data-link-name="switch to @edition.id edition" href="/@{Editionalise("", edition)}">@edition.displayName</a></li>
+                <li class="nav__item"><a class="nav__link edition" data-edition="@edition.id" data-link-name="switch to @edition.id edition" href="@InBodyLink{/}(edition)">@edition.displayName</a></li>
             }
         }
     </ul>

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,10 +1,10 @@
-@(content: model.Content)
+@(content: model.Content)(implicit request: RequestHeader)
 
 @* live with empty standfirst as it is used to hook things into the page with javascript *@
 <p class="article-standfirst type-7" itemprop="description" data-link-name="standfirst">
     @content.standfirst.map { s =>
         @withJsoup(BulletCleaner(s))(
-            InBodyLinkCleaner("in standfirst link")
+            InBodyLinkCleaner("in standfirst link")(Edition(request))
         )
         @content.starRating.map { s =>
             <span class="stars s-@s"><meta itemprop="reviewRating" content="@s">@s</meta> / 5 stars</span>

--- a/common/app/views/fragments/trailblocks/link.scala.html
+++ b/common/app/views/fragments/trailblocks/link.scala.html
@@ -1,4 +1,4 @@
-@(trails: Seq[Trail], numItemsVisible: Int = 5)
+@(trails: Seq[Trail], numItemsVisible: Int = 5)(implicit request: RequestHeader)
 
 <ul class="unstyled">
      @trails.take(numItemsVisible).zipWithRowInfo.map{ case (trail, info) =>

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -6,15 +6,15 @@
     @fragments.relativeDate(trail.webPublicationDate, trail.isLive, isFront=true)
 
     <h@headingLevel class="type-3">
-        <a href="@trail.url" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
+        <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
             @RemoveOuterParaHtml(trail.headline)
         </a>
     </h@headingLevel>
 
-    @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)</div> }
+    @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)(Edition(request))</div> }
 
     @trail.mainPicture(width=220).map{ smallCrop =>
-        <a href="@trail.url" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image">
+        <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image">
             <img class="maxed" src="@smallCrop.path"
                 data-force-upgrade="true"
                 data-thumb-width="@smallCrop.width"

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -6,7 +6,7 @@
     @fragments.relativeDate(trail.webPublicationDate, trail.isLive, isFront=true)
 
     <h@headingLevel class="type-3">
-        <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
+        <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
             @RemoveOuterParaHtml(trail.headline)
         </a>
     </h@headingLevel>
@@ -14,7 +14,7 @@
     @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)(Edition(request))</div> }
 
     @trail.mainPicture(width=220).map{ smallCrop =>
-        <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image">
+        <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image">
             <img class="maxed" src="@smallCrop.path"
                 data-force-upgrade="true"
                 data-thumb-width="@smallCrop.width"

--- a/common/app/views/fragments/trails/headline.scala.html
+++ b/common/app/views/fragments/trails/headline.scala.html
@@ -5,8 +5,8 @@
     @fragments.relativeDate(trail.webPublicationDate, trail.isLive, isFront=true)
 
     <h@headingLevel class="trail__headline type-5">
-        <a href="@trail.url" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
-            @cleanTrailText(trail.headline)
+        <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
+            @cleanTrailText(trail.headline)(Edition(request))
         </a>
     </h@headingLevel>
 

--- a/common/app/views/fragments/trails/headline.scala.html
+++ b/common/app/views/fragments/trails/headline.scala.html
@@ -5,7 +5,7 @@
     @fragments.relativeDate(trail.webPublicationDate, trail.isLive, isFront=true)
 
     <h@headingLevel class="trail__headline type-5">
-        <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
+        <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
             @cleanTrailText(trail.headline)(Edition(request))
         </a>
     </h@headingLevel>

--- a/common/app/views/fragments/trails/link.scala.html
+++ b/common/app/views/fragments/trails/link.scala.html
@@ -2,7 +2,7 @@
 
 <span class="count">@rowNum</span> 
 <p class="type-7">
-    <a href="@InBodyLink{@trail.url}" data-link-name="Top stories:link text:item @rowNum">
+    <a href="@LinkTo{@trail.url}" data-link-name="Top stories:link text:item @rowNum">
         @RemoveOuterParaHtml(trail.linkText)
     </a>
 </p>

--- a/common/app/views/fragments/trails/link.scala.html
+++ b/common/app/views/fragments/trails/link.scala.html
@@ -1,8 +1,8 @@
-@(trail: Trail, rowNum: Int)
+@(trail: Trail, rowNum: Int)(implicit request: RequestHeader)
 
 <span class="count">@rowNum</span> 
 <p class="type-7">
-    <a href="@trail.url" data-link-name="Top stories:link text:item @rowNum">
+    <a href="@InBodyLink{@trail.url}" data-link-name="Top stories:link text:item @rowNum">
         @RemoveOuterParaHtml(trail.linkText)
     </a>
 </p>

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -7,7 +7,7 @@
     <div class="media">
         @if(showThumbnail) {
             @trail.thumbnailPath.map{ thumbnailPath =>
-                <a href="@InBodyLink{@trail.url}" class="media__img" data-link-name="@rowNum | image">
+                <a href="@LinkTo{@trail.url}" class="media__img" data-link-name="@rowNum | image">
                     <img class="maxed" src="@thumbnailPath"
                         data-thumb-width="140"
                         @trail.mainPicture(width=220).map { largeCrop =>
@@ -23,7 +23,7 @@
         }
 
         <h@headingLevel class="media__body trail__headline type-5">
-            <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
+            <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
                 @RemoveOuterParaHtml(trail.headline)
             </a>
         </h@headingLevel>

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -7,7 +7,7 @@
     <div class="media">
         @if(showThumbnail) {
             @trail.thumbnailPath.map{ thumbnailPath =>
-                <a href="@trail.url" class="media__img" data-link-name="@rowNum | image">
+                <a href="@InBodyLink{@trail.url}" class="media__img" data-link-name="@rowNum | image">
                     <img class="maxed" src="@thumbnailPath"
                         data-thumb-width="140"
                         @trail.mainPicture(width=220).map { largeCrop =>
@@ -23,12 +23,12 @@
         }
 
         <h@headingLevel class="media__body trail__headline type-5">
-            <a href="@trail.url" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
+            <a href="@InBodyLink{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | text">
                 @RemoveOuterParaHtml(trail.headline)
             </a>
         </h@headingLevel>
 
-        @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)</div> }
+        @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)(Edition(request))</div> }
     </div>
 
 </@element>

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -189,7 +189,7 @@ case class InBodyLinkCleaner(dataLinkName: String)(implicit val edition: Edition
     val links = body.getElementsByTag("a")
 
     links.foreach { link =>
-      link.attr("href", InBodyLink(link.attr("href")))
+      link.attr("href", LinkTo(link.attr("href")))
       link.attr("data-link-name", dataLinkName)
     }
     body

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -184,7 +184,7 @@ object BulletCleaner {
   def apply(body: String): String = body.replace("•", """<span class="bullet">•</span>""")
 }
 
-case class InBodyLinkCleaner(dataLinkName: String) extends HtmlCleaner {
+case class InBodyLinkCleaner(dataLinkName: String)(implicit val edition: Edition) extends HtmlCleaner {
   def clean(body: Document): Document = {
     val links = body.getElementsByTag("a")
 
@@ -323,7 +323,7 @@ object Format {
 }
 
 object cleanTrailText {
-  def apply(text: String): Html = {
+  def apply(text: String)(implicit edition: Edition): Html = {
     `package`.withJsoup(RemoveOuterParaHtml(BulletCleaner(text)))(InBodyLinkCleaner("in trail text link"))
   }
 }

--- a/common/test/common/InBodyLinkTest.scala
+++ b/common/test/common/InBodyLinkTest.scala
@@ -4,10 +4,13 @@ import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
 import play.api.Play
 import InBodyLink.unSupportedContentTypes
+import common.editions.Uk
 
 class InBodyLinkTest extends FlatSpec with ShouldMatchers {
 
   Play.unsafeApplication
+
+  implicit val edition = Uk
 
   val realUrls = Seq(
 
@@ -16,23 +19,30 @@ class InBodyLinkTest extends FlatSpec with ShouldMatchers {
     //tags
     ("http://www.guardian.co.uk/sport/olympics-2012", "/sport/olympics-2012"),
     ("http://www.guardiannews.com/sport/olympics-2012", "/sport/olympics-2012"),
+    ("http://www.theguardian.com/sport/olympics-2012", "/sport/olympics-2012"),
 
     //series, blogs, book sections, other 3 part urls
     ("http://www.guardian.co.uk/football/series/thefiver", "/football/series/thefiver"),
     ("http://www.guardiannews.com/football/series/thefiver", "/football/series/thefiver"),
+    ("http://www.theguardian.com/football/series/thefiver", "/football/series/thefiver"),
 
     //section
     ("http://www.guardian.co.uk/sport", "/sport"),
     ("http://www.guardiannews.com/lifeandstyle", "/lifeandstyle"),
+    ("http://www.theguardian.com/lifeandstyle", "/lifeandstyle"),
 
     //gallery
     ("http://www.guardian.co.uk/news/gallery/2012/jun/07/picture-desk-live-gallery",
       "/news/gallery/2012/jun/07/picture-desk-live-gallery"),
     ("http://www.guardiannews.com/news/gallery/2012/jun/07/picture-desk-live-gallery",
       "/news/gallery/2012/jun/07/picture-desk-live-gallery"),
+    ("http://www.theguardian.com/news/gallery/2012/jun/07/picture-desk-live-gallery",
+      "/news/gallery/2012/jun/07/picture-desk-live-gallery"),
     ("http://www.guardian.co.uk/technology/gamesblog/gallery/2012/jun/01/e3-2012-10-most-anticipated-games",
       "/technology/gamesblog/gallery/2012/jun/01/e3-2012-10-most-anticipated-games"),
     ("http://www.guardiannews.com/technology/gamesblog/gallery/2012/jun/01/e3-2012-10-most-anticipated-games",
+      "/technology/gamesblog/gallery/2012/jun/01/e3-2012-10-most-anticipated-games"),
+    ("http://www.theguardian.com/technology/gamesblog/gallery/2012/jun/01/e3-2012-10-most-anticipated-games",
       "/technology/gamesblog/gallery/2012/jun/01/e3-2012-10-most-anticipated-games"),
 
     //article
@@ -40,9 +50,13 @@ class InBodyLinkTest extends FlatSpec with ShouldMatchers {
       "/football/blog/2012/jun/07/euro-2012-live-blog"),
     ("http://www.guardiannews.com/football/blog/2012/jun/07/euro-2012-live-blog",
       "/football/blog/2012/jun/07/euro-2012-live-blog"),
+    ("http://www.theguardian.com/football/blog/2012/jun/07/euro-2012-live-blog",
+      "/football/blog/2012/jun/07/euro-2012-live-blog"),
     ("http://www.guardian.co.uk/politics/2012/jun/07/politics-live-readers-edition-7-june",
       "/politics/2012/jun/07/politics-live-readers-edition-7-june"),
     ("http://www.guardiannews.com/politics/2012/jun/07/politics-live-readers-edition-7-june",
+      "/politics/2012/jun/07/politics-live-readers-edition-7-june"),
+    ("http://www.theguardian.com/politics/2012/jun/07/politics-live-readers-edition-7-june",
       "/politics/2012/jun/07/politics-live-readers-edition-7-june"),
 
     //dot in words for url
@@ -66,7 +80,22 @@ class InBodyLinkTest extends FlatSpec with ShouldMatchers {
     ("http://www.guardian.co.uk/news/datablog/interactive/2012/jun/07/iraq-afghanistan-coverage-interactive-timeline",
       "http://www.guardian.co.uk/news/datablog/interactive/2012/jun/07/iraq-afghanistan-coverage-interactive-timeline"),
     ("http://www.guardiannews.com/news/datablog/interactive/2012/jun/07/iraq-afghanistan-coverage-interactive-timeline",
-      "http://www.guardiannews.com/news/datablog/interactive/2012/jun/07/iraq-afghanistan-coverage-interactive-timeline")
+      "http://www.guardiannews.com/news/datablog/interactive/2012/jun/07/iraq-afghanistan-coverage-interactive-timeline"),
+    ("http://www.theguardian.com/news/datablog/interactive/2012/jun/07/iraq-afghanistan-coverage-interactive-timeline",
+      "http://www.theguardian.com/news/datablog/interactive/2012/jun/07/iraq-afghanistan-coverage-interactive-timeline"),
+
+    // TODO we only really care about this for theguardian.com - other domains will be removed later from other tests
+
+    //editionalised urls
+    ("http://www.theguardian.com/commentisfree/uk-edition", "/commentisfree/uk-edition"),
+    ("http://www.theguardian.com/commentisfree", "/commentisfree/uk-edition"),
+    ("http://www.theguardian.com", "/uk-edition"),
+
+    //editionalised paths
+    ("/culture/uk-edition", "/culture/uk-edition"),
+    ("/culture", "/culture/uk-edition"),
+    ("/", "/uk-edition")
+
   )
 
   "InBodyLink" should "understand which urls we support" in {
@@ -82,7 +111,9 @@ class InBodyLinkTest extends FlatSpec with ShouldMatchers {
         s"http://www.guardian.co.uk/section/$contentType/2011/jan/01/words-for-url",
         s"http://www.guardian.co.uk/section/blog/$contentType/2011/jan/01/words-for-url",
         s"http://www.guardiannews.com/section/$contentType/2011/jan/01/words-for-url",
-        s"http://www.guardiannews.com/section/blog/$contentType/2011/jan/01/words-for-url"
+        s"http://www.guardiannews.com/section/blog/$contentType/2011/jan/01/words-for-url",
+        s"http://www.theguardian.com/section/$contentType/2011/jan/01/words-for-url",
+        s"http://www.theguardian.com/section/blog/$contentType/2011/jan/01/words-for-url"
       )
     }
     urls foreach { url => InBodyLink(url) should be(url) }

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -3,10 +3,10 @@ package common
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
 import play.api.Play
-import InBodyLink.unSupportedContentTypes
+import LinkTo.unSupportedContentTypes
 import common.editions.Uk
 
-class InBodyLinkTest extends FlatSpec with ShouldMatchers {
+class LinkToTest extends FlatSpec with ShouldMatchers {
 
   Play.unsafeApplication
 
@@ -27,7 +27,7 @@ class InBodyLinkTest extends FlatSpec with ShouldMatchers {
     ("http://www.theguardian.com/football/series/thefiver", "/football/series/thefiver"),
 
     //section
-    ("http://www.guardian.co.uk/sport", "/sport"),
+    ("http://www.guardian.co.uk/books", "/books"),
     ("http://www.guardiannews.com/lifeandstyle", "/lifeandstyle"),
     ("http://www.theguardian.com/lifeandstyle", "/lifeandstyle"),
 
@@ -98,9 +98,9 @@ class InBodyLinkTest extends FlatSpec with ShouldMatchers {
 
   )
 
-  "InBodyLink" should "understand which urls we support" in {
+  "LinkTo" should "understand which urls we support" in {
     realUrls foreach {
-      case (originalUrl, expectedUrl) => InBodyLink(originalUrl) should be(expectedUrl)
+      case (originalUrl, expectedUrl) => LinkTo(originalUrl) should be(expectedUrl)
 
     }
   }
@@ -116,23 +116,23 @@ class InBodyLinkTest extends FlatSpec with ShouldMatchers {
         s"http://www.theguardian.com/section/blog/$contentType/2011/jan/01/words-for-url"
       )
     }
-    urls foreach { url => InBodyLink(url) should be(url) }
+    urls foreach { url => LinkTo(url) should be(url) }
   }
 
   it should "not resolve direct comment links" in {
 
-    InBodyLink("http://www.guardian.co.uk/discussion/comment-permalink/19452022") should
+    LinkTo("http://www.guardian.co.uk/discussion/comment-permalink/19452022") should
       be("http://www.guardian.co.uk/discussion/comment-permalink/19452022")
 
   }
 
   it should "not resolve feed articles" in {
-    InBodyLink("http://www.guardian.co.uk/football/feedarticle/10541078") should
+    LinkTo("http://www.guardian.co.uk/football/feedarticle/10541078") should
       be("http://www.guardian.co.uk/football/feedarticle/10541078")
   }
 
   it should "not resolve comment links" in {
-    InBodyLink("http://www.guardian.co.uk/commentisfree/2013/jan/13/obama-foreign-policy-lessons-iraq?mobile-redirect=false#comment-20590999") should
+    LinkTo("http://www.guardian.co.uk/commentisfree/2013/jan/13/obama-foreign-policy-lessons-iraq?mobile-redirect=false#comment-20590999") should
       be("http://www.guardian.co.uk/commentisfree/2013/jan/13/obama-foreign-policy-lessons-iraq?mobile-redirect=false#comment-20590999")
   }
 }

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -93,7 +93,7 @@ class TemplatesTest extends FlatSpec with ShouldMatchers {
   }
 
   "InBodyLinkCleaner" should "clean links" in {
-    val body = XML.loadString(withJsoup(bodyTextWithLinks)(InBodyLinkCleaner("in body link")).body.trim)
+    val body = XML.loadString(withJsoup(bodyTextWithLinks)(InBodyLinkCleaner("in body link")(Uk)).body.trim)
 
     val link = (body \\ "a").head
 

--- a/core-navigation/app/views/fragments/mostPopular.scala.html
+++ b/core-navigation/app/views/fragments/mostPopular.scala.html
@@ -1,4 +1,4 @@
-@(popular: Seq[model.MostPopular], visibleTrails: Int)
+@(popular: Seq[model.MostPopular], visibleTrails: Int)(implicit request: RequestHeader)
 
 @defining(popular.size > 1){ isTabbed =>
 

--- a/core-navigation/app/views/fragments/topStoriesBody.scala.html
+++ b/core-navigation/app/views/fragments/topStoriesBody.scala.html
@@ -1,4 +1,4 @@
-@(trails: Seq[Trail])
+@(trails: Seq[Trail])(implicit request: RequestHeader)
 
 <h2 class="type-1 article-zone">Top stories</h2>
 <div class="headline-list box-indent" data-link-name="top-stories" role="navigation">

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -1,6 +1,6 @@
 package discussion
 
-import common.{InBodyLink, ExecutionContexts, Logging}
+import common.{ExecutionContexts, Logging}
 import common.DiscussionMetrics.DiscussionHttpTimingMetric
 import conf.Switches.ShortDiscussionSwitch
 import model._
@@ -75,7 +75,7 @@ trait DiscussionApi extends ExecutionContexts with Logging {
           CommentPage(
             id = s"discussion/$id",
             title = (json \ "discussion" \ "title").as[String],
-            contentUrl = InBodyLink((json \ "discussion" \ "webUrl").as[String]),
+            contentUrl = (json \ "discussion" \ "webUrl").as[String],
             comments = comments,
             currentPage =  (json \ "currentPage").as[Int],
             pages = (json \ "pages").as[Int]

--- a/discussion/app/views/comments.scala.html
+++ b/discussion/app/views/comments.scala.html
@@ -8,14 +8,14 @@
         <div class="article-body">
             <header class="article__head">
                 <h1 class="article-headline">
-                    <a href="@page.contentUrl">@Html(page.title)</a>
+                    <a href="@InBodyLink{@page.contentUrl}">@Html(page.title)</a>
                 </h1>
             </header>
         
             @fragments.commentsBody(page)
 
             @if(page.currentPage + 1 <= page.pages){
-              <a href="/@page.id?page=@(page.currentPage + 1)">Next page</a>
+              <a href="@InBodyLink{/@page.id?page=@(page.currentPage + 1)}">Next page</a>
             }
         </div>
     </div>

--- a/discussion/app/views/comments.scala.html
+++ b/discussion/app/views/comments.scala.html
@@ -8,14 +8,14 @@
         <div class="article-body">
             <header class="article__head">
                 <h1 class="article-headline">
-                    <a href="@InBodyLink{@page.contentUrl}">@Html(page.title)</a>
+                    <a href="@LinkTo{@page.contentUrl}">@Html(page.title)</a>
                 </h1>
             </header>
         
             @fragments.commentsBody(page)
 
             @if(page.currentPage + 1 <= page.pages){
-              <a href="@InBodyLink{/@page.id?page=@(page.currentPage + 1)}">Next page</a>
+              <a href="@LinkTo{/@page.id?page=@(page.currentPage + 1)}">Next page</a>
             }
         </div>
     </div>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -39,7 +39,7 @@
                     Replies may also be deleted. For more detail see <a href="http://www.guardian.co.uk/community-faqs" data-link-name="FAQs">our FAQs</a>.
                 }else{
                     @withJsoup(BulletCleaner(comment.body))(
-                        InBodyLinkCleaner("in body link")
+                        InBodyLinkCleaner("in body link")(Edition(request))
                     )
                 }
             </div>

--- a/event/app/views/fragments/agent.scala.html
+++ b/event/app/views/fragments/agent.scala.html
@@ -3,7 +3,7 @@
     @if(agent.hasLink) {
         @agent.url.map{ url =>
             @agent.picture.map{ pic =>
-                <a href="@InBodyLink{@url}" target="_blank" data-link-name="img"><img class="js-swipe__img agent__img" src="@pic" /></a>
+                <a href="@LinkTo{@url}" target="_blank" data-link-name="img"><img class="js-swipe__img agent__img" src="@pic" /></a>
             }
         }
     } else {
@@ -14,7 +14,7 @@
         @if(agent.hasLink) {
             @agent.url.map{ url =>
                 @agent.name.map{ name =>
-                    <h3 class="agent__name"><a href="@InBodyLink{@url}" target="_blank" data-link-name="agent name">@name</a></h3>
+                    <h3 class="agent__name"><a href="@LinkTo{@url}" target="_blank" data-link-name="agent name">@name</a></h3>
                 }
             }
         } else {

--- a/event/app/views/fragments/agent.scala.html
+++ b/event/app/views/fragments/agent.scala.html
@@ -1,9 +1,9 @@
-@(agent: Agent)
+@(agent: Agent)(implicit request: RequestHeader)
 <figure class="js-swipe__item agent" data-link-name="agent">
     @if(agent.hasLink) {
         @agent.url.map{ url =>
             @agent.picture.map{ pic =>
-                <a href="@url" target="_blank" data-link-name="img"><img class="js-swipe__img agent__img" src="@pic" /></a>
+                <a href="@InBodyLink{@url}" target="_blank" data-link-name="img"><img class="js-swipe__img agent__img" src="@pic" /></a>
             }
         }
     } else {
@@ -14,7 +14,7 @@
         @if(agent.hasLink) {
             @agent.url.map{ url =>
                 @agent.name.map{ name =>
-                    <h3 class="agent__name"><a href="@url" target="_blank" data-link-name="agent name">@name</a></h3>
+                    <h3 class="agent__name"><a href="@InBodyLink{@url}" target="_blank" data-link-name="agent name">@name</a></h3>
                 }
             }
         } else {

--- a/event/app/views/fragments/agents.scala.html
+++ b/event/app/views/fragments/agents.scala.html
@@ -1,4 +1,4 @@
-@(story: Story)
+@(story: Story)(implicit request: RequestHeader)
 
 @if(story.hasAgents) {
     <section class="story-agents" data-link-name="Agents">

--- a/event/app/views/fragments/latest.scala.html
+++ b/event/app/views/fragments/latest.scala.html
@@ -33,7 +33,7 @@
                         )
                     </div>
                     <p>
-                        <a class="cta-new js-continue" data-link-name="Continue reading" data-is-ajax data-skip-paras="@paras" href="@InBodyLink{@a.url}">
+                        <a class="cta-new js-continue" data-link-name="Continue reading" data-is-ajax data-skip-paras="@paras" href="@LinkTo{@a.url}">
                             <span class="cta-new__text">Continue reading</span>
                             <button class="cta-new__btn cta-new__btn--right">
                                 <i class="i i-arrow-blue-down cta-new__icn"></i>

--- a/event/app/views/fragments/latest.scala.html
+++ b/event/app/views/fragments/latest.scala.html
@@ -24,7 +24,7 @@
                     <div class="sample-paras">
                         @withJsoup(BulletCleaner(a.body))(
                             PictureCleaner(a),
-                            InBodyLinkCleaner("in body link"),
+                            InBodyLinkCleaner("in body link")(Edition(request)),
                             BlockNumberCleaner,
                             TweetCleaner,
                             WitnessCleaner,
@@ -33,7 +33,7 @@
                         )
                     </div>
                     <p>
-                        <a class="cta-new js-continue" data-link-name="Continue reading" data-is-ajax data-skip-paras="@paras" href="@a.url">
+                        <a class="cta-new js-continue" data-link-name="Continue reading" data-is-ajax data-skip-paras="@paras" href="@InBodyLink{@a.url}">
                             <span class="cta-new__text">Continue reading</span>
                             <button class="cta-new__btn cta-new__btn--right">
                                 <i class="i i-arrow-blue-down cta-new__icn"></i>

--- a/event/app/views/fragments/latestStories.scala.html
+++ b/event/app/views/fragments/latestStories.scala.html
@@ -1,4 +1,4 @@
-@(stories: Seq[Story])
+@(stories: Seq[Story])(implicit request: RequestHeader)
 
 <h3 class="article-zone type-2">Latest stories</h3>
 

--- a/event/app/views/fragments/latestWithContent.scala.html
+++ b/event/app/views/fragments/latestWithContent.scala.html
@@ -31,7 +31,7 @@
                         </a>
                     </h2>
 
-                    @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)</div> }
+                    @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)(Edition(request))</div> }
                 </div>
 
             </li>

--- a/event/app/views/fragments/liveBlog.scala.html
+++ b/event/app/views/fragments/liveBlog.scala.html
@@ -1,7 +1,7 @@
 @(article: Article)(implicit request: RequestHeader)
 
 <h2 class="article-zone type-1">
-    <a class="zone-color" data-link-name="article section" href="/@article.section">@Html(article.sectionName)</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/@article.section}">@Html(article.sectionName)</a>
 </h2>
 
 <article id="article" class="article @if(article.isLive){is-live}"
@@ -36,7 +36,7 @@
         @* <!-- ordering of cleaners is important --> *@
         @withJsoup(BulletCleaner(article.body))(
             PictureCleaner(article),
-            InBodyLinkCleaner("in body link"),
+            InBodyLinkCleaner("in body link")(Edition(request)),
             BlockNumberCleaner,
             TweetCleaner,
             WitnessCleaner,

--- a/event/app/views/fragments/liveBlog.scala.html
+++ b/event/app/views/fragments/liveBlog.scala.html
@@ -1,7 +1,7 @@
 @(article: Article)(implicit request: RequestHeader)
 
 <h2 class="article-zone type-1">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/@article.section}">@Html(article.sectionName)</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName)</a>
 </h2>
 
 <article id="article" class="article @if(article.isLive){is-live}"

--- a/event/app/views/fragments/quote.scala.html
+++ b/event/app/views/fragments/quote.scala.html
@@ -25,7 +25,7 @@
                     }
                     <cite class="story-quote__cite">@quote.by.getOrElse(article.byline) @quote.subject.map{ subject => on @subject}</cite>
 
-                    <a class="cta-new" data-link-name="Continue reading" href="@InBodyLink{@article.url}">
+                    <a class="cta-new" data-link-name="Continue reading" href="@LinkTo{@article.url}">
                         Continue reading
                         <button class="cta-new__btn cta-new__btn--right">
                             <i class="i i-arrow-blue-down cta-new__icn"></i>

--- a/event/app/views/fragments/quote.scala.html
+++ b/event/app/views/fragments/quote.scala.html
@@ -1,4 +1,4 @@
-@(story: Story, index: Int)
+@(story: Story, index: Int)(implicit request: RequestHeader)
 
 @if(story.hasQuotes) {
     @story.contentWithQuotes.filter(_.colour > 0).drop(index).headOption.map{ article =>
@@ -20,12 +20,12 @@
                 <blockquote class="story-quote__quote" data-link-name="story quote">
                     @quote.text.map{ text =>
                       <p>
-                        @cleanTrailText(text)
+                        @cleanTrailText(text)(Edition(request))
                       </p>
                     }
                     <cite class="story-quote__cite">@quote.by.getOrElse(article.byline) @quote.subject.map{ subject => on @subject}</cite>
 
-                    <a class="cta-new" data-link-name="Continue reading" href="@article.url">
+                    <a class="cta-new" data-link-name="Continue reading" href="@InBodyLink{@article.url}">
                         Continue reading
                         <button class="cta-new__btn cta-new__btn--right">
                             <i class="i i-arrow-blue-down cta-new__icn"></i>

--- a/event/app/views/fragments/reaction.scala.html
+++ b/event/app/views/fragments/reaction.scala.html
@@ -1,4 +1,4 @@
-@(story: Story)
+@(story: Story)(implicit request: RequestHeader)
 
 @if(story.hasReaction) {
 
@@ -16,7 +16,7 @@
                             <img class="story-reaction__img" src="@url" />
                         }
                     }
-                    <a class="cta-new" data-link-name="Continue reading" href="@a.url">
+                    <a class="cta-new" data-link-name="Continue reading" href="@InBodyLink{@a.url}">
                         Continue reading
                         <button class="cta-new__btn cta-new__btn--right">
                             <i class="i i-arrow-blue-down cta-new__icn cta-new__icn--right"></i>

--- a/event/app/views/fragments/reaction.scala.html
+++ b/event/app/views/fragments/reaction.scala.html
@@ -16,7 +16,7 @@
                             <img class="story-reaction__img" src="@url" />
                         }
                     }
-                    <a class="cta-new" data-link-name="Continue reading" href="@InBodyLink{@a.url}">
+                    <a class="cta-new" data-link-name="Continue reading" href="@LinkTo{@a.url}">
                         Continue reading
                         <button class="cta-new__btn cta-new__btn--right">
                             <i class="i i-arrow-blue-down cta-new__icn cta-new__icn--right"></i>

--- a/event/app/views/fragments/storyArticle.scala.html
+++ b/event/app/views/fragments/storyArticle.scala.html
@@ -25,7 +25,7 @@
             WitnessCleaner,
             Summary(2)
             )
-            <p><a href="@InBodyLink{@a.url}">Continue reading...</a></p>
+            <p><a href="@LinkTo{@a.url}">Continue reading...</a></p>
         </div>
     </article>
 </li>

--- a/event/app/views/fragments/storyArticle.scala.html
+++ b/event/app/views/fragments/storyArticle.scala.html
@@ -19,13 +19,13 @@
         <div class="article-body from-content-api @if(a.isLive) {live-blog}">
             @withJsoup(BulletCleaner(a.body))(
             PictureCleaner(a),
-            InBodyLinkCleaner("in body link"),
+            InBodyLinkCleaner("in body link")(Edition(request)),
             BlockNumberCleaner,
             TweetCleaner,
             WitnessCleaner,
             Summary(2)
             )
-            <p><a href="@a.url">Continue reading...</a></p>
+            <p><a href="@InBodyLink{@a.url}">Continue reading...</a></p>
         </div>
     </article>
 </li>

--- a/event/app/views/fragments/storyHeadlineTrail.scala.html
+++ b/event/app/views/fragments/storyHeadlineTrail.scala.html
@@ -1,4 +1,4 @@
-@(story: Story, info: RowInfo)
+@(story: Story, info: RowInfo)(implicit request: RequestHeader)
 <h2 class="trail__headline type-5">
     <a href="/stories/@story.id" data-link-name="info.rowNum | text">
     @cleanTrailText(story.title)

--- a/event/app/views/fragments/storyThumbnailTrail.scala.html
+++ b/event/app/views/fragments/storyThumbnailTrail.scala.html
@@ -17,7 +17,5 @@
                 @RemoveOuterParaHtml(story.title)
             </a>
         </h2>
-
-        <!-- @story.explainer.map { text => <div class="trail__text">@cleanTrailText(text)</div> } -->
     </div>
 </li>

--- a/event/app/views/fragments/timeline.scala.html
+++ b/event/app/views/fragments/timeline.scala.html
@@ -9,7 +9,7 @@
         <i class="chapter__marker chapter__marker--small"></i>
         @fragments.relativeDate(a.webPublicationDate, false, false)
         <h4 class="article-headline">
-            <a href="@InBodyLink{@a.url}">
+            <a href="@LinkTo{@a.url}">
                 @a.headlineOverride
             </a>
         </h4>
@@ -21,12 +21,12 @@
         <i class="chapter__marker chapter__marker--small"></i>
         @fragments.relativeDate(g.webPublicationDate, false, false)
         <h4 class="article-headline">
-            <a href="@InBodyLink{@g.url}">
+            <a href="@LinkTo{@g.url}">
                 @g.headlineOverride
             </a>
         </h4>
         @g.images.take(4).zipWithRowInfo.map{ case(image, info) =>
-            <a href="@InBodyLink{@g.url?index=@info.rowNum}"><img src="@image.url" alt="@Html(image.caption.getOrElse(""))" /></a>
+            <a href="@LinkTo{@g.url?index=@info.rowNum}"><img src="@image.url" alt="@Html(image.caption.getOrElse(""))" /></a>
         }
     </li>
 }
@@ -36,7 +36,7 @@
     <i class="chapter__marker chapter__marker--small"></i>
     @fragments.relativeDate(v.webPublicationDate, false, false)
     <h4 class="article-headline">
-        <a href="@InBodyLink{@v.url}">
+        <a href="@LinkTo{@v.url}">
             @v.headlineOverride
         </a>
     </h4>

--- a/event/app/views/fragments/timeline.scala.html
+++ b/event/app/views/fragments/timeline.scala.html
@@ -9,7 +9,7 @@
         <i class="chapter__marker chapter__marker--small"></i>
         @fragments.relativeDate(a.webPublicationDate, false, false)
         <h4 class="article-headline">
-            <a href="@a.url">
+            <a href="@InBodyLink{@a.url}">
                 @a.headlineOverride
             </a>
         </h4>
@@ -21,12 +21,12 @@
         <i class="chapter__marker chapter__marker--small"></i>
         @fragments.relativeDate(g.webPublicationDate, false, false)
         <h4 class="article-headline">
-            <a href="@g.url">
+            <a href="@InBodyLink{@g.url}">
                 @g.headlineOverride
             </a>
         </h4>
         @g.images.take(4).zipWithRowInfo.map{ case(image, info) =>
-            <a href="@g.url?index=@info.rowNum"><img src="@image.url" alt="@Html(image.caption.getOrElse(""))" /></a>
+            <a href="@InBodyLink{@g.url?index=@info.rowNum}"><img src="@image.url" alt="@Html(image.caption.getOrElse(""))" /></a>
         }
     </li>
 }
@@ -36,7 +36,7 @@
     <i class="chapter__marker chapter__marker--small"></i>
     @fragments.relativeDate(v.webPublicationDate, false, false)
     <h4 class="article-headline">
-        <a href="@v.url">
+        <a href="@InBodyLink{@v.url}">
             @v.headlineOverride
         </a>
     </h4>

--- a/football/app/views/fragments/competitionMatches.scala.html
+++ b/football/app/views/fragments/competitionMatches.scala.html
@@ -1,4 +1,4 @@
-@(competition: model.Competition)
+@(competition: model.Competition)(implicit request: RequestHeader)
 <ol class="matches unstyled">
     @competition.matches.map{theMatch => @fragments.renderMatch(theMatch) }
 </ol>

--- a/football/app/views/fragments/competitionsBody.scala.html
+++ b/football/app/views/fragments/competitionsBody.scala.html
@@ -7,7 +7,7 @@
             <ul class="nav nav--columns nav--top-border-off cf">
                 @filters.map{ competition =>
                     <li class="nav__item">
-                        <a href="@InBodyLink{@competition.url}" class="nav__link" data-link-name="@HtmlFormat.raw(competition.name)">
+                        <a href="@LinkTo{@competition.url}" class="nav__link" data-link-name="@HtmlFormat.raw(competition.name)">
                         @HtmlFormat.raw(competition.name)
                         </a>
                     </li>
@@ -18,7 +18,7 @@
 }
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
 </h2>
 
 <h1 class="page-head">@page.webTitle</h1>

--- a/football/app/views/fragments/competitionsBody.scala.html
+++ b/football/app/views/fragments/competitionsBody.scala.html
@@ -7,7 +7,7 @@
             <ul class="nav nav--columns nav--top-border-off cf">
                 @filters.map{ competition =>
                     <li class="nav__item">
-                        <a href="@competition.url" class="nav__link" data-link-name="@HtmlFormat.raw(competition.name)">
+                        <a href="@InBodyLink{@competition.url}" class="nav__link" data-link-name="@HtmlFormat.raw(competition.name)">
                         @HtmlFormat.raw(competition.name)
                         </a>
                     </li>
@@ -18,7 +18,7 @@
 }
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="/football">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
 </h2>
 
 <h1 class="page-head">@page.webTitle</h1>

--- a/football/app/views/fragments/filters.scala.html
+++ b/football/app/views/fragments/filters.scala.html
@@ -5,7 +5,7 @@
         <li class="cf">
             <h2>@name</h2>
             <ul class="nav nav--columns nav--columns-football nav--top-border-off sections">
-                @filters.map{ filter => <li class="nav__item"><a class="nav__link" href="@InBodyLink{@filter.url}" data-link-name="@filter.name">@filter.name</a></li> }
+                @filters.map{ filter => <li class="nav__item"><a class="nav__link" href="@LinkTo{@filter.url}" data-link-name="@filter.name">@filter.name</a></li> }
             </ul>
         </li>
     }
@@ -21,7 +21,7 @@
         @renderFilter("Rest of world")
 
         <li class="cf">
-            <a href="@InBodyLink{/@page.id}" class="cta type-8" data-link-name="@page.webTitle.toLowerCase">View all @pageTitle</a>
+            <a href="@LinkTo{/@page.id}" class="cta type-8" data-link-name="@page.webTitle.toLowerCase">View all @pageTitle</a>
         </li>
     </ol>
 }

--- a/football/app/views/fragments/filters.scala.html
+++ b/football/app/views/fragments/filters.scala.html
@@ -1,11 +1,11 @@
-@(filterMap: Map[String, Seq[CompetitionFilter]], page: MetaData, pageTitle: String)
+@(filterMap: Map[String, Seq[CompetitionFilter]], page: MetaData, pageTitle: String)(implicit request: RequestHeader)
 
 @renderFilter(name: String) = {
     @filterMap.get(name).map{ filters =>
         <li class="cf">
             <h2>@name</h2>
             <ul class="nav nav--columns nav--columns-football nav--top-border-off sections">
-                @filters.map{ filter => <li class="nav__item"><a class="nav__link" href="@filter.url" data-link-name="@filter.name">@filter.name</a></li> }
+                @filters.map{ filter => <li class="nav__item"><a class="nav__link" href="@InBodyLink{@filter.url}" data-link-name="@filter.name">@filter.name</a></li> }
             </ul>
         </li>
     }
@@ -21,7 +21,7 @@
         @renderFilter("Rest of world")
 
         <li class="cf">
-            <a href="/@page.id" class="cta type-8" data-link-name="@page.webTitle.toLowerCase">View all @pageTitle</a>
+            <a href="@InBodyLink{/@page.id}" class="cta type-8" data-link-name="@page.webTitle.toLowerCase">View all @pageTitle</a>
         </li>
     </ol>
 }

--- a/football/app/views/fragments/fixture.scala.html
+++ b/football/app/views/fragments/fixture.scala.html
@@ -1,7 +1,7 @@
-@(fixture: pa.Fixture)
+@(fixture: pa.Fixture)(implicit request: RequestHeader)
 
 <li class="match">
-    <a href="@MatchUrl(fixture)" data-link-name="fixture stats" data-match-id="@fixture.id">
+    <a href="@InBodyLink{@MatchUrl(fixture)}" data-link-name="fixture stats" data-match-id="@fixture.id">
         <p class="match-desc type-10">
 
             <span class="match-home match-team">@fixture.homeTeam.name</span>

--- a/football/app/views/fragments/fixture.scala.html
+++ b/football/app/views/fragments/fixture.scala.html
@@ -1,7 +1,7 @@
 @(fixture: pa.Fixture)(implicit request: RequestHeader)
 
 <li class="match">
-    <a href="@InBodyLink{@MatchUrl(fixture)}" data-link-name="fixture stats" data-match-id="@fixture.id">
+    <a href="@LinkTo{@MatchUrl(fixture)}" data-link-name="fixture stats" data-match-id="@fixture.id">
         <p class="match-desc type-10">
 
             <span class="match-home match-team">@fixture.homeTeam.name</span>

--- a/football/app/views/fragments/footballMatchBody.scala.html
+++ b/football/app/views/fragments/footballMatchBody.scala.html
@@ -3,7 +3,7 @@
 @import implicits.Football._
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="/football">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
 </h2>
 
 <article class="article" role="main">

--- a/football/app/views/fragments/footballMatchBody.scala.html
+++ b/football/app/views/fragments/footballMatchBody.scala.html
@@ -3,7 +3,7 @@
 @import implicits.Football._
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
 </h2>
 
 <article class="article" role="main">

--- a/football/app/views/fragments/frontMatchBlock.scala.html
+++ b/football/app/views/fragments/frontMatchBlock.scala.html
@@ -1,9 +1,9 @@
-@(competition: model.Competition, numVisible: Int, isCompetitionPage: Boolean)
+@(competition: model.Competition, numVisible: Int, isCompetitionPage: Boolean)(implicit request: RequestHeader)
 <li class="front-competition-fixtures competition-table js-front-trailblock rolled-out" data-link-name="front scores"
     data-count="@{competition.matches.length - numVisible}">
 
     <h3 class="type-5">Today's matches</h3>
-    <a href="@competition.url" class="competition-title football-table-link box-indent zone-color type-5" data-link-name="all todays matches">
+    <a href="@InBodyLink{@competition.url}" class="competition-title football-table-link box-indent zone-color type-5" data-link-name="all todays matches">
        @competition.fullName <i class="i i-sport-arrow"></i>
     </a>
 
@@ -19,11 +19,11 @@
 </li>
 
 @if(isCompetitionPage) {
-<a href="@competition.url/fixtures" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all competition fixtures">
+<a href="@InBodyLink{@competition.url/fixtures}" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all competition fixtures">
     View all @competition.fullName fixtures<i class="i i-sport-arrow-small"></i>
 </a>
 } else {
-<a href="/football/live" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all matches">
+<a href="@InBodyLink{/football/live}" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all matches">
     View all today's matches<i class="i i-sport-arrow-small"></i>
 </a>
 }

--- a/football/app/views/fragments/frontMatchBlock.scala.html
+++ b/football/app/views/fragments/frontMatchBlock.scala.html
@@ -3,7 +3,7 @@
     data-count="@{competition.matches.length - numVisible}">
 
     <h3 class="type-5">Today's matches</h3>
-    <a href="@InBodyLink{@competition.url}" class="competition-title football-table-link box-indent zone-color type-5" data-link-name="all todays matches">
+    <a href="@LinkTo{@competition.url}" class="competition-title football-table-link box-indent zone-color type-5" data-link-name="all todays matches">
        @competition.fullName <i class="i i-sport-arrow"></i>
     </a>
 
@@ -19,11 +19,11 @@
 </li>
 
 @if(isCompetitionPage) {
-<a href="@InBodyLink{@competition.url/fixtures}" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all competition fixtures">
+<a href="@LinkTo{@competition.url/fixtures}" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all competition fixtures">
     View all @competition.fullName fixtures<i class="i i-sport-arrow-small"></i>
 </a>
 } else {
-<a href="@InBodyLink{/football/live}" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all matches">
+<a href="@LinkTo{/football/live}" class="cta-small cta-small-border type-8 zone-color" data-link-name="View all matches">
     View all today's matches<i class="i i-sport-arrow-small"></i>
 </a>
 }

--- a/football/app/views/fragments/frontTableBlock.scala.html
+++ b/football/app/views/fragments/frontTableBlock.scala.html
@@ -1,4 +1,4 @@
-@(table: Table, highlightTeamId: Option[String] = None)
+@(table: Table, highlightTeamId: Option[String] = None)(implicit request: RequestHeader)
 
 <li id="front-competition-table" class="competition-table" data-link-name="front table">
     <h3 class="type-5">@table.competition.fullName table</h3>
@@ -30,5 +30,5 @@
         }
     </table>
 
-    <a href='@{table.competition.url + "/table"}' data-link-name='full table' class="cta-small cta-small-border type-8 zone-color">View full table <i class="i i-sport-arrow-small"></i></a>
+    <a href='@InBodyLink{@{table.competition.url + "/table"}}' data-link-name='full table' class="cta-small cta-small-border type-8 zone-color">View full table <i class="i i-sport-arrow-small"></i></a>
 </li>

--- a/football/app/views/fragments/frontTableBlock.scala.html
+++ b/football/app/views/fragments/frontTableBlock.scala.html
@@ -30,5 +30,5 @@
         }
     </table>
 
-    <a href='@InBodyLink{@{table.competition.url + "/table"}}' data-link-name='full table' class="cta-small cta-small-border type-8 zone-color">View full table <i class="i i-sport-arrow-small"></i></a>
+    <a href='@LinkTo{@{table.competition.url + "/table"}}' data-link-name='full table' class="cta-small cta-small-border type-8 zone-color">View full table <i class="i i-sport-arrow-small"></i></a>
 </li>

--- a/football/app/views/fragments/liveMatch.scala.html
+++ b/football/app/views/fragments/liveMatch.scala.html
@@ -1,8 +1,8 @@
-@(live: pa.FootballMatch)
+@(live: pa.FootballMatch)(implicit request: RequestHeader)
 @import implicits.Football._
 
 <li class="match live-match">
-    <a href="@MatchUrl(live)" data-link-name="stats" data-match-id="@live.id">
+    <a href="@InBodyLink{@MatchUrl(live)}" data-link-name="stats" data-match-id="@live.id">
         <p class="match-desc type-10">
             <span class="match-home match-team">@live.homeTeam.name</span>
             <span class="match-result">@live.homeTeam.score-@live.awayTeam.score</span>

--- a/football/app/views/fragments/liveMatch.scala.html
+++ b/football/app/views/fragments/liveMatch.scala.html
@@ -2,7 +2,7 @@
 @import implicits.Football._
 
 <li class="match live-match">
-    <a href="@InBodyLink{@MatchUrl(live)}" data-link-name="stats" data-match-id="@live.id">
+    <a href="@LinkTo{@MatchUrl(live)}" data-link-name="stats" data-match-id="@live.id">
         <p class="match-desc type-10">
             <span class="match-home match-team">@live.homeTeam.name</span>
             <span class="match-result">@live.homeTeam.score-@live.awayTeam.score</span>

--- a/football/app/views/fragments/matchNav.scala.html
+++ b/football/app/views/fragments/matchNav.scala.html
@@ -1,4 +1,4 @@
-@(component: controllers.MatchNav)
+@(component: controllers.MatchNav)(implicit request: RequestHeader)
 @import implicits.Football._
 
 
@@ -6,7 +6,7 @@
     @if(component.currentPage.exists(_.url == trail.url)){
         <li class="tabs-selected"><a href="#">@text</a></li>
     } else {
-        <li><a href="@trail.url" data-link-name="@text">@text</a></li>
+        <li><a href="@InBodyLink{@trail.url}" data-link-name="@text">@text</a></li>
     }
 }
 

--- a/football/app/views/fragments/matchNav.scala.html
+++ b/football/app/views/fragments/matchNav.scala.html
@@ -6,7 +6,7 @@
     @if(component.currentPage.exists(_.url == trail.url)){
         <li class="tabs-selected"><a href="#">@text</a></li>
     } else {
-        <li><a href="@InBodyLink{@trail.url}" data-link-name="@text">@text</a></li>
+        <li><a href="@LinkTo{@trail.url}" data-link-name="@text">@text</a></li>
     }
 }
 

--- a/football/app/views/fragments/matchesBody.scala.html
+++ b/football/app/views/fragments/matchesBody.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
 </h2>
 
 @if(model.pageType == "live") {
@@ -25,8 +25,8 @@
 
     @if(model.previousPage.isDefined || model.nextPage.isDefined) {
         <div class="js-matches-nav matches-nav cf js-not-ajax" data-link-name="@model.pageType nav">
-            @model.previousPage.map{url => <a href="@InBodyLink{@url}" class="type-11 match-prev" data-js-title="Show previous day's matches" data-link-name="previous">Previous day</a>}
-            @model.nextPage.map{url => <a href="@InBodyLink{@url}" class="type-11 match-next" data-js-title="Show next day's matches" data-link-name="next">Next day</a>}
+            @model.previousPage.map{url => <a href="@LinkTo{@url}" class="type-11 match-prev" data-js-title="Show previous day's matches" data-link-name="previous">Previous day</a>}
+            @model.nextPage.map{url => <a href="@LinkTo{@url}" class="type-11 match-next" data-js-title="Show next day's matches" data-link-name="next">Next day</a>}
         </div>
     }
 

--- a/football/app/views/fragments/matchesBody.scala.html
+++ b/football/app/views/fragments/matchesBody.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="/football">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
 </h2>
 
 @if(model.pageType == "live") {
@@ -25,8 +25,8 @@
 
     @if(model.previousPage.isDefined || model.nextPage.isDefined) {
         <div class="js-matches-nav matches-nav cf js-not-ajax" data-link-name="@model.pageType nav">
-            @model.previousPage.map{url => <a href="@url" class="type-11 match-prev" data-js-title="Show previous day's matches" data-link-name="previous">Previous day</a>}
-            @model.nextPage.map{url => <a href="@url" class="type-11 match-next" data-js-title="Show next day's matches" data-link-name="next">Next day</a>}
+            @model.previousPage.map{url => <a href="@InBodyLink{@url}" class="type-11 match-prev" data-js-title="Show previous day's matches" data-link-name="previous">Previous day</a>}
+            @model.nextPage.map{url => <a href="@InBodyLink{@url}" class="type-11 match-next" data-js-title="Show next day's matches" data-link-name="next">Next day</a>}
         </div>
     }
 

--- a/football/app/views/fragments/matchesList.scala.html
+++ b/football/app/views/fragments/matchesList.scala.html
@@ -6,7 +6,7 @@
         @day.competitions.zipWithRowInfo.map{ case (comp, row) =>
 
         	<li class="competition" data-link-name="competition | @comp.fullName" data-competition-id="@comp.id">
-	            <a class="competition-title football-table-link zone-color type-7" href="@InBodyLink{@comp.url}" data-link-name="view competition">
+	            <a class="competition-title football-table-link zone-color type-7" href="@LinkTo{@comp.url}" data-link-name="view competition">
 	                @comp.fullName
 	                <i class="i i-sport-arrow"></i>
 	            </a>

--- a/football/app/views/fragments/matchesList.scala.html
+++ b/football/app/views/fragments/matchesList.scala.html
@@ -6,7 +6,7 @@
         @day.competitions.zipWithRowInfo.map{ case (comp, row) =>
 
         	<li class="competition" data-link-name="competition | @comp.fullName" data-competition-id="@comp.id">
-	            <a class="competition-title football-table-link zone-color type-7" href="@comp.url" data-link-name="view competition">
+	            <a class="competition-title football-table-link zone-color type-7" href="@InBodyLink{@comp.url}" data-link-name="view competition">
 	                @comp.fullName
 	                <i class="i i-sport-arrow"></i>
 	            </a>

--- a/football/app/views/fragments/renderMatch.scala.html
+++ b/football/app/views/fragments/renderMatch.scala.html
@@ -1,4 +1,4 @@
-@(game: pa.FootballMatch)
+@(game: pa.FootballMatch)(implicit request: RequestHeader)
 
 @game match {
     case fixture: pa.Fixture    => { @fragments.fixture(fixture) }

--- a/football/app/views/fragments/tablesBody.scala.html
+++ b/football/app/views/fragments/tablesBody.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
 </h2>
 
 <div class="live-matches-dateline">

--- a/football/app/views/fragments/tablesBody.scala.html
+++ b/football/app/views/fragments/tablesBody.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="/football">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
 </h2>
 
 <div class="live-matches-dateline">

--- a/football/app/views/fragments/teamFixtures.scala.html
+++ b/football/app/views/fragments/teamFixtures.scala.html
@@ -1,4 +1,4 @@
-@(team:pa.FootballTeam, previousResult: Seq[TeamFixture], upcomingFixtures: Seq[TeamFixture])
+@(team:pa.FootballTeam, previousResult: Seq[TeamFixture], upcomingFixtures: Seq[TeamFixture])(implicit request: RequestHeader)
 @import org.joda.time.DateTime
 
 <li class="team-fixtures competition-table js-front-trailblock" data-link-name="Team fixtures">

--- a/football/app/views/fragments/teamFixturesBody.scala.html
+++ b/football/app/views/fragments/teamFixturesBody.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="/football">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
 </h2>
 
 @fragments.filterBar(page.webTitle)

--- a/football/app/views/fragments/teamFixturesBody.scala.html
+++ b/football/app/views/fragments/teamFixturesBody.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
 </h2>
 
 @fragments.filterBar(page.webTitle)

--- a/football/app/views/fragments/teamlistBody.scala.html
+++ b/football/app/views/fragments/teamlistBody.scala.html
@@ -7,7 +7,7 @@
         <ul class="nav nav--columns nav--top-border-off cf">
             @comp.teams.map{ team =>
             <li class="nav__item" data-team-id="@team.id">
-                @TeamUrl(team).map{ url => <a href="@InBodyLink{@url}" class="nav__link" data-link-name="@team.name">
+                @TeamUrl(team).map{ url => <a href="@LinkTo{@url}" class="nav__link" data-link-name="@team.name">
                     @team.name
                 </a> }.getOrElse{ <span class="nav__link no-link-team">@team.name</span> }
 
@@ -18,7 +18,7 @@
 }
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
 </h2>
 
 <h1 class="page-head">@pageModel.page.webTitle</h1>

--- a/football/app/views/fragments/teamlistBody.scala.html
+++ b/football/app/views/fragments/teamlistBody.scala.html
@@ -7,7 +7,7 @@
         <ul class="nav nav--columns nav--top-border-off cf">
             @comp.teams.map{ team =>
             <li class="nav__item" data-team-id="@team.id">
-                @TeamUrl(team).map{ url => <a href="@url" class="nav__link" data-link-name="@team.name">
+                @TeamUrl(team).map{ url => <a href="@InBodyLink{@url}" class="nav__link" data-link-name="@team.name">
                     @team.name
                 </a> }.getOrElse{ <span class="nav__link no-link-team">@team.name</span> }
 
@@ -18,7 +18,7 @@
 }
 
 <h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="/football">Football</a>
+    <a class="zone-color" data-link-name="article section" href="@InBodyLink{/football}">Football</a>
 </h2>
 
 <h1 class="page-head">@pageModel.page.webTitle</h1>

--- a/project/SbtGruntPlugin.scala
+++ b/project/SbtGruntPlugin.scala
@@ -58,7 +58,7 @@ object SbtGruntPlugin extends Plugin {
       }
       writeCacheFile(lastUpdated, newestSize, newestSource)
     } else {
-      s.log.info("No need to run grunt task: " + taskName)
+      s.log.debug("No need to run grunt task: " + taskName)
     }
   }
 


### PR DESCRIPTION
I know this is quite a big pull request, but it consists mainly of wrapping hrefs...

`href="@foo"` becomes `href="@InBodyLink{@foo}"`

You do not have to use this, e.g. it is not much use for `href="/top-stories"`, but it is probably a good idea for any dynamic url.
