### PR TITLE
Feature diagnostics

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -56,7 +56,8 @@ define('bootstraps/app', [
             e.init();
             common.mediator.on("module:error", e.log);
         },
-        
+       
+       // RUM on features
        sendInTheCanary: function (config) {
             var c = new Canary({
                 isDev: config.page.isDev

--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -4,6 +4,7 @@ define('bootstraps/app', [
     "ajax",
     'modules/detect',
     'modules/errors',
+    'modules/analytics/canary',
     'modules/fonts',
     'modules/debug',
     "modules/router",
@@ -24,6 +25,7 @@ define('bootstraps/app', [
     ajax,
     detect,
     Errors,
+    Canary,
     Fonts,
     Debug,
     Router,
@@ -54,6 +56,13 @@ define('bootstraps/app', [
             e.init();
             common.mediator.on("module:error", e.log);
         },
+        
+       sendInTheCanary: function (config) {
+            var c = new Canary({
+                isDev: config.page.isDev
+            });
+            c.init();
+        },
     
         initialiseAbTest: function (config) {
             ab.segment(config);
@@ -82,6 +91,7 @@ define('bootstraps/app', [
             modules.initialiseAjax(config);
             modules.initialiseAbTest(config);
             modules.attachGlobalErrorHandler(config);
+            modules.sendInTheCanary(config);
             modules.loadFonts(config, navigator.userAgent);
             modules.showDebug();
 
@@ -132,7 +142,6 @@ define('bootstraps/app', [
             };
 
             common.mediator.on('page:ready', pageRoute);
-            
             common.mediator.emit('page:ready', config, context);
         });
     };

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -31,21 +31,27 @@ define(['common'], function (common) {
                 var url = makeUrl(feature);
                 createImage(url);
             },
+            evaluateClick = function(clickSpec) {
+                // https://github.com/guardian/frontend/pull/1237#issuecomment-21261022
+                [
+                    { 
+                        linkname: 'global navigation: header | sections',
+                        feature: 'navigation'
+                    }
+                ].forEach(function(spec) {
+                    if (clickSpec.toLowerCase().indexOf(spec.linkname) > -1) {
+                        log(spec.feature); 
+                    }
+                })
+            },
             init = function() {
                
                 if (Math.random() > sample) {
                     return false;
                 }
                 
-                // https://github.com/guardian/frontend/pull/1237#issuecomment-21261022
-
-                // navigation
                 common.mediator.on('module:clickstream:click', function (clickSpec) {
-                    
-                    if (clickSpec.toLowerCase().indexOf('global navigation: header | sections') > -1) {
-                        log('navigation');
-                    }
-
+                    evaluateClick(clickSpec);
                 });
 
             };

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -6,13 +6,14 @@ define(['common'], function (common) {
     // before affecting the miners. Signs of distress from the bird indicated to the miners that
     // conditions were unsafe.
 
-    // Our canary logs feature interactions to help quickly find broken features..
+    // Our canary logs feature interactions (clickstream) to help quickly find broken features.
     
     var Canary = function (config) {
 
         var c = config || {},
             isDev = (c.isDev !== undefined) ? c.isDev : false,
             url = "//beacon." + window.location.hostname,
+            sample = c.sample || 0.01, // only sample 1:100 requests (we are interested in % of drop, not absolute numbers)
             path = '/px.gif',
             cons = c.console || window.console,
             body = document.body,
@@ -31,12 +32,22 @@ define(['common'], function (common) {
                 createImage(url);
             },
             init = function() {
+               
+                if (Math.random() > sample) {
+                    return false;
+                }
+                
+                // https://github.com/guardian/frontend/pull/1237#issuecomment-21261022
+
                 // navigation
                 common.mediator.on('module:clickstream:click', function (clickSpec) {
+                    
                     if (clickSpec.toLowerCase().indexOf('global navigation: header | sections') > -1) {
                         log('navigation');
                     }
+
                 });
+
             };
 
         return {

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -23,7 +23,7 @@ define(['common'], function (common) {
                 body.appendChild(image);
             },
             makeUrl = function(feature) {
-                return url + path + '?' + 'feature/' + feature ;
+                return url + path + '?' + 'canary/' + feature ;
             },
             log = function(feature) {
                 var url = makeUrl(feature);

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -34,6 +34,7 @@ define(['common'], function (common) {
                 common.mediator.on('module:clickstream:click', function (clickSpec) {
                     if (clickSpec.toLowerCase().indexOf('global navigation: header | sections') > -1) {
                         log('navigation');
+                    }
                 });
             };
 

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -32,7 +32,7 @@ define(['common'], function (common) {
             },
             init = function() {
                 common.mediator.on('module:clickstream:click', function (clickSpec) {
-                    if (clickSpec.toLowerCase().indexOf('global navigation: header | sections') > -1)
+                    if (clickSpec.toLowerCase().indexOf('global navigation: header | sections') > -1) {
                         log('navigation');
                 });
             };

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -26,7 +26,6 @@ define(['common'], function (common) {
                 return url + path + '?' + 'feature/' + feature ;
             },
             log = function(feature) {
-                cons.log('canary ' + feature);
                 var url = makeUrl(feature);
                 createImage(url);
             },

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -5,6 +5,8 @@ define(['common'], function (common) {
     // such as carbon monoxide, methane or carbon dioxide in the mine would kill the bird
     // before affecting the miners. Signs of distress from the bird indicated to the miners that
     // conditions were unsafe.
+
+    // Our canary logs feature interactions to help quickly find broken features..
     
     var Canary = function (config) {
 
@@ -13,7 +15,6 @@ define(['common'], function (common) {
             url = "//beacon." + window.location.hostname,
             path = '/px.gif',
             cons = c.console || window.console,
-            win = c.window || window,
             body = document.body,
             createImage = function(url) {
                 var image = new Image();
@@ -30,6 +31,7 @@ define(['common'], function (common) {
                 createImage(url);
             },
             init = function() {
+                // navigation
                 common.mediator.on('module:clickstream:click', function (clickSpec) {
                     if (clickSpec.toLowerCase().indexOf('global navigation: header | sections') > -1) {
                         log('navigation');

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -15,7 +15,6 @@ define(['common'], function (common) {
             url = "//beacon." + window.location.hostname,
             sample = c.sample || 0.01, // only sample 1:100 requests (we are interested in % of drop, not absolute numbers)
             path = '/px.gif',
-            cons = c.console || window.console,
             body = document.body,
             createImage = function(url) {
                 var image = new Image();

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -1,0 +1,48 @@
+/*global Event:true */
+define(['common'], function (common) {
+
+    // Canaries were once regularly used in coal mining as an early warning system. Toxic gases
+    // such as carbon monoxide, methane or carbon dioxide in the mine would kill the bird
+    // before affecting the miners. Signs of distress from the bird indicated to the miners that
+    // conditions were unsafe.
+    
+    var Canary = function (config) {
+
+        var c = config || {},
+            isDev = (c.isDev !== undefined) ? c.isDev : false,
+            url = "//beacon." + window.location.hostname,
+            path = '/px.gif',
+            cons = c.console || window.console,
+            win = c.window || window,
+            body = document.body,
+            createImage = function(url) {
+                var image = new Image();
+                image.id = 'js-canary';
+                image.className = 'h';
+                image.src = url;
+                body.appendChild(image);
+            },
+            makeUrl = function(feature) {
+                return url + path + '?' + 'feature/' + feature ;
+            },
+            log = function(feature) {
+                cons.log('canary ' + feature);
+                var url = makeUrl(feature);
+                createImage(url);
+            },
+            init = function() {
+                common.mediator.on('module:clickstream:click', function (clickSpec) {
+                    if (clickSpec.toLowerCase().indexOf('global navigation: header | sections') > -1)
+                        log('navigation');
+                });
+            };
+
+        return {
+            log: log,
+            init: init
+        };
+
+    };
+
+    return Canary;
+});

--- a/common/app/assets/javascripts/modules/analytics/canary.js
+++ b/common/app/assets/javascripts/modules/analytics/canary.js
@@ -34,15 +34,15 @@ define(['common'], function (common) {
             evaluateClick = function(clickSpec) {
                 // https://github.com/guardian/frontend/pull/1237#issuecomment-21261022
                 [
-                    { 
+                    {
                         linkname: 'global navigation: header | sections',
                         feature: 'navigation'
                     }
                 ].forEach(function(spec) {
                     if (clickSpec.toLowerCase().indexOf(spec.linkname) > -1) {
-                        log(spec.feature); 
+                        log(spec.feature);
                     }
-                })
+                });
             },
             init = function() {
                

--- a/common/test/assets/javascripts/runner.html
+++ b/common/test/assets/javascripts/runner.html
@@ -138,6 +138,7 @@
         </li>
         <li><a href="#Ajax">Ajax</a></li>
         <li><a href="#Aware">Aware</a></li>
+        <li><a href="#Canary">Canary</a></li>
         <li><a href="#Common">Common</a></li>
         <li><a href="#Detect">Detect</a></li>
         <li><a href="#Errors">Errors</a></li>

--- a/common/test/assets/javascripts/spec/Canary.spec.js
+++ b/common/test/assets/javascripts/spec/Canary.spec.js
@@ -2,14 +2,18 @@ define(['common', 'bean', 'modules/analytics/canary'], function(common, bean, Ca
 
     describe("Canary", function() {
        
-        var e,
-            p = '/uk/2012/oct/15/mod-military-arms-firms',
-            w = {},
-            fakeError = { 'message': 'foo', lineno: 1, filename: 'foo.js' };
+        var w = {};
         
         it("should exist", function(){
-            e = new Canary({window: w});
-            expect(e).toBeDefined();
+            var c = new Canary({window: w});
+            expect(c).toBeDefined();
+        });
+        
+        it("should log interactions with features", function(){
+            var c = new Canary();
+            c.init();
+            common.mediator.emit('module:clickstream:click', 'Article | global navigation: header | sections | Culture')
+            expect(document.querySelector('#js-canary').getAttribute('src')).toContain('px.gif?canary/navigation');
         });
 
     })

--- a/common/test/assets/javascripts/spec/Canary.spec.js
+++ b/common/test/assets/javascripts/spec/Canary.spec.js
@@ -3,7 +3,11 @@ define(['common', 'bean', 'modules/analytics/canary'], function(common, bean, Ca
     describe("Canary", function() {
        
         var w = {};
-        
+       
+        beforeEach(function(){
+            console.log(common.$g('#js-canary').remove());
+        })
+
         it("should exist", function(){
             var c = new Canary({window: w});
             expect(c).toBeDefined();
@@ -20,7 +24,7 @@ define(['common', 'bean', 'modules/analytics/canary'], function(common, bean, Ca
             var c = new Canary({ sample: 1 });
             c.init();
             common.mediator.emit('module:clickstream:click', 'Unknown | clickstream | event')
-            expect(document.querySelectorAll('#js-canary').length).toBe(1);
+            expect(document.querySelectorAll('#js-canary').length).toBe(0);
         });
 
     })

--- a/common/test/assets/javascripts/spec/Canary.spec.js
+++ b/common/test/assets/javascripts/spec/Canary.spec.js
@@ -1,0 +1,16 @@
+define(['common', 'bean', 'modules/analytics/canary'], function(common, bean, Canary) {
+
+    describe("Canary", function() {
+       
+        var e,
+            p = '/uk/2012/oct/15/mod-military-arms-firms',
+            w = {},
+            fakeError = { 'message': 'foo', lineno: 1, filename: 'foo.js' };
+        
+        it("should exist", function(){
+            e = new Canary({window: w});
+            expect(e).toBeDefined();
+        });
+
+    })
+});

--- a/common/test/assets/javascripts/spec/Canary.spec.js
+++ b/common/test/assets/javascripts/spec/Canary.spec.js
@@ -9,11 +9,18 @@ define(['common', 'bean', 'modules/analytics/canary'], function(common, bean, Ca
             expect(c).toBeDefined();
         });
         
-        it("should log interactions with features", function(){
+        it("should log interactions with features we want to track", function(){
             var c = new Canary({ sample: 1 });
             c.init();
             common.mediator.emit('module:clickstream:click', 'Article | global navigation: header | sections | Culture')
             expect(document.querySelector('#js-canary').getAttribute('src')).toContain('px.gif?canary/navigation');
+        });
+        
+        it("should ignore interactions that we don't want to track", function(){
+            var c = new Canary({ sample: 1 });
+            c.init();
+            common.mediator.emit('module:clickstream:click', 'Unknown | clickstream | event')
+            expect(document.querySelectorAll('#js-canary').length).toBe(1);
         });
 
     })

--- a/common/test/assets/javascripts/spec/Canary.spec.js
+++ b/common/test/assets/javascripts/spec/Canary.spec.js
@@ -5,7 +5,7 @@ define(['common', 'bean', 'modules/analytics/canary'], function(common, bean, Ca
         var w = {};
        
         beforeEach(function(){
-            console.log(common.$g('#js-canary').remove());
+            common.$g('#js-canary').remove();
         })
 
         it("should exist", function(){

--- a/common/test/assets/javascripts/spec/Canary.spec.js
+++ b/common/test/assets/javascripts/spec/Canary.spec.js
@@ -10,7 +10,7 @@ define(['common', 'bean', 'modules/analytics/canary'], function(common, bean, Ca
         });
         
         it("should log interactions with features", function(){
-            var c = new Canary();
+            var c = new Canary({ sample: 1 });
             c.init();
             common.mediator.emit('module:clickstream:click', 'Article | global navigation: header | sections | Culture')
             expect(document.querySelector('#js-canary').getAttribute('src')).toContain('px.gif?canary/navigation');

--- a/diagnostics/app/metrics/NginxLog.scala
+++ b/diagnostics/app/metrics/NginxLog.scala
@@ -32,10 +32,10 @@ object NginxLog {
   }
 
   // handle feature healthchecks
-  object feature {
+  object canary {
     
-    val navigation = new CountMetric("diagnostics", "feature_navigation", "Interactions with navigation bar", "")
-    val other = new CountMetric("diagnostics", "feature_other", "Uncaught interactions", "")
+    val navigation = new CountMetric("diagnostics", "canary_navigation", "Interactions with navigation bar", "")
+    val other = new CountMetric("diagnostics", "canary_other", "Uncaught interactions", "")
     
     val metrics: Seq[Metric] = Seq(navigation)
 
@@ -99,7 +99,7 @@ object NginxLog {
   }
 
   // combine all the metrics
-  val metrics: Seq[Metric] = entry.metrics ++ js.metrics ++ ads.metrics ++ feature.metrics
+  val metrics: Seq[Metric] = entry.metrics ++ js.metrics ++ ads.metrics ++ canary.metrics
 
   Tailer.create(new File(Configuration.nginx.log), new TailerListenerAdapter() {
     override def handle(line: String) {
@@ -126,7 +126,7 @@ object NginxLog {
         namespace.getOrElse("unknown") match {
           case "js" => js(userAgent)
           case "ads" => ads()
-          case "feature" => feature(path)
+          case "canary" => canary(path)
           case _ => null
         }
 

--- a/diagnostics/app/metrics/NginxLog.scala
+++ b/diagnostics/app/metrics/NginxLog.scala
@@ -59,87 +59,34 @@ object NginxLog {
   object js {
 
     val total = new CountMetric("diagnostics", "js", "Total JavaScript non-advert errors", "", None)
-
-    /*  iOS */
-    val js_ios_6_mobilesafari = new CountMetric("diagnostics", "js_ios_6_safari", "iOS 6 Safari JS errors", "")
-    val js_ios_5_mobilesafari = new CountMetric("diagnostics", "js_ios_5_safari", "iOS 5 Safari JS errors", "")
-    val js_ios_4_and_lower_mobilesafari = new CountMetric("diagnostics", "js_ios_4_and_lower_safari", "iOS 4 and lower Safari JS errors", "")
-    val js_ios_x_chrome = new CountMetric("diagnostics", "js_ios_x_chrome", "iOS Chrome JS errors", "")
-    val js_ios_other = new CountMetric("diagnostics", "js_ios_other", "iOS other JS errors", "")
-
-    /*  Android */
-    val js_android_4_safari = new CountMetric("diagnostics", "js_android_4_safari", "Android 4 Safari JS errors", "")
-    val js_android_3_and_lower_safari = new CountMetric("diagnostics", "js_android_3_and_lower_safari", "Android 3 and lower Safari JS errors", "")
-    val js_android_other = new CountMetric("diagnostics", "js_android_other", "Android other errors", "")
-
-    /* Windows */
-    val js_windows_8_ie10 = new CountMetric("diagnostics", "js_windows_8_ie10", "Windows 8 IE 10 JS errors", "")
-    val js_windows_7_iemobile = new CountMetric("diagnostics", "js_windows_7_iemobile", "Windows 7 IE JS errors", "")
-    val js_windows_other = new CountMetric("diagnostics", "js_windows_other", "Windows other JS errors", "")
-
-    /* OSX */
-    val js_osx_safari = new CountMetric("diagnostics", "js_osx_safari", "OSX Safari JS errors", "")
-    val js_osx_other = new CountMetric("diagnostics", "js_osx_other", "OSX other JS errors", "")
-
-    /* RIM, Symbian, Linux, Other */
+    val js_ios = new CountMetric("diagnostics", "js_ios", "iOS JS errors", "")
+    val js_android = new CountMetric("diagnostics", "js_android", "Android JS errors", "")
+    val js_windows = new CountMetric("diagnostics", "js_windows", "Windows JS errors", "")
+    val js_osx = new CountMetric("diagnostics", "js_osx", "OSX JS errors", "")
     val js_rimos = new CountMetric("diagnostics", "js_rimos", "RIMOS JS errors", "")
     val js_linux = new CountMetric("diagnostics", "js_linux", "Linux JS errors", "")
     val js_symbianos = new CountMetric("diagnostics", "js_symbianos", "SymbianOS JS errors", "")
     val js_other = new CountMetric("diagnostics", "js_other", "JS errors other agents", "")
 
-    val metrics: Seq[Metric] = Seq(total,
-      js_ios_6_mobilesafari, js_ios_5_mobilesafari, js_ios_4_and_lower_mobilesafari, js_ios_x_chrome, js_ios_other,
-      js_android_4_safari, js_android_3_and_lower_safari, js_android_other,
-      js_windows_7_iemobile, js_windows_other, js_windows_8_ie10,
-      js_osx_safari, js_osx_other,
-      js_rimos, js_linux, js_symbianos, js_other
-    )
+    val metrics: Seq[Metric] = Seq(total, js_ios, js_android, js_windows, js_osx, js_rimos, js_linux, js_symbianos, js_other)
 
     def apply(userAgent: String) {
+
       total.recordCount(1)
 
       val ua = agent.parse(userAgent)
       val os = ua.getOperatingSystem
-
-      val uaFamily = ua.getFamily.getName.replaceAll(" ", "")
       val osFamily = os.getFamilyName.replaceAll(" ", "")
-      val osVersion = os.getVersionNumber.getMajor
 
-      val key = Array(osFamily.toLowerCase, osVersion, uaFamily.toLowerCase).mkString("_")
+      println(osFamily)
 
       osFamily.toLowerCase match {
 
-        case "ios" => key match {
-          case "ios_6_mobilesafari" => js_ios_6_mobilesafari.recordCount(1)
-          case "ios_5_mobilesafari" => js_ios_5_mobilesafari.recordCount(1)
-          case "ios_4_mobilesafari" | "ios_3_mobilesafari" => js_ios_4_and_lower_mobilesafari.recordCount(1)
-          case "ios_5_chromemobile" | "ios_6_chromemobile" => js_ios_x_chrome.recordCount(1)
-          case _ => js_ios_other.recordCount(1)
-        }
-
-        case "android" => key match {
-          case "android_4_safari" | "android_4_androidwebkit" => js_android_4_safari.recordCount(1)
-          case "android_3_safari" | "android_2_safari" | "android_2_androidwebkit" => js_android_3_and_lower_safari.recordCount(1)
-          case _ => js_android_other.recordCount(1)
-        }
-
-        case "windows" => key match {
-          case "windows_7_iemobile" => js_windows_7_iemobile.recordCount(1)
-          case _ => {
-            if (userAgent contains "MSIE 10.0; Windows Phone 8.0") {
-              js_windows_8_ie10.recordCount(1)
-            } else {
-              js_windows_other.recordCount(1)
-            }
-          }
-        }
-
-        case "osx" => key match {
-          case "osx_10_safari" => js_osx_safari.recordCount(1)
-          case _ => js_osx_other.recordCount(1)
-        }
-
+        case "ios" => js_ios.recordCount(1)
+        case "android" => js_android.recordCount(1)
+        case "windows" => js_windows.recordCount(1)
         case "rimos" => js_rimos.recordCount(1)
+        case "osx" => js_osx.recordCount(1)
         case "symbianos" => js_symbianos.recordCount(1)
         case "linux" => js_linux.recordCount(1)
         case _ => js_other.recordCount(1)

--- a/diagnostics/app/metrics/NginxLog.scala
+++ b/diagnostics/app/metrics/NginxLog.scala
@@ -31,19 +31,6 @@ object NginxLog {
     }
   }
 
-  // handle _fonts_ namespaced errors
-  object fonts {
-
-    println("- fonts -")
-
-    val total = new CountMetric("diagnostics", "fonts", "Font render time warnings", "")
-    val metrics: Seq[Metric] = Seq(total)
-
-    def apply() {
-      total.recordCount(1)
-    }
-  }
-  
   // handle feature healthchecks
   object feature {
     
@@ -161,7 +148,7 @@ object NginxLog {
   }
 
   // combine all the metrics
-  val metrics: Seq[Metric] = entry.metrics ++ js.metrics ++ fonts.metrics ++ ads.metrics ++ feature.metrics
+  val metrics: Seq[Metric] = entry.metrics ++ js.metrics ++ ads.metrics ++ feature.metrics
 
   Tailer.create(new File(Configuration.nginx.log), new TailerListenerAdapter() {
     override def handle(line: String) {
@@ -190,7 +177,6 @@ object NginxLog {
         
         // handle individual errors
         namespace.getOrElse("unknown") match {
-          case "fonts" => fonts()
           case "js" => js(userAgent)
           case "ads" => ads()
           case "feature" => feature()


### PR DESCRIPTION
Experimental.

Sometime we break key features on the website, and sometimes there's a perception that something is broken when it is not - Eg, we break a minor function that has little bearing on usage. The latter problem can create greater volumes of upset than it needs to.

To help cut the wheat from the chaff I propose this.

For each feature we build we should identify the key thing it does and sample some usage statistics of that key thing on to the diagnostic box. When the graph flatlines it means we've broken something. When talking about a _problem_ in retrospect we can look at the graph to decide if it had an impact on our users.

Eg, for the 'video' feature the critical thing is the ability to play it.
