### PR TITLE
Fix JS error on football pages

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -163,8 +163,7 @@ define([
                 }
                 break;
         }
-    
-        modules.showHomescreen(config);
+
     };
 
     return {


### PR DESCRIPTION
We removed the home screen cta ages ago, but seems this was left in the bootstrap file causing a JS error to be thrown on all football related pages.
