### PR TITLE
Block ads for identity pages

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -275,7 +275,7 @@ define([
         loadAdverts: function () {
             if (!userPrefs.isOff('adverts')){
                 common.mediator.on('page:common:deferred:loaded', function(config, context) {
-                    if (config.switches && config.switches.adverts) {
+                    if (config.switches && config.switches.adverts && !config.page.blockAds) {
                         Adverts.init(config, context);
                     }
                 });

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -22,7 +22,8 @@ trait MetaData {
     "section" -> section,
     "web-title" -> webTitle,
     "build-number" -> buildNumber,
-    "analytics-name" -> analyticsName
+    "analytics-name" -> analyticsName,
+    "blockAds" -> false
   )
 
   def openGraph: List[(String, Any)] = List(

--- a/identity/app/model/IdentityPage.scala
+++ b/identity/app/model/IdentityPage.scala
@@ -2,4 +2,7 @@ package model
 
 
 class IdentityPage(id: String, webTitle: String, analyticsName: String)
-  extends Page(id, "identity", webTitle, analyticsName)
+  extends Page(id, "identity", webTitle, analyticsName) {
+
+  override def metaData: Map[String, Any] = super.metaData + ("blockAds" -> true)
+}


### PR DESCRIPTION
Adds blockAds property to metadata and check when bootstrapping, not only for video ads.
