### PR TITLE
Fix swipe back button functionality

### DIFF
--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -206,8 +206,7 @@ define(['modules/userPrefs'], function (userPrefs) {
         os = getMobileOS();
         // iOS
         if (os.name === 'iOS' && os.version >= 6) {
-            // This'll be true only for iPhone5:
-            return window.devicePixelRatio >= 2 && screen.availHeight === 548;
+            return true;
         }
         /*
         // Android

--- a/common/app/assets/javascripts/modules/gallery.js
+++ b/common/app/assets/javascripts/modules/gallery.js
@@ -110,13 +110,35 @@ define(["bean", "swipe", "common", "modules/detect", "modules/url", "bonzo"], fu
 
                 }
 
-                // this means the user used the back/forward buttons
-                // so we should change gallery state to match
-                window.onpopstate = function(event) {
-                    if (event.state && event.state.index && (event.state.index !== view.galleryConfig.currentIndex)) {
-                        window.location.reload();
-                    }
-                };
+                if(!detect.canSwipe()) {
+                    // this means the user used the back/forward buttons
+                    // so we should change gallery state to match
+                    window.onpopstate = function(event) {
+                        if (event.state && event.state.index && (event.state.index !== view.galleryConfig.currentIndex)) {
+
+                            // if it's swipe we need to animate the slider
+                            // so first we work out which direction to move in
+                            if (view.galleryConfig.inSwipeMode) {
+
+                                var currentSlide = context.getElementsByClassName(view.galleryConfig.currentSlideClassName)[0];
+                                var currentIndex = parseInt(currentSlide.getAttribute('data-index'), 10);
+
+                                // we don't need to manually update URLs as popstate does it for us
+                                view.galleryConfig.stopUpdatingURL = true;
+
+                                if (currentIndex <= event.state.index) {
+                                    view.galleryConfig.gallerySwipe.next();
+                                } else {
+                                    view.galleryConfig.gallerySwipe.prev();
+                                }
+
+                            } else {
+                                // in non-touch mode, so just move to a specific slide
+                                view.advanceGallery(null, event.state.index);
+                            }
+                        }
+                    };
+                }
 
             },
 
@@ -181,7 +203,7 @@ define(["bean", "swipe", "common", "modules/detect", "modules/url", "bonzo"], fu
                 // we don't need to do this when using customItemIndexToShow
                 // as popState does this for us
                 if (!customItemIndexToShow) {
-                    if (!view.galleryConfig.stopUpdatingURL) {
+                    if (!view.galleryConfig.stopUpdatingURL && !detect.canSwipe()) {
                         view.updateURL('index=' + newSlideIndex, newSlideIndex);
                     } else {
                         // reset this so other things can update URLs

--- a/common/app/assets/javascripts/modules/gallery.js
+++ b/common/app/assets/javascripts/modules/gallery.js
@@ -114,27 +114,7 @@ define(["bean", "swipe", "common", "modules/detect", "modules/url", "bonzo"], fu
                 // so we should change gallery state to match
                 window.onpopstate = function(event) {
                     if (event.state && event.state.index && (event.state.index !== view.galleryConfig.currentIndex)) {
-
-                        // if it's swipe we need to animate the slider
-                        // so first we work out which direction to move in
-                        if (view.galleryConfig.inSwipeMode) {
-
-                            var currentSlide = context.getElementsByClassName(view.galleryConfig.currentSlideClassName)[0];
-                            var currentIndex = parseInt(currentSlide.getAttribute('data-index'), 10);
-
-                            // we don't need to manually update URLs as popstate does it for us
-                            view.galleryConfig.stopUpdatingURL = true;
-
-                            if (currentIndex <= event.state.index) {
-                                view.galleryConfig.gallerySwipe.next();
-                            } else {
-                                view.galleryConfig.gallerySwipe.prev();
-                            }
-
-                        } else {
-                            // in non-touch mode, so just move to a specific slide
-                            view.advanceGallery(null, event.state.index);
-                        }
+                        window.location.reload();
                     }
                 };
 

--- a/common/app/assets/javascripts/modules/swipenav.js
+++ b/common/app/assets/javascripts/modules/swipenav.js
@@ -175,7 +175,7 @@ define([
 
         if (initiatedBy === 'initial') {
             loadSidePanes();
-            urls.pushUrl({}, document.title, window.location.href);
+            urls.pushUrl({title: document.title}, document.title, window.location.href, true);
             return;
         }
 
@@ -195,15 +195,15 @@ define([
         // Update canonical tag using pushed location
         canonicalLink.attr('href', window.location.href);
 
-        if (!noHistoryPush) {
-            urls.pushUrl({}, document.title, url);
+        //Push state change to history
+        if(referrer.indexOf(url) === -1) {
+            urls.pushUrl({title: document.title}, document.title, url);
         }
-        noHistoryPush = false;
 
         config.swipe = {
             initiatedBy: initiatedBy,
             referrer: referrer,
-            referrerPageName: referrerPageName,
+            referrerPageName: referrerPageName
         };
 
         common.mediator.emit('page:ready', pageConfig(config), context);
@@ -287,7 +287,6 @@ define([
                             sequenceCache[s.url] = s;
                             sequence.push(s);
                             sequenceLen += 1;
-                            //window.console.log(i + " " + s.url);
                         }
                     }
                     setSequencePos(window.location.pathname);
@@ -523,22 +522,9 @@ define([
 
         // Bind back/forward button behavior
         window.onpopstate = function (event) {
-            var state = event.state,
-                popId,
-                dir;
-
             // Ignore inital popstate that some browsers fire on page load
-            if (!state || initiatedBy === 'initial') { return; }
-
-            initiatedBy = 'browser_history';
-
-            // Prevent a history state from being pushed as a result of calling gotoUrl
-            noHistoryPush = true;
-
-            // Reveal the newly poped location, if new
-            if(referrer !== window.location.href) {
-                gotoUrl(urlAbsPath(window.location.href));
-            }
+            if (!event.state && !event.state.title) { return; }
+            window.location.reload();
         };
 
         // Set a periodic height adjustment for the content area. Necessary to account for diverse heights of side-panes as they slide in, and dynamic page elements.

--- a/common/app/assets/javascripts/modules/swipenav.js
+++ b/common/app/assets/javascripts/modules/swipenav.js
@@ -30,7 +30,6 @@ define([
         initiatedBy = 'initial',
         initialUrl,
         linkContext,
-        noHistoryPush = false,
         panes,
         paneNow = 1,
         paneThen = 1,
@@ -234,7 +233,7 @@ define([
         return pos > -1 && pos < sequenceLen ? sequence[pos].url : sequence[0].url;
     }
 
-    function loadSequence(callback) {
+    function loadSequence(config, callback) {
         var sequenceUrl = linkContext;
 
         if (sequenceUrl) {
@@ -248,9 +247,9 @@ define([
                 sequenceUrl = '/' + sequenceUrl;
                 storage.remove(storePrefix + 'linkContext');
             } else {
-                // No data-link-context, so infer the section from current url
-                sequenceUrl = window.location.pathname.match(/^\/([^\/]+)/);
-                sequenceUrl = '/front-trails' + (sequenceUrl ? '/' + sequenceUrl[1] : '');
+                // No data-link-context, so infer the section from page config
+                sequenceUrl = (config.page && config.page.section) ? config.page.section : null;
+                sequenceUrl = '/front-trails' + (sequenceUrl ? '/' + sequenceUrl : '');
             }
         }
 
@@ -534,7 +533,7 @@ define([
     }
 
     var initialise = function(config) {
-        loadSequence(function(){
+        loadSequence(config, function(){
             var loc = window.location.href;
 
             initialUrl       = urlAbsPath(loc);


### PR DESCRIPTION
This fixes the back button functionality when swipe is turned on by not doing any fancy state management and simple reloading the window the traditional way.

Also a quick fix for sequencing on editionalised fronts in preperation for theguardian.com
