### PR TITLE
Add Fastly metric graphs to admin

### DIFF
--- a/admin/app/controllers/metrics/FastlyController.scala
+++ b/admin/app/controllers/metrics/FastlyController.scala
@@ -1,0 +1,12 @@
+package controllers.metrics
+
+import play.api.mvc.Controller
+import controllers.{AuthAction, AuthLogging}
+import common.Logging
+import tools.CloudWatch
+
+object FastlyController extends Controller with Logging with AuthLogging {
+  def render() = AuthAction{ request =>
+      Ok(views.html.fastly("PROD", CloudWatch.fastlyStatistics))
+  }
+}

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -4,6 +4,8 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
 import conf.Configuration
 import com.amazonaws.services.cloudwatch.model._
 import org.joda.time.DateTime
+import com.amazonaws.handlers.AsyncHandler
+import common.Logging
 
 
 trait CloudWatch {
@@ -15,6 +17,17 @@ trait CloudWatch {
     "frontend-Applicat-V36EHVHAEI15" -> "Applications"
   )
 
+  private val fastlyMetrics = List(
+    ("Fastly Errors (Europe)", "errors", "europe", "2eYr6Wx3ZCUoVPShlCM61l"),
+    ("Fastly 5xx (Europe)", "status_5xx", "europe", "2eYr6Wx3ZCUoVPShlCM61l"),
+    ("Fastly Hits (Europe)", "hits", "europe", "2eYr6Wx3ZCUoVPShlCM61l"),
+    ("Fastly Misses (Europe)", "miss", "europe", "2eYr6Wx3ZCUoVPShlCM61l"),
+    ("Fastly Errors (USA)", "errors", "usa", "2eYr6Wx3ZCUoVPShlCM61l"),
+    ("Fastly 5xx (USA)", "status_5xx", "usa", "2eYr6Wx3ZCUoVPShlCM61l"),
+    ("Fastly Hits (USA)", "hits", "usa", "2eYr6Wx3ZCUoVPShlCM61l"),
+    ("Fastly Misses (USA)", "miss", "usa", "2eYr6Wx3ZCUoVPShlCM61l")
+  )
+
   lazy val cloudClient = {
     val c = new AmazonCloudWatchAsyncClient(Configuration.aws.credentials)
     c.setEndpoint("monitoring.eu-west-1.amazonaws.com")
@@ -24,14 +37,15 @@ trait CloudWatch {
   def latency = loadBalancers.map{ case (loadBalancer, name) =>
     new LatencyGraph(name ,
       cloudClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
-      .withStartTime(new DateTime().minusHours(2).toDate)
-      .withEndTime(new DateTime().toDate)
-      .withPeriod(60)
-      .withUnit(StandardUnit.Seconds)
-      .withStatistics("Average")
-      .withNamespace("AWS/ELB")
-      .withMetricName("Latency")
-      .withDimensions(new Dimension().withName("LoadBalancerName").withValue(loadBalancer)))
+        .withStartTime(new DateTime().minusHours(2).toDate)
+        .withEndTime(new DateTime().toDate)
+        .withPeriod(60)
+        .withUnit(StandardUnit.Seconds)
+        .withStatistics("Average")
+        .withNamespace("AWS/ELB")
+        .withMetricName("Latency")
+        .withDimensions(new Dimension().withName("LoadBalancerName").withValue(loadBalancer)),
+        asyncHandler)
     )
   }.toSeq
 
@@ -44,9 +58,36 @@ trait CloudWatch {
         .withStatistics("Sum")
         .withNamespace("AWS/ELB")
         .withMetricName("HTTPCode_Backend_2XX")
-        .withDimensions(new Dimension().withName("LoadBalancerName").withValue(loadBalancer)))
+        .withDimensions(new Dimension().withName("LoadBalancerName").withValue(loadBalancer)),
+        asyncHandler)
     )
   }.toSeq
+
+  def fastlyStatistics = fastlyMetrics.map{ case (graphTitle, metric, region, service) =>
+    new FastlyMetricGraph( graphTitle, metric,
+      cloudClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+        .withStartTime(new DateTime().minusHours(6).toDate)
+        .withEndTime(new DateTime().toDate)
+        .withPeriod(120)
+        .withStatistics("Average")
+        .withNamespace("Fastly")
+        .withMetricName(metric)
+        .withDimensions(new Dimension().withName("region").withValue(region),
+                        new Dimension().withName("service").withValue(service)),
+        asyncHandler)
+    )
+  }.toSeq
+
+  object asyncHandler extends AsyncHandler[GetMetricStatisticsRequest, GetMetricStatisticsResult] with Logging
+  {
+    def onError(exception: Exception)
+    {
+      log.info(s"CloudWatch GetMetricStatisticsRequest error: ${exception.getMessage}}")
+    }
+    def onSuccess(request: GetMetricStatisticsRequest, result: GetMetricStatisticsResult )
+    {
+    }
+  }
 }
 
 object CloudWatch extends CloudWatch

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -200,3 +200,19 @@ object ActiveUserProportionGraph extends Chart with implicits.Tuples with implic
     }
   }
 }
+
+case class FastlyMetricGraph(
+  name: String,
+  private val metric: String,
+  private val metricResults: Future[GetMetricStatisticsResult]) extends Chart {
+
+  override lazy val labels = Seq("Time", metric)
+
+  override lazy val yAxis = Some(metric)
+
+  private lazy val datapoints = metricResults.get().getDatapoints.sortBy(_.getTimestamp.getTime).toSeq
+
+  override lazy val dataset = datapoints.map(d => DataPoint(
+    new DateTime(d.getTimestamp.getTime).toString("HH:mm"), Seq(d.getAverage))
+  )
+}

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -30,6 +30,7 @@
         <p class="muted">Ops metrics (is the site healthy?)</p>
         <ul>
             <li><a href="@controllers.metrics.routes.DashboardController.render()">Load Balancers</a></li>
+            <li><a href="@controllers.metrics.routes.FastlyController.render()">Fastly</a></li>
         </ul>
     </div>
 }

--- a/admin/app/views/fastly.scala.html
+++ b/admin/app/views/fastly.scala.html
@@ -1,0 +1,24 @@
+@(env: String, charts: Seq[tools.Chart])
+
+@admin_main("Fastly Metrics", env, isAuthed = true) {
+
+<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+<script type="text/javascript">
+    google.load("visualization", "1", {packages:["corechart"]});
+    google.setOnLoadCallback(drawCharts);
+
+    function drawCharts() {
+    @charts.map{ chart =>
+            new google.visualization.LineChart(document.getElementById('@chart.id'))
+                    .draw(google.visualization.arrayToDataTable(@Html(chart.asDataset)), {
+                title: '@chart.name',
+                        legend: 'none' @chart.yAxis.map{ title =>, vAxis: {title: "@title"} }
+            });
+        }
+    }
+</script>
+
+
+@charts.map{ chart => <div id="@chart.id" style="max-width: 900px"></div> }
+
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -77,10 +77,10 @@ POST      /fronts/api/:edition/:section/:block           controllers.FrontsContr
 POST      /fronts/api/:edition/:section/:block/*trail    controllers.FrontsController.updateTrail(edition, section, block, trail)
 DELETE    /fronts/api/:edition/:section/:block/*trail    controllers.FrontsController.deleteTrail(edition, section, block, trail)
 
-
 # Analytics
 GET     /analytics/kpis                  controllers.AnalyticsController.kpis()
 GET     /analytics/pageviews             controllers.AnalyticsController.pageviews()
 
 # Metrics
 GET     /metrics/loadbalancers           controllers.metrics.DashboardController.render()
+GET     /metrics/fastly                  controllers.metrics.FastlyController.render()


### PR DESCRIPTION
Collects Fastly api outputs from cloudwatch to the admin dashboard for europe and usa regions.
