### PR TITLE
Fix bug in presentation of A/B test results

### DIFF
--- a/admin/app/tools/charts/ABTestResultGraph.scala
+++ b/admin/app/tools/charts/ABTestResultGraph.scala
@@ -51,7 +51,9 @@ trait ABTestResultGraph extends Chart with implicits.Dates {
       }
     }
 
-    groupedData.toList map {
+    groupedData.toList.sortBy {
+      case (day, _) => day
+    } map {
       case (dayOfEpoch, durations) => DataPoint(Epoch.day(dayOfEpoch).toString("dd/MM"), durations)
     }
   }

--- a/admin/test/tools/charts/ABTestResultGraphTest.scala
+++ b/admin/test/tools/charts/ABTestResultGraphTest.scala
@@ -15,11 +15,10 @@ class ABTestResultGraphTest extends FeatureSpec with ShouldMatchers {
     }
 
     val data = List(
-      (1537, "control", 34167.3),
-      (1534, "control", 17.3),
+      (1524, "control", 17.3),
       (1534, "B", 27.3),
+      (1537, "control", 34167.3),
       (1534, "A", 7.3),
-      (1533, "A", 12.1234),
       (1536, "B", 45.45541),
       (1533, "control", 112.1234),
       (1533, "B", 1112.1234),
@@ -29,7 +28,23 @@ class ABTestResultGraphTest extends FeatureSpec with ShouldMatchers {
       (1536, "control", 451.4554),
       (1536, "A", 45.4554),
       (1537, "A", 54167.3),
-      (1537, "B", 1687.3)
+      (1537, "B", 1687.3),
+      (1533, "A", 12.1234),
+      (1534, "control", 17.3),
+      (1524, "B", 27.3),
+      (1527, "control", 34167.3),
+      (1524, "A", 7.3),
+      (1526, "B", 45.45541),
+      (1523, "control", 112.1234),
+      (1523, "B", 1112.1234),
+      (1525, "A", 3.2345),
+      (1525, "B", 23.234),
+      (1525, "control", 3.234),
+      (1526, "control", 451.4554),
+      (1526, "A", 45.4554),
+      (1527, "A", 54167.3),
+      (1527, "B", 1687.3),
+      (1523, "A", 12.1234)
     )
 
     scenario("Labels") {
@@ -38,6 +53,11 @@ class ABTestResultGraphTest extends FeatureSpec with ShouldMatchers {
 
     scenario("Dataset") {
       val dataset = List(
+        DataPoint("04/03", List(112.1234, 12.1234, 1112.1234)),
+        DataPoint("05/03", List(17.3, 7.3, 27.3)),
+        DataPoint("06/03", List(3.234, 3.2345, 23.234)),
+        DataPoint("07/03", List(451.4554, 45.4554, 45.45541)),
+        DataPoint("08/03", List(34167.3, 54167.3, 1687.3)),
         DataPoint("14/03", List(112.1234, 12.1234, 1112.1234)),
         DataPoint("15/03", List(17.3, 7.3, 27.3)),
         DataPoint("16/03", List(3.234, 3.2345, 23.234)),


### PR DESCRIPTION
The fixtures in ABTestResultGraphTest somehow didn't catch the fact that days can be plotted in the wrong order in the results of A/B tests.  This change should fix the problem.
