### PR TITLE
Add geolocation to idapi registration calls

### DIFF
--- a/identity/app/Global.scala
+++ b/identity/app/Global.scala
@@ -1,10 +1,11 @@
 import com.google.inject.Guice
 import conf.{TestModule, DevModule, RequestMeasurementMetrics, ProdModule}
+import filters.HeaderLoggingFilter
 import play.api.mvc.WithFilters
 import play.api.{Mode, Play}
 import play.api.Play.current
 
-object Global extends WithFilters(RequestMeasurementMetrics.asFilters: _*) {
+object Global extends WithFilters(HeaderLoggingFilter :: RequestMeasurementMetrics.asFilters: _*) {
   private lazy val injector = {
     val module =
       Play.mode match {

--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -53,7 +53,7 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
         case(email, username, password, gnmMarketing, thirdPartyMarketing) => {
           val user = userCreationService.createUser(email, username, password, gnmMarketing, thirdPartyMarketing)
           Async {
-            api.register(user, omnitureData) map ( _ match {
+            api.register(user, omnitureData, Some(request.remoteAddress)) map ( _ match {
               case Left(errors) => {
                 val formWithError = errors.foldLeft(boundForm) {  (form, error) =>
                   error match {

--- a/identity/app/filters/HeaderLoggingFilter.scala
+++ b/identity/app/filters/HeaderLoggingFilter.scala
@@ -1,0 +1,28 @@
+package filters
+
+import play.api.mvc._
+import utils.SafeLogging
+import common.ExecutionContexts
+
+
+object HeaderLoggingFilter extends Filter with SafeLogging with ExecutionContexts {
+  def apply(next: (RequestHeader) => Result)(rh: RequestHeader) = {
+    def logHeaders(result: PlainResult): Result = {
+      if(logger.isDebugEnabled) {
+        val headerStr = rh.headers.keys
+          .filterNot(name => "Cookie" == name || "User-Agent" == name || "Authorization" == name)
+          .flatMap(headerKey => {
+            rh.headers.getAll(headerKey).map(value => s"$headerKey=$value")
+          })
+          .mkString("&")
+        logger.debug(s"Request headers: $headerStr")
+      }
+      result
+    }
+
+    next(rh) match {
+      case plain: PlainResult => logHeaders(plain)
+      case async: AsyncResult => async.transform(logHeaders)
+    }
+  }
+}

--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -82,7 +82,7 @@ abstract class IdApi(apiRootUrl: String, http: Http, jsonBodyParser: JsonBodyPar
     val userData = write(user)
     val response = http.POST(apiUrl("user"), Some(userData),
       clientAuth.parameters ++ trackingParameters.parameters,
-      clientAuth.headers ++ clientIp.map(ip => Iterable("X-GU-ID-IP" -> ip)).getOrElse(Iterable.empty)
+      clientAuth.headers ++ clientIp.map(ip => Iterable("X-GU-ID-REMOTE-IP" -> ip)).getOrElse(Iterable.empty)
     )
     response map jsonBodyParser.extract[User](jsonField("user"))
   }

--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -78,9 +78,12 @@ abstract class IdApi(apiRootUrl: String, http: Http, jsonBodyParser: JsonBodyPar
     response map jsonBodyParser.extract[Unit]({_ => JNothing})
   }
 
- def register(user: User, trackingParameters : OmnitureTracking): Future[Response[User]] = {
+ def register(user: User, trackingParameters : OmnitureTracking, clientIp: Option[String]): Future[Response[User]] = {
     val userData = write(user)
-    val response = http.POST(apiUrl("user"), Some(userData), clientAuth.parameters ++ trackingParameters.parameters)
+    val response = http.POST(apiUrl("user"), Some(userData),
+      clientAuth.parameters ++ trackingParameters.parameters,
+      clientAuth.headers ++ clientIp.map(ip => Iterable("X-GU-ID-IP" -> ip)).getOrElse(Iterable.empty)
+    )
     response map jsonBodyParser.extract[User](jsonField("user"))
   }
 

--- a/identity/app/services/RemoteAddress.scala
+++ b/identity/app/services/RemoteAddress.scala
@@ -1,0 +1,22 @@
+package services
+
+import play.api.mvc.{Request, AnyContent}
+import common.Logging
+
+trait RemoteAddress extends Logging {
+  private val Ip = """(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})""".r
+
+  def clientIp(request: Request[AnyContent]): Option[String] = {
+    request.headers.get("X-Forwarded-For").flatMap { xForwardedFor =>
+      xForwardedFor.split(", ").find {  // leftmost non-private IP from header is client
+        case Ip(a, b, c, d) => {
+          if ("10" == a) false
+          else if ("192" == a && "168" == b) false
+          else if ("172" == a && (16 to 31).map(_.toString).contains(b)) false
+          else true
+        }
+        case _ => false
+      }
+    }
+  }
+}

--- a/identity/app/utils/IdentitySafeLogging.scala
+++ b/identity/app/utils/IdentitySafeLogging.scala
@@ -28,6 +28,7 @@ class IdentitySafeLogger(wrappedLogger: LocationAwareLogger, classname : String)
         getVariableMatcher("email"),
         getVariableMatcher("trackingUserAgent"),
         getVariableMatcher("trackingIpAddress"),
+        getVariableMatcher("Authorization"),
         jsonStringMatcher("token"),
         jsonStringMatcher("accessToken"),
         jsonStringMatcher("password"),

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -51,5 +51,3 @@ play {
     }
 
 }
-
-trustxforwarded=true

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -52,3 +52,4 @@ play {
 
 }
 
+trustxforwarded=true

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -7,7 +7,7 @@ import test.{TestRequest, Fake}
 import idapiclient.{EmailPassword, OmnitureTracking, IdApiClient}
 import services._
 import play.api.test.Helpers._
-import play.api.test.FakeRequest
+import play.api.test.{FakeHeaders, FakeRequest}
 import com.gu.identity.model.User
 import org.mockito.Mockito._
 import org.mockito.Matchers
@@ -32,10 +32,13 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
   val identityRequest = IdentityRequest(omnitureData, Some("http://example.com/comeback"))
   val conf = new IdentityConfiguration
   val signinService = new PlaySigninService(conf)
+  when(userCreationService.createUser(Matchers.any[String], Matchers.any[String], Matchers.any[String], Matchers.any[Boolean], Matchers.any[Boolean]))
+    .thenReturn(user)
 
 
   val registrationController = new RegistrationController(returnUrlVerifier, userCreationService, api, requestParser, urlBuilder, signinService)
   when(requestParser.apply(Matchers.anyObject())).thenReturn(identityRequest)
+  val testIp = "127.0.0.1"
 
 
   "the renderRegistrationForm" - {
@@ -47,10 +50,12 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
 
   "the process Registration method " - {
     "should not handle incomplete data" - {
-      val badFakeRequest = FakeRequest(POST, "/register").withFormUrlEncodedBody("user.primaryEmailAddress" -> "test@example.com")
+      val badFakeRequest = FakeRequest(POST, "/register")
+        .withFormUrlEncodedBody("user.primaryEmailAddress" -> "test@example.com")
+        .withHeaders("X-Forwarded-For" -> testIp)
       "so the api is not called" in Fake {
         registrationController.processForm()(badFakeRequest)
-        verify(api, never).register(Matchers.any[User], Matchers.same(omnitureData))
+        verify(api, never).register(Matchers.any[User], Matchers.same(omnitureData), Matchers.any[Option[String]])
       }
    }
 
@@ -59,8 +64,10 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
       val username = "username"
       val password = "password"
       val auth = EmailPassword(email, password)
-      val fakeRequest = FakeRequest(POST, "/register").withFormUrlEncodedBody("user.primaryEmailAddress" -> email, "user.publicFields.username" -> username, "user.password" -> password )
-      when(api.register(user, omnitureData)).thenReturn(Future.successful(Right(createdUser)))
+      val fakeRequest = FakeRequest(POST, "/register")
+        .withFormUrlEncodedBody("user.primaryEmailAddress" -> email, "user.publicFields.username" -> username, "user.password" -> password )
+        .withHeaders("X-Forwarded-For" -> testIp)
+      when(api.register(user, omnitureData, Some(testIp))).thenReturn(Future.successful(Right(createdUser)))
       when(api.authBrowser(EmailPassword(email, password), omnitureData)).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("testCookie", "testVal"), CookieResponse("SC_testCookie", "secureVal"))))))
 
       "should create the user with the username, email and password required" in Fake {
@@ -77,12 +84,17 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
 
       "should pass the created user to the api object to the api" in Fake {
         registrationController.processForm()(fakeRequest)
-        verify(api).register(Matchers.same(user), Matchers.anyObject())
+        verify(api).register(Matchers.same(user), Matchers.anyObject(), Matchers.anyObject())
       }
 
       "shuold pass the the omniture data to the the api" in Fake {
         registrationController.processForm()(fakeRequest)
-        verify(api).register(Matchers.anyObject(), Matchers.same(omnitureData))
+        verify(api).register(Matchers.anyObject(), Matchers.same(omnitureData), Matchers.anyObject())
+      }
+
+      "shoud pass the X-Forwarded-For header's value as the registration IP" in Fake {
+        registrationController.processForm()(fakeRequest)
+        verify(api).register(Matchers.anyObject(), Matchers.anyObject(), Matchers.eq(Some(testIp)))
       }
 
       "should try to sign the user in after registration" ignore  {
@@ -110,14 +122,16 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
     }
 
     "with an invalid api response" - {
-      val fakeRequest = FakeRequest(POST, "/register").withFormUrlEncodedBody("user.primaryEmailAddress" -> "test@example.com", "user.publicFields.username" -> "username", "user.password" -> "password" )
+      val fakeRequest = FakeRequest(POST, "/register")
+        .withFormUrlEncodedBody("user.primaryEmailAddress" -> "test@example.com", "user.publicFields.username" -> "username", "user.password" -> "password" )
+        .withHeaders("X-Forwarded-For" -> testIp)
       val badPassword = List(Error("Invalid password:", "Password should be between 6 and 20 characters long:", 500, Some("user.password")))
 
-     when(api.register(user, omnitureData)).thenReturn(Future.successful(Left(badPassword)))
+     when(api.register(user, omnitureData, Some(testIp))).thenReturn(Future.successful(Left(badPassword)))
 
      "there is no attempt to sign the user in" in Fake {
         registrationController.processForm()(fakeRequest)
-        verify(api).register(Matchers.anyObject(), Matchers.same(omnitureData))
+        verify(api).register(Matchers.anyObject(), Matchers.same(omnitureData), Matchers.anyObject())
         verifyNoMoreInteractions(api)
      }
    }
@@ -126,10 +140,12 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
 
       val email = "test@example.com"
       val password = "password"
-      val fakeRequest = FakeRequest(POST, "/register").withFormUrlEncodedBody("user.primaryEmailAddress" -> email, "user.publicFields.username" -> "username", "user.password" -> password )
+      val fakeRequest = FakeRequest(POST, "/register")
+        .withFormUrlEncodedBody("user.primaryEmailAddress" -> email, "user.publicFields.username" -> "username", "user.password" -> password )
+        .withHeaders("X-Forwarded-For" -> testIp)
       val errors = List(Error("Message", "Description", 500, Some("Context")))
 
-      when(api.register(user, omnitureData)).thenReturn(Future.successful(Right(createdUser)))
+      when(api.register(user, omnitureData, Some(testIp))).thenReturn(Future.successful(Right(createdUser)))
       when(api.authBrowser(EmailPassword(email, password), omnitureData)).thenReturn(Future.successful(Left(errors)))
       when(returnUrlVerifier.getVerifiedReturnUrl(fakeRequest)).thenReturn(Some("http://example.com/return"))
 

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -401,7 +401,7 @@ class IdApiTest extends path.FreeSpec with ShouldMatchers with MockitoSugar {
 
       "passes the user's IP details as provided" in {
         api.register(user, trackingParameters, Some("127.0.0.1"))
-        verify(http).POST(Matchers.any[String], Matchers.eq(Some(expectedPostData)), Matchers.any[Parameters], argThat(new ParamsIncludes(Iterable("X-GU-ID-IP" -> "127.0.0.1"))))
+        verify(http).POST(Matchers.any[String], Matchers.eq(Some(expectedPostData)), Matchers.any[Parameters], argThat(new ParamsIncludes(Iterable("X-GU-ID-REMOTE-IP" -> "127.0.0.1"))))
       }
     }
 

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -380,23 +380,28 @@ class IdApiTest extends path.FreeSpec with ShouldMatchers with MockitoSugar {
 
 
       "accesses the user endpoint" in {
-        api.register(user, trackingParameters)
+        api.register(user, trackingParameters, None)
         verify(http).POST(Matchers.eq("http://example.com/user"), Matchers.any[Option[String]], Matchers.any[Parameters], Matchers.any[Parameters])
       }
 
       "adds the client access token parameter to the request" in {
-        api.register(user, trackingParameters)
+        api.register(user, trackingParameters, None)
         verify(http).POST(Matchers.eq("http://example.com/user"), Matchers.any[Option[String]], argThat(new ParamsIncludes(Iterable(("accessToken", "clientAccessToken")))), Matchers.any[Parameters])
       }
 
       "adds the the omniture tracking data to the request" in {
-        api.register(user, trackingParameters)
+        api.register(user, trackingParameters, None)
         verify(http).POST(Matchers.eq("http://example.com/user"), Matchers.any[Option[String]], argThat(new ParamsIncludes(Iterable("tracking" -> "param"))), Matchers.any[Parameters])
       }
 
       "posts the user data to the endpoint" in {
-        api.register(user, trackingParameters)
+        api.register(user, trackingParameters, None)
         verify(http).POST(Matchers.any[String], Matchers.eq(Some(expectedPostData)), Matchers.any[Parameters], Matchers.any[Parameters])
+      }
+
+      "passes the user's IP details as provided" in {
+        api.register(user, trackingParameters, Some("127.0.0.1"))
+        verify(http).POST(Matchers.any[String], Matchers.eq(Some(expectedPostData)), Matchers.any[Parameters], argThat(new ParamsIncludes(Iterable("X-GU-ID-IP" -> "127.0.0.1"))))
       }
     }
 
@@ -404,7 +409,7 @@ class IdApiTest extends path.FreeSpec with ShouldMatchers with MockitoSugar {
       when(http.POST(Matchers.any[String], Matchers.any[Option[String]], Matchers.any[Parameters], Matchers.any[Parameters]))
         .thenReturn(toFuture(Left(errors)))
        "returns the errors" - {
-         api.register(user, trackingParameters).map(_ match {
+         api.register(user, trackingParameters, None).map(_ match {
            case Right(result) => fail("Got Right(%s), instead of expected Left".format(result.toString))
            case Left(responseErrors) => {
              responseErrors should equal(errors)

--- a/identity/test/services/RemoteAddressTest.scala
+++ b/identity/test/services/RemoteAddressTest.scala
@@ -1,0 +1,33 @@
+package services
+
+import org.scalatest.FunSuite
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import org.scalatest.matchers.ShouldMatchers
+
+class RemoteAddressTest extends FunSuite with ShouldMatchers {
+  object TestRemoteAddress extends RemoteAddress
+
+  val xFor = "X-Forwarded-For"
+  def fakeRequest(xForHeader: String) = FakeRequest(GET, "uri").withHeaders(xFor -> xForHeader)
+
+  test("extract a simple IP address") {
+    TestRemoteAddress.clientIp(fakeRequest("123.456.789.012")) should equal(Some("123.456.789.012"))
+    TestRemoteAddress.clientIp(fakeRequest("1.23.4.567")) should equal(Some("1.23.4.567"))
+  }
+
+  test("extract leftmost IP from X-Forwarded-For list") {
+    TestRemoteAddress.clientIp(fakeRequest("123.456.789.012, 987.654.321.098")) should equal(Some("123.456.789.012"))
+    TestRemoteAddress.clientIp(fakeRequest("123.456.789.012, 987.654.321.098, 1.2.3.4")) should equal(Some("123.456.789.012"))
+  }
+
+  test("skips internal IPs at left of list") {
+    TestRemoteAddress.clientIp(fakeRequest("192.168.1.1, 123.456.789.012")) should equal(Some("123.456.789.012"))
+    TestRemoteAddress.clientIp(fakeRequest("172.25.1.1, 123.456.789.012")) should equal(Some("123.456.789.012"))
+    TestRemoteAddress.clientIp(fakeRequest("10.0.1.1, 123.456.789.012")) should equal(Some("123.456.789.012"))
+  }
+
+  test("extracts nothing from invalid header") {
+    TestRemoteAddress.clientIp(fakeRequest("not an ip address")) should equal(None)
+  }
+}


### PR DESCRIPTION
Also adds a HeaderLoggingFilter to Identity so we can verify this is working (and because it's a jolly useful thing to have generally), since it depends on the ELBs providing the X-Forwarded-For header.
