### PR TITLE
Gallery endpoint fix

### DIFF
--- a/common/app/assets/javascripts/modules/lightbox-gallery.js
+++ b/common/app/assets/javascripts/modules/lightbox-gallery.js
@@ -40,7 +40,7 @@ define(["bean",
                 bonzo(context.querySelectorAll(self.selector + ' a')).attr('data-is-ajax', '1');
 
                 bean.on(context, 'click', self.selector + ' a', function(e) {
-                    var galleryUrl = e.currentTarget.href;
+                    var galleryUrl = e.currentTarget.getAttribute('href');
 
                     self.galleryEndpoint = galleryUrl.split('?')[0] + '/lightbox.json';
 

--- a/common/test/assets/javascripts/spec/LightboxGallery.spec.js
+++ b/common/test/assets/javascripts/spec/LightboxGallery.spec.js
@@ -189,6 +189,10 @@ define(['common',
             })
         });
 
+        it("should have an AJAX url to the gallery without a hostname", function() {
+            expect(document.querySelectorAll('.overlay .gallery').length).toBe(1);
+            expect(gallery.galleryEndpoint).not.toContain('://');
+        });
 
     });
 });

--- a/common/test/assets/javascripts/spec/LightboxGallery.spec.js
+++ b/common/test/assets/javascripts/spec/LightboxGallery.spec.js
@@ -190,7 +190,6 @@ define(['common',
         });
 
         it("should have an AJAX url to the gallery without a hostname", function() {
-            expect(document.querySelectorAll('.overlay .gallery').length).toBe(1);
             expect(gallery.galleryEndpoint).not.toContain('://');
         });
 


### PR DESCRIPTION
Fixes Lightbox galleries not doing AJAX requests through the proper endpoint

Visiting this URL, without the proper **gu_view** cookie would fail to load the gallery
http://www.theguardian.com/environment/gallery/2013/aug/28/wildlife-photographer-of-the-year-2013-in-pictures?view=mobile
