### PR TITLE
AB test - Lightbox galleries

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -4,7 +4,8 @@ define([
 
     //Current tests
     'modules/experiments/tests/paragraph-spacing',
-    'modules/experiments/tests/aa'
+    'modules/experiments/tests/aa',
+    'modules/experiments/tests/lightbox-galleries'
 ], function (
     common,
     store,
@@ -54,7 +55,7 @@ define([
         dataLinkTest.push(['AB', test.id + ' test', variantId]. join(' | '));
         common.$g(document.body).attr('data-link-test', dataLinkTest.join(', '));
     }
-        
+
     function getActiveTests() {
         return TESTS.filter(function(test) {
             var expired = (new Date() - new Date(test.expiry)) > 0;
@@ -93,7 +94,7 @@ define([
         if (!isParticipating(test) || !testCanBeRun(test, config)) {
             return false;
         }
-        
+
         var participations = getParticipations(),
             variantId = participations[test.id].variant;
             test.variants.some(function(variant) {
@@ -106,7 +107,7 @@ define([
     }
 
     function bucket(test, config) {
-        
+
         // if user not in test, bucket them
         if (isParticipating(test) || !testCanBeRun(test, config)) {
             return false;
@@ -136,7 +137,7 @@ define([
         addTest: function(test) {
             TESTS.push(test);
         },
-        
+
         clearTests: function() {
             TESTS = [];
         },
@@ -147,7 +148,7 @@ define([
                 bucket(test, config);
             });
         },
-        
+
         run: function(config, context, options) {
             var opts = options || {};
             getActiveTests().forEach(function(test) {

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -10,12 +10,14 @@ define([
     common,
     store,
     ParagraphSpacing,
-    Aa
+    Aa,
+    LightboxGalleries
     ) {
 
     var TESTS = [
             new ParagraphSpacing(),
-            new Aa()
+            new Aa(),
+            new LightboxGalleries()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/lightbox-galleries.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/lightbox-galleries.js
@@ -5,7 +5,7 @@ define(['common', 'modules/lightbox-gallery'], function (common, LightboxGallery
     var LightboxGalleries = function () {
 
         this.id = 'LightboxGalleries';
-        this.expiry = '2013-08-08';
+        this.expiry = '2013-08-12';
         this.audience = 1;
         this.description = 'Tests the lightbox gallery variants between no lightbox, lightbox and lightbox with swipe';
         this.canRun = function(config) {

--- a/common/app/assets/javascripts/modules/experiments/tests/lightbox-galleries.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/lightbox-galleries.js
@@ -1,0 +1,47 @@
+define(['common', 'modules/lightbox-gallery'], function (common, LightboxGallery) {
+
+    var _config;
+
+    var LightboxGalleries = function () {
+
+        this.id = 'LightboxGalleries';
+        this.expiry = '2013-08-08';
+        this.audience = 1;
+        this.description = 'Tests the lightbox gallery variants between no lightbox, lightbox and lightbox with swipe';
+        this.canRun = function(config) {
+            _config = config;
+            return true;
+        };
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                   return true;
+                }
+            },
+            {
+                id: 'lightbox',
+                test: function (context) {
+                    var galleries = new LightboxGallery(_config, context);
+                    galleries.init({
+                        overrideSwitch: true,
+                        disableSwipe: true
+                    });
+                }
+            },
+            {
+                id: 'lightbox-swipe',
+                test: function (context) {
+                    var galleries = new LightboxGallery(_config, context);
+                    galleries.init({
+                        overrideSwitch: true
+                    });
+                }
+            }
+
+        ];
+    };
+    
+    return LightboxGalleries;
+
+});

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -174,6 +174,11 @@ object Switches extends Collections {
     "If this is switched on an AA test runs to prove the assignment of users in to segments is working reliably.",
     safeState = Off)
 
+  val ABLightboxGalleries = Switch("A/B Tests", "ab-lightbox-galleries",
+    "If this is switched on an AB test runs to test lightbox gallery variants (lightbox and lightbox with swipe)",
+    safeState = Off)
+
+
   // Sport Switch
 
   val LiveCricketSwitch = Switch("Live Cricket", "live-cricket",

--- a/docs/experiments/gallery-lightbox.md
+++ b/docs/experiments/gallery-lightbox.md
@@ -1,0 +1,23 @@
+# Hypothesis
+
+People who use the lightbox consume more of our photographs.
+
+# Buckets
+
+- Control: Viewing the original galleries (33%)
+- Variant A: Viewing pictures in the lightbox - swipe (33%)
+- Variant B: Viewing pictures in the lightbox - no swipe (33%)
+
+# Predictions
+
+## Chris
+
+- Number of photographs seen increases by 10% without swipe.
+- Number of photographs seen increases by 10% with swipe.
+
+## Jim
+
+- Number of photographs seen increases by 5% without swipe.
+- Number of photographs seen increases by 13% with swipe.
+
+# Summary


### PR DESCRIPTION
Tests the effectiveness of having galleries popup in an overlay, and if having swipe capability increases usage.

The variants are split 3 ways:
1/3 - link straight to gallery page (current behaviour - control)
1/3 - lightbox gallery
1/3 - lightbox gallery with swipe
