### PR TITLE
Close li tags in navigation

### DIFF
--- a/common/app/views/fragments/sections.scala.html
+++ b/common/app/views/fragments/sections.scala.html
@@ -22,8 +22,8 @@
     </ul>
 
     <ul class="nav nav--columns nav--section-divider @if(isFooter){ nav--top-border-off nav--footer} cf">
-        <li class="nav__item"><a class="nav__link" href="https://soulmates.theguardian.com/" target="_blank" data-link-name="Soulmates">Soulmates</a>
-        <li class="nav__item"><a class="nav__link" href="http://jobs.theguardian.com/" target="_blank" data-link-name="Jobs">Jobs</a>
+        <li class="nav__item"><a class="nav__link" href="https://soulmates.theguardian.com/" target="_blank" data-link-name="Soulmates">Soulmates</a></li>
+        <li class="nav__item"><a class="nav__link" href="http://jobs.theguardian.com/" target="_blank" data-link-name="Jobs">Jobs</a></li>
 
         @*<!-- TODO EDITIONS -->*@
         @Edition.others(request).map{ edition =>


### PR DESCRIPTION
For some reason 2 `li` tags were not closed. This PR fixes it.

![Zlatan](http://i.imgur.com/Tv9BFDE.gif)
