### PR TITLE
Add a variant in the inline link card test

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/inline-link-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/inline-link-card.js
@@ -40,6 +40,19 @@ function (
                         }
                     });
                 }
+            },
+            {
+                id: 'link-card-all-origins',
+                test: function (config, context) {
+                    common.mediator.on('page:article:ready', function(config, context) {
+                        if (!config.switches.externalLinksCards) {
+                            var card = new LeftHandCard({
+                                origin: 'all',
+                                context: context
+                            });
+                        }
+                    });
+                }
             }
         ];
     };


### PR DESCRIPTION
As per @commuterjoy request, we now have 3 variants in the inline link card test:
- control (no cards)
- link-card (internal links get cardified)
- link-card-all-origins (links to whitelisted domains get cardified)

Related: #1466 #1342.

We need to adapt [the hypothesis](https://github.com/guardian/frontend/blob/master/docs/experiments/linked-content-cards-sidebar.md): place your bets!
### A yummy example:

Thanks Matt for pointing to this great card (in /lifeandstyle/2010/feb/06/experience-bubonic-plague): 

![screen shot 2013-09-09 at 15 52 30](https://f.cloud.github.com/assets/85783/1107551/816bb442-195f-11e3-8292-f14efd8dcd09.PNG)

![ ](http://s1.developerslife.ru/public/images/gifs/284c24e2-9fdd-45e6-be57-3f4f1f458cc7.gif)
