### PR TITLE
Fixes sequence url on fronts

### DIFF
--- a/common/app/assets/javascripts/modules/swipe/swipenav.js
+++ b/common/app/assets/javascripts/modules/swipe/swipenav.js
@@ -243,7 +243,7 @@ define([
             } else {
                 // No data-link-context, so infer the section/tag component from the url,
                 if("page" in config) {
-                    sequenceUrl = (config.page.section ? config.page.section : '');
+                    sequenceUrl = (config.page.section ? config.page.section : config.page.edition.toLowerCase());
                 } else {
                     sequenceUrl = window.location.pathname.match(/^\/([^0-9]+)/);
                     sequenceUrl = (sequenceUrl ? sequenceUrl[1] : '');


### PR DESCRIPTION
This fixes a regression I introduced yesterday when fixing the large ammount of 404's. It was preventing users swipe on network fronts.

Editionalised network fronts don't have a their sections defined as their edition and therefore, we must use the `config.page.editon` as the sequence endpoint.
