### PR TITLE
AB tweaks take two

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -47,7 +47,7 @@ define([
         if (currentDataLinkTest) {
             dataLinkTest.push(currentDataLinkTest);
         }
-        dataLinkTest.push('AB | ' + test.id + ' test | ' + variantId);
+        dataLinkTest.push(['AB', test.id + ' test', variantId]. join(' | '));
         common.$g(document.body).attr('data-link-test', dataLinkTest.join(', '));
     }
 

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -42,6 +42,7 @@ define([
     }
 
     function initTracking(test, variantId) {
+        var dataLinkTest = common.$g(document.body).attr('data-link-test');
         var data = 'AB | ' + test.id + ' test | ' + variantId;
         common.$g(document.body).attr('data-link-test', data);
     }
@@ -49,6 +50,10 @@ define([
     //Finds variant in specific tests and exec's
     function run(test, config, context) {
         if (test.canRun(config, context) && config.switches['ab' + test.id]) {
+            // if user not in test, bucket them
+            if (!isParticipating(test)) {
+                bucket(test);
+            }
             var participations = getParticipations(),
                 variantId = participations[test.id].variant;
             test.variants.some(function(variant) {
@@ -116,10 +121,6 @@ define([
             store.remove('gu.ab.participation');
 
             TESTS.forEach(function(test) {
-                // if user not in a test, bucket them
-                if (!isParticipating(test)) {
-                    bucket(test);
-                }
                 run(test, config, context);
             });
         }

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -42,9 +42,13 @@ define([
     }
 
     function initTracking(test, variantId) {
-        var dataLinkTest = common.$g(document.body).attr('data-link-test');
-        var data = 'AB | ' + test.id + ' test | ' + variantId;
-        common.$g(document.body).attr('data-link-test', data);
+        var dataLinkTest = [],
+            currentDataLinkTest = common.$g(document.body).attr('data-link-test');
+        if (currentDataLinkTest) {
+            dataLinkTest.push(currentDataLinkTest);
+        }
+        dataLinkTest.push('AB | ' + test.id + ' test | ' + variantId);
+        common.$g(document.body).attr('data-link-test', dataLinkTest.join(', '));
     }
 
     //Finds variant in specific tests and exec's

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -1,4 +1,4 @@
-define(['modules/experiments/ab', '../fixtures/ab-test'], function(AB, Test) {
+define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
 
     describe('AB Testing', function() {
 
@@ -8,31 +8,31 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(AB, Test) {
             participationsKey = 'gu.ab.participations';
 
         beforeEach(function() {
-            AB.clearTests();
-            test = new Test(),
+            ab.clearTests();
+            test = new ABTest(),
             controlSpy = sinon.spy(test.variants[0], 'test'),
             variantSpy = sinon.spy(test.variants[1], 'test');
             // add a test
-            AB.addTest(test);
+            ab.addTest(test);
         });
 
         afterEach(function() {
-            AB.clearTests();
+            ab.clearTests();
             localStorage.removeItem(participationsKey);
         });
 
         it('should exist', function() {
             // basic, check it exists
-            expect(AB).toBeDefined();
+            expect(ab).toBeDefined();
         });
 
         it('should be able to start test', function() {
-            AB.init({ switches: {'abDummyTest': true} }, document);
+            ab.init({ switches: {'abDummyTest': true} }, document);
             expect(controlSpy.called || variantSpy.called).toBeTruthy();
         });
 
         it('should allow forcing of test via url', function() {
-            AB.init({
+            ab.init({
                 switches: {
                     abDummyTest: true
                 }
@@ -50,7 +50,7 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(AB, Test) {
         it('should put all non-participating users in control group', function() {
             test.audience = 0;
 
-            AB.init({
+            ab.init({
                 switches: {
                     abDummyTest: true
                 }
@@ -59,11 +59,11 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(AB, Test) {
         });
 
         it('should store all the tests user is in', function() {
-            var otherTest = new Test();
+            var otherTest = new ABTest();
             otherTest.id = 'DummyTest2';
-            AB.addTest(otherTest);
+            ab.addTest(otherTest);
 
-            AB.init({
+            ab.init({
                 switches: {
                     abDummyTest: true,
                     abDummyTest2: true,
@@ -75,24 +75,24 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(AB, Test) {
         });
         
         it('should get all the tests user is in', function() {
-            var otherTest = new Test();
+            var otherTest = new ABTest();
             otherTest.id = 'DummyTest2';
-            AB.addTest(otherTest);
+            ab.addTest(otherTest);
 
-            AB.init({
+            ab.init({
                 switches: {
                     abDummyTest: true,
                     abDummyTest2: true,
                 }
             });
         
-            var tests = Object.keys(AB.getParticipations()).map(function(k){ return k; }).toString()
+            var tests = Object.keys(ab.getParticipations()).map(function(k){ return k; }).toString()
             expect(tests).toBe('DummyTest,DummyTest2');
             
         });
 
         it('should not run if switch is off', function() {
-            AB.init({
+            ab.init({
                 switches: {
                     abDummyTest: false,
                 }
@@ -101,12 +101,24 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(AB, Test) {
         });
 
         it('should add "data-link-test" tracking to body', function() {
-            AB.init({
+            ab.init({
                 switches: {
-                    abDummyTest: true,
+                    abDummyTest: true
                 }
             });
             expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide)$/);
+        });
+
+        it('should not bucket user if test can\'t be run', function() {
+            test.canRun = function() { return false; }
+
+            ab.init({
+                switches: {
+                    abDummyTest: true
+                }
+            });
+            expect(controlSpy.called || variantSpy.called).toBeFalsy();
+            expect(ab.getParticipations()).toEqual([]);
         });
 
     });

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -19,6 +19,8 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
         afterEach(function() {
             ab.clearTests();
             localStorage.removeItem(participationsKey);
+            // remove tracking from body
+            document.body.removeAttribute('data-link-test');
         });
 
         it('should exist', function() {
@@ -82,7 +84,7 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
             ab.init({
                 switches: {
                     abDummyTest: true,
-                    abDummyTest2: true,
+                    abDummyTest2: true
                 }
             });
         
@@ -107,6 +109,20 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
                 }
             });
             expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide)$/);
+        });
+
+        it('should concat "data-link-test" tracking when more than one test', function() {
+            var otherTest = new ABTest();
+            otherTest.id = 'DummyTest2';
+            ab.addTest(otherTest);
+
+            ab.init({
+                switches: {
+                    abDummyTest: true,
+                    abDummyTest2: true,
+                }
+            });
+            expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide), AB \| DummyTest2 test \| (control|hide)$/);
         });
 
         it('should not bucket user if test can\'t be run', function() {


### PR DESCRIPTION
- only bucket user if test can be run
- handle multiple tests in `data-link-test` attribute
