### PR TITLE
All trails but gallery trails have borders between them

### DIFF
--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -51,7 +51,9 @@ $darkBlue: #152E5F;
 $lightBlue: #95B2CB;
 $linkBlue: #005689;
 $mushroom: #F4F4EE;
+$medianMushroom: #EDEDE7;
 $darkMushroom: #E3E3DB;
+
 
 
 /* Zones

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -31,7 +31,7 @@
 .ad-slot-middle-banner-ad {
     background-color: #fff;
     min-height: 0;
-    border-bottom: 1px solid #EDEDE7;
+    border-bottom: 1px solid $medianMushroom;
 }
 
 .ad-slot-middle-banner-ad .ad-container {

--- a/common/app/assets/stylesheets/module/_cta.scss
+++ b/common/app/assets/stylesheets/module/_cta.scss
@@ -54,7 +54,7 @@ button.cta {
     padding: $baseline*2 0 $baseline*3 0;
 
     &.cta-small-border {
-        border-bottom: 1px solid #EDEDE7;
+        border-bottom: 1px solid $medianMushroom;
     }
 }
 

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -95,7 +95,7 @@ $keylineSize: 1px;
 .d-comment {
     color: #333;
     font-family: sans-serif;
-    border-top: 1px solid #EDEDE7;
+    border-top: 1px solid $medianMushroom;
 }
 .d-comment--has-replies + .d-comment {
     border-top: 2px solid $darkMushroom;

--- a/common/app/assets/stylesheets/module/experiments/_story.scss
+++ b/common/app/assets/stylesheets/module/experiments/_story.scss
@@ -217,7 +217,7 @@ $orange: #FF7F00;
 }
 
 .story-article .article-body p:last-child {
-    border-bottom: 1px solid #EDEDE7;
+    border-bottom: 1px solid $medianMushroom;
     padding-bottom: 8px;
 }
 

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -298,7 +298,7 @@
 }
 
 .localnav__inner {
-    border-bottom: 1px solid #EDEDE7;
+    border-bottom: 1px solid $medianMushroom;
     margin: 0 $gutter;
 }
 

--- a/common/app/assets/stylesheets/module/trails/_trail.scss
+++ b/common/app/assets/stylesheets/module/trails/_trail.scss
@@ -7,16 +7,16 @@
     overflow: hidden;
     margin: 0;
     padding: $baseline*3 0 $baseline*3;
-
 }
 
-
-.trail--featured + .trail--thumbnail,
-.trail--thumbnail + .trail--thumbnail {
+.trail + .trail {
     border-top: 1px solid #EDEDE7;
 }
 
-
+.trail + .trail--gallery,
+.trail--gallery + .trail {
+    border-top: none;
+}
 
 .trail__headline {
     @media (min-width: 25em) { @extend %type-4; }

--- a/common/app/assets/stylesheets/module/trails/_trail.scss
+++ b/common/app/assets/stylesheets/module/trails/_trail.scss
@@ -10,7 +10,7 @@
 }
 
 .trail + .trail {
-    border-top: 1px solid #EDEDE7;
+    border-top: 1px solid $medianMushroom;
 }
 
 .trail + .trail--gallery,

--- a/common/app/assets/stylesheets/module/trails/_trailblock.scss
+++ b/common/app/assets/stylesheets/module/trails/_trailblock.scss
@@ -5,18 +5,29 @@
 .trailblock {
     max-height: none;
     padding: 0 $gutter;
-}
 
-    .trailblock ul {
+    > ul {
         margin-bottom: 0;
+
+        + ul {
+            border-top: 1px solid #EDEDE7;
+        }
     }
+}
 
 
 /* Trailblock expandables
    ========================================================================== */
 
-.trailblock.shut .count {
-    display: inline-block;
+.trailblock.shut {
+    > ul {
+        + ul {
+            border-top: none;
+        }
+    }
+    .count {
+        display: inline-block;
+    }
 }
 
 .trailblock.rolled-up,

--- a/common/app/assets/stylesheets/module/trails/_trailblock.scss
+++ b/common/app/assets/stylesheets/module/trails/_trailblock.scss
@@ -10,7 +10,7 @@
         margin-bottom: 0;
 
         + ul {
-            border-top: 1px solid #EDEDE7;
+            border-top: 1px solid $medianMushroom;
         }
     }
 }


### PR DESCRIPTION
On fronts and read-more lists of trails, there was no border between some of the trails.
## Before

![screen shot 2013-07-16 at 11 51 12](https://f.cloud.github.com/assets/85783/804200/1ec031fc-ee07-11e2-9de3-081ab28e64fd.PNG)
## After

![screen shot 2013-07-16 at 12 04 49](https://f.cloud.github.com/assets/85783/804218/98bdffca-ee07-11e2-979e-c0031ff5c96c.PNG)
## Known issue

When an adslot div "ad-slot-middle-banner-ad" is included between two trails, there is no border between trails. Btw this should be addressed, as a `div` cannot be direct child of a `ul`.
On this screenshot, there is no border between the first trail and second trail because of this.
![screen shot 2013-07-16 at 12 03 13](https://f.cloud.github.com/assets/85783/804209/7c47bac0-ee07-11e2-9c62-1a9b37c8c9c5.PNG)

![Easy](http://i.minus.com/ibGG9fKbKVNlA.gif)
