### PR TITLE
Update US network front to reflect what is on mobile prod front

### DIFF
--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -165,9 +165,14 @@ object Au extends Edition(
 
   val configuredFrontsFacia = Map(
     (Editionalise("", Au), Seq(
-      RunningOrderTrailblockDescription("news", "au/news/top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("news", "au/news/features", "Features", 5),
-      RunningOrderTrailblockDescription("news", "au/news/editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("news", "au/news/top-stories", "Top Stories", 5, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "au/sport/top-stories", "Sports", 5, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "au/commentisfree/top-stories", "Comment is free", 3, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "au/culture/top-stories", "Culture", 3, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "au/business/top-stories", "Business", 1),
+      RunningOrderTrailblockDescription("news", "au/lifeandstyle/top-stories", "Life and style", 1, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "au/technology/top-stories", "Technology", 1, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "au/travel/top-stories", "Travel", 1, style = Some(Thumbnail))
     )),
 
     (Editionalise("culture", Au), Seq(

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -111,9 +111,14 @@ object Uk extends Edition(
 
   val configuredFrontsFacia = Map(
     (Editionalise("", Uk), Seq(
-      RunningOrderTrailblockDescription("news", "uk/news/top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("news", "uk/news/features", "Features", 5),
-      RunningOrderTrailblockDescription("news", "uk/news/editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("news", "uk/news/top-stories", "Top Stories", 5, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "uk/sport/top-stories", "Sports", 5, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "uk/commentisfree/top-stories", "Comment is free", 3, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "uk/culture/top-stories", "Culture", 3, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "uk/business/top-stories", "Business", 1),
+      RunningOrderTrailblockDescription("news", "uk/lifeandstyle/top-stories", "Life and style", 1, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "uk/technology/top-stories", "Technology", 1, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "uk/travel/top-stories", "Travel", 1, style = Some(Thumbnail))
     )),
 
     (Editionalise("culture", Uk), Seq(

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -103,9 +103,14 @@ object Us extends Edition(
 
   val configuredFrontsFacia = Map(
     (Editionalise("", Us), Seq(
-      RunningOrderTrailblockDescription("news", "us/news/top-stories", "Top Stories", 5),
-      RunningOrderTrailblockDescription("news", "us/news/features", "Features", 5),
-      RunningOrderTrailblockDescription("news", "us/news/editors-picks", "Editor's Picks", 5)
+      RunningOrderTrailblockDescription("news", "us/news/top-stories", "Top Stories", 5, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "us/sport/top-stories", "Sports", 5, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "us/commentisfree/top-stories", "Comment is free", 3, style = Some(Featured)),
+      RunningOrderTrailblockDescription("news", "us/culture/top-stories", "Culture", 3, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "us/business/top-stories", "Business", 1),
+      RunningOrderTrailblockDescription("news", "us/lifeandstyle/top-stories", "Life and style", 1, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "us/technology/top-stories", "Technology", 1, style = Some(Thumbnail)),
+      RunningOrderTrailblockDescription("news", "us/travel/top-stories", "Travel", 1, style = Some(Thumbnail))
     )),
 
     (Editionalise("culture", Us), Seq(


### PR DESCRIPTION
This is just config to have the facia US front look like what the current mobile front looks like (In terms of which collections exist, not content)

In order to update each collection, the schema.json must be updated in S3 for PROD environments.

UPDATE: AU front too!
UPDATE: UK!
