### PR TITLE
Hide empty links from screen readers

### DIFF
--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -16,7 +16,7 @@
     @trail.trailText.map { text => <div class="trail__text">@cleanTrailText(text)(Edition(request))</div> }
 
     @trail.mainPicture(width=220).map{ smallCrop =>
-        <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image" role="presentation">
+        <a href="@LinkTo{@trail.url}" @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image" aria-hidden="true">
             <img class="maxed" src="@smallCrop.path"
                 data-force-upgrade="true"
                 data-thumb-width="@smallCrop.width"

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -9,7 +9,7 @@
     <div class="media">
         @if(showThumbnail) {
             @trail.thumbnailPath.map{ thumbnailPath =>
-                <a href="@LinkTo{@trail.url}" class="media__img trail__img" data-link-name="@rowNum | image" role="presentation">
+                <a href="@LinkTo{@trail.url}" class="media__img trail__img" data-link-name="@rowNum | image" aria-hidden="true">
                     <img class="maxed" data-lowsrc="@thumbnailPath"
                         data-thumb-width="140"
                         @trail.mainPicture(width=220).map { largeCrop =>


### PR DESCRIPTION
Fixes a bug where VoiceOver would read "LINK" on an empty link (containing an image) instead of skipping it.
Makes a better experience with less noise for our readers using assistive technologies.

![in the eyes](http://i.imgur.com/NK3F0gA.gif)
