### PR TITLE
Front Facia Redirect

### DIFF
--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -128,7 +128,7 @@ class FrontController extends Controller with Logging with JsonTrails with Execu
   }
 
   private def faciaRedirect(path: String, request: RequestHeader) =
-    request.headers.get("X-Gu-Facia") map {_ => Ok.withHeaders("X-Accel-Redirect" -> s"/redirect/facia/$path")}
+    request.headers.get("X-Gu-Facia") filter(_ == "true") map {_ => Ok.withHeaders("X-Accel-Redirect" -> s"/redirect/facia/$path")}
 
   def render(path: String) = Action { implicit request =>
 

--- a/front/test/FrontControllerTest.scala
+++ b/front/test/FrontControllerTest.scala
@@ -91,4 +91,21 @@ class FrontControllerTest extends FlatSpec with ShouldMatchers {
     status(result) should be(200)
   }
 
+  it should "200 with an X-Accel-Redirect when X-Gu-Facia is true" in Fake {
+    val fakeRequest = FakeRequest(GET, "/uk/culture")
+      .withHeaders("X-Gu-Facia" -> "true")
+
+    val result = controllers.FrontController.render("uk/culture")(fakeRequest)
+    status(result) should be(200)
+    header("X-Accel-Redirect", result) should be (Some("/redirect/facia/uk/culture"))
+  }
+
+  it should "200 with an X-Accel-Redirect when X-Gu-Facia is false" in Fake {
+    val fakeRequest = FakeRequest(GET, "/uk/culture")
+      .withHeaders("X-Gu-Facia" -> "false")
+
+    val result = controllers.FrontController.render("uk/culture")(fakeRequest)
+    status(result) should be(200)
+    header("X-Accel-Redirect", result) should be (None)
+  }
 }


### PR DESCRIPTION
This checks all requests coming into the front project for an X-Gu-Facia header.

If set to true, you get an internal X-Accel-Redirect to the facia app with the same path, otherwise you continue your journey in the front project.

There is (going to be) another pull request in provisioning for this to work properly. On top of this, fastly will also be updated to insert the header for when a user has the AB testing cookie.

This diff looks a lot bigger than it should, it's all the indenting!
