### PR TITLE
Active link state fix and removed unused CSS

### DIFF
--- a/common/app/assets/stylesheets/base/_base.scss
+++ b/common/app/assets/stylesheets/base/_base.scss
@@ -50,10 +50,6 @@ ul {
 }
 
 /* pasteup overrides */
-.zone-border {
-    padding-top: 0;
-}
-
 a:active {
     background-color: transparent;
 }

--- a/common/app/assets/stylesheets/base/_base.scss
+++ b/common/app/assets/stylesheets/base/_base.scss
@@ -48,8 +48,3 @@ ol,
 ul {
     list-style-position: inside;
 }
-
-/* pasteup overrides */
-a:active {
-    background-color: transparent;
-}

--- a/common/app/assets/stylesheets/base/_links.scss
+++ b/common/app/assets/stylesheets/base/_links.scss
@@ -1,8 +1,12 @@
 a {
     color: $linkBlue;
     text-decoration: none;
-}
-a:hover,
-a:focus {
-    text-decoration: underline;
+
+    &:hover,
+    &:focus {
+       text-decoration: underline;
+    }
+    &:active {
+        color: $darkBlue;
+    }
 }

--- a/common/app/assets/stylesheets/base/_links.scss
+++ b/common/app/assets/stylesheets/base/_links.scss
@@ -6,6 +6,3 @@ a:hover,
 a:focus {
     text-decoration: underline;
 }
-a:active {
-    color: $darkBlue;
-}

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -306,7 +306,12 @@ $keylineSize: 1px;
     background: #F6644F;
     text-align: center;
     color: white;
-    text-decoration: none;
+
+    &,
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
 
     &:after {
         content: "";


### PR DESCRIPTION
@phamann: not sure why there was a transparent background applied to :active states?

Also, we don't make use of the default active state of links anywhere. So I removed it so we can override link styles more easily.

Fixes a bug where the speech bubble would get underline text on hover.

![ ](http://s2.developerslife.ru/public/images/gifs/2ddc069f-c96b-4a66-b42b-427f3cef0b3f.gif)
