### PR TITLE
Inline Link cards: prevent selflinking

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/left-hand-card.js
+++ b/common/app/assets/javascripts/modules/experiments/left-hand-card.js
@@ -90,7 +90,9 @@ function (
                 numberOfLinksInParagraph,
                 i = 0,
                 j,
-                linkWasCardified;
+                linkWasCardified,
+                normalisedHref,
+                hrefPath;
 
             // Looking for links every insertCardEveryNParagraphs paragraphs
             while (i < (numberOfArticleParagraphs - lastParagraphsToNotCardify)) {
@@ -101,7 +103,12 @@ function (
 
                 if (numberOfLinksInParagraph > 0) {
                     while (j < numberOfLinksInParagraph) {
-                        if (isWhiteListed(linksInParagraph[j].getAttribute('href').trim(), self.options.origin)) {
+                        normalisedHref = linksInParagraph[j].getAttribute('href').trim();
+                        hrefPath = new RegExp(normalisedHref.split("?")[0].split("#")[0]);
+                        if (
+                            isWhiteListed(normalisedHref, self.options.origin)
+                            && !hrefPath.test(window.location) // No link to self
+                            ) {
                             cardifyRelatedInBodyLink(linksInParagraph[j]);
                             linkWasCardified = true;
 

--- a/common/app/assets/javascripts/modules/experiments/left-hand-card.js
+++ b/common/app/assets/javascripts/modules/experiments/left-hand-card.js
@@ -107,7 +107,7 @@ function (
                         hrefPath = new RegExp(normalisedHref.split("?")[0].split("#")[0]);
                         if (
                             isWhiteListed(normalisedHref, self.options.origin)
-                            && !hrefPath.test(window.location) // No link to self
+                            && !(hrefPath).test(window.location) // No link to self
                             ) {
                             cardifyRelatedInBodyLink(linksInParagraph[j]);
                             linkWasCardified = true;


### PR DESCRIPTION
In live blogs it is common for a journalist to link towards an older update (of the same event). This prevents those links to be turned into left-column cards.

Thanks @papalozarou for notifying it (cf screenshot of http://www.theguardian.com/science/2012/jun/05/transit-of-venus-live-coverage).

![screen shot 2013-08-30 at 14 58 14](https://f.cloud.github.com/assets/85783/1057822/405a6f92-117c-11e3-8027-6a229e3b3976.PNG)

![ ](http://s1.developerslife.ru/public/images/gifs/77998a02-f2d0-4b40-9a84-02ecf04c3381.gif)
