### PR TITLE
Ab test fixes

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -54,7 +54,12 @@ define([
         if (currentDataLinkTest) {
             dataLinkTest.push(currentDataLinkTest);
         }
-        dataLinkTest.push(['AB', test.id + ' test', variantId]. join(' | '));
+
+        var testName = ['AB', test.id + ' test', variantId]. join(' | ');
+        if (!currentDataLinkTest || currentDataLinkTest.indexOf(testName) === -1) {
+            dataLinkTest.push(testName);
+        }
+
         common.$g(document.body).attr('data-link-test', dataLinkTest.join(', '));
     }
 

--- a/common/app/assets/javascripts/modules/experiments/tests/lightbox-galleries.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/lightbox-galleries.js
@@ -10,7 +10,7 @@ define(['common', 'modules/lightbox-gallery'], function (common, LightboxGallery
         this.description = 'Tests the lightbox gallery variants between no lightbox, lightbox and lightbox with swipe';
         this.canRun = function(config) {
             _config = config;
-            return true;
+            return document.querySelector('.trail--gallery');
         };
         this.variants = [
             {

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -156,6 +156,15 @@ define(['modules/experiments/ab', '../fixtures/ab-test'], function(ab, ABTest) {
                 ab.run(switches.both_tests_on);
                 expect(document.body.getAttribute('data-link-test')).toBe('AB | DummyTest test | control, AB | DummyTest2 test | control');
             });
+
+            it('should not have duplicate "data-link-test" tracking when a test is run more than once', function() {
+                Math.seedrandom('gu');
+                ab.addTest(test.two);
+                ab.segment(switches.test_one_on);
+                ab.run(switches.test_one_on);
+                ab.run(switches.test_one_on);
+                expect(document.body.getAttribute('data-link-test')).toBe('AB | DummyTest test | control');
+            });
             
             it('should generate a string for Omniture to tag the test(s) the user is in', function() {
                 Math.seedrandom('gu');


### PR DESCRIPTION
- Prevents duplication of testnames on **data-link-test** on body
- Restrict the gallery A/B test to pages which have the special gallery trail on them
