### PR TITLE
Ensure nav style doesn't conflict with most popular headings

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_localnav.scss
+++ b/common/app/assets/stylesheets/module/nav/_localnav.scss
@@ -23,7 +23,7 @@
         }
     }
 
-    h2.article-zone,
+    .article-zone:only-child,
     .section-head,
     .front-section:first-child .sub-section-head {
         display: none;


### PR DESCRIPTION
Sub nav styles were preventing headings on most popular components from showing on mobile breakpoints. Only on pages where sub nav's exist.

This is a quick fix to prevent that from happening.

/cc @kaelig 
