### PR TITLE
Get more accurate data from Fastly stats api

### DIFF
--- a/common/app/conf/UrlPagesHealthcheckManagementPage.scala
+++ b/common/app/conf/UrlPagesHealthcheckManagementPage.scala
@@ -12,11 +12,11 @@ import scala.concurrent.duration._
 
 class UrlPagesHealthcheckManagementPage(val urls: String*) extends ManagementPage with Logging with ExecutionContexts {
 
-  val path = "/management/healthcheck"
+  override val path = "/management/healthcheck"
 
   val base = "http://localhost:9000"
 
-  def get(req: HttpRequest) = {
+  override def get(req: HttpRequest) = {
     val checks = urls map { base + _ } map { url =>
       log.info(s"Healthcheck: Checking $url")
 

--- a/porter/app/controllers/IndexController.scala
+++ b/porter/app/controllers/IndexController.scala
@@ -3,5 +3,5 @@ package controllers
 import play.api.mvc.{ Action, Controller }
 
 object IndexController extends Controller {
-  def index() = Action { Ok("") }
+  def index() = Action { Ok("Ok") }
 }

--- a/porter/app/jobs/FastlyCloudwatchLoadJob.scala
+++ b/porter/app/jobs/FastlyCloudwatchLoadJob.scala
@@ -6,16 +6,19 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.collection.mutable
 import conf.Configuration
+import org.joda.time.DateTime
 
 class FastlyCloudwatchLoadJob extends Job {
-  val cron = "0 * * * * ?"
+  val cron = "0 0/2 * * * ?"
   val metric = PorterMetrics.FastlyCloudwatchLoadTimingMetric
 
   // Samples in CloudWatch are additive so we want to
   // limit duplicate reporting as much as reasonable.
   // We do not want to corrupt the past either.
+  // Choose a default value that accounts for the Fastly api query,
+  // which omits the most recent 15 minutes of results.
   val latestTimestampsSent = mutable.Map[(String, String), Long]().
-    withDefaultValue(System.currentTimeMillis)
+    withDefaultValue( DateTime.now().minusMinutes(15).getMillis() )
 
   def run() {
     log.info("Loading statistics from Fastly to CloudWatch.")

--- a/porter/app/services/Fastly.scala
+++ b/porter/app/services/Fastly.scala
@@ -21,7 +21,7 @@ case class FastlyStatistic(service: String, timestamp: Long, name: String, value
 object Fastly extends ExecutionContexts with Logging {
 
   def apply(): Future[List[FastlyStatistic]] = {
-    val response: Future[String] = WS.url("https://api.fastly.com/stats?by=minute&from=30+minutes+ago").withHeaders(
+    val response: Future[String] = WS.url("https://api.fastly.com/stats?by=minute&from=45+minutes+ago&to=15+minutes+ago").withHeaders(
       "Fastly-Key" -> PorterConfiguration.fastly.key
     ).get() map { _.body }
 


### PR DESCRIPTION
Move the query window of the Fastly api query to avoid incomplete blocks.
Set the default timestamps to reflect the new query window.
Reduce the fastly job frequency, and give a simple text reponse in the controller.
