### PR TITLE
Inline image fixes

### DIFF
--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -120,11 +120,13 @@
     clear: left;
     margin: 3px 0 0 0;
     padding-right: $gs-gutter/2;
-    @include mq(mobileLandscape) {
-        padding-right: $gs-gutter;
-    }
     padding-bottom: 15px;
     background: white;
+
+    @include mq(mobileLandscape) {
+        padding-right: $gs-gutter;
+        width: gs-span(2);
+    }
 
     figcaption {
         word-wrap: break-word;

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -119,7 +119,10 @@
     float: left;
     clear: left;
     margin: 3px 0 0 0;
-    padding-right: 10px;
+    padding-right: $gs-gutter/2;
+    @include mq(mobileLandscape) {
+        padding-right: $gs-gutter;
+    }
     padding-bottom: 15px;
     background: white;
 


### PR DESCRIPTION
- [new] Takes advantage of screen width to display wider images.
- [fixed] Horizontal spacing of inline images follows the new grid (10px/20px)
### Before (mobile landscape and above)

![screen shot 2013-09-09 at 14 52 28](https://f.cloud.github.com/assets/85783/1107195/08c5dff6-1958-11e3-9c95-c0fad896c9df.PNG)
### After (mobile landscape and above)

![screen shot 2013-09-09 at 14 55 59](https://f.cloud.github.com/assets/85783/1107197/163c82fc-1958-11e3-965e-8fa4050b7828.PNG)

And a homemade gif… /cc @oncletom
![hacking-kaelig-oncletom](https://f.cloud.github.com/assets/85783/1107212/7b9d7868-1958-11e3-8d29-85d49b6369c1.gif)
