### PR TITLE
Brower support tables

### DIFF
--- a/admin/app/controllers/AnalyticsController.scala
+++ b/admin/app/controllers/AnalyticsController.scala
@@ -26,4 +26,8 @@ object AnalyticsController extends Controller with Logging with AuthLogging {
         PageviewsByOperatingSystemTreeMapGraph
       )))
   }
+  
+  def browsers() = AuthAction { request =>
+      Ok(views.html.browsers("PROD", Analytics.getPageviewsByOperatingSystem(), Analytics.getPageviewsByBrowser()))
+  }
 }

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -16,6 +16,7 @@
         <ul>
             <li><a href="@routes.AnalyticsController.kpis()">KPIs</a></li>
             <li><a href="@routes.AnalyticsController.pageviews()">Pageviews</a></li>
+            <li><a href="@routes.AnalyticsController.browsers()">Browser support tables</a></li>
         </ul>
     </div>
     <div class="row">
@@ -35,7 +36,7 @@
     </div>
     <div class="row">
         <h3>Radiator</h3>
-        <p class="muted">Big screen display. Navigation is for display purposes only.</p>
+        <p class="muted">Big screen display.</p>
         <ul>
             <li><a href="@controllers.routes.RadiatorController.render()">Radiator</a></li>
         </ul>

--- a/admin/app/views/browsers.scala.html
+++ b/admin/app/views/browsers.scala.html
@@ -3,28 +3,41 @@
 @admin_main("Browsers", env, isAuthed = true) {
 
     <h1>Browser usage on theguardian.com</h1>
-    <p>Collected from Ophan data covering March 1, 2013 to present.</p>
+    
+    <p>
+        Collected from Ophan data covering March 1, 2013 to present.
+    </p>
 
+    <p style="background-color:#ffc;padding:1em;">
+        Warning. These statistics only cover the <a href="http://m.guardian.co.uk">mobile site</a>. 
+    </p>
+    
     <h3>By operating system</h3>
-    <p>Page views over 10k broken down by operating system version</p>
+
+    <p>
+        Page views over 10k broken down by operating system version
+    </p>
+    
     <table border="1" cellpadding="5">
-        @defining(os.toList.map{_._2}.sum) { total =>
-            @os.toList.sortBy{_._2}.reverse.filter { _._2 >= 10000 }.zipWithIndex.map { case (row, i) =>
-                    <tr>
-                        <td>@{i+1}</td>
-                        <td>@row._1</td>
-                        <td>@row._2.toInt</td>
-                    </tr>
-                    }
-                }
+        @os.toList.sortBy{_._2}.reverse.filter { _._2 >= 10000 }.zipWithIndex.map { case (row, index) =>
+            <tr>
+                <td>@{index + 1}</td>
+                <td>@row._1</td>
+                <td>@row._2.toInt</td>
+            </tr>
+        }
     </table>
     
     <h2>Browser vendor</h2>
-    <p>Page views over 10k broken down by browser family and version</p>
+    
+    <p>
+        Page views over 10k broken down by browser family and version.
+    </p>
+
     <table border="1" cellpadding="5">
-        @browser.toList.sortBy{_._2}.reverse.filter { _._2 >= 10000 }.zipWithIndex.map { case (row, i) =>
+        @browser.toList.sortBy{_._2}.reverse.filter { _._2 >= 10000 }.zipWithIndex.map { case (row, index) =>
             <tr>
-                <td>@{i+1}</td>
+                <td>@{index + 1}</td>
                 <td>@row._1</td>
                 <td>@row._2.toInt</td>
             </tr>

--- a/admin/app/views/browsers.scala.html
+++ b/admin/app/views/browsers.scala.html
@@ -1,0 +1,33 @@
+@(env: String, os: Map[String, Long], browser: Map[String, Long])
+
+@admin_main("Browsers", env, isAuthed = true) {
+
+    <h1>Browser usage on theguardian.com</h1>
+    <p>Collected from Ophan data covering March 1, 2013 to present.</p>
+
+    <h3>By operating system</h3>
+    <p>Page views over 10k broken down by operating system version</p>
+    <table border="1" cellpadding="5">
+        @defining(os.toList.map{_._2}.sum) { total =>
+            @os.toList.sortBy{_._2}.reverse.filter { _._2 >= 10000 }.zipWithIndex.map { case (row, i) =>
+                    <tr>
+                        <td>@{i+1}</td>
+                        <td>@row._1</td>
+                        <td>@row._2.toInt</td>
+                    </tr>
+                    }
+                }
+    </table>
+    
+    <h2>Browser vendor</h2>
+    <p>Page views over 10k broken down by browser family and version</p>
+    <table border="1" cellpadding="5">
+        @browser.toList.sortBy{_._2}.reverse.filter { _._2 >= 10000 }.zipWithIndex.map { case (row, i) =>
+            <tr>
+                <td>@{i+1}</td>
+                <td>@row._1</td>
+                <td>@row._2.toInt</td>
+            </tr>
+        }
+    </table>
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -80,6 +80,7 @@ DELETE    /fronts/api/:edition/:section/:block/*trail    controllers.FrontsContr
 # Analytics
 GET     /analytics/kpis                  controllers.AnalyticsController.kpis()
 GET     /analytics/pageviews             controllers.AnalyticsController.pageviews()
+GET     /analytics/browsers              controllers.AnalyticsController.browsers()
 
 # Metrics
 GET     /metrics/loadbalancers           controllers.metrics.DashboardController.render()

--- a/porter/app/jobs/AnalyticsLoadJob.scala
+++ b/porter/app/jobs/AnalyticsLoadJob.scala
@@ -36,6 +36,14 @@ class AnalyticsLoadJob extends Job {
       Analytics.getPageviewsByOperatingSystem() map { CSV.write } mkString "\n",
       "text/csv"
     )
+    
+    log.info("Generating analytics for pageviews by operating system and browser and uploading to S3.")
+    S3.putPrivate(
+      s"${Configuration.environment.stage.toUpperCase}/analytics/pageviews-by-operating-system-and-browser.csv",
+      Analytics.getPageviewsByOperatingSystemAndBrowser() map { CSV.write } mkString "\n",
+      "text/csv"
+    )
+
 
     log.info("Generating analytics for pageviews by browser and uploading to S3.")
     S3.putPrivate(


### PR DESCRIPTION
Initial cut. Ignore fafd055 - it's covered in https://github.com/guardian/frontend/pull/1269

![browsers](https://f.cloud.github.com/assets/84996/861632/b8e1c5b8-f5d5-11e2-95d8-1cb60d687766.png)

![browsers2](https://f.cloud.github.com/assets/84996/861631/b58e25a0-f5d5-11e2-9415-67ddb2a12766.png)
