### PR TITLE
Moving domain for code evironment to newer domain scheme

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/video.js
+++ b/common/app/assets/javascripts/modules/adverts/video.js
@@ -193,7 +193,7 @@ define([
 
     Video.prototype.init = function(config) {
         var id = (config.pageId === '') ? '' : config.pageId + '/',
-            host = (window.location.hostname === "localhost") ? "m.gucode.co.uk" :  window.location.hostname,
+            host = (window.location.hostname === "localhost") ? "m.code.dev-theguardian.com" :  window.location.hostname,
             url = "http://" + config.oasHost + "//2/" + host + "/" + id + "oas.html/" + (new Date().getTime()) + "@x50";
 
         this.getVastData(url);

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -22,13 +22,13 @@ football.api.host=http://football-stats-stub.appspot.com/2012-10-20/16-05
 ajax.url=http://code.api.nextgen.guardianapps.co.uk
 
 # no spaces
-ajax.cors.origin=http://m.gucode.com,http://m.gucode.co.uk
+ajax.cors.origin=http://m.code.dev-theguardian.com
 
 # Admin switches
 admin.config.file=CODE/config/front.json
 switches.file=CODE/config/switches.properties
 
-oas.siteId.host=m.gucode.co.uk
+oas.siteId.host=m.code.dev-theguardian.com
 
 frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 


### PR DESCRIPTION
You can see the code envronment on m.code.dev-theguardian.com, this is just a search and replace on m.gucode.co.uk, let me know if you think something is going to break.

Once every one is happy ill remove the old domains.
