### PR TITLE
Facia contentapi client

### DIFF
--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -2,11 +2,13 @@ package conf
 
 import common.{ StaticAssets, GuardianConfiguration }
 import com.gu.management.play.RequestMetrics
-import contentapi.ContentApiClient
+import contentapi.{FaciaContentApi, ContentApiClient}
 
 object Configuration extends GuardianConfiguration("frontend", webappConfDirectory = "env")
 
 object ContentApi extends ContentApiClient(Configuration)
+
+object FaciaContentApi extends FaciaContentApi(Configuration)
 
 object Static extends StaticAssets(Configuration.assets.path)
 

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -1,7 +1,7 @@
 package contentapi
 
 import com.gu.openplatform.contentapi.{FutureAsyncApi, Api}
-import com.gu.openplatform.contentapi.connection.{Proxy => ContentApiProxy}
+import com.gu.openplatform.contentapi.connection.{Proxy => ContentApiProxy, Dispatch}
 import conf.Configuration
 import scala.concurrent.Future
 import common.{ExecutionContexts, Edition, Logging, GuardianConfiguration}
@@ -89,6 +89,11 @@ class ContentApiClient(configuration: GuardianConfiguration) extends FutureAsync
   }
 
   private def isTagQuery(url: String) = url.endsWith("/tags")
+}
 
-
+class FaciaContentApi(configuration: GuardianConfiguration) extends ContentApiClient(configuration) with Dispatch {
+  override lazy val maxConnections: Int = 1
+  override lazy val connectionTimeoutInMs: Int = 1000
+  override lazy val requestTimeoutInMs: Int = 2000
+  override lazy val compressionEnabled: Boolean = true
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -1,6 +1,6 @@
 package model
 
-import conf.{Configuration, FaciaContentApi => ContentApi}
+import conf.{Configuration, FaciaContentApi, ContentApi}
 import common._
 import contentapi.QueryDefaults
 import org.joda.time.DateTime
@@ -132,7 +132,7 @@ class RunningOrderTrailblockDescription(
             }
 
             val idSearch = {
-              val response = ContentApi.search(edition).ids(articles.mkString(",")).pageSize(List(articles.size, 50).min).response
+              val response = FaciaContentApi.search(edition).ids(articles.mkString(",")).pageSize(List(articles.size, 50).min).response
               val results = response map {r => r.results map{new Content(_)} }
               val sorted = results map { _.sortBy(t => articles.indexWhere(_ == t.id))}
               sorted fallbackTo Future(Nil)
@@ -141,7 +141,7 @@ class RunningOrderTrailblockDescription(
             val contentApiQuery = (parse(r.body) \ "contentApiQuery").asOpt[String] map { query =>
               val queryParams: Map[String, String] = QueryParams.get(query).mapValues{_.mkString("")}
               val queryParamsWithEdition = queryParams + ("edition" -> queryParams.getOrElse("edition", Edition.defaultEdition.id))
-              val search = ContentApi.search(edition)
+              val search = FaciaContentApi.search(edition)
               val queryParamsAsStringParams = queryParamsWithEdition map {case (k, v) => k -> search.StringParameter(k, Some(v))}
               val newSearch = search.updated(search.parameterHolder ++ queryParamsAsStringParams)
 

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -1,6 +1,6 @@
 package model
 
-import conf.{Configuration, ContentApi}
+import conf.{Configuration, FaciaContentApi => ContentApi}
 import common._
 import contentapi.QueryDefaults
 import org.joda.time.DateTime


### PR DESCRIPTION
This creates a new ContentApi client for use in the facia application.

I have created a new client so that the current client for mobile remains unchanged.

I am not happy with the defaults on the client. Did you know that it has a default maxConnections of 10? This doesn't match a default `connection timeout of 1000` and a default `request timeout of 2000`, because they constantly timeout on the default maxConnections of 10.

The values of these variables are up for debate. You could leave the maxConnections to 10 and increase the timeout, or you could decrease the max connections to 1 and let them all queue. I think the latter is a better default, and do not notice the front loading any slower on only using one connection.

I have only changed `maxConnections`, but have added the other defaults alongside it so they are visible to everyone.

I think it would be good if we also changed the original ContentApi client, so that we all use the same one.
