### PR TITLE
New default styling of inline table from content API

### DIFF
--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -148,3 +148,35 @@ figure {
         }
     }
 }
+
+/* Tables
+   ========================================================================== */
+.from-content-api {
+    table {
+        margin-bottom: $baseline*4;
+    }
+
+    //This is a weird xml output from the api
+    table caption {
+        @extend %type-5;
+        padding: $baseline*2 0;
+        text-align: left;
+        border-top: 1px solid #B3B3B4;
+    }
+
+    th, td {
+        @extend %type-11;
+        padding: $baseline*2;
+        color: #676767;
+    }
+
+    th {
+        font-weight: 600;
+        color: #333;
+    }
+
+    tbody tr:nth-child(odd) td {
+        background-color: #F9F9F7;
+    }
+}
+


### PR DESCRIPTION
This fixes #1201 

New tables based on Jim's designs

![littlesnapper](https://f.cloud.github.com/assets/80089/789334/b65de5c8-eb0e-11e2-902c-b86005c7f565.png)
