### PR TITLE
Wrap scorecard link around feature switch

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,5 +1,5 @@
 @(article: Article, storyPackage: List[Trail])(implicit request: RequestHeader)
-@import conf.Switches.DiscussionSwitch
+@import conf.Switches._
 
 <div class="article-wrapper monocolumn-wrapper">
 
@@ -15,13 +15,15 @@
 
             @fragments.headline(article.headline)
 
-            @article.cricketMatch.map { id =>
-                <div class="after-headline">
-                    <a class="cta-small type-8 zone-color" href="@LinkTo{/sport@id}" data-link-name="view scorecard: @id"
-                        itemprop="significantLink" id="schema-WebPage">View full scorecard
-                        <i class="i i-sport-arrow-small"></i>
-                    </a>
-                </div>
+            @if(LiveCricketSwitch.isSwitchedOn) {
+                @article.cricketMatch.map { id =>
+                    <div class="after-headline">
+                        <a class="cta-small type-8 zone-color" href="@LinkTo{/sport@id}" data-link-name="view scorecard: @id"
+                            itemprop="significantLink" id="schema-WebPage">View full scorecard
+                            <i class="i i-sport-arrow-small"></i>
+                        </a>
+                    </div>
+                }
             }
 
             @fragments.standfirst(article)

--- a/common/app/assets/javascripts/modules/cricket.js
+++ b/common/app/assets/javascripts/modules/cricket.js
@@ -54,6 +54,10 @@ define(['common', 'bonzo', 'ajax'], function (common, bonzo, ajax) {
             return;
         }
 
+        if (!config.switches.liveCricket) {
+            return;
+        }
+
         var firstCricketBlock = bonzo(cricketElement);
 
         ajax({

--- a/sport/app/conf/context.scala
+++ b/sport/app/conf/context.scala
@@ -15,7 +15,9 @@ object Management extends GuManagement {
   lazy val pages = List(
     new ManifestPage,
     new UrlPagesHealthcheckManagementPage(
-      "/sport/cricket/match/34822"
+      //"/sport/cricket/match/34822",
+      // Failed healthcheck
+      "/sport/cricket"
     ),
     StatusPage(applicationName, metrics),
     new PropertiesPage(Configuration.toString),


### PR DESCRIPTION
Whilst the feed is down, the live cricket switch can be disabled, and the full scorecard link would be hidden.
