### PR TITLE
Small fixes for inline most popular test

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/expandable-mostpopular.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/expandable-mostpopular.js
@@ -21,6 +21,14 @@ define(['common', 'bean', 'modules/popular'], function (common, bean, popular) {
                 id: 'expandable-most-popular',
                 test: function (context) {
                     if((/^Video|Article|Gallery$/).test(guardian.config.page.contentType)) {
+                        var related = context.getElementsByClassName('related-trails')[0].getElementsByClassName('trail');
+                        common.toArray(related).forEach(function(el){
+                            var img = el.getElementsByClassName('trail__img')[0],
+                                text = el.getElementsByClassName('trail__text')[0];
+                            if(img) img.remove();
+                            if(text) text.remove();
+                        });
+
                         popular(guardian.config, context, true);
                         bean.on(document.body, 'change', '.trail__expander-trigger', function(e) {
                             var trail = e.target.parentNode;

--- a/common/app/assets/javascripts/modules/experiments/tests/expandable-mostpopular.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/expandable-mostpopular.js
@@ -25,8 +25,8 @@ define(['common', 'bean', 'modules/popular'], function (common, bean, popular) {
                         common.toArray(related).forEach(function(el){
                             var img = el.getElementsByClassName('trail__img')[0],
                                 text = el.getElementsByClassName('trail__text')[0];
-                            if(img) img.remove();
-                            if(text) text.remove();
+                            if(img) { img.remove(); }
+                            if(text) { text.remove(); }
                         });
 
                         popular(guardian.config, context, true);

--- a/common/app/views/fragments/relatedTrails.scala.html
+++ b/common/app/views/fragments/relatedTrails.scala.html
@@ -8,7 +8,7 @@
         role="complementary"
         aria-labelledby="related-content-head">
         @* order the related trails by date *@
-        @fragments.trailblocks.headline(trails.sortBy(-_.webPublicationDate.getMillis), numItemsVisible = visibleTrails, related = true, isPanel = false, headingLevel = 3, expandable = false)
+        @fragments.trailblocks.thumbnail(trails.sortBy(-_.webPublicationDate.getMillis), numItemsVisible = visibleTrails, related = true, headingLevel = 3, expandable = false)
         @fragments.trailblocks.headline(trails.sortBy(-_.webPublicationDate.getMillis).drop(visibleTrails), numItemsVisible = trails.size - visibleTrails, related = true, isPanel = true, headingLevel = 3, expandable = false)
     </div>
 }

--- a/core-navigation/app/Global.scala
+++ b/core-navigation/app/Global.scala
@@ -1,7 +1,7 @@
 import common.{ CoreNavivationMetrics, Jobs }
 import conf.RequestMeasurementMetrics
 import dev.DevParametersLifecycle
-import feed.MostPopularAgent
+import feed.{MostPopularExpandableAgent, MostPopularAgent}
 import play.api.mvc.WithFilters
 import play.api.{ Application => PlayApp, Play, GlobalSettings }
 import play.api.Play.current
@@ -14,6 +14,7 @@ trait MostPopularLifecycle extends GlobalSettings {
     Jobs.deschedule("MostPopularAgentRefreshJob")
     Jobs.schedule("MostPopularAgentRefreshJob",  "0 * * * * ?", CoreNavivationMetrics.MostPopularLoadTimingMetric) {
       MostPopularAgent.refresh()
+      MostPopularExpandableAgent.refresh()
     }
 
     if (Play.isTest) {


### PR DESCRIPTION
Two fixes for the inline most popular A/B test based on feedback.
- Kick off the Akka agent to show most popular across the Guardian (forgot to do this part of the puzzle :wink: )
- Only show headline trails in story package when inside the experiment bucket of test.
