### PR TITLE
A beta logo for tablet viewports and above

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -228,6 +228,19 @@ define([
             });
 
         },
+        
+        betaMessage: function () {
+            var isBeta = /#beta/.test(window.location.hash);
+            if (isBeta) {
+                bonzo(bonzo.create('<div class="message" id="message">Visit <a href="#" id="beta-pref">beta</a> or <a href="#" id="desktop-pref">desktop</a></div>')).insertBefore(common.$g('#preload-1 .parts__head'));
+            
+                /* TODO 
+                 *  - Is user over a certain screen size? 1024px
+                 *  - Attach a cookie write opertion to the desktop & mobile users
+                 *  - Attach a full reload to the desktop, sans the querystring & hash
+                 * */
+            }
+        },
 
         // Temporary - for a user zoom survey
         paragraphSpacing: function () {
@@ -342,6 +355,7 @@ define([
             modules.transcludeCommentCounts();
             modules.initLightboxGalleries();
             modules.paragraphSpacing();
+            modules.betaMessage();
         }
         common.mediator.emit("page:common:ready", config, context);
     };

--- a/common/app/assets/stylesheets/module/_headers.scss
+++ b/common/app/assets/stylesheets/module/_headers.scss
@@ -78,3 +78,9 @@
     }
 }
 
+.message {
+    
+    padding: 11px;
+    background-color: #ffe;
+
+}

--- a/common/app/assets/stylesheets/module/_headers.scss
+++ b/common/app/assets/stylesheets/module/_headers.scss
@@ -63,18 +63,14 @@
 
 
 .beta {
-    
     display: none;
-
     @include mq(tablet) {
-        
-        margin: 18px 0 0 2px;
+        margin: 18px 0 0 0;
         color:  white;
-        display: inline-block;
         font-size: 10px;
         float:  left;
+        display: inline-block;
         color: #95B1CA;
-
     }
 }
 

--- a/common/app/assets/stylesheets/module/_headers.scss
+++ b/common/app/assets/stylesheets/module/_headers.scss
@@ -58,3 +58,23 @@
     @extend %type-4;
     padding: 0 $gutter $baseline*2;
 }
+
+
+
+
+.beta {
+    
+    display: none;
+
+    @include mq(tablet) {
+        
+        margin: 18px 0 0 2px;
+        color:  white;
+        display: inline-block;
+        font-size: 10px;
+        float:  left;
+        color: #95B1CA;
+
+    }
+}
+

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -42,6 +42,9 @@ object Switches extends Collections {
     "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
     safeState = Off)
 
+  val BetaServerSwitch = Switch("Beta", "beta",
+    "If this is switced on users with a #beta in the URL will be messaged",
+    safeState = Off)
 
   // Advertising Switches
 
@@ -207,6 +210,7 @@ object Switches extends Collections {
     SocialSwitch,
     SearchSwitch,
     ImageServerSwitch,
+    BetaServerSwitch,
     AustraliaFrontSwitch,
     FontDelaySwitch,
     ABParagraphSpacingSwitch,

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -6,7 +6,7 @@
         <a @SiteOr{ site => href="/" }{ href="@LinkTo{/}" }
             id="logo" class="i i-guardian-logo" data-link-name="site logo">The Guardian</a>
 
-        <span class="beta">BETA</span>
+        <span class="beta">Beta</span>
 
         <div class="nav-container">
             <ul class="nav nav--global" data-link-name="Sections">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -6,6 +6,8 @@
         <a @SiteOr{ site => href="/" }{ href="@LinkTo{/}" }
             id="logo" class="i i-guardian-logo" data-link-name="site logo">The Guardian</a>
 
+        <span class="beta">BETA</span>
+
         <div class="nav-container">
             <ul class="nav nav--global" data-link-name="Sections">
                 @Edition(request).navigation(page).map{ nav =>


### PR DESCRIPTION
The beta logo is displayed on tablet viewports,

![beta-logo](https://f.cloud.github.com/assets/84996/850257/0fd9636a-f484-11e2-8e6c-afd42632c77e.png)

And it disappears on smaller viewports,

![beta-small](https://f.cloud.github.com/assets/84996/850258/11bacbb0-f484-11e2-9f81-66ce0c4907f6.png)
