### PR TITLE
Remove extraneous commas in MVT tag for Omniture

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -103,12 +103,16 @@ define([
     }
 
     function makeOmnitureTag (config) {
-        var participations = getParticipations();
-        return Object.keys(participations).map(function (k) {
+        var participations = getParticipations(),
+            tag = [];
+
+        Object.keys(participations).forEach(function (k) {
             if (testCanBeRun(getTest(k), config)) {
-                return ['AB', k, participations[k].variant].join(' | ');
+                tag.push(['AB', k, participations[k].variant].join(' | '));
             }
-        }).join(',');
+        });
+
+        return tag.join(',');
     }
 
     // Finds variant in specific tests and runs it

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -181,7 +181,18 @@ define(['modules/experiments/ab', 'fixtures/ab-test'], function(ab, ABTest) {
                 ab.segment(switches.both_tests_on);
                 ab.run(switches.both_tests_on);
                 expect(ab.makeOmnitureTag(switches.both_tests_on)).toBe("AB | DummyTest | control,AB | DummyTest2 | control");
-        
+
+            });
+
+            it('should generate Omniture tags when there is two tests, but one cannot run', function() {
+                Math.seedrandom('gu');
+                test.one.canRun = function() { return false; }
+                ab.addTest(test.one);
+                test.two.audience = 1;
+                ab.addTest(test.two);
+                ab.segment(switches.both_tests_on);
+                ab.run(switches.both_tests_on);
+                expect(ab.makeOmnitureTag(switches.both_tests_on)).toBe("AB | DummyTest2 | control");
             });
             
             it('should not generate Omniture tags when a test can not be run', function() {


### PR DESCRIPTION
Fixes AB tests in Omniture being reported incorrectly

**Before:** 
`,AB | ExpandableMostPopular | expandable-most-popular,,,`

**After:**
`AB | ExpandableMostPopular | expandable-most-popular`
