### PR TITLE
Fix bug with gallery count with swipe

### DIFF
--- a/common/app/assets/javascripts/modules/gallery.js
+++ b/common/app/assets/javascripts/modules/gallery.js
@@ -21,6 +21,9 @@ define(["bean", "swipe", "common", "modules/detect", "modules/url", "bonzo"], fu
             // runs on domready
             bindGallery: function () {
 
+                //Reset counter
+                context.querySelector('.js-gallery-index').innerHTML = urlParams.index || 1;
+
                 if (detect.hasTouchScreen()) { // only enable swiping for touch devices, duh.
 
                     view.galleryConfig.inSwipeMode = true;


### PR DESCRIPTION
Fixes issue noticed by @kaelig with gallery counter displaying incorrect count after swiping back to page.
