### PR TITLE
Search box fixes & improve desktop + tablet search form

### DIFF
--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -21,7 +21,7 @@
     top: 0;
     left: 0;
     right: 0;
-    z-index: 99;
+    z-index: 1050; // On top of Google "Adchoices" label which has z-index: 1040…
 
     /* These styles extend the top bars to the screen edges */
     @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/_search.scss
+++ b/common/app/assets/stylesheets/module/_search.scss
@@ -14,7 +14,7 @@
             top: 0;
             bottom: 0;
             left: 0;
-            background: rgb(227,227,219);
+            background: $darkMushroom;
         }
     }
     @include mq(1117px) { // When the layout starts to be centered

--- a/common/app/assets/stylesheets/module/_search.scss
+++ b/common/app/assets/stylesheets/module/_search.scss
@@ -2,6 +2,11 @@
     min-height: 47px;
 }
 
+.gsc-search-box {
+    padding: 0;
+    max-width: none;
+}
+
 .search-box {
     margin: 0 $gutter;
 }

--- a/common/app/assets/stylesheets/module/_search.scss
+++ b/common/app/assets/stylesheets/module/_search.scss
@@ -1,5 +1,26 @@
 .nav-popup-search {
     min-height: 47px;
+
+    @include mq(tablet) {
+        right: 0;
+        max-width: 512px;
+
+        &:before,
+        &:after {
+            content: '';
+            display: block;
+            width: 1px;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            background: rgb(227,227,219);
+        }
+    }
+    @include mq(1117px) { // When the layout starts to be centered
+        right: -1px;
+        &:after { left: auto; right: 0; }
+    }
 }
 
 .gsc-search-box {

--- a/common/app/assets/stylesheets/module/nav/_control.scss
+++ b/common/app/assets/stylesheets/module/nav/_control.scss
@@ -93,7 +93,7 @@ span.control__menu.i-menu {
     @include mq(tablet) {
         margin-right: $gutter/4*3;
         border-color: #BBBBBB;
-        background-color: #E3E3DB;
+        background-color: $darkMushroom;
     }
 }
 


### PR DESCRIPTION
- Fixes a regression caused by the inclusion of default form styles
- improve usability of the search form by capping its width
- Make sure header always goes on top of ads
## Before

![screen shot 2013-08-08 at 12 33 31](https://f.cloud.github.com/assets/85783/930985/66ed5238-001e-11e3-8025-aa1649babf66.PNG)
![screen shot 2013-08-08 at 12 33 04](https://f.cloud.github.com/assets/85783/930986/6999a540-001e-11e3-9f94-18d9780e0303.PNG)
## After

![screen shot 2013-08-08 at 12 31 03](https://f.cloud.github.com/assets/85783/930987/6eb5cbda-001e-11e3-821b-6b34cef5b7ec.PNG)

![Hum](http://i.imgur.com/nZsHdtG.gif)
