### PR TITLE
Added simple Football Troubleshooter

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -10,6 +10,13 @@ object AdminConfiguration {
     lazy val connection = configuration.getStringProperty("mongo.connection.password").getOrElse(throw new RuntimeException("Mongo connection not configured"))
   }
 
+  object pa {
+    lazy val apiKey = configuration.getStringProperty("pa.api.key")
+        .getOrElse(throw new RuntimeException("unable to load pa api key"))
+
+    lazy val host = configuration.getStringProperty("football.api.host").getOrElse("http://pads6.pa-sport.com")
+  }
+
   lazy val configKey = configuration.getStringProperty("admin.config.file").getOrElse(throw new RuntimeException("Config file name is not setup"))
   lazy val switchesKey = configuration.getStringProperty("switches.file").getOrElse(throw new RuntimeException("Switches file name is not setup"))
   lazy val topStoriesKey = configuration.getStringProperty("top-stories.config").getOrElse(throw new RuntimeException("Top Stories file name is not setup"))

--- a/admin/app/controllers/FootballTroubleshooterController.scala
+++ b/admin/app/controllers/FootballTroubleshooterController.scala
@@ -1,0 +1,12 @@
+package controllers
+
+import play.api.mvc.Controller
+import common.Logging
+import conf.Configuration
+
+object FootballTroubleshooterController extends Controller with Logging with AuthLogging {
+
+  def render() = AuthAction{ implicit request =>
+      Ok(views.html.footballTroubleshooter(Configuration.environment.stage))
+  }
+}

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -40,4 +40,11 @@
             <li><a href="@controllers.routes.RadiatorController.render()">Radiator</a></li>
         </ul>
     </div>
+    <div class="row">
+        <h3>Troubleshoot</h3>
+        <p class="muted">Diagnose problems with features.</p>
+        <ul>
+            <li><a href="@controllers.routes.FootballTroubleshooterController.render()">Football feeds</a></li>
+        </ul>
+    </div>
 }

--- a/admin/app/views/footballTroubleshooter.scala.html
+++ b/admin/app/views/footballTroubleshooter.scala.html
@@ -14,6 +14,8 @@
 
     <p>To log a support call with PA email <a href="mailto:customer.services@@pressassociation.com">customer.services@@pressassociation.com</a> or call <i>01430 455337</i></p>
 
+    <p>The PA API explorer is <a href="http://pads.pa-sport.com/api/football/">here</a>.</p>
+
     <h2>Competitions feed</h2>
 
     <p>This shows us all the competitions we have access to. You can use it to find the ID of a competition
@@ -52,6 +54,11 @@
 
     <a href="@pa.host/api/football/competition/results/@pa.apiKey/100/@{new DateTime().minusMonths(6).toString("yyyyMMdd")}">@pa.host/api/football/competition/results/@pa.apiKey/<strong>100</strong>/<strong>@{new DateTime().minusMonths(6).toString("yyyyMMdd")}</strong></a>
 
+    <h2>Match stats</h2>
+
+    <p>Detailed match stats for a specific match. You would get the match ID from the either fixtures or matchday or results feed</p>
+
+    <a href="@pa.host/api/football/match/stats/@pa.apiKey/3630511">@pa.host/api/football/match/stats/@pa.apiKey/<strong>3630511</strong></a>
 
 }
 

--- a/admin/app/views/footballTroubleshooter.scala.html
+++ b/admin/app/views/footballTroubleshooter.scala.html
@@ -1,0 +1,58 @@
+@(env: String)
+@import conf.AdminConfiguration.pa
+@import org.joda.time.DateTime
+
+@admin_main("Football Troubleshooter", env, isAuthed = true) {
+
+@defining(new DateTime().toString("yyyyMMdd")){ today =>
+
+    <h1>Football Troubleshooter</h1>
+
+    <p>How to access the raw feeds to determine if a problem lies in the feeds or in the application</p>
+
+    <p>The current API host is <i>@pa.host</i> and the API key is <i>@pa.apiKey</i>.</p>
+
+    <p>To log a support call with PA email <a href="mailto:customer.services@@pressassociation.com">customer.services@@pressassociation.com</a> or call <i>01430 455337</i></p>
+
+    <h2>Competitions feed</h2>
+
+    <p>This shows us all the competitions we have access to. You can use it to find the ID of a competition
+    that we can use to access other feeds.</p>
+
+    <a href="@pa.host/api/football/competitions/competitions/@pa.apiKey">@pa.host/api/football/competitions/competitions/@pa.apiKey</a>
+
+    <h2>Fixtures feed</h2>
+
+    <p>Matches will first appear in the fixtures feed. We query each competition separately for all upcoming fixtures.</p>
+
+    <p>Here is the API call for all upcoming fixtures in the Premier League (id 100). You can get other competition IDs
+        from the Competitions feed above.</p>
+
+    <a href="@pa.host/api/football/competition/fixtures/@pa.apiKey/100">@pa.host/api/football/competition/fixtures/@pa.apiKey/<strong>100</strong></a>
+
+    <h2>Matchday Feed</h2>
+
+    <p>This is the feed you are most likely to be interested in. This feed shows detailed information on today&apos;s
+        matches and is the feed we use while the match is live</p>
+
+    <p>A single call to this api loads match data for today for <i>all</i> competitions and the date format is <i>YYYYMMDD</i></p>
+
+    <p>This api call also includes today&apos;s fixtures and results.</p>
+
+    <p>Here is the API call for today&apos;s live matches</p>
+
+    <a href="@pa.host/api/football/competitions/matchDay/@pa.apiKey/@today">@pa.host/api/football/competitions/matchDay/@pa.apiKey/<strong>@today</strong></a>
+
+    <h2>Results feed</h2>
+
+    <p>Shows the results for completed matches. We query each competition separately for results.</p>
+
+    <p>Here is the API call for results in the Premier League (id 100) in the last 6 months. You can get other competition IDs
+        from the Competitions feed above and the date format is <i>YYYYMMDD</i>.</p>
+
+    <a href="@pa.host/api/football/competition/results/@pa.apiKey/100/@{new DateTime().minusMonths(6).toString("yyyyMMdd")}">@pa.host/api/football/competition/results/@pa.apiKey/<strong>100</strong>/<strong>@{new DateTime().minusMonths(6).toString("yyyyMMdd")}</strong></a>
+
+
+}
+
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -53,3 +53,6 @@ GET     /metrics/fastly                  controllers.metrics.FastlyController.re
 # Radiator
 GET     /radiator                        controllers.RadiatorController.render()
 GET     /radiator/pingdom                controllers.RadiatorController.pingdom()
+
+# Football Troubleshooter
+GET     /troubleshoot/football           controllers.FootballTroubleshooterController.render()


### PR DESCRIPTION
With football season upon us we are more likely to be getting football related issues.

A simple screen with some advice and examples for troubleshooting feed problems. The attached screenshot shows the api key as XXXX, but in the actual thing has the correct key.

There is also a link from the front page.

![football-problems](https://f.cloud.github.com/assets/76709/907117/253eb0f2-fd0d-11e2-8dca-aaf16382fd21.png)
