### PR TITLE
Extend deploy timeout to 20 minutes

### DIFF
--- a/admin/conf/deploy.json
+++ b/admin/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::front" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/applications/conf/deploy.json
+++ b/applications/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::applications" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/article/conf/deploy.json
+++ b/article/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::article" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/core-navigation/conf/deploy.json
+++ b/core-navigation/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::core-navigation" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/diagnostics/conf/deploy.json
+++ b/diagnostics/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::diagnostics" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/discussion/conf/deploy.json
+++ b/discussion/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::discussion" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/facia/conf/deploy.json
+++ b/facia/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::facia" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/football/conf/deploy.json
+++ b/football/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::football" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/front/conf/deploy.json
+++ b/front/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::front" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/identity/conf/deploy.json
+++ b/identity/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::identity" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/image/conf/deploy.json
+++ b/image/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::image" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/interactive/conf/deploy.json
+++ b/interactive/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::interactive" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/porter/conf/deploy.json
+++ b/porter/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::porter" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/router/conf/deploy.json
+++ b/router/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::router" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/sport/conf/deploy.json
+++ b/sport/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::sport" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",

--- a/style-guide/conf/deploy.json
+++ b/style-guide/conf/deploy.json
@@ -4,7 +4,7 @@
             "type":"asg-elb",
             "apps":[ "frontend::style-guide" ],
             "data":{
-                "secondsToWait":900,
+                "secondsToWait":1200,
                 "port":18080,
                 "healthcheckGrace":20,
                 "bucket":"aws-frontend-artifacts",


### PR DESCRIPTION
This could help deploys which encounter a failed box, and require an additional cycle of -unhealthy-terminate-pending for another box.
