### PR TITLE
Split out contentApiQuery request in Facia

### DIFF
--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -15,6 +15,7 @@ case class Collection(items: Seq[Trail],
 
 object Collection {
   def apply(items: Seq[Trail]): Collection = Collection(items, None)
+  def apply(items: Seq[Trail], name: String): Collection = Collection(items, Some(name))
 }
 
 case class FaciaPage(


### PR DESCRIPTION
Before we used to have the key `contentApiQuery` inside `collection.json`, which meant that when the request for that failed then so did the whole request chain.

Now it exists in `config.json`. So we don't necessarily want the chain to fail if `collection.json` doesn't exist, as content could still be coming from the `contentApiQuery` value from `config.json`.

This ensures that when a request for `collection.json` fails for the reason of not existing, that the `contentApiQuery` can still pull in content.

This only fails for successful requests to S3, in which a 403 is returned. If a failure happens at a more TCP level, then the whole chain in this round fails, which is what happens now.
