### PR TITLE
removing hreflang as it is provided by sitemap.xml

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -8,8 +8,7 @@ import model.{MetaData, TrailblockDescription}
 abstract class Edition(
     val id: String,
     val displayName: String,
-    val timezone: DateTimeZone,
-    val hreflang: String // see http://support.google.com/webmasters/bin/answer.py?hl=en&answer=189077
+    val timezone: DateTimeZone
   ) {
   def configuredFronts: Map[String, Seq[TrailblockDescription]]
   def configuredFrontsFacia: Map[String, Seq[TrailblockDescription]]

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -17,8 +17,8 @@ import common.NavItem
 object Au extends Edition(
   id = "AU",
   displayName = "Australia edition",
-  DateTimeZone.forID("Australia/Sydney"),
-  hreflang = "en-au") with Sections with Zones with QueryDefaults {
+  DateTimeZone.forID("Australia/Sydney")
+  ) with Sections with Zones with QueryDefaults {
 
   implicit val AU = Au
 

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -11,8 +11,8 @@ import common.NavItem
 object Uk extends Edition(
   id = "UK",
   displayName = "UK edition",
-  timezone = DateTimeZone.forID("Europe/London"),
-  hreflang = "en-gb") with Sections with Zones {
+  timezone = DateTimeZone.forID("Europe/London")
+  ) with Sections with Zones {
 
   implicit val UK = Uk
   val zones = Seq(

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -11,8 +11,8 @@ import contentapi.QueryDefaults
 object Us extends Edition(
   id = "US",
   displayName = "US edition",
-  timezone = DateTimeZone.forID("America/New_York"),
-  hreflang = "en-us") with Sections with Zones with QueryDefaults {
+  timezone = DateTimeZone.forID("America/New_York")
+  ) with Sections with Zones with QueryDefaults {
 
   implicit val US = Us
   val zones = Seq(

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -2,18 +2,9 @@
 @import common._
 @import model._
 @import conf._
-@import common.editions.EditionalisedSections
 
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
-
-
-    @*<!-- TODO EDITIONS -->*@
-    @if(EditionalisedSections.isEditionalised(item.id)){
-        @Edition.others.map{ ed =>
-            <link rel="alternate" hreflang="@ed.hreflang" href="/@Editionalise(item.id, ed)" />
-        }
-    }
 
     @* https://support.google.com/plus/answer/1713826 *@
     <link rel="publisher" href="https://plus.google.com/113000071431138202574"/>


### PR DESCRIPTION
Removing hreflang from localised pages as it is specified instead by 
http://spiderbytes.theguardian.com/editionalised-sitemap.xml

This is recommended by Joost to avoid duplication. cc @marcjones
 fixes #1294 
