### PR TITLE
Added 'zone-uk' back into zones css to defend against old content

### DIFF
--- a/common/app/assets/stylesheets/theme/_zones.scss
+++ b/common/app/assets/stylesheets/theme/_zones.scss
@@ -43,6 +43,7 @@
 .zone-technology .zone-color,
 .zone-society .zone-color,
 .zone-politics .zone-color,
+.zone-uk .zone-color,
 .zone-uk-news .zone-color,
 .zone-media .zone-color,
 .zone-world .zone-color {
@@ -99,6 +100,7 @@
 .zone-technology .zone-background,
 .zone-society .zone-background,
 .zone-politics .zone-background,
+.zone-uk .zone-background,
 .zone-uk-news .zone-background,
 .zone-media .zone-background,
 .zone-world .zone-background {
@@ -156,6 +158,7 @@
 .zone-technology .zone-border,
 .zone-society .zone-border,
 .zone-politics .zone-border,
+.zone-uk .zone-border,
 .zone-uk-news .zone-border,
 .zone-media .zone-border,
 .zone-world .zone-border {


### PR DESCRIPTION
Some old tag content still have zone of 'uk' not 'uk-news' therefore we need to defend against this in the css to prevent styling issues.
### Before

![Before](http://cl.ly/image/3G0P0N2t1q33/before.jpg)
### After

![After](http://cl.ly/image/0v1Z1H0k0G3s/after.jpg)
