### PR TITLE
Content API timeout value is now configurable per environment

### DIFF
--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -16,9 +16,11 @@ trait WsHttp extends Http[Future] with ExecutionContexts {
 
   override def GET(url: String, headers: Iterable[(String, String)]) = {
     val urlWithHost = url + s"&host-name=${encode(host.name, "UTF-8")}"
+  
+    val contentApiTimeout = Configuration.contentApi.timeout
 
     val start = currentTimeMillis
-    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(2000).get()
+    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withTimeout(contentApiTimeout).get()
 
     // record metrics
     response.onSuccess {


### PR DESCRIPTION
It now uses `content.api.timeout.millis` in the configuration (which was already there) via the Configuration object.

This is mainly useful for OSX developers who like to raise their timeout value to 5000ms because of their tardy hardware.

/cc @gklopper @phamann 
