### PR TITLE
Upped cache times.

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -88,8 +88,8 @@ class Content(
   ) ++ Map(("references", delegate.references.map(r => Reference(r.id))))
 
   override lazy val cacheSeconds = {
-    if (isLive) 5
-    else if (lastModified > DateTime.now - 24.hours) 60
+    if (isLive) 30 // live blogs can expect imminent updates
+    else if (lastModified > DateTime.now - 1.hour) 60 // an hour gives you time to fix obvious typos and stuff
     else 900
   }
 }

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -21,14 +21,14 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
     val headers = result.header.headers
 
-    headers("Cache-Control") should be("max-age=5, s-maxage=5, stale-while-revalidate=5, stale-if-error=345600")
+    headers("Cache-Control") should be("max-age=30, s-maxage=30, stale-while-revalidate=30, stale-if-error=345600")
   }
 
-  it should "cache content less than 24 hours old for 1 minute" in {
+  it should "cache content less than 1 hour old for 1 minute" in {
     Switches.DoubleCacheTimesSwitch.switchOff()
 
-    val modifiedAlmost24HoursAgo = (DateTime.now - 23.hours) - 50.minutes
-    val liveContent = content(lastModified = modifiedAlmost24HoursAgo, live = false)
+    val modifiedAlmost1HourAgo = DateTime.now - 58.minutes
+    val liveContent = content(lastModified = modifiedAlmost1HourAgo, live = false)
 
     val result = Cached(liveContent)(Ok("foo")).asInstanceOf[SimpleResult[Html]]
     val headers = result.header.headers


### PR DESCRIPTION
I want to see if significantly larger cache times have on effect on hit ratio and 'freshness of content'

At the moment we tend to do between 55% & 65% hit ratio. I am going to see if this goes up. It got up to about 70% in a lesser test (changing 1 minute to 2 minutes).

![hitratio](https://f.cloud.github.com/assets/76709/854681/d322e1b6-f50b-11e2-8f69-d0f0b064cfa0.png)
