### PR TITLE
Better facia status codes, Remove film

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -204,11 +204,6 @@ object Switches extends Collections {
     "Switch that is only used while running tests. You never need to change this switch.",
     safeState = Off)
 
-  //Fronts film switch
-  val FilmFrontFacia = Switch("Facia", "facia-film",
-    "Switch to redirect traffic to the facia film front instead of front film front",
-    safeState = Off)
-
   val FaciaSwitch = Switch("Facia", "facia",
     "Switch to redirect to facia if request has X-Gu-Facia=true",
     safeState = Off
@@ -247,7 +242,6 @@ object Switches extends Collections {
     ExternalLinksCardsSwitch,
     LiveSummarySwitch,
     LiveCricketSwitch,
-    FilmFrontFacia,
     FaciaSwitch,
     AdSlotImpressionStatsSwitch,
     ABGalleryStyle,

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -144,19 +144,20 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
 
       val editionalisedPath = editionPath(path, Edition(request))
 
-      FrontPage(editionalisedPath).map { frontPage =>
+      FrontPage(editionalisedPath).flatMap { frontPage =>
 
         // get the trailblocks
-        val faciaPage: FaciaPage = front(editionalisedPath)
-
-        if (path != editionalisedPath) {
-          Redirect(editionalisedPath)
-        } else if (faciaPage.collections.isEmpty) {
-          InternalServerError
-        } else {
-          val htmlResponse = () => views.html.front(frontPage, faciaPage)
-          val jsonResponse = () => views.html.fragments.frontBody(frontPage, faciaPage)
-          renderFormat(htmlResponse, jsonResponse, frontPage, Switches.all)
+        val faciaPageOption: Option[FaciaPage] = front(editionalisedPath)
+        faciaPageOption map { faciaPage =>
+          if (path != editionalisedPath) {
+            Redirect(editionalisedPath)
+          } else if (faciaPage.collections.isEmpty) {
+            InternalServerError
+          } else {
+            val htmlResponse = () => views.html.front(frontPage, faciaPage)
+            val jsonResponse = () => views.html.fragments.frontBody(frontPage, faciaPage)
+            renderFormat(htmlResponse, jsonResponse, frontPage, Switches.all)
+          }
         }
       }.getOrElse(NotFound) //TODO is 404 the right thing here
   }
@@ -168,7 +169,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
     FrontPage(editionalisedPath).map{ frontPage =>
 
       // get the first trailblock
-      val collection: Option[(Config, Collection)] = front(editionalisedPath).collections.headOption
+      val collection: Option[(Config, Collection)] = front(editionalisedPath).flatMap(_.collections.headOption)
 
       if (path != editionalisedPath) {
         Redirect(editionalisedPath)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -133,13 +133,6 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
     case _ => Editionalise(path, edition)
   }
 
-  def renderFilm() = {
-    if (Switches.FilmFrontFacia.isSwitchedOn)
-      render("film")
-    else
-      Action { Ok.withHeaders("X-Accel-Redirect" -> "/redirect/film/film") }
-  }
-
   def render(path: String) = Action { implicit request =>
 
       val editionalisedPath = editionPath(path, Edition(request))

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -151,8 +151,6 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
         faciaPageOption map { faciaPage =>
           if (path != editionalisedPath) {
             Redirect(editionalisedPath)
-          } else if (faciaPage.collections.isEmpty) {
-            InternalServerError
           } else {
             val htmlResponse = () => views.html.front(frontPage, faciaPage)
             val jsonResponse = () => views.html.fragments.frontBody(frontPage, faciaPage)
@@ -173,8 +171,6 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
 
       if (path != editionalisedPath) {
         Redirect(editionalisedPath)
-      } else if (collection.isEmpty) {
-        InternalServerError
       } else {
         val trails: Seq[Trail] = collection.map(_._2.items).getOrElse(Nil)
         val response = () => views.html.fragments.trailblocks.headline(trails, numItemsVisible = trails.size)

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -137,7 +137,7 @@ trait ParseCollection extends ExecutionContexts with Logging {
 }
 
 class Query(id: String, edition: Edition) extends ParseConfig with ParseCollection with Logging {
-  private lazy val queryAgent = AkkaAgent[List[(Config, Collection)]](Nil)
+  private lazy val queryAgent = AkkaAgent[Option[List[(Config, Collection)]]](None)
 
   def getItems: Future[List[(Config, Either[Throwable, Collection])]] = {
     val futureConfig = getConfig(id) map {config =>
@@ -157,14 +157,16 @@ class Query(id: String, edition: Edition) extends ParseConfig with ParseCollecti
   def refresh() =
     getItems map { newConfigList =>
       queryAgent.send { oldConfigList =>
-        lazy val oldConfigMap = oldConfigList.map{case (config, collection) => (config.id, collection)}.toMap
-        newConfigList flatMap { collectionConfig =>
-          collectionConfig match {
-            case (config, Left(exception)) => {
-              log.warn("Updating ID %s failed".format(config.id))
-              oldConfigMap.get(config.id).map(oldCollection => (config, oldCollection))
+        lazy val oldConfigMap = oldConfigList.map{_.map{case (config, collection) => (config.id, collection)}.toMap}
+        Option {
+          newConfigList flatMap { collectionConfig =>
+            collectionConfig match {
+              case (config, Left(exception)) => {
+                log.warn("Updating ID %s failed".format(config.id))
+                oldConfigMap.flatMap{_.get(config.id).map(oldCollection => (config, oldCollection))}
+              }
+              case (config, Right(newCollection)) => Some((config, newCollection))
             }
-            case (config, Right(newCollection)) => Some((config, newCollection))
           }
         }
       }
@@ -186,7 +188,7 @@ class PageFront(val id: String, edition: Edition) {
   def refresh() = query.refresh()
   def close() = query.close()
 
-  def apply(): FaciaPage = FaciaPage(id, query.items)
+  def apply(): Option[FaciaPage] = query.items.map(FaciaPage(id, _))
 }
 
 trait ConfigAgent extends ExecutionContexts {

--- a/facia/app/controllers/front/Front.scala
+++ b/facia/app/controllers/front/Front.scala
@@ -37,7 +37,7 @@ class Front extends Logging {
       refreshPageFrontAgent()
     }) ++ pageFrontAgent().values.map{ agent => () => agent.refresh() }
 
-  def apply(path: String): FaciaPage = pageFrontAgent()(path)()
+  def apply(path: String): Option[FaciaPage] = pageFrontAgent().get(path).map(pageFront => pageFront())
 }
 
 object Front extends Front

--- a/facia/app/controllers/front/Front.scala
+++ b/facia/app/controllers/front/Front.scala
@@ -37,7 +37,7 @@ class Front extends Logging {
       refreshPageFrontAgent()
     }) ++ pageFrontAgent().values.map{ agent => () => agent.refresh() }
 
-  def apply(path: String): Option[FaciaPage] = pageFrontAgent().get(path).map(pageFront => pageFront())
+  def apply(path: String): Option[FaciaPage] = pageFrontAgent().get(path).flatMap(pageFront => pageFront())
 }
 
 object Front extends Front


### PR DESCRIPTION
This changes the following:
- If there has been no attempt to load a config.json yet, then this will be a 404.
- If a config.json file is empty (Empty array []), then an empty page will show, 200.

This also removes the film switch and the film route from facia.
@gklopper @stephanfowler 
