### PR TITLE
BEMify article child components

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -10,7 +10,7 @@
     <article class="js-gallery article gallery-page" itemprop="mainContentOfPage"
          itemscope itemtype="@gallery.schemaType" role="main">
         <div class="article__main-column">
-            <header class="article-head">
+            <header class="article__head">
                 @fragments.dateline(gallery.webPublicationDate, gallery.isLive)
                 @fragments.headline(gallery.headline)
             </header>

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -11,7 +11,7 @@
         <article id="article" class="article video @if(video.isLive){is-live}" itemprop="mainContentOfPage"
                  itemscope itemtype="@video.schemaType" role="main">
             <div class="article__main-column">
-                <header class="article-head">
+                <header class="article__head">
                     @fragments.dateline(video.webPublicationDate, video.isLive)
                     @fragments.headline(video.headline)
                 </header>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -11,7 +11,7 @@
         <article id="article" class="article @if(article.isLive){is-live}"
             itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
             <div class="article-v2__inner">
-                <header class="article-head">
+                <header class="article__head">
                     @fragments.dateline(article.webPublicationDate)
 
                     @fragments.headline(article.headline)

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -11,7 +11,7 @@
         <article id="article" class="article @if(article.isLive){is-live}"
             itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
             <div class="article-v2__inner">
-                <header class="article-head">
+                <header class="article__head">
                     @fragments.dateline(article.webPublicationDate, article.isLive)
 
                     @fragments.headline(article.headline)

--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -116,8 +116,8 @@ define([
                     var options = { url: cricketMatchRefs[0],
                                 loadSummary: true,
                                 loadScorecard: true,
-                                summaryElement: '.article-headline',
-                                scorecardElement: '.article-headline',
+                                summaryElement: '.article__headline',
+                                scorecardElement: '.article__headline',
                                 summaryManipulation: 'after',
                                 scorecardManipulation: 'after' };
                     Cricket.cricketArticle(config, context, options);

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -36,7 +36,7 @@
     padding-top: $baseline*3;
 }
 
-.article-headline {
+.article__headline {
     @extend %type-3;
     margin-bottom: $baseline*2;
 

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -68,7 +68,7 @@
     }
 }
 
-.article-standfirst {
+.article__standfirst {
     margin-bottom: $baseline*4;
     text-rendering: optimizeLegibility;
 

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -32,7 +32,7 @@
     @extend %type-6;
 }
 
-.article-head {
+.article__head {
     padding-top: $baseline*3;
 }
 
@@ -183,7 +183,7 @@ video {
    ========================================================================== */
 
 @include mq(tablet) {
-    .article-head,
+    .article__head,
     .main-caption {
         padding-left: 0 !important;
         padding-right: 0 !important;
@@ -293,7 +293,7 @@ video {
     .article-v2__main-column {
         padding-left: $a-leftCol-width + $gs-gutter;
     }
-    .article-head {
+    .article__head {
         padding-top: $baseline*2;
         padding-bottom: $baseline*2;
     }

--- a/common/app/assets/stylesheets/module/experiments/_ab-expandable-trails.scss
+++ b/common/app/assets/stylesheets/module/experiments/_ab-expandable-trails.scss
@@ -11,7 +11,7 @@
 .trail__expander-trigger:checked {
     + .trail__expander-wrapper {
         .trail__headline {
-            @extend .article-headline;
+            @extend .article__headline;
         }
         .trail__expander-headline {
             float: none;

--- a/common/app/assets/stylesheets/module/nav/_localnav.scss
+++ b/common/app/assets/stylesheets/module/nav/_localnav.scss
@@ -24,7 +24,7 @@
 
     h2.article-zone:only-child,
     .parts__body > .article-zone,
-    .article-head > .article-zone,
+    .article__head > .article-zone,
     .section-head,
     .front-section:first-child .sub-section-head {
         display: none;

--- a/common/app/views/fragments/expiredBody.scala.html
+++ b/common/app/views/fragments/expiredBody.scala.html
@@ -7,7 +7,7 @@
 
     <article id="article" class="article" itemprop="mainContentOfPage" itemscope itemtype="@content.schemaType" role="main">
 
-        <header class="article-head">
+        <header class="article__head">
             @fragments.dateline(content.webPublicationDate, false)
             @fragments.headline(content.headline)
         </header>

--- a/common/app/views/fragments/headline.scala.html
+++ b/common/app/views/fragments/headline.scala.html
@@ -1,2 +1,2 @@
 @(headline: String, classes: List[String] = Nil)(implicit request: RequestHeader)
-<h1 itemprop="headline" class="article-headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>
+<h1 itemprop="headline" class="article__headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,7 +1,7 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
 @* live with empty standfirst as it is used to hook things into the page with javascript *@
-<p class="article-standfirst type-7" itemprop="description" data-link-name="standfirst">
+<p class="article__standfirst type-7" itemprop="description" data-link-name="standfirst">
     @content.standfirst.map { s =>
         @withJsoup(BulletCleaner(s))(
             InBodyLinkCleaner("in standfirst link")(Edition(request))

--- a/discussion/app/views/comments.scala.html
+++ b/discussion/app/views/comments.scala.html
@@ -7,7 +7,7 @@
 
         <div class="article-body">
             <header class="article__head">
-                <h1 class="article-headline">
+                <h1 class="article__headline">
                     <a href="@LinkTo{@page.contentUrl}">@Html(page.title)</a>
                 </h1>
             </header>

--- a/football/app/views/fragments/competitionsBody.scala.html
+++ b/football/app/views/fragments/competitionsBody.scala.html
@@ -16,7 +16,7 @@
         </section>
     }
 }
-<header class="article-head">
+<header class="article__head">
     <h2 class="article-zone type-1 sport-header">
         <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
     </h2>

--- a/football/app/views/fragments/footballMatchBody.scala.html
+++ b/football/app/views/fragments/footballMatchBody.scala.html
@@ -8,7 +8,7 @@
     </h2>
 
     <article class="article football-article @if(page.theMatch.isLive){is-live}" role="main">
-        <header class="article-head">
+        <header class="article__head">
             <p class="dateline type-11">
                 @fragments.status(page.theMatch)
                 <time data-timestamp="@page.theMatch.date.getMillis">

--- a/interactive/app/views/fragments/interactiveBody.scala.html
+++ b/interactive/app/views/fragments/interactiveBody.scala.html
@@ -13,7 +13,7 @@
         itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
         
         <div class="article__main-column">
-            <header class="article-head">
+            <header class="article__head">
                 @fragments.dateline(interactive.webPublicationDate, interactive.isLive)
                 @fragments.headline(interactive.headline)
                 @fragments.standfirst(interactive)

--- a/style-guide/app/views/styleGuide/modules.scala.html
+++ b/style-guide/app/views/styleGuide/modules.scala.html
@@ -8,7 +8,7 @@
             <h1 class="article-zone type-1">@metaData.webTitle</h1>
         </header>
 
-        <section id="article-header" class="u-cf">
+        <section id="article__header" class="u-cf">
 
             <h2 class="article-zone type-2 margin-bottom u-cf">Article header</h2>
 


### PR DESCRIPTION
This simply renames article child components to be inline with our [B.E.M naming conventions](https://github.com/guardian/frontend/wiki/CSS-guidelines#framework-specific-css-guidelines)
