### PR TITLE
Fix body exception that appears in facia on contentApiQuery

### DIFF
--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -146,7 +146,7 @@ class RunningOrderTrailblockDescription(
             val contentApiQuery = (parse(r.body) \ "contentApiQuery").asOpt[String] map { query =>
               val queryParams: Map[String, String] = QueryParams.get(query).mapValues{_.mkString("")}
               val queryParamsWithEdition = queryParams + ("edition" -> queryParams.getOrElse("edition", Edition.defaultEdition.id))
-              val search = ContentApi.search(edition)
+              val search = ContentApi.search(edition).showFields("all")
               val queryParamsAsStringParams = queryParamsWithEdition map {case (k, v) => k -> search.StringParameter(k, Some(v))}
               val newSearch = search.updated(search.parameterHolder ++ queryParamsAsStringParams)
 


### PR DESCRIPTION
This ensures that the body field is available in the Article class.

The Article class is used in the templates in facia. When masthead calls mainPicture, this eventually uses body which then causes an exception as we didn't request it with the defaults.

In the future, Article.body needs to be made more safe than using Map.apply which causes nasty exceptions. After this is done, then we can go back and look at what we are requesting, and what we need.

Apart of the work I am currently doing is to look at what sort of queries we need for facia, and to create specific queries with only the fields we need.
