### PR TITLE
Endpoints Refactor

### DIFF
--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -63,7 +63,8 @@ object FrontsController extends Controller with Logging {
   def deleteTrail(edition: String, section: String, blockId: String) = AuthAction { request =>
     request.body.asJson flatMap JsonExtract.build map {
       case update: UpdateList => {
-        UpdateActions.updateActionFilter(edition, section, blockId, update)
+        val identity = Identity(request).get
+        UpdateActions.updateActionFilter(edition, section, blockId, update, identity)
         Ok
       }
       case _ => NotFound

--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -41,14 +41,20 @@ object FrontsController extends Controller with Logging {
       }
       case blockAction: BlockActionJson => {
         blockAction.publish.filter {_ == true}
-          .map { _ => FrontsApi.publishBlock(edition, section, blockId) }
+          .map { _ =>
+            FrontsApi.publishBlock(edition, section, blockId)
+            Ok
+          }
           .orElse {
-          blockAction.discard.filter {_ == true}.map(_ => FrontsApi.discardBlock(edition, section, blockId))
+          blockAction.discard.filter {_ == true}.map { _ =>
+            FrontsApi.discardBlock(edition, section, blockId)
+            Ok
+          }
         } getOrElse NotFound("Invalid JSON")
-        Ok
       }
       case updateTrailblock: UpdateTrailblockJson => {
-        UpdateActions.updateTrailblockJson(edition, section, blockId, updateTrailblock)
+        val identity = Identity(request).get
+        UpdateActions.updateTrailblockJson(edition, section, blockId, updateTrailblock, identity)
         Ok
       }
       case _ => NotFound

--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -35,15 +35,9 @@ object FrontsController extends Controller with Logging {
       case update: UpdateList if update.item == update.position.getOrElse("") => Conflict
       case update: UpdateList => {
         val identity = Identity(request).get
-        FrontsApi.getBlock(edition, section, blockId).map { block =>
-          UpdateActions.updateBlock(edition, section, blockId, update, identity, block)
-          FrontsApi.archive(edition, section, block)
-          Ok
-        } getOrElse {
-          UpdateActions.createBlock(edition, section, blockId, identity, update)
-          Created
+        UpdateActions.updateBlock(edition, section, blockId, update, identity)
+        Ok
         }
-      }
       case blockAction: BlockActionJson => {
         blockAction.publish.filter {_ == true}
           .map { _ => FrontsApi.publishBlock(edition, section, blockId) }
@@ -53,17 +47,9 @@ object FrontsController extends Controller with Logging {
         Ok
       }
       case updateTrailblock: UpdateTrailblockJson => {
-        FrontsApi.getBlock(edition, section, blockId).map { block =>
-          val newBlock = block.copy(
-            contentApiQuery = updateTrailblock.config.contentApiQuery orElse None,
-            //These defaults will move somewhere better during refactor
-            min = updateTrailblock.config.min orElse Some(0),
-            max = updateTrailblock.config.max orElse Some(20)
-          )
-          FrontsApi.putBlock(edition, section, newBlock)
-          Ok
-        } getOrElse NotFound
-      }
+        UpdateActions.updateTrailblockJson(edition, section, blockId, updateTrailblock)
+        Ok
+        }
       case _ => NotFound
     } getOrElse NotFound
   }

--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -36,8 +36,9 @@ object FrontsController extends Controller with Logging {
       case update: UpdateList => {
         val identity = Identity(request).get
         UpdateActions.updateBlock(edition, section, blockId, update, identity)
+        //TODO: How do we know if it was updated or created? Do we need to know?
         Ok
-        }
+      }
       case blockAction: BlockActionJson => {
         blockAction.publish.filter {_ == true}
           .map { _ => FrontsApi.publishBlock(edition, section, blockId) }
@@ -49,7 +50,7 @@ object FrontsController extends Controller with Logging {
       case updateTrailblock: UpdateTrailblockJson => {
         UpdateActions.updateTrailblockJson(edition, section, blockId, updateTrailblock)
         Ok
-        }
+      }
       case _ => NotFound
     } getOrElse NotFound
   }

--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -13,10 +13,6 @@ import tools.FrontsApi
 
 
 object FrontsController extends Controller with Logging {
-  implicit val updateListRead = Json.reads[UpdateList]
-  implicit val blockActionRead = Json.reads[BlockAction]
-  implicit val updateMetaRead = Json.reads[UpdateTrailblockConfig]
-  implicit val updateTrailblockRead = Json.reads[UpdateTrailblock]
 
   def index() = AuthAction{ request =>
     Ok(views.html.fronts(Configuration.environment.stage))
@@ -28,84 +24,50 @@ object FrontsController extends Controller with Logging {
     } getOrElse NotFound
   }
 
-
   def readBlock(edition: String, section: String, blockId: String) = AuthAction{ request =>
     S3FrontsApi.getBlock(edition, section, blockId) map { json =>
       Ok(json).as("application/json")
     } getOrElse NotFound
   }
 
-  def updateBlock(edition: String, section: String, blockId: String): Action[AnyContent] = AuthAction{ request =>
-    request.body.asJson.map { json =>
-        json.asOpt[UpdateList].map { update: UpdateList =>
-            if (update.item == update.position.getOrElse(""))
-              Conflict
-            else {
-              val identity = Identity(request).get
-              FrontsApi.getBlock(edition, section, blockId).map { block =>
-                  updateBlock(edition, section, blockId, update, identity, block)
-                  FrontsApi.archive(edition, section, block)
-                  Ok
-              } getOrElse {
-                createBlock(edition, section, blockId, identity, update)
-                Created
-              }
-            }
-        } orElse json.asOpt[UpdateTrailblock]
-          .map {update =>
-            FrontsApi.getBlock(edition, section, blockId).map { block =>
-              val newBlock = block.copy(
-                contentApiQuery = update.config.contentApiQuery orElse None,
-                //These defaults will move somewhere better during refactor
-                min = update.config.min orElse Some(0),
-                max = update.config.max orElse Some(20)
-              )
-              FrontsApi.putBlock(edition, section, newBlock)
-              Ok
-            } getOrElse NotFound
-        } orElse json.asOpt[BlockAction]
-          .map {blockAction => blockAction
-          blockAction.publish.filter {_ == true}
-            .map { _ => FrontsApi.publishBlock(edition, section, blockId) }
-            .orElse {
-            blockAction.discard.filter {_ == true}.map(_ => FrontsApi.discardBlock(edition, section, blockId))
-          } getOrElse NotFound("Invalid JSON")
+  def updateBlock(edition: String, section: String, blockId: String): Action[AnyContent] = AuthAction { request =>
+    request.body.asJson flatMap JsonExtract.build map {
+      case update: UpdateList if update.item == update.position.getOrElse("") => Conflict
+      case update: UpdateList => {
+        val identity = Identity(request).get
+        FrontsApi.getBlock(edition, section, blockId).map { block =>
+          UpdateActions.updateBlock(edition, section, blockId, update, identity, block)
+          FrontsApi.archive(edition, section, block)
           Ok
+        } getOrElse {
+          UpdateActions.createBlock(edition, section, blockId, identity, update)
+          Created
+        }
+      }
+      case blockAction: BlockActionJson => {
+        blockAction.publish.filter {_ == true}
+          .map { _ => FrontsApi.publishBlock(edition, section, blockId) }
+          .orElse {
+          blockAction.discard.filter {_ == true}.map(_ => FrontsApi.discardBlock(edition, section, blockId))
         } getOrElse NotFound("Invalid JSON")
-    } getOrElse NotFound("Problem parsing json")
+        Ok
+      }
+      case updateTrailblock: UpdateTrailblockJson => {
+        FrontsApi.getBlock(edition, section, blockId).map { block =>
+          val newBlock = block.copy(
+            contentApiQuery = updateTrailblock.config.contentApiQuery orElse None,
+            //These defaults will move somewhere better during refactor
+            min = updateTrailblock.config.min orElse Some(0),
+            max = updateTrailblock.config.max orElse Some(20)
+          )
+          FrontsApi.putBlock(edition, section, newBlock)
+          Ok
+        } getOrElse NotFound
+      }
+      case _ => NotFound
+    } getOrElse NotFound
   }
 
-  private def updateBlock(edition: String, section: String, blockId: String, update: UpdateList, identity: Identity, block: Block): Unit = {
-    var newBlock: Block = block.copy(lastUpdated = DateTime.now.toString, updatedBy = identity.fullName, updatedEmail = identity.email)
-    if (update.draft) {
-      val trails = updateList(update, block.draft)
-      newBlock = newBlock.copy(draft = trails)
-    }
-    if (update.live) {
-      val trails = updateList(update, block.live)
-      newBlock = newBlock.copy(live = trails)
-    }
-
-    newBlock = newBlock.copy(areEqual = newBlock.live==newBlock.draft)
-
-    FrontsApi.putBlock(edition, section, blockId, newBlock)
-  }
-
-  private def updateList(update: UpdateList, blocks: List[Trail]): List[Trail] = {
-    val listWithoutItem = blocks.filterNot(_.id == update.item)
-    val index = update.after.filter {_ == true}
-      .map {_ => listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) + 1}
-      .getOrElse { listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) }
-    val splitList = listWithoutItem.splitAt(index)
-    splitList._1 ++ List(Trail(update.item, None, None, None)) ++ splitList._2
-  }
-
-  private def createBlock(edition: String, section: String, block: String, identity: Identity, update: UpdateList) {
-      FrontsApi.putBlock(edition, section, block, Block(block, None, List(Trail(update.item, None, None, None)), List(Trail(update.item, None, None, None)), areEqual=true, DateTime.now.toString, identity.fullName, identity.email, None, None, None))
-  }
-  /**
-   * @todo
-   */
   def updateTrail(edition: String, section: String, blockId: String, trailId: String) = AuthAction{ request =>
     request.body.asJson.map{ json =>
     }
@@ -113,25 +75,13 @@ object FrontsController extends Controller with Logging {
   }
 
   def deleteTrail(edition: String, section: String, blockId: String) = AuthAction { request =>
-    request.body.asJson.map { json =>
-      json.asOpt[UpdateList].map { update: UpdateList =>
-        FrontsApi.getBlock(edition, section, blockId) map { block: Block =>
-          var newBlock = block.copy()
-          if (update.draft) {
-            val trails = block.draft.filterNot(_.id == update.item)
-            newBlock = newBlock.copy(draft = trails)
-          }
-          if (update.live) {
-            val trails = block.live.filterNot(_.id == update.item)
-            newBlock = newBlock.copy(live = trails)
-          }
-          newBlock = newBlock.copy(areEqual = newBlock.live==newBlock.draft)
-
-          FrontsApi.putBlock(edition, section, block.id, newBlock)
-          Ok
-        } getOrElse NotFound("No edition or section") //To be more silent in the future?
-      } getOrElse NotFound("Invalid JSON")
-    } getOrElse NotFound("Problem parsing json")
+    request.body.asJson flatMap JsonExtract.build map {
+      case update: UpdateList => {
+        UpdateActions.updateActionFilter(edition, section, blockId, update)
+        Ok
+      }
+      case _ => NotFound
+    } getOrElse NotFound
   }
 
 }

--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -35,7 +35,7 @@ object FrontsController extends Controller with Logging {
       case update: UpdateList if update.item == update.position.getOrElse("") => Conflict
       case update: UpdateList => {
         val identity = Identity(request).get
-        UpdateActions.updateBlock(edition, section, blockId, update, identity)
+        UpdateActions.updateCollectionList(edition, section, blockId, update, identity)
         //TODO: How do we know if it was updated or created? Do we need to know?
         Ok
       }
@@ -71,7 +71,7 @@ object FrontsController extends Controller with Logging {
     request.body.asJson flatMap JsonExtract.build map {
       case update: UpdateList => {
         val identity = Identity(request).get
-        UpdateActions.updateActionFilter(edition, section, blockId, update, identity)
+        UpdateActions.updateCollectionFilter(edition, section, blockId, update, identity)
         Ok
       }
       case _ => NotFound

--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -1,6 +1,12 @@
 package frontsapi.model
 
-case class Block(
+import play.api.libs.json.{Json, JsValue}
+import play.api.mvc.Results.Status
+import tools.FrontsApi
+import controllers.Identity
+import org.joda.time.DateTime
+
+sealed case class Block(
                   id: String,
                   name: Option[String],
                   live: List[Trail],
@@ -14,15 +20,104 @@ case class Block(
                   contentApiQuery: Option[String]
                   )
 
-case class Trail(
+sealed case class Trail(
                   id: String,
                   title: Option[String],
                   trailImage: Option[String],
                   linkText: Option[String]
                   )
 
-case class UpdateList(item: String, position: Option[String], after: Option[Boolean], live: Boolean, draft: Boolean)
-case class BlockAction(publish: Option[Boolean], discard: Option[Boolean])
 
-case class UpdateTrailblock(config: UpdateTrailblockConfig)
-case class UpdateTrailblockConfig(contentApiQuery: Option[String], max: Option[Int], min: Option[Int])
+case class BlockActionJson(publish: Option[Boolean], discard: Option[Boolean])
+
+trait Update
+case class Publish(id: String)
+case class Discard(id: String)
+
+case class UpdateTrailblockJson(config: UpdateTrailblockConfigJson)
+case class UpdateTrailblockConfigJson(contentApiQuery: Option[String], max: Option[Int], min: Option[Int])
+
+trait DeleteAction
+
+case class UpdateList(item: String, position: Option[String], after: Option[Boolean], live: Boolean, draft: Boolean) {
+
+  def updateList(update: UpdateList, blocks: List[Trail]): List[Trail] = {
+    val listWithoutItem = blocks.filterNot(_.id == update.item)
+    val index = update.after.filter {_ == true}
+      .map {_ => listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) + 1}
+      .getOrElse { listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) }
+    val splitList = listWithoutItem.splitAt(index)
+    splitList._1 ++ List(Trail(update.item, None, None, None)) ++ splitList._2
+  }
+
+}
+
+object JsonExtract {
+  implicit val updateListRead = Json.reads[UpdateList]
+  implicit val trailActionRead = Json.reads[Trail]
+  implicit val blockActionRead = Json.reads[Block]
+  implicit val blockActionJsonRead = Json.reads[BlockActionJson]
+  implicit val updateMetaRead = Json.reads[UpdateTrailblockConfigJson]
+  implicit val updateTrailblockRead = Json.reads[UpdateTrailblockJson]
+
+  private def extractJson(v: JsValue): Either[String, Any] =
+    v.asOpt[Block]
+      .orElse{v.asOpt[UpdateList]}
+      .orElse{v.asOpt[UpdateTrailblockJson]}
+      .orElse{v.asOpt[BlockActionJson]}
+      .toRight("Invalid Json")
+
+  def build(v: JsValue) = extractJson(v).right.toOption
+}
+
+trait UpdateActions {
+
+  def updateActionFilter(edition: String, section: String, blockId: String, update: UpdateList): Either[String, String] =
+    FrontsApi.getBlock(edition, section, blockId) map { block: Block =>
+      var newBlock = block.copy()
+      if (update.draft) {
+        val trails = block.draft.filterNot(_.id == update.item)
+        newBlock = newBlock.copy(draft = trails)
+      }
+      if (update.live) {
+        val trails = block.live.filterNot(_.id == update.item)
+        newBlock = newBlock.copy(live = trails)
+      }
+      newBlock = newBlock.copy(areEqual = newBlock.live==newBlock.draft)
+
+      FrontsApi.putBlock(edition, section, block.id, newBlock)
+      Right("OK")
+    } getOrElse Left("No edition or section") //To be more silent in the future?
+
+
+  private def updateList(update: UpdateList, blocks: List[Trail]): List[Trail] = {
+    val listWithoutItem = blocks.filterNot(_.id == update.item)
+    val index = update.after.filter {_ == true}
+      .map {_ => listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) + 1}
+      .getOrElse { listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) }
+    val splitList = listWithoutItem.splitAt(index)
+    splitList._1 ++ List(Trail(update.item, None, None, None)) ++ splitList._2
+  }
+
+  def updateBlock(edition: String, section: String, blockId: String, update: UpdateList, identity: Identity, block: Block): Unit = {
+    var newBlock: Block = block.copy(lastUpdated = DateTime.now.toString, updatedBy = identity.fullName, updatedEmail = identity.email)
+    if (update.draft) {
+      val trails = updateList(update, block.draft)
+      newBlock = newBlock.copy(draft = trails)
+    }
+    if (update.live) {
+      val trails = updateList(update, block.live)
+      newBlock = newBlock.copy(live = trails)
+    }
+
+    newBlock = newBlock.copy(areEqual = newBlock.live==newBlock.draft)
+
+    FrontsApi.putBlock(edition, section, blockId, newBlock)
+  }
+
+  def createBlock(edition: String, section: String, block: String, identity: Identity, update: UpdateList) {
+    FrontsApi.putBlock(edition, section, block, Block(block, None, List(Trail(update.item, None, None, None)), List(Trail(update.item, None, None, None)), areEqual = true, DateTime.now.toString, identity.fullName, identity.email, None, None, None))
+  }
+}
+
+object UpdateActions extends UpdateActions

--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -112,16 +112,21 @@ trait UpdateActions {
     FrontsApi.putBlock(edition, section, block, Block(block, None, List(trailWithId(update.item)), List(trailWithId(update.item)), areEqual = true, DateTime.now.toString, identity.fullName, identity.email, None, None, None))
   }
 
-  def updateTrailblockJson(edition: String, section: String, blockId: String, updateTrailblock: UpdateTrailblockJson) = {
+  def updateTrailblockJson(edition: String, section: String, blockId: String, updateTrailblock: UpdateTrailblockJson, identity: Identity) = {
     FrontsApi.getBlock(edition, section, blockId).map { block =>
       val newBlock = block.copy(
         contentApiQuery = updateTrailblock.config.contentApiQuery orElse None,
         min = updateTrailblock.config.min orElse Some(defaultMinimumTrailblocks),
         max = updateTrailblock.config.max orElse Some(defaultMaximumTrailblocks)
       )
-      FrontsApi.putBlock(edition, section, newBlock)
+      if (newBlock != block) {
+        FrontsApi.putBlock(edition, section, updateIdentity(newBlock, identity))
+      }
     }
   }
+
+  def updateIdentity(block: Block, identity: Identity): Block = block.copy(lastUpdated = DateTime.now.toString, updatedBy = identity.fullName, updatedEmail = identity.email)
+
 }
 
 object UpdateActions extends UpdateActions

--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -28,17 +28,11 @@ sealed case class Trail(
                   )
 
 
+
+
 case class BlockActionJson(publish: Option[Boolean], discard: Option[Boolean])
-
-trait Update
-case class Publish(id: String)
-case class Discard(id: String)
-
 case class UpdateTrailblockJson(config: UpdateTrailblockConfigJson)
 case class UpdateTrailblockConfigJson(contentApiQuery: Option[String], max: Option[Int], min: Option[Int])
-
-trait DeleteAction
-
 case class UpdateList(item: String, position: Option[String], after: Option[Boolean], live: Boolean, draft: Boolean)
 
 object JsonExtract {

--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -58,7 +58,8 @@ trait UpdateActions {
 
   lazy val defaultMinimumTrailblocks = 0
   lazy val defaultMaximumTrailblocks = 20
-  def trailWithId(id: String) = Trail(id, None, None, None)
+
+  def emptyTrailWithId(id: String) = Trail(id, None, None, None)
 
   def updateActionFilter(edition: String, section: String, blockId: String, update: UpdateList, identity: Identity): Either[String, String] =
     FrontsApi.getBlock(edition, section, blockId) map { block: Block =>
@@ -84,7 +85,7 @@ trait UpdateActions {
       .map {_ => listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) + 1}
       .getOrElse { listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) }
     val splitList = listWithoutItem.splitAt(index)
-    splitList._1 ++ List(trailWithId(update.item)) ++ splitList._2
+    splitList._1 ++ List(emptyTrailWithId(update.item)) ++ splitList._2
   }
 
   def updateBlock(edition: String, section: String, blockId: String, update: UpdateList, identity: Identity): Unit = {
@@ -109,7 +110,7 @@ trait UpdateActions {
   }
 
   def createBlock(edition: String, section: String, block: String, identity: Identity, update: UpdateList) {
-    FrontsApi.putBlock(edition, section, block, Block(block, None, List(trailWithId(update.item)), List(trailWithId(update.item)), areEqual = true, DateTime.now.toString, identity.fullName, identity.email, None, None, None))
+    FrontsApi.putBlock(edition, section, block, Block(block, None, List(emptyTrailWithId(update.item)), List(emptyTrailWithId(update.item)), areEqual = true, DateTime.now.toString, identity.fullName, identity.email, None, None, None))
   }
 
   def updateTrailblockJson(edition: String, section: String, blockId: String, updateTrailblock: UpdateTrailblockJson, identity: Identity) = {

--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -31,7 +31,7 @@ case class UpdateTrailblockJson(config: UpdateTrailblockConfigJson)
 case class UpdateTrailblockConfigJson(contentApiQuery: Option[String], max: Option[Int], min: Option[Int])
 case class UpdateList(item: String, position: Option[String], after: Option[Boolean], live: Boolean, draft: Boolean)
 
-object JsonExtract {
+trait JsonExtract {
   implicit val updateListRead = Json.reads[UpdateList]
   implicit val trailActionRead = Json.reads[Trail]
   implicit val blockActionRead = Json.reads[Block]
@@ -48,6 +48,8 @@ object JsonExtract {
 
   def build(v: JsValue) = extractJson(v).right.toOption
 }
+
+object JsonExtract extends JsonExtract
 
 trait UpdateActions {
 

--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -1,12 +1,11 @@
 package frontsapi.model
 
 import play.api.libs.json.{Json, JsValue}
-import play.api.mvc.Results.Status
 import tools.FrontsApi
 import controllers.Identity
 import org.joda.time.DateTime
 
-sealed case class Block(
+case class Block(
                   id: String,
                   name: Option[String],
                   live: List[Trail],
@@ -20,15 +19,12 @@ sealed case class Block(
                   contentApiQuery: Option[String]
                   )
 
-sealed case class Trail(
+case class Trail(
                   id: String,
                   title: Option[String],
                   trailImage: Option[String],
                   linkText: Option[String]
                   )
-
-
-
 
 case class BlockActionJson(publish: Option[Boolean], discard: Option[Boolean])
 case class UpdateTrailblockJson(config: UpdateTrailblockConfigJson)

--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -39,18 +39,7 @@ case class UpdateTrailblockConfigJson(contentApiQuery: Option[String], max: Opti
 
 trait DeleteAction
 
-case class UpdateList(item: String, position: Option[String], after: Option[Boolean], live: Boolean, draft: Boolean) {
-
-  def updateList(update: UpdateList, blocks: List[Trail]): List[Trail] = {
-    val listWithoutItem = blocks.filterNot(_.id == update.item)
-    val index = update.after.filter {_ == true}
-      .map {_ => listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) + 1}
-      .getOrElse { listWithoutItem.indexWhere(_.id == update.position.getOrElse("")) }
-    val splitList = listWithoutItem.splitAt(index)
-    splitList._1 ++ List(Trail(update.item, None, None, None)) ++ splitList._2
-  }
-
-}
+case class UpdateList(item: String, position: Option[String], after: Option[Boolean], live: Boolean, draft: Boolean)
 
 object JsonExtract {
   implicit val updateListRead = Json.reads[UpdateList]


### PR DESCRIPTION
This is the latest refactor of the fronts api. This moves away logic from the controller into a trait and the extraction of JSON into a trait also.

Instead of creating new business objects, I decided to just keep the case classes closely bound to the JSON, and have traits that work around these objects. When/If things get more complicated in the future, separate objects can be created.

There could still be some more refactoring done around the responses, to make the more RESTy.

This pull request does not change how anything works, but does fix a few very minor bugs.
