### PR TITLE
Article: Organization microdata for the header

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -2,10 +2,10 @@
 @import conf.Switches.SearchSwitch
 @import conf.Switches.IdentityProfileNavigationSwitch
 
-<header id="header" role="banner" data-link-name="global navigation: header">
+<header id="header" role="banner" data-link-name="global navigation: header" itemscope itemtype="http://schema.org/Organization">
     <div class="header__inner gs-container cf">
         <a href="@LinkTo{/}"
-            id="logo" class="i i-guardian-logo" data-link-name="site logo">The Guardian</a>
+            id="logo" class="i i-guardian-logo" data-link-name="site logo" itemprop="url">The Guardian</a>
 
         <span class="beta">Beta</span>
 

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -4,6 +4,7 @@
 
 <header id="header" role="banner" data-link-name="global navigation: header" itemscope itemtype="http://schema.org/Organization">
     <div class="header__inner gs-container cf">
+        <meta itemprop="logo" content="http://static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png"/>
         <a href="@LinkTo{/}"
             id="logo" class="i i-guardian-logo" data-link-name="site logo" itemprop="url">The Guardian</a>
 


### PR DESCRIPTION
As part of building support for Google's [In-depth callouts](http://googlewebmastercentral.blogspot.co.uk/2013/08/in-depth-articles-in-search-results.html) this change adds a small amount of microdata to the article header to identify the organisation.

This change aligns to the desktop site changes (which only applies it the network front pages).
