### PR TITLE
This should make those Macbooks run a bit faster...

### DIFF
--- a/sbt012
+++ b/sbt012
@@ -76,7 +76,7 @@ java -Xmx4096M -XX:MaxPermSize=2048m \
   -Dsbt.boot.directory=$SBT_BOOT_DIR \
   -Djava.awt.headless=true \
   $DEBUG_PARAMS \
-  -DAPP_SECRET="myKV8HQkjcaxygbDyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS" \
+  -DAPP_SECRET="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS" \
   $BUILD_PARAMS \
   $IVY_PARAMS \
   $SBT_EXTRA_PARAMS \

--- a/sbt012
+++ b/sbt012
@@ -71,10 +71,12 @@ export GRUNT_ISDEV=1
 
 java -Xmx4096M -XX:MaxPermSize=2048m \
   -XX:ReservedCodeCacheSize=128m \
+  -XX:+UseConcMarkSweepGC \
+  -XX:+CMSIncrementalMode \
   -Dsbt.boot.directory=$SBT_BOOT_DIR \
   -Djava.awt.headless=true \
   $DEBUG_PARAMS \
-  -DAPP_SECRET="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS" \
+  -DAPP_SECRET="myKV8HQkjcaxygbDyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS" \
   $BUILD_PARAMS \
   $IVY_PARAMS \
   $SBT_EXTRA_PARAMS \

--- a/sbt012-tc
+++ b/sbt012-tc
@@ -53,26 +53,15 @@ echo $IVY_PARAMS
 
 DOMAIN=`hostname -d`
 
-if [ "$DOMAIN" != "gc2.dc1.gnm" ]; then
-    # proxy that Play uses
-    export proxy_host=devproxy.gul3.gnl
-    export proxy_port=3128
-fi
-
-if [ "$DOMAIN" = "gc2.dc1.gnm" ]; then
-    PROXY_CONF=""
-else
-    PROXY_CONF="-Dhttp.proxyHost=devproxy.gul3.gnl -Dhttp.proxyPort=3128"
-fi
-
 #MaxPermSize specifies the the maximum size for the permanent generation heap,
 # a heap that holds objects such as classes and methods. Xmx is the heap size.
 cat /dev/null | java -Xmx4096M -XX:MaxPermSize=2048m \
   -XX:ReservedCodeCacheSize=128m \
   -Dsbt.boot.directory=$SBT_BOOT_DIR \
   -Dsbt.log.noformat=true \
+  -XX:+UseConcMarkSweepGC \
+  -XX:+CMSIncrementalMode \
   -DAPP_SECRET="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS" \
-  $PROXY_CONF \
   $BUILD_PARAMS \
   $IVY_PARAMS \
   $SBT_EXTRA_PARAMS \


### PR DESCRIPTION
Adding -XX:+UseConcMarkSweepGC  &&  -XX:+CMSIncrementalMode for dev machines and teamcity agents.

It is recommended you use  -XX:+CMSIncrementalMode if you hae 1 or 2 CPUs (like your macbook or an EC2 box). Want to try it out here before running it on our EC2 boxes.

http://www.oracle.com/technetwork/java/javase/gc-tuning-6-140523.html#icms
