### PR TITLE
Selenium version bump for Firefox 23.

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -76,7 +76,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>2.32.0</version>
+			<version>2.35.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>xerces</groupId>


### PR DESCRIPTION
Running integration tests locally against Firefox 23 fails because of [this](http://code.google.com/p/selenium/issues/detail?id=6051). Bump version to 2.35.

@gidsg Okay?
