### PR TITLE
Add the healthcheck and switchboard plugin to sport server

### DIFF
--- a/sport/app/conf/context.scala
+++ b/sport/app/conf/context.scala
@@ -1,0 +1,24 @@
+package conf
+
+import common.Metrics
+import com.gu.management.{ PropertiesPage, StatusPage, ManifestPage }
+import com.gu.management.play.{ Management => GuManagement }
+import com.gu.management.logback.LogbackLevelPage
+import play.api.{ Application => PlayApp }
+
+class SwitchBoardPlugin(app: PlayApp) extends SwitchBoardAgent(Configuration)
+
+object Management extends GuManagement {
+  val applicationName = "frontend-sport"
+  val metrics = Metrics.contentApi ++ Metrics.common
+
+  lazy val pages = List(
+    new ManifestPage,
+    new UrlPagesHealthcheckManagementPage(
+      "/cricket/match/34822"
+    ),
+    StatusPage(applicationName, metrics),
+    new PropertiesPage(Configuration.toString),
+    new LogbackLevelPage(applicationName)
+  )
+}

--- a/sport/conf/play.plugins
+++ b/sport/conf/play.plugins
@@ -1,1 +1,4 @@
+100:conf.SwitchBoardPlugin
+
 1000:assets.AssetsPlugin
+1000:com.gu.management.play.InternalManagementPlugin


### PR DESCRIPTION
Specify a cricket match page as the healthcheck management page.
