### PR TITLE
Update sass-mq

### DIFF
--- a/common/app/assets/stylesheets/components/sass-mq/README.md
+++ b/common/app/assets/stylesheets/components/sass-mq/README.md
@@ -105,6 +105,18 @@ $mq-responsive: false;
 }
 ```
 
+### Adding custom breakpoints
+
+```scss
+$mq-breakpoints: mq-add-breakpoint(tvscreen, 1920px);
+
+.hide-on-tv {
+    @include mq(tvscreen) {
+        display: none;
+    }
+}
+```
+
 ## Test
 
 1. cd into the `test` folder

--- a/common/app/assets/stylesheets/components/sass-mq/_mq.scss
+++ b/common/app/assets/stylesheets/components/sass-mq/_mq.scss
@@ -12,10 +12,6 @@ $mq-breakpoints: (
     (tablet  600px)
     (desktop 900px)
     (wide    1260px)
-
-    // Tweakpoints
-    (desktopAd 810px)
-    (mobileLandscape 480px)
 ) !default;
 
 
@@ -68,7 +64,7 @@ $mq-breakpoints: (
     $max-width: 0;
     $mediaQuery: '';
 
-    // From: this breakpoint
+    // From: this breakpoint (inclusive)
     @if $from {
         @if type-of($from) == number {
             $min-width: px2em($from);
@@ -77,7 +73,7 @@ $mq-breakpoints: (
         }
     }
 
-    // To: that breakpoint
+    // To: that breakpoint (exclusive)
     @if $to {
         @if type-of($to) == number {
             $max-width: px2em($to);
@@ -106,4 +102,13 @@ $mq-breakpoints: (
             @content;
         }
     }
+}
+
+// Add a breakpoint
+// Usage: $mq-breakpoints: mq-add-breakpoint(tvscreen, 1920px);
+// Credit goes to Sam Richard (author of the `respond-to()` mixin)
+@function mq-add-breakpoint($name, $breakpoint) {
+  $breakpoint: $name $breakpoint;
+  $output: append($mq-breakpoints, $breakpoint, 'space');
+  @return $output;
 }

--- a/common/app/assets/stylesheets/components/sass-mq/bower.json
+++ b/common/app/assets/stylesheets/components/sass-mq/bower.json
@@ -10,7 +10,7 @@
     "queries",
     "media"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "_mq.scss",
   "author": "Guardian Media Group",
   "ignore": [

--- a/common/app/assets/stylesheets/components/sass-mq/test/test.css
+++ b/common/app/assets/stylesheets/components/sass-mq/test/test.css
@@ -25,6 +25,12 @@
 @media all and (min-width: 48em) and (max-width: 63.9375em) and (orientation: portrait) {
   .responsive {
     color: lightcoral; } }
+@media all and (min-width: 120em) {
+  .responsive {
+    color: DarkOliveGreen; } }
+@media all and (max-width: 119.9375em) {
+  .responsive {
+    color: DeepSkyBlue; } }
 
 .responsive-disabled {
   color: red;

--- a/common/app/assets/stylesheets/components/sass-mq/test/test.scss
+++ b/common/app/assets/stylesheets/components/sass-mq/test/test.scss
@@ -42,6 +42,14 @@ $mq-breakpoints: (
     @include mq(768, 1023, $and: '(orientation: portrait)') {
         color: lightcoral;
     }
+    // Add a custom breakpoint
+    $mq-breakpoints: mq-add-breakpoint(tvscreen, 1920px);
+    @include mq(tvscreen) {
+        color: DarkOliveGreen;
+    }
+    @include mq($to: tvscreen) {
+        color: DeepSkyBlue;
+    }
 }
 
 

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -3,6 +3,9 @@ $a-leftCol-trigger:  gs-span(13) + $gutter*2;
 $a-rightCol-width:   gs-span(4);
 $a-rightCol-trigger: gs-span(11) + $gutter*2;
 
+$mq-breakpoints: mq-add-breakpoint(rightCol, $a-rightCol-trigger);
+$mq-breakpoints: mq-add-breakpoint(leftCol, $a-leftCol-trigger);
+
 .article-zone {
     padding: 13px 0 14px;
     margin-left: $gutter;
@@ -105,14 +108,14 @@ $a-rightCol-trigger: gs-span(11) + $gutter*2;
     margin-bottom: $baseline*2;
     padding: $baseline 0 $baseline*4 0;
 
-    @include mq(tablet, ($a-leftCol-trigger - 1px)) {
+    @include mq(tablet, leftCol) {
         font-size: 16px;
         font-size: 1.6rem;
     }
-    @include mq($a-rightCol-trigger) {
+    @include mq(rightCol) {
         display: block;
     }
-    @include mq($a-leftCol-trigger) {
+    @include mq(leftCol) {
         position: absolute;
         top: 0;
         left: 0;
@@ -210,7 +213,7 @@ video {
     }
 }
 
-@include mq($a-leftCol-trigger) {
+@include mq(leftCol) {
     #preloads {
         padding: 0 $gutter;
     }


### PR DESCRIPTION
Update the sass-mq mixin to benefit from the ability to add custom breakpoints from within the application (outside of the _var.scss file). Makes the article layout code easier to understand.
## Release notes:
- [Removed] Guardian-specific tweakpoints
- [New] Add custom breakpoints:

``` scss
$mq-breakpoints: mq-add-breakpoint(tvscreen, 1920px);

.hide-on-tv {
    @include mq(tvscreen) {
        display: none;
    }
}
```

![Mind blowing dance skills](http://www.stupidgifs.com/images/full/864.gif)
