### PR TITLE
Fix isTimeout in http module for contentApi timeout logging

### DIFF
--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -33,9 +33,10 @@ trait WsHttp extends Http[Future] with ExecutionContexts {
   }
 
 
-  private def isTimeout(e: Throwable): Boolean = Option(e.getCause)
-    .map(_.getClass == classOf[TimeoutException])
-    .getOrElse(false)
+  private def isTimeout(e: Throwable): Boolean = e match {
+    case t: TimeoutException => true
+    case _  => false
+  }
 }
 
 


### PR DESCRIPTION
The metric content-api-timeouts is not working.
Things are timing out and this boolean is broken.
