### PR TITLE
Fix visual spacing issues in Football scores

### DIFF
--- a/common/app/assets/stylesheets/football.scss
+++ b/common/app/assets/stylesheets/football.scss
@@ -6,6 +6,5 @@
 
 @import "module/football/_stats";
 @import "module/football/_tables";
-//@import "module/football/_matches"; // Already included in global.scss
 @import "module/football/_match-stat";
 @import "module/football/_match-summary";

--- a/common/app/assets/stylesheets/football.scss
+++ b/common/app/assets/stylesheets/football.scss
@@ -6,6 +6,6 @@
 
 @import "module/football/_stats";
 @import "module/football/_tables";
-@import "module/football/_matches";
+//@import "module/football/_matches"; // Already included in global.scss
 @import "module/football/_match-stat";
 @import "module/football/_match-summary";

--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -1,7 +1,5 @@
 .match-summary {
     padding-top: 5px;
-    padding-bottom: $baseline !important;
-    margin-bottom: $baseline*3;
 
     h2 {
         margin-bottom: $baseline*2;

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -1,5 +1,3 @@
-@charset "UTF-8";
-
 .competitions-date,
 .football-table-header {
     padding-top: $baseline*2;
@@ -80,9 +78,6 @@ a.competition-title {
     position: relative;
     margin-bottom: 0;
     border: none;
-    padding: 0;
-    font-weight: normal;
-    font-family: $sans-serif;
     overflow: hidden;
     margin-right: 36px; // offsets the FT/HT box
 }
@@ -356,8 +351,3 @@ a.competition-title {
         padding-top: 12px;
     }
 }
-
-
-
-
-

--- a/common/app/assets/stylesheets/module/football/_tables.scss
+++ b/common/app/assets/stylesheets/module/football/_tables.scss
@@ -68,7 +68,7 @@
     font-weight: 500;
 }
 
-@media (min-width: 40.0625em) {
+@media (min-width: 40.0625*16em) {
 
     .table-football th,
     .table-football td {

--- a/common/app/assets/stylesheets/module/football/_tables.scss
+++ b/common/app/assets/stylesheets/module/football/_tables.scss
@@ -68,7 +68,7 @@
     font-weight: 500;
 }
 
-@media (min-width: 40.0625*16em) {
+@media (min-width: 40.0625em) {
 
     .table-football th,
     .table-football td {

--- a/football/app/implicits/Football.scala
+++ b/football/app/implicits/Football.scala
@@ -89,6 +89,10 @@ trait Football {
   implicit class Match2hasStarted(m: FootballMatch) {
     lazy val hasStarted = m.isLive || m.isResult
   }
+
+  implicit class TeamHasScored(t: MatchDayTeam) {
+    lazy val hasScored = t.score.exists(_ != 0)
+  }
 }
 
 object Football extends Football

--- a/football/app/views/fragments/competitionsBody.scala.html
+++ b/football/app/views/fragments/competitionsBody.scala.html
@@ -16,12 +16,12 @@
         </section>
     }
 }
-
-<h2 class="article-zone type-1 sport-header">
-    <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
-</h2>
-
-<h1 class="page-head">@page.webTitle</h1>
+<header class="article-head">
+    <h2 class="article-zone type-1 sport-header">
+        <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
+    </h2>
+    <h1 class="page-head">@page.webTitle</h1>
+</header>
 
 @competitionList.map{ comp =>
     @renderFilter(comp)

--- a/football/app/views/fragments/footballMatchBody.scala.html
+++ b/football/app/views/fragments/footballMatchBody.scala.html
@@ -6,17 +6,18 @@
     <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
 </h2>
 
-<article class="article" role="main">
-    <p class="dateline box-indent">
-        @fragments.status(page.theMatch)
-        <time data-timestamp="@page.theMatch.date.getMillis">
-            @Format(page.theMatch.date, "EEEE d MMMM y HH.mm z")
-        </time>
-    </p>
-
-    <div class="match-summary box-indent" data-match-id="@page.theMatch.id">
-        @fragments.matchSummary(page.theMatch)
-    </div>
+<article class="article football-article" role="main">
+    <header class="article-head">
+        <p class="dateline box-indent">
+            @fragments.status(page.theMatch)
+            <time data-timestamp="@page.theMatch.date.getMillis">
+                @Format(page.theMatch.date, "EEEE d MMMM y HH.mm z")
+            </time>
+        </p>
+        <div class="match-summary box-indent" data-match-id="@page.theMatch.id">
+            @fragments.matchSummary(page.theMatch)
+        </div>
+    </header>
 
     @if(page.theMatch.isLive) {
         <div class="update update-live-matches update-match-stats" data-link-name="autoupdate"></div>

--- a/football/app/views/fragments/matchSummary.scala.html
+++ b/football/app/views/fragments/matchSummary.scala.html
@@ -8,9 +8,14 @@
 @defining((theMatch.homeTeam, theMatch.awayTeam)){ case (homeTeam, awayTeam) =>
   @if(theMatch.isLive || theMatch.isResult){
     <h2 class="type-3">@homeTeam.name @homeTeam.score</h2>
-    <p class="home-scorers type-11">@cleanScorers(homeTeam.scorers)</p>
+    @if(homeTeam.hasScored){
+        <p class="home-scorers type-11">@cleanScorers(homeTeam.scorers)</p>
+    }
     <h2 class="away-team type-3">@awayTeam.name @awayTeam.score</h2>
-    <p class="type-11">@cleanScorers(awayTeam.scorers)</p>
+
+    @if(awayTeam.hasScored){
+        <p class="type-11">@cleanScorers(awayTeam.scorers)</p>
+    }
   } else {
     <h2 class="type-3">@homeTeam.name v @awayTeam.name</h2>
   }


### PR DESCRIPTION
And also removed the matches SCSS partial from the football CSS since it is already in global.scss
## Before:
- No space below the secondary nav
- too much space below the away team score

![screen shot 2013-07-09 at 17 36 37](https://f.cloud.github.com/assets/85783/769456/c71b9ece-e8b5-11e2-9948-f83fd570a02d.PNG)
## After:

![screen shot 2013-07-09 at 17 36 06](https://f.cloud.github.com/assets/85783/769459/ccfd6ba6-e8b5-11e2-8b4f-fd4ab8f2f185.PNG)

Thanks to @gklopper for pimping this page with me and @phamann for the help.

![Pimp it](http://global3.memecdn.com/pimp-ma-ride_o_573991.jpg)
