### PR TITLE
Bump sbt-assembly to 0.9.0 for caching features.

### DIFF
--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -88,7 +88,7 @@ trait Prototypes {
   val frontendAssemblySettings = Seq(
     test in assembly := {},
     executableName <<= (name) { "frontend-%s" format _ },
-    jarName in assembly <<= (executableName) { "%s.jar" format _ },
+    jarName in assembly <<= (executableName) map { "%s.jar" format _ },
 
     mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
       {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,6 @@ addSbtPlugin("play" % "sbt-plugin" % "2.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.0.1")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.0")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.3")


### PR DESCRIPTION
Should make the builds faster. Will maybe need a clean checkout in TeamCity.
