### PR TITLE
Comments fixes

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/discussion.js
+++ b/common/app/assets/javascripts/modules/discussion/discussion.js
@@ -137,6 +137,7 @@ define([
 
                         commentsHaveLoaded = true;
                         currentPage = response.currentPage;
+
                         common.mediator.emit('fragment:ready:dates', self.discussionContainerNode);
                     },
                     error: function() {
@@ -250,6 +251,7 @@ define([
                         }
                     }
 
+                    common.mediator.emit('modules:discussion:show');
                     location.hash = 'comments';
                 });
 

--- a/common/app/assets/javascripts/modules/discussion/discussion.js
+++ b/common/app/assets/javascripts/modules/discussion/discussion.js
@@ -256,7 +256,7 @@ define([
                 });
 
                 bean.on(context, 'click', '.js-show-article', function(e) {
-                    e.preventDefault();
+                    // No preventDefault here, as there may be links in the byline
 
                     bonzo(tabsNode.querySelectorAll('.d-tabs__item')).removeClass('d-tabs__item--is-active');
                     bonzo(tabsNode.querySelector('.d-tabs__item--byline')).addClass('d-tabs__item--is-active');

--- a/common/app/assets/javascripts/modules/swipe/swipenav.js
+++ b/common/app/assets/javascripts/modules/swipe/swipenav.js
@@ -358,7 +358,7 @@ define([
         }
 
         el = panes.masterPages[mod3(paneNow + dir)];
-        
+
         // Only load if not already loaded into this pane
         if (el.url !== url) {
             load({
@@ -405,6 +405,7 @@ define([
         $(panes.masterPages[mod3(paneNow-1)]).css('marginTop', 0);
         // And reset the scroll
         body.scrollTop(0);
+        swipeContainerEl.scrollTop = 0;
         recalcHeight(true);
 
         visiblePaneMargin = 0;
@@ -541,7 +542,10 @@ define([
         common.mediator.on('modules:discussion:show', function(callback) {
             resetScrollPos();
             recalcHeight(true);
-            callback();
+
+            if (callback) {
+                callback();
+            }
         });
 
         // Set a periodic height adjustment for the content area. Necessary to account for diverse heights of side-panes as they slide in, and dynamic page elements.


### PR DESCRIPTION
Fixes:
- On Swipe, comments sometimes truncate due to #preloads scrollTop not being 0 (screenshot)
- Links in byline Tab should now work again

![comments-truncate](https://f.cloud.github.com/assets/518943/1074396/e9bb5d68-14b9-11e3-85d9-a9971b866f05.png)
