### PR TITLE
Got rid of Canonical URL

### DIFF
--- a/admin/app/views/events.scala.html
+++ b/admin/app/views/events.scala.html
@@ -7,7 +7,7 @@
     <form class="form-inline muted" onsubmit="return false">
         <h3>Articles</h3>
         <p class="meta">Drag articles into story chapters from the list below, from the 
-        <a target="_blank" href="http://www.guardian.co.uk">Guardian</a> website, or from <a target="_blank" href="http://www.google.co.uk/search?q=site%3Awww.guardian.co.uk">Google</a> search results.</p> 
+        <a target="_blank" href="http://www.theguardian.com">Guardian</a> website, or from <a target="_blank" href="http://www.google.co.uk/search?q=site%3Awww.theguardian.com">Google</a> search results.</p>
         <input type="text" placeholder="Search" 
             data-bind='event: {keyup: articles.search, mousedown: articles.articleSearch, afterpaste: articles.articleSearch}, value:
             articles.term, valueUpdate: ["afterkeydown", "afterpaste"]'/>

--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -138,7 +138,7 @@
 
             <div class="trail__meta">
                 <span data-bind="html: _humanDate() ? _humanDate : 'Loading...'"></span>
-                <a data-bind="attr: {href: 'http://m.guardian.co.uk/' + id()}">view</a>
+                <a data-bind="attr: {href: 'http://www.theguardian.com/' + id()}">view</a>
                 <a data-bind="attr: {href: 'http://dashboard.ophan.co.uk/summary?path=/' + id()}">stats</a>
             </div>
 

--- a/applications/app/controllers/SectionsController.scala
+++ b/applications/app/controllers/SectionsController.scala
@@ -7,7 +7,7 @@ import play.api.mvc.{ Controller, Action }
 
 object SectionsController extends Controller with Logging {
 
-  val page = Page(canonicalUrl = None, "sections", "sections", "All sections", "GFE:All sections")
+  val page = Page("sections", "sections", "All sections", "GFE:All sections")
 
   def renderJson() = render()
   def render = Action { implicit request =>

--- a/article/app/views/fragments/witnessCallToAction.scala.html
+++ b/article/app/views/fragments/witnessCallToAction.scala.html
@@ -2,7 +2,7 @@
 
 @if(content.allowUserGeneratedContent) {
     @content.witnessAssignment.map{ assignmentId =>
-        @defining(s"https://witness.guardian.co.uk/assignment/$assignmentId#contribute"){ assignmentUrl =>
+        @defining(s"https://witness.theguardian.com/assignment/$assignmentId#contribute"){ assignmentUrl =>
             <div class="witness-call-to-action">
                 <a href="@LinkTo{@assignmentUrl}" data-link-name="witness cta plus">
                     <i class="i i-ee-add-button"></i>

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -358,10 +358,10 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
       HtmlUnit("/film/2012/nov/11/margin-call-cosmopolis-friends-with-kids-dvd-review") { browser =>
         import browser._
 
-        val mailShareUrl = "mailto:?subject=Mark%20Kermode%27s%20DVD%20round-up&body=http%3A%2F%2Fwww.guardian.co.uk%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review"
-        val fbShareUrl = "http://m.facebook.com/dialog/feed?app_id=180444840287&display=touch&redirect_uri=http%3A%2F%2Fwww.guardian.co.uk%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&link=http%3A%2F%2Fwww.guardian.co.uk%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&ref=responsive"
-        val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark+Kermode%27s+DVD+round-up&url=http%3A%2F%2Fwww.guardian.co.uk%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review"
-        val gplusShareUrl = "https://plus.google.com/share?url=http%3A%2F%2Fwww.guardian.co.uk%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&hl=en-GB&wwc=1"
+        val mailShareUrl = "mailto:?subject=Mark%20Kermode%27s%20DVD%20round-up&body=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review"
+        val fbShareUrl = "http://m.facebook.com/dialog/feed?app_id=180444840287&display=touch&redirect_uri=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&link=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&ref=responsive"
+        val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark+Kermode%27s+DVD+round-up&url=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review"
+        val gplusShareUrl = "https://plus.google.com/share?url=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&hl=en-GB&wwc=1"
 
         Then("I should see buttons for my favourite social network")
         findFirst(".social__item--mail .social__action").getAttribute("href") should be(mailShareUrl)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -121,7 +121,7 @@ class GuardianConfiguration(
   }
 
   object oas {
-    lazy val siteIdHost = configuration.getStringProperty("oas.siteId.host").getOrElse("m.guardian.co.uk")
+    lazy val siteIdHost = configuration.getStringProperty("oas.siteId.host").getOrElse(".guardian.co.uk")
   }
 
   object javascript {

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -10,8 +10,6 @@ case class Section(private val delegate: ApiSection) extends MetaData {
   lazy val webUrl: String = delegate.webUrl
   lazy val webTitle: String = delegate.webTitle
 
-  lazy val canonicalUrl = Some(webUrl)
-
   lazy val url: String = SupportedUrl(delegate)
   lazy val linkText: String = webTitle
 

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -17,8 +17,6 @@ case class Tag(private val delegate: ApiTag) extends MetaData {
   lazy val webUrl: String = delegate.webUrl
   lazy val webTitle: String = delegate.webTitle
 
-  lazy val canonicalUrl = Some(webUrl)
-
   lazy val url: String = SupportedUrl(delegate)
   lazy val linkText: String = webTitle
   lazy val pageId = delegate

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -50,8 +50,6 @@ class Content(
 
   lazy val allowUserGeneratedContent: Boolean = fields.get("allowUgc").map(_.toBoolean).getOrElse(false)
 
-  override lazy val canonicalUrl = Some(webUrl)
-
   lazy val isLive: Boolean = fields("liveBloggingNow").toBoolean
   lazy val isCommentable: Boolean = fields.get("commentable").map(_ == "true").getOrElse(false)
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -3,11 +3,6 @@ package model
 import common.ManifestData
 
 trait MetaData {
-  // indicates the absolute url of this page (the one to be used for search engine indexing)
-  // see http://googlewebmastercentral.blogspot.co.uk/2009/02/specify-your-canonical.html
-  // never give this a default value, we need people to think each time before using it
-  def canonicalUrl: Option[String]
-
   def id: String
   def section: String
   def webTitle: String
@@ -27,13 +22,12 @@ trait MetaData {
     "web-title" -> webTitle,
     "build-number" -> buildNumber,
     "analytics-name" -> analyticsName
-  ) ++ canonicalUrl.map { url => Map("canonical-url" -> url) }.getOrElse(Map.empty)
+  )
 
   def cacheSeconds = 60
 }
 
 class Page(
-  val canonicalUrl: Option[String],
   val id: String,
   val section: String,
   val webTitle: String,
@@ -41,11 +35,10 @@ class Page(
 
 object Page {
   def apply(
-    canonicalUrl: Option[String],
     id: String,
     section: String,
     webTitle: String,
-    analyticsName: String) = new Page(canonicalUrl, id, section, webTitle, analyticsName)
+    analyticsName: String) = new Page(id, section, webTitle, analyticsName)
 }
 
 trait Images {

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -26,7 +26,7 @@
         </a>
 
         @if(SearchSwitch.isSwitchedOn) {
-            <a href="https://www.google.co.uk/advanced_search?q=site:www.guardian.co.uk" data-is-ajax data-link-name="Search icon" class="control control--search" data-control-for="nav-popup-search">
+            <a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax data-link-name="Search icon" class="control control--search" data-control-for="nav-popup-search">
                 <i class="i i-nav-divider"></i>
                 <span class="h">Search</span>
                 <i class="i i-search"></i>

--- a/common/app/views/fragments/sections.scala.html
+++ b/common/app/views/fragments/sections.scala.html
@@ -22,8 +22,8 @@
     </ul>
 
     <ul class="nav nav--columns nav--section-divider @if(isFooter){ nav--top-border-off nav--footer} cf">
-        <li class="nav__item"><a class="nav__link" href="https://soulmates.guardian.co.uk/" target="_blank" data-link-name="Soulmates">Soulmates</a>
-        <li class="nav__item"><a class="nav__link" href="http://jobs.guardian.co.uk/" target="_blank" data-link-name="Jobs">Jobs</a>
+        <li class="nav__item"><a class="nav__link" href="https://soulmates.theguardian.com/" target="_blank" data-link-name="Soulmates">Soulmates</a>
+        <li class="nav__item"><a class="nav__link" href="http://jobs.theguardian.com/" target="_blank" data-link-name="Jobs">Jobs</a>
 
         @*<!-- TODO EDITIONS -->*@
         @Edition.others(request).map{ edition =>

--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -2,7 +2,7 @@
 
 @if(Switches.SocialSwitch.isSwitchedOn) {
 
-@defining(page.canonicalUrl.getOrElse(s"http://${request.host}${request.path}")){ url =>
+@defining(s"http://${request.host}${request.path}"){ url =>
     <div class="social-wrapper">
         <ul class="social unstyled">
             <li class="social__item--mail social__item">

--- a/common/test/assets/javascripts/spec/Omniture.spec.js
+++ b/common/test/assets/javascripts/spec/Omniture.spec.js
@@ -85,23 +85,8 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
             expect(s.prop19).toBe("frontend");
             expect(s.eVar19).toBe("frontend");
             expect(s.cookieDomainPeriods).toBe("2")
-
-            //check we have not overridden these
-            expect(s.trackingServer).toBe(undefined);
-            expect(s.trackingServerSecure).toBe(undefined);
-
-        });
-
-        it("should correctly set omniture domain if it is www.theguardian.com", function(){
-
-            s.linkInternalFilters = 'guardian.co.uk,guardiannews.co.uk'
-
-            var o = new Omniture(s, w);
-            o.go(config);
-
-            expect(s.trackingServer).toBe('hits.theguardian.com');
+            expect(s.trackingServer).toBe("hits.theguardian.com");
             expect(s.trackingServerSecure).toBe('hits-secure.theguardian.com');
-            expect(s.cookieDomainPeriods).toBe('2');
 
         });
 
@@ -116,7 +101,7 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
             var o = new Omniture(s, w);
             o.go(config);
 
-            expect(s.cookieDomainPeriods).toBe("3")
+            expect(s.cookieDomainPeriods).toBe("2")
         });
 
         it("should log a page view event", function() {

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -52,8 +52,6 @@ class CachedTest extends FlatSpec with ShouldMatchers with Results {
     Switches.DoubleCacheTimesSwitch.switchOff()
 
     val page = new MetaData {
-      def canonicalUrl = None
-
       def id = ""
 
       def section = ""

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -58,20 +58,6 @@ class ContentTest extends FlatSpec with ShouldMatchers {
 
   }
 
-  "Canonical urls" should "point back to guardian.co.uk" in {
-    val apiContent = ApiContent("foo/2012/jan/07/bar", None, None, new DateTime, "Some article",
-      "http://www.guardian.co.uk/foo/2012/jan/07/bar",
-      "http://content.guardianapis.com/foo/2012/jan/07/bar",
-      elements = None
-    )
-
-    val apiTag = tag(url = "http://www.guardian.co.uk/sport/cycling")
-
-    new Content(apiContent).canonicalUrl should be(Some("http://www.guardian.co.uk/foo/2012/jan/07/bar"))
-
-    Tag(apiTag).canonicalUrl should be(Some("http://www.guardian.co.uk/sport/cycling"))
-  }
-
   private def tag(id: String = "/id", tagType: String = "keyword", name: String = "", url: String = "") = {
     ApiTag(id = id, `type` = tagType, webTitle = name,
       sectionId = None, sectionName = None, webUrl = url, apiUrl = "apiurl", references = Nil)

--- a/core-navigation/app/controllers/MostPopularController.scala
+++ b/core-navigation/app/controllers/MostPopularController.scala
@@ -11,7 +11,6 @@ import concurrent.Future
 object MostPopularController extends Controller with Logging with ExecutionContexts {
 
   val page = new Page(
-    Some("http://www.guardian.co.uk/"),
     "most-read",
     "most-read",
     "Most read",

--- a/core-navigation/app/controllers/TopStoriesController.scala
+++ b/core-navigation/app/controllers/TopStoriesController.scala
@@ -45,7 +45,6 @@ object TopStoriesController extends Controller with Logging with Paging with Jso
 
   private def renderTopStories(trails: Seq[Trail])(implicit request: RequestHeader) = {
     val page = new Page(
-      Some("http://www.guardian.co.uk/"),
       "top-stories",
       "top-stories",
       "Top Stories",

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -16,7 +16,7 @@ case class CommentPage(
   contentUrl: String,
   currentPage: Int,
   pages: Int
-) extends Page(canonicalUrl = None, id = id, section = "Global", webTitle = title, analyticsName = s"GFE:Article:Comment discussion page $currentPage") {
+) extends Page(id = id, section = "Global", webTitle = title, analyticsName = s"GFE:Article:Comment discussion page $currentPage") {
   lazy val hasMore: Boolean = currentPage < pages
 }
 

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -35,8 +35,8 @@
         <div class="d-comment__main">
             <div class="d-comment__body">
                 @if(comment.isBlocked){
-                    This comment was removed by a moderator because it didn't abide by our <a href="http://www.guardian.co.uk/community-standards" data-link-name="community standards">community standards</a>.
-                    Replies may also be deleted. For more detail see <a href="http://www.guardian.co.uk/community-faqs" data-link-name="FAQs">our FAQs</a>.
+                    This comment was removed by a moderator because it didn't abide by our <a href="http://www.theguardian.com/community-standards" data-link-name="community standards">community standards</a>.
+                    Replies may also be deleted. For more detail see <a href="http://www.theguardian.com/community-faqs" data-link-name="FAQs">our FAQs</a>.
                 }else{
                     @withJsoup(BulletCleaner(comment.body))(
                         InBodyLinkCleaner("in body link")(Edition(request))
@@ -46,7 +46,7 @@
             @if(!comment.isBlocked){
                 <div class="d-comment__actions">
                     <div class="d-comment__actions__main">
-                        <a href="http://discussion.guardian.co.uk/components/report-abuse/@comment.id" class="d-comment__action d-comment__action--report" target="_blank">Report</a>
+                        <a href="http://discussion.theguardian.com/components/report-abuse/@comment.id" class="d-comment__action d-comment__action--report" target="_blank">Report</a>
                     </div>
                 </div>
             }

--- a/event/app/controllers/StoryController.scala
+++ b/event/app/controllers/StoryController.scala
@@ -8,7 +8,6 @@ import conf._
 import concurrent.Future
 
 case class StoriesPage(stories: Seq[Story]) extends Page(
-  canonicalUrl = None,
   "stories",
   "news", "stories",
   "GFE:story:stories") {
@@ -16,7 +15,6 @@ case class StoriesPage(stories: Seq[Story]) extends Page(
 }
 
 case class StoryPage(story: Story) extends Page(
-  canonicalUrl = None,
   s"stories/${story.id}",
   "news", story.title,
   s"GFE:story:${story.title}") {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -13,7 +13,6 @@ object FrontPage {
   private val fronts = Seq(
 
     new MetaData {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/australia")
       override val id = "australia"
       override val section = "australia"
       override val webTitle = "The Guardian"
@@ -26,7 +25,6 @@ object FrontPage {
     },
 
     new MetaData {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/sport")
       override val id = "sport"
       override val section = "sport"
       override val webTitle = "Sport"
@@ -40,7 +38,6 @@ object FrontPage {
     },
 
     new MetaData {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/culture")
       override val id = "culture"
       override val section = "culture"
       override val webTitle = "Culture"
@@ -55,7 +52,6 @@ object FrontPage {
 
     //TODO important this one is last for matching purposes
     new MetaData {
-      override val canonicalUrl = Some("http://www.guardian.co.uk")
       override val id = ""
       override val section = ""
       override val webTitle = "The Guardian"

--- a/football/app/controllers/CompetitionListController.scala
+++ b/football/app/controllers/CompetitionListController.scala
@@ -8,7 +8,7 @@ import play.api.mvc.{ Controller, Action }
 
 object CompetitionListController extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
 
-  val page = Page(canonicalUrl = None, "football/competitions", "football", "Leagues & competitions", "GFE:Football:automatic:Leagues & competitions")
+  val page = Page("football/competitions", "football", "Leagues & competitions", "GFE:Football:automatic:Leagues & competitions")
 
   def renderJson() = render()
   def render = Action { implicit request =>

--- a/football/app/controllers/FixturesController.scala
+++ b/football/app/controllers/FixturesController.scala
@@ -66,7 +66,6 @@ trait FixtureRenderer extends Controller with CompetitionFixtureFilters {
 object FixturesController extends FixtureRenderer with Logging with ExecutionContexts {
 
   val page = new Page(
-    Some("http://www.guardian.co.uk/football/matches"),
     "football/fixtures",
     "football",
     "All fixtures",
@@ -113,7 +112,6 @@ object CompetitionFixturesController extends FixtureRenderer with Logging {
   def render(competitionName: String, competition: Competition, date: Option[DateMidnight] = None) = Action { implicit request =>
 
     val page = new Page(
-      Some("http://www.guardian.co.uk/football/matches"),
       "football/fixtures",
       "football",
       s"${competition.fullName} fixtures",
@@ -146,7 +144,6 @@ object TeamFixturesController extends Controller with Logging with CompetitionFi
       val upcomingFixtures = fixtures.filter(_.fixture.date >= startDate)
 
       val page = new Page(
-        Some(s"http://www.guardian.co.uk/football/$teamName/fixtures"),
         s"football/$teamName/fixtures",
         "football",
         s"${team.name} fixtures",

--- a/football/app/controllers/LeagueTableController.scala
+++ b/football/app/controllers/LeagueTableController.scala
@@ -27,7 +27,6 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
   def render() = Action { implicit request =>
 
     val page = new Page(
-      canonicalUrl = None,
       "football/tables",
       "football",
       "All tables",
@@ -52,7 +51,6 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
   def renderTeamlist() = Action { implicit request =>
 
     val page = new Page(
-      Some("http://www.guardian.co.uk/football/clubs"),
       "football/teams",
       "football",
       "All teams",
@@ -75,7 +73,6 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
     loadTables.find(_.competition.url.endsWith(s"/$competition")).map { table =>
 
       val page = new Page(
-        Some(s"http://www.guardian.co.uk/football/$competition/tables"),
         "football/tables",
         "football",
         s"${table.competition.fullName} table",

--- a/football/app/controllers/LiveMatchesController.scala
+++ b/football/app/controllers/LiveMatchesController.scala
@@ -12,8 +12,7 @@ import conf.Configuration
 
 object LiveMatchesController extends Controller with CompetitionLiveFilters with Logging with ExecutionContexts {
 
-  val page = new Page(Some("http://www.guardian.co.uk/football/matches"), "football/live", "football",
-    "Today's matches", "GFE:Football:automatic:live matches") {
+  val page = new Page("football/live", "football", "Today's matches", "GFE:Football:automatic:live matches") {
     override val cacheSeconds = 10
   }
 

--- a/football/app/controllers/MatchController.scala
+++ b/football/app/controllers/MatchController.scala
@@ -18,7 +18,6 @@ case class MatchPage(theMatch: FootballMatch, lineUp: LineUp) extends MetaData w
   lazy val matchStarted = theMatch.isLive || theMatch.isResult
   lazy val hasLineUp = lineUp.awayTeam.players.nonEmpty && lineUp.homeTeam.players.nonEmpty
 
-  override lazy val canonicalUrl = None
   override lazy val id = MatchUrl(theMatch)
   override lazy val section = "football"
   override lazy val webTitle = s"${theMatch.homeTeam.name} ${theMatch.homeTeam.score.getOrElse("")} - ${theMatch.awayTeam.score.getOrElse("")} ${theMatch.awayTeam.name}"

--- a/football/app/controllers/ResultsController.scala
+++ b/football/app/controllers/ResultsController.scala
@@ -67,7 +67,6 @@ sealed trait ResultsRenderer extends Controller with Logging with CompetitionRes
 object ResultsController extends ResultsRenderer with Logging {
 
   val page = new Page(
-    Some("http://www.guardian.co.uk/football/matches"),
     "football/results",
     "football",
     "All results",
@@ -114,7 +113,6 @@ object CompetitionResultsController extends ResultsRenderer with Logging {
   def render(competitionName: String, competition: Competition, date: Option[DateMidnight] = None) = Action { implicit request =>
 
     val page = new Page(
-      Some("http://www.guardian.co.uk/football/matches"),
       "football/results",
       "football",
       s"${competition.fullName} results",
@@ -146,7 +144,6 @@ object TeamResultsController extends Controller with Logging with CompetitionRes
       val upcomingFixtures = fixtures.filter(_.fixture.date <= startDate).reverse
 
       val page = new Page(
-        Some(s"http://www.guardian.co.uk/$teamName/results"),
         s"/football/$teamName/results",
         "football",
         s"${team.name} results",

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -16,7 +16,6 @@ object FrontPage {
   private val fronts = Seq(
 
     new FrontPage(isNetworkFront = false) {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/australia")
       override val id = "australia"
       override val section = "australia"
       override val webTitle = "The Guardian"
@@ -29,7 +28,6 @@ object FrontPage {
     },
 
     new FrontPage(isNetworkFront = false) {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/sport")
       override val id = "sport"
       override val section = "sport"
       override val webTitle = "Sport"
@@ -43,7 +41,6 @@ object FrontPage {
     },
 
     new FrontPage(isNetworkFront = false) {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/money")
       override val id = "money"
       override val section = "money"
       override val webTitle = "Money"
@@ -57,7 +54,6 @@ object FrontPage {
     },
 
     new FrontPage(isNetworkFront = false) {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/commentisfree")
       override val id = "commentisfree"
       override val section = "commentisfree"
       override val webTitle = "commentisfree"
@@ -71,7 +67,6 @@ object FrontPage {
     },
 
     new FrontPage(isNetworkFront = false) {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/business")
       override val id = "business"
       override val section = "business"
       override val webTitle = "business"
@@ -85,7 +80,6 @@ object FrontPage {
     },
 
     new FrontPage(isNetworkFront = false) {
-      override val canonicalUrl = Some("http://www.guardian.co.uk/culture")
       override val id = "culture"
       override val section = "culture"
       override val webTitle = "Culture"
@@ -100,7 +94,6 @@ object FrontPage {
 
     //TODO important this one is last for matching purposes
     new FrontPage(isNetworkFront = true) {
-      override val canonicalUrl = Some("http://www.guardian.co.uk")
       override val id = ""
       override val section = ""
       override val webTitle = "The Guardian"

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -12,7 +12,7 @@ import com.google.inject.{Inject, Singleton}
 @Singleton
 class SigninController @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Controller with ExecutionContexts {
 
-  val page = new IdentityPage("https://profile.theguardian.com/signin", "/signin", "Signin", "signin")
+  val page = new IdentityPage("/signin", "Signin", "signin")
 
   val form = Form(
     Forms.tuple(

--- a/identity/app/model/IdentityPage.scala
+++ b/identity/app/model/IdentityPage.scala
@@ -1,5 +1,5 @@
 package model
 
 
-class IdentityPage(canonicalUrl: String, id: String, webTitle: String, analyticsName: String)
-  extends Page(Option(canonicalUrl), id, "identity", webTitle, analyticsName)
+class IdentityPage(id: String, webTitle: String, analyticsName: String)
+  extends Page(id, "identity", webTitle, analyticsName)

--- a/sport/app/controllers/cricketMatchController.scala
+++ b/sport/app/controllers/cricketMatchController.scala
@@ -8,7 +8,6 @@ import cricketModel.Match
 
 case class CricketMatchPage(theMatch: Match, matchId: String) extends MetaData with ExecutionContexts {
 
-  override lazy val canonicalUrl = None
   override lazy val id = s"sport/cricket/match/$matchId"
   override lazy val section = "cricket"
   override lazy val webTitle = s"${theMatch.description}, ${theMatch.venueName}"
@@ -16,8 +15,6 @@ case class CricketMatchPage(theMatch: Match, matchId: String) extends MetaData w
 }
 
 object CricketMatchController extends Controller with Logging with ExecutionContexts {
-
-  private val page = Page(canonicalUrl = None, "cricket/competitions", "cricket", "Leagues & competitions", "GFE:Cricket:automatic:Leagues & competitions")
 
   def renderMatchId(matchId: String) = Action { implicit request =>
 

--- a/style-guide/app/controllers/StyleGuideController.scala
+++ b/style-guide/app/controllers/StyleGuideController.scala
@@ -16,21 +16,21 @@ case class ZoneColour(className: String, selectors: List[String], zoneName: Stri
 object StyleGuideController extends Controller with Logging with ExecutionContexts {
 
   def renderIndex = Action { implicit request =>
-    val page = Page(canonicalUrl = None, "style-guide", "style-guide", "Style guide: home", "GFE:Style-guide")
+    val page = Page("style-guide", "style-guide", "Style guide: home", "GFE:Style-guide")
     Cached(60) {
       Ok(views.html.styleGuide.index(page))
     }
   }
 
   def renderTypography = Action { implicit request =>
-    val page = Page(canonicalUrl = None, "typography", "style-guide", "Typography", "GFE:Style-guide:typography")
+    val page = Page("typography", "style-guide", "Typography", "GFE:Style-guide:typography")
     Cached(60) {
       Ok(views.html.styleGuide.typography(page))
     }
   }
 
   def renderZones = Action { implicit request =>
-    val page = Page(canonicalUrl = None, "zones", "style-guide", "Zones", "GFE:Style-guide:zones")
+    val page = Page("zones", "style-guide", "Zones", "GFE:Style-guide:zones")
 
     val zoneList = Seq(
       ZoneColour("zone-news", List(".zone-news", ".zone-journalismcompetition", ".zone-global-development", ".zone-law", ".zone-theobserver", ".zone-science", ".zone-theguardian", ".zone-education", ".zone-technology", ".zone-society", ".zone-politics", ".zone-uk", ".zone-media", ".zone-world"), "News (default)", "#D61D00"),
@@ -50,7 +50,7 @@ object StyleGuideController extends Controller with Logging with ExecutionContex
   }
 
   def renderSprites = Action { implicit request =>
-    val page = Page(canonicalUrl = None, "sprites", "style-guide", "CSS sprites", "GFE:Style-guide:sprites")
+    val page = Page("sprites", "style-guide", "CSS sprites", "GFE:Style-guide:sprites")
     Cached(60) {
       Ok(views.html.styleGuide.sprites(page))
     }
@@ -79,7 +79,7 @@ object StyleGuideController extends Controller with Logging with ExecutionContex
   }
 
   private def renderModuleOutput(model: ArticlePage)(implicit request: RequestHeader) = {
-    val page = Page(canonicalUrl = None, "modules", "style-guide", "Modules", "GFE:Style-guide:modules")
+    val page = Page("modules", "style-guide", "Modules", "GFE:Style-guide:modules")
 
     Cached(60) {
       Ok(views.html.styleGuide.modules(page, model.article, model.storyPackage))
@@ -87,14 +87,14 @@ object StyleGuideController extends Controller with Logging with ExecutionContex
   }
 
   def cssHelpers = Action { implicit request =>
-    val page = Page(canonicalUrl = None, "css-helpers", "style-guide", "CSS helpers", "GFE:Style-guide:css-helpers")
+    val page = Page("css-helpers", "style-guide", "CSS helpers", "GFE:Style-guide:css-helpers")
     Cached(60) {
       Ok(views.html.styleGuide.csshelpers(page))
     }
   }
 
   def codingStandards = Action { implicit request =>
-    val page = Page(canonicalUrl = None, "coding-standards", "style-guide", "Coding standards", "GFE:Style-guide:coding-standards")
+    val page = Page("coding-standards", "style-guide", "Coding standards", "GFE:Style-guide:coding-standards")
     Cached(60) {
       Ok(views.html.styleGuide.codingstandards(page))
     }

--- a/style-guide/app/views/styleGuide/index.scala.html
+++ b/style-guide/app/views/styleGuide/index.scala.html
@@ -17,7 +17,7 @@
 
             <p>Welcome to the Guardian's responsive style guide. If you're looking for tips on how best to use apostrophes, you probably want <a href="http://www.guardian.co.uk/styleguide">this style guide instead</a>. If you're coming in search of semi-colons, though, you're in the right place.</p>
 
-            <p>Use the navigation menu above or below to learn about how to build components and styles for the <a href="http://m.guardian.co.uk">Guardian responsive website</a>.</p>
+            <p>Use the navigation menu above or below to learn about how to build components and styles for the <a href="http://ww.theguardian.com">Guardian responsive website</a>.</p>
         </div>
 
     </article>


### PR DESCRIPTION
We no longer need this after moving to one domain.

Sorry about the name of the branch, I started doing something else and got side tracked.

Also changed some 3rd party sites like Soulmates to ___.theguardian.com
