### PR TITLE
Fixed styling issue with blocks on Network Fronts.

### DIFF
--- a/common/app/views/fragments/headers/frontSectionHead.scala.html
+++ b/common/app/views/fragments/headers/frontSectionHead.scala.html
@@ -1,5 +1,5 @@
-@(description: TrailblockDescription,  edition: Option[Edition] = None)(implicit request: RequestHeader)
-<div class="@if(request.path == "/"){front-section-head zone-background} else {sub-section-head}">
+@(description: TrailblockDescription, isFront: Boolean, edition: Option[Edition] = None)(implicit request: RequestHeader)
+<div class="@if(isFront){front-section-head zone-background} else {sub-section-head}">
     <h1>
        <a @if(request.path != ""){class="zone-color"} data-link-name="section heading" href="@LinkTo{/@description.id}">
          @description.name

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -9,11 +9,14 @@ import model.Trailblock
 import Switches.EditionRedirectSwitch
 
 // TODO, this needs a rethink, does not seem elegant
+
+abstract class FrontPage(val isNetworkFront: Boolean) extends MetaData
+
 object FrontPage {
 
   private val fronts = Seq(
 
-    new MetaData {
+    new FrontPage(isNetworkFront = false) {
       override val canonicalUrl = Some("http://www.guardian.co.uk/australia")
       override val id = "australia"
       override val section = "australia"
@@ -26,7 +29,7 @@ object FrontPage {
       )
     },
 
-    new MetaData {
+    new FrontPage(isNetworkFront = false) {
       override val canonicalUrl = Some("http://www.guardian.co.uk/sport")
       override val id = "sport"
       override val section = "sport"
@@ -40,7 +43,7 @@ object FrontPage {
       )
     },
 
-    new MetaData {
+    new FrontPage(isNetworkFront = false) {
       override val canonicalUrl = Some("http://www.guardian.co.uk/money")
       override val id = "money"
       override val section = "money"
@@ -54,7 +57,7 @@ object FrontPage {
       )
     },
 
-    new MetaData {
+    new FrontPage(isNetworkFront = false) {
       override val canonicalUrl = Some("http://www.guardian.co.uk/commentisfree")
       override val id = "commentisfree"
       override val section = "commentisfree"
@@ -68,7 +71,7 @@ object FrontPage {
       )
     },
 
-    new MetaData {
+    new FrontPage(isNetworkFront = false) {
       override val canonicalUrl = Some("http://www.guardian.co.uk/business")
       override val id = "business"
       override val section = "business"
@@ -82,7 +85,7 @@ object FrontPage {
       )
     },
 
-    new MetaData {
+    new FrontPage(isNetworkFront = false) {
       override val canonicalUrl = Some("http://www.guardian.co.uk/culture")
       override val id = "culture"
       override val section = "culture"
@@ -97,7 +100,7 @@ object FrontPage {
     },
 
     //TODO important this one is last for matching purposes
-    new MetaData {
+    new FrontPage(isNetworkFront = true) {
       override val canonicalUrl = Some("http://www.guardian.co.uk")
       override val id = ""
       override val section = ""
@@ -111,7 +114,7 @@ object FrontPage {
     }
   )
 
-  def apply(path: String): Option[MetaData] = fronts.find(f => path.startsWith(f.id))
+  def apply(path: String): Option[FrontPage] = fronts.find(f => path.startsWith(f.id))
 
 }
 

--- a/front/app/views/fragments/frontBlock.scala.html
+++ b/front/app/views/fragments/frontBlock.scala.html
@@ -1,4 +1,4 @@
-@(block: Trailblock)(implicit request: RequestHeader)
+@(block: Trailblock, page: FrontPage)(implicit request: RequestHeader)
 
 <section 
     class="front-section zone-@block.description.section" 
@@ -9,7 +9,7 @@
 	    @if("/" + block.description.id == request.path) {
             @fragments.headers.sectionHead(block.description.name)
 	    } else {
-	       @fragments.headers.frontSectionHead(block.description, Some(Edition(request)))
+	       @fragments.headers.frontSectionHead(block.description, page.isNetworkFront, Some(Edition(request)))
         } 
 	}
 

--- a/front/app/views/fragments/frontBody.scala.html
+++ b/front/app/views/fragments/frontBody.scala.html
@@ -1,8 +1,8 @@
-@(front: MetaData, trailblocks: Seq[Trailblock])(implicit request: RequestHeader)
+@(front: FrontPage, trailblocks: Seq[Trailblock])(implicit request: RequestHeader)
 
 <div class="front-container cf" data-link-name="Front" role="main">
     @trailblocks.map{ block =>
-        @fragments.frontBlock(block)
+        @fragments.frontBlock(block, front)
     }
 </div>
 

--- a/front/app/views/front.scala.html
+++ b/front/app/views/front.scala.html
@@ -1,7 +1,6 @@
-@(front: MetaData, trailblocks: Seq[Trailblock])(implicit request: RequestHeader)
+@(front: FrontPage, trailblocks: Seq[Trailblock])(implicit request: RequestHeader)
 
 @main(front, Switches.all){
 }{
     @fragments.frontBody(front, trailblocks)
-    
 }


### PR DESCRIPTION
The page now understands whether it is a network front or not.

This applies to www.theguardian.com - solid background colours were not showing for headings on the editionalised fronts

![front](https://f.cloud.github.com/assets/76709/862037/076c73b0-f5e3-11e2-827d-8e944ab334f5.png)
