### PR TITLE
Multiple football styling fixes

### DIFF
--- a/common/app/assets/stylesheets/module/_tabs.scss
+++ b/common/app/assets/stylesheets/module/_tabs.scss
@@ -35,8 +35,6 @@ $tabBorderWidth: 2px;
     }
 }
 
-
-
 @include mq($to: 300px) {
     .tabs li a {
         font-size: 14px;
@@ -76,8 +74,7 @@ $tabBorderWidth: 2px;
     width: auto;
     float: none;
 
-    &:first-child,
-    &:last-child {
+    &:first-child {
         border-left: none;
     }
 }

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -64,7 +64,7 @@ a.competition-title {
         padding: $baseline*2;
 
         &:active {
-            background: #666;
+            background: $darkMushroom;
             color: #fff !important;
             text-decoration: none;
         }

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -74,38 +74,42 @@ a.competition-title {
 
 
 .match-desc {
+    display: table;
+    width:  90%;
     color: #333;
-    position: relative;
     margin-bottom: 0;
     border: none;
     overflow: hidden;
-    margin-right: 36px; // offsets the FT/HT box
 }
 
-.match-team {
-    float: left;
-    width: 50%;
+.match-desc__team {
+    display: table-cell;
+    width: 40%;
     @include box-sizing(border-box);
 }
 
-.match-home {
-    text-align: right;
-    padding-right: $gutter;
-}
+    .match-desc__team--home {
+        text-align: right;
+        @include mq($to: tablet) {
+            padding-right: $gutter/4;
+        }
+    }
+    .match-desc__team--away {
+        text-align: left;
+        @include mq($to: tablet) {
+            padding-left: $gutter/4;
+        }
+    }
 
-.match-away {
-    padding-left: $gutter;
-}
-
-.match-result {
-    position: absolute;
-    display: block;
-    width: 40px;
-    left: 50.5%;
-    margin-left: -20px;
+.match-desc__result {
+    display: table-cell;
+    width: 10%;
     text-align: center;
     font-weight: bold;
     letter-spacing: 2px;
+
+    @include mq($from: tablet) { width: 8%; }
+    @include mq($from: desktop) { width: 6%; }
 }
 
 .match-status {

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -183,8 +183,7 @@ a.competition-title {
             content: "+ ";
         }
         &:active {
-            background: #666;
-            color: #fff;
+            background: $darkMushroom;
             text-decoration: none;
         }
     }

--- a/football/app/views/fragments/fixture.scala.html
+++ b/football/app/views/fragments/fixture.scala.html
@@ -4,9 +4,9 @@
     <a href="@LinkTo{@MatchUrl(fixture)}" data-link-name="fixture stats" data-match-id="@fixture.id">
         <p class="match-desc type-10">
 
-            <span class="match-home match-team">@fixture.homeTeam.name</span>
-            <span class="match-result">v</span>
-            <span class="match-away match-team">@fixture.awayTeam.name</span>
+            <span class="match-desc__team match-desc__team--home">@fixture.homeTeam.name</span>
+            <span class="match-desc__result">v</span>
+            <span class="match-desc__team match-desc__team--away">@fixture.awayTeam.name</span>
         </p>
         <p class="match-status type-12">
             <span class="match-status-desc">Kick-off:</span> @fixture.date.toString("HH:mm")

--- a/football/app/views/fragments/liveMatch.scala.html
+++ b/football/app/views/fragments/liveMatch.scala.html
@@ -4,9 +4,9 @@
 <li class="match live-match">
     <a href="@LinkTo{@MatchUrl(live)}" data-link-name="stats" data-match-id="@live.id">
         <p class="match-desc type-10">
-            <span class="match-home match-team">@live.homeTeam.name</span>
-            <span class="match-result">@live.homeTeam.score-@live.awayTeam.score</span>
-            <span class="match-away match-team">@live.awayTeam.name</span>
+            <span class="match-desc__team match-desc__team--home">@live.homeTeam.name</span>
+            <span class="match-desc__result">@live.homeTeam.score-@live.awayTeam.score</span>
+            <span class="match-desc__team match-desc__team--away">@live.awayTeam.name</span>
         </p>
 
         <p class="match-status type-12">

--- a/football/app/views/fragments/matchesBody.scala.html
+++ b/football/app/views/fragments/matchesBody.scala.html
@@ -13,7 +13,9 @@
 }
 
 @if(model.pageType == "live") {
-    <div class="update update-live-matches" data-link-name="autoupdate"></div>
+    <div class="box-indent">
+        <div class="update update-live-matches" data-link-name="autoupdate"></div>
+    </div>
 }
 
 @fragments.filterBar(model.page.webTitle)

--- a/football/app/views/fragments/matchesList.scala.html
+++ b/football/app/views/fragments/matchesList.scala.html
@@ -20,7 +20,7 @@
 	            @* Shows the live blog (if there is one) after the first competition *@
 	            @if(row.isFirst){
 	                @model.blog.map{ blog =>
-	                    <div class="trail">@fragments.trails.thumbnail(blog, row.rowNum)</div>
+	                    @fragments.trails.thumbnail(blog, row.rowNum, element = "div")
 	                }
 	            }
        		</li>


### PR DESCRIPTION
Fixes various football styling regressions in preparation for start of premiership.
- Border issues on match nav multiple tabs
- Active state colour for tap/click on matches lists
- Auto-update component margin
- Featured trail on live fixtures pages
- Alignment on fixture/result listings
