### PR TITLE
Remove alt and title attributes from trail images

### DIFF
--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -14,7 +14,7 @@
     @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)(Edition(request))</div> }
 
     @trail.mainPicture(width=220).map{ smallCrop =>
-        <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image">
+        <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image" role="presentation">
             <img class="maxed" src="@smallCrop.path"
                 data-force-upgrade="true"
                 data-thumb-width="@smallCrop.width"
@@ -23,8 +23,7 @@
                     data-full-width="@largeCrop.width"
                 }
                 itemprop="contentURL"
-                alt="@Html(smallCrop.altText.getOrElse(""))"
-                title="@StripHtmlTagsAndUnescapeEntities(smallCrop.caption.getOrElse(""))"
+                alt=""
             />
         </a>
     }

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -7,14 +7,13 @@
     <div class="media">
         @if(showThumbnail) {
             @trail.thumbnailPath.map{ thumbnailPath =>
-                <a href="@LinkTo{@trail.url}" class="media__img trail__img" data-link-name="@rowNum | image">
+                <a href="@LinkTo{@trail.url}" class="media__img trail__img" data-link-name="@rowNum | image" role="presentation">
                     <img class="maxed" data-lowsrc="@thumbnailPath"
                         data-thumb-width="140"
                         @trail.mainPicture(width=220).map { largeCrop =>
                             data-fullsrc="@largeCrop.path"
                             data-full-width="@largeCrop.width"
-                            alt="@Html(largeCrop.altText.getOrElse(""))"
-                            title="@StripHtmlTagsAndUnescapeEntities(largeCrop.caption.getOrElse(""))"
+                            alt=""
                         }
                         itemprop="contentURL"
                     />


### PR DESCRIPTION
I removed alt and title attributes from images in trails.
### Why
- this information do not bring any value to our readers (no hovering of image elements on mobile)
- It's actually a problem for visually impaired users who get extraneous noise-like information through assistive technology.
- More data to download (~4KB on the homepage at this instant)
### Accessibility

Also, I added an aria role (role="presentation") to tell assistive technologies not to take the link into account. The title of the story is the only relevant thing here, no need to have 2 links per story for a user using a screen reader.

![Plouf](http://i.imgur.com/bF5Euki.gif)
