### PR TITLE
Allow update of displayName of non existant collection

### DIFF
--- a/admin/app/model/frontsapi.scala
+++ b/admin/app/model/frontsapi.scala
@@ -119,6 +119,9 @@ trait UpdateActions {
       if (newBlock != block) {
         FrontsApi.putBlock(id, newBlock, identity)
       }
+    } getOrElse {
+      val newBlock = Block(id, None, Nil, None, DateTime.now.toString, identity.fullName, identity.email, updateTrailblock.config.displayName)
+      FrontsApi.putBlock(id, newBlock, identity)
     }
   }
 }


### PR DESCRIPTION
When updating a displayName for a collection that does not exist, it now gets created.

@stephanfowler @ironsidevsquincy 
