### PR TITLE
Bullet points do not perturbate vertical rhythm

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -100,7 +100,7 @@ $mq-breakpoints: mq-add-breakpoint(leftCol, $a-leftCol-trigger);
     font-size: 13px;
     display: inline-block;
     color: #999999;
-    margin: $baseline/2 4px 0 0;
+    margin: $baseline/2 4px $baseline/-2 0;
 
     &:first-of-type {
         margin-top: $baseline;


### PR DESCRIPTION
There was too much space between the first and second lines of text in lists. This fixes it.
### Before

![screen shot 2013-09-09 at 15 28 53](https://f.cloud.github.com/assets/85783/1107423/ceb4c124-195c-11e3-9bcd-3c91379a0afa.PNG)
### After

![screen shot 2013-09-09 at 15 29 00](https://f.cloud.github.com/assets/85783/1107426/d183cbf2-195c-11e3-9198-fff177c244ed.PNG)

![ ](http://s1.developerslife.ru/public/images/gifs/a80ec80e-957f-4ec4-a848-a8c374b1dbed.gif)
