### PR TITLE
Content API timeout exposé

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -42,31 +42,38 @@ trait QueryDefaults extends implicits.Collections with ExecutionContexts {
   }
 }
 
-trait ApiQueryDefaults extends QueryDefaults with implicits.Collections { self: Api[Future] =>
+trait ApiQueryDefaults extends QueryDefaults with implicits.Collections with Logging { self: Api[Future] =>
 
   def item (id: String, edition: Edition): ItemQuery = item(id, edition.id)
 
   //common fields that we use across most queries.
-  def item(id: String, edition: String): ItemQuery = item.itemId(id)
-  .edition(edition)
-  .showTags("all")
-  .showFields(trailFields)
-  .showInlineElements(inlineElements)
-  .showMedia("all")
-  .showReferences(references)
-  .showStoryPackage(true)
-  .tag(supportedTypes)
+  def item(id: String, edition: String): ItemQuery = {
+    val query = item.itemId(id)
+                .edition(edition)
+                .showTags("all")
+                .showFields(trailFields)
+                .showInlineElements(inlineElements)
+                .showMedia("all")
+                .showReferences(references)
+                .showStoryPackage(true)
+                .tag(supportedTypes)
+    query.response.onFailure{case t: Throwable => log.warn("%s: %s".format(id, t.toString))}
+    query
+  }
 
   //common fields that we use across most queries.
-  def search(edition: Edition): SearchQuery = search
-  .edition(edition.id)
-  .showTags("all")
-  .showInlineElements(inlineElements)
-  .showReferences(references)
-  .showFields(trailFields)
-  .showMedia("all")
-  .tag(supportedTypes)
-
+  def search(edition: Edition): SearchQuery = {
+    val query = search
+                .edition(edition.id)
+                .showTags("all")
+                .showInlineElements(inlineElements)
+                .showReferences(references)
+                .showFields(trailFields)
+                .showMedia("all")
+                .tag(supportedTypes)
+    query.response.onFailure{case t: Throwable => log.warn("%s".format(t.toString))}
+    query
+  }
 }
 
 class ContentApiClient(configuration: GuardianConfiguration) extends FutureAsyncApi with ApiQueryDefaults with DelegateHttp

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -136,7 +136,6 @@ class RunningOrderTrailblockDescription(
                 Future(Nil)
               } else {
                 val response = ContentApi.search(edition).ids(articles.mkString(",")).showFields("all").pageSize(List(articles.size, 50).min).response
-                response onFailure {case t: Throwable => log.warn("%s: %s".format(blockId, t.toString))}
                 val results = response map {r => r.results map{Content(_)} }
                 val sorted = results map { _.sortBy(t => articles.indexWhere(_ == t.id))}
                 sorted
@@ -149,8 +148,6 @@ class RunningOrderTrailblockDescription(
               val search = ContentApi.search(edition)
               val queryParamsAsStringParams = queryParamsWithEdition map {case (k, v) => k -> search.StringParameter(k, Some(v))}
               val newSearch = search.updated(search.parameterHolder ++ queryParamsAsStringParams)
-
-              newSearch.response onFailure {case t: Throwable => log.warn("%s (%s)".format(t.toString, query))}
 
               newSearch.response map { r =>
                 r.results.map(Content(_))


### PR DESCRIPTION
This removes the current logging that I had been doing in code specific to Facia, and instead moves it upstream as far as the content API client.

This is obviously only for content API queries, and there are probably other call outs that have no logging, but I have decided to have this exposé on content API queries only by going upstream from everything on them.

If you would prefer the logging not to happen here, then please say why, and I will consider moving the logging to more specific points.

Here is a fun(???) test: Checkout this branch, run front.
tail frontend-front.log -f | grep java.util

Enjoy!
