### PR TITLE
Add hit-miss charts to radiator

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -15,7 +15,8 @@ object RadiatorController extends Controller with Logging with AuthLogging {
 
   def render() = AuthAction{ implicit request =>
       val graphs = (CloudWatch.latency filter { _.name == "Router" }) ++ CloudWatch.fastlyStatistics
-      Ok(views.html.radiator(graphs, Configuration.environment.stage))
+      val multilineGraphs = CloudWatch.fastlyHitMissStatistics
+      Ok(views.html.radiator(graphs, multilineGraphs, Configuration.environment.stage))
   }
 
   def pingdom() = AuthAction{ implicit request =>

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -19,9 +19,7 @@ trait CloudWatch {
 
   private val fastlyMetrics = List(
     ("Fastly Errors (Europe) - errors per minute, average", "errors", "europe", "2eYr6Wx3ZCUoVPShlCM61l"),
-    ("Fastly 5xx (Europe) - 5xxs per minute, average", "status_5xx", "europe", "2eYr6Wx3ZCUoVPShlCM61l"),
-    ("Fastly Errors (USA) - errors per minute, average", "errors", "usa", "2eYr6Wx3ZCUoVPShlCM61l"),
-    ("Fastly 5xx (USA) - 5xxs per minute, average", "status_5xx", "usa", "2eYr6Wx3ZCUoVPShlCM61l")
+    ("Fastly Errors (USA) - errors per minute, average", "errors", "usa", "2eYr6Wx3ZCUoVPShlCM61l")
   )
 
   private val fastlyHitMissMetrics = List(

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -1,4 +1,4 @@
-@(charts: Seq[tools.Chart], env: String)
+@(charts: Seq[tools.Chart], hitMissCharts: Seq[tools.Chart], env: String)
 <!DOCTYPE html>
 <html>
   <head>
@@ -34,14 +34,28 @@
                         backgroundColor: '#fff',
                         colors: ['#333'],
                         height: 120,
+                        title: '@chart.name',
                         hAxis: { textStyle: {color: '#ccc'}, gridlines: { count: 0 }, showTextEvery: 15, baselineColor: '#fff' },
                         legend: 'none' @chart.yAxis.map{ title =>, vAxis: {title: "@title", textStyle: {color: '#ccc'}, gridlines: { count: 3, color: '#ccc' }} }
+                    });
+                }
+
+                @hitMissCharts.map{ chart =>
+                    new google.visualization.LineChart(document.getElementById('@chart.id'))
+                        .draw(google.visualization.arrayToDataTable(@Html(chart.asDataset)), {
+                        title: '@chart.name',
+                        backgroundColor: '#fff',
+                        height: 175,
+                        legend: 'in',
+                        hAxis: { textStyle: {color: '#ccc'}, gridlines: { count: 0 }, showTextEvery: 15, baselineColor: '#fff' },
+                        vAxis: { textStyle: {color: '#ccc'}, gridlines: { count: 3, color: '#ccc' } }
                     });
                 }
             }
         </script>
 
         @charts.map{ chart => <div id="@chart.id" class="charts"></div> }
+        @hitMissCharts.map{ chart => <div id="@chart.id" class="charts"></div> }
 
         <!-- TODO - add team city & pager duty -->
 


### PR DESCRIPTION
Remove redundant graphs from the fastly metrics list.
