### PR TITLE
Add cricket summary to front, section and tag trail

### DIFF
--- a/applications/app/views/fragments/tagBody.scala.html
+++ b/applications/app/views/fragments/tagBody.scala.html
@@ -24,7 +24,9 @@
 
     @if(leadContent.nonEmpty) {
         @leadContent.zipWithRowInfo.map{ case (trail, info) =>
-            <div class="box-indent lead-content @if(info.rowNum == 1 && trail.mainPicture) {has-image}" data-link-name="lead content">
+            <div class="box-indent lead-content @if(info.rowNum == 1 && trail.mainPicture) {has-image}"
+                data-link-name="lead content"
+                @CricketMatch(trail).map{ id => data-cricket-match="@id" }>
                 <ul class="unstyled">
                     @fragments.trails.featured(trail, info.rowNum)
                 </ul>

--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -11,7 +11,7 @@ define([
     MatchNav,
     Reading,
     Discussion,
-    cricket
+    Cricket
 ) {
 
     var modules = {
@@ -65,7 +65,7 @@ define([
             });
         },
 
-        logReading: function(context) {
+        logReading: function() {
             common.mediator.on('page:article:ready', function(config, context) {
                 var wordCount = config.page.wordCount;
                 if(wordCount !== "") {
@@ -82,21 +82,20 @@ define([
             });
         },
 
-        initCricket: function(context) {
+        initCricket: function() {
             common.mediator.on('page:article:ready', function(config, context) {
 
                 var cricketMatchRefs = config.referencesOfType('esaCricketMatch');
-                var options;
 
                 if(cricketMatchRefs[0]) {
-                    options = { url: cricketMatchRefs[0],
+                    var options = { url: cricketMatchRefs[0],
                                 loadSummary: true,
                                 loadScorecard: true,
                                 summaryElement: '.article-headline',
                                 scorecardElement: '.article-headline',
                                 summaryManipulation: 'after',
                                 scorecardManipulation: 'after' };
-                    cricket(config, context, options);
+                    Cricket.cricketArticle(config, context, options);
                 }
             });
         }
@@ -107,9 +106,9 @@ define([
             this.initialised = true;
             modules.matchNav();
             modules.initLiveBlogging();
-            modules.logReading(context);
+            modules.logReading();
             modules.initDiscussion();
-            modules.initCricket(context);
+            modules.initCricket();
         }
         common.mediator.emit("page:article:ready", config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/front.js
+++ b/common/app/assets/javascripts/bootstraps/front.js
@@ -6,18 +6,25 @@ define([
     //Modules
     "modules/trailblocktoggle",
     "modules/trailblock-show-more",
-    "modules/footballfixtures"
+    "modules/footballfixtures",
+    "modules/cricket"
 ], function (
     common,
     bonzo,
     domReady,
-
     TrailblockToggle,
     TrailblockShowMore,
-    FootballFixtures
+    FootballFixtures,
+    Cricket
 ) {
 
     var modules = {
+
+        showCricket: function(){
+            common.mediator.on('page:front:ready', function(config, context) {
+                Cricket.cricketTrail(config, context);
+            });
+        },
             
         showTrailblockToggles: function () {
             var tt = new TrailblockToggle();
@@ -87,6 +94,7 @@ define([
             modules.showTrailblockToggles();
             modules.showTrailblockShowMore();
             modules.showFootballFixtures();
+            modules.showCricket();
         }
         common.mediator.emit("page:front:ready", config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/tag.js
+++ b/common/app/assets/javascripts/bootstraps/tag.js
@@ -3,25 +3,13 @@ define([
     "modules/cricket"
 ], function (
     common,
-    cricket
+    Cricket
 ) {
     var modules = {
 
-        initCricket: function(context) {
+        showCricket: function() {
             common.mediator.on('page:tag:ready', function(config, context) {
-
-                var options;
-                if (config.page.pageId === 'sport/cricket' ) {
-
-                    options = { url: "/cricket/match/34780",
-                                loadSummary: true,
-                                loadScorecard: false,
-                                summaryElement: '.t1',
-                                scorecardElement: '.t1',
-                                summaryManipulation: 'append',
-                                scorecardManipulation: 'append' };
-                    cricket(config, context, options);
-                }
+                Cricket.cricketTrail(config, context);
             });
         }
     };
@@ -29,7 +17,7 @@ define([
     var ready = function (config, context) {
         if (!this.initialised) {
             this.initialised = true;
-            modules.initCricket(context);
+            modules.showCricket(context);
         }
         common.mediator.emit("page:tag:ready", config, context);
     };

--- a/common/app/assets/javascripts/modules/cricket.js
+++ b/common/app/assets/javascripts/modules/cricket.js
@@ -1,6 +1,6 @@
 define(['common', 'bonzo', 'ajax'], function (common, bonzo, ajax) {
 
-    function cricket(config, context, options) {
+    function cricketArticle(config, context, options) {
 
         /*
          Accepts these options:
@@ -26,14 +26,14 @@ define(['common', 'bonzo', 'ajax'], function (common, bonzo, ajax) {
             function(resp) {
                 if (options.loadScorecard) {
                     var $scorecardInto = bonzo.create('<div>' + resp.scorecard + '</div>');
-                    bonzo($scorecardInto).addClass('after-headline lazyloaded');
+                    bonzo($scorecardInto).addClass('cricket-scorecard lazyloaded');
                     common.$g(options.scorecardElement)[options.scorecardManipulation]($scorecardInto);
 
                     common.mediator.emit('modules:cricketscorecard:loaded', config, context);
                 }
                 if (options.loadSummary) {
                     var $summaryInto = bonzo.create('<div>' + resp.summary + '</div>');
-                    bonzo($summaryInto).addClass('after-headline lazyloaded');
+                    bonzo($summaryInto).addClass('cricket-summary lazyloaded');
                     common.$g(options.summaryElement)[options.summaryManipulation]($summaryInto);
 
                     common.mediator.emit('modules:cricketsummary:loaded', config, context);
@@ -46,5 +46,33 @@ define(['common', 'bonzo', 'ajax'], function (common, bonzo, ajax) {
         common.mediator.emit('modules:cricket:loaded', config, context);
     }
 
-    return cricket;
+    function cricketTrail(config, context) {
+
+        var cricketElement = context.querySelector('[data-cricket-match]');
+
+        if (!cricketElement) {
+            return;
+        }
+
+        var firstCricketBlock = bonzo(cricketElement);
+
+        ajax({
+            url: "/sport" + cricketElement.getAttribute('data-cricket-match') + '.json',
+            type: 'json',
+            crossOrigin: true
+        }).then(
+            function(resp) {
+                firstCricketBlock.append(bonzo.create(resp.summary));
+            },
+            function(req) {
+                common.mediator.emit('module:error', 'Failed to load cricket: ' + req.statusText, 'modules/cricketsummary.js');
+            }
+        );
+        common.mediator.emit('modules:cricket:loaded', config, context);
+    }
+
+    return {
+        cricketArticle: cricketArticle,
+        cricketTrail: cricketTrail
+    };
 });

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -65,6 +65,9 @@ class Content(
   lazy val witnessAssignment = delegate.references.find(_.`type` == "witness-assignment")
     .map(_.id).map(Reference(_)).map(_._2)
 
+  lazy val cricketMatch: Option[String] = delegate.references.find(_.`type` == "esa-cricket-match")
+    .map(_.id).map(Reference(_)).map(_._2)
+
   // Meta Data used by plugins on the page
   // people (including 3rd parties) rely on the names of these things, think carefully before changing them
   override def metaData: Map[String, Any] = super.metaData ++ Map(

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -1,7 +1,9 @@
 @(trail: Trail, rowNum: Int, related: Boolean = false, element: String = "li", headingLevel: Int = 2)(implicit request: RequestHeader)
 
 <@element class="trail trail--featured t@rowNum @if(trail.mainPicture(width=220)) { trail--has-image}"
-    data-link-name="trail" @trail.discussionId.map{ id => data-discussion-id="@id" }>
+     data-link-name="trail"
+    @trail.discussionId.map{ id => data-discussion-id="@id" }
+    @CricketMatch(trail).map{ id => data-cricket-match="@id" }>
 
     @fragments.relativeDate(trail.webPublicationDate, trail.isLive, isFront=true)
 

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -1,6 +1,8 @@
 @(trail: Trail, rowNum: Int, related: Boolean = false, showThumbnail: Boolean = true, element: String = "li", headingLevel: Int = 2)(implicit request: RequestHeader)
 
-<@element class="trail trail--thumbnail t@rowNum" data-link-name="trail" @trail.discussionId.map{ id => data-discussion-id="@id" }>
+<@element class="trail trail--thumbnail t@rowNum" data-link-name="trail"
+    @trail.discussionId.map{ id => data-discussion-id="@id" }
+    @CricketMatch(trail).map{ id => data-cricket-match="@id" } >
 
     @fragments.relativeDate(trail.webPublicationDate, trail.isLive, isFront=true)
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -375,3 +375,10 @@ object Head {
   private def volatileCss: String = io.Source.fromInputStream(getClass.getResourceAsStream("/public/stylesheets/head.min.css")).mkString
   private lazy val persistantCss: String = volatileCss
 }
+
+object CricketMatch {
+  def apply(trail: Trail): Option[String] = trail match {
+    case c: Content => c.cricketMatch
+    case _ => None
+  }
+}


### PR DESCRIPTION
Added the data-cricket-match attribute to trail through the Content class.
Change bootstrap so the tag and front inject a cricket summary into the first featured/thumbnail trail which is attributed as a cricket match.
