### PR TITLE
Add tag bootstrap for cricket lazy load

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -15,7 +15,8 @@ define('bootstraps/app', [
     "bootstraps/gallery",
     "bootstraps/interactive",
     "bootstraps/story",
-    "modules/pageconfig"
+    "modules/pageconfig",
+    "bootstraps/tag"
 ], function (
     common,
     domReady,
@@ -33,7 +34,8 @@ define('bootstraps/app', [
     Gallery,
     Interactive,
     Story,
-    pageConfig
+    pageConfig,
+    Tag
 ) {
 
     var modules = {
@@ -112,6 +114,10 @@ define('bootstraps/app', [
 
                 if (config.page.contentType === "Interactive") {
                     Interactive.init(config, context);
+                }
+
+                if (config.page.contentType === "Tag") {
+                    Tag.init(config, context);
                 }
 
                 //Kick it all off

--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -93,7 +93,9 @@ define([
                                 loadSummary: true,
                                 loadScorecard: true,
                                 summaryElement: '.article-headline',
-                                scorecardElement: '.article-headline' };
+                                scorecardElement: '.article-headline',
+                                summaryManipulation: 'after',
+                                scorecardManipulation: 'after' };
                     cricket(config, context, options);
                 }
             });

--- a/common/app/assets/javascripts/bootstraps/tag.js
+++ b/common/app/assets/javascripts/bootstraps/tag.js
@@ -1,0 +1,41 @@
+define([
+    "common",
+    "modules/cricket"
+], function (
+    common,
+    cricket
+) {
+    var modules = {
+
+        initCricket: function(context) {
+            common.mediator.on('page:tag:ready', function(config, context) {
+
+                var options;
+                if (config.page.pageId === 'sport/cricket' ) {
+
+                    options = { url: "/cricket/match/34780",
+                                loadSummary: true,
+                                loadScorecard: false,
+                                summaryElement: '.t1',
+                                scorecardElement: '.t1',
+                                summaryManipulation: 'append',
+                                scorecardManipulation: 'append' };
+                    cricket(config, context, options);
+                }
+            });
+        }
+    };
+
+    var ready = function (config, context) {
+        if (!this.initialised) {
+            this.initialised = true;
+            modules.initCricket(context);
+        }
+        common.mediator.emit("page:tag:ready", config, context);
+    };
+
+    return {
+        init: ready
+    };
+
+});

--- a/common/app/assets/javascripts/modules/cricket.js
+++ b/common/app/assets/javascripts/modules/cricket.js
@@ -5,39 +5,37 @@ define(['common', 'bonzo', 'ajax'], function (common, bonzo, ajax) {
         /*
          Accepts these options:
 
-         url               - string
-         loadSummary       - bool
-         loadScorecard     - bool
-         summaryElement    - the element which the summary will be placed after
-         scorecardElement  - the element which the scorecard will be placed after
+         url                    - string
+         loadSummary            - bool
+         loadScorecard          - bool
+         summaryElement         - the element which the summary will be placed after
+         scorecardElement       - the element which the scorecard will be placed after
+         summaryManipulation    - the manipulation type for the summary DOM injection
+         scorecardManipulation  - the manipulation type for the scorecard DOM injection
          */
 
-        var url = "/sport" + options.url + ".json";
-
-        var summaryContainer = document.createElement("div");
-        summaryContainer.className = "after-headline";
-        var summaryInto = bonzo(summaryContainer);
-
-        var miniScorecardContainer = document.createElement("div");
-        miniScorecardContainer.className = "after-headline";
-        var scorecardInto = bonzo(miniScorecardContainer);
+        if (!config.switches.liveCricket) {
+            return
+        }
 
         ajax({
-            url: url,
+            url: "/sport" + options.url + ".json",
             type: 'json',
             crossOrigin: true
         }).then(
             function(resp) {
-                if (!scorecardInto.hasClass('lazyloaded') && options.loadScorecard) {
-                    scorecardInto.html(resp.scorecard);
-                    scorecardInto.addClass('lazyloaded');
-                    bonzo(context.querySelector('.article-headline')).after(miniScorecardContainer);
+                if (options.loadScorecard) {
+                    var $scorecardInto = bonzo.create('<div>' + resp.scorecard + '</div>');
+                    bonzo($scorecardInto).addClass('after-headline lazyloaded');
+                    common.$g(options.scorecardElement)[options.scorecardManipulation]($scorecardInto);
+
                     common.mediator.emit('modules:cricketscorecard:loaded', config, context);
                 }
-                if (!summaryInto.hasClass('lazyloaded') && options.loadSummary) {
-                    summaryInto.html(resp.summary);
-                    summaryInto.addClass('lazyloaded');
-                    bonzo(context.querySelector('.article-headline')).after(summaryContainer);
+                if (options.loadSummary) {
+                    var $summaryInto = bonzo.create('<div>' + resp.summary + '</div>');
+                    bonzo($summaryInto).addClass('after-headline lazyloaded');
+                    common.$g(options.summaryElement)[options.summaryManipulation]($summaryInto);
+
                     common.mediator.emit('modules:cricketsummary:loaded', config, context);
                 }
             },

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -167,6 +167,12 @@ object Switches extends Collections {
     "If this is switched on an AA test runs to prove the assignment of users in to segments is working reliably.",
     safeState = Off)
 
+  // Sport Switch
+
+  val LiveCricketSwitch = Switch("Live Cricket", "live-cricket",
+    "If this is switched on the live cricket blocks are added to cricket articles, cricket tag and sport front.",
+    safeState = Off);
+
   // Dummy Switch
 
   val IntegrationTestSwitch = Switch("Unwired Test Switch", "integration-test-switch",
@@ -204,7 +210,8 @@ object Switches extends Collections {
     iPhoneAppSwitch,
     LocalNavSwitch,
     ABAa,
-    LightboxGalleriesSwitch
+    LightboxGalleriesSwitch,
+    LiveCricketSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }


### PR DESCRIPTION
Change the cricket js module so that clients can choose which bonzo DOM manipulation type to use.
Add init to tag page, and make the cricket Tag append the scorecard into the first trail element.
Add a live cricket switch to the switchboard.
