### PR TITLE
Remove show/hide toggles from editionalised fronts

### DIFF
--- a/front/app/views/fragments/frontBlock.scala.html
+++ b/front/app/views/fragments/frontBlock.scala.html
@@ -1,4 +1,5 @@
-@(block: Trailblock, page: FrontPage)(implicit request: RequestHeader)
+@(block: Trailblock, page: FrontPage, index: Int)(implicit request: RequestHeader)
+@import model.Trailblock
 
 <section 
     class="front-section zone-@block.description.section" 
@@ -6,9 +7,8 @@
     data-link-context="front-trails/@block.description.section">
 
     @if(block.description.id != "") {
-	    @if("/" + block.description.id == request.path ||
-            LinkTo("/" + block.description.id, Edition(request)) == request.path) {
-                @fragments.headers.sectionHead(block.description.name)
+	    @if(index == 0 && !page.isNetworkFront) {
+           @fragments.headers.sectionHead(block.description.name)
 	    } else {
 	       @fragments.headers.frontSectionHead(block.description, page.isNetworkFront, Some(Edition(request)))
         } 

--- a/front/app/views/fragments/frontBlock.scala.html
+++ b/front/app/views/fragments/frontBlock.scala.html
@@ -6,8 +6,9 @@
     data-link-context="front-trails/@block.description.section">
 
     @if(block.description.id != "") {
-	    @if("/" + block.description.id == request.path) {
-            @fragments.headers.sectionHead(block.description.name)
+	    @if("/" + block.description.id == request.path ||
+            LinkTo("/" + block.description.id, Edition(request)) == request.path) {
+                @fragments.headers.sectionHead(block.description.name)
 	    } else {
 	       @fragments.headers.frontSectionHead(block.description, page.isNetworkFront, Some(Edition(request)))
         } 

--- a/front/app/views/fragments/frontBody.scala.html
+++ b/front/app/views/fragments/frontBody.scala.html
@@ -1,8 +1,8 @@
 @(front: FrontPage, trailblocks: Seq[Trailblock])(implicit request: RequestHeader)
 
 <div class="front-container cf" data-link-name="Front" role="main">
-    @trailblocks.map{ block =>
-        @fragments.frontBlock(block, front)
+    @trailblocks.zipWithIndex.map{ case(block, index) =>
+        @fragments.frontBlock(block, front, index)
     }
 </div>
 


### PR DESCRIPTION
Since the domain change, editionalised fronts (comment, business, culture, etc) started getting hide/show toggles. This fixes it.

@gklopper Can check this makes sense?
