### PR TITLE
Changes to Omnituire tracking for www.theguardian.com

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -90,9 +90,15 @@ define([
         this.populatePageProperties = function() {
 
             // http://www.scribd.com/doc/42029685/15/cookieDomainPeriods
-            s.cookieDomainPeriods = config.page.edition === "US" ? "2" : "3";
 
-            s.linkInternalFilters += ',localhost,gucode.co.uk,gucode.com,guardiannews.com,int.gnl,proxylocal.com';
+            //TODO temporary till after theguardian.com
+            if(config.page.isDotcom){
+                s.cookieDomainPeriods = "2";
+            } else {
+                s.cookieDomainPeriods = config.page.edition === "US" ? "2" : "3";
+            }
+
+            s.linkInternalFilters += ',localhost,gucode.co.uk,gucode.com,guardiannews.com,int.gnl,proxylocal.com,theguardian.com';
 
             //TODO temporary till after dotcom switch
             // then make this permanent in the omniture vendor file

--- a/common/app/public/javascripts/vendor/omniture.js
+++ b/common/app/public/javascripts/vendor/omniture.js
@@ -32,7 +32,7 @@ function s_doPlugins(s) {
 //    s.prop62 = "Mdot Guardian H.25.3 v1 20130122";
 
     /* URL */
-//    s.prop61 = "D=g";
+    s.prop61 = "D=g";
 
     /* Set Page View Event */
 //    s.events=s.apl(s.events,'event4',',',2);

--- a/common/test/assets/javascripts/spec/Analytics.spec.js
+++ b/common/test/assets/javascripts/spec/Analytics.spec.js
@@ -52,7 +52,7 @@ define(['analytics'], function(Analytics) {
             new Analytics().setup(config, detect, s);
 
             //then all omniture properties should be set
-            expect(s.linkInternalFilters).toBe("guardian.co.uk,guardiannews.co.uk,localhost,gucode.co.uk,gucode.com,guardiannews.com");
+            expect(s.linkInternalFilters).toBe("guardian.co.uk,guardiannews.co.uk,localhost,gucode.co.uk,gucode.com,guardiannews.com,theguardian.com");
 
             expect(s.pageName).toBe("a really long title a really long title a really long title a really lon:Article:12345");
 

--- a/common/test/assets/javascripts/spec/Omniture.spec.js
+++ b/common/test/assets/javascripts/spec/Omniture.spec.js
@@ -68,7 +68,7 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
             var o = new Omniture(s, w);
             o.go(config);
 
-            expect(s.linkInternalFilters).toBe("guardian.co.uk,guardiannews.co.uk,localhost,gucode.co.uk,gucode.com,guardiannews.com,int.gnl,proxylocal.com");
+            expect(s.linkInternalFilters).toBe("guardian.co.uk,guardiannews.co.uk,localhost,gucode.co.uk,gucode.com,guardiannews.com,int.gnl,proxylocal.com,theguardian.com");
             expect(s.pageName).toBe("GFE:theworld:a-really-long-title-a-really-long-title-a-really-long-title-a-really-long");
             expect(s.prop9).toBe("Article");
             expect(s.channel).toBe("theworld");
@@ -105,6 +105,7 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
 
             expect(s.trackingServer).toBe('hits.theguardian.com');
             expect(s.trackingServerSecure).toBe('hits-secure.theguardian.com');
+            expect(s.cookieDomainPeriods).toBe('2');
 
         });
 


### PR DESCRIPTION
Track the URL we are on - prop 61
Correct 'cookieDomainPeriods' for www.theguardian.com'
Add hteguardian.com to 'linkInternalFilters'
