### PR TITLE
A/B test fixes

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -125,7 +125,7 @@ define([
             if (participationsKeys.length > 0) {
                 
                 var testData = participationsKeys.map(function(k){
-                    return ['AB', k, participations[k].variant].join('|');
+                    return ['AB', k, participations[k].variant].join(' | ');
                 }).join(',');
 
                 s.prop51  = testData;

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -129,8 +129,15 @@ define([
             store.clearByPrefix('gu.prefs.ab');
             store.remove('gu.ab.current');
             store.remove('gu.ab.participation');
-
-            TESTS.forEach(function(test) {
+            
+            TESTS.filter(function(test) {
+                var expired = (new Date() - new Date(test.expiry)) > 0;
+                if (expired) {
+                    removeParticipation(test);
+                    return false;
+                }
+                return true;
+            }).forEach(function(test) {
                 run(test, config, context);
             });
         }

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -78,7 +78,7 @@ define([
 
     function bucket(test) {
         // always at least place in control
-        var testVariantId = 'null';
+        var testVariantId = 'notintest';
 
         //Only run on test required audience segment
         if (Math.random() < test.audience) {

--- a/common/test/assets/javascripts/fixtures/ab-test.js
+++ b/common/test/assets/javascripts/fixtures/ab-test.js
@@ -4,6 +4,7 @@ define([], function () {
 
         this.id = 'DummyTest';
         this.audience = 1;
+        this.expiry = '2020-01-01';
         this.description = 'Dummy test';
         this.canRun = function(config) {
             return true;

--- a/common/test/assets/javascripts/fixtures/ab-test.js
+++ b/common/test/assets/javascripts/fixtures/ab-test.js
@@ -4,7 +4,7 @@ define([], function () {
 
         this.id = 'DummyTest';
         this.audience = 1;
-        this.expiry = '2020-01-01';
+        this.expiry = '2045-01-01';
         this.description = 'Dummy test';
         this.canRun = function(config) {
             return true;

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -138,20 +138,30 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
         });
 
         it('should refuse to run the after the expiry date', function () {
+            
             test.expiry = "2012-01-01";
             ab.init({
                 switches: {
                     abDummyTest: true
                 }
             });
-            expect(controlSpy.called || variantSpy.called).toBeFalsy();
-            expect(ab.getParticipations()).toEqual([]);
+        });
+
+        it('should remove expired tests from being logged', function () {
+            localStorage.setItem(participationsKey, '{"value":{"DummyTest":{"variant":"null"}}}');
+            test.expiry = "2012-01-01";
+            ab.init({
+                switches: {
+                    abDummyTest: true
+                }
+            });
+            expect(localStorage.getItem(participationsKey)).toBe('{"value":{}}');
         });
         
         it('should run the test if it has not expired', function () {
             var futureDate = new Date();
             futureDate.setHours(futureDate.getHours() + 10);
-            test.expiry = futureDate;
+            test.expiry = futureDate.toString();
             ab.init({
                 switches: {
                     abDummyTest: true

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -49,7 +49,7 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
             expect(variantSpy).toHaveBeenCalled();
         });
 
-        it('should put all non-participating users in a null group', function() {
+        it('should put all non-participating users in a "not in test" group', function() {
             test.audience = 0;
             ab.init({
                 switches: {
@@ -58,7 +58,7 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
             });
             expect(controlSpy).not.toHaveBeenCalled();
             var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
-            expect(storedParticipated.DummyTest.variant).toBe("null");
+            expect(storedParticipated.DummyTest.variant).toBe("notintest");
         });
 
         it('should store all the tests user is in', function() {


### PR DESCRIPTION
- Formatting of the web bug
- Swap null to notintest to record non-participants
- Throw away expired tests (so we stop logging)

/cc @ironsidevsquincy 
