### PR TITLE
We currently have a 0.2 - 0.4 percent chance of a request timing out.

### DIFF
--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -18,7 +18,7 @@ trait WsHttp extends Http[Future] with ExecutionContexts {
     val urlWithHost = url + s"&host-name=${encode(host.name, "UTF-8")}"
 
     val start = currentTimeMillis
-    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(2000).get()
+    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(3000).get()
 
     // record metrics
     response.onSuccess {


### PR DESCRIPTION
Temporarily modifying to measure what difference it makes.
