### PR TITLE
Fronts admin: ophan pageviews proxy

### DIFF
--- a/admin/app/controllers/Api.scala
+++ b/admin/app/controllers/Api.scala
@@ -25,19 +25,25 @@ object Api extends Controller with Logging with AuthLogging with ExecutionContex
   }
 
   def ophanPageViews(path: String) = AuthAction { request =>
-    val url = "%s?api-key=%s&path=/%s".format(
-      Configuration.ophanApi.host,
-      Configuration.ophanApi.key,
-      path
-    )
+    (for {
+      host <- Configuration.ophanApi.host
+      key  <- Configuration.ophanApi.key
+    } yield {
+      val url = "%s?api-key=%s&path=/%s".format(
+        host,
+        key,
+        path
+      )
 
-    log("Proxying Ophan pageviews query to: %s" format url, request)
+      log("Proxying Ophan pageviews query to: %s" format url, request)
 
-    Async {
-      WS.url(url).get().map { response =>
-        Ok(response.body).as("application/json")
+      Async {
+        WS.url(url).get().map { response =>
+          Ok(response.body).as("application/json")
+        }
       }
-    }
+
+    }).getOrElse(Ok)
   }
 
   def tag(q: String, callback: String) = AuthAction { request =>

--- a/admin/app/controllers/Api.scala
+++ b/admin/app/controllers/Api.scala
@@ -29,7 +29,7 @@ object Api extends Controller with Logging with AuthLogging with ExecutionContex
       host <- Configuration.ophanApi.host
       key  <- Configuration.ophanApi.key
     } yield {
-      val url = "%s?api-key=%s&path=/%s".format(
+      val url = "%s/breakdown?api-key=%s&path=/%s".format(
         host,
         key,
         path

--- a/admin/app/controllers/Api.scala
+++ b/admin/app/controllers/Api.scala
@@ -24,6 +24,22 @@ object Api extends Controller with Logging with AuthLogging with ExecutionContex
     }
   }
 
+  def ophanPageViews(path: String) = AuthAction { request =>
+    val url = "%s?api-key=%s&path=/%s".format(
+      Configuration.ophanApi.host,
+      Configuration.ophanApi.key,
+      path
+    )
+
+    log("Proxying Ophan pageviews query to: %s" format url, request)
+
+    Async {
+      WS.url(url).get().map { response =>
+        Ok(response.body).as("application/json")
+      }
+    }
+  }
+
   def tag(q: String, callback: String) = AuthAction { request =>
     val url = "%s/tags?format=json&page-size=50&api-key=%s&callback=%s&q=%s".format(
       Configuration.contentApi.host,

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -28,6 +28,7 @@ GET     /api/proxy/*path                 controllers.Api.proxy(path, callback)
 GET     /api/tag                         controllers.Api.tag(q, callback)
 GET     /api/item/*path                  controllers.Api.item(path, callback)
 GET     /json/proxy/*absUrl              controllers.Api.json(absUrl)
+GET     /ophan/pageviews/*path           controllers.Api.ophanPageViews(path)
 
 #Development endpoints
 GET     /dev/switchboard                 controllers.SwitchboardController.render()

--- a/admin/public/javascripts/models/fronts/ophanApi.js
+++ b/admin/public/javascripts/models/fronts/ophanApi.js
@@ -42,7 +42,7 @@ function (
 
         if(data.seriesData && data.seriesData.length) {
             simpleSeries = data.seriesData.map(function(series) {
-                return _.pluck(series.data, 'y')                
+                return _.pluck(series.data, 'count')                
             })
             // Add all the series to the first series            
             _.rest(simpleSeries).forEach(function(simples) {
@@ -58,8 +58,8 @@ function (
         cache.put('pageViews', id, {failed: true});
 
         Reqwest({
-            url: 'http://dashboard.ophan.co.uk/graph/breakdown/data?path=' + encodeURIComponent('/' + id),
-            type: 'jsonp'
+            url: '/ophan/pageviews/' + id,
+            type: 'json'
         }).then(
             function (resp) {
                 callback(resp);

--- a/admin/public/javascripts/models/fronts/ophanApi.js
+++ b/admin/public/javascripts/models/fronts/ophanApi.js
@@ -10,11 +10,7 @@ function (
     common,
     cache
 ){
-    var enable = _.has(common.util.queryParams(), 'pageViews');
-
     function decorateItems(items) {
-        if (!enable) { return; }
-
         items.slice(0, common.config.maxOphanCallsPerBlock).forEach(function(item){
             var id = item.meta.id(),
                 data = cache.get('pageViews', id);

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -71,8 +71,8 @@ class GuardianConfiguration(
   }
 
   object ophanApi {
-    lazy val host = configuration.getStringProperty("ophan.api.host").getOrElse("")
-    lazy val key  = configuration.getStringProperty("ophan.api.key").getOrElse("")
+    lazy val host = configuration.getStringProperty("ophan.api.host").filter(_.nonEmpty)
+    lazy val key  = configuration.getStringProperty("ophan.api.key").filter(_.nonEmpty)
   }
 
   object mongo {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -70,6 +70,11 @@ class GuardianConfiguration(
     }
   }
 
+  object ophanApi {
+    lazy val host = configuration.getStringProperty("ophan.api.host").getOrElse("")
+    lazy val key  = configuration.getStringProperty("ophan.api.key").getOrElse("")
+  }
+
   object mongo {
     lazy val connection = configuration.getStringProperty("mongo.connection.readonly.password").getOrElse(throw new RuntimeException("Mongo connection not configured"))
   }


### PR DESCRIPTION
Hit the Ophan pageviews api via a proxy (mostly because admin tools runs under https, so we can't do jsonp to http endpoints)

See PR https://github.com/guardian/platform/pull/200 - requires this in frontend.properties:
ophan.api.host=http://dashboard.ophan.co.uk/api
ophan.api.key=...
