### PR TITLE
Database config query

### DIFF
--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -1,13 +1,10 @@
 package controllers
 
 import frontsapi.model._
-import frontsapi.model.Block
-import frontsapi.model.Trail
 import frontsapi.model.UpdateList
 import play.api.mvc.{AnyContent, Action, Controller}
 import play.api.libs.json._
 import common.{ExecutionContexts, S3FrontsApi, Logging}
-import org.joda.time.DateTime
 import conf.Configuration
 import tools.FrontsApi
 import scala.concurrent.Future

--- a/admin/app/controllers/FrontsController.scala
+++ b/admin/app/controllers/FrontsController.scala
@@ -6,13 +6,14 @@ import frontsapi.model.Trail
 import frontsapi.model.UpdateList
 import play.api.mvc.{AnyContent, Action, Controller}
 import play.api.libs.json._
-import common.{S3FrontsApi, Logging}
+import common.{ExecutionContexts, S3FrontsApi, Logging}
 import org.joda.time.DateTime
 import conf.Configuration
 import tools.FrontsApi
+import scala.concurrent.Future
 
 
-object FrontsController extends Controller with Logging {
+object FrontsController extends Controller with Logging with ExecutionContexts {
 
   def index() = AuthAction{ request =>
     Ok(views.html.fronts(Configuration.environment.stage))
@@ -22,6 +23,22 @@ object FrontsController extends Controller with Logging {
     S3FrontsApi.getSchema map { json: String =>
       Ok(json).as("application/json")
     } getOrElse NotFound
+  }
+
+  def listCollections = AuthAction { request =>
+    Async {
+      Future{
+        Ok(Json.toJson(S3FrontsApi.listCollectionIds))
+      }
+    }
+  }
+
+  def listConfigs = AuthAction { request =>
+    Async {
+      Future{
+        Ok(Json.toJson(S3FrontsApi.listConfigsIds))
+      }
+    }
   }
 
   def readBlock(id: String) = AuthAction{ request =>

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -40,6 +40,8 @@ GET       /fronts/config/*id             controllers.FrontsController.getConfig(
 GET       /fronts/api/*id                controllers.FrontsController.readBlock(id)
 POST      /fronts/api/*id                controllers.FrontsController.updateBlock(id)
 DELETE    /fronts/api/*id                controllers.FrontsController.deleteTrail(id)
+GET       /fronts/collection             controllers.FrontsController.listCollections
+GET       /fronts/config                 controllers.FrontsController.listConfigs
 
 # Analytics
 GET     /analytics/kpis                  controllers.AnalyticsController.kpis()

--- a/common/app/common/S3.scala
+++ b/common/app/common/S3.scala
@@ -86,6 +86,6 @@ object S3FrontsApi extends S3 {
 
   def archive(id: String, json: String) = {
     val now = DateTime.now
-    putPrivate(s"${location}/collection/${id}/history/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.json", json, "application/json")
+    putPrivate(s"${location}/history/collection/${id}/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.json", json, "application/json")
   }
 }

--- a/common/app/common/S3.scala
+++ b/common/app/common/S3.scala
@@ -50,6 +50,20 @@ trait S3 extends Logging {
     client.putObject(request)
     client.shutdown()
   }
+
+  private def getListing(prefix: String, dropText: String): List[String] = {
+    import scala.collection.JavaConversions._
+    val summaries = client.listObjects(bucket, prefix).getObjectSummaries.toList
+    summaries
+      .map(_.getKey.split(prefix))
+      .filter(_.nonEmpty)
+      .map(_.last)
+      .filterNot(_.endsWith("/"))
+      .map(_.split(dropText).head)
+  }
+
+  def getConfigIds(prefix: String): List[String] = getListing(prefix, "/config.json")
+  def getCollectionIds(prefix: String): List[String] = getListing(prefix, "/collection.json")
 }
 
 object S3 extends S3
@@ -65,6 +79,8 @@ object S3FrontsApi extends S3 {
   def getSchema = get(s"${location}/schema.json")
   def getConfig(id: String) = get(s"${location}/config/${id}/config.json")
   def getBlock(id: String) = get(s"${location}/collection/${id}/collection.json")
+  def listConfigsIds: List[String] = getConfigIds(s"$location/config/")
+  def listCollectionIds: List[String] = getCollectionIds(s"$location/collection/")
   def putBlock(id: String, json: String) =
     putPublic(s"${location}/collection/${id}/collection.json", json, "application/json")
 


### PR DESCRIPTION
This adds JSON endpoints to query all available configurations and collections to the admin application where the facia fronts tool lives.

The main consumers of this will be the Facia fronts app and the Facia tool.

This is a part of the move to have the configuration in a database instead of in code. The new mechanism for configured facia pages will use this to figure out what pages are available. (Although it will use the internal database calls rather than the endpoints) The tool will use it in the same way.

This pull request also changes the way history is stored. History is no longer stored along side what it is keeping a history of, instead it is namespaced with history. This allows querying of the configs and collections.
