### PR TITLE
Facia individual collection refresh

### DIFF
--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -155,7 +155,7 @@ trait ParseCollection extends ExecutionContexts with Logging {
 
 }
 
-class Query(id: String, edition: Edition) extends ParseConfig with ParseCollection {
+class Query(id: String, edition: Edition) extends ParseConfig with ParseCollection with Logging {
   private lazy val queryAgent = AkkaAgent[List[(Config, Collection)]](Nil)
 
   def getItems: Future[List[(Config, Either[Throwable, Collection])]] = {
@@ -179,7 +179,10 @@ class Query(id: String, edition: Edition) extends ParseConfig with ParseCollecti
         lazy val oldConfigMap = oldConfigList.map{case (config, collection) => (config.id, collection)}.toMap
         newConfigList flatMap { collectionConfig =>
           collectionConfig match {
-            case (config, Left(exception)) => oldConfigMap.get(config.id).map(oldCollection => (config, oldCollection))
+            case (config, Left(exception)) => {
+              log.warn("Updating ID %s failed".format(config.id))
+              oldConfigMap.get(config.id).map(oldCollection => (config, oldCollection))
+            }
             case (config, Right(newCollection)) => Some((config, newCollection))
           }
         }

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -174,13 +174,13 @@ class Query(id: String, edition: Edition) extends ParseConfig with ParseCollecti
   }
 
   def refresh() =
-    getItems map {m =>
-      queryAgent.send{ old =>
-        lazy val oldConfigMap = old.map{case (c, e) => (c.id, e)}.toMap
-        m.flatMap{collection =>
-          collection match {
-            case (config, Left(t)) => oldConfigMap.get(config.id).map(c => (config, c))
-            case (config, Right(c)) => Some((config, c))
+    getItems map { newConfigList =>
+      queryAgent.send { oldConfigList =>
+        lazy val oldConfigMap = oldConfigList.map{case (config, collection) => (config.id, collection)}.toMap
+        newConfigList flatMap { collectionConfig =>
+          collectionConfig match {
+            case (config, Left(exception)) => oldConfigMap.get(config.id).map(oldCollection => (config, oldCollection))
+            case (config, Right(newCollection)) => Some((config, newCollection))
           }
         }
       }


### PR DESCRIPTION
This uses `Either` to tell if the retrieving of a collection has failed at some point. If getting a collection has failed, the agent either does not receive the collection and stays without it, or keeps on using the collection that it currently has.

If getting the collection has been successful, then it updates.
In each instance of getting a collection (Success and Failure), the config is always updated.

If getting the config fails for an ID (Essentially a path), then the whole request for the page will fail until the next round.

In the future, as we will be getting the configuration less frequently, we will then implement updating a collection with only the old config object.
