### PR TITLE
Handle rate limit error on signin form

### DIFF
--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -63,10 +63,7 @@ class ResetPasswordController @Inject()( api : IdApiClient, idRequestParser: IdR
             case Left(errors) => {
               log.info("User not found for request new password.")
               val formWithError = errors.foldLeft(boundForm) { (form, error) =>
-                error match {
-                  case Error(_, description, _, context) =>
-                    form.withError(context.getOrElse(""), description)
-                }
+                form.withError(error.context.getOrElse(""), error.description)
               }
               Ok(views.html.password.request_password_reset(page, idRequest, idUrlBuilder, formWithError, errors))
             }

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -62,7 +62,9 @@ class SigninController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
             case Left(errors) => {
               logger.error(errors.toString())
               logger.info("Auth failed for user")
-              val formWithErrors = boundForm.withError(FormError("", Messages("error.login")))
+              val formWithErrors = errors.find(_.message == "Rate limit exceeded").map { e =>
+                boundForm.withError(FormError("", e.description))
+              }.getOrElse(boundForm.withError(FormError("", Messages("error.login"))))
               Ok(views.html.signin(page, idRequest, idUrlBuilder, formWithErrors))
             }
             case Right(apiCookiesResponse) => {


### PR DESCRIPTION
Signin controller now defers errors to the API as the other controllers do. This enables display of non-standard errors like the ID API rate limit error.
