### PR TITLE
Fronts admin: uses pushState, adds editable settings to trailblocks

### DIFF
--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -55,36 +55,36 @@
                         <span class="list-header__title__part" data-bind="text: $data"></span> 
                     </div>
                     <div class="list-header__meta">
-                        <!-- ko if: timeAgo -->
-                            updated <span class="list-header__meta__last-updated" data-bind="text: timeAgo"></span> 
+                        <!-- ko if: state.timeAgo -->
+                            updated <span class="list-header__meta__last-updated" data-bind="text: state.timeAgo"></span> 
                             by <a class="list-header__meta__user" data-bind="
                                 text: meta.updatedBy,
                                 attr: {href: 'mailto:' + meta.updatedEmail}
                                 "></a>
                         <!-- /ko -->
-                        <!-- ko ifnot: timeAgo -->
+                        <!-- ko ifnot: state.timeAgo -->
                             Empty
                         <!-- /ko -->
                     </div>
                     <div class="list-header__status">
                         <div class="list-header__status__live" data-bind="
                             css: {
-                                active: liveMode()
+                                active: state.liveMode()
                             }">
                             <span class="list-header__status__live__title" data-bind="click: setLiveMode">LIVE</span>
                         </div>                    
                         <div class="list-header__status__draft" data-bind="
                             css: {
-                                active: !liveMode(),
-                                hasUnPublishedEdits: hasUnPublishedEdits()
+                                active: !state.liveMode(),
+                                hasUnPublishedEdits: state.hasUnPublishedEdits()
                             }">
                             <span class="list-header__status__draft__title" data-bind="click: setDraftMode">
                                 DRAFT
-                                <span data-bind="if: hasUnPublishedEdits()">
+                                <span data-bind="if: state.hasUnPublishedEdits()">
                                     has edits
                                 </span>
                             </span>
-                            <span data-bind="if: !liveMode() && hasUnPublishedEdits()">
+                            <span data-bind="if: !state.liveMode() && state.hasUnPublishedEdits()">
                                 &middot; <a class="list-header__status__control" data-bind="click: publishDraft">publish</a>
                                 &middot; <a class="list-header__status__control" data-bind="click: discardDraft">discard</a>
                             </span>
@@ -94,18 +94,18 @@
                 <div class="connectedList" data-bind="
                     attr: {
                         'data-list-id': id,
-                        'data-live-edit': liveMode()
+                        'data-live-edit': state.liveMode()
                     },
-                    css: {pending: loadIsPending},
-                    template: {name: 'template_article', foreach: liveMode() ? live : draft}"></div>
+                    css: {pending: state.loadIsPending},
+                    template: {name: 'template_article', foreach: state.liveMode() ? live : draft}"></div>
 
                 <div class="needs-more" data-bind="if: needsMore">
                     Needs at least <span class="needs-more__num" data-bind="text: config.min"></span> 
                     article<span data-bind="text: config.min() > 1 ? 's' : ''"></span>
                 </div>
-                <div class="list-footer" data-bind="css: {editable: editingConfig}">
+                <div class="list-footer" data-bind="css: {editable: state.editingConfig}">
                     <a data-bind="click: toggleShowSettings">Settings</a>
-                    <div data-bind="visible: editingConfig" class="settings">
+                    <div data-bind="visible: state.editingConfig" class="settings">
                         <div>
                             Number of articles:
                         </div>

--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -58,8 +58,8 @@
                         <!-- ko if: timeAgo -->
                             updated <span class="list-header__meta__last-updated" data-bind="text: timeAgo"></span> 
                             by <a class="list-header__meta__user" data-bind="
-                                text: updatedBy,
-                                attr: {href: 'mailto:' + updatedEmail}
+                                text: meta.updatedBy,
+                                attr: {href: 'mailto:' + meta.updatedEmail}
                                 "></a>
                         <!-- /ko -->
                         <!-- ko ifnot: timeAgo -->
@@ -100,7 +100,27 @@
                     template: {name: 'template_article', foreach: liveMode() ? live : draft}"></div>
 
                 <div class="needs-more" data-bind="if: needsMore">
-                    Needs at least <span class="needs-more__num" data-bind="text: min"></span> articles
+                    Needs at least <span class="needs-more__num" data-bind="text: config.min"></span> 
+                    article<span data-bind="text: config.min() > 1 ? 's' : ''"></span>
+                </div>
+                <div class="list-footer" data-bind="css: {editable: editingConfig}">
+                    <a data-bind="click: toggleShowSettings">Settings</a>
+                    <div data-bind="visible: editingConfig" class="settings">
+                        <div>
+                            Number of articles:
+                        </div>
+                        <div>
+                            <input type="text" class="tiny" data-bind="value: config.min"/> Minumum
+                        </div>
+                        <div>
+                            <input type="text" class="tiny" data-bind="value: config.max"/> Maximum
+                        </div>
+                        <div>
+                            ContentApi query for trail automation:
+                            <input type="text" data-bind="value: config.contentApiQuery"/>
+                        </div>
+                        <input type="submit" class="btn" value="Save Settings" data-bind="click: saveConfig"/>
+                    </div>
                 </div>
             </div>
         </div>
@@ -109,7 +129,7 @@
     <script type="text/html" id="template_article">
         <div class="trail cf" data-bind="
                 attr: {'data-url': id},
-                css: {redundant: $parent.max ? (0 + $index()) >= (0 + $parent.max()) : false}
+                css: {redundant: $parent.config && $parent.config.max ? (0 + $index()) >= (0 + $parent.config.max()) : false}
             ">
 
             <a class="trail__control" data-bind="click: $parent.dropItem">

--- a/admin/public/css/style.css
+++ b/admin/public/css/style.css
@@ -525,7 +525,7 @@ a.cta, .cta a {
 }
 
 .fronts .lists .connectedList {
-    min-height: 100px;
+    min-height: 50px;
 }
 
 .fronts .lists .connectedList.pending {
@@ -740,12 +740,35 @@ a.cta, .cta a {
 }
 
 .fronts .needs-more {
+    padding: 0 0 0 10px;
     color: #d61d00;
-    padding: 5px 0 0 10px;
     font-size: 12px;
     text-transform: uppercase;    
 }
 
 .fronts .needs-more__num {
     font-weight: bold;
+}
+
+.fronts .list-footer {
+    padding: 2px 10px 10px 10px;
+    font-size: 10px;    
+    border-top: 3px solid #ccc;
+}
+
+.fronts .list-footer.editable {
+    background-color: #eee;
+}
+
+.fronts .list-footer a {
+    color: #666;
+    cursor: pointer;
+}
+
+.fronts .list-footer .settings input {
+}
+
+.fronts .list-footer .settings input.tiny {
+    width: 40px;
+    text-align: right;
 }

--- a/admin/public/javascripts/models/fronts/contentApi.js
+++ b/admin/public/javascripts/models/fronts/contentApi.js
@@ -1,15 +1,16 @@
 define([
     'Config',
     'Common',
-    'Reqwest'
+    'Reqwest',
+    'models/fronts/globals'
 ], 
 function (
     Config,
     Common,
-    Reqwest
+    Reqwest,
+    globals
 ){
-    var apiUrlBase = "/api/proxy/search",
-        cache = {};
+    var cache = {};
 
     var decorateItems = function(items) {
         var fetch = [];
@@ -44,7 +45,7 @@ function (
     var fetchArticles = function(ids, callback) {
         var apiUrl;
         if (ids.length) {
-            apiUrl = apiUrlBase + "?page-size=50&format=json&show-fields=all&show-tags=all&api-key=" + Config.apiKey;
+            apiUrl = globals.apiSearchBase + "?page-size=50&format=json&show-fields=all&show-tags=all&api-key=" + Config.apiKey;
             apiUrl += "&ids=" + ids.map(function(id){
                 return encodeURIComponent(id);
             }).join(',');

--- a/admin/public/javascripts/models/fronts/globals.js
+++ b/admin/public/javascripts/models/fronts/globals.js
@@ -1,11 +1,8 @@
-define([
-    'knockout'
-], function(
-    knockout
-) {
-    var globals = {
-        activeInteraction: false
+define([], function() {
+    return {
+        // Configuration
+        apiBase: '/fronts/api',
+        apiSearchBase: '/api/proxy/search',
+        defaultToLiveMode: true
     };
-
-    return globals;
 });

--- a/admin/public/javascripts/models/fronts/latestArticles.js
+++ b/admin/public/javascripts/models/fronts/latestArticles.js
@@ -71,11 +71,13 @@ define([
             return true; // ensure default click happens on all the bindings
         };
 
-        this.startPoller = function() {
+        function _startPoller() {
             setInterval(function(){
                 self.search();
             }, 10000);
         }
+
+        this.startPoller = _.once(_startPoller);
     };
 });
 

--- a/admin/public/javascripts/models/fronts/list.js
+++ b/admin/public/javascripts/models/fronts/list.js
@@ -40,11 +40,8 @@ define([
         this.load();
     }
 
-    List.prototype.asObservableProps = function(props, obj) {
+    List.prototype.asObservableProps = function(props) {
         return _.object(props.map(function(prop){
-            if (obj) {
-                obj[prop] = ko.observable();
-            }
             return [prop, ko.observable()];
         }));
     };

--- a/admin/public/javascripts/models/fronts/list.js
+++ b/admin/public/javascripts/models/fronts/list.js
@@ -11,8 +11,6 @@ define([
     Article,
     ContentApi
 ) {
-    var defaultToLiveMode = true,
-        apiBase = '/fronts/api';
 
     function List(id, opts) {
         var self = this;
@@ -20,14 +18,14 @@ define([
         this.id = id;
         this.crumbs = id.split(/\//g);
 
-        this.live         = ko.observableArray();
-        this.draft        = ko.observableArray();
+        this.live   = ko.observableArray();
+        this.draft  = ko.observableArray();
 
         this.meta   = this.asObservableProps(['lastUpdated', 'updatedBy', 'updatedEmail']);
         this.config = this.asObservableProps(['contentApiQuery', 'min', 'max']);
         this.state  = this.asObservableProps(['liveMode', 'hasUnPublishedEdits', 'loadIsPending', 'editingConfig', 'timeAgo']);
 
-        this.state.liveMode(defaultToLiveMode);
+        this.state.liveMode(globals.defaultToLiveMode);
 
         this.needsMore = ko.computed(function() {
             if (self.state.liveMode()  && self.live().length  < self.config.min()) { return true; }
@@ -75,7 +73,7 @@ define([
         var self = this;
 
         reqwest({
-            url: apiBase + '/' + this.id,
+            url: globals.apiBase + '/' + this.id,
             method: 'post',
             type: 'json',
             contentType: 'application/json',
@@ -100,7 +98,7 @@ define([
         self.state.loadIsPending(true);
         reqwest({
             method: 'delete',
-            url: apiBase + '/' + self.id,
+            url: globals.apiBase + '/' + self.id,
             type: 'json',
             contentType: 'application/json',
             data: JSON.stringify({
@@ -122,7 +120,7 @@ define([
         var self = this;
         opts = opts || {};
         reqwest({
-            url: apiBase + '/' + this.id,
+            url: globals.apiBase + '/' + this.id,
             type: 'json'
         }).always(
             function(resp) {
@@ -192,7 +190,7 @@ define([
     List.prototype.saveConfig = function(key, val) {
         var self = this;
         reqwest({
-            url: apiBase + '/' + this.id,
+            url: globals.apiBase + '/' + this.id,
             method: 'post',
             type: 'json',
             contentType: 'application/json',

--- a/admin/public/javascripts/models/fronts/list.js
+++ b/admin/public/javascripts/models/fronts/list.js
@@ -12,7 +12,7 @@ define([
     ContentApi
 ) {
 
-    function List(id, opts) {
+    function List(id) {
         var self = this;
 
         this.id = id;
@@ -171,6 +171,7 @@ define([
             }
         });
 
+        // Only refresh config properties if they're not currently being edited
         if (!this.state.editingConfig()) {
             _.keys(this.config).forEach(function(key){
                 self.config[key](opts[key]);

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -174,7 +174,7 @@ define([
             }
         };
 
-        function startPoller() {
+        function _startPoller() {
             setInterval(function(){
                 viewModel.listsDisplayed().forEach(function(list){
                     if (!dragging) {
@@ -183,6 +183,7 @@ define([
                 });
             }, 5000);
         }
+        var startPoller = _.once(_startPoller);
 
         function fetchSchema(callback) {
             reqwest({

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -90,6 +90,7 @@ define([
 
             sortables.sortable({
                 helper: 'clone',
+                opacity: 0.9,
                 revert: 200,
                 scroll: true,
                 start: function(event, ui) {

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -162,7 +162,7 @@ define([
                     } 
                 }
 
-                listObj.loadIsPending(true);
+                listObj.state.loadIsPending(true);
 
                 reqwest({
                     method: 'post',

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -13,8 +13,7 @@ define([
     Article,
     LatestArticles
 ) {
-    var apiBase = '/fronts/api',
-        maxDisplayableLists = 3,
+    var maxDisplayableLists = 3,
         dragging = false,
         loc = window.location;
 
@@ -166,7 +165,7 @@ define([
 
                 reqwest({
                     method: 'post',
-                    url: apiBase + '/' + listId,
+                    url: globals.apiBase + '/' + listId,
                     type: 'json',
                     contentType: 'application/json',
                     data: JSON.stringify(delta)
@@ -188,7 +187,7 @@ define([
 
         function fetchSchema(callback) {
             reqwest({
-                url: apiBase,
+                url: globals.apiBase,
                 type: 'json'
             }).then(
                 function(resp) {

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -20,7 +20,6 @@ define([
     return function(selector) {
 
         var viewModel = {},
-            schemaLookUp = {},
             self = this;
 
         function queryParams() {
@@ -74,7 +73,7 @@ define([
                 }    
             });
             chosen.forEach(function(id){
-                viewModel.listsDisplayed.push(new List(id, schemaLookUp[id]));
+                viewModel.listsDisplayed.push(new List(id));
             });
             connectSortableLists();
         }
@@ -191,15 +190,6 @@ define([
                 type: 'json'
             }).then(
                 function(resp) {
-                    // Make a flat version of schema for lookup by id path, e.g. "uk/news/top-stories" 
-                    [].concat(resp.editions).forEach(function(edition){
-                        [].concat(edition.sections).forEach(function(section){
-                            [].concat(section.blocks).forEach(function(block){
-                                schemaLookUp[edition.id + '/' + section.id + '/' + block.id] = block;
-                            });
-                        });
-                    });
-
                     viewModel.editions = resp.editions;
                     if (typeof callback === 'function') { callback(); }
                 },

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -47,12 +47,14 @@ define([
         }
 
         function setDisplayedLists(listIDs) {
-            var q = queryParams();
-            q.blocks = listIDs.join(',');
-            q = _.pairs(q).map(function(p){
-                return p[0] + (p[1] ? '=' + p[1] : '');
-            }).join('&');
-            history.pushState({}, "", loc.pathname + '?' + q);
+            var qp = queryParams();
+            qp.blocks = listIDs.join(',');
+            qp = _.pairs(qp)
+                .filter(function(p){ return !!p[0]; })
+                .map(function(p){ return p[0] + (p[1] ? '=' + p[1] : ''); })
+                .join('&');
+
+            history.pushState({}, "", loc.pathname + '?' + qp);
             renderLists();
         }
 


### PR DESCRIPTION
- URLs that specify which trailblocks to render now survive OAuth handshakes, because they use a query string param instead of the hash fragment.
- trailblocks have a 'settings' form to specify a ContentApi query and min/max trail length.
- group the List object properties by 'meta', 'config', and 'state' types.
