### PR TITLE
Prevent UTF-7 Cross Scripting Attacks

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -4,7 +4,6 @@
 @import conf._
 @import Switches._
 
-    <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
     @* https://support.google.com/plus/answer/1713826 *@

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html class="js-off" lang="en-GB">
 <head>
+    <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>
     @fragments.metaData(metaData)
     @fragments.commonCssSetup()


### PR DESCRIPTION
The `<meta charset>` attribute sets the character encoding of an HTML document. It is extremely important that you explicitly declare the encoding of every HTML document; failing to do so will cause browsers to guess the encoding, which can lead to cross-site scripting attacks if they guess incorrectly.

In order for all browsers to recognize a `<meta charset>` declaration, it must be:
- Within the `<head>` element,
- Before any elements that contain text, such as the `<title>` element, AND
- Within the first 512 bytes of your document, including DOCTYPE and whitespace.
- This patch simply places the `<meta charset>` tag above the `<title>` tag, instead of below it

Source: https://code.google.com/p/doctype-mirror/wiki/MetaCharsetAttribute

![ ](http://s2.developerslife.ru/public/images/gifs/14912644-8e1e-499f-b4d0-988bab40a580.gif)
