### PR TITLE
Namespace Change

### DIFF
--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -30,6 +30,12 @@ object FrontsController extends Controller with Logging {
     } getOrElse NotFound
   }
 
+  def getConfig(id: String) = AuthAction{ request =>
+    S3FrontsApi.getConfig(id) map { json =>
+      Ok(json).as("application/json")
+    } getOrElse NotFound
+  }
+
   def updateBlock(id: String): Action[AnyContent] = AuthAction { request =>
     request.body.asJson flatMap JsonExtract.build map {
       case update: UpdateList if update.item == update.position.getOrElse("") => Conflict

--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -24,54 +24,54 @@ object FrontsController extends Controller with Logging {
     } getOrElse NotFound
   }
 
-  def readBlock(edition: String, section: String, blockId: String) = AuthAction{ request =>
-    S3FrontsApi.getBlock(edition, section, blockId) map { json =>
+  def readBlock(id: String) = AuthAction{ request =>
+    S3FrontsApi.getBlock(id) map { json =>
       Ok(json).as("application/json")
     } getOrElse NotFound
   }
 
-  def updateBlock(edition: String, section: String, blockId: String): Action[AnyContent] = AuthAction { request =>
+  def updateBlock(id: String): Action[AnyContent] = AuthAction { request =>
     request.body.asJson flatMap JsonExtract.build map {
       case update: UpdateList if update.item == update.position.getOrElse("") => Conflict
       case update: UpdateList => {
         val identity = Identity(request).get
-        UpdateActions.updateCollectionList(edition, section, blockId, update, identity)
+        UpdateActions.updateCollectionList(id, update, identity)
         //TODO: How do we know if it was updated or created? Do we need to know?
         Ok
       }
       case blockAction: BlockActionJson => {
         blockAction.publish.filter {_ == true}
           .map { _ =>
-            FrontsApi.publishBlock(edition, section, blockId)
+            FrontsApi.publishBlock(id)
             Ok
           }
           .orElse {
           blockAction.discard.filter {_ == true}.map { _ =>
-            FrontsApi.discardBlock(edition, section, blockId)
+            FrontsApi.discardBlock(id)
             Ok
           }
         } getOrElse NotFound("Invalid JSON")
       }
       case updateTrailblock: UpdateTrailblockJson => {
         val identity = Identity(request).get
-        UpdateActions.updateTrailblockJson(edition, section, blockId, updateTrailblock, identity)
+        UpdateActions.updateTrailblockJson(id, updateTrailblock, identity)
         Ok
       }
       case _ => NotFound
     } getOrElse NotFound
   }
 
-  def updateTrail(edition: String, section: String, blockId: String, trailId: String) = AuthAction{ request =>
+  def updateTrail(id: String, trailId: String) = AuthAction{ request =>
     request.body.asJson.map{ json =>
     }
     Ok
   }
 
-  def deleteTrail(edition: String, section: String, blockId: String) = AuthAction { request =>
+  def deleteTrail(id: String) = AuthAction { request =>
     request.body.asJson flatMap JsonExtract.build map {
       case update: UpdateList => {
         val identity = Identity(request).get
-        UpdateActions.updateCollectionFilter(edition, section, blockId, update, identity)
+        UpdateActions.updateCollectionFilter(id, update, identity)
         Ok
       }
       case _ => NotFound

--- a/admin/app/tools/FrontsApi.scala
+++ b/admin/app/tools/FrontsApi.scala
@@ -7,15 +7,15 @@ import play.api.libs.json.Json
 
 trait FrontsApiRead {
   def getSchema: Option[String]
-  def getBlock(edition: String, section: String, blockId: String): Option[Block]
+  def getBlock(id: String): Option[Block]
   def getBlocksSince(since: DateTime): Seq[Block]
   def getBlocksSince(since: String): Seq[Block] = getBlocksSince(DateTime.parse(since))
 }
 
 trait FrontsApiWrite {
-  def putBlock(edition: String, section: String, block: Block): Unit
-  def publishBlock(edition: String, section: String, blockId: String): Unit
-  def archive(edition: String, section: String, block: Block): Unit
+  def putBlock(id: String, block: Block): Unit
+  def publishBlock(id: String): Unit
+  def archive(id: String, block: Block): Unit
 }
 
 object FrontsApi extends FrontsApiRead with FrontsApiWrite {
@@ -26,16 +26,15 @@ object FrontsApi extends FrontsApiRead with FrontsApiWrite {
   implicit val blockWrite = Json.writes[Block]
 
   def getSchema = S3FrontsApi.getSchema
-  def getBlock(edition: String, section: String, blockId: String) = for {
-    blockJson <- S3FrontsApi.getBlock(edition, section, blockId)
+  def getBlock(id: String) = for {
+    blockJson <- S3FrontsApi.getBlock(id)
     block <- Json.parse(blockJson).asOpt[Block]
   } yield block
 
   def getBlocksSince(since: DateTime) = ???
 
-  def putBlock(edition: String, section: String, blockId: String, block: Block) = S3FrontsApi.putBlock(edition, section, blockId, Json.prettyPrint(Json.toJson(block)))
-  def putBlock(edition: String, section: String, block: Block) = putBlock(edition, section, block.id, block)
-  def publishBlock(edition: String, section: String, blockId: String) = getBlock(edition, section, blockId) foreach { block => putBlock(edition, section, blockId, block.copy(live = block.draft, areEqual=true))}
-  def discardBlock(edition: String, section: String, blockId: String) = getBlock(edition, section, blockId) foreach { block => putBlock(edition,section, blockId, block.copy(draft = block.live, areEqual=true))}
-  def archive(edition: String, section: String, block: Block) = S3FrontsApi.archive(edition, section, block.id, Json.prettyPrint(Json.toJson(block)))
+  def putBlock(id: String, block: Block) = S3FrontsApi.putBlock(id, Json.prettyPrint(Json.toJson(block)))
+  def publishBlock(id: String) = getBlock(id) foreach { block => putBlock(id, block.copy(live = block.draft, areEqual=true))}
+  def discardBlock(id: String) = getBlock(id) foreach { block => putBlock(id, block.copy(draft = block.live, areEqual=true))}
+  def archive(id: String, block: Block) = S3FrontsApi.archive(id, Json.prettyPrint(Json.toJson(block)))
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -36,6 +36,7 @@ POST    /dev/switchboard                 controllers.SwitchboardController.save(
 # Fronts
 GET       /fronts                        controllers.FrontsController.index()
 GET       /fronts/api                    controllers.FrontsController.schema()
+GET       /fronts/config/*id             controllers.FrontsController.getConfig(id)
 GET       /fronts/api/*id                controllers.FrontsController.readBlock(id)
 POST      /fronts/api/*id                controllers.FrontsController.updateBlock(id)
 DELETE    /fronts/api/*id                controllers.FrontsController.deleteTrail(id)

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -34,12 +34,11 @@ GET     /dev/switchboard                 controllers.SwitchboardController.rende
 POST    /dev/switchboard                 controllers.SwitchboardController.save()
 
 # Fronts
-GET       /fronts                                        controllers.FrontsController.index()
-GET       /fronts/api                                    controllers.FrontsController.schema()
-GET       /fronts/api/:edition/:section/:block           controllers.FrontsController.readBlock(edition, section, block)
-POST      /fronts/api/:edition/:section/:block           controllers.FrontsController.updateBlock(edition, section, block)
-POST      /fronts/api/:edition/:section/:block/*trail    controllers.FrontsController.updateTrail(edition, section, block, trail)
-DELETE    /fronts/api/:edition/:section/:block           controllers.FrontsController.deleteTrail(edition, section, block)
+GET       /fronts                        controllers.FrontsController.index()
+GET       /fronts/api                    controllers.FrontsController.schema()
+GET       /fronts/api/*id                controllers.FrontsController.readBlock(id)
+POST      /fronts/api/*id                controllers.FrontsController.updateBlock(id)
+DELETE    /fronts/api/*id                controllers.FrontsController.deleteTrail(id)
 
 # Analytics
 GET     /analytics/kpis                  controllers.AnalyticsController.kpis()

--- a/common/app/common/S3.scala
+++ b/common/app/common/S3.scala
@@ -68,12 +68,12 @@ object S3FrontsApi extends S3 {
     putPublic(s"${location}/${edition}/${section}/latest/latest.json", json, "application/json")
 
 
-  def getBlock(edition: String, section: String, block: String) = get(s"${location}/${edition}/${section}/${block}/latest/latest.json")
-  def putBlock(edition: String, section: String, block: String, json: String) =
-    putPublic(s"${location}/${edition}/${section}/${block}/latest/latest.json", json, "application/json")
+  def getBlock(id: String) = get(s"${location}/${id}/latest/latest.json")
+  def putBlock(id: String, json: String) =
+    putPublic(s"${location}/${id}/latest/latest.json", json, "application/json")
 
-  def archive(edition: String, section: String, block: String, json: String) = {
+  def archive(id: String, json: String) = {
     val now = DateTime.now
-    putPrivate(s"${location}/${edition}/${section}/${block}/history/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.json", json, "application/json")
+    putPrivate(s"${location}/${id}/history/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.json", json, "application/json")
   }
 }

--- a/common/app/common/S3.scala
+++ b/common/app/common/S3.scala
@@ -63,12 +63,12 @@ object S3FrontsApi extends S3 {
 
 
   def getSchema = get(s"${location}/schema.json")
-  def getBlock(id: String) = get(s"${location}/${id}/latest/latest.json")
+  def getBlock(id: String) = get(s"${location}/collection/${id}/collection.json")
   def putBlock(id: String, json: String) =
-    putPublic(s"${location}/${id}/latest/latest.json", json, "application/json")
+    putPublic(s"${location}/collection/${id}/collection.json", json, "application/json")
 
   def archive(id: String, json: String) = {
     val now = DateTime.now
-    putPrivate(s"${location}/${id}/history/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.json", json, "application/json")
+    putPrivate(s"${location}/collection/${id}/history/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.json", json, "application/json")
   }
 }

--- a/common/app/common/S3.scala
+++ b/common/app/common/S3.scala
@@ -63,6 +63,7 @@ object S3FrontsApi extends S3 {
 
 
   def getSchema = get(s"${location}/schema.json")
+  def getConfig(id: String) = get(s"${location}/config/${id}/config.json")
   def getBlock(id: String) = get(s"${location}/collection/${id}/collection.json")
   def putBlock(id: String, json: String) =
     putPublic(s"${location}/collection/${id}/collection.json", json, "application/json")

--- a/common/app/common/S3.scala
+++ b/common/app/common/S3.scala
@@ -63,11 +63,6 @@ object S3FrontsApi extends S3 {
 
 
   def getSchema = get(s"${location}/schema.json")
-  def getFront(edition: String, section: String) = get(s"${location}/${edition}/${section}/latest/latest.json")
-  def putFront(edition: String, section: String, json: String) =
-    putPublic(s"${location}/${edition}/${section}/latest/latest.json", json, "application/json")
-
-
   def getBlock(id: String) = get(s"${location}/${id}/latest/latest.json")
   def putBlock(id: String, json: String) =
     putPublic(s"${location}/${id}/latest/latest.json", json, "application/json")

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -165,31 +165,31 @@ object Au extends Edition(
 
   val configuredFrontsFacia = Map(
     (Editionalise("", Au), Seq(
-      RunningOrderTrailblockDescription("news", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("news", "features", "Features", 5),
-      RunningOrderTrailblockDescription("news", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("news", "au/news/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("news", "au/news/features", "Features", 5),
+      RunningOrderTrailblockDescription("news", "au/news/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("culture", Au), Seq(
-      RunningOrderTrailblockDescription("culture", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("culture", "features", "Features", 5),
-      RunningOrderTrailblockDescription("culture", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("culture", "au/culture/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("culture", "au/culture/features", "Features", 5),
+      RunningOrderTrailblockDescription("culture", "au/culture/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("fashion", Au), Seq(
-      RunningOrderTrailblockDescription("fashion", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("fashion", "features", "Features", 5),
-      RunningOrderTrailblockDescription("fashion", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("fashion", "au/fashion/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("fashion", "au/fashion/features", "Features", 5),
+      RunningOrderTrailblockDescription("fashion", "au/fashion/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("technology", Au), Seq(
-      RunningOrderTrailblockDescription("technology", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("technology", "features", "Features", 5),
-      RunningOrderTrailblockDescription("technology", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("technology", "au/technology/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("technology", "au/technology/features", "Features", 5),
+      RunningOrderTrailblockDescription("technology", "au/technology/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("film", Au), Seq(
-      RunningOrderTrailblockDescription("film", "top-stories", "Film", 15)
+      RunningOrderTrailblockDescription("film", "au/film/top-stories", "Film", 15)
     ))
   )
 }

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -111,31 +111,31 @@ object Uk extends Edition(
 
   val configuredFrontsFacia = Map(
     (Editionalise("", Uk), Seq(
-      RunningOrderTrailblockDescription("news", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("news", "features", "Features", 5),
-      RunningOrderTrailblockDescription("news", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("news", "uk/news/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("news", "uk/news/features", "Features", 5),
+      RunningOrderTrailblockDescription("news", "uk/news/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("culture", Uk), Seq(
-      RunningOrderTrailblockDescription("culture", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("culture", "features", "Features", 5),
-      RunningOrderTrailblockDescription("culture", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("culture", "uk/culture/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("culture", "uk/culture/features", "Features", 5),
+      RunningOrderTrailblockDescription("culture", "uk/culture/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("fashion", Uk), Seq(
-      RunningOrderTrailblockDescription("fashion", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("fashion", "features", "Features", 5),
-      RunningOrderTrailblockDescription("fashion", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("fashion", "uk/fashion/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("fashion", "uk/fashion/features", "Features", 5),
+      RunningOrderTrailblockDescription("fashion", "uk/fashion/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("technology", Uk), Seq(
-      RunningOrderTrailblockDescription("technology", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("technology", "features", "Features", 5),
-      RunningOrderTrailblockDescription("technology", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("technology", "uk/technology/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("technology", "uk/technology/features", "Features", 5),
+      RunningOrderTrailblockDescription("technology", "uk/technology/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("film", Uk), Seq(
-      RunningOrderTrailblockDescription("film", "top-stories", "Film", 15, style = Some(SectionFront))
+      RunningOrderTrailblockDescription("film", "uk/film/top-stories", "Film", 15, style = Some(SectionFront))
     ))
   )
 }

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -103,31 +103,31 @@ object Us extends Edition(
 
   val configuredFrontsFacia = Map(
     (Editionalise("", Us), Seq(
-      RunningOrderTrailblockDescription("news", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("news", "features", "Features", 5),
-      RunningOrderTrailblockDescription("news", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("news", "us/news/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("news", "us/news/features", "Features", 5),
+      RunningOrderTrailblockDescription("news", "us/news/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("culture", Us), Seq(
-      RunningOrderTrailblockDescription("culture", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("culture", "features", "Features", 5),
-      RunningOrderTrailblockDescription("culture", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("culture", "us/culture/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("culture", "us/culture/features", "Features", 5),
+      RunningOrderTrailblockDescription("culture", "us/culture/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("fashion", Us), Seq(
-      RunningOrderTrailblockDescription("fashion", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("fashion", "features", "Features", 5),
-      RunningOrderTrailblockDescription("fashion", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("fashion", "us/fashion/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("fashion", "us/fashion/features", "Features", 5),
+      RunningOrderTrailblockDescription("fashion", "us/fashion/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("technology", Us), Seq(
-      RunningOrderTrailblockDescription("technology", "top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("technology", "features", "Features", 5),
-      RunningOrderTrailblockDescription("technology", "editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("technology", "us/technology/top-stories", "Top Stories", 5),
+      RunningOrderTrailblockDescription("technology", "us/technology/features", "Features", 5),
+      RunningOrderTrailblockDescription("technology", "us/technology/editors-picks", "Editor's Picks", 5)
     )),
 
     (Editionalise("film", Us), Seq(
-      RunningOrderTrailblockDescription("film", "top-stories", "Film", 15)
+      RunningOrderTrailblockDescription("film", "us/film/top-stories", "Film", 15)
     ))
   )
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -119,7 +119,7 @@ class RunningOrderTrailblockDescription(
 
   def configuredQuery() = {
     // get the running order from the api
-    val configUrl = s"${Configuration.frontend.store}/${S3FrontsApi.location}/${edition.id.toLowerCase}/$section/$blockId/latest/latest.json"
+    val configUrl = s"${Configuration.frontend.store}/${S3FrontsApi.location}/collection/$blockId/collection.json"
     log.info(s"loading running order configuration from: $configUrl")
     parseResponse(WS.url(s"$configUrl").withTimeout(2000).get())
   }


### PR DESCRIPTION
This implements the discussed namespace change in the S3 buckets. It gets rid of the URL matching that was used to match against /edition/section/collectionid, in place of just ID.

This allows us to create different types of collections more easily that doesn't have anything to do with an edition or section.

Also provides an endpoint that will return the config.json file for a specific ID, although we are not yet using this.

Finally, facia changed to use new namespacing.

UPDATE: I forgot to mention, this will reset everything that you may have carefully curated.
