### PR TITLE
Main image tweak

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -82,20 +82,18 @@ trait Images {
     mainPictureCrops.filter(_.width == width).filter(_.height == height).headOption.orElse(mainPicture)
 
   //the canonical main picture, the actual one the editor chose
+  // Assume it's the one with the lowest index (including videos)
   lazy val mainPicture: Option[Image] = if (hasMainPicture)
-    images.filter(List("body", "main", "gallery") contains _.rel).filter(_.index == 1).headOption
+    (images.filter(List("body", "main", "gallery") contains _.rel) ++ videoImages).sortBy(_.index).headOption
   else
-    // we might have videos
-    videoImages.sortBy(_.index).filter(_.index == 1).headOption.orElse {
-      // otherwise just get the 460 sized crop
-      // NOTE safe?
-      images.filter(_.rel == "alt-size").filter(_.width == 460).headOption
-    }
+    // otherwise just get the 460 sized crop
+    // NOTE safe?
+    images.filter(_.rel == "alt-size").filter(_.width == 460).headOption
 
   //Assumption number 2 - the first rel="body" picture is the main picture if (and only if) there are more rel="body"
   //pictures than there are in-body pictures. If there are the same amount, then there is no main picture.
   lazy val hasMainPicture: Boolean = {
-    val bodyPictureCount = images.filter(List("body", "main" , "gallery") contains _.rel).size
+    val bodyPictureCount = (images.filter(List("body", "main" , "gallery") contains _.rel) ++ videoImages).size
     bodyPictureCount > inBodyPictureCount
   }
 

--- a/common/test/model/ImagesTest.scala
+++ b/common/test/model/ImagesTest.scala
@@ -112,6 +112,20 @@ class ImagesTest extends FlatSpec with ShouldMatchers {
     images.mainPicture.foreach(_.caption should be(Some("a")))
   }
 
+  it should "understand that main image is the image with the lowest index" in {
+
+    val pictureMedia = List(image("b", 69, index = 2))
+    val videoMedia = List(image("a", 50, `type` = "video", index = 1))
+
+    val images = new Images {
+      def images = pictureMedia.map(Image(_))
+      def videoImages = videoMedia.map(Image(_))
+    }
+
+    images.mainPicture.size should be(1)
+    images.mainPicture.foreach(_.caption should be(Some("a")))
+  }
+
   it should "return crops with index 1 if more than one body picture" in {
 
     val imageMedia = List(image("a", 50, index = 1), image("b", 69, index = 2), image("c", 50, rel = "alt-size", index = 1), image("d", 69, rel = "alt-size", index = 2))
@@ -156,7 +170,7 @@ class ImagesTest extends FlatSpec with ShouldMatchers {
   }
 
   private def image(caption: String, width: Int, rel: String = "body", index: Int = 1, `type`: String = "picture") = {
-    MediaAsset(`type`, rel, 1, Some("http://www.foo.com/bar"),
+    MediaAsset(`type`, rel, index, Some("http://www.foo.com/bar"),
       Some(Map("caption" -> caption, "width" -> width.toString)))
   }
 }


### PR DESCRIPTION
Rather than taking the image with index == 1 as the main pic, take the image (including video) with the lowest index
