### PR TITLE
Front block ids

### DIFF
--- a/common/app/views/fragments/headers/frontSectionHead.scala.html
+++ b/common/app/views/fragments/headers/frontSectionHead.scala.html
@@ -1,6 +1,6 @@
 @(description: TrailblockDescription, isFront: Boolean, edition: Option[Edition] = None)(implicit request: RequestHeader)
 <div class="@if(isFront){front-section-head zone-background} else {sub-section-head}">
-    <h1>
+    <h1 id="@SafeName(description)">
        <a @if(request.path != ""){class="zone-color"} data-link-name="section heading" href="@LinkTo{/@description.id}">
          @description.name
         </a>

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -258,7 +258,7 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
         browser =>
           import browser._
 
-          Then("I should have anchors for each block")
+          Then("I should have ids for each block")
           findFirst("h1[id='commentisfree']").getText should startWith ("Comment is free")
       }
     }

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -252,6 +252,16 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
       }
     }
 
+    scenario("Front block anchors") {
+      Given("I visit the network front")
+      HtmlUnit("/uk") {
+        browser =>
+          import browser._
+
+          Then("I should have anchors for each block")
+          findFirst("h1[id='commentisfree']").getText should startWith ("Comment is free")
+      }
+    }
 
     // this is so that the load balancer knows this server has a problem
     scenario("Return error if front is empty") {


### PR DESCRIPTION
Each block on the network front now gets an ID attribute.

You can now link directly to blocks on the front e.g. http://www.theguardian.com/uk#sport

This is to support some requested tooling.
