### PR TITLE
Fronts top stories redux

### DIFF
--- a/common/app/assets/javascripts/bootstraps/facia.js
+++ b/common/app/assets/javascripts/bootstraps/facia.js
@@ -22,7 +22,7 @@ define([
 
         showTopStoriesShowMore: function () {
             common.mediator.on('page:front:ready', function(config, context) {
-                common.$g('.section--small-stories', context).each(function(topStories) {
+                common.$g('.collection--small-stories', context).each(function(topStories) {
                     var t = new TopStoriesShowMore(topStories);
                 });
             });

--- a/common/app/assets/javascripts/bootstraps/facia.js
+++ b/common/app/assets/javascripts/bootstraps/facia.js
@@ -40,7 +40,6 @@ define([
         if (!this.initialised) {
             this.initialised = true;
             modules.relativiseMastheadDates();
-            modules.showTopStoriesShowMore();
             modules.showFaciaPopular();
         }
         common.mediator.emit("page:front:ready", config, context);

--- a/common/app/assets/javascripts/bootstraps/facia.js
+++ b/common/app/assets/javascripts/bootstraps/facia.js
@@ -22,7 +22,7 @@ define([
 
         showTopStoriesShowMore: function () {
             common.mediator.on('page:front:ready', function(config, context) {
-                common.$g('.section--top-stories', context).each(function(topStories) {
+                common.$g('.section--small-stories', context).each(function(topStories) {
                     var t = new TopStoriesShowMore(topStories);
                 });
             });
@@ -40,6 +40,7 @@ define([
         if (!this.initialised) {
             this.initialised = true;
             modules.relativiseMastheadDates();
+            modules.showTopStoriesShowMore();
             modules.showFaciaPopular();
         }
         common.mediator.emit("page:front:ready", config, context);

--- a/common/app/assets/javascripts/bootstraps/front.js
+++ b/common/app/assets/javascripts/bootstraps/front.js
@@ -7,10 +7,7 @@ define([
     "modules/trailblocktoggle",
     "modules/trailblock-show-more",
     "modules/footballfixtures",
-    "modules/cricket",
-    "modules/masthead-relative-dates",
-    'modules/top-stories-show-more',
-    'modules/facia-popular'
+    "modules/cricket"
 ], function (
     common,
     bonzo,

--- a/common/app/assets/javascripts/modules/discussion/commentCount.js
+++ b/common/app/assets/javascripts/modules/discussion/commentCount.js
@@ -39,7 +39,7 @@ define([
                     data = tpl.replace("[URL]", url);
 
                 // put in trail__meta, if exists
-                var meta = node.querySelector('.item__meta, .item__meta-new'),
+                var meta = node.querySelector('.item__meta'),
                     $node = meta ? bonzo(meta) : bonzo(node);
 
                 $node.append(data.replace("[COUNT]", c.count));

--- a/common/app/assets/javascripts/modules/discussion/commentCount.js
+++ b/common/app/assets/javascripts/modules/discussion/commentCount.js
@@ -39,7 +39,7 @@ define([
                     data = tpl.replace("[URL]", url);
 
                 // put in trail__meta, if exists
-                var meta = node.querySelector('.item__meta'),
+                var meta = node.querySelector('.item__meta, .item__meta-new'),
                     $node = meta ? bonzo(meta) : bonzo(node);
 
                 $node.append(data.replace("[COUNT]", c.count));

--- a/common/app/assets/javascripts/modules/facia-popular.js
+++ b/common/app/assets/javascripts/modules/facia-popular.js
@@ -1,8 +1,8 @@
 define(['common', 'ajax', 'bonzo'], function (common, ajax, bonzo) {
 
     var sectionTmpl =
-        '<section class="section--popular">' +
-            '<h2 class="section__title">Most Read</h2>' +
+        '<section class="collection collection--popular">' +
+            '<h2 class="collection__title">Most Read</h2>' +
         '</section>',
         itemTmpl = '<li class="item"><a href="" class="item__link"></a></li>';
 
@@ -17,7 +17,7 @@ define(['common', 'ajax', 'bonzo'], function (common, ajax, bonzo) {
                 crossOrigin: true
             }).then(
                 function(resp) {
-                    var $collection = bonzo(bonzo.create('<ul class="unstyled collection"></ul>')),
+                    var $collection = bonzo(bonzo.create('<ul class="unstyled items"></ul>')),
                         $trails = bonzo(bonzo.create(resp.html));
                     // create the items (from first 5 trails)
                     common.$g('#tabs-popular-1 li:nth-child(-n + 5) a', bonzo(bonzo.create(resp.html))).each(function(trail) {
@@ -33,7 +33,7 @@ define(['common', 'ajax', 'bonzo'], function (common, ajax, bonzo) {
                     // add the popular section after the highlights
                     bonzo(bonzo.create(sectionTmpl))
                         .append($collection)
-                        .insertAfter('.section--highlights');
+                        .insertAfter('.collection--highlights');
                 },
                 function(req) {
                     common.mediator.emit('module:error', 'Failed to load facia popular: ' + req.statusText, 'modules/facia-popular.js');

--- a/common/app/assets/javascripts/modules/top-stories-show-more.js
+++ b/common/app/assets/javascripts/modules/top-stories-show-more.js
@@ -21,18 +21,19 @@ define(['common', 'bonzo', 'bean', 'qwery', 'modules/detect'], function (common,
             },
             _getRowSize = function () {
                 switch (detect.getBreakpoint()) {
-                    case 'mobile':
-                        return 1;
-                    case 'tablet':
+                    case 'wide':
+                        return 4;
                     case 'desktop':
                         return 3;
+                    case 'tablet':
+                        return 2;
                     default:
                         return 4;
                 }
             };
 
         // hide stories
-        common.$g('.item:nth-child(n + ' + ((_getRowSize() * 2) + 1) + ')', topStories).each(function(item) {
+        common.$g('.item:nth-child(n + ' + (_getRowSize() + 1) + ')', topStories).each(function(item) {
             bonzo(item).addClass('u-h');
         });
         // add toggle button

--- a/common/app/assets/javascripts/modules/top-stories-show-more.js
+++ b/common/app/assets/javascripts/modules/top-stories-show-more.js
@@ -2,13 +2,13 @@ define(['common', 'bonzo', 'bean', 'qwery', 'modules/detect'], function (common,
 
     var TopStoriesShowMore = function(topStories) {
 
-        var _button = bonzo.create('<button class="collection__show-more">Show more news</button>')[0],
+        var _button = bonzo.create('<button class="items__show-more">Show more news</button>')[0],
             _renderToggle = function(section) {
                 bonzo(section).append(_button);
                 bean.on(_button, 'click', function(e) {
                     // show x more, depending on current breakpoint
                     var rowSize = _getRowSize(),
-                        moreHidden = qwery('.item.h', topStories).some(function(item, index) {
+                        moreHidden = qwery('.item.u-h', topStories).some(function(item, index) {
                             if (index === rowSize) {
                                 return true;
                             }

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -44,7 +44,7 @@ $a-rightCol-trigger: gs-span(11) + $gutter*2;
 
 $mq-breakpoints: (
     (mobile  gs-span(4) + $gutter*2)  // 332px
-    (tablet  gs-span(9) + $gutter*2)  // 732px
+    (tablet  gs-span(8) + $gutter*2)  // 652px
     (desktop gs-span(12) + $gutter*2) // 972px
     (wide    gs-span(16) + $gutter*2) // 1292px
 

--- a/common/app/assets/stylesheets/module/_facia.scss
+++ b/common/app/assets/stylesheets/module/_facia.scss
@@ -1,3 +1,7 @@
+.facia-container {
+    overflow: hidden;
+}
+
 @import "facia/_items";
 @import "facia/_masthead";
 @import "facia/_top-stories";

--- a/common/app/assets/stylesheets/module/_facia.scss
+++ b/common/app/assets/stylesheets/module/_facia.scss
@@ -8,7 +8,7 @@
     @include mq(wide) {
         width: gs-span(16);
     }
-    section {
+    .collection {
         margin-top: $gs-baseline;
     }
 }

--- a/common/app/assets/stylesheets/module/_facia.scss
+++ b/common/app/assets/stylesheets/module/_facia.scss
@@ -1,5 +1,14 @@
 .facia-container {
     overflow: hidden;
+    @include mq(tablet) {
+        width: gs-span(8);
+    }
+    @include mq(desktop) {
+        width: gs-span(12);
+    }
+    @include mq(wide) {
+        width: gs-span(16);
+    }
 }
 
 @import "facia/_items";

--- a/common/app/assets/stylesheets/module/_facia.scss
+++ b/common/app/assets/stylesheets/module/_facia.scss
@@ -16,5 +16,6 @@
 @import "facia/_items";
 @import "facia/_masthead";
 @import "facia/_top-stories";
+@import "facia/_small-stories";
 @import "facia/_highlights";
 @import "facia/_popular";

--- a/common/app/assets/stylesheets/module/_facia.scss
+++ b/common/app/assets/stylesheets/module/_facia.scss
@@ -3,6 +3,17 @@
 }
 
 @import "facia/_items";
+
+.section__title {
+    @include font($serifheadline, 800, 16);
+    @include box-sizing(border-box);
+    height: gs-height(1);
+    padding: $gs-baseline/3 0 0 $gs-gutter/5;
+    color: #ffffff;
+    background-color: $blue;
+    border-top: $gs-baseline/3 solid $light-blue;
+}
+
 @import "facia/_masthead";
 @import "facia/_top-stories";
 @import "facia/_highlights";

--- a/common/app/assets/stylesheets/module/_facia.scss
+++ b/common/app/assets/stylesheets/module/_facia.scss
@@ -16,6 +16,7 @@
 @import "facia/_items";
 @import "facia/_masthead";
 @import "facia/_top-stories";
+@import "facia/_medium-stories";
 @import "facia/_small-stories";
 @import "facia/_highlights";
 @import "facia/_popular";

--- a/common/app/assets/stylesheets/module/_facia.scss
+++ b/common/app/assets/stylesheets/module/_facia.scss
@@ -1,5 +1,4 @@
 .facia-container {
-    overflow: hidden;
     @include mq(tablet) {
         width: gs-span(8);
     }
@@ -9,20 +8,12 @@
     @include mq(wide) {
         width: gs-span(16);
     }
+    section {
+        margin-top: $gs-baseline;
+    }
 }
 
 @import "facia/_items";
-
-.section__title {
-    @include font($serifheadline, 800, 16);
-    @include box-sizing(border-box);
-    height: gs-height(1);
-    padding: $gs-baseline/3 0 0 $gs-gutter/5;
-    color: #ffffff;
-    background-color: $blue;
-    border-top: $gs-baseline/3 solid $light-blue;
-}
-
 @import "facia/_masthead";
 @import "facia/_top-stories";
 @import "facia/_highlights";

--- a/common/app/assets/stylesheets/module/facia/_highlights.scss
+++ b/common/app/assets/stylesheets/module/facia/_highlights.scss
@@ -1,5 +1,4 @@
 .section--highlights {
-    margin-top: $gs-baseline;
     @include mq(tablet) {
         vertical-align: top;
         display: inline-block;
@@ -26,11 +25,6 @@
     .item {
         float: none;
         margin-right: 0;
-        @include mq($to: tablet) {
-            margin-top: ($baseline*2) - 1;
-            padding-top: $baseline*2;
-            border-top: 1px solid $grey;
-        }
         @include mq(tablet) {
             @include box-sizing(content-box);
             height: auto;
@@ -38,9 +32,8 @@
             display: inline-block;
             vertical-align: top;
             border-right: 1px dotted $grey;
-            padding: 0 $gs-gutter/2 gs-height(5) $gs-gutter/2 - 1;
+            padding: 0 $gs-gutter/2 gs-height(4) $gs-gutter/2 - 1;
             width: gs-span(4);
-            min-height: gs-height(3) + $gs-baseline;
             &:first-child {
                 padding-left: 0;
             }
@@ -48,9 +41,24 @@
                 padding-right: 0;
                 border-right-style: none;
             }
+            .item__title {
+                min-height: gs-height(4) + $gs-baseline;
+                padding-bottom: gs-height(1);
+            }
+        }
+    }
+    .item--feature-new {
+        @include mq(tablet) {
+            background-color: #ffffff;
+        }
+        .item__title {
+             background-color: #ededed;
         }
     }
     @include mq($to: tablet) {
+        .item:first-child {
+            margin-top: $gs-baseline;
+        }
         .item__image {
             display: none;
         }
@@ -58,10 +66,6 @@
     .item__title {
         @include font-size(26, 28);
         font-weight: normal;
-        @include mq(tablet) {
-            border-top: 2px solid $blue;
-            padding-top: $gs-baseline/3;
-        }
     }
     .item__image-container {
         position: absolute;
@@ -72,28 +76,10 @@
     .item__image {
         height: 100%;
     }
-    .item__meta {
-        position: absolute;
-        bottom: gs-height(4) + $gs-baseline;
-        height: gs-height(1) - $gs-baseline;
-    }
-    .item__timestamp {
-        height: 100%;
-        min-width: gs-span(1) - 16;
-        padding: 0 $gs-gutter/2 0 16px;
-        margin-right: 0;
-        border-left-style: none;
-        padding-bottom: 0;
-        i {
-            left: 0;
-        }
-    }
-    .trail__count {
-        height: 100%;
-        padding-bottom: 0;
-        padding-left: 28px;
-        i {
-            left: $gs-gutter/2 - 1;
+    .item__meta-new {
+        @include mq(tablet) {
+            position: absolute;
+            bottom: gs-height(4) + $gs-baseline;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_highlights.scss
+++ b/common/app/assets/stylesheets/module/facia/_highlights.scss
@@ -1,4 +1,4 @@
-.section--highlights {
+.collection--highlights {
     @include mq(tablet) {
         vertical-align: top;
         display: inline-block;
@@ -10,7 +10,7 @@
     @include mq(wide) {
         width: gs-span(12);
     }
-    .collection {
+    .items {
         @include mq(tablet) {
             font-size: 0;
             white-space: nowrap;

--- a/common/app/assets/stylesheets/module/facia/_highlights.scss
+++ b/common/app/assets/stylesheets/module/facia/_highlights.scss
@@ -1,11 +1,9 @@
 .section--highlights {
-    margin-top: $baseline * 4;
-    padding-bottom: ($baseline * 3) - 1;
+    margin-top: $gs-baseline;
     @include mq(tablet) {
-        border-bottom: solid 1px $grey;
         float: left;
         width: gs-span(6);
-        margin-bottom: $baseline * 4;
+        margin-bottom: $gs-baseline;
     }
     @include mq(desktop) {
         width: gs-span(8);
@@ -14,41 +12,44 @@
         width: gs-span(12);
     }
     .section__title {
-        @include font($serifheadline, 800, 16, 16);
+        @include font($serifheadline, 800, 16);
         @include box-sizing(border-box);
-        height: $baseline * 12;
-        color: $blue;
-        border-top: 2px solid $blue;
+        height: gs-height(1);
+        padding: $gs-baseline/3 0 0 $gs-baseline/3;
+        color: #ffffff;
+        background-color: $blue;
+        border-top: $baseline solid $light-blue;
     }
     .collection {
         @include mq(tablet) {
+            margin-top: $gs-baseline;
             font-size: 0;
             white-space: nowrap;
-            overflow: auto;
-            height: gs-height(6);
+            height: gs-height(8);
+        }
+        @include mq(tablet, wide) {
+            overflow-x: scroll;
+            overflow-y: hidden;
         }
     }
     .item {
         float: none;
-        margin: ($baseline * 2) - 1 0 0;
-        padding: $baseline * 2 0 gs-height(1);
-        border-top: 1px solid $grey;
-        &:first-child {
-            margin-top: 0;
-            padding-top: 0;
-            border-top-style: none;
+        margin-right: 0;
+        @include mq($to: tablet) {
+            margin-top: ($baseline*2) - 1;
+            padding-top: $baseline*2;
+            border-top: 1px solid $grey;
         }
         @include mq(tablet) {
             @include box-sizing(content-box);
+            height: auto;
             white-space: normal;
             display: inline-block;
             vertical-align: top;
-            height: 100%;
-            border-top-style: none;
             border-right: 1px dotted $grey;
-            margin-top: 0;
-            padding: 0 $gs-gutter / 2 0 ($gs-gutter / 2) - 1;
-            width: gs-span(3);
+            padding-left: $gs-gutter/2 - 1;
+            padding-right: $gs-gutter/2;
+            width: gs-span(4);
             &:first-child {
                 padding-left: 0;
             }
@@ -59,29 +60,43 @@
         }
     }
     .item__image {
-        margin-bottom: $baseline * 2;
         display: none;
         @include mq(tablet) {
             display: block;
         }
     }
     .item__title {
-        @include font-size(22, 24);
-    }
-    .item__standfirst {
-        margin-top: $baseline;
-        @include font-size(16, 20);
-        color: #666666;
-    }
-    .item:first-child .item__standfirst {
-        display: block;
+        @include font-size(26, 28);
+        font-weight: normal;
         @include mq(tablet) {
-            display: none;
+            border-top: 2px solid $blue;
+            padding-top: $gs-baseline/3;
+            min-height: gs-height(3) + $gs-baseline;
+            margin-bottom: gs-height(1) + $gs-baseline;
         }
     }
-    @include mq(tablet) {
-        .item--without-image .item__standfirst {
-            display: block;
+    .item__meta {
+        position: absolute;
+        bottom: gs-height(4) + $gs-baseline;
+        height: gs-height(1) - $gs-baseline;
+    }
+    .item__timestamp {
+        height: 100%;
+        min-width: gs-span(1) - 16;
+        padding: 0 $gs-gutter/2 0 16px;
+        margin-right: 0;
+        border-left-style: none;
+        padding-bottom: 0;
+        i {
+            left: 0;
+        }
+    }
+    .trail__count {
+        height: 100%;
+        padding-bottom: 0;
+        padding-left: 24px;
+        i {
+            right: $gs-gutter/2;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_highlights.scss
+++ b/common/app/assets/stylesheets/module/facia/_highlights.scss
@@ -12,7 +12,6 @@
     }
     .collection {
         @include mq(tablet) {
-            margin-top: $gs-baseline;
             font-size: 0;
             white-space: nowrap;
             height: gs-height(8);
@@ -56,9 +55,6 @@
         }
     }
     @include mq($to: tablet) {
-        .item:first-child {
-            margin-top: $gs-baseline;
-        }
         .item__image {
             display: none;
         }

--- a/common/app/assets/stylesheets/module/facia/_highlights.scss
+++ b/common/app/assets/stylesheets/module/facia/_highlights.scss
@@ -11,15 +11,6 @@
     @include mq(wide) {
         width: gs-span(12);
     }
-    .section__title {
-        @include font($serifheadline, 800, 16);
-        @include box-sizing(border-box);
-        height: gs-height(1);
-        padding: $gs-baseline/3 0 0 $gs-baseline/3;
-        color: #ffffff;
-        background-color: $blue;
-        border-top: $baseline solid $light-blue;
-    }
     .collection {
         @include mq(tablet) {
             margin-top: $gs-baseline;
@@ -47,9 +38,9 @@
             display: inline-block;
             vertical-align: top;
             border-right: 1px dotted $grey;
-            padding-left: $gs-gutter/2 - 1;
-            padding-right: $gs-gutter/2;
+            padding: 0 $gs-gutter/2 gs-height(5) $gs-gutter/2 - 1;
             width: gs-span(4);
+            min-height: gs-height(3) + $gs-baseline;
             &:first-child {
                 padding-left: 0;
             }
@@ -59,10 +50,9 @@
             }
         }
     }
-    .item__image {
-        display: none;
-        @include mq(tablet) {
-            display: block;
+    @include mq($to: tablet) {
+        .item__image {
+            display: none;
         }
     }
     .item__title {
@@ -71,9 +61,16 @@
         @include mq(tablet) {
             border-top: 2px solid $blue;
             padding-top: $gs-baseline/3;
-            min-height: gs-height(3) + $gs-baseline;
-            margin-bottom: gs-height(1) + $gs-baseline;
         }
+    }
+    .item__image-container {
+        position: absolute;
+        bottom: 0;
+        height: gs-height(4);
+        width: gs-span(4);
+    }
+    .item__image {
+        height: 100%;
     }
     .item__meta {
         position: absolute;
@@ -94,9 +91,9 @@
     .trail__count {
         height: 100%;
         padding-bottom: 0;
-        padding-left: 24px;
+        padding-left: 28px;
         i {
-            right: $gs-gutter/2;
+            left: $gs-gutter/2 - 1;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_highlights.scss
+++ b/common/app/assets/stylesheets/module/facia/_highlights.scss
@@ -22,17 +22,15 @@
         }
     }
     .item {
-        float: none;
-        margin-right: 0;
         @include mq(tablet) {
             @include box-sizing(content-box);
-            height: auto;
             white-space: normal;
             display: inline-block;
             vertical-align: top;
             border-right: 1px dotted $grey;
             padding: 0 $gs-gutter/2 gs-height(4) $gs-gutter/2 - 1;
             width: gs-span(4);
+            background-color: #ffffff;
             &:first-child {
                 padding-left: 0;
             }
@@ -44,14 +42,9 @@
                 min-height: gs-height(4) + $gs-baseline;
                 padding-bottom: gs-height(1);
             }
-        }
-    }
-    .item--feature-new {
-        @include mq(tablet) {
-            background-color: #ffffff;
-        }
-        .item__title {
-             background-color: #ededed;
+            &.item--feature .item__title {
+                background-color: #ededed;
+            }
         }
     }
     @include mq($to: tablet) {
@@ -61,7 +54,6 @@
     }
     .item__title {
         @include font-size(26, 28);
-        font-weight: normal;
     }
     .item__image-container {
         position: absolute;
@@ -72,7 +64,7 @@
     .item__image {
         height: 100%;
     }
-    .item__meta-new {
+    .item__meta {
         @include mq(tablet) {
             position: absolute;
             bottom: gs-height(4) + $gs-baseline;

--- a/common/app/assets/stylesheets/module/facia/_highlights.scss
+++ b/common/app/assets/stylesheets/module/facia/_highlights.scss
@@ -1,9 +1,9 @@
 .section--highlights {
     margin-top: $gs-baseline;
     @include mq(tablet) {
-        float: left;
-        width: gs-span(6);
-        margin-bottom: $gs-baseline;
+        vertical-align: top;
+        display: inline-block;
+        width: gs-span(4);
     }
     @include mq(desktop) {
         width: gs-span(8);

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -369,3 +369,74 @@ a.item__link,
         }
     }
 }
+
+
+/**** NEW DESIGNS *****/
+
+.item__meta-new {
+    position: relative;
+    height: gs-height(1) - $gs-baseline;
+    border-color: $grey;
+    color: $grey;
+    @include font($sans-serif, lighter, 12, 12);
+    margin-top: $gs-baseline;
+    .item__timestamp,
+    .item .trail__count {
+        float: left;
+        i {
+            margin:0;
+            position: absolute;
+            top: 0;
+        }
+    }
+    .item__timestamp {
+        height: 100%;
+        min-width: gs-span(1) - 16;
+        padding: 0 $gs-gutter/2 0 16px;
+        margin-right: 0;
+        border-left-style: none;
+        padding-bottom: 0;
+        i {
+            left: 0;
+        }
+    }
+    .trail__count {
+        height: 100%;
+        padding-bottom: 0;
+        padding-left: 28px;
+        border-left: 1px solid;
+        /* inherit doesn't work in above shorthand, for some reason */
+        border-color: inherit;
+        i {
+            left: $gs-gutter/2 - 1;
+        }
+    }
+}
+.item--news-new {
+    .item__title {
+        border-top: 2px solid $blue;
+        padding-top: $gs-baseline/2;
+        padding-right: $gs-gutter/2;
+    }
+}
+.item--feature-new {
+    background-color: #ededed;
+    .item__title {
+        border-top: 2px solid $pink;
+        padding: $gs-baseline/2 $gs-gutter/2 0;
+    }
+    .item__standfirst,
+    .item__meta-new {
+        margin-left: $gs-gutter/2;
+    }
+}
+.section__title {
+    @include font($serifheadline, 800, 16);
+    @include box-sizing(border-box);
+    height: gs-height(1);
+    padding: $gs-baseline/3 0 0 $gs-gutter/5;
+    color: #ffffff;
+    background-color: $blue;
+    border-top: $gs-baseline/3 solid $light-blue;
+    margin-bottom: $gs-baseline;
+}

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -416,7 +416,6 @@ a.item__link,
     .item__title {
         border-top: 2px solid $blue;
         padding-top: $gs-baseline/2;
-        padding-right: $gs-gutter/2;
     }
 }
 .item--feature-new {
@@ -429,6 +428,9 @@ a.item__link,
     .item__meta-new {
         margin-left: $gs-gutter/2;
     }
+    .item__standfirst {
+        margin-right: $gs-gutter/2;
+    }
 }
 .section__title {
     @include font($serifheadline, 800, 16);
@@ -439,4 +441,15 @@ a.item__link,
     background-color: $blue;
     border-top: $gs-baseline/3 solid $light-blue;
     margin-bottom: $gs-baseline;
+}
+.collection__show-more {
+    background-color: #9b9b9b;
+    border-style: none;
+    min-width: gs-span(2);
+    min-height: gs-height(1);
+    color: #ffffff;
+    @include font($serifheadline, 800, 14);
+    position: relative;
+    left: 50%;
+    margin-left: -(gs-span(1) + $gs-gutter/2);
 }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -6,7 +6,7 @@ $grey: #cccccc;
 $green: #6ca940;
 $dark-green: #19646c;
 
-.section__title {
+.collection__title {
     @include font($serifheadline, 800, 16);
     @include box-sizing(border-box);
     height: gs-height(1);

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -6,79 +6,68 @@ $grey: #cccccc;
 $green: #6ca940;
 $dark-green: #19646c;
 
+.section__title {
+    @include font($serifheadline, 800, 16);
+    @include box-sizing(border-box);
+    height: gs-height(1);
+    padding: $gs-baseline/3 0 0 $gs-gutter/5;
+    color: #ffffff;
+    background-color: $blue;
+    border-top: $gs-baseline/3 solid $light-blue;
+    margin-bottom: $gs-baseline;
+}
 .item {
-    float: left;
-    height: 100%;
     position: relative;
-    overflow: hidden;
-    margin-right: $gs-gutter;
     color: #000000;
     font-family: $serifheadline;
+    font-weight: normal;
     @include box-sizing(border-box);
-}
-.item:last-child {
-    margin-right: 0;
-}
-.item__image {
-    width: 100%;
-    display: block;
 }
 a.item__link,
-.item__title{
+.item__title {
     color: inherit;
     font-family: inherit;
+    font-weight: normal;
 }
 .item__title {
-    font-weight: 700;
-    @include font-size(24, 28);
     @include box-sizing(border-box);
 }
-.item__standfirst {
-    display: none;
-    margin: $baseline*5 0 0;
-}
 .item__meta {
+    height: gs-height(1) - $gs-baseline;
     color: $grey;
-    position: absolute;
-    bottom: 0;
-    border-color: $grey;
     @include font($sans-serif, lighter, 12, 12);
-}
-.item__timestamp,
-.item .trail__count {
-    padding-bottom: $baseline * 5;
-    float: left;
-    border-left: 1px solid;
-    /* inherit doesn't work in above shorthand, for some reason */
-    border-color: inherit;
-    i {
-        margin:0;
-        position: absolute;
+    margin-top: $gs-baseline;
+    .item__timestamp,
+    .trail__count {
+        position: relative;
+        height: 100%;
+        float: left;
+        i {
+            margin:0;
+            position: absolute;
+            top: 0;
+        }
+    }
+    .item__timestamp {
+        min-width: gs-span(1) - 16;
+        padding: 0 $gs-gutter/2 0 16px;
+        i {
+            @extend .i-clock-grey;
+            left: 0;
+        }
+    }
+    .trail__count {
+        padding-bottom: 0;
+        padding-left: 28px;
+        border-left: 1px solid $grey;
         top: 0;
-        left: 4px;
-    }
-}
-.item__timestamp {
-    min-width: 58px;
-    margin-right: $gutter/4;
-    padding-left: 21px;
-    i {
-        @extend .i-clock-blue;
-    }
-}
-.item .trail__count {
-    position: relative;
-    top: auto;
-    padding-left: 23px;
-    a {
-        color: inherit;
-        line-height: inherit;
-        float: none;
-        display: inline;
-        margin: 0;
-    }
-    i {
-        @extend .i-comment-blue;
+        a {
+            color: inherit;
+        }
+        i {
+            @extend .i-comment-grey;
+            left: $gs-gutter/2 - 1;
+        }
     }
 }
 .item__duration {
@@ -94,353 +83,30 @@ a.item__link,
         margin-right: $baseline;
     }
 }
-.item__meta--grey {
-    .item__timestamp i {
-        @extend .i-clock-grey;
-    }
-    .trail__count i {
-        @extend .i-comment-grey;
-    }
+.item__title {
+    border-top: 2px solid $blue;
+    padding-top: $gs-baseline/2;
 }
 .item--feature {
-    border: none;
-    background-color: $pink !important;
-    color: #ffffff;
-    border-bottom-style: none !important;
-    border-top-color: $light-pink !important;
-    .item__title {
-        font-weight: normal;
-        padding: 0 $baseline*2;
-    }
-    .item__meta {
-        color: #ffffff;
-        border-color: $light-pink !important;
-    }
-    .item__timestamp {
-        border-left-style: none;
-        i {
-            @extend .i-clock-pink;
-        }
-    }
-    .trail__count i {
-        @extend .i-comment-pink;
-    }
-    .item__duration {
-        background-color: $light-pink;
-    }
-}
-.item--comment {
-    color: #000000 !important;
-    background: none !important;
-    border-top-color: $green !important;
-    border-bottom: 1px solid $grey;
-    .i-quotes-green {
-        margin-top: $baseline * 2;
-    }
-    .item__image-container {
-        display: none;
-    }
-    .item__title {
-        position: relative !important;
-        background: none !important;
-        width: auto !important;
-        padding: 0 !important;
-        margin: $baseline * 2 0 0 !important;
-    }
-    .item__byline {
-        color: $dark-green;
-        font-family: $serifheadline;
-        font-weight: bold;
-    }
-    .item__meta {
-        color: $grey  !important;
-        border-color: $grey  !important;
-    }
-    .item__timestamp {
-        border-left-style: solid  !important;
-        i {
-            @extend .i-clock-green;
-        }
-    }
-    .trail__count i {
-        @extend .i-comment-green;
-    }
-}
-
-@mixin item--with-overlay {
-    width: gs-span(6);
-    color: #ffffff;
-    .item__title {
-        position:absolute;
-        bottom: 0;
-        background-color: $blue;
-        background-color: rgba($blue, 0.7);
-        padding: $baseline*2 $gutter/2 $baseline*13;
-    }
-    .item__meta {
-        color: #ffffff;
-        border-color: $light-blue;
-        .item__timestamp {
-            border-left-style: none;
-        }
-    }
-    &.item--feature .item__title {
-        background-color: $pink;
-        background-color: rgba($pink, 0.7);
-    }
-}
-%item--with-overlay {
-    @include mq(tablet, desktop) {
-        @include item--with-overlay;
-    }
-    @include mq(desktop, wide) {
-        @include item--with-overlay;
-    }
-    @include mq(wide) {
-        @include item--with-overlay;
-    }
-}
-@mixin customise-item--with-overlay($width, $font-size) {
-    width: $width;
-    .item__title {
-        width: $width - $gs-column-width - $gs-gutter;
-        @include font-size($font-size, $font-size+4);
-    }
-}
-
-@mixin item--small {
-    height: 50%;
-    float: none;
-    padding-top: $baseline*2;
-    border-top: 2px solid $blue;
-    margin-right: 0;
-    .item__image-container,
-    .item__meta,
-    .item__duration {
-        display: none;
-    }
-    .item__title {
-        @include font-size(20, 24);
-    }
-}
-%item--small {
-    @include mq(tablet, desktop) {
-        @include item--small;
-    }
-    @include mq(desktop, wide) {
-        @include item--small;
-    }
-    @include mq(wide) {
-        @include item--small;
-    }
-}
-@mixin customise-item--small($num: false, $show-meta: false, $font-size: false) {
-    @if $num != false {
-        height: 100% / $num;
-    }
-    @if $show-meta == true {
-        &:last-child {
-            border-bottom: 1px solid $grey
-        }
-        .item__meta {
-            display: block;
-        }
-    }
-    @if $font-size != false {
-        .item__title {
-            @include font-size($font-size, $font-size + 4);
-        }
-    }
-}
-
-@mixin item--medium {
-    width: gs-span(4);
-    border-bottom: 1px solid $grey;
-    .item__image {
-        margin-bottom: $baseline*3;
-    }
-}
-%item--medium {
-    @include mq(desktop, wide) {
-        @include item--medium;
-    }
-    @include mq(wide) {
-        @include item--medium;
-    }
-}
-@mixin customise-item--medium($width, $font-size: false) {
-    width: $width;
-    @if $font-size != false {
-        .item__title {
-            @include font-size($font-size, $font-size + 4);
-        }
-    }
-}
-
-@mixin item--large {
-    background-color: $blue;
-    color: #ffffff;
-    .item__image {
-        float: left;
-        margin-right: $gs-gutter;
-    }
-    .item__title,
-    .item__standfirst {
-        margin-left: $gutter/2;
-        margin-right: $gutter/2;
-    }
-    .item__title {
-        padding-top: $baseline*2;
-    }
-    .item__meta {
-        color: #ffffff;
-        border-color: $light-blue;
-        .item__timestamp {
-            border-left-style: solid;
-        }
-    }
-}
-%item--large {
-    @include mq(tablet, desktop) {
-        @include item--large;
-    }
-    @include mq(desktop, wide) {
-        @include item--large;
-    }
-    @include mq(wide) {
-        @include item--large;
-    }
-}
-@mixin customise-item--large($width, $img-width, $show-standfirst: false, $font-size: false) {
-    width: $width;
-    .item__image {
-        width: $img-width;
-    }
-    .item__meta {
-        left: $img-width + $gs-gutter;
-    }
-    @if $show-standfirst == true {
-        .item__standfirst {
-            display: block;
-            @if $font-size != false {
-                @include font-size($font-size - 8, $font-size - 4);
-            }
-        }
-    }
-    @if $font-size != false {
-        .item__title {
-            @include font-size($font-size, $font-size + 4);
-        }
-    }
-}
-
-@mixin collection--stacked {
-    .item {
-        width: 100%;
-        float: none;
-        margin-right: 0;
-    }
-    .item:nth-child(1) {
-        background-color: $blue;
-        padding-bottom: $baseline*10;
-        color: #ffffff;
-        .item__title {
-            margin: $baseline*2 $baseline*2 0;
-        }
-        .item__meta {
-            color: #ffffff;
-            border-color: $light-blue;
-            .item__timestamp {
-                border-left-style: none;
-            }
-        }
-    }
-    .item:nth-child(n+2) {
-        border-top: 2px solid $blue;
-        .item__title {
-            margin-top: $baseline*2;
-            margin-bottom: $baseline*4;
-            @include font-size(20, 24);
-        }
-        .item__image-container,
-        .item__meta,
-        .item__duration {
-            display: none;
-        }
-    }
-}
-
-
-/**** NEW DESIGNS *****/
-
-.item__meta-new {
-    position: relative;
-    height: gs-height(1) - $gs-baseline;
-    border-color: $grey;
-    color: $grey;
-    @include font($sans-serif, lighter, 12, 12);
-    margin-top: $gs-baseline;
-    .item__timestamp,
-    .item .trail__count {
-        float: left;
-        i {
-            margin:0;
-            position: absolute;
-            top: 0;
-        }
-    }
-    .item__timestamp {
-        height: 100%;
-        min-width: gs-span(1) - 16;
-        padding: 0 $gs-gutter/2 0 16px;
-        margin-right: 0;
-        border-left-style: none;
-        padding-bottom: 0;
-        i {
-            left: 0;
-        }
-    }
-    .trail__count {
-        height: 100%;
-        padding-bottom: 0;
-        padding-left: 28px;
-        border-left: 1px solid;
-        /* inherit doesn't work in above shorthand, for some reason */
-        border-color: inherit;
-        i {
-            left: $gs-gutter/2 - 1;
-        }
-    }
-}
-.item--news-new {
-    .item__title {
-        border-top: 2px solid $blue;
-        padding-top: $gs-baseline/2;
-    }
-}
-.item--feature-new {
     background-color: #ededed;
     .item__title {
-        border-top: 2px solid $pink;
-        padding: $gs-baseline/2 $gs-gutter/2 0;
+        border-top-color: $pink;
+        padding-left: $gs-gutter/2;
+        padding-right: $gs-gutter/2;
     }
     .item__standfirst,
-    .item__meta-new {
+    .item__meta {
         margin-left: $gs-gutter/2;
     }
     .item__standfirst {
         margin-right: $gs-gutter/2;
     }
 }
-.section__title {
-    @include font($serifheadline, 800, 16);
-    @include box-sizing(border-box);
-    height: gs-height(1);
-    padding: $gs-baseline/3 0 0 $gs-gutter/5;
-    color: #ffffff;
-    background-color: $blue;
-    border-top: $gs-baseline/3 solid $light-blue;
-    margin-bottom: $gs-baseline;
+
+.item--comment {
+    .item__title {
+        border-top-color: $green;
+    }
 }
 .collection__show-more {
     background-color: #9b9b9b;

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -108,14 +108,3 @@ a.item__link,
         border-top-color: $green;
     }
 }
-.collection__show-more {
-    background-color: #9b9b9b;
-    border-style: none;
-    min-width: gs-span(2);
-    min-height: gs-height(1);
-    color: #ffffff;
-    @include font($serifheadline, 800, 14);
-    position: relative;
-    left: 50%;
-    margin-left: -(gs-span(1) + $gs-gutter/2);
-}

--- a/common/app/assets/stylesheets/module/facia/_masthead.scss
+++ b/common/app/assets/stylesheets/module/facia/_masthead.scss
@@ -1,6 +1,15 @@
 .section--masthead {
     clear: left;
     margin-top: $baseline * 4;
+    @include mq(tablet) {
+        min-width: gs-span(9);
+    }
+    @include mq(desktop) {
+        min-width: gs-span(12);
+    }
+    @include mq(wide) {
+        width: gs-span(16);
+    }
     .section__title {
         background-color: #3b65ad;
         border-bottom: 4px solid #64abe1;
@@ -11,15 +20,13 @@
     }
     .collection {
         margin-top: $baseline * 4;
-        max-width: gs-span(16);
-        @include mq(tablet, wide) {
+        @include mq(tablet) {
             height: gs-height(6);
         }
         @include mq(wide) {
             height: gs-height(8);
         }
     }
-
     @include mq($to: tablet) {
         @include collection--stacked;
     }

--- a/common/app/assets/stylesheets/module/facia/_masthead.scss
+++ b/common/app/assets/stylesheets/module/facia/_masthead.scss
@@ -202,7 +202,7 @@
     }
 }
 
-.section--masthead {
+.collection--masthead {
     .item {
         float: left;
         height: 100%;
@@ -235,7 +235,7 @@
         border-top-color: $pink !important;
     }
 
-    .collection {
+    .items {
         @include mq(tablet) {
             height: gs-height(6);
         }

--- a/common/app/assets/stylesheets/module/facia/_masthead.scss
+++ b/common/app/assets/stylesheets/module/facia/_masthead.scss
@@ -3,7 +3,7 @@
     width: gs-span(6);
     color: #ffffff;
     .item__title {
-        position:absolute;
+        position: absolute;
         bottom: 0;
         background-color: $blue;
         background-color: rgba($blue, 0.7);
@@ -67,10 +67,10 @@
     }
 }
 @mixin customise-item--small($num: false, $show-meta: false, $font-size: false) {
-    @if $num != false {
+    @if $num {
         height: 100% / $num;
     }
-    @if $show-meta == true {
+    @if $show-meta {
         &:last-child {
             border-bottom: 1px solid $grey
         }
@@ -78,7 +78,7 @@
             display: block;
         }
     }
-    @if $font-size != false {
+    @if $font-size {
         .item__title {
             @include font-size($font-size, $font-size + 4);
         }
@@ -154,12 +154,12 @@
     @if $show-standfirst == true {
         .item__standfirst {
             display: block;
-            @if $font-size != false {
+            @if $font-size {
                 @include font-size($font-size - 8, $font-size - 4);
             }
         }
     }
-    @if $font-size != false {
+    @if $font-size {
         .item__title {
             @include font-size($font-size, $font-size + 4);
         }

--- a/common/app/assets/stylesheets/module/facia/_masthead.scss
+++ b/common/app/assets/stylesheets/module/facia/_masthead.scss
@@ -1,25 +1,241 @@
-.section--masthead {
-    clear: left;
-    margin-top: $baseline * 4;
-    @include mq(tablet) {
-        min-width: gs-span(9);
+
+@mixin item--with-overlay {
+    width: gs-span(6);
+    color: #ffffff;
+    .item__title {
+        position:absolute;
+        bottom: 0;
+        background-color: $blue;
+        background-color: rgba($blue, 0.7);
+        padding: $baseline*2 $gutter/2 $baseline*13;
     }
-    @include mq(desktop) {
-        min-width: gs-span(12);
+    .item__meta {
+        color: #ffffff;
+        border-color: $light-blue;
+        .item__timestamp {
+            border-left-style: none;
+        }
+    }
+    &.item--feature .item__title {
+        background-color: $pink;
+        background-color: rgba($pink, 0.7);
+    }
+}
+%item--with-overlay {
+    @include mq(tablet, desktop) {
+        @include item--with-overlay;
+    }
+    @include mq(desktop, wide) {
+        @include item--with-overlay;
     }
     @include mq(wide) {
-        width: gs-span(16);
+        @include item--with-overlay;
     }
-    .section__title {
-        background-color: #3b65ad;
-        border-bottom: 4px solid #64abe1;
+}
+@mixin customise-item--with-overlay($width, $font-size) {
+    width: $width;
+    .item__title {
+        width: $width - $gs-column-width - $gs-gutter;
+        @include font-size($font-size, $font-size+4);
+    }
+}
+
+@mixin item--small {
+    height: 50%;
+    float: none;
+    padding-top: $baseline*2;
+    border-top: 2px solid $blue;
+    margin-right: 0;
+    .item__image-container,
+    .item__meta,
+    .item__duration {
+        display: none;
+    }
+    .item__title {
+        @include font-size(20, 24);
+    }
+}
+%item--small {
+    @include mq(tablet, desktop) {
+        @include item--small;
+    }
+    @include mq(desktop, wide) {
+        @include item--small;
+    }
+    @include mq(wide) {
+        @include item--small;
+    }
+}
+@mixin customise-item--small($num: false, $show-meta: false, $font-size: false) {
+    @if $num != false {
+        height: 100% / $num;
+    }
+    @if $show-meta == true {
+        &:last-child {
+            border-bottom: 1px solid $grey
+        }
+        .item__meta {
+            display: block;
+        }
+    }
+    @if $font-size != false {
+        .item__title {
+            @include font-size($font-size, $font-size + 4);
+        }
+    }
+}
+
+@mixin item--medium {
+    width: gs-span(4);
+    border-bottom: 1px solid $grey;
+    .item__image {
+        margin-bottom: $baseline*3;
+    }
+}
+%item--medium {
+    @include mq(desktop, wide) {
+        @include item--medium;
+    }
+    @include mq(wide) {
+        @include item--medium;
+    }
+}
+@mixin customise-item--medium($width, $font-size: false) {
+    width: $width;
+    @if $font-size != false {
+        .item__title {
+            @include font-size($font-size, $font-size + 4);
+        }
+    }
+}
+
+@mixin item--large {
+    background-color: $blue;
+    color: #ffffff;
+    .item__image {
+        float: left;
+        margin-right: $gs-gutter;
+    }
+    .item__title,
+    .item__standfirst {
+        margin-left: $gutter/2;
+        margin-right: $gutter/2;
+    }
+    .item__title {
+        padding-top: $baseline*2;
+    }
+    .item__meta {
         color: #ffffff;
-        @include font-size(20);
-        font-weight: lighter;
-        padding: $baseline*2 $gutter/2 $baseline*3;
+        border-color: $light-blue;
+        .item__timestamp {
+            border-left-style: solid;
+        }
     }
+}
+%item--large {
+    @include mq(tablet, desktop) {
+        @include item--large;
+    }
+    @include mq(desktop, wide) {
+        @include item--large;
+    }
+    @include mq(wide) {
+        @include item--large;
+    }
+}
+@mixin customise-item--large($width, $img-width, $show-standfirst: false, $font-size: false) {
+    width: $width;
+    .item__image {
+        width: $img-width;
+    }
+    .item__meta {
+        left: $img-width + $gs-gutter;
+    }
+    @if $show-standfirst == true {
+        .item__standfirst {
+            display: block;
+            @if $font-size != false {
+                @include font-size($font-size - 8, $font-size - 4);
+            }
+        }
+    }
+    @if $font-size != false {
+        .item__title {
+            @include font-size($font-size, $font-size + 4);
+        }
+    }
+}
+
+@mixin collection--stacked {
+    .item {
+        width: 100%;
+        float: none;
+        margin-right: 0;
+    }
+    .item:nth-child(1) {
+        background-color: $blue;
+        padding-bottom: $baseline*10;
+        color: #ffffff;
+        .item__title {
+            margin: $baseline*2 $baseline*2 0;
+        }
+        .item__meta {
+            color: #ffffff;
+            border-color: $light-blue;
+            .item__timestamp {
+                border-left-style: none;
+            }
+        }
+    }
+    .item:nth-child(n+2) {
+        border-top: 2px solid $blue;
+        .item__title {
+            margin-top: $baseline*2;
+            margin-bottom: $baseline*4;
+            @include font-size(20, 24);
+        }
+        .item__image-container,
+        .item__meta,
+        .item__duration {
+            display: none;
+        }
+    }
+}
+
+.section--masthead {
+    .item {
+        float: left;
+        height: 100%;
+        position: relative;
+        overflow: hidden;
+        margin-right: $gs-gutter;
+    }
+    .item:last-child {
+        margin-right: 0;
+    }
+    .item__image {
+        width: 100%;
+        display: block;
+    }
+    .item__title {
+        @include font-size(24, 28);
+        @include box-sizing(border-box);
+        border-top-style: none;
+        padding-top: 0;
+    }
+    .item__standfirst {
+        display: none;
+        margin: $gs-baseline 0 0;
+    }
+    .item__meta {
+        position:absolute;
+        bottom: 0;
+    }
+    .item--feature {
+        border-top-color: $pink !important;
+    }
+
     .collection {
-        margin-top: $baseline * 4;
         @include mq(tablet) {
             height: gs-height(6);
         }

--- a/common/app/assets/stylesheets/module/facia/_medium-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_medium-stories.scss
@@ -13,17 +13,15 @@
         }
     }
     .item {
-        float: none;
-        margin-right: 0;
         @include mq(tablet) {
             @include box-sizing(content-box);
-            height: auto;
             white-space: normal;
             display: inline-block;
             vertical-align: top;
             border-right: 1px dotted $grey;
             padding: 0 $gs-gutter/2 gs-height(4) $gs-gutter/2 - 1;
             width: gs-span(4);
+            background-color: #ffffff;
             &:first-child {
                 padding-left: 0;
             }
@@ -35,14 +33,9 @@
                 min-height: gs-height(4) + $gs-baseline;
                 padding-bottom: gs-height(1);
             }
-        }
-    }
-    .item--feature-new {
-        @include mq(tablet) {
-            background-color: #ffffff;
-        }
-        .item__title {
-             background-color: #ededed;
+            &.item--feature .item__title {
+                background-color: #ededed;
+            }
         }
     }
     @include mq($to: tablet) {
@@ -52,7 +45,6 @@
     }
     .item__title {
         @include font-size(26, 28);
-        font-weight: normal;
     }
     .item__image-container {
         position: absolute;
@@ -63,7 +55,7 @@
     .item__image {
         height: 100%;
     }
-    .item__meta-new {
+    .item__meta {
         @include mq(tablet) {
             position: absolute;
             bottom: gs-height(4) + $gs-baseline;

--- a/common/app/assets/stylesheets/module/facia/_medium-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_medium-stories.scss
@@ -1,0 +1,72 @@
+.section--medium-stories {
+    .section__title {
+        display: none;
+    }
+    .collection {
+        @include mq(tablet) {
+            font-size: 0;
+            white-space: nowrap;
+        }
+        @include mq(tablet, wide) {
+            overflow-x: scroll;
+            overflow-y: hidden;
+        }
+    }
+    .item {
+        float: none;
+        margin-right: 0;
+        @include mq(tablet) {
+            @include box-sizing(content-box);
+            height: auto;
+            white-space: normal;
+            display: inline-block;
+            vertical-align: top;
+            border-right: 1px dotted $grey;
+            padding: 0 $gs-gutter/2 gs-height(4) $gs-gutter/2 - 1;
+            width: gs-span(4);
+            &:first-child {
+                padding-left: 0;
+            }
+            &:last-child {
+                padding-right: 0;
+                border-right-style: none;
+            }
+            .item__title {
+                min-height: gs-height(4) + $gs-baseline;
+                padding-bottom: gs-height(1);
+            }
+        }
+    }
+    .item--feature-new {
+        @include mq(tablet) {
+            background-color: #ffffff;
+        }
+        .item__title {
+             background-color: #ededed;
+        }
+    }
+    @include mq($to: tablet) {
+        .item__image {
+            display: none;
+        }
+    }
+    .item__title {
+        @include font-size(26, 28);
+        font-weight: normal;
+    }
+    .item__image-container {
+        position: absolute;
+        bottom: 0;
+        height: gs-height(4);
+        width: gs-span(4);
+    }
+    .item__image {
+        height: 100%;
+    }
+    .item__meta-new {
+        @include mq(tablet) {
+            position: absolute;
+            bottom: gs-height(4) + $gs-baseline;
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia/_medium-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_medium-stories.scss
@@ -1,8 +1,8 @@
-.section--medium-stories {
-    .section__title {
+.collection--medium-stories {
+    .collection__title {
         display: none;
     }
-    .collection {
+    .items {
         @include mq(tablet) {
             font-size: 0;
             white-space: nowrap;

--- a/common/app/assets/stylesheets/module/facia/_popular.scss
+++ b/common/app/assets/stylesheets/module/facia/_popular.scss
@@ -1,4 +1,4 @@
-.section--popular {
+.collection--popular {
     @include mq(tablet) {
         display: inline-block;
         width: gs-span(4);
@@ -7,7 +7,7 @@
         padding-left: ($gs-gutter/2) - 1;
         border-left: 1px solid $grey;
     }
-    .collection {
+    .items {
         margin-top: $baseline*3;
         counter-reset: most-read;
         @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/facia/_popular.scss
+++ b/common/app/assets/stylesheets/module/facia/_popular.scss
@@ -9,7 +9,6 @@
     }
     .collection {
         margin-top: $baseline*3;
-        list-style-type: decimal;
         counter-reset: most-read;
         @include mq(tablet) {
             min-height: gs-height(8);
@@ -17,8 +16,6 @@
     }
     .item {
         padding: $gs-baseline/3 $gs-gutter/5 $gs-baseline/3 $gs-gutter;
-        margin: 0;
-        float: none;
         border-top: 1px dotted $grey;
         color: #000000;
         @include font($serifheadline, normal, 18);

--- a/common/app/assets/stylesheets/module/facia/_popular.scss
+++ b/common/app/assets/stylesheets/module/facia/_popular.scss
@@ -1,57 +1,57 @@
 .section--popular {
-    margin-top: $baseline * 4;
+    margin-top: $gs-baseline;
     @include mq(tablet) {
         min-height: gs-height(7);
-        padding-left: $gs-gutter / 2;
+        padding-left: ($gs-gutter/2) - 1;
         border-left: 1px solid $grey;
-        margin-left: gs-span(6) + ($gs-gutter / 2) - 1;
+        margin-left: gs-span(6) + ($gs-gutter/2);
     }
     @include mq(desktop) {
-        margin-left: gs-span(8) + ($gs-gutter / 2) - 1;
+        margin-left: gs-span(8) + ($gs-gutter/2);
     }
     @include mq(wide) {
-        margin-left: gs-span(12) + ($gs-gutter / 2) - 1;
+        margin-left: gs-span(12) + ($gs-gutter/2);
     }
     .section__title {
         @include font($serifheadline, 800, 16);
+        @include box-sizing(border-box);
+        height: gs-height(1);
+        padding: $gs-baseline/3 0 0 $gs-gutter/5;
         color: #ffffff;
         background-color: $blue;
-        padding: 4px;
-        @include box-sizing(border-box);
-        height: $baseline * 9;
+        border-top: $gs-baseline/3 solid $light-blue;
     }
     .collection {
-        margin-top: $baseline * 3;
+        margin-top: $baseline*3;
         list-style-type: decimal;
-        margin: 0;
         counter-reset: most-read;
-        margin-top: $baseline * 3;
         @include mq(tablet) {
-            padding-bottom: ($baseline * 3) - 1;
-            height: gs-height(6);
+            min-height: gs-height(8);
         }
     }
     .item {
-        padding: $baseline $gutter / 3 $baseline ($gutter * (3 / 2));
+        padding: $gs-baseline/3 $gs-gutter/5 $gs-baseline/3 $gs-gutter;
         margin: 0;
         float: none;
         border-top: 1px dotted $grey;
         color: #000000;
-        height: 56px;
-        @include font($serifheadline, 700, 18);
+        @include font($serifheadline, normal, 18);
+        min-height: gs-height(1);
+        @include mq(tablet) {
+            min-height: gs-height(8)/5;
+        }
     }
     .item:before {
         content: counter(most-read);
         counter-increment: most-read;
         color: $grey;
         position: absolute;
-        top: 4px;
-        left: 4px;
+        left: 0;
+        top: 50%;
+        @include font-size(20);
+        margin-top: -10px;
     }
     .item:last-child {
-        @include mq(tablet) {
-            height: 64px;
-            border-bottom: 1px solid $grey;
-        }
+        border-bottom: 1px solid $grey;
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_popular.scss
+++ b/common/app/assets/stylesheets/module/facia/_popular.scss
@@ -1,5 +1,4 @@
 .section--popular {
-    margin-top: $gs-baseline;
     @include mq(tablet) {
         display: inline-block;
         width: gs-span(4);

--- a/common/app/assets/stylesheets/module/facia/_popular.scss
+++ b/common/app/assets/stylesheets/module/facia/_popular.scss
@@ -1,16 +1,12 @@
 .section--popular {
     margin-top: $gs-baseline;
     @include mq(tablet) {
+        display: inline-block;
+        width: gs-span(4);
         min-height: gs-height(7);
+        margin-left: $gs-gutter/2;
         padding-left: ($gs-gutter/2) - 1;
         border-left: 1px solid $grey;
-        margin-left: gs-span(6) + ($gs-gutter/2);
-    }
-    @include mq(desktop) {
-        margin-left: gs-span(8) + ($gs-gutter/2);
-    }
-    @include mq(wide) {
-        margin-left: gs-span(12) + ($gs-gutter/2);
     }
     .collection {
         margin-top: $baseline*3;

--- a/common/app/assets/stylesheets/module/facia/_popular.scss
+++ b/common/app/assets/stylesheets/module/facia/_popular.scss
@@ -12,15 +12,6 @@
     @include mq(wide) {
         margin-left: gs-span(12) + ($gs-gutter/2);
     }
-    .section__title {
-        @include font($serifheadline, 800, 16);
-        @include box-sizing(border-box);
-        height: gs-height(1);
-        padding: $gs-baseline/3 0 0 $gs-gutter/5;
-        color: #ffffff;
-        background-color: $blue;
-        border-top: $gs-baseline/3 solid $light-blue;
-    }
     .collection {
         margin-top: $baseline*3;
         list-style-type: decimal;

--- a/common/app/assets/stylesheets/module/facia/_small-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_small-stories.scss
@@ -63,4 +63,28 @@
             bottom: 0;
         }
     }
+    .collection__show-more {
+        background-color: #9b9b9b;
+        border-style: none;
+        min-width: gs-span(2);
+        min-height: gs-height(1);
+        color: #ffffff;
+        @include font($serifheadline, 800, 14);
+        position: relative;
+        left: 50%;
+        margin-left: -(gs-span(1) + $gs-gutter/2);
+        margin-bottom: 8px;
+    }
+    .collection__show-more:after {
+        width: 0;
+        height: 0;
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        border-top: 8px solid #9b9b9b;
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -8px;
+    }
 }

--- a/common/app/assets/stylesheets/module/facia/_small-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_small-stories.scss
@@ -63,6 +63,8 @@
             bottom: 0;
         }
     }
+
+    $arrow-height: $gs-gutter*(2/3);
     .collection__show-more {
         background-color: #9b9b9b;
         border-style: none;
@@ -73,14 +75,14 @@
         position: relative;
         left: 50%;
         margin-left: -(gs-span(1) + $gs-gutter/2);
-        margin-bottom: 8px;
+        margin-bottom: $arrow-height;
     }
     .collection__show-more:after {
         width: 0;
         height: 0;
-        border-left: 8px solid transparent;
-        border-right: 8px solid transparent;
-        border-top: 8px solid #9b9b9b;
+        border-left: $arrow-height solid transparent;
+        border-right: $arrow-height solid transparent;
+        border-top: $arrow-height solid #9b9b9b;
         content: "";
         position: absolute;
         top: 100%;

--- a/common/app/assets/stylesheets/module/facia/_small-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_small-stories.scss
@@ -8,20 +8,21 @@
         }
     }
     .item {
-        float: none;
-        margin-right: 0;
         @include mq(tablet) {
             @include box-sizing(content-box);
-            height: auto;
             display: inline-block;
             vertical-align: top;
             border-right: 1px dotted $grey;
             padding-left: ($gs-gutter/2) - 1;
             padding-right: $gs-gutter/2;
             width: gs-span(4);
+            background-color: #ffffff;
             .item__title {
                 min-height: gs-height(3) + $gs-baseline;
                 padding-bottom: gs-height(1);
+            }
+            &.item--feature .item__title {
+                background-color: #ededed;
             }
         }
         @include mq(tablet, desktop) {
@@ -53,19 +54,10 @@
             }
         }
     }
-    .item--feature-new {
-        @include mq(tablet) {
-            background-color: #ffffff;
-        }
-        .item__title {
-            background-color: #ededed;
-        }
-    }
     .item__title {
         @include font-size(26, 28);
-        font-weight: normal;
     }
-    .item__meta-new {
+    .item__meta {
         @include mq(tablet) {
             position: absolute;
             bottom: 0;

--- a/common/app/assets/stylesheets/module/facia/_small-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_small-stories.scss
@@ -1,8 +1,8 @@
-.section--small-stories {
-    .section__title {
+.collection--small-stories {
+    .collection__title {
         display: none;
     }
-    .collection {
+    .items {
         @include mq(tablet) {
             font-size: 0;
         }
@@ -65,7 +65,7 @@
     }
 
     $arrow-height: $gs-gutter*(2/3);
-    .collection__show-more {
+    .items__show-more {
         background-color: #9b9b9b;
         border-style: none;
         min-width: gs-span(2);
@@ -77,7 +77,7 @@
         margin-left: -(gs-span(1) + $gs-gutter/2);
         margin-bottom: $arrow-height;
     }
-    .collection__show-more:after {
+    .items__show-more:after {
         width: 0;
         height: 0;
         border-left: $arrow-height solid transparent;

--- a/common/app/assets/stylesheets/module/facia/_small-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_small-stories.scss
@@ -1,0 +1,74 @@
+.section--small-stories {
+    .section__title {
+        display: none;
+    }
+    .collection {
+        @include mq(tablet) {
+            font-size: 0;
+        }
+    }
+    .item {
+        float: none;
+        margin-right: 0;
+        @include mq(tablet) {
+            @include box-sizing(content-box);
+            height: auto;
+            display: inline-block;
+            vertical-align: top;
+            border-right: 1px dotted $grey;
+            padding-left: ($gs-gutter/2) - 1;
+            padding-right: $gs-gutter/2;
+            width: gs-span(4);
+            .item__title {
+                min-height: gs-height(3) + $gs-baseline;
+                padding-bottom: gs-height(1);
+            }
+        }
+        @include mq(tablet, desktop) {
+            &:nth-child(2n + 1) {
+                padding-left: 0;
+            }
+            &:nth-child(2n + 2) {
+                padding-right: 0;
+                border-right-style: none;
+            }
+        }
+        @include mq(desktop, wide) {
+            &:nth-child(3n + 1) {
+                padding-left: 0;
+            }
+            &:nth-child(3n + 3) {
+                padding-right: 0;
+                border-right-style: none;
+            }
+
+        }
+        @include mq(wide) {
+            &:nth-child(4n + 1) {
+                padding-left: 0;
+            }
+            &:nth-child(4n + 4) {
+                padding-right: 0;
+                border-right-style: none;
+            }
+        }
+    }
+    .item--feature-new {
+        @include mq(tablet) {
+            background-color: #ffffff;
+        }
+        .item__title {
+            background-color: #ededed;
+        }
+    }
+    .item__title {
+        @include font-size(26, 28);
+        font-weight: normal;
+    }
+    .item__meta-new {
+        @include mq(tablet) {
+            position: absolute;
+            bottom: 0;
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia/_top-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_top-stories.scss
@@ -15,20 +15,21 @@
     }
     .item {
         margin-right: 0;
-        @include mq(tablet) {
-            padding-bottom: gs-height(5);
-        }
-        @include mq(desktop) {
-            padding-bottom: gs-height(6) + $gs-baseline;
-        }
-        @include mq(wide) {
-            padding-bottom: gs-height(9);
-        }
+        border: 10px none #ffffff;
         @include box-sizing(border-box);
         @include mq(tablet) {
             width: 50%;
+            padding-bottom: gs-height(5);
+            min-height: gs-height(8);
         }
-        border: 10px none #ffffff;
+        @include mq(desktop) {
+            padding-bottom: gs-height(7);
+            min-height: gs-height(9);
+        }
+        @include mq(wide) {
+            padding-bottom: gs-height(9);
+            min-height: gs-height(12);
+        }
     }
     .item:first-child {
         border-right-style: solid;
@@ -75,11 +76,11 @@
     .item__meta {
         position: absolute;
         height: gs-height(1) - $gs-baseline;
-        @include mq(desktop, wide) {
-            display: none;
-        }
         @include mq(tablet) {
             bottom: gs-height(4) + $gs-baseline;
+        }
+        @include mq(desktop) {
+            bottom: gs-height(6) + $gs-baseline;
         }
         @include mq(wide) {
             bottom: gs-height(8) + $gs-baseline;

--- a/common/app/assets/stylesheets/module/facia/_top-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_top-stories.scss
@@ -1,43 +1,107 @@
 .section--top-stories {
-    .section__title {
-        display: inline-block;
-        min-width: gs-span(4);
-        height: gs-height(1);
-        color: #ffffff;
-        background-color: $blue;
-        border-top: 2px solid $light-blue;
-        padding: $baseline $baseline 0;
-        @include font($serifheadline, 800, 16);
-        @include box-sizing(border-box);
+    overflow: hidden;
+    margin: 0 auto;
+    @include mq(tablet) {
+        width: gs-span(8);
+    }
+    @include mq(desktop) {
+        width: gs-span(12);
+    }
+    @include mq(wide) {
+        width: gs-span(16);
     }
     .collection {
-        margin-top: $baseline * 2;
-        height: gs-height(8);
+        margin-top: $gs-baseline;
+    }
+    .item {
+        margin-right: 0;
+        @include mq(tablet) {
+            padding-bottom: gs-height(5);
+        }
+        @include mq(desktop) {
+            padding-bottom: gs-height(6) + $gs-baseline;
+        }
+        @include mq(wide) {
+            padding-bottom: gs-height(9);
+        }
+        @include box-sizing(border-box);
+        @include mq(tablet) {
+            width: 50%;
+        }
+        border: 10px none #ffffff;
     }
     .item:first-child {
-        width: gs-span(12);
+        border-right-style: solid;
+    }
+    .item:last-child {
+        border-left-style: solid;
+    }
+    .item__title {
         border-top: 2px solid $blue;
-        .item__image-container {
-            float: left;
-            width: gs-span(8);
+        padding-top: $gs-baseline/3;
+        font-weight: normal;
+        @include mq(tablet) {
+            @include font-size(26, 28);
         }
-        .item__title {
-            padding-top: $baseline * 2;
-            margin-left: gs-span(8) + $gs-gutter;
-        }
-        .item__standfirst {
-            display: block;
-            margin: gs-height(1) - $baseline 0 0 gs-span(8) + $gs-gutter;
-            @include font-size(20, 24);
+        @include mq(wide) {
+            @include font-size(34, 36);
         }
     }
-    .item:nth-child(n + 2) {
-        @include item--small;
-        .item__title {
-            @include font-size(26, 28);
+    .item__image-container {
+        position: absolute;
+        bottom: 0;
+        @include mq(tablet) {
+            height: gs-height(4);
+        }
+        @include mq(desktop) {
+            height: gs-height(6);
+        }
+        @include mq(wide) {
+            height: gs-height(8);
         }
     }
     .item__image {
-        width: 100%;
+        height: 100%;
+        width: auto;
+    }
+    @include mq(wide) {
+        .item__standfirst {
+            display: block;
+            margin-top: $gs-baseline;
+            @include font-size(20, 24);
+            font-weight: normal;
+        }
+    }
+    .item__meta {
+        position: absolute;
+        height: gs-height(1) - $gs-baseline;
+        @include mq(desktop, wide) {
+            display: none;
+        }
+        @include mq(tablet) {
+            bottom: gs-height(4) + $gs-baseline;
+        }
+        @include mq(wide) {
+            bottom: gs-height(8) + $gs-baseline;
+        }
+    }
+    .item__timestamp {
+        height: 100%;
+        min-width: gs-span(1) - 16;
+        padding: 0 $gs-gutter/2 0 16px;
+        margin-right: 0;
+        border-left-style: none;
+        padding-bottom: 0;
+        i {
+            left: 0;
+        }
+    }
+    .trail__count {
+        height: 100%;
+        padding-bottom: 0;
+        padding-left: 28px;
+        i {
+            left: $gs-gutter/2 - 1;
+        }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_top-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_top-stories.scss
@@ -1,113 +1,43 @@
-@mixin row($row-size) {
-    &:nth-child(#{$row-size}n + 1) {
-        padding-left: 0;
-    }
-    &:nth-child(#{$row-size}n + #{$row-size}) {
-        padding-right: 0;
-        border-right-style: none;
-    }
-    &:nth-child(n + #{$row-size + 1}) {
-        padding-top: 5px;
-        border-top: 1px dotted $grey;
-        min-height: gs-height(4);
-    }
-    &:nth-child(-n + #{$row-size}) {
-        min-height: gs-height(8);
-        .item__image-container {
-            display: block;
-        }
-    }
-}
-
 .section--top-stories {
-    margin: 0 auto;
-    @include mq(tablet) {
-        width: gs-span(9);
-    }
-    @include mq(desktop) {
-        width: gs-span(12);
-    }
-    @include mq(wide) {
-        width: gs-span(16);
-    }
     .section__title {
-        display: none;
+        display: inline-block;
+        min-width: gs-span(4);
+        height: gs-height(1);
+        color: #ffffff;
+        background-color: $blue;
+        border-top: 2px solid $light-blue;
+        padding: $baseline $baseline 0;
+        @include font($serifheadline, 800, 16);
+        @include box-sizing(border-box);
     }
     .collection {
-        font-size: 0;
-        margin-top: ($gs-gutter / 2) - 1;
-        padding: ($gs-gutter / 2) 0 ($gs-gutter / 2 - 1);
-        border-top: solid 1px $grey;
-        border-bottom: solid 1px $grey;
+        margin-top: $baseline * 2;
+        height: gs-height(8);
     }
-    .item {
-        margin: 0;
-        padding-top: 5px;
-        padding-bottom: 6px;
-        float: none;
-        @include box-sizing(content-box);
-        &:first-child {
-            padding-top: 0;
-            border-top-style: none;
+    .item:first-child {
+        width: gs-span(12);
+        border-top: 2px solid $blue;
+        .item__image-container {
+            float: left;
+            width: gs-span(8);
         }
-        @include mq(tablet) {
-            border-right: 1px dotted $grey;
-            display: inline-block;
-            vertical-align: top;
-            padding-top: 0;
-            padding-right: ($gs-gutter / 2 - 1);
-            padding-left: $gs-gutter / 2;
+        .item__title {
+            padding-top: $baseline * 2;
+            margin-left: gs-span(8) + $gs-gutter;
         }
-        @include mq(tablet, desktop) {
-            width: gs-span(3);
-            @include row(3);
-        }
-        @include mq(desktop, wide) {
-            width: gs-span(4);
-            @include row(3);
-        }
-        @include mq(wide) {
-            width: gs-span(4);
-            @include row(4);
+        .item__standfirst {
+            display: block;
+            margin: gs-height(1) - $baseline 0 0 gs-span(8) + $gs-gutter;
+            @include font-size(20, 24);
         }
     }
-    .item__image-container {
-         display: none;
-     }
-    .item:first-child .item__image-container {
-        display: block;
+    .item:nth-child(n + 2) {
+        @include item--small;
+        .item__title {
+            @include font-size(26, 28);
+        }
     }
     .item__image {
-        margin-bottom: $baseline * 2;
-    }
-    .item__title {
-        @include font-size(22, 24);
-    }
-    .item__standfirst {
-        display: block;
-        margin-top: $baseline;
-        @include font-size(16, 20);
-        color: #666666;
-    }
-    .item__meta {
-        position: relative;
-        margin-top: $baseline * 2;
-        .item__timestamp {
-            border-left-style: none !important;
-            @include font-size(12, 13);
-            padding-bottom: 0;
-            padding-left: 17px;
-            .i {
-                left: 0;
-                @extend .i-clock-grey;
-            }
-        }
-    }
-    .collection__show-more {
-        border-style: none;
-        @extend %type-7;
-        display: block;
-        margin: 0 auto;
-        background-color: #dddddd;
+        width: 100%;
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_top-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_top-stories.scss
@@ -1,16 +1,22 @@
 .section--top-stories {
     overflow: hidden;
-    .collection {
-        margin-top: $gs-baseline;
-    }
     .item {
         margin-right: 0;
-        border: 10px none #ffffff;
         @include box-sizing(border-box);
+        @include mq($to: tablet) {
+            float: none;
+        }
         @include mq(tablet) {
+            border: 10px none #ffffff;
             width: 50%;
             padding-bottom: gs-height(5);
             min-height: gs-height(8);
+            &:first-child {
+                border-right-style: solid;
+            }
+            &:last-child {
+                border-left-style: solid;
+            }
         }
         @include mq(desktop) {
             padding-bottom: gs-height(7);
@@ -21,15 +27,7 @@
             min-height: gs-height(12);
         }
     }
-    .item:first-child {
-        border-right-style: solid;
-    }
-    .item:last-child {
-        border-left-style: solid;
-    }
     .item__title {
-        border-top: 2px solid $blue;
-        padding-top: $gs-baseline/3;
         font-weight: normal;
         @include mq(tablet) {
             @include font-size(26, 28);
@@ -39,9 +37,12 @@
         }
     }
     .item__image-container {
-        position: absolute;
-        bottom: 0;
+        @include mq($to: tablet) {
+            display:none;
+        }
         @include mq(tablet) {
+            position: absolute;
+            bottom: 0;
             height: gs-height(4);
         }
         @include mq(desktop) {
@@ -63,10 +64,9 @@
             font-weight: normal;
         }
     }
-    .item__meta {
-        position: absolute;
-        height: gs-height(1) - $gs-baseline;
+    .item__meta-new {
         @include mq(tablet) {
+            position: absolute;
             bottom: gs-height(4) + $gs-baseline;
         }
         @include mq(desktop) {
@@ -74,25 +74,6 @@
         }
         @include mq(wide) {
             bottom: gs-height(8) + $gs-baseline;
-        }
-    }
-    .item__timestamp {
-        height: 100%;
-        min-width: gs-span(1) - 16;
-        padding: 0 $gs-gutter/2 0 16px;
-        margin-right: 0;
-        border-left-style: none;
-        padding-bottom: 0;
-        i {
-            left: 0;
-        }
-    }
-    .trail__count {
-        height: 100%;
-        padding-bottom: 0;
-        padding-left: 28px;
-        i {
-            left: $gs-gutter/2 - 1;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_top-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_top-stories.scss
@@ -1,12 +1,8 @@
 .section--top-stories {
     overflow: hidden;
     .item {
-        margin-right: 0;
-        @include box-sizing(border-box);
-        @include mq($to: tablet) {
-            float: none;
-        }
         @include mq(tablet) {
+            float: left;
             border: 10px none #ffffff;
             width: 50%;
             padding-bottom: gs-height(5);
@@ -28,7 +24,6 @@
         }
     }
     .item__title {
-        font-weight: normal;
         @include mq(tablet) {
             @include font-size(26, 28);
         }
@@ -52,19 +47,22 @@
             height: gs-height(8);
         }
     }
+    @include mq($to: wide) {
+        .item__standfirst {
+            display: none;
+        }
+    }
     .item__image {
         height: 100%;
-        width: auto;
     }
     @include mq(wide) {
         .item__standfirst {
             display: block;
             margin-top: $gs-baseline;
             @include font-size(20, 24);
-            font-weight: normal;
         }
     }
-    .item__meta-new {
+    .item__meta {
         @include mq(tablet) {
             position: absolute;
             bottom: gs-height(4) + $gs-baseline;

--- a/common/app/assets/stylesheets/module/facia/_top-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_top-stories.scss
@@ -1,4 +1,4 @@
-.section--top-stories {
+.collection--top-stories {
     overflow: hidden;
     .item {
         @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/facia/_top-stories.scss
+++ b/common/app/assets/stylesheets/module/facia/_top-stories.scss
@@ -1,15 +1,5 @@
 .section--top-stories {
     overflow: hidden;
-    margin: 0 auto;
-    @include mq(tablet) {
-        width: gs-span(8);
-    }
-    @include mq(desktop) {
-        width: gs-span(12);
-    }
-    @include mq(wide) {
-        width: gs-span(16);
-    }
     .collection {
         margin-top: $gs-baseline;
     }

--- a/common/app/views/fragments/trailblocks/highlights.scala.html
+++ b/common/app/views/fragments/trailblocks/highlights.scala.html
@@ -2,7 +2,7 @@
 
 <ul class="unstyled collection item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
-        <li class="item @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+        <li class="item @trail.trailType.map("item--" + _ + "-new") @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
             <a href="@LinkTo{@trail.url}" class="item__link">
                 <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
@@ -12,7 +12,7 @@
                     </div>
                 }
             </a>
-            <div class="item__meta item__meta--grey">
+            <div class="item__meta-new item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"
                       datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/fragments/trailblocks/highlights.scala.html
+++ b/common/app/views/fragments/trailblocks/highlights.scala.html
@@ -1,6 +1,6 @@
 @(trails: Seq[Trail])(implicit request: RequestHeader)
 
-<ul class="unstyled collection item-count-@trails.size">
+<ul class="unstyled items item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
         <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>

--- a/common/app/views/fragments/trailblocks/highlights.scala.html
+++ b/common/app/views/fragments/trailblocks/highlights.scala.html
@@ -2,7 +2,7 @@
 
 <ul class="unstyled collection item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
-        <li class="item @trail.trailType.map("item--" + _ + "-new") @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+        <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
             <a href="@LinkTo{@trail.url}" class="item__link">
                 <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
@@ -12,7 +12,7 @@
                     </div>
                 }
             </a>
-            <div class="item__meta-new item__meta--grey">
+            <div class="item__meta item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"
                       datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/fragments/trailblocks/highlights.scala.html
+++ b/common/app/views/fragments/trailblocks/highlights.scala.html
@@ -4,16 +4,14 @@
     @trails.zipWithIndex.map{ case (trail, index) =>
         <li class="item @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
-            <h2 class="item__title">
-                <a href="@LinkTo{@trail.url}" class="item__link">
-                    @RemoveOuterParaHtml(trail.headline)
-                </a>
-            </h2>
-            @trail.mainPicture(620).map{ mainPicture =>
-                <div class="item__image-container">
-                    <img class="item__image" src="@mainPicture.path" alt="" />
-                </div>
-            }
+            <a href="@LinkTo{@trail.url}" class="item__link">
+                <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
+                @trail.mainPicture(620).map{ mainPicture =>
+                    <div class="item__image-container">
+                        <img class="item__image" src="@mainPicture.path" alt="" />
+                    </div>
+                }
+            </a>
             <div class="item__meta item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"

--- a/common/app/views/fragments/trailblocks/highlights.scala.html
+++ b/common/app/views/fragments/trailblocks/highlights.scala.html
@@ -4,16 +4,15 @@
     @trails.zipWithIndex.map{ case (trail, index) =>
         <li class="item @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
-            <a href="@LinkTo{@trail.url}" class="item__link">
-                @trail.mainPicture(620).map{ mainPicture =>
-                    <div class="item__image-container">
-                        <img class="item__image" src="@mainPicture.path" alt="" />
-                    </div>
-                }
-                <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
-            </a>
-            @trail.trailText.map { text =>
-                <p class="item__standfirst">@cleanTrailText(text)(Edition(request))</p>
+            <h2 class="item__title">
+                <a href="@LinkTo{@trail.url}" class="item__link">
+                    @RemoveOuterParaHtml(trail.headline)
+                </a>
+            </h2>
+            @trail.mainPicture(620).map{ mainPicture =>
+                <div class="item__image-container">
+                    <img class="item__image" src="@mainPicture.path" alt="" />
+                </div>
             }
             <div class="item__meta item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"

--- a/common/app/views/fragments/trailblocks/masthead.scala.html
+++ b/common/app/views/fragments/trailblocks/masthead.scala.html
@@ -1,6 +1,6 @@
 @(trails: Seq[Trail])(implicit request: RequestHeader)
 
-<ul class="unstyled collection item-count-@trails.size">
+<ul class="unstyled items item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
         <li class="item @trail.trailType.map("item--" + _)" data-link-name="trail | @{index + 1}" @trail.discussionId.map{ id => data-discussion-id="@id" }>
             @if(trail.trailType == Option("comment")) {

--- a/common/app/views/fragments/trailblocks/mediumStories.scala.html
+++ b/common/app/views/fragments/trailblocks/mediumStories.scala.html
@@ -1,6 +1,6 @@
 @(trails: Seq[Trail])(implicit request: RequestHeader)
 
-<ul class="unstyled collection item-count-@trails.size">
+<ul class="unstyled items item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
         <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>

--- a/common/app/views/fragments/trailblocks/mediumStories.scala.html
+++ b/common/app/views/fragments/trailblocks/mediumStories.scala.html
@@ -2,7 +2,7 @@
 
 <ul class="unstyled collection item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
-        <li class="item @trail.trailType.map("item--" + _ + "-new") @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+        <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
             <a href="@LinkTo{@trail.url}" class="item__link">
                 <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
@@ -12,7 +12,7 @@
                     </div>
                 }
             </a>
-            <div class="item__meta-new item__meta--grey">
+            <div class="item__meta item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"
                       datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/fragments/trailblocks/mediumStories.scala.html
+++ b/common/app/views/fragments/trailblocks/mediumStories.scala.html
@@ -1,0 +1,26 @@
+@(trails: Seq[Trail])(implicit request: RequestHeader)
+
+<ul class="unstyled collection item-count-@trails.size">
+    @trails.zipWithIndex.map{ case (trail, index) =>
+        <li class="item @trail.trailType.map("item--" + _ + "-new") @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+            @trail.discussionId.map{ id => data-discussion-id="@id" }>
+            <a href="@LinkTo{@trail.url}" class="item__link">
+                <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
+                @trail.mainPicture(620).map{ mainPicture =>
+                    <div class="item__image-container">
+                        <img class="item__image" src="@mainPicture.path" alt="" />
+                    </div>
+                }
+            </a>
+            <div class="item__meta-new item__meta--grey">
+                <time class="item__timestamp js-item__timestamp"
+                      itemprop="datePublished"
+                      datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                      data-timestamp="@trail.webPublicationDate.getMillis">
+                    <i class="i"></i>
+                    <span class="timestamp__text"><span class="h">Published: </span>@Format(trail.webPublicationDate, "d MMM y")</span>
+                </time>
+            </div>
+        </li>
+    }
+</ul>

--- a/common/app/views/fragments/trailblocks/smallStories.scala.html
+++ b/common/app/views/fragments/trailblocks/smallStories.scala.html
@@ -1,0 +1,21 @@
+@(trails: Seq[Trail])(implicit request: RequestHeader)
+
+<ul class="unstyled collection item-count-@trails.size">
+    @trails.zipWithIndex.map{ case (trail, index) =>
+        <li class="item @trail.trailType.map("item--" + _ + "-new")" data-link-name="trail | @{index + 1}"
+            @trail.discussionId.map{ id => data-discussion-id="@id" }>
+            <a href="@LinkTo{@trail.url}" class="item__link">
+                <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
+            </a>
+            <div class="item__meta-new item__meta--grey">
+                <time class="item__timestamp js-item__timestamp"
+                      itemprop="datePublished"
+                      datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                      data-timestamp="@trail.webPublicationDate.getMillis">
+                    <i class="i"></i>
+                    <span class="timestamp__text"><span class="h">Published: </span>@Format(trail.webPublicationDate, "d MMM y")</span>
+                </time>
+            </div>
+        </li>
+    }
+</ul>

--- a/common/app/views/fragments/trailblocks/smallStories.scala.html
+++ b/common/app/views/fragments/trailblocks/smallStories.scala.html
@@ -1,6 +1,6 @@
 @(trails: Seq[Trail])(implicit request: RequestHeader)
 
-<ul class="unstyled collection item-count-@trails.size">
+<ul class="unstyled items item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
         <li class="item @trail.trailType.map("item--" + _)" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>

--- a/common/app/views/fragments/trailblocks/smallStories.scala.html
+++ b/common/app/views/fragments/trailblocks/smallStories.scala.html
@@ -2,12 +2,12 @@
 
 <ul class="unstyled collection item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
-        <li class="item @trail.trailType.map("item--" + _ + "-new")" data-link-name="trail | @{index + 1}"
+        <li class="item @trail.trailType.map("item--" + _)" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
             <a href="@LinkTo{@trail.url}" class="item__link">
                 <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
             </a>
-            <div class="item__meta-new item__meta--grey">
+            <div class="item__meta item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"
                       datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/fragments/trailblocks/topStories.scala.html
+++ b/common/app/views/fragments/trailblocks/topStories.scala.html
@@ -1,6 +1,6 @@
 @(trails: Seq[Trail])(implicit request: RequestHeader)
 
-<ul class="unstyled collection item-count-@trails.size">
+<ul class="unstyled items item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
         <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>

--- a/common/app/views/fragments/trailblocks/topStories.scala.html
+++ b/common/app/views/fragments/trailblocks/topStories.scala.html
@@ -2,19 +2,20 @@
 
 <ul class="unstyled collection item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
-        <li class="item @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}">
+        <li class="item @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+            @trail.discussionId.map{ id => data-discussion-id="@id" }>
             <a href="@LinkTo{@trail.url}" class="item__link">
+                <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
                 @trail.mainPicture(620).map{ mainPicture =>
                     <div class="item__image-container">
                         <img class="item__image" src="@mainPicture.path" alt="" />
                     </div>
                 }
-                <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
             </a>
             @trail.trailText.map { text =>
                 <p class="item__standfirst">@cleanTrailText(text)(Edition(request))</p>
             }
-            <div class="item__meta">
+            <div class="item__meta item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"
                       datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/fragments/trailblocks/topStories.scala.html
+++ b/common/app/views/fragments/trailblocks/topStories.scala.html
@@ -2,7 +2,7 @@
 
 <ul class="unstyled collection item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
-        <li class="item @trail.trailType.map("item--" + _ + "-new") @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+        <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
             <a href="@LinkTo{@trail.url}" class="item__link">
                 <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
@@ -15,7 +15,7 @@
             @trail.trailText.map { text =>
                 <p class="item__standfirst">@cleanTrailText(text)(Edition(request))</p>
             }
-            <div class="item__meta-new item__meta--grey">
+            <div class="item__meta item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"
                       datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/fragments/trailblocks/topStories.scala.html
+++ b/common/app/views/fragments/trailblocks/topStories.scala.html
@@ -2,7 +2,7 @@
 
 <ul class="unstyled collection item-count-@trails.size">
     @trails.zipWithIndex.map{ case (trail, index) =>
-        <li class="item @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+        <li class="item @trail.trailType.map("item--" + _ + "-new") @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
             @trail.discussionId.map{ id => data-discussion-id="@id" }>
             <a href="@LinkTo{@trail.url}" class="item__link">
                 <h2 class="item__title">@RemoveOuterParaHtml(trail.headline)</h2>
@@ -15,7 +15,7 @@
             @trail.trailText.map { text =>
                 <p class="item__standfirst">@cleanTrailText(text)(Edition(request))</p>
             }
-            <div class="item__meta item__meta--grey">
+            <div class="item__meta-new item__meta--grey">
                 <time class="item__timestamp js-item__timestamp"
                       itemprop="datePublished"
                       datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -48,6 +48,8 @@ object Masthead extends Style { val className = "masthead" }
 
 object TopStories extends Style { val className = "top-stories" }
 
+object SmallStories extends Style { val className = "small-stories" }
+
 object Highlights extends Style { val className = "highlights" }
 
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -48,6 +48,8 @@ object Masthead extends Style { val className = "masthead" }
 
 object TopStories extends Style { val className = "top-stories" }
 
+object MediumStories extends Style { val className = "medium-stories" }
+
 object SmallStories extends Style { val className = "small-stories" }
 
 object Highlights extends Style { val className = "highlights" }

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -51,15 +51,16 @@ trait ParseConfig extends ExecutionContexts {
 
   //TODO: Should probably live along side styles with object.apply
   def getStyle(style: String): Option[Style] = style match {
-    case "featured"     => Some(Featured)
-    case "thumbnail"    => Some(Thumbnail)
-    case "headline"     => Some(Headline)
-    case "sectionfront" => Some(SectionFront)
-    case "masthead"     => Some(Masthead)
-    case "topStories"   => Some(TopStories)
-    case "smallStories" => Some(SmallStories)
-    case "highlights"   => Some(Highlights)
-    case _              => None
+    case "featured"      => Some(Featured)
+    case "thumbnail"     => Some(Thumbnail)
+    case "headline"      => Some(Headline)
+    case "sectionfront"  => Some(SectionFront)
+    case "masthead"      => Some(Masthead)
+    case "topStories"    => Some(TopStories)
+    case "mediumStories" => Some(MediumStories)
+    case "smallStories"  => Some(SmallStories)
+    case "highlights"    => Some(Highlights)
+    case _               => None
   }
 }
 

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -57,6 +57,7 @@ trait ParseConfig extends ExecutionContexts {
     case "sectionfront" => Some(SectionFront)
     case "masthead"     => Some(Masthead)
     case "topStories"   => Some(TopStories)
+    case "smallStories" => Some(SmallStories)
     case "highlights"   => Some(Highlights)
     case _              => None
   }

--- a/facia/app/views/fragments/frontBlock.scala.html
+++ b/facia/app/views/fragments/frontBlock.scala.html
@@ -19,6 +19,7 @@
             case Some(SectionFront) => { @trailblocks.section(items, config.numItemsVisible, numWithImages = 3 ) }
             case Some(Masthead)     => { @trailblocks.masthead(items.take(config.numItemsVisible)) }
             case Some(TopStories)   => { @trailblocks.topStories(items.take(config.numItemsVisible)) }
+            case Some(SmallStories) => { @trailblocks.smallStories(items.take(config.numItemsVisible)) }
             case Some(Highlights)   => { @trailblocks.highlights(items.take(config.numItemsVisible)) }
             case _                  => { @trailblocks.featured(items, config.numItemsVisible) }
         }

--- a/facia/app/views/fragments/frontBlock.scala.html
+++ b/facia/app/views/fragments/frontBlock.scala.html
@@ -2,7 +2,7 @@
 
 @if(items.nonEmpty){
 
-    <section class="section--@config.style.map(_.className)"
+    <section class="collection collection--@config.style.map(_.className)"
             data-link-name="block | @config.name"
             data-section-id="@config.id"
              @defining(Edition(request).id.toLowerCase()) { edition =>
@@ -10,7 +10,7 @@
              }
 
         @if(config.name) {
-            <h2 class="section__title">@config.name</h2>
+            <h2 class="collection__title">@config.name</h2>
         }
 
         @config.style match {

--- a/facia/app/views/fragments/frontBlock.scala.html
+++ b/facia/app/views/fragments/frontBlock.scala.html
@@ -14,14 +14,15 @@
         }
 
         @config.style match {
-            case Some(Thumbnail)    => { @trailblocks.thumbnail(items, config.numItemsVisible) }
-            case Some(Headline)     => { @trailblocks.headline(items, config.numItemsVisible) }
-            case Some(SectionFront) => { @trailblocks.section(items, config.numItemsVisible, numWithImages = 3 ) }
-            case Some(Masthead)     => { @trailblocks.masthead(items.take(config.numItemsVisible)) }
-            case Some(TopStories)   => { @trailblocks.topStories(items.take(config.numItemsVisible)) }
-            case Some(SmallStories) => { @trailblocks.smallStories(items.take(config.numItemsVisible)) }
-            case Some(Highlights)   => { @trailblocks.highlights(items.take(config.numItemsVisible)) }
-            case _                  => { @trailblocks.featured(items, config.numItemsVisible) }
+            case Some(Thumbnail)     => { @trailblocks.thumbnail(items, config.numItemsVisible) }
+            case Some(Headline)      => { @trailblocks.headline(items, config.numItemsVisible) }
+            case Some(SectionFront)  => { @trailblocks.section(items, config.numItemsVisible, numWithImages = 3 ) }
+            case Some(Masthead)      => { @trailblocks.masthead(items.take(config.numItemsVisible)) }
+            case Some(TopStories)    => { @trailblocks.topStories(items.take(config.numItemsVisible)) }
+            case Some(MediumStories) => { @trailblocks.mediumStories(items.take(config.numItemsVisible)) }
+            case Some(SmallStories)  => { @trailblocks.smallStories(items.take(config.numItemsVisible)) }
+            case Some(Highlights)    => { @trailblocks.highlights(items.take(config.numItemsVisible)) }
+            case _                   => { @trailblocks.featured(items, config.numItemsVisible) }
         }
 
     </section>


### PR DESCRIPTION
New styling for (facia) fronts

Note, tablet breakpoint has been reduces to 8 grid units (new design size going forward)
## Wide

![wide](https://f.cloud.github.com/assets/74132/1124697/de15bed6-1b03-11e3-8286-27525a8bc031.gif)
## Desktop

![desktop](https://f.cloud.github.com/assets/74132/1124695/d9b9ccf6-1b03-11e3-9214-9acd211d868e.gif)
## Tablet

![tablet](https://f.cloud.github.com/assets/74132/1124698/e4e07fe4-1b03-11e3-8aef-9f63d74ca97f.gif)
## Mobile

![mobile](https://f.cloud.github.com/assets/74132/1124699/e62a5654-1b03-11e3-9797-ef76dc85ac9b.gif)
