### PR TITLE
Added prop67 to Omniture.

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -141,6 +141,8 @@ define([
 
             s.prop65    = config.page.headline || '';
 
+            s.prop67    = "nextgen-served";
+
             s.prop68    = detect.getConnectionSpeed(w.performance, null, true);
 
             if (config.page.webPublicationDate) {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -336,6 +336,7 @@ object OmnitureAnalyticsData {
       ("c14", data("build-number")),
       ("c19", platform),
       ("v19", platform),
+      ("v67", "nextgen-served"),
       ("c30", (if (isContent) "content" else "non-content")),
       ("c56", jsSupport)
     )

--- a/common/test/assets/javascripts/spec/Omniture.spec.js
+++ b/common/test/assets/javascripts/spec/Omniture.spec.js
@@ -83,6 +83,7 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
             expect(s.prop56).toBe("Javascript");
             expect(s.prop30).toBe("content");
             expect(s.prop19).toBe("frontend");
+            expect(s.prop67).toBe("nextgen-served");
             expect(s.eVar19).toBe("frontend");
             expect(s.cookieDomainPeriods).toBe("2")
             expect(s.trackingServer).toBe("hits.theguardian.com");


### PR DESCRIPTION
This property basically says that the page was served by next-gen. I know that in this context it is the same as prop17, but the corresponding R2 change will work with this to show us the things we do not serve.
