### PR TITLE
Fix JS error with inline most popular A/B test

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -128,7 +128,9 @@ define([
 
         transcludeRelated: function () {
             common.mediator.on("page:common:ready", function(config, context){
-                related(config, context);
+                if('abExpandableMostPopular' in config.switches && !config.switches.abExpandableMostPopular) {
+                    related(config, context);
+                }
             });
         },
 

--- a/common/app/assets/javascripts/modules/experiments/tests/expandable-mostpopular.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/expandable-mostpopular.js
@@ -1,7 +1,31 @@
 /*global guardian */
-define(['common', 'bean', 'modules/popular'], function (common, bean, popular) {
+define(['common', 'bean', 'modules/popular', 'modules/related'], function (common, bean, popular, related) {
 
     var ExperimentExpandableMostPopular = function () {
+
+        var cleanStoryPackage = function(context) {
+            var transformTrails = function(container) {
+                var trails = container.getElementsByClassName('trail');
+                common.toArray(trails).forEach(function(el){
+                    var img = el.getElementsByClassName('trail__img')[0],
+                        text = el.getElementsByClassName('trail__text')[0];
+                    if(img) { img.remove(); }
+                    if(text) { text.remove(); }
+                });
+            };
+            var relatedContainer = context.getElementsByClassName('related-trails')[0];
+            if(relatedContainer) {
+                transformTrails(relatedContainer);
+            } else {
+                common.mediator.on('modules:related:loaded', function() {
+                    transformTrails(context.getElementsByClassName('related-trails')[0]);
+                });
+                common.mediator.on('page:common:ready', function() {
+                    related(guardian.config, context);
+                });
+                related(guardian.config, context);
+            }
+        };
 
         this.id = 'ExpandableMostPopular';
         this.expiry = '2013-09-30';
@@ -14,21 +38,15 @@ define(['common', 'bean', 'modules/popular'], function (common, bean, popular) {
             {
                 id: 'control',
                 test: function (context) {
+                    cleanStoryPackage(context);
                     popular(guardian.config, context);
                 }
             },
             {
                 id: 'expandable-most-popular',
                 test: function (context) {
+                    cleanStoryPackage(context);
                     if((/^Video|Article|Gallery$/).test(guardian.config.page.contentType)) {
-                        var related = context.getElementsByClassName('related-trails')[0].getElementsByClassName('trail');
-                        common.toArray(related).forEach(function(el){
-                            var img = el.getElementsByClassName('trail__img')[0],
-                                text = el.getElementsByClassName('trail__text')[0];
-                            if(img) { img.remove(); }
-                            if(text) { text.remove(); }
-                        });
-
                         popular(guardian.config, context, true);
                         bean.on(document.body, 'change', '.trail__expander-trigger', function(e) {
                             var trail = e.target.parentNode;


### PR DESCRIPTION
This ensures that people in the control bucket still get standard story package trails with thumbnails, and those in the experiment don't.

It takes control of the related content bootstrap and then cleans the dom once they have loaded, or instantly if we are on a page with a curated story packages.

I have heavily tested it this time :wink:

![Fail](http://31.media.tumblr.com/tumblr_m6z6jyoBiN1r8cvzdo1_400.gif)
