### PR TITLE
Add witness embeds back into white list of elements

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -233,7 +233,8 @@ object InBodyElementCleaner extends HtmlCleaner {
     "element-tweet",
     "element-video",
     "element-image",
-    "element-witness"
+    "element-witness",
+    "element-comment"
   )
 
   override def clean(document: Document): Document = {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -232,7 +232,8 @@ object InBodyElementCleaner extends HtmlCleaner {
   private val supportedElements = Seq(
     "element-tweet",
     "element-video",
-    "element-image"
+    "element-image",
+    "element-witness"
   )
 
   override def clean(document: Document): Document = {


### PR DESCRIPTION
We forgot to include witness and comments in our whitelist of supported embeds.
