### PR TITLE
Base urls now redirect to editions

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -1,6 +1,7 @@
 package implicits
 
 import play.api.mvc.RequestHeader
+import common.Site
 
 trait Requests {
   implicit class Request2rich(r: RequestHeader) {
@@ -10,6 +11,9 @@ trait Requests {
     def getIntParameter(name: String): Option[Int] = getParameter(name).map(_.toInt)
 
     def getBooleanParameter(name: String): Option[Boolean] = getParameter(name).map(_.toBoolean)
+
+    // TODO only needed till we are live in www.theguardian.com
+    lazy val isSingleDomain = !Site(r).isDefined
 
     lazy val isJson = r.getQueryString("callback").isDefined || r.headers.get("Accept").exists{ header =>
       header.contains("application/json") ||

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -157,7 +157,9 @@ class FrontController extends Controller with Logging with JsonTrails with Execu
         }
       }
 
-      if (trailblocks.isEmpty) {
+      if (request.isSingleDomain && path != realPath) {
+        Redirect(s"/$realPath")
+      } else if (trailblocks.isEmpty) {
         InternalServerError
       } else {
         val htmlResponse = () => views.html.front(frontPage, trailblocks)

--- a/front/test/FrontControllerTest.scala
+++ b/front/test/FrontControllerTest.scala
@@ -10,9 +10,33 @@ class FrontControllerTest extends FlatSpec with ShouldMatchers {
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"
   val callbackName = "aFunction"
 
+  val mobileRequest = FakeRequest().withHeaders("host" -> "m.guardian.co.uk")
+  val responsiveRequest = FakeRequest().withHeaders("host" -> "www.theguardian.com")
+
   "Front Controller" should "200 when content type is front" in Fake {
     val result = controllers.FrontController.render("")(TestRequest())
     status(result) should be(200)
+  }
+
+  it should "redirect base page to edition page if on www.theguardian.com" in Fake {
+
+    val result = controllers.FrontController.render("")(responsiveRequest.withHeaders("X-GU-Edition" -> "US"))
+    status(result) should be(303)
+    header("Location", result) should be (Some("/us"))
+
+    val result2 = controllers.FrontController.render("culture")(responsiveRequest.withHeaders("X-GU-Edition" -> "AU"))
+    status(result2) should be(303)
+    header("Location", result2) should be (Some("/au/culture"))
+
+  }
+
+  it should "NOT redirect base page to edition page if on m.guardian.co.uk" in Fake {
+
+    val result = controllers.FrontController.render("")(mobileRequest.withHeaders("X-GU-Edition" -> "US"))
+    status(result) should be(200)
+
+    val result2 = controllers.FrontController.render("culture")(mobileRequest.withHeaders("X-GU-Edition" -> "AU"))
+    status(result2) should be(200)
   }
 
   it should "understand the editionalised network front" in Fake {


### PR DESCRIPTION
NOTE: this only happens on www.theguardian.com

A base url for a configured page will redirect to the proper edition page e.g.

/sport  ->  /au/sport

/  ->  /us
