### PR TITLE
Inline images and tweet fixes

### DIFF
--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -77,10 +77,14 @@
 .inline-image {
     width: $inArticleInlineImgWidth;
     float: left;
-    margin: 0;
-    margin-right: 10px;
-    margin-bottom: 15px;
-    margin-top: 3px;
+    margin: 3px 0 0 0;
+    padding-right: 10px;
+    padding-bottom: 15px;
+    background: white;
+
+    figcaption {
+        word-wrap: break-word;
+    }
 }
 
 .img-tiny.inline-image {

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -77,6 +77,7 @@
 .inline-image {
     width: $inArticleInlineImgWidth;
     float: left;
+    clear: left;
     margin: 3px 0 0 0;
     padding-right: 10px;
     padding-bottom: 15px;

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -89,6 +89,7 @@
    ========================================================================== */
 
 .tweet {
+    clear: both;
     background-color: #f4f4f4;
     background-image: url(../images/twitter/bird.fc3f9a265a2d205df6f372402546bef1.png) !important;
     background-position: $baseline*2 $baseline*2 !important;


### PR DESCRIPTION
Some blocks in live pages are bizarrely floated.

See http://m.guardian.co.uk/music/musicblog/2013/jun/27/glastonbury-2013-festival-liveblog-thursday1

(do not mind lacking tweet icons in following screenshots, they will be there on a live environment)
## Before

![before - floated consecutive images](https://f.cloud.github.com/assets/85783/721837/463cc1ce-dff1-11e2-92a6-891a566965f2.png)

![tweet float](https://f.cloud.github.com/assets/85783/721838/488b6af2-dff1-11e2-80a1-d8a147bfd5d0.png)
## After

![after - consecutive floated images](https://f.cloud.github.com/assets/85783/721839/4d4063c2-dff1-11e2-8ad6-09ca5e640258.png)

![after tweet floated](https://f.cloud.github.com/assets/85783/721843/72b0b044-dff1-11e2-9c01-1c2dac18100c.png)
