### PR TITLE
Add clear fix to article contain to prevent leakage.

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -44,7 +44,7 @@
 
             @fragments.byline(article.byline, article)
 
-            <div class="js-article__container article__container">
+            <div class="js-article__container article__container cf">
                 @if(article.isLive) {
                     @fragments.autoUpdate()
                 }


### PR DESCRIPTION
This prevents elements that our floated at the bottom of articles leaking into our sections.
## Before

![Before](http://cl.ly/image/0S2s3E1W143j/Image%202013.08.22%2011%3A35%3A40.png)
## After

![After](http://cl.ly/image/3k0N280p1v0g/Image%202013.08.22%2011%3A39%3A06.png)
