### PR TITLE
Fix scroll and render issues with swipe and comments

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/discussion.js
+++ b/common/app/assets/javascripts/modules/discussion/discussion.js
@@ -243,13 +243,18 @@ define([
                     }
 
                     if (e.currentTarget.className.indexOf('js-top') !== -1) {
-                        self.jumpToTop();
+                        if(document.body.className.indexOf('has-swipe') !== -1) {
+                            common.mediator.emit('modules:discussion:show', self.jumpToTop);
+                        } else {
+                            self.jumpToTop();
+                        }
                     }
 
                     location.hash = 'comments';
                 });
 
                 bean.on(context, 'click', '.js-show-article', function(e) {
+                    e.preventDefault();
 
                     bonzo(tabsNode.querySelectorAll('.d-tabs__item')).removeClass('d-tabs__item--is-active');
                     bonzo(tabsNode.querySelector('.d-tabs__item--byline')).addClass('d-tabs__item--is-active');
@@ -260,10 +265,12 @@ define([
                     self.discussionContainerNode.style.display = 'none';
                     self.articleContainerNode.style.display = 'block';
 
-                    common.mediator.emit('modules:discussion:show');
-
                     if (e.currentTarget.className.indexOf('js-top') !== -1) {
-                        self.jumpToTop();
+                        if(document.body.className.indexOf('has-swipe') !== -1) {
+                            common.mediator.emit('modules:discussion:show', self.jumpToTop);
+                        } else {
+                            self.jumpToTop();
+                        }
                     }
 
                     // We force analytics on the Article/Byline tab, because

--- a/common/app/assets/javascripts/modules/swipe/swipenav.js
+++ b/common/app/assets/javascripts/modules/swipe/swipenav.js
@@ -538,9 +538,10 @@ define([
             }
         };
 
-        common.mediator.on('modules:discussion:show', function() {
-            recalcHeight();
-            pushDownSidepanes();
+        common.mediator.on('modules:discussion:show', function(callback) {
+            resetScrollPos();
+            recalcHeight(true);
+            callback();
         });
 
         // Set a periodic height adjustment for the content area. Necessary to account for diverse heights of side-panes as they slide in, and dynamic page elements.


### PR DESCRIPTION
This fixes a big render and scroll position bug when swipe is enabled and a user views comments. Thanks to @kaelig for making me aware of this. I have tested heavily on iPhone 5, am going to merge and deploy to article server for the weekend, and will discuss with @stephanfowler on Monday if there is a cleaner solution.
