### PR TITLE
Secure assets can be enabled via SecureAssetsPlugin

### DIFF
--- a/common/app/assets/AssetsPlugin.scala
+++ b/common/app/assets/AssetsPlugin.scala
@@ -32,6 +32,8 @@ object `package` {
 }
 
 class AssetsPlugin(val app: Application) extends Plugin with Logging {
+  val secure = false
+
   override def onStart() {
     // Trap: The following has global application and may interfere with caching on non-local fetching
     // http://stackoverflow.com/questions/1374438/disappearing-jar-entry-when-loading-using-spi
@@ -41,13 +43,16 @@ class AssetsPlugin(val app: Application) extends Plugin with Logging {
 
   private val reloadAssetMapsOnAccess = app.mode == Mode.Dev
 
-  def getAssetMappings(base: String = ""): String => String = reloadAssetMapsOnAccess match {
-    case true =>
-      asset: String => loadAssetMappings(base)(asset)
+  def getAssetMappings(base: String = "", secureBase: String = ""): String => String = {
+    val assetBase = if (secure) secureBase else base
+    reloadAssetMapsOnAccess match {
+      case true =>
+        asset: String => loadAssetMappings(assetBase)(asset)
 
-    case false =>
-      val cachedMappings = loadAssetMappings(base)
-      asset: String => cachedMappings(asset)
+      case false =>
+        val cachedMappings = loadAssetMappings(assetBase)
+        asset: String => cachedMappings(asset)
+    }
   }
 
   private def loadAssetMappings(base: String = ""): Map[String, String] = {
@@ -91,4 +96,8 @@ class AssetsPlugin(val app: Application) extends Plugin with Logging {
 
     case _ => List()
   }
+}
+
+class SecureAssetsPlugin(app: Application) extends AssetsPlugin(app) {
+  override val secure = true
 }

--- a/common/app/common/StaticAssets.scala
+++ b/common/app/common/StaticAssets.scala
@@ -2,15 +2,17 @@ package common
 
 import assets.AssetsPlugin
 import play.api.Play
+import play.api.mvc.RequestHeader
 
-class StaticAssets(val base: String = "") extends Logging {
+class StaticAssets(val base: String = "", val secureBase: String = "") extends Logging {
 
   val plugin: AssetsPlugin = Play.current.plugin[AssetsPlugin] getOrElse {
     log.error("Trying to use Static without including AssetPlugin. Is your play.plugins correct?")
     throw new RuntimeException("Missing AssetPlugin.")
   }
 
-  val assetMappings: String => String = plugin.getAssetMappings(base)
+  val assetMappings: String => String = plugin.getAssetMappings(base, secureBase)
+
   def apply(path: String) = new StaticPath(assetMappings(path))
 }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -127,6 +127,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
   object assets {
     lazy val path = configuration.getMandatoryStringProperty("assets.path")
+    lazy val securePath = configuration.getMandatoryStringProperty("assets.securePath")
   }
 
   object oas {

--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -14,6 +14,6 @@ object SwitchingContentApi {
   def apply() = if (Switches.ElasticSearchSwitch.isSwitchedOn) ElasticSearchContentApi else ContentApi
 }
 
-object Static extends StaticAssets(Configuration.assets.path)
+object Static extends StaticAssets(Configuration.assets.path, Configuration.assets.securePath)
 
 object RequestMeasurementMetrics extends RequestMetrics.Standard

--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -1,4 +1,4 @@
-@()
+@()(implicit request: RequestHeader)
 <!--[if (gt IE 8) | (IEMobile)]><!-->
 <style type="text/css">
     @Html(Head.css)

--- a/common/app/views/fragments/loadCss.scala.html
+++ b/common/app/views/fragments/loadCss.scala.html
@@ -1,4 +1,4 @@
-@()
+@()(implicit request: RequestHeader)
 @import conf.Switches._
 
 @if(CssFromStorageSwitch.isSwitchedOn) {

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -3,6 +3,7 @@
 #
 
 assets.path=http://aws-frontend-static.s3.amazonaws.com/CODE/frontend-static/
+assets.securePath=https://aws-frontend-static.s3.amazonaws.com/CODE/frontend-static/
 images.path=http://i.gucode.co.uk
 static.path=http://static.guim.co.uk
 

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -3,6 +3,7 @@
 #
 
 assets.path=/assets/
+assets.securePath=/assets/
 images.path=http://i.gucode.co.uk
 static.path=http://static.guim.co.uk
 

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -5,6 +5,7 @@
 #This is for TeamCity
 
 assets.path=/assets/
+assets.securePath=/assets/
 images.path=http://i.gucode.co.uk
 static.path=http://static.guim.co.uk
 

--- a/common/conf/env/GUDEV.properties
+++ b/common/conf/env/GUDEV.properties
@@ -5,6 +5,7 @@
 #This is for TeamCity
 
 assets.path=/assets/
+assets.securePath=/assets/
 images.path=http://i.gucode.co.uk
 static.path=http://static.guim.co.uk
 

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -2,6 +2,7 @@
 # This is a publicly hosted file - no passwords or keys
 #
 assets.path=http://assets.guim.co.uk/
+assets.securePath=https://assets-secure.guim.co.uk/
 images.path=http://i.guim.co.uk
 static.path=http://static.guim.co.uk
 

--- a/identity/conf/play.plugins
+++ b/identity/conf/play.plugins
@@ -1,4 +1,4 @@
 100:conf.SwitchBoardPlugin
 
-1000:assets.AssetsPlugin
+1000:assets.SecureAssetsPlugin
 1000:com.gu.management.play.InternalManagementPlugin


### PR DESCRIPTION
Assets plugin is now passed the new secure and insecure configuration properties. The secure version of the plugin will use the former when it constructs asset paths.

The Identity project has been updated to use this new plugin.

Note:
The corresponding static.path property appears to be unused in the application but a similar approach may be required if static components start to get added to common.
