### PR TITLE
Blockquotes do not perturbate the flow of the article when a card is next to it

### DIFF
--- a/common/app/assets/stylesheets/theme/_icons.scss
+++ b/common/app/assets/stylesheets/theme/_icons.scss
@@ -94,10 +94,8 @@ figcaption:before {
 .from-content-api .block .quoted:before {
     @extend .i;
     @extend .i-livequote-before;
-    display: block;
     content: '';
-    margin: 21px 0 $baseline*2;
-    clear: both;
+    margin: 13px 0 0;
 
     @if ($svg-support) {
         .svg & {
@@ -110,9 +108,8 @@ figcaption:before {
 .from-content-api .block .quoted:after {
     @extend .i;
     @extend .i-livequote-after;
-    display: block;
     content: '';
-    margin-bottom: 22px;
+    margin-bottom: 6px;
 
     @if ($svg-support) {
         .svg & {


### PR DESCRIPTION
This change avoids that kind of situation (massive space between a paragraph and a quote) while keeping the same design of quotes:
## Screengrab of the bug

![screen shot 2013-08-20 at 19 55 15](https://f.cloud.github.com/assets/85783/996270/864c3b0a-09cc-11e3-9366-7656985bfaaf.PNG)
