### PR TITLE
Paragraph spacing for userzoom test

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -229,6 +229,24 @@ define([
 
         },
 
+        // Temporary - for a user zoom survey
+        paragraphSpacing: function () {
+            common.mediator.on('page:common:ready', function(config, context) {
+                var typographyPrefs = userPrefs.get('paragraphSpacing');
+                switch (typographyPrefs) {
+                    case 'none':
+                        common.$g('body').addClass('test-paragraph-spacing--no-spacing');
+                        break;
+                    case 'indents':
+                        common.$g('body').addClass('test-paragraph-spacing--no-spacing-indents');
+                        break;
+                    case 'more':
+                        common.$g('body').addClass('test-paragraph-spacing--more-spacing');
+                        break;
+                }
+            });
+        },
+
         loadAdverts: function () {
             if (!userPrefs.isOff('adverts')){
                 common.mediator.on('page:common:deferred:loaded', function(config, context) {
@@ -319,6 +337,7 @@ define([
             modules.initSwipe(config);
             modules.transcludeCommentCounts();
             modules.initLightboxGalleries();
+            modules.paragraphSpacing();
         }
         common.mediator.emit("page:common:ready", config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -231,8 +231,9 @@ define([
 
         // Temporary - for a user zoom survey
         paragraphSpacing: function () {
+            var key = 'paragraphSpacing';
             common.mediator.on('page:common:ready', function(config, context) {
-                var typographyPrefs = userPrefs.get('paragraphSpacing');
+                var typographyPrefs = userPrefs.get(key);
                 switch (typographyPrefs) {
                     case 'none':
                         common.$g('body').addClass('test-paragraph-spacing--no-spacing');
@@ -242,6 +243,9 @@ define([
                         break;
                     case 'more':
                         common.$g('body').addClass('test-paragraph-spacing--more-spacing');
+                        break;
+                    case 'clear':
+                        userPrefs.remove(key);
                         break;
                 }
             });


### PR DESCRIPTION
Temporary user preference for a userzoom study.

Control it like this,
- http://localhost:9000/world/2013/jul/19/g20-report-warns-global-tax-chaos#gu.prefs.paragraphSpacing=none
- http://localhost:9000/world/2013/jul/19/g20-report-warns-global-tax-chaos#gu.prefs.paragraphSpacing=indents
- http://localhost:9000/world/2013/jul/19/g20-report-warns-global-tax-chaos#gu.prefs.paragraphSpacing=more
