### PR TITLE
Switch PROD to use new ajax url.

### DIFF
--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -15,7 +15,7 @@ debug.enabled=false
 guardian.page.omnitureAccount=guardiangu-frontend,guardiangu-network
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 
-ajax.url=http://m.guardian.co.uk
+ajax.url=http://api.nextgen.guardianapps.co.uk
 
 # no spaces
 ajax.cors.origin=http://www.theguardian.com,http://m.guardian.co.uk,http://m.guardiannews.com


### PR DESCRIPTION
**Reason:**

This will enable us to move totally away from m.guardian.co.uk on launch of www.theguardian.com (we will be able to redirect all m. traffic to www.)

**Success looks like:**

All ajax endpoints work on the new URL.
