### PR TITLE
AU Election 2013 block in Front

### DIFF
--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -102,6 +102,7 @@ object Au extends Edition(
   val configuredFronts = Map(
     Editionalise("", Au) -> Seq(
       ItemTrailblockDescription("", "News", numItemsVisible = 8, style = Some(Featured), showMore = true),
+      RunningOrderTrailblockDescription("news", "au/news/election2013", "Election 2013", 3, style = Some(Featured)),
       ItemTrailblockDescription("sport", "Sport", numItemsVisible = 3, style = Some(Featured), showMore = true),
       ItemTrailblockDescription("sport/australia-sport", "Australia sport", numItemsVisible = 3, style = Some(Thumbnail), showMore = true),
       Au.cultureCustomBlock,

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -5,7 +5,7 @@ import model._
 import common._
 import views.support._
 import scala.concurrent.Future
-import conf.ContentApi
+import conf.{Switches, ContentApi}
 import contentapi.QueryDefaults
 import com.gu.openplatform.contentapi.model.ItemResponse
 import common.NavItem
@@ -102,7 +102,7 @@ object Au extends Edition(
   val configuredFronts = Map(
     Editionalise("", Au) -> Seq(
       ItemTrailblockDescription("", "News", numItemsVisible = 8, style = Some(Featured), showMore = true),
-      RunningOrderTrailblockDescription("news", "au/news/election2013", "Election 2013", 3, style = Some(Featured)),
+      RunningOrderTrailblockDescriptionSwitch("news", "au/news/election2013", "Election 2013", 3, Switches.AuElections2013, style = Some(Featured)),
       ItemTrailblockDescription("sport", "Sport", numItemsVisible = 3, style = Some(Featured), showMore = true),
       ItemTrailblockDescription("sport/australia-sport", "Australia sport", numItemsVisible = 3, style = Some(Thumbnail), showMore = true),
       Au.cultureCustomBlock,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -201,6 +201,11 @@ object Switches extends Collections {
     safeState = Off
   )
 
+  val AuElections2013 = Switch("Front", "front-elections-2013",
+    "Switch to use collection from fronts API under au/news/elections2013",
+    safeState = Off
+  )
+
   val all: List[Switch] = List(
     AutoRefreshSwitch,
     DoubleCacheTimesSwitch,
@@ -239,7 +244,8 @@ object Switches extends Collections {
     ABGalleryCta,
     ABSwipeCtas,
     ABExpandableTrails,
-    ABRightHandCard
+    ABRightHandCard,
+    AuElections2013
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -95,8 +95,10 @@ object CustomTrailblockDescription {
 
 
 trait ConfiguredTrailblockDescription extends TrailblockDescription {
-  def query() = scala.concurrent.future {
-    Nil
+  def query() = configuredQuery() flatMap { q =>
+    q map {trailblockDescription =>
+      trailblockDescription.query()
+    } getOrElse Future(Nil)
   }
 
   def configuredQuery(): Future[Option[TrailblockDescription]]

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -1,6 +1,6 @@
 package model
 
-import conf.{Configuration, ContentApi}
+import conf.{Switch, Configuration, ContentApi}
 import common._
 import contentapi.QueryDefaults
 import org.joda.time.DateTime
@@ -181,4 +181,22 @@ class RunningOrderTrailblockDescription(
 object RunningOrderTrailblockDescription {
   def apply(id: String, blockId: String, name: String, numItemsVisible: Int, style: Option[Style] = None, showMore: Boolean = false, isConfigured: Boolean = false)(implicit edition: Edition) =
     new RunningOrderTrailblockDescription(id, blockId, name, numItemsVisible, style, showMore, edition, isConfigured)
+}
+
+
+class RunningOrderTrailblockDescriptionSwitch(id: String, blockId: String, name: String, numItemsVisible: Int, style: Option[Style] = None, showMore: Boolean = false, edition: Edition, isConfigured: Boolean = false, switch: Switch)
+  extends RunningOrderTrailblockDescription(id, blockId, name, numItemsVisible, style, showMore, edition, isConfigured) {
+
+  override def configuredQuery(): Future[Option[TrailblockDescription]] = {
+    if (switch.isSwitchedOff) {
+      Future(None)
+    } else {
+      super.configuredQuery()
+    }
+  }
+}
+
+object RunningOrderTrailblockDescriptionSwitch {
+  def apply(id: String, blockId: String, name: String, numItemsVisible: Int, switch: Switch, style: Option[Style] = None, showMore: Boolean = false, isConfigured: Boolean = false)(implicit edition: Edition) =
+    new RunningOrderTrailblockDescriptionSwitch(id, blockId, name, numItemsVisible, style, showMore, edition, isConfigured, switch)
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -183,6 +183,17 @@ object RunningOrderTrailblockDescription {
 class RunningOrderTrailblockDescriptionSwitch(id: String, blockId: String, name: String, numItemsVisible: Int, style: Option[Style] = None, showMore: Boolean = false, edition: Edition, isConfigured: Boolean = false, switch: Switch)
   extends RunningOrderTrailblockDescription(id, blockId, name, numItemsVisible, style, showMore, edition, isConfigured) {
 
+  override def query(): Future[Seq[Trail]] = configuredQuery() flatMap { q =>
+    q map {trailblockDescription =>
+      trailblockDescription.query()
+    } getOrElse {
+      if (switch.isSwitchedOff)
+        Future(Nil)
+      else
+        Future.failed(throw new java.util.concurrent.TimeoutException("Query Failed"))
+    }
+  }
+
   override def configuredQuery(): Future[Option[TrailblockDescription]] = {
     if (switch.isSwitchedOff) {
       Future(None)

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -10,7 +10,6 @@ import play.api.libs.json.JsObject
 import scala.concurrent.Future
 import tools.QueryParams
 import views.support.Style
-import java.util.concurrent.TimeoutException
 
 
 trait Trail extends Images with Tags {

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -10,6 +10,7 @@ import play.api.libs.json.JsObject
 import scala.concurrent.Future
 import tools.QueryParams
 import views.support.Style
+import java.util.concurrent.TimeoutException
 
 
 trait Trail extends Images with Tags {
@@ -98,7 +99,7 @@ trait ConfiguredTrailblockDescription extends TrailblockDescription {
   def query() = configuredQuery() flatMap { q =>
     q map {trailblockDescription =>
       trailblockDescription.query()
-    } getOrElse Future(Nil)
+    } getOrElse Future.failed(throw new java.util.concurrent.TimeoutException("Query Failed"))
   }
 
   def configuredQuery(): Future[Option[TrailblockDescription]]

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -96,11 +96,7 @@ object CustomTrailblockDescription {
 
 
 trait ConfiguredTrailblockDescription extends TrailblockDescription {
-  def query() = configuredQuery() flatMap { q =>
-    q map {trailblockDescription =>
-      trailblockDescription.query()
-    } getOrElse Future.failed(throw new java.util.concurrent.TimeoutException("Query Failed"))
-  }
+  def query(): Future[Seq[Trail]] = Future(Nil)
 
   def configuredQuery(): Future[Option[TrailblockDescription]]
 }

--- a/front/app/views/fragments/frontBody.scala.html
+++ b/front/app/views/fragments/frontBody.scala.html
@@ -2,7 +2,9 @@
 
 <div class="front-container cf" data-link-name="Front" role="main">
     @trailblocks.zipWithIndex.map{ case(block, index) =>
-        @fragments.frontBlock(block, front, index)
+        @if(block.trails.nonEmpty) {
+            @fragments.frontBlock(block, front, index)
+        }
     }
 </div>
 


### PR DESCRIPTION
This allows the configuration for a Front to use the `RunningOrderTrailblockDescription` that is used in Facia. In doing so this will pull a specific collection from the Facia database.

It introduces a new class specifically for the case of having a switch around a `RunningOrderTrailblockDescription` with `RunningOrderTrailblockDescriptionSwitch`.

It also links query to configuredQuery in the override for `ConfiguredQuery`.

And to top it all off a switch called `AuElection2013`.
