### PR TITLE
Make the url for the facia load test absolute to the current location

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/facia-load.js
+++ b/common/app/assets/javascripts/modules/experiments/facia-load.js
@@ -6,7 +6,7 @@ define([
 
     return function() {
         ajax({
-            url: '/facia' + window.location.pathname,
+            url: 'http://' + window.location.host + '/facia' + window.location.pathname,
             type: 'text' // don't parse
         }).always(function(resp) {
             resp = null; // help the garbage collector?


### PR DESCRIPTION
We want to hit the non .json endpoint, which does not return any Access-Control-Allow-Origin, so our call gets blocked.

We have exposed facia under the same domain so this is why we have switched to an absolute ajax request.
