### PR TITLE
Sbt assembly bump

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -72,7 +72,7 @@ object Frontend extends Build with Prototypes {
     )
   )
 
-  val dev = application("dev-build")
+  val dev = base("dev-build")
     .dependsOn(front)
     .dependsOn(article)
     .dependsOn(applications)
@@ -99,7 +99,6 @@ object Frontend extends Build with Prototypes {
     router,
     diagnostics,
     styleGuide,
-    dev,
     admin
   )
 }

--- a/project/PlayAssetHash.scala
+++ b/project/PlayAssetHash.scala
@@ -51,14 +51,19 @@ object PlayAssetHash extends Plugin {
     }
   }
 
-  def deleteAssetMaps = (streams, resourceManaged, target) map { (s, resources, target) =>
-    val log = s.log
-    val assetMapDir = target / "dist" / "assetmaps"
-    if (assetMapDir.exists()) {
-      FileUtils.deleteDirectory(assetMapDir)
-      log.info("Deleted assetmap dir " + assetMapDir)
-    }
+  def deleteAssetMaps = (streams, resourceManaged, target, assemblyDirectory in assembly, name) map {
+    (s, resources, target, assemblyDirectory, name) =>
+        val log = s.log
+        val assetMapDir = target / "dist" / "assetmaps"
+        if (assetMapDir.exists()) {
+          FileUtils.deleteDirectory(assetMapDir)
+          log.info("Deleted assetmap dir " + assetMapDir)
+        }
+
+        println("Delete cached *_dir files and folders from: %s. Cache may contain invalid hash maps".format(name))
+        IO.delete((assemblyDirectory * "*dir").get)
   }
+
   def generatorTransform(sourceDirectory: File, resourceManaged: File, assetFinder: PathFinder, assetRoots: Seq[File]) = {
     val copies = assetFinder.get.filterNot(_.isDirectory) map {
       asset => {

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -125,16 +125,16 @@ trait Prototypes {
     )
 
   def base(name: String) = play.Project(name, version, path = file(name))
-    .settings(playAssetHashDistSettings: _*)
     .settings(VersionInfo.settings:_*)
     .settings(frontendCompilationSettings:_*)
     .settings(frontendDependencyManagementSettings:_*)
-    .settings(frontendClientSideSettings:_*)
     .settings(frontendTestSettings:_*)
 
   def application(name: String) = base(name)
+    .settings(playAssetHashDistSettings: _*)
+    .settings(frontendClientSideSettings:_*)
     .settings(frontendAssemblySettings:_*)
 
-  def grunt(name: String) = base(name)
+  def grunt(name: String) = application(name)
     .settings(frontendGruntSettings:_*)
 }

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -23,7 +23,7 @@ trait Prototypes {
     ),
     scalacOptions := Seq("-unchecked", "-optimise", "-deprecation",
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings",
-      "Xfatal-warnings")
+      "-Xfatal-warnings")
   )
 
   val frontendDependencyManagementSettings = Seq(

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -88,7 +88,7 @@ trait Prototypes {
   val frontendAssemblySettings = Seq(
     test in assembly := {},
     executableName <<= (name) { "frontend-%s" format _ },
-    jarName in assembly <<= (executableName) { "%s.jar" format _ },
+    jarName in assembly <<= (executableName) map { "%s.jar" format _ },
 
     mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
       {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,6 @@ addSbtPlugin("play" % "sbt-plugin" % "2.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.0.1")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.0")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.3")


### PR DESCRIPTION
These changes enable us to use sbt assembly plugin version 0.9.0 (without causing clashes in the assetmap).

There are also some changes intended for improving the team city build time, which allow us to dist the root sbt project.
