### PR TITLE
Fixes video article styling at larger breakpoints

### DIFF
--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -1,38 +1,41 @@
 @(page: VideoPage)(implicit request: RequestHeader)
 
 @defining(page.video){ video =>
-    <div class="monocolumn-wrapper">
+    <div class="article-wrapper monocolumn-wrapper">
         <h2 class="article-zone type-1">
             <a class="zone-color" data-link-name="article section" href="/@LinkTo(video.section)">@Html(video.sectionName)</a>
         </h2>
     
-        <article id="article" class="article video @if(video.isLive){is-live}" itemprop="mainContentOfPage"
+        <article id="article" class="article article--video video @if(video.isLive){is-live}" itemprop="mainContentOfPage"
                  itemscope itemtype="@video.schemaType" role="main">
             
             <header class="article-head">
                 @fragments.dateline(video.webPublicationDate, video.isLive)
                 @fragments.headline(video.headline)
             </header>
-        
-            <div class="player">
-                <video controls="controls" poster="@video.imageOfWidth(640).map{ image => @image.path }.getOrElse("")">
-                    @video.encodings.map{ encoding =>
-                        <source src="@encoding.url" />
-                    }
-                    Your browser does not support the video tag.
-                </video>
-            </div>
 
-            <div class="gallery-byline">
-                @fragments.byline(video.byline, video)
-            </div>
-            <div class="video-standfirst">
-                @fragments.standfirst(video)
+            <div class="article__inner">
+        
+                <div class="player">
+                    <video controls="controls" poster="@video.imageOfWidth(640).map{ image => @image.path }.getOrElse("")">
+                        @video.encodings.map{ encoding =>
+                            <source src="@encoding.url" />
+                        }
+                        Your browser does not support the video tag.
+                    </video>
+                </div>
+
+                <div class="gallery-byline">
+                    @fragments.byline(video.byline, video)
+                </div>
+                <div class="video-standfirst">
+                    @fragments.standfirst(video)
+                </div>
+
+                @fragments.social(video)
             </div>
 
         </article>
-
-        @fragments.social(video)
     </div>
     @if(page.storyPackage.nonEmpty) {
         <aside role="complementary">

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -6,7 +6,7 @@
             <a class="zone-color" data-link-name="article section" href="/@LinkTo(video.section)">@Html(video.sectionName)</a>
         </h2>
     
-        <article id="article" class="article article--video video @if(video.isLive){is-live}" itemprop="mainContentOfPage"
+        <article id="article" class="article video @if(video.isLive){is-live}" itemprop="mainContentOfPage"
                  itemscope itemtype="@video.schemaType" role="main">
             
             <header class="article-head">

--- a/common/app/assets/stylesheets/module/_video.scss
+++ b/common/app/assets/stylesheets/module/_video.scss
@@ -18,7 +18,3 @@ video {
 .gallery-byline {
     margin-top: $baseline*4;
 }
-
-.video h1 {
-    margin-bottom: 0;
-}


### PR DESCRIPTION
This fixes some serious video template regressions caused by @kaelig's recent article layout and refactoring changes. 
## Before

![Broken](http://f.cl.ly/items/021V0n3f3S1R103C1B46/video-template.png)
## After

![Fixed](http://cl.ly/image/1Q1a3O0W2c1a/video_template_2.png)
