### PR TITLE
Base urls now redirect to editions

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -152,6 +152,10 @@ object Switches extends Collections {
     "If this switch is on, gallery trails are opened in a lightbox.",
     safeState = Off)
 
+  val EditionRedirectSwitch = Switch("Feature Switches", "edition-redirects",
+    "If this switch is on, editionalised pages will redirect from the root to the appropriate edition, e.g. culture -> uk/culture (only on www.theguardian.com)",
+    safeState = Off)
+
 
   // A/B Test Switches
 
@@ -211,6 +215,7 @@ object Switches extends Collections {
     LocalNavSwitch,
     ABAa,
     LightboxGalleriesSwitch,
+    EditionRedirectSwitch,
     LiveCricketSwitch
   )
 

--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -25,6 +25,9 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
 
   */
 
+  /*
+    IMPORTANT - we strip out other parameters in the CDN - simply adding a parameter here is not enough
+  */
   val allowedParams = Seq(
     "index",
     "page"

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -1,6 +1,7 @@
 package implicits
 
 import play.api.mvc.RequestHeader
+import common.Site
 
 trait Requests {
   implicit class Request2rich(r: RequestHeader) {
@@ -10,6 +11,9 @@ trait Requests {
     def getIntParameter(name: String): Option[Int] = getParameter(name).map(_.toInt)
 
     def getBooleanParameter(name: String): Option[Boolean] = getParameter(name).map(_.toBoolean)
+
+    // TODO only needed till we are live in www.theguardian.com
+    lazy val isSingleDomain = !Site(r).isDefined
 
     lazy val isJson = r.getQueryString("callback").isDefined || r.headers.get("Accept").exists{ header =>
       header.contains("application/json") ||

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -6,9 +6,7 @@ import model._
 import conf._
 import play.api.mvc._
 import model.Trailblock
-import scala.Some
-
-import concurrent.Future
+import Switches.EditionRedirectSwitch
 
 // TODO, this needs a rethink, does not seem elegant
 object FrontPage {
@@ -157,7 +155,9 @@ class FrontController extends Controller with Logging with JsonTrails with Execu
         }
       }
 
-      if (trailblocks.isEmpty) {
+      if (EditionRedirectSwitch.isSwitchedOn && request.isSingleDomain && path != realPath) {
+        Redirect(s"/$realPath")
+      } else if (trailblocks.isEmpty) {
         InternalServerError
       } else {
         val htmlResponse = () => views.html.front(frontPage, trailblocks)

--- a/front/test/FrontControllerTest.scala
+++ b/front/test/FrontControllerTest.scala
@@ -4,15 +4,55 @@ import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.FlatSpec
+import conf.Switches.EditionRedirectSwitch
 
 class FrontControllerTest extends FlatSpec with ShouldMatchers {
   
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"
   val callbackName = "aFunction"
 
+  val mobileRequest = FakeRequest().withHeaders("host" -> "m.guardian.co.uk")
+  val responsiveRequest = FakeRequest().withHeaders("host" -> "www.theguardian.com")
+
   "Front Controller" should "200 when content type is front" in Fake {
     val result = controllers.FrontController.render("")(TestRequest())
     status(result) should be(200)
+  }
+
+  it should "redirect base page to edition page if on www.theguardian.com" in Fake {
+
+    EditionRedirectSwitch.switchOn()
+
+    val result = controllers.FrontController.render("")(responsiveRequest.withHeaders("X-GU-Edition" -> "US"))
+    status(result) should be(303)
+    header("Location", result) should be (Some("/us"))
+
+    val result2 = controllers.FrontController.render("culture")(responsiveRequest.withHeaders("X-GU-Edition" -> "AU"))
+    status(result2) should be(303)
+    header("Location", result2) should be (Some("/au/culture"))
+
+  }
+
+  it should "NOT redirect base page to edition page if on m.guardian.co.uk" in Fake {
+
+    EditionRedirectSwitch.switchOn()
+
+    val result = controllers.FrontController.render("")(mobileRequest.withHeaders("X-GU-Edition" -> "US"))
+    status(result) should be(200)
+
+    val result2 = controllers.FrontController.render("culture")(mobileRequest.withHeaders("X-GU-Edition" -> "AU"))
+    status(result2) should be(200)
+  }
+
+  it should "NOT redirect base page to edition page if switched off" in Fake {
+
+    EditionRedirectSwitch.switchOff()
+
+    val result = controllers.FrontController.render("")(responsiveRequest.withHeaders("X-GU-Edition" -> "US"))
+    status(result) should be(200)
+
+    val result2 = controllers.FrontController.render("culture")(responsiveRequest.withHeaders("X-GU-Edition" -> "AU"))
+    status(result2) should be(200)
   }
 
   it should "understand the editionalised network front" in Fake {


### PR DESCRIPTION
(same pull request as yesterday, but then I took down the site, so this time I have a switch)

NOTE: on www.theguardian.com only

A base url for a configured page will redirect to the proper edition page e.g.

/sport -> /au/sport

/ -> /us
