### PR TITLE
Use a fixed salat snapshot

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -32,7 +32,7 @@ object Frontend extends Build with Prototypes {
   val article = application("article").dependsOn(commonWithTests)
   val applications = application("applications").dependsOn(commonWithTests)
   val event = application("event").dependsOn(commonWithTests).settings(
-    libraryDependencies += "com.novus" %% "salat" % "1.9.2-SNAPSHOT"
+    libraryDependencies += "com.novus" %% "salat" % "1.9.2-SNAPSHOT-20130624"
   )
   val football = application("football").dependsOn(commonWithTests).settings(
     libraryDependencies += "com.gu" %% "pa-client" % "4.0",
@@ -67,7 +67,7 @@ object Frontend extends Build with Prototypes {
 
   val admin = application("admin").dependsOn(commonWithTests).settings(
     libraryDependencies ++= Seq(
-      "com.novus" %% "salat" % "1.9.2-SNAPSHOT"
+      "com.novus" %% "salat" % "1.9.2-SNAPSHOT-20130624"
     )
   )
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -39,9 +39,7 @@ trait Prototypes {
       Resolver.url("Typesafe Ivy Releases", url("http://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns),
       "JBoss Releases" at "http://repository.jboss.org/nexus/content/repositories/releases",
       "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-      "Akka" at "http://repo.akka.io/releases",
-      // No released version of Salat for 2.10.0
-      "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+      "Akka" at "http://repo.akka.io/releases"
     )
   )
 


### PR DESCRIPTION
Update project dependencies so that frontend uses a non-changing snapshot of salat provided by guardian github.
