### PR TITLE
Fronts admin: use configs & restyle

### DIFF
--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -158,7 +158,10 @@
             <div class="trail__meta">
                 <span data-bind="html: humanDate() ? humanDate : 'Loading...'"></span>
                 <!--a class="trail__meta__tweak"  data-bind="click: toggleEditingConfig">tweak</a-->
-                <a class="trail__meta__remove" data-bind="click: $parent.dropItem">remove</a>
+            </div>
+
+            <div class="trail__actions">
+                <i class="icon-trash list-tool trail__actions__remove" data-bind="click: $parent.dropItem"></i>
             </div>
 
             <a class="trail_stats cf" target="_blank" data-bind="attr: {href: 'http://dashboard.ophan.co.uk/summary?path=/' + meta.id()}">

--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -6,19 +6,10 @@
 
     <div class="fronts" data-bind="visible: true, makeDropabble: true" style="display: none">
         <header>
-            <div class="tool-title">Collections Editor</div>
+            <div class="tool-title">Front Collections Editor</div>
             <div class="list-picker">
-                <span class="list-picker__title">Choose collections:</span>
-
-                <select data-bind="options: editions, value: edition, optionsCaption: 'edition...'"></select>
-
-                <select data-bind="options: sections, value: section, enable: edition, optionsCaption: 'section...'"></select>
-
-                <select data-bind="options: blocks, value: block, enable: section, optionsCaption: 'all collections'"></select>
-
-                <button class="strong" data-bind="enable: section, click: actions.displaySelectedBlocks">Show</button>
-                
-                <button data-bind="enable: listsDisplayed().length, click: actions.clearAll">Hide all</button>
+                <select data-bind="options: configs, value: config, optionsCaption: 'Choose a Front...'"></select>
+                <button data-bind="enable: collections().length, click: actions.clearAll">Clear</button>
             </div>
         </header>
 
@@ -65,12 +56,12 @@
             </div>
         </script>
 
-        <div id="trailblocks" data-bind="foreach: listsDisplayed">
+        <div id="trailblocks" data-bind="foreach: collections">
             <div class="trailblock">
                 <div class="list-header">
                     <i class="icon-cog icon-white list-tool" data-bind="click: toggleEditingConfig"></i>
 
-                    <a data-bind="click: $root.actions.dropList" class="list-header__hide" title="Hide this block">HIDE</a>
+                    <a data-bind="click: $root.actions.dropCollection" class="list-header__hide" title="Hide this block">HIDE</a>
                     <div class="list-header__title" data-bind="foreach: crumbs">
                         <span class="list-header__title__part" data-bind="text: $data"></span> 
                     </div>

--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -173,9 +173,9 @@
             <span class="webTitle webTitle--override" data-bind="html: config.webTitle"></span>
             <!-- /ko -->
 
-            <a class="webTitle" data-bind="
-            html: meta.webTitle, 
-            attr: {href: 'http://www.theguardian.com/' + meta.id()}"></a>
+            <a class="webTitle" target="_blank" data-bind="
+                html: meta.webTitle, 
+                attr: {href: 'http://www.theguardian.com/' + meta.id()}"></a>
 
         </div>
     </script>

--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -59,25 +59,13 @@
         <div id="trailblocks" data-bind="foreach: collections">
             <div class="trailblock">
                 <div class="list-header">
-                    <i class="icon-cog icon-white list-tool" data-bind="click: toggleEditingConfig"></i>
+                    <i class="icon-cog list-tool" data-bind="click: toggleEditingConfig"></i>
 
                     <a data-bind="click: $root.actions.dropCollection" class="list-header__hide" title="Hide this block">HIDE</a>
                     <div class="list-header__title" data-bind="foreach: crumbs">
                         <span class="list-header__title__part" data-bind="text: $data"></span> 
                     </div>
                     <div data-bind="visible: !state.editingConfig()">
-                        <div class="list-header__meta">
-                            <!-- ko if: state.timeAgo -->
-                                updated <span class="list-header__meta__last-updated" data-bind="text: state.timeAgo"></span> 
-                                by <a class="list-header__meta__user" data-bind="
-                                    text: meta.updatedBy,
-                                    attr: {href: 'mailto:' + meta.updatedEmail}
-                                    "></a>
-                            <!-- /ko -->
-                            <!-- ko ifnot: state.timeAgo -->
-                                Empty
-                            <!-- /ko -->
-                        </div>
                         <div class="list-header__status">
                             <div class="list-header__status__live" data-bind="
                                 css: {
@@ -101,7 +89,19 @@
                                     &middot; <a class="list-header__status__control" data-bind="click: discardDraft">discard</a>
                                 </span>
                             </div>                    
-                        </div>                    
+                        </div>
+                        <div class="list-header__meta">
+                            <!-- ko if: state.timeAgo -->
+                                updated <span class="list-header__meta__last-updated" data-bind="text: state.timeAgo"></span> 
+                                by <a class="list-header__meta__user" data-bind="
+                                    text: meta.updatedBy,
+                                    attr: {href: 'mailto:' + meta.updatedEmail}
+                                    "></a>
+                            <!-- /ko -->
+                            <!-- ko ifnot: state.timeAgo -->
+                                Empty
+                            <!-- /ko -->
+                        </div>
                     </div>                    
                 </div>
                 <div class="list-config" data-bind="visible: state.editingConfig">
@@ -153,26 +153,25 @@
                 <button class="btn" value="Cancel" data-bind="click: $parent.forceRefresh">Cancel</button>
             </div>
 
-            <!-- ko if: (config.webTitle() && (meta.webTitle() !== config.webTitle())) -->
-            <span class="webTitle webTitle--override" data-bind="text: config.webTitle"></span>
-            <!-- /ko -->
-
             <img data-bind="attr: {src: fields.thumbnail}" />
 
             <div class="trail__meta">
                 <span data-bind="html: humanDate() ? humanDate : 'Loading...'"></span>
-                <a class="trail__meta__stats"  data-bind="attr: {href: 'http://dashboard.ophan.co.uk/summary?path=/' + meta.id()}">stats</a>
                 <!--a class="trail__meta__tweak"  data-bind="click: toggleEditingConfig">tweak</a-->
                 <a class="trail__meta__remove" data-bind="click: $parent.dropItem">remove</a>
             </div>
 
-            <div class="trail_stats cf">
+            <a class="trail_stats cf" target="_blank" data-bind="attr: {href: 'http://dashboard.ophan.co.uk/summary?path=/' + meta.id()}">
                 <div class="pageviews" data-bind="if: pageViewsCommas(), text: pageViewsCommas"></div>
                 <div class="pageviews-graph" data-bind="if: state.pageViewsSeries(), sparkline: state.pageViewsSeries"></div>
-            </div>
+            </a>
+
+            <!-- ko if: (config.webTitle() && (meta.webTitle() !== config.webTitle())) -->
+            <span class="webTitle webTitle--override" data-bind="html: config.webTitle"></span>
+            <!-- /ko -->
 
             <a class="webTitle" data-bind="
-            text: meta.webTitle, 
+            html: meta.webTitle, 
             attr: {href: 'http://www.theguardian.com/' + meta.id()}"></a>
 
         </div>

--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -164,7 +164,7 @@
                 <i class="icon-trash list-tool trail__actions__remove" data-bind="click: $parent.dropItem"></i>
             </div>
 
-            <a class="trail_stats cf" target="_blank" data-bind="attr: {href: 'http://dashboard.ophan.co.uk/summary?path=/' + meta.id()}">
+            <a class="trail_stats cf" target="_blank" data-bind="attr: {href: 'http://dashboard.ophan.co.uk/graph/breakdown?path=/' + meta.id()}">
                 <div class="pageviews" data-bind="if: pageViewsCommas(), text: pageViewsCommas"></div>
                 <div class="pageviews-graph" data-bind="if: state.pageViewsSeries(), sparkline: state.pageViewsSeries"></div>
             </a>

--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -157,10 +157,6 @@
             <span class="webTitle webTitle--override" data-bind="text: config.webTitle"></span>
             <!-- /ko -->
 
-            <a class="webTitle" data-bind="
-            text: meta.webTitle, 
-            attr: {href: 'http://www.theguardian.com/' + meta.id()}"></a>
-
             <img data-bind="attr: {src: fields.thumbnail}" />
 
             <div class="trail__meta">
@@ -174,6 +170,10 @@
                 <div class="pageviews" data-bind="if: pageViewsCommas(), text: pageViewsCommas"></div>
                 <div class="pageviews-graph" data-bind="if: state.pageViewsSeries(), sparkline: state.pageViewsSeries"></div>
             </div>
+
+            <a class="webTitle" data-bind="
+            text: meta.webTitle, 
+            attr: {href: 'http://www.theguardian.com/' + meta.id()}"></a>
 
         </div>
     </script>

--- a/admin/public/css/style.css
+++ b/admin/public/css/style.css
@@ -401,7 +401,7 @@ a.cta, .cta a {
     float: right;
     cursor: pointer;
     margin: 3px 2px 0 0;
-    opacity: 0.4;
+    opacity: 0.5;
 }
 
 .fronts .list-tool:hover {
@@ -544,8 +544,8 @@ a.cta, .cta a {
     box-sizing: border-box;
     width: 100%;
     float: left;
-    padding: 0 0 10px 0;
-    border-top: 4px solid #999999;
+    padding: 0 0 20px 0;
+    border-top: 3px solid #999999;
 }
 
 .fronts .trailblock:first-child {
@@ -561,6 +561,7 @@ a.cta, .cta a {
     background-color: #ededed;
     padding: 2px 5px 7px 6px;
     border-bottom: 1px dashed #CCCCCC;
+    position: relative;
 }
 
 .fronts .trail:last-child {
@@ -583,21 +584,6 @@ a.cta, .cta a {
     height: 60px !important;
     background-color: #47ae38 !important;
     visibility: visible !important;
-}
-
-.fronts .trail .trail__controls {
-}
-
-.fronts .trailblock .trail .trail__controls {
-    display: block;
-    float: right;
-    font-size: 10px;
-    margin: -6px -2px 0 0;
-}
-
-.fronts .trail__controls a.trail__control {
-    font-size: 9px;
-    margin: 0 2px 0 0;
 }
 
 .fronts .trail img {
@@ -674,6 +660,17 @@ a.cta, .cta a {
     border-left: 1px #dddddd solid;
     padding-left: 4px;
     cursor: pointer;
+}
+
+.fronts .trail .trail__actions {
+    display: none;
+}
+
+.fronts .trail:hover .trail__actions {
+    display: block;
+    position: absolute;
+    top: 2px;
+    right: 3px;
 }
 
 .fronts .trail_tweaks {

--- a/admin/public/css/style.css
+++ b/admin/public/css/style.css
@@ -616,7 +616,7 @@ a.cta, .cta a {
 
 .fronts .trailblock .trail .webTitle {
     font-size: 15px;
-    margin-right: 200px;
+    margin-right: 140px;
 }
 
 .fronts .trail .webTitle--override {
@@ -666,7 +666,7 @@ a.cta, .cta a {
     display: none;
 }
 
-.fronts .trail:hover .trail__actions {
+.fronts .trailblock .trail:hover .trail__actions {
     display: block;
     position: absolute;
     top: 2px;

--- a/admin/public/css/style.css
+++ b/admin/public/css/style.css
@@ -350,11 +350,15 @@ a.cta, .cta a {
 .cf:after{clear:both}
 .cf{zoom:1}
 
+.fronts {
+    color: #000000;
+}
+
 .fronts .finder {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     float: left;
-    width: 300px;
+    width: 350px;
     padding: 10px;
 }
 
@@ -426,8 +430,7 @@ a.cta, .cta a {
 }
 
 .fronts #trailblocks .connectedList {
-    min-height: 100px;
-    background: #eee;
+    min-height: 50px;
 }
 
 .fronts #trailblocks .connectedList.pending {
@@ -436,38 +439,40 @@ a.cta, .cta a {
 }
 
 .fronts .list-header {
-    background-color: #666666;
-    color: #ffffff;
-    padding: 0;
+    padding: 5px 0 0 0;
     overflow: auto;
 }
 
 .fronts .list-header a,
 .fronts .list-header a:hover,
 .fronts .list-header a:visited {
-    color: #ffffff;
+    color: #999999;
 }
 
 .fronts .list-header__title {
-    font-size: 18px;
-    padding: 3px 0 0 6px;
+    padding: 2px 0 2px 7px;
 }
 
 .fronts .list-header__title__part {
-    font-size: 18px;
+    font-size: 16px;
     display: inline-block;
-    padding-left: 4px;
-    border-left: 1px solid #cccccc;
+    padding-left: 0px;
+    text-transform: uppercase;
 }
 
 .fronts .list-header__title__part:first-child {
-    padding-left: 0;
-    border-left: 0;
+    color: #999999;
+}
+
+.fronts .list-header__title__part:last-child {
+    font-weight: bold;
 }
 
 .fronts .list-header__meta {
-    padding: 0 6px;
+    padding: 0 0 0 5px;
     font-size: 10px;
+    float: left;
+    color: #ccc;
 }
 
 .fronts .list-header__meta__last-updated {
@@ -482,34 +487,26 @@ a.cta, .cta a {
     font-size: 12px;
     float: left;
     padding: 0 6px;
-    margin: 0 0 0 1px;
+    margin: 0 1px;
     height: 19px;
-    background-color: #999999;    
     cursor: pointer;
+    color: #666666;
+    font-weight: bold;
 }
 
 .fronts .list-header__status__live.active {
     color: #47ae38;
     height: 20px;
-    background-color: #ffffff;    
 }
 
 .fronts .list-header__status__draft.hasUnPublishedEdits {
-    background-color: #f89406;
+    color: #f89406;
 }
 
 .fronts .list-header__status__draft.active {
     height: 20px;
     color: #f89406;
     background-color: #ededed;    
-}
-
-.fronts .list-header__status__live__title {
-    font-weight: bold;
-}
-
-.fronts .list-header__status__draft__title {
-    font-weight: bold;
 }
 
 .fronts a.list-header__status__control {
@@ -539,7 +536,7 @@ a.cta, .cta a {
 }
 
 .fronts #trailblocks {
-    margin: 0 0 0 300px;
+    margin: 0 0 0 350px;
 }
 
 .fronts .trailblock {
@@ -547,7 +544,13 @@ a.cta, .cta a {
     box-sizing: border-box;
     width: 100%;
     float: left;
-    padding: 10px 0 0 10px;
+    padding: 0 0 10px 0;
+    border-top: 4px solid #999999;
+}
+
+.fronts .trailblock:first-child {
+    border-top: 0;
+    margin-top: 25px;
 }
 
 .fronts .trail {
@@ -557,22 +560,15 @@ a.cta, .cta a {
     cursor: move;
     background-color: #ededed;
     padding: 2px 5px 7px 6px;
-    border-left: 1px solid #666666;
-    border-right: 1px solid #666666;
-    border-bottom: 1px solid #666666;
+    border-bottom: 1px dashed #CCCCCC;
+}
+
+.fronts .trail:last-child {
+    border-bottom: 0;
 }
 
 .fronts .is-live .trail {
     background-color: #ffffff;
-}
-
-.fronts .finder .trail {
-    border: 0;
-    border-top: 1px solid #cccccc;
-    background-color: #ffffff;
-}
-
-.fronts .finder .trail:first-child {
 }
 
 .fronts .trail:hover {
@@ -583,11 +579,9 @@ a.cta, .cta a {
     opacity: 0.2;
 }
 
-.fronts .ui-sortable-placeholder {
-    height: 10px;
-    border-top: 3px solid #666666;
-    border-bottom: 3px solid #666666;
-    background-color: #DFF0D8;
+.fronts .trail.ui-sortable-placeholder {
+    height: 60px !important;
+    background-color: #47ae38 !important;
     visibility: visible !important;
 }
 
@@ -609,8 +603,9 @@ a.cta, .cta a {
 .fronts .trail img {
     float: left;
     width: 75px;
+    height: 45px;
     margin: 5px 0 0 0;
-    background-color: #eee;
+    background-color: #EEEEEE;
 }
 
 .fronts .trailblock .trail img,
@@ -624,14 +619,18 @@ a.cta, .cta a {
 }
 
 .fronts .trail .webTitle {
-    margin: 0 0 0 85px;
+    margin-top: 2px;
+    margin-left: 80px;
     display: block;
     text-decoration: none;
-    font-size: 14px;
+    font-size: 13px;
     line-height: 16px;
     color: #000000;
-    margin: 2px 200px 5px 85px;
-    overflow: hidden;
+}
+
+.fronts .trailblock .trail .webTitle {
+    font-size: 15px;
+    margin-right: 200px;
 }
 
 .fronts .trail .webTitle--override {
@@ -647,14 +646,22 @@ a.cta, .cta a {
 }
 
 .fronts .trail .trail__meta {
-    float: right;
-    clear: right;
-    width: 180px;
+    float: left;
+    clear: left;
+    width: 75px;
     height: 16px;
     color: #999999;
     font-size: 10px;
     line-height: 10px;
-    margin: 4px 32px 0px 0;
+    margin-top: 4px;
+}
+
+.fronts .trailblock .trail .trail__meta {
+    float: right;
+    clear: right;
+    text-align: right;
+    width: inherit;
+    margin-right: 32px;
 }
 
 .fronts .trail .trail__meta a {

--- a/admin/public/css/style.css
+++ b/admin/public/css/style.css
@@ -554,7 +554,6 @@ a.cta, .cta a {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     overflow: hidden;
-    height: 107px;
     cursor: move;
     background-color: #ededed;
     padding: 5px 5px 10px 10px;
@@ -628,7 +627,6 @@ a.cta, .cta a {
     text-decoration: none;
     color: #000000;
     margin: 0 0 5px 0;
-    height: 40px;
     overflow: hidden;
 }
 
@@ -676,7 +674,7 @@ a.cta, .cta a {
 
 .fronts select {
     height: 30px;
-    width: 125px;
+    width: 160px;
     margin: 0;
 }
 

--- a/admin/public/css/style.css
+++ b/admin/public/css/style.css
@@ -545,7 +545,7 @@ a.cta, .cta a {
 .fronts .trailblock {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
-    width: 290px;
+    width: 100%;
     float: left;
     padding: 10px 0 0 10px;
 }
@@ -556,7 +556,7 @@ a.cta, .cta a {
     overflow: hidden;
     cursor: move;
     background-color: #ededed;
-    padding: 5px 5px 10px 10px;
+    padding: 2px 5px 7px 6px;
     border-left: 1px solid #666666;
     border-right: 1px solid #666666;
     border-bottom: 1px solid #666666;
@@ -609,6 +609,7 @@ a.cta, .cta a {
 .fronts .trail img {
     float: left;
     width: 75px;
+    margin: 5px 0 0 0;
     background-color: #eee;
 }
 
@@ -623,10 +624,13 @@ a.cta, .cta a {
 }
 
 .fronts .trail .webTitle {
+    margin: 0 0 0 85px;
     display: block;
     text-decoration: none;
+    font-size: 14px;
+    line-height: 16px;
     color: #000000;
-    margin: 0 0 5px 0;
+    margin: 2px 200px 5px 85px;
     overflow: hidden;
 }
 
@@ -643,12 +647,14 @@ a.cta, .cta a {
 }
 
 .fronts .trail .trail__meta {
+    float: right;
+    clear: right;
     width: 180px;
     height: 16px;
-    float: right;
     color: #999999;
     font-size: 10px;
     line-height: 10px;
+    margin: 4px 32px 0px 0;
 }
 
 .fronts .trail .trail__meta a {
@@ -755,6 +761,7 @@ a.cta, .cta a {
     width: 180px;
     height: 30px;
     float: right;
+    clear: right;
     font-size: 9px;
     line-height: 12px;
     position: relative;

--- a/admin/public/javascripts/models/fronts/common.js
+++ b/admin/public/javascripts/models/fronts/common.js
@@ -16,7 +16,7 @@ define([
             cacheExpiryMs:         300000, // 300000 = five mins 
             defaultToLiveMode:     true,
             sectionSearches: {
-                "news": "news|uk|uk-news|world",
+                "default": "news|uk|uk-news|world",
                 "culture": "cluture|film|music|books|artanddesign|tv-and-radio|stage"
             },
 

--- a/admin/public/javascripts/models/fronts/common.js
+++ b/admin/public/javascripts/models/fronts/common.js
@@ -5,9 +5,6 @@ define([
     EventEmitter,
     ko
 ) {
-    var _listsContainerID = '#trailblocks',
-        _masonryEl;
-
     return {
         config: {
             searchPageSize:        20,
@@ -99,15 +96,6 @@ define([
                 _.keys(target).forEach(function(key){
                     target[key](opts[key]);
                 });
-            },
-
-            pageReflow: function() {
-                if(_masonryEl) {
-                    _masonryEl.masonry('destroy');
-                } else {
-                    _masonryEl = $(_listsContainerID);
-                }
-                _masonryEl.masonry();
             }
         }
 

--- a/admin/public/javascripts/models/fronts/common.js
+++ b/admin/public/javascripts/models/fronts/common.js
@@ -8,7 +8,7 @@ define([
     return {
         config: {
             searchPageSize:        20,
-            maxDisplayableLists:   6,
+            maxDisplayableLists:   20,
             maxOphanCallsPerBlock: 50,
             cacheExpiryMs:         300000, // 300000 = five mins 
             defaultToLiveMode:     true,

--- a/admin/public/javascripts/models/fronts/ophanApi.js
+++ b/admin/public/javascripts/models/fronts/ophanApi.js
@@ -49,11 +49,12 @@ function (
                     }) || groups[0]; // ...defaulting to the first ('Other')
 
                 // How many 1 min points are we adding into each slot
-                var perSlot = Math.max(1, Math.floor(s.data.length / slots));
+                var minsPerSlot = Math.max(1, Math.floor(s.data.length / slots));
+                group.minsPerSlot = minsPerSlot;
 
                 // ...sum the data into each group
-                _.each(_.first(_.last(s.data, 1+perSlot*slots), perSlot*slots), function(d,index) {
-                    var i = Math.floor(index / perSlot);
+                _.each(_.first(_.last(s.data, 1+minsPerSlot*slots), minsPerSlot*slots), function(d,index) {
+                    var i = Math.floor(index / minsPerSlot);
                     group.data[i] = (group.data[i] || 0) + d.count;
                     group.max = Math.max(group.max, group.data[i]);
                 });

--- a/admin/public/javascripts/models/fronts/ophanApi.js
+++ b/admin/public/javascripts/models/fronts/ophanApi.js
@@ -37,9 +37,7 @@ function (
                 {name: 'Guardian', data: [], color: '4572A7', max: 0}
             ];
 
-        if(data.totalHits) {
-            item.state.pageViews(data.totalHits);
-        }
+        item.state.pageViews(data.totalHits);
 
         if(data.seriesData && data.seriesData.length) {
             _.each(data.seriesData, function(s){

--- a/admin/public/javascripts/models/fronts/ophanApi.js
+++ b/admin/public/javascripts/models/fronts/ophanApi.js
@@ -31,6 +31,7 @@ function (
 
     function decorateItem(data, item) {
         var simpleSeries,
+            slots = 100,
             groups = [
                 {name: 'Other',    data: [], color: 'd61d00', max: 0}, // required
                 {name: 'Google',   data: [], color: '89A54E', max: 0},
@@ -44,11 +45,15 @@ function (
 
                 // Pick the relevant group...
                 var group = _.find(groups, function(g){ 
-                    return g.name === s.name;
-                }) || groups[0]; // ...defaulting to the first ('Other')
+                        return g.name === s.name;
+                    }) || groups[0]; // ...defaulting to the first ('Other')
 
-                // ...sum the data into that group
-                _.each(s.data, function(d,i) {
+                // How many 1 min points are we adding into each slot
+                var perSlot = Math.max(1, Math.floor(s.data.length / slots));
+
+                // ...sum the data into each group
+                _.each(_.first(_.last(s.data, 1+perSlot*slots), perSlot*slots), function(d,index) {
+                    var i = Math.floor(index / perSlot);
                     group.data[i] = (group.data[i] || 0) + d.count;
                     group.max = Math.max(group.max, group.data[i]);
                 });

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -283,8 +283,6 @@ define([
                         var data = group.data,
                             isHot = (_.last(data)/group.minsPerSlot) > 10;
 
-                        console.log(group);
-
                         $(element).sparkline(data, {
                             chartRangeMax: max,
                             defaultPixelsPerValue: data.length < 50 ? data.length < 30 ? 3 : 2 : 1,

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -277,15 +277,18 @@ define([
                         // Put biggest groups first, so that its fill color is behind the other groups
                         return -1 * g.max;
                     }).each(function(group, i){
-                        $(element).sparkline(group.data, {
+                        var data = group.data;
+
+                        $(element).sparkline(data, {
                             chartRangeMax: max,
+                            defaultPixelsPerValue: data.length < 50 ? data.length < 30 ? 3 : 2 : 1,
                             height: Math.max(10, Math.min(30, max)),
                             lineColor: '#' + group.color,
-                            fillColor: _.last(group.data) > 25 ? '#eeeeee' : false,
+                            fillColor: _.last(data) > 25 ? '#eeeeee' : false,
                             spotColor: false,
                             minSpotColor: false,
                             maxSpotColor: false,
-                            lineWidth: _.last(group.data) > 25 ? 2 : 1,
+                            lineWidth: _.last(data) > 25 ? 2 : 1,
                             composite: i > 0
                         });
                     });

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -292,18 +292,6 @@ define([
                 }
             };
 
-            common.util.mediator.on('list:load:start', function() {
-                listLoadsPending += 1;
-            });
-
-            common.util.mediator.on('list:load:end', function() {
-                listLoadsPending -= 1;
-                if (listLoadsPending < 1) {
-                    listLoadsPending = 0;
-                    common.util.pageReflow();
-                }
-            });
-
             fetchConfigs(function(){
                 knockout.applyBindings(model);
 

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -277,18 +277,24 @@ define([
                         // Put biggest groups first, so that its fill color is behind the other groups
                         return -1 * g.max;
                     }).each(function(group, i){
-                        var data = group.data;
+
+                        group.data.pop(); // drop the last data point. 
+
+                        var data = group.data,
+                            isHot = (_.last(data)/group.minsPerSlot) > 10;
+
+                        console.log(group);
 
                         $(element).sparkline(data, {
                             chartRangeMax: max,
                             defaultPixelsPerValue: data.length < 50 ? data.length < 30 ? 3 : 2 : 1,
                             height: Math.max(10, Math.min(30, max)),
                             lineColor: '#' + group.color,
-                            fillColor: _.last(data) > 25 ? '#eeeeee' : false,
                             spotColor: false,
                             minSpotColor: false,
                             maxSpotColor: false,
-                            lineWidth: _.last(data) > 25 ? 2 : 1,
+                            lineWidth: isHot ? 2 : 1,
+                            fillColor: isHot ? '#eeeeee' : false,
                             composite: i > 0
                         });
                     });

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -301,7 +301,7 @@ define([
 
                 startPoller();
                 model.latestArticles.search();
-                model.latestArticles.startPoller();
+                //model.latestArticles.startPoller();
             });
         };
 

--- a/admin/public/javascripts/modules/fronts/listManager.js
+++ b/admin/public/javascripts/modules/fronts/listManager.js
@@ -17,7 +17,7 @@ define([
     contentApi,
     ophanApi
 ) {
-    var collections = {},
+    var configs = {},
         dragging = false,
         clipboardEl = document.querySelector('#clipboard'),
         listLoadsPending = 0,
@@ -28,30 +28,22 @@ define([
         var model = {},
             self = this;
 
-        function chosenLists() {
-            return [].concat(_.filter((common.util.queryParams().blocks || "").split(","), function(str){ return !!str; }));
+        function chosenCollections() {
+            return [].concat(_.filter((common.util.queryParams().collections || "").split(","), function(str){ return !!str; }));
         }
 
-        function addList(id) {
-            var lists = chosenLists();
-            lists = _.without(lists, id);
-            lists.unshift(id);
-            lists = _.first(lists, common.config.maxDisplayableLists || 3);
-            setDisplayedLists(lists);
-        }
-
-        function dropList(list) {
-            setDisplayedLists(_.reject(chosenLists(), function(id){ return id === list.id; }));
-            common.util.pageReflow();
+        function dropCollection(list) {
+            setDisplayedLists(_.reject(chosenCollections(), function(id){ return id === list.id; }));
         }
 
         function clearAll() {
+            model.config(undefined);
             setDisplayedLists([]);
         }
 
         function setDisplayedLists(listIDs) {
             var qp = common.util.queryParams();
-            qp.blocks = listIDs.join(',');
+            qp.collections = listIDs.join(',');
             qp = _.pairs(qp)
                 .filter(function(p){ return !!p[0]; })
                 .map(function(p){ return p[0] + (p[1] ? '=' + p[1] : ''); })
@@ -61,37 +53,13 @@ define([
             renderLists();
         }
 
-        function displayInAllEditions() {
-            setDisplayedLists(model.editions().map(function(edition){
-                return [edition, model.section(), model.block()].join('/'); 
-            }));
-        }
-
-        function renderLists(opts) {
-            var chosen = chosenLists(),
-                first;
-
-            opts = opts || {};
-
-            model.listsDisplayed.remove(function(list){
-                if (chosen.indexOf(list.id) === -1) {
-                    return true;
-                } else {
-                    chosen = _.without(chosen, list.id);
-                    return false;
-                }    
-            });
-
-            chosen.forEach(function(id){
-                model.listsDisplayed.push(new List(id));
-            });
-
-            if(opts.inferDefaults && chosen[0]) {
-                first = chosen[0].split('/');
-                model.edition(first.shift());
-                model.section(first.shift());
-            }
-
+        function renderLists() {
+            model.collections.removeAll();
+            model.collections(
+                chosenCollections().map(function(id){
+                    return new List(id);
+                })
+            );
             connectSortableLists();
         }
 
@@ -192,7 +160,7 @@ define([
 
         function _startPoller() {
             setInterval(function(){
-                model.listsDisplayed().forEach(function(list){
+                model.collections().forEach(function(list){
                     if (!dragging) {
                         list.refresh();
                     }
@@ -201,43 +169,41 @@ define([
         }
         var startPoller = _.once(_startPoller);
 
-        function fetchCollections(callback) {
+        function fetchConfigs(callback) {
             reqwest({
-                url: common.config.apiBase + '/collection',
+                url: common.config.apiBase + '/config',
                 type: 'json'
             }).then(
                 function(resp) {
+                    if (!_.isArray(resp) || resp.length === 0) {
+                        window.console.log("ERROR: No configs were found");      
+                        return; 
+                    }
+                    model.configs(resp.sort());
+
                     resp.forEach(function(id){
-                        // Only use "first/three/levels" of the collection id path
-                        treeAdd(_.first(id.split('/'), 3), collections);
-                    });                    
-                    model.editions(_.keys(collections));
+                        fetchConfig(id, function(c){
+                            configs[id] = c; 
+                        })                        
+                    });
+
                     if (_.isFunction(callback)) { callback(); }
                 },
-                function(xhr) { window.console.log("ERROR: There was a problem listing the available collections"); }
+                function(xhr) { window.console.log("ERROR: There was a problem listing the configs"); }
             );
+            //window.configs = configs;
         };
 
-        function treeAdd(path, obj) {
-            var f = _.first(path),
-                r = _.rest(path);
-
-            obj[f] = obj[f] || {};
-            if (r.length) {
-                treeAdd(r, obj[f]);
-            }
-        };
-
-        function displaySelectedBlocks() {           
-            var blocks = model.block() ? [model.block()] : model.blocks();
-
-            blocks.forEach(function(block){
-                addList([
-                    model.edition(),
-                    model.section(),
-                    block
-                ].join('/'));
-            })
+        function fetchConfig(id, callback) {
+            reqwest({
+                url: common.config.apiBase + '/config/' + id,
+                type: 'json'
+            }).then(
+                function(resp) {
+                    if (_.isFunction(callback)) { callback(resp); }
+                },
+                function(xhr) { window.console.log("ERROR: There was a problem fetching the config for " + id); }
+            );
         };
 
         function flushClipboard() {
@@ -270,47 +236,26 @@ define([
 
         this.init = function(callback) {
             model.latestArticles  = new LatestArticles();
-            model.listsDisplayed  = knockout.observableArray();
             model.clipboard        = knockout.observableArray();
 
-            model.editions = knockout.observableArray();
-            model.edition  = knockout.observable();
-
-            model.sections = knockout.observableArray();
-            model.section  = knockout.observable();
-
-            model.blocks   = knockout.observableArray();
-            model.block    = knockout.observable();
+            model.configs     = knockout.observableArray();
+            model.config      = knockout.observable();
+            model.collections = knockout.observableArray();
 
             model.actions = {
-                displaySelectedBlocks: displaySelectedBlocks,
-                displayInAllEditions: displayInAllEditions,
-                dropList: dropList,
+                dropCollection: dropCollection,
                 clearAll: clearAll,
                 flushClipboard: flushClipboard
             }
 
-            model.edition.subscribe(function(edition) {
-                model.sections.removeAll();
-                if (common.util.hasNestedProperty(collections, [edition])) {
-                    model.sections(_.keys(collections[edition]));
-                }
-                model.section(undefined);
+            model.config.subscribe(function(config) {
+                if (!config) { return; }
 
-                model.blocks.removeAll();
-                model.block(undefined);
-            });
+                var section = config.split('/')[1]; // assumes ids are formed "edition/section/.."
 
-            model.section.subscribe(function(section) {
-                model.blocks.removeAll();
-                if (common.util.hasNestedProperty(collections, [model.edition(), section])) {
-                    model.blocks(_.keys(collections[model.edition()][section]));
-                }
-                model.block(undefined);
+                model.latestArticles.section(common.config.sectionSearches[section || 'default'] || section);
 
-                if (section) {
-                    model.latestArticles.section(common.config.sectionSearches[section] || section);
-                }
+                setDisplayedLists(_.pluck(configs[config], 'id'));
             });
 
             knockout.bindingHandlers.makeDropabble = {
@@ -359,10 +304,10 @@ define([
                 }
             });
 
-            fetchCollections(function(){
+            fetchConfigs(function(){
                 knockout.applyBindings(model);
 
-                renderLists({inferDefaults: true});
+                renderLists();
 
                 window.onpopstate = renderLists;
 
@@ -370,7 +315,6 @@ define([
                 model.latestArticles.search();
                 model.latestArticles.startPoller();
             });
-
         };
 
     };


### PR DESCRIPTION
- Present user with the list of config'd fronts, then load all collections for the chosen config.
- Stack the collections vertically, to visually maintain their order within the config.
- Show more collections than was previously possible.

![tool](https://f.cloud.github.com/assets/1147913/1089754/9d1e0226-1649-11e3-837f-80a244e049b1.png)
