### PR TITLE
Enforce correct content api host when running tests.

### DIFF
--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -11,7 +11,6 @@ import recorder.ContentApiHttpRecorder
 import com.gu.management.play.InternalManagementPlugin
 import play.api.GlobalSettings
 import concurrent.Future
-import play.api.mvc.Codec
 import org.apache.commons.codec.digest.DigestUtils
 
 trait TestSettings {

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,6 +1,6 @@
 package test
 
-import conf.ContentApi
+import conf.{Configuration, ContentApi}
 import play.api.test._
 import play.api.test.Helpers._
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
@@ -11,6 +11,8 @@ import recorder.ContentApiHttpRecorder
 import com.gu.management.play.InternalManagementPlugin
 import play.api.GlobalSettings
 import concurrent.Future
+import play.api.mvc.Codec
+import org.apache.commons.codec.digest.DigestUtils
 
 trait TestSettings {
   def globalSettingsOverride: Option[GlobalSettings] = None
@@ -27,6 +29,17 @@ trait TestSettings {
   val originalHttp = ContentApi.http
 
   ContentApi.http = new Http[Future] {
+
+    if (DigestUtils.sha256Hex(Configuration.contentApi.host) != "b9648d72721756bad977220f11d5c239e17cb5ca34bb346de506f9b145ac39d1") {
+
+      // the println makes it easier to spot what is wrong in tests
+      println()
+      println("----------- YOU ARE NOT USING THE CORRECT CONTENT API HOST -----------")
+      println()
+
+      throw new RuntimeException("You are not using the correct content api host...")
+    }
+
     override def GET(url: String, headers: scala.Iterable[scala.Tuple2[java.lang.String, java.lang.String]]) = {
       recorder.load(url, headers.toMap) {
         originalHttp.GET(url, headers)


### PR DESCRIPTION
Every now and again someone forgets about using the correct content api host.

Now tests will die on you with a suitable error message.
