### PR TITLE
Release message

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -317,7 +317,7 @@ define([
         // display a flash message to devices over 600px who don't have the mobile cookie
         displayReleaseMessage: function (config) {
             var alreadyOptedIn = (Cookies.get('GU_VIEW') === 'mobile');
-            if (config.switches.releaseMessage && window.screen.width >= 600 &! alreadyOptedIn) {
+            if (config.switches.releaseMessage && !alreadyOptedIn && (window.screen.width >= 600)) {
                 
                 // un-hide the release message
                 common.$g('#header').addClass('js-release-message');
@@ -325,7 +325,7 @@ define([
                     el.className = el.className.replace('u-h', '');
                 });
 
-                // force the visitor in to the alpha release 
+                // force the visitor in to the alpha release
                 Cookies.add("GU_VIEW", "mobile", 365);
             }
         },

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -321,7 +321,7 @@ define([
 
             var alreadyOptedIn = !!userPrefs.get('releaseMessage');
 
-            if (config.switches.releaseMessage && !alreadyOptedIn && (detect.getBreakpoint() != 'mobile')) {
+            if (config.switches.releaseMessage && !alreadyOptedIn && (detect.getBreakpoint() !== 'mobile')) {
                
                 // un-hide the release message
                 common.$g('#header').addClass('js-release-message');

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -319,23 +319,29 @@ define([
         // display a flash message to devices over 600px who don't have the mobile cookie
         displayReleaseMessage: function (config) {
 
-            var alreadyOptedIn = !!userPrefs.get('releaseMessage');
+            var alreadyOptedIn = !!userPrefs.get('releaseMessage'),
+                releaseMessage = {
+                    show: function () {
+                        common.$g('#header').addClass('js-release-message');
+                        common.$g('.release-message').removeClass('u-h');
+                    },
+                    hide: function () {
+                        userPrefs.set('releaseMessage', true);
+                        common.$g('#header').removeClass('js-release-message');
+                        common.$g('.release-message').addClass('u-h');
+                    }
+                };
 
             if (config.switches.releaseMessage && !alreadyOptedIn && (detect.getBreakpoint() !== 'mobile')) {
-               
-                // un-hide the release message
-                common.$g('#header').addClass('js-release-message');
-                common.$g('.release-message').removeClass('u-h');
 
                 // force the visitor in to the alpha release for subsequent visits
                 Cookies.add("GU_VIEW", "mobile", 365);
                
-                bean.on(document, 'click', '.release-message-ack', function(e) {
-                    userPrefs.set('releaseMessage', true);
-                    common.$g('#header').removeClass('js-release-message');
-                    common.$g('.release-message').addClass('u-h');
-                });
+                releaseMessage.show();
                 
+                bean.on(document, 'click', '.release-message-ack', function(e) {
+                    releaseMessage.hide();
+                });
             }
         },
         

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -314,11 +314,19 @@ define([
             }
         },
 
-        displayReleaseMessage: function () {
-            if (window.screen.width >= 600) {
+        // display a flash message to devices over 600px who don't have the mobile cookie
+        displayReleaseMessage: function (config) {
+            var alreadyOptedIn = (Cookies.get('GU_VIEW') === 'mobile');
+            if (config.switches.releaseMessage && window.screen.width >= 600 &! alreadyOptedIn) {
+                
+                // un-hide the release message
+                common.$g('#header').addClass('js-release-message');
                 Array.prototype.forEach.call(document.querySelectorAll('.release-message'), function (el) {
                     el.className = el.className.replace('u-h', '');
                 });
+
+                // force the visitor in to the alpha release 
+                Cookies.add("GU_VIEW", "mobile", 365);
             }
         },
         
@@ -385,7 +393,7 @@ define([
             modules.transcludeCommentCounts();
             modules.initLightboxGalleries();
             modules.optIn();
-            modules.displayReleaseMessage();
+            modules.displayReleaseMessage(config);
             modules.externalLinksCards();
         }
         common.mediator.emit("page:common:ready", config, context);

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -321,7 +321,7 @@ define([
 
             var alreadyOptedIn = !!userPrefs.get('releaseMessage');
 
-            if (config.switches.releaseMessage && !alreadyOptedIn && (window.screen.width >= 600)) {
+            if (config.switches.releaseMessage && !alreadyOptedIn && (detect.getBreakpoint() != 'mobile')) {
                
                 // un-hide the release message
                 common.$g('#header').addClass('js-release-message');

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -6,6 +6,7 @@ define([
     //Vendor libraries
     'domReady',
     'bonzo',
+    'bean',
     //Modules
     'modules/storage',
     'modules/detect',
@@ -44,6 +45,7 @@ define([
 
     domReady,
     bonzo,
+    bean,
 
     storage,
     detect,
@@ -316,17 +318,24 @@ define([
 
         // display a flash message to devices over 600px who don't have the mobile cookie
         displayReleaseMessage: function (config) {
-            var alreadyOptedIn = (Cookies.get('GU_VIEW') === 'mobile');
+
+            var alreadyOptedIn = !!userPrefs.get('releaseMessage');
+
             if (config.switches.releaseMessage && !alreadyOptedIn && (window.screen.width >= 600)) {
-                
+               
                 // un-hide the release message
                 common.$g('#header').addClass('js-release-message');
-                Array.prototype.forEach.call(document.querySelectorAll('.release-message'), function (el) {
-                    el.className = el.className.replace('u-h', '');
-                });
+                common.$g('.release-message').removeClass('u-h');
 
-                // force the visitor in to the alpha release
+                // force the visitor in to the alpha release for subsequent visits
                 Cookies.add("GU_VIEW", "mobile", 365);
+               
+                bean.on(document, 'click', '.release-message-ack', function(e) {
+                    userPrefs.set('releaseMessage', true);
+                    common.$g('#header').removeClass('js-release-message');
+                    common.$g('.release-message').addClass('u-h');
+                });
+                
             }
         },
         

--- a/common/app/assets/stylesheets/base/_links.scss
+++ b/common/app/assets/stylesheets/base/_links.scss
@@ -9,3 +9,8 @@ a:focus {
 a:active {
     color: $darkBlue;
 }
+
+a.u-underline {
+    text-decoration: underline;
+}
+

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -17,6 +17,10 @@ $headerHeight: 58px;
 /* Global header and navigation
    ========================================================================== */
 
+#header.js-release-message {
+    top: auto
+}
+
 #header {
     min-height: $headerHeight;
     position: absolute;

--- a/common/app/assets/stylesheets/module/_release-message.scss
+++ b/common/app/assets/stylesheets/module/_release-message.scss
@@ -1,3 +1,3 @@
 .release-message {
-    padding-top: 22px;  /* vertical spacing at the top of the article is a bit shot, so this is a bit aligned by skill of eye */
+    padding: 22px;  /* vertical spacing at the top of the article is a bit shot, so this is a bit aligned by skill of eye */
 }

--- a/common/app/views/fragments/releaseMessage.scala.html
+++ b/common/app/views/fragments/releaseMessage.scala.html
@@ -5,8 +5,9 @@
     <div class="release-message u-h monocolumn-wrapper type-7">
         <p>
             You've opted in to an early release of the Guardian's new website.
-            We'd love to hear your <a href="mailto:userhelp@@guardian.co.uk">feedback</a>.
-            You can also <a class="js-main-site-link" rel="nofollow" href="@LinkTo{/}?view=desktop">opt-out</a> and continue using the existing website.
+            We'd love to hear your <a href="mailto:userhelp@@guardian.co.uk" class="u-underliner">feedback</a>.
+            You can also <a class="js-main-site-link" rel="nofollow" href="@LinkTo{/}?view=desktop" class="u-underline">opt-out</a> and
+            continue using the existing website. <a class="release-message-ack">Hide this message</a>.
         </p>
     </div> 
 }

--- a/common/app/views/fragments/releaseMessage.scala.html
+++ b/common/app/views/fragments/releaseMessage.scala.html
@@ -7,7 +7,7 @@
             You've opted in to an early release of the Guardian's new website.
             We'd love to hear your <a href="mailto:userhelp@@guardian.co.uk" class="u-underliner">feedback</a>.
             You can also <a class="js-main-site-link" rel="nofollow" href="@LinkTo{/}?view=desktop" class="u-underline">opt-out</a> and
-            continue using the existing website. <a class="release-message-ack">Hide this message</a>.
+            continue using the existing website. <a class="release-message-ack" data-link-name="hide release message">Hide this message</a>.
         </p>
     </div> 
 }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -14,6 +14,7 @@
 </head>
 <body id="top" class="zone-@metaData.section" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
 
+    @fragments.releaseMessage()
     @fragments.header(metaData)
 
     <div id="preloads">
@@ -24,7 +25,6 @@
                         @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="x54")
                     </div>
                     <div class="parts__body">
-                        @fragments.releaseMessage()
                         @body
                     </div>
                     <div class="parts__foot">


### PR DESCRIPTION
- Displays to all viewports above mobile above the global header
- Allows users to hide the message (which persists in localStorage)
- Pug ugly - needs some design love.

/cc @kungpochicken 

![gu-release-message](https://f.cloud.github.com/assets/84996/1172431/33378e8a-2121-11e3-81ff-c01beae48f17.gif)
