### PR TITLE
Ab test segmentation refactor

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -56,7 +56,7 @@ define('bootstraps/app', [
         },
     
         initialiseAbTest: function (config) {
-            ab.init(config);
+            ab.segment(config);
         },
 
         loadFonts: function(config, ua) {

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -153,6 +153,12 @@ define([
                 });
             });
         },
+        
+        runAbTests: function () {
+            common.mediator.on('page:common:ready', function(config, context) {
+                ab.run(config, context);
+            });
+        },
 
         loadAnalytics: function () {
             var omniture = new Omniture();
@@ -294,6 +300,7 @@ define([
             this.initialised = true;
             modules.upgradeImages();
             modules.showTabs();
+            modules.runAbTests();
             modules.showRelativeDates();
             modules.transcludeRelated();
             modules.transcludePopular();

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -128,18 +128,12 @@ define([
             s.prop31    = id.isLoggedIn() ? "Logged in user" : "Guest user";
 
             s.prop47    = config.page.edition || '';
-    
-            var participations = ab.getParticipations(),
-                participationsKeys = Object.keys(participations);
+   
+            var mvt = ab.makeOmnitureTag(config, document);
+            if (mvt.length > 0) {
 
-            if (participationsKeys.length > 0) {
-                
-                var testData = participationsKeys.map(function(k){
-                    return ['AB', k, participations[k].variant].join(' | ');
-                }).join(',');
-
-                s.prop51  = testData;
-                s.eVar51  = testData;
+                s.prop51  = mvt;
+                s.eVar51  = mvt;
                 s.events = s.apl(s.events,'event58',',');
 
             }

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -54,22 +54,49 @@ define([
         dataLinkTest.push(['AB', test.id + ' test', variantId]. join(' | '));
         common.$g(document.body).attr('data-link-test', dataLinkTest.join(', '));
     }
-
-    //Finds variant in specific tests and exec's
-    function run(test, config, context) {
-        var expired = (new Date() - new Date(test.expiry)) > 0;
-        if (test.canRun(config, context) && !expired && config.switches['ab' + test.id]) {
         
-            // if user not in test, bucket them
-            if (!isParticipating(test)) {
-                bucket(test);
+    function getActiveTests() {
+        return TESTS.filter(function(test) {
+            var expired = (new Date() - new Date(test.expiry)) > 0;
+            if (expired) {
+                removeParticipation(test);
+                return false;
             }
-            
-            return;
-        }
+            return true;
+        })
+    };
+
+    function testCanBeRun (test, config, context) {
+        var expired = (new Date() - new Date(test.expiry)) > 0;
+        return (test.canRun(config, context) && !expired && config.switches['ab' + test.id])
     }
 
-    function bucket(test) {
+    // Finds variant in specific tests and runs it 
+    function run(test, config, context) {
+
+        if (!isParticipating(test) || !testCanBeRun(test, config, context)) {
+            return false;
+        }
+        
+        var participations = getParticipations(),
+            variantId = participations[test.id].variant;
+        
+            test.variants.some(function(variant) {
+                if (variant.id === variantId) {
+                    variant.test();
+                    initTracking(test, variantId);
+                    return true;
+                }
+        });
+    }
+
+    function bucket(test, config, context) {
+        
+        // if user not in test, bucket them
+        if (isParticipating(test) || !testCanBeRun(test, config, context)) {
+            return false;
+        }
+
         // always at least place in control
         var testVariantId = 'notintest';
 
@@ -85,36 +112,35 @@ define([
 
         // store
         addParticipation(test, testVariantId);
+
+        return true;
     }
 
     var ab = {
 
-        //For testing purposes
         addTest: function(test) {
             TESTS.push(test);
         },
-
-        getParticipations: getParticipations,
         
         clearTests: function() {
             TESTS = [];
         },
 
         init: function(config, context, options) {
-            var hash = window.location.hash.substring(1),
-                opts = options || {};
-
-            TESTS.filter(function(test) {
-                var expired = (new Date() - new Date(test.expiry)) > 0;
-                if (expired) {
-                    removeParticipation(test);
-                    return false;
-                }
-                return true;
-            }).forEach(function(test) {
+            var opts = options || {};
+            getActiveTests().forEach(function(test) {
+                bucket(test, config, context);
+            });
+        },
+        
+        run: function(config, context, options) {
+            var opts = options || {};
+            getActiveTests().forEach(function(test) {
                 run(test, config, context);
             });
-        }
+        },
+
+        getParticipations: getParticipations
 
     };
 

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -63,15 +63,15 @@ define([
                 return false;
             }
             return true;
-        })
-    };
+        });
+    }
 
     function testCanBeRun (test, config, context) {
         var expired = (new Date() - new Date(test.expiry)) > 0;
-        return (test.canRun(config, context) && !expired && config.switches['ab' + test.id])
+        return (test.canRun(config, context) && !expired && config.switches['ab' + test.id]);
     }
 
-    // Finds variant in specific tests and runs it 
+    // Finds variant in specific tests and runs it
     function run(test, config, context) {
 
         if (!isParticipating(test) || !testCanBeRun(test, config, context)) {

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -66,9 +66,9 @@ define([
         });
     }
 
-    function testCanBeRun (test, config, context) {
+    function testCanBeRun (test, config) {
         var expired = (new Date() - new Date(test.expiry)) > 0;
-        return (test.canRun(config, context) && !expired && config.switches['ab' + test.id]);
+        return (test.canRun(config) && !expired && config.switches['ab' + test.id]);
     }
 
     function getTest(id) {
@@ -78,10 +78,10 @@ define([
         return (test) ? test[0] : '';
     }
 
-    function makeOmnitureTag (config, context) {
+    function makeOmnitureTag (config) {
         var participations = getParticipations();
         return Object.keys(participations).map(function (k) {
-            if (testCanBeRun(getTest(k), config, context)) {
+            if (testCanBeRun(getTest(k), config)) {
                 return ['AB', k, participations[k].variant].join(' | ');
             }
         }).join(',');
@@ -90,30 +90,29 @@ define([
     // Finds variant in specific tests and runs it
     function run(test, config, context) {
 
-        if (!isParticipating(test) || !testCanBeRun(test, config, context)) {
+        if (!isParticipating(test) || !testCanBeRun(test, config)) {
             return false;
         }
         
         var participations = getParticipations(),
             variantId = participations[test.id].variant;
-        
             test.variants.some(function(variant) {
                 if (variant.id === variantId) {
-                    variant.test();
+                    variant.test(context);
                     initTracking(test, variantId);
                     return true;
                 }
         });
     }
 
-    function bucket(test, config, context) {
+    function bucket(test, config) {
         
         // if user not in test, bucket them
-        if (isParticipating(test) || !testCanBeRun(test, config, context)) {
+        if (isParticipating(test) || !testCanBeRun(test, config)) {
             return false;
         }
 
-        // always at least place in control
+        // always at least place in a notintest control
         var testVariantId = 'notintest';
 
         //Only run on test required audience segment
@@ -142,10 +141,10 @@ define([
             TESTS = [];
         },
 
-        segment: function(config, context, options) {
+        segment: function(config, options) {
             var opts = options || {};
             getActiveTests().forEach(function(test) {
-                bucket(test, config, context);
+                bucket(test, config);
             });
         },
         

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -142,7 +142,7 @@ define([
             TESTS = [];
         },
 
-        init: function(config, context, options) {
+        segment: function(config, context, options) {
             var opts = options || {};
             getActiveTests().forEach(function(test) {
                 bucket(test, config, context);

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -71,6 +71,22 @@ define([
         return (test.canRun(config, context) && !expired && config.switches['ab' + test.id]);
     }
 
+    function getTest(id) {
+        var test = TESTS.filter(function (test) {
+            return (test.id === id);
+        });
+        return (test) ? test[0] : '';
+    }
+
+    function makeOmnitureTag (config, context) {
+        var participations = getParticipations();
+        return Object.keys(participations).map(function (k) {
+            if (testCanBeRun(getTest(k), config, context)) {
+                return ['AB', k, participations[k].variant].join(' | ');
+            }
+        }).join(',');
+    }
+
     // Finds variant in specific tests and runs it
     function run(test, config, context) {
 
@@ -140,7 +156,8 @@ define([
             });
         },
 
-        getParticipations: getParticipations
+        getParticipations: getParticipations,
+        makeOmnitureTag: makeOmnitureTag
 
     };
 

--- a/common/test/assets/javascripts/fixtures/ab-test.js
+++ b/common/test/assets/javascripts/fixtures/ab-test.js
@@ -1,8 +1,8 @@
 define([], function () {
 
-    var ABTest = function () {
+    var ABTest = function (id) {
 
-        this.id = 'DummyTest';
+        this.id = id;
         this.audience = 1;
         this.expiry = '2045-01-01';
         this.description = 'Dummy test';

--- a/common/test/assets/javascripts/fixtures/ab-test.js
+++ b/common/test/assets/javascripts/fixtures/ab-test.js
@@ -12,14 +12,12 @@ define([], function () {
         this.variants = [
             {
                 id: 'control',
-                split: 50,
                 test: function () {
                     console.log('Control ran');
                 }
             },
             {
                 id: 'hide',
-                split: 50,
                 test: function () {
                     console.log('Hide ran');
                 }

--- a/common/test/assets/javascripts/fixtures/ab-test.js
+++ b/common/test/assets/javascripts/fixtures/ab-test.js
@@ -12,14 +12,14 @@ define([], function () {
         this.variants = [
             {
                 id: 'control',
-                test: function () {
-                    console.log('Control ran');
+                test: function (context) {
+                    console.log('Control ran', context);
                 }
             },
             {
                 id: 'hide',
-                test: function () {
-                    console.log('Hide ran');
+                test: function (context) {
+                    console.log('Hide ran', context);
                 }
             }
         ];

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -50,11 +50,9 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
                 expect(controlSpy.called || variantSpy.called).toBeFalsy();
             });
             
-            it('should segment the user in to a test', function() {
-                
+            it('should assign the user to a segment (aka. variant)', function() {
                 ab.addTest(test.two);
                 ab.segment(switches.both_tests_on);
-                
                 var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
                 expect(storedParticipated.DummyTest.variant).not.toBeUndefined();
                 expect(storedParticipated.DummyTest2.variant).not.toBeUndefined();
@@ -79,10 +77,8 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
             it('should get all the tests user is in', function() {
                 ab.addTest(test.two);
                 ab.segment(switches.both_tests_on);
-                var tests = Object.keys(ab.getParticipations()).map(function(k){
-                    return k; }).toString()
+                var tests = Object.keys(ab.getParticipations()).map(function(k){ return k; }).toString()
                 expect(tests).toBe('DummyTest,DummyTest2');
-                
             });
             
             it('should remove expired tests from being logged', function () {

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -5,7 +5,7 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
         var test,
             controlSpy,
             variantSpy,
-            participationsKey = 'gu.ab.participations'
+            participationsKey = 'gu.ab.participations',
             getItem = function (testId) {
                 return JSON.parse(localStorage.getItem(participationsKey)).value[testId];
             };

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -8,25 +8,36 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
             participationsKey = 'gu.ab.participations';
 
         beforeEach(function() {
+            
             ab.clearTests();
-            test = new ABTest(),
-            controlSpy = sinon.spy(test.variants[0], 'test'),
-            variantSpy = sinon.spy(test.variants[1], 'test');
-            // add a test
-            ab.addTest(test);
+
+            // a list of ab-tests that can be used in the spec's 
+            test = {
+                one: new ABTest('DummyTest'),
+                two: new ABTest('DummyTest2')
+            }
+             
+            switches = {
+                test_one_off: { switches: { abDummyTest: false }},
+                test_one_on: { switches: { abDummyTest: true }},
+                both_tests_on: { switches: { abDummyTest: true, abDummyTest2: true }}
+            }
+
+            controlSpy = sinon.spy(test.one.variants[0], 'test'),
+            variantSpy = sinon.spy(test.one.variants[1], 'test');
+            
+            ab.addTest(test.one);
         });
 
         afterEach(function() {
             ab.clearTests();
             localStorage.removeItem(participationsKey);
-            // remove tracking from body
             document.body.removeAttribute('data-link-test');
         });
 
         describe("Ab", function () {
         
             it('should exist', function() {
-                // basic, check it exists
                 expect(ab).toBeDefined();
             });
         
@@ -35,79 +46,49 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
         describe("User segmentation", function () {
             
             it('should not run if switch is off', function() {
-                ab.init({
-                    switches: {
-                        abDummyTest: false,
-                    }
-                });
+                ab.segment(switches.test_one_off);
                 expect(controlSpy.called || variantSpy.called).toBeFalsy();
             });
-
+            
+            it('should segment the user in to a test', function() {
+                
+                ab.addTest(test.two);
+                ab.segment(switches.both_tests_on);
+                
+                var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
+                expect(storedParticipated.DummyTest.variant).not.toBeUndefined();
+                expect(storedParticipated.DummyTest2.variant).not.toBeUndefined();
+            });
+            
             it('should put all non-participating users in a "not in test" group', function() {
-                test.audience = 0;
-                ab.init({
-                    switches: {
-                        abDummyTest: true
-                    }
-                });
+                test.one.audience = 0;
+                ab.segment(switches.test_one_on);
                 expect(controlSpy).not.toHaveBeenCalled();
                 var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
                 expect(storedParticipated.DummyTest.variant).toBe("notintest");
             });
             
             it("should not segment user if test can't be run", function() {
-                test.canRun = function() { return false; }
-                ab.init({
-                    switches: {
-                        abDummyTest: true
-                    }
-                });
+                test.one.canRun = function() { return false; }
+                ab.segment(switches.test_one_on);
                 expect(controlSpy.called || variantSpy.called).toBeFalsy();
                 expect(ab.getParticipations()).toEqual([]);
             });
 
 
-            it('should store all the tests user is in', function() {
-                var otherTest = new ABTest();
-                otherTest.id = 'DummyTest2';
-                ab.addTest(otherTest);
-
-                ab.init({
-                    switches: {
-                        abDummyTest: true,
-                        abDummyTest2: true,
-                    }
-                });
-                var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
-                expect(storedParticipated.DummyTest.variant).not.toBeUndefined();
-                expect(storedParticipated.DummyTest2.variant).not.toBeUndefined();
-            });
-            
             it('should get all the tests user is in', function() {
-                var otherTest = new ABTest();
-                otherTest.id = 'DummyTest2';
-                ab.addTest(otherTest);
-
-                ab.init({
-                    switches: {
-                        abDummyTest: true,
-                        abDummyTest2: true
-                    }
-                });
-            
-                var tests = Object.keys(ab.getParticipations()).map(function(k){ return k; }).toString()
+                ab.addTest(test.two);
+                ab.segment(switches.both_tests_on);
+                var tests = Object.keys(ab.getParticipations()).map(function(k){
+                    return k; }).toString()
                 expect(tests).toBe('DummyTest,DummyTest2');
                 
             });
             
             it('should remove expired tests from being logged', function () {
                 localStorage.setItem(participationsKey, '{"value":{"DummyTest":{"variant":"null"}}}');
-                test.expiry = "2012-01-01";
-                ab.init({
-                    switches: {
-                        abDummyTest: true
-                    }
-                });
+                test.one.expiry = "2012-01-01";
+                ab.segment(switches.test_one_on);
                 expect(localStorage.getItem(participationsKey)).toBe('{"value":{}}');
             });
 
@@ -116,36 +97,30 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
         describe("Running tests", function () {
             
             it('should be able to start test', function() {
-                ab.init({ switches: {'abDummyTest': true} }, document);
-                ab.run({ switches: {'abDummyTest': true} }, document);
+                ab.segment(switches.test_one_on);
+                ab.run(switches.test_one_on);
                 expect(controlSpy.called || variantSpy.called).toBeTruthy();
             });
 
             it('should not run the test if the user has not been put in a segment', function () {
-                // Nb. no call to ab.init(...)
-                ab.run({ switches: { abDummyTest: true } });
+                // Nb. no call to ab.segment(...)
+                ab.run(switches.test_one_on);
                 expect(controlSpy.called || variantSpy.called).toBeFalsy();
             });
 
             it('should refuse to run the after the expiry date', function () {
-                test.expiry = "2012-01-01";
-                ab.init({
-                    switches: {
-                        abDummyTest: true
-                    }
-                });
+                test.one.expiry = "2012-01-01";
+                ab.segment(switches.test_one_on);
+                ab.run(switches.test_one_on);
+                expect(controlSpy.called || variantSpy.called).toBeFalsy();
             });
 
             it('should run the test if it has not expired', function () {
                 var futureDate = new Date();
                 futureDate.setHours(futureDate.getHours() + 10);
                 test.expiry = futureDate.toString();
-                ab.init({
-                    switches: {
-                        abDummyTest: true
-                    }
-                });
-                ab.run({ switches: { abDummyTest: true } });
+                ab.segment(switches.test_one_on);
+                ab.run(switches.test_one_on);
                 expect(controlSpy.called || variantSpy.called).toBeTruthy();
             });
             
@@ -154,50 +129,34 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
         describe("Analytics", function () {
             
             it('should add "data-link-test" tracking to body', function() {
-                ab.init({
-                    switches: {
-                        abDummyTest: true
-                    }
-                });
-                ab.run({ switches: {'abDummyTest': true} }, document);
+                ab.segment(switches.test_one_on);
+                ab.run(switches.test_one_on);
                 expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide)$/);
             });
 
             it('should concat "data-link-test" tracking when more than one test', function() {
-                var otherTest = new ABTest();
-                otherTest.id = 'DummyTest2';
-                ab.addTest(otherTest);
-                var s = {
-                    abDummyTest: true,
-                    abDummyTest2: true,
-                    }
-                ab.init({ switches: s });
-                ab.run({ switches: s }, document);
+                ab.addTest(test.two);
+                ab.segment(switches.both_tests_on);
+                ab.run(switches.both_tests_on);
                 expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide), AB \| DummyTest2 test \| (control|hide)$/);
             });
             
             it('should generate a string for Omniture to tag the test(s) the user is in', function() {
                 Math.seedrandom('gu');
-                var otherTest = new ABTest()
-                  , conf = { switches: { abDummyTest: true, abDummyTest2: true }};
-                otherTest.id = 'DummyTest2';
-                otherTest.audience = 1; 
-                ab.addTest(otherTest);
-                ab.init(conf);
-                ab.run(conf, document);
-                expect(ab.makeOmnitureTag(conf, document)).toBe("AB | DummyTest | control,AB | DummyTest2 | control");
+                test.two.audience = 1; 
+                ab.addTest(test.two);
+                ab.segment(switches.both_tests_on);
+                ab.run(switches.both_tests_on);
+                expect(ab.makeOmnitureTag(switches.both_tests_on)).toBe("AB | DummyTest | control,AB | DummyTest2 | control");
         
             });
             
             it('should not generate Omniture tags when a test can not be run', function() {
-                var otherTest = new ABTest()
-                  , conf = { switches: { abDummyTest: true, abDummyTest2: true }};
-                otherTest.id = 'DummyTest2';
-                otherTest.canRun = function() { return false; }
-                ab.addTest(otherTest);
-                ab.init(conf);
-                ab.run(conf, document);
-                expect(ab.makeOmnitureTag(conf, document)).toBe("AB | DummyTest | control");
+                test.two.canRun = function() { return false; }
+                ab.addTest(test.two);
+                ab.segment(switches.both_tests_on);
+                ab.run(switches.both_tests_on);
+                expect(ab.makeOmnitureTag(switches.both_tests_on)).toBe("AB | DummyTest | control");
             });
         
         });

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -23,142 +23,183 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
             document.body.removeAttribute('data-link-test');
         });
 
-        it('should exist', function() {
-            // basic, check it exists
-            expect(ab).toBeDefined();
-        });
-
-        it('should be able to start test', function() {
-            ab.init({ switches: {'abDummyTest': true} }, document);
-            ab.run({ switches: {'abDummyTest': true} }, document);
-            expect(controlSpy.called || variantSpy.called).toBeTruthy();
-        });
-
-        it('should put all non-participating users in a "not in test" group', function() {
-            test.audience = 0;
-            ab.init({
-                switches: {
-                    abDummyTest: true
-                }
-            });
-            expect(controlSpy).not.toHaveBeenCalled();
-            var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
-            expect(storedParticipated.DummyTest.variant).toBe("notintest");
-        });
-
-        it('should store all the tests user is in', function() {
-            var otherTest = new ABTest();
-            otherTest.id = 'DummyTest2';
-            ab.addTest(otherTest);
-
-            ab.init({
-                switches: {
-                    abDummyTest: true,
-                    abDummyTest2: true,
-                }
-            });
-            var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
-            expect(storedParticipated.DummyTest.variant).not.toBeUndefined();
-            expect(storedParticipated.DummyTest2.variant).not.toBeUndefined();
-        });
+        describe("Ab", function () {
         
-        it('should get all the tests user is in', function() {
-            var otherTest = new ABTest();
-            otherTest.id = 'DummyTest2';
-            ab.addTest(otherTest);
-
-            ab.init({
-                switches: {
-                    abDummyTest: true,
-                    abDummyTest2: true
-                }
+            it('should exist', function() {
+                // basic, check it exists
+                expect(ab).toBeDefined();
             });
         
-            var tests = Object.keys(ab.getParticipations()).map(function(k){ return k; }).toString()
-            expect(tests).toBe('DummyTest,DummyTest2');
+        });
+
+        describe("User segmentation", function () {
+            
+            it('should not run if switch is off', function() {
+                ab.init({
+                    switches: {
+                        abDummyTest: false,
+                    }
+                });
+                expect(controlSpy.called || variantSpy.called).toBeFalsy();
+            });
+
+            it('should put all non-participating users in a "not in test" group', function() {
+                test.audience = 0;
+                ab.init({
+                    switches: {
+                        abDummyTest: true
+                    }
+                });
+                expect(controlSpy).not.toHaveBeenCalled();
+                var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
+                expect(storedParticipated.DummyTest.variant).toBe("notintest");
+            });
+            
+            it("should not segment user if test can't be run", function() {
+                test.canRun = function() { return false; }
+                ab.init({
+                    switches: {
+                        abDummyTest: true
+                    }
+                });
+                expect(controlSpy.called || variantSpy.called).toBeFalsy();
+                expect(ab.getParticipations()).toEqual([]);
+            });
+
+
+            it('should store all the tests user is in', function() {
+                var otherTest = new ABTest();
+                otherTest.id = 'DummyTest2';
+                ab.addTest(otherTest);
+
+                ab.init({
+                    switches: {
+                        abDummyTest: true,
+                        abDummyTest2: true,
+                    }
+                });
+                var storedParticipated = JSON.parse(localStorage.getItem(participationsKey)).value;
+                expect(storedParticipated.DummyTest.variant).not.toBeUndefined();
+                expect(storedParticipated.DummyTest2.variant).not.toBeUndefined();
+            });
+            
+            it('should get all the tests user is in', function() {
+                var otherTest = new ABTest();
+                otherTest.id = 'DummyTest2';
+                ab.addTest(otherTest);
+
+                ab.init({
+                    switches: {
+                        abDummyTest: true,
+                        abDummyTest2: true
+                    }
+                });
+            
+                var tests = Object.keys(ab.getParticipations()).map(function(k){ return k; }).toString()
+                expect(tests).toBe('DummyTest,DummyTest2');
+                
+            });
+            
+            it('should remove expired tests from being logged', function () {
+                localStorage.setItem(participationsKey, '{"value":{"DummyTest":{"variant":"null"}}}');
+                test.expiry = "2012-01-01";
+                ab.init({
+                    switches: {
+                        abDummyTest: true
+                    }
+                });
+                expect(localStorage.getItem(participationsKey)).toBe('{"value":{}}');
+            });
+
+        });
+    
+        describe("Running tests", function () {
+            
+            it('should be able to start test', function() {
+                ab.init({ switches: {'abDummyTest': true} }, document);
+                ab.run({ switches: {'abDummyTest': true} }, document);
+                expect(controlSpy.called || variantSpy.called).toBeTruthy();
+            });
+
+            it('should not run the test if the user has not been put in a segment', function () {
+                // Nb. no call to ab.init(...)
+                ab.run({ switches: { abDummyTest: true } });
+                expect(controlSpy.called || variantSpy.called).toBeFalsy();
+            });
+
+            it('should refuse to run the after the expiry date', function () {
+                test.expiry = "2012-01-01";
+                ab.init({
+                    switches: {
+                        abDummyTest: true
+                    }
+                });
+            });
+
+            it('should run the test if it has not expired', function () {
+                var futureDate = new Date();
+                futureDate.setHours(futureDate.getHours() + 10);
+                test.expiry = futureDate.toString();
+                ab.init({
+                    switches: {
+                        abDummyTest: true
+                    }
+                });
+                ab.run({ switches: { abDummyTest: true } });
+                expect(controlSpy.called || variantSpy.called).toBeTruthy();
+            });
             
         });
 
-        it('should not run if switch is off', function() {
-            ab.init({
-                switches: {
-                    abDummyTest: false,
-                }
+        describe("Analytics", function () {
+            
+            it('should add "data-link-test" tracking to body', function() {
+                ab.init({
+                    switches: {
+                        abDummyTest: true
+                    }
+                });
+                ab.run({ switches: {'abDummyTest': true} }, document);
+                expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide)$/);
             });
-            expect(controlSpy.called || variantSpy.called).toBeFalsy();
-        });
 
-        it('should add "data-link-test" tracking to body', function() {
-            ab.init({
-                switches: {
-                    abDummyTest: true
-                }
+            it('should concat "data-link-test" tracking when more than one test', function() {
+                var otherTest = new ABTest();
+                otherTest.id = 'DummyTest2';
+                ab.addTest(otherTest);
+                var s = {
+                    abDummyTest: true,
+                    abDummyTest2: true,
+                    }
+                ab.init({ switches: s });
+                ab.run({ switches: s }, document);
+                expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide), AB \| DummyTest2 test \| (control|hide)$/);
             });
-            ab.run({ switches: {'abDummyTest': true} }, document);
-            expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide)$/);
-        });
-
-        it('should concat "data-link-test" tracking when more than one test', function() {
-            var otherTest = new ABTest();
-            otherTest.id = 'DummyTest2';
-            ab.addTest(otherTest);
-            var s = {
-                abDummyTest: true,
-                abDummyTest2: true,
-                }
-            ab.init({ switches: s });
-            ab.run({ switches: s }, document);
-            expect(document.body.getAttribute('data-link-test')).toMatch(/^AB \| DummyTest test \| (control|hide), AB \| DummyTest2 test \| (control|hide)$/);
-        });
-
-        it("should not bucket user if test can't be run", function() {
-            test.canRun = function() { return false; }
-            ab.init({
-                switches: {
-                    abDummyTest: true
-                }
-            });
-            expect(controlSpy.called || variantSpy.called).toBeFalsy();
-            expect(ab.getParticipations()).toEqual([]);
-        });
+            
+            it('should generate a string for Omniture to tag the test(s) the user is in', function() {
+                Math.seedrandom('gu');
+                var otherTest = new ABTest()
+                  , conf = { switches: { abDummyTest: true, abDummyTest2: true }};
+                otherTest.id = 'DummyTest2';
+                otherTest.audience = 1; 
+                ab.addTest(otherTest);
+                ab.init(conf);
+                ab.run(conf, document);
+                expect(ab.makeOmnitureTag(conf, document)).toBe("AB | DummyTest | control,AB | DummyTest2 | control");
         
-        it('should not run the test if the user has not been put in a bucket', function () {
-            // Nb. no call to ab.init(...)
-            ab.run({ switches: { abDummyTest: true } });
-            expect(controlSpy.called || variantSpy.called).toBeFalsy();
-        });
-
-        it('should refuse to run the after the expiry date', function () {
-            test.expiry = "2012-01-01";
-            ab.init({
-                switches: {
-                    abDummyTest: true
-                }
             });
-        });
-
-        it('should run the test if it has not expired', function () {
-            var futureDate = new Date();
-            futureDate.setHours(futureDate.getHours() + 10);
-            test.expiry = futureDate.toString();
-            ab.init({
-                switches: {
-                    abDummyTest: true
-                }
+            
+            it('should not generate Omniture tags when a test can not be run', function() {
+                var otherTest = new ABTest()
+                  , conf = { switches: { abDummyTest: true, abDummyTest2: true }};
+                otherTest.id = 'DummyTest2';
+                otherTest.canRun = function() { return false; }
+                ab.addTest(otherTest);
+                ab.init(conf);
+                ab.run(conf, document);
+                expect(ab.makeOmnitureTag(conf, document)).toBe("AB | DummyTest | control");
             });
-            ab.run({ switches: { abDummyTest: true } });
-            expect(controlSpy.called || variantSpy.called).toBeTruthy();
-        });
         
-        it('should remove expired tests from being logged', function () {
-            localStorage.setItem(participationsKey, '{"value":{"DummyTest":{"variant":"null"}}}');
-            test.expiry = "2012-01-01";
-            ab.init({
-                switches: {
-                    abDummyTest: true
-                }
-            });
-            expect(localStorage.getItem(participationsKey)).toBe('{"value":{}}');
         });
 
     });

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -133,7 +133,7 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
                 expect(controlSpy.called || variantSpy.called).toBeFalsy();
             });
             
-            it('DOM should be able to start test', function() {
+            it('The current DOM context should be passed to the test variant functions', function() {
                 ab.segment(switches.test_one_on);
                 ab.run(switches.test_one_on, document.createElement('div'));
                 expect(test.one.variants[1].test.lastCall.args[0].nodeName).toBe('DIV');

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -132,6 +132,13 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
                 ab.run(switches.test_one_on);
                 expect(controlSpy.called || variantSpy.called).toBeFalsy();
             });
+            
+            it('DOM should be able to start test', function() {
+                ab.segment(switches.test_one_on);
+                ab.run(switches.test_one_on, document.createElement('div'));
+                expect(test.one.variants[1].test.lastCall.args[0].nodeName).toBe('DIV');
+            });
+
         });
 
         describe("Analytics", function () {

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,3 +1,4 @@
+
 This explains how to run an A/B test in frontend.
 
 We have a homebrewed AB testing framework running in the application. The data it collects is logged with both Ophan and Omniture.
@@ -59,19 +60,19 @@ define(['bonzo'], function (bonzo) {
         this.audience = 0.2;
         this.description = 'Hides related content block on article to see if increases click through on most popular';
         this.canRun = function(config) {
-          return (config.page && config.page.contentType === "Article" && document.querySelector('.js-related')) ? true : false;
+          return (config.page && config.page.contentType === "Article") ? true : false;
         };
         this.variants = [
             {
                 id: 'control',
-                test: function () {
+                test: function (context) { 
                    return true;
                 }
             },
             {
                 id: 'hide',
-                test: function () {
-                    bonzo(document.querySelector('.js-related')).hide();
+                test: function (context) {
+                    bonzo(context.querySelector('.js-related')).hide();
                 }
             }
         ];


### PR DESCRIPTION
Test framework is now a bit more robust. We've run an AA test to prove the data it collects is valid. This will help us determine the features that are performing well in the application. 

Main changes,
- The segmentation happens once in bootstraps/app
- The test execution happens on every page view (simulated by swipe or otherwise)
- Test Jasmine Spec files should also now be much clearer.
