### PR TITLE
Interactives fullscreen

### DIFF
--- a/common/app/assets/javascripts/modules/interactive.js
+++ b/common/app/assets/javascripts/modules/interactive.js
@@ -9,6 +9,12 @@ define([
         var url = config.page.interactiveUrl + el.getAttribute('data-interactive'),
             element = el;
 
+        this.api = { 
+            fullscreen: function () {
+                common.mediator.emit('chrome:fullscreen');
+            }
+        }
+
         this.init = function () {
 
             // The contract here is that the interactive module MUST return an object

--- a/common/app/assets/javascripts/modules/interactive.js
+++ b/common/app/assets/javascripts/modules/interactive.js
@@ -8,13 +8,7 @@ define([
 
         var url = config.page.interactiveUrl + el.getAttribute('data-interactive'),
             element = el;
-
-        this.api = { 
-            fullscreen: function () {
-                common.mediator.emit('chrome:fullscreen');
-            }
-        }
-
+        
         this.init = function () {
 
             // The contract here is that the interactive module MUST return an object

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -18,7 +18,7 @@ trait WsHttp extends Http[Future] with ExecutionContexts {
     val urlWithHost = url + s"&host-name=${encode(host.name, "UTF-8")}"
 
     val start = currentTimeMillis
-    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(2000).get()
+    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(5000).get()
 
     // record metrics
     response.onSuccess {

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -18,7 +18,7 @@ trait WsHttp extends Http[Future] with ExecutionContexts {
     val urlWithHost = url + s"&host-name=${encode(host.name, "UTF-8")}"
 
     val start = currentTimeMillis
-    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(5000).get()
+    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(2000).get()
 
     // record metrics
     response.onSuccess {

--- a/interactive/app/views/fragments/interactiveBody.scala.html
+++ b/interactive/app/views/fragments/interactiveBody.scala.html
@@ -1,32 +1,24 @@
 @(interactive: Interactive, storyPackage: List[Trail], index: Int, trail: Boolean)(implicit request: RequestHeader)
 @import conf.Switches.DiscussionSwitch
 
-<div class="monocolumn-wrapper">
-    
-    <h2 class="article-zone type-1">
-        <a class="zone-color" data-link-name="article section" href="@LinkTo{/@interactive.section}">@Html(interactive.sectionName)</a>
-    </h2>
+<h2 class="article-zone type-1">
+    <a class="zone-color" data-link-name="article section" href="@LinkTo{/@interactive.section}">@Html(interactive.sectionName)</a>
+</h2>
 
-    <article id="article" class="article"
-        itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
-       
-        <header class="article-head">
-            @fragments.dateline(interactive.webPublicationDate, interactive.isLive)
-        </header>
+<article id="article" class="article"
+    itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
 
-        <div class="after-header"></div>
+     <div class="article__container">
+         
+        <div class="article-body from-content-api">
 
-         <div class="article__container">
-             
-            <div class="article-body from-content-api">
+            <figure class="interactive" data-interactive="@request.path.drop(1)">
+                <!-- FIXME using data-interactive attributes is fine until data comes from Composer -->
+            </figure>
 
-                <figure class="interactive" data-interactive="@request.path.drop(1)">
-                    <!-- FIXME using data-interactive attributes is fine until data comes from Composer -->
-                </figure>
-
-            </div>
         </div>
+    </div>
 
-    </article>
+</article>
 
 </div>

--- a/interactive/app/views/fragments/interactiveBody.scala.html
+++ b/interactive/app/views/fragments/interactiveBody.scala.html
@@ -9,16 +9,8 @@
     itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
 
      <div class="article__container">
-         
-        <div class="article-body from-content-api">
-
-            <figure class="interactive" data-interactive="@request.path.drop(1)">
-                <!-- FIXME using data-interactive attributes is fine until data comes from Composer -->
-            </figure>
-
-        </div>
-    </div>
-
+         <figure class="interactive" data-interactive="@request.path.drop(1)"></figure>
+     </div>
 </article>
 
 </div>


### PR DESCRIPTION
For the time being it's best the standalone interactive elements do not sit inside our article css classes as it constrains their dimensions.

![fs](https://f.cloud.github.com/assets/84996/923265/f866840a-ff42-11e2-843b-219b731faecd.png)
