### PR TITLE
Prefix main-site-link with js-

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -228,7 +228,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         import browser._
 
         Then("I should see a link to the corresponding desktop article")
-        findFirst(".main-site-link").getAttribute("href") should be("http://localhost:9000/environment/2012/feb/22/capitalise-low-carbon-future?view=desktop")
+        findFirst(".js-main-site-link").getAttribute("href") should be("http://localhost:9000/environment/2012/feb/22/capitalise-low-carbon-future?view=desktop")
       }
     }
 
@@ -239,7 +239,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         import browser._
 
         Then("I should see a link to the corresponding desktop article")
-        findFirst(".main-site-link").getAttribute("href") should
+        findFirst(".js-main-site-link").getAttribute("href") should
           be("http://localhost:9000/environment/2012/feb/22/capitalise-low-carbon-future?view=desktop")
       }
     }

--- a/common/app/assets/javascripts/modules/navigation/platform-switch.js
+++ b/common/app/assets/javascripts/modules/navigation/platform-switch.js
@@ -5,7 +5,7 @@ define([
     function (common, bean, Cookies) {
 
         function PlatformSwitch() {
-            var platformLinks = common.$g(".main-site-link");
+            var platformLinks = common.$g(".js-main-site-link");
             platformLinks.each(function (link) {
                 bean.on(link, "click", function (event) {
                     var expiryDays = 7;

--- a/common/app/views/fragments/mainSiteLink.scala.html
+++ b/common/app/views/fragments/mainSiteLink.scala.html
@@ -2,6 +2,6 @@
 @import common._
 @import model.MetaData
 
-<a class="main-site-link" rel="nofollow" href="@LinkTo{/@item.id}?view=desktop" data-link-name="desktop version @Edition(request).id - bottom of page">Desktop version</a>
+<a class="js-main-site-link" rel="nofollow" href="@LinkTo{/@item.id}?view=desktop" data-link-name="desktop version @Edition(request).id - bottom of page">Desktop version</a>
 
 

--- a/common/app/views/fragments/releaseMessage.scala.html
+++ b/common/app/views/fragments/releaseMessage.scala.html
@@ -6,7 +6,7 @@
         <p>
             You've opted in to an early release of the Guardian's new website.
             We'd love to hear your <a href="mailto:userhelp@@guardian.co.uk">feedback</a>.
-            You can also <a class="main-site-link" rel="nofollow" href="@LinkTo{/}?view=desktop">opt-out</a> and continue using the existing website.
+            You can also <a class="js-main-site-link" rel="nofollow" href="@LinkTo{/}?view=desktop">opt-out</a> and continue using the existing website.
         </p>
     </div> 
 }

--- a/common/test/assets/javascripts/runner.html
+++ b/common/test/assets/javascripts/runner.html
@@ -615,7 +615,7 @@
     <a class="au-test nav__link edition" data-link-name="switch to us edition" href="#edition-switch">US edition</a>
 
 <!-- PlatformSwitch.spec -->
-<a class="main-site-link" href="#foo"></a>
+<a class="js-main-site-link" href="#foo"></a>
 
 </body>
 </html>

--- a/common/test/assets/javascripts/spec/PlatformSwitch.spec.js
+++ b/common/test/assets/javascripts/spec/PlatformSwitch.spec.js
@@ -7,7 +7,7 @@ define(['modules/navigation/platform-switch', 'modules/cookies', 'common', 'bean
         beforeEach(function() {
             Cookies.cleanUp(['GU_VIEW']);
 
-            common.$g('.main-site-link').each(function(link){
+            common.$g('.js-main-site-link').each(function(link){
                 bean.add(link, 'click', function(e) {
                     e.preventDefault();
                 });
@@ -17,7 +17,7 @@ define(['modules/navigation/platform-switch', 'modules/cookies', 'common', 'bean
         });
 
         it('should set the "view" cookie when switching to desktop view', function() {
-            var platformLink = document.querySelector(".main-site-link");
+            var platformLink = document.querySelector(".js-main-site-link");
 
             expect(document.cookie).not.toMatch(/GU_VIEW=desktop/);
 

--- a/football/test/FixturesFeatureTest.scala
+++ b/football/test/FixturesFeatureTest.scala
@@ -62,7 +62,7 @@ class FixturesFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatc
         import browser._
 
         Then("the 'Desktop version' link should point to '/football/fixtures?view=desktop'")
-        findFirst(".main-site-link").getAttribute("href") should be("http://localhost:9000/football/fixtures?view=desktop")
+        findFirst(".js-main-site-link").getAttribute("href") should be("http://localhost:9000/football/fixtures?view=desktop")
       }
 
       Given("I visit the fixtures page")
@@ -71,7 +71,7 @@ class FixturesFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatc
         import browser._
 
         Then("the 'Desktop version' link should point to '/football/fixtures?view=desktop'")
-        findFirst(".main-site-link").getAttribute("href") should be("http://localhost:9000/football/fixtures?view=desktop")
+        findFirst(".js-main-site-link").getAttribute("href") should be("http://localhost:9000/football/fixtures?view=desktop")
       }
 
     }

--- a/football/test/LiveMatchesFeatureTest.scala
+++ b/football/test/LiveMatchesFeatureTest.scala
@@ -42,7 +42,7 @@ class LiveMatchesFeatureTest extends FeatureSpec with GivenWhenThen with ShouldM
         import browser._
 
         Then("the 'Desktop version' link should point to '/football/live?view=desktop'")
-        findFirst(".main-site-link").getAttribute("href") should be("http://localhost:9000/football/live?view=desktop")
+        findFirst(".js-main-site-link").getAttribute("href") should be("http://localhost:9000/football/live?view=desktop")
       }
 
       Given("I visit the live page")
@@ -51,7 +51,7 @@ class LiveMatchesFeatureTest extends FeatureSpec with GivenWhenThen with ShouldM
         import browser._
 
         Then("the 'Desktop version' link should point to '/football/matches?view=desktop'")
-        findFirst(".main-site-link").getAttribute("href") should be("http://localhost:9000/football/live?view=desktop")
+        findFirst(".js-main-site-link").getAttribute("href") should be("http://localhost:9000/football/live?view=desktop")
       }
 
     }

--- a/football/test/ResultsFeatureTest.scala
+++ b/football/test/ResultsFeatureTest.scala
@@ -78,7 +78,7 @@ class ResultsFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         import browser._
 
         Then("the 'Desktop version' link should point to '/football/results?view=desktop'")
-        findFirst(".main-site-link").getAttribute("href") should be("http://localhost:9000/football/results?view=desktop")
+        findFirst(".js-main-site-link").getAttribute("href") should be("http://localhost:9000/football/results?view=desktop")
       }
 
       Given("I visit the results page")
@@ -87,7 +87,7 @@ class ResultsFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         import browser._
 
         Then("the 'Desktop version' link should point to '/football/results?view=desktop'")
-        findFirst(".main-site-link").getAttribute("href") should be("http://localhost:9000/football/results?view=desktop")
+        findFirst(".js-main-site-link").getAttribute("href") should be("http://localhost:9000/football/results?view=desktop")
       }
 
     }

--- a/front/test/FrontFeatureTest.scala
+++ b/front/test/FrontFeatureTest.scala
@@ -64,7 +64,7 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
           import browser._
 
           Then("I should see the link for the desktop site")
-          findFirst(".main-site-link").href should endWith("/uk?view=desktop")
+          findFirst(".js-main-site-link").href should endWith("/uk?view=desktop")
       }
     }
 
@@ -75,7 +75,7 @@ class FrontFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatcher
           import browser._
 
           Then("I should see the link for the desktop site")
-          findFirst(".main-site-link").href should endWith("/us?view=desktop")
+          findFirst(".js-main-site-link").href should endWith("/us?view=desktop")
       }
     }
 


### PR DESCRIPTION
The `main-site-link` class is used only for JS reasons (setting up a desktop cookie). Therefore it should be prefixed with `js-`.

![ ](http://s2.developerslife.ru/public/images/gifs/52525378-3364-42ae-9de8-52f881b7b952.gif)
