### PR TITLE
Football fixes

### DIFF
--- a/applications/app/views/fragments/sectionBody.scala.html
+++ b/applications/app/views/fragments/sectionBody.scala.html
@@ -3,16 +3,16 @@
 <section class="front-section zone-@section.section" role="main">
 
     @fragments.headers.sectionHead(section.name)
-    
+
     <div class="trailblock" data-count="@trails.length" data-link-name="Section | block | @section.section">
         @fragments.trailblocks.section(trails, numWithImages = 3, numItemsVisible = trails.size)
     </div>
 
 </section>
 
-@if(section.name == "Football") {
-    @fragments.footballNav("/football")
-}
 <div class="box-indent article-zone-no-indent">
+    @if(section.name == "Football") {
+        @fragments.footballNav("/football")
+    }
     @fragments.mostPopularPlaceholder(section.section)
 </div>

--- a/applications/app/views/fragments/tagBody.scala.html
+++ b/applications/app/views/fragments/tagBody.scala.html
@@ -45,14 +45,14 @@
 
 </section>
 
-@if(tag.section == "football") {
-    @if(tag.isFootballCompetition) {
-        @fragments.footballNav("/" + tag.id, Some(tag.webTitle), Some("/" + tag.id))
-    } else {
-        @fragments.footballNav("/football")
-    }
-}
-
 <div class="box-indent article-zone-no-indent">
+    @if(tag.section == "football") {
+        @if(tag.isFootballCompetition) {
+            @fragments.footballNav("/" + tag.id, Some(tag.webTitle), Some("/" + tag.id))
+        } else {
+            @fragments.footballNav("/football")
+        }
+    }
+
     @fragments.mostPopularPlaceholder(tag.section)
 </div>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -9,7 +9,7 @@
             </h2>
         </div>
         <article id="article" class="article @if(article.isLive){is-live}"
-            itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
+                 itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
             <div class="article-v2__inner">
                 <header class="article__head">
 
@@ -73,10 +73,7 @@
                     </div>
                 </div>
             </div>
-
-
         </article>
-
 
         <div class="article-v2__inner">
             @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {
@@ -98,7 +95,7 @@
                 <aside class="js-related" role="complementary" data-link-context="related@article.url"></aside>
             }
 
-            <div class="js-popular" role="complementary"></div>
+            <div class="js-popular article__popular" role="complementary"></div>
         </div>
     </div>
 }

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -144,7 +144,7 @@
                 <aside class="js-related" role="complementary" data-link-context="related@article.url"></aside>
             }
 
-            <div class="js-popular" role="complementary"></div>
+            <div class="js-popular article__popular" role="complementary"></div>
         </div>
     </div>
     }

--- a/common/app/assets/javascripts/modules/experiments/tests/most-popular-from-facebook.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/most-popular-from-facebook.js
@@ -44,7 +44,7 @@ define(['common', 'bonzo', 'modules/popular'], function (common, bonzo, popular)
                     var $jsPopularEl = bonzo(context.querySelector('.js-popular'));
 
                     $jsPopularEl.hide();
-                    $jsPopularEl.after('<div class="js-popular-facebook"></div>');
+                    $jsPopularEl.after('<div class="js-popular-facebook article__popular"></div>');
 
                     popular(_config, context, false, '/most-read-facebook', '.js-popular-facebook');
                 }

--- a/common/app/assets/javascripts/modules/navigation/top-stories.js
+++ b/common/app/assets/javascripts/modules/navigation/top-stories.js
@@ -18,7 +18,7 @@ define(['common', 'ajax', 'bonzo', 'modules/lazyload'], function (common, ajax, 
                     container: container,
                     beforeInsert: function (html) {
                         return '' +
-                            '<h3 class="headline-list__title type-5">Top stories</h3>' +
+                            '<h3 class="headline-list__title">Top stories</h3>' +
                             '<div class="headline-list headline-list--top box-indent" data-link-name="top-stories">' +
                                 html +
                             '</div>';

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -18,7 +18,7 @@
         border-top: none;
     }
 
-    .js-popular & {
+    .article__popular & {
         border-bottom: none;
     }
     .article-zone-no-indent &,
@@ -312,6 +312,7 @@ video {
         padding-right: gs-span(1) + $gs-gutter*2;
     }
     .article-v2__columning-wrapper {
+        width: 100%;
         display: table;
         table-layout: fixed;
         padding-right: 0;

--- a/common/app/assets/stylesheets/module/_headline-list.scss
+++ b/common/app/assets/stylesheets/module/_headline-list.scss
@@ -1,12 +1,8 @@
-.headline-list ul {
-
-}
-
 .headline-list {
     li {
         display: block;
         overflow: auto;
-        border-bottom: 1px solid #ddd;
+        border-bottom: 1px solid #dddddd;
         padding: $baseline*2 0;
 
         &:last-child {
@@ -21,26 +17,25 @@
     }
 
     a {
-        color: #333;
+        color: #333333;
 
         &:visited {
-            color:#777;
+            color: #777777;
         }
     }
 
     .count {
         @extend %type-7;
-        float:left;
-        line-height: 16px;
-        color: #777;
+        float: left;
+        line-height: 20px;
+        line-height: 2rem;
+        color: #777777;
         width: 12px;
     }
 }
 
 
 .headline-list__title {
-    @extend %type-6;
-    color: #333;
     margin: 0 $gs-gutter/2 $baseline;
     @include mq(mobileLandscape) {
         margin-left: $gs-gutter;

--- a/common/app/views/fragments/expiredBody.scala.html
+++ b/common/app/views/fragments/expiredBody.scala.html
@@ -29,4 +29,4 @@
 
 <div id="js-related"></div>
 
-<div class="js-popular"></div>
+<div class="js-popular article__popular"></div>

--- a/common/app/views/fragments/footballNav.scala.html
+++ b/common/app/views/fragments/footballNav.scala.html
@@ -1,10 +1,10 @@
 @(urlBase: String, competitionName: Option[String] = None, competitionUrl: Option[String] = None)(implicit request: RequestHeader)
 @import common._
 
-<h3 class="article-zone type-2">
-    <a class="zone-color" href="@LinkTo{@competitionUrl.getOrElse("/football")}" data-link-name="football index">@competitionName.getOrElse("Football")</a>
-</h3>
-<div class="box-indent">
+<div class="box-indent article-zone-no-indent">
+    <h3 class="article-zone type-2">
+        <a class="zone-color" href="@LinkTo{@competitionUrl.getOrElse("/football")}" data-link-name="football index">@competitionName.getOrElse("Football")</a>
+    </h3>
     <div class="sections u-cf football-nav" data-link-name="football bottom nav">
         <ul class="nav nav--columns nav--top-border-off sections u-cf">
             @defining({

--- a/common/app/views/fragments/footballNav.scala.html
+++ b/common/app/views/fragments/footballNav.scala.html
@@ -1,46 +1,45 @@
 @(urlBase: String, competitionName: Option[String] = None, competitionUrl: Option[String] = None)(implicit request: RequestHeader)
 @import common._
 
-<div class="box-indent article-zone-no-indent">
-    <h3 class="article-zone type-2">
-        <a class="zone-color" href="@LinkTo{@competitionUrl.getOrElse("/football")}" data-link-name="football index">@competitionName.getOrElse("Football")</a>
-    </h3>
-    <div class="sections u-cf football-nav" data-link-name="football bottom nav">
-        <ul class="nav nav--columns nav--top-border-off sections u-cf">
-            @defining({
-                var linkList = List(
-                    Link("/football/competitions", "leagues and competitions", "Leagues & competitions")
-                )
 
-                if (competitionName.nonEmpty) {
-                    if (TeamCompetitions(competitionName.get)) {
-	                    linkList ::= Link("/football/teams#" + urlBase.split("/")(2), "teams", "Teams")
-                    }
+<h3 class="article-zone type-2">
+    <a class="zone-color" href="@LinkTo{@competitionUrl.getOrElse("/football")}" data-link-name="football index">@competitionName.getOrElse("Football")</a>
+</h3>
+<div class="sections u-cf football-nav" data-link-name="football bottom nav">
+    <ul class="nav nav--columns nav--top-border-off sections u-cf">
+        @defining({
+            var linkList = List(
+                Link("/football/competitions", "leagues and competitions", "Leagues & competitions")
+            )
+
+            if (competitionName.nonEmpty) {
+                if (TeamCompetitions(competitionName.get)) {
+                    linkList ::= Link("/football/teams#" + urlBase.split("/")(2), "teams", "Teams")
+                }
+            } else {
+                linkList ::=  Link("/football/teams", "teams", "Teams")
+            }
+
+            linkList :::= List(
+                Link(urlBase + "/live", "livescores", "Live scores"),
+                Link(urlBase + "/fixtures", "fixtures", "Fixtures"),
+                Link(urlBase + "/results", "results", "Results")
+            )
+
+            if(!competitionName.getOrElse("").contains("Cup")) {
+                if (urlBase == "/football") {
+                  linkList ::= Link(urlBase + "/tables", "tables", "Tables")
                 } else {
-                    linkList ::=  Link("/football/teams", "teams", "Teams")
-                }
-
-                linkList :::= List(
-                    Link(urlBase + "/live", "livescores", "Live scores"),
-                    Link(urlBase + "/fixtures", "fixtures", "Fixtures"),
-                    Link(urlBase + "/results", "results", "Results")
-                )
-
-                if(!competitionName.getOrElse("").contains("Cup")) {
-                    if (urlBase == "/football") {
-                      linkList ::= Link(urlBase + "/tables", "tables", "Tables")
-                    } else {
-                      linkList ::= Link(urlBase + "/table", "tables", "Tables")
-                    }
-                }
-
-                linkList
-
-            }) { links =>
-                @links.map{ l =>
-                    <li class="nav__item"><a class="nav__link" href="@LinkTo{@l.url}" data-link-name="@l.linkName">@l.linkText</a></li>
+                  linkList ::= Link(urlBase + "/table", "tables", "Tables")
                 }
             }
-        </ul>
-    </div>
+
+            linkList
+
+        }) { links =>
+            @links.map{ l =>
+                <li class="nav__item"><a class="nav__link" href="@LinkTo{@l.url}" data-link-name="@l.linkName">@l.linkText</a></li>
+            }
+        }
+    </ul>
 </div>

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -1,7 +1,7 @@
 @(section: String)(implicit request: RequestHeader)
 
 @defining(Some(section).filter{ section => section.nonEmpty && !section.equals("global")}.map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
-    <div class="js-popular">
+    <div class="js-popular article__popular">
         <h2 class="type-2 article-zone">
             <a class="most-viewed-no-js" href="@LinkTo{@url}" data-link-name="Most viewed @section">Most read <i class="i i-filter-arrow-right"></i></a>
         </h2>

--- a/common/test/assets/javascripts/spec/TopStories.spec.js
+++ b/common/test/assets/javascripts/spec/TopStories.spec.js
@@ -52,7 +52,7 @@ define([ 'common', 'ajax', 'modules/navigation/top-stories', 'helpers/fixtures']
                     button    = document.querySelector('#topstories-context .control');
 
                 expect(callback).toHaveBeenCalledOnce();
-                expect(container.innerHTML).toBe('<h3 class="headline-list__title type-5">Top stories</h3><div class="headline-list headline-list--top box-indent" data-link-name="top-stories"><b>top stories</b></div>');
+                expect(container.innerHTML).toBe('<h3 class="headline-list__title">Top stories</h3><div class="headline-list headline-list--top box-indent" data-link-name="top-stories"><b>top stories</b></div>');
                 expect(button.className).not.toContain('is-off');
             })
         });

--- a/data/database/07058a9ca1335ae95b19bf70c6d381a7404d72d0
+++ b/data/database/07058a9ca1335ae95b19bf70c6d381a7404d72d0
@@ -1,0 +1,2278 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":10,
+    "startIndex":1,
+    "pageSize":10,
+    "currentPage":1,
+    "pages":1,
+    "orderBy":"newest",
+    "results":[{
+      "id":"business/2013/sep/20/ryanir-pissing-people-off-michael-oleary",
+      "sectionId":"business",
+      "sectionName":"Business",
+      "webPublicationDate":"2013-09-20T13:12:24Z",
+      "webTitle":"Ryanair must stop 'unnecessarily pissing people off', says O'Leary",
+      "webUrl":"http://www.theguardian.com/business/2013/sep/20/ryanir-pissing-people-off-michael-oleary",
+      "apiUrl":"http://content.guardianapis.com/business/2013/sep/20/ryanir-pissing-people-off-michael-oleary",
+      "fields":{
+        "trailText":"Boss of budget airline – voted worst of 100 biggest brands by Which? readers – vows to transform 'abrupt culture'",
+        "headline":"Ryanair must stop 'unnecessarily pissing people off', says O'Leary",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3jvdv",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682475922/Ryanair-003.jpg",
+        "wordcount":"628",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"business/ryanair",
+        "type":"keyword",
+        "webTitle":"Ryanair",
+        "webUrl":"http://www.theguardian.com/business/ryanair",
+        "apiUrl":"http://content.guardianapis.com/business/ryanair",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/theairlineindustry",
+        "type":"keyword",
+        "webTitle":"Airline industry",
+        "webUrl":"http://www.theguardian.com/business/theairlineindustry",
+        "apiUrl":"http://content.guardianapis.com/business/theairlineindustry",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"world/ireland",
+        "type":"keyword",
+        "webTitle":"Ireland",
+        "webUrl":"http://www.theguardian.com/world/ireland",
+        "apiUrl":"http://content.guardianapis.com/world/ireland",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/europe-news",
+        "type":"keyword",
+        "webTitle":"Europe",
+        "webUrl":"http://www.theguardian.com/world/europe-news",
+        "apiUrl":"http://content.guardianapis.com/world/europe-news",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"business/michael-oleary",
+        "type":"keyword",
+        "webTitle":"Michael O'Leary",
+        "webUrl":"http://www.theguardian.com/business/michael-oleary",
+        "apiUrl":"http://content.guardianapis.com/business/michael-oleary",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-417852402",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682472966/Ryanair-001.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"54",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682474852/Ryanair-002.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"130",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682475922/Ryanair-003.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"84",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682476975/Ryanair-004.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"132",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682478257/Ryanair-005.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"168",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682479359/Ryanair-006.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"180",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682480405/Ryanair-007.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"228",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682481620/Ryanair-008.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"276",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682481620/Ryanair-008.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"276",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. Photograph: Corbis",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-417852403",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Business/Pix/pictures/2013/9/20/1379682475922/Ryanair-003.jpg",
+          "typeData":{
+            "source":"Corbis",
+            "altText":"Ryanair",
+            "height":"84",
+            "credit":"Corbis",
+            "caption":"'I've seen people crying at boarding gates,' one shareholder told Michael O'Leary at the Ryanair AGM. 'There is something wrong there that needs to be addressed.' Photograph: Corbis",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"science/brain-flapping/2013/sep/20/video-games-cause-violence-claims-cause-violence",
+      "sectionId":"science",
+      "sectionName":"Science",
+      "webPublicationDate":"2013-09-20T06:00:00Z",
+      "webTitle":"Claims that 'video games lead to violence' lead to violence | Dean Burnett",
+      "webUrl":"http://www.theguardian.com/science/brain-flapping/2013/sep/20/video-games-cause-violence-claims-cause-violence",
+      "apiUrl":"http://content.guardianapis.com/science/brain-flapping/2013/sep/20/video-games-cause-violence-claims-cause-violence",
+      "fields":{
+        "trailText":"<p><strong>Dean Burnett:</strong> The persistent claims that video games cause violence are likely to result in violence</p>",
+        "headline":"Claims that 'video games lead to violence' lead to violence",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3jv2a",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2011/12/22/1324570538373/Call-of-Duty-Modern-Warfa-002.jpg",
+        "wordcount":"857",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"science/psychology",
+        "type":"keyword",
+        "webTitle":"Psychology",
+        "webUrl":"http://www.theguardian.com/science/psychology",
+        "apiUrl":"http://content.guardianapis.com/science/psychology",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"science/brain-flapping",
+        "type":"blog",
+        "webTitle":"Brain flapping",
+        "webUrl":"http://www.theguardian.com/science/brain-flapping",
+        "apiUrl":"http://content.guardianapis.com/science/brain-flapping",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"science/science",
+        "type":"keyword",
+        "webTitle":"Science",
+        "webUrl":"http://www.theguardian.com/science/science",
+        "apiUrl":"http://content.guardianapis.com/science/science",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"technology/games",
+        "type":"keyword",
+        "webTitle":"Games",
+        "webUrl":"http://www.theguardian.com/technology/games",
+        "apiUrl":"http://content.guardianapis.com/technology/games",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"media/media",
+        "type":"keyword",
+        "webTitle":"Media",
+        "webUrl":"http://www.theguardian.com/media/media",
+        "apiUrl":"http://content.guardianapis.com/media/media",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"profile/dean-burnett",
+        "type":"contributor",
+        "webTitle":"Dean Burnett",
+        "webUrl":"http://www.theguardian.com/profile/dean-burnett",
+        "apiUrl":"http://content.guardianapis.com/profile/dean-burnett",
+        "bio":"<p>Dean Burnett is a doctor of neuroscience, but moonlights as a comedy writer and stand-up comedian. He <a href=\"http://www.mscpsychiatry.co.uk/\">tutors and lectures at Cardiff University</a></p>",
+        "r2ContributorId":"48703",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"technology/technology",
+        "type":"keyword",
+        "webTitle":"Technology",
+        "webUrl":"http://www.theguardian.com/technology/technology",
+        "apiUrl":"http://content.guardianapis.com/technology/technology",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-417837122",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2009/5/18/1242608388785/Grand-Theft-Auto-IV-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "altText":"Grand Theft Auto IV",
+            "height":"276",
+            "credit":"AP",
+            "caption":"More tea, Vicar?  Photograph: AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-417837123",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2011/12/22/1324570538373/Call-of-Duty-Modern-Warfa-002.jpg",
+          "typeData":{
+            "source":"Activision/AP",
+            "altText":"Call of Duty: Modern Warfare 3 was a retail blockbuster video game of 2011. ",
+            "height":"84",
+            "credit":"Activision/AP",
+            "caption":"Call of Duty: Modern Warfare 3 was a retail blockbuster video game of 2011.   Photograph: Activision/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/sep/19/pope-francis-vision-new-catholic-church",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-09-19T18:19:00Z",
+      "webTitle":"Pope Francis sets out vision for more gay people and women in 'new' church",
+      "webUrl":"http://www.theguardian.com/world/2013/sep/19/pope-francis-vision-new-catholic-church",
+      "apiUrl":"http://content.guardianapis.com/world/2013/sep/19/pope-francis-vision-new-catholic-church",
+      "fields":{
+        "trailText":"<p>Pope Francis gives wide-ranging interview to Italian journal and urges Catholics to show 'audacity and courage' in drive for reform</p>",
+        "headline":"Pope Francis sets out vision for more gay people and women in 'new' church",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3tqp8",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379610374137/Pope-Francis-005.jpg",
+        "wordcount":"882",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/pope-francis",
+        "type":"keyword",
+        "webTitle":"Pope Francis",
+        "webUrl":"http://www.theguardian.com/world/pope-francis",
+        "apiUrl":"http://content.guardianapis.com/world/pope-francis",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/catholicism",
+        "type":"keyword",
+        "webTitle":"Catholicism",
+        "webUrl":"http://www.theguardian.com/world/catholicism",
+        "apiUrl":"http://content.guardianapis.com/world/catholicism",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/religion",
+        "type":"keyword",
+        "webTitle":"Religion",
+        "webUrl":"http://www.theguardian.com/world/religion",
+        "apiUrl":"http://content.guardianapis.com/world/religion",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/christianity",
+        "type":"keyword",
+        "webTitle":"Christianity",
+        "webUrl":"http://www.theguardian.com/world/christianity",
+        "apiUrl":"http://content.guardianapis.com/world/christianity",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/gay-rights",
+        "type":"keyword",
+        "webTitle":"Gay rights",
+        "webUrl":"http://www.theguardian.com/world/gay-rights",
+        "apiUrl":"http://content.guardianapis.com/world/gay-rights",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"profile/edpilkington",
+        "type":"contributor",
+        "webTitle":"Ed Pilkington",
+        "webUrl":"http://www.theguardian.com/profile/edpilkington",
+        "apiUrl":"http://content.guardianapis.com/profile/edpilkington",
+        "bio":"<p>Ed Pilkington is the chief reporter for Guardian US. He is a former national and foreign editor of the paper, and author of Beyond the Mother Country</p>",
+        "rcsId":"GNL038863",
+        "r2ContributorId":"15609",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Global/content/icons/2012/3/27/1332862968426/edpilkington_140x140.jpg",
+        "references":[]
+      },{
+        "id":"theguardian/mainsection/international",
+        "type":"newspaper-book-section",
+        "webTitle":"International",
+        "webUrl":"http://www.theguardian.com/theguardian/mainsection/international",
+        "apiUrl":"http://content.guardianapis.com/theguardian/mainsection/international",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/mainsection",
+        "type":"newspaper-book",
+        "webTitle":"Main section",
+        "webUrl":"http://www.theguardian.com/theguardian/mainsection",
+        "apiUrl":"http://content.guardianapis.com/theguardian/mainsection",
+        "sectionId":"news",
+        "sectionName":"News",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-417801085",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379610383465/Pope-Francis-010.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"AGF",
+            "altText":"Pope Francis",
+            "height":"276",
+            "credit":"AGF/Rex Features",
+            "caption":"Pope Francis said unless a new balance is found, 'the moral edifice of the church is likely to fall like a house of cards'. Photograph: AGF/Rex Features",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-417801086",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379610374137/Pope-Francis-005.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"AGF",
+            "altText":"Pope Francis",
+            "height":"84",
+            "credit":"AGF/Rex Features",
+            "caption":"Pope Francis. Photograph: AGF/Rex Features",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/the-womens-blog-with-jane-martinson/2013/sep/19/freshers-week-sexism-women",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-09-19T14:49:39Z",
+      "webTitle":"Freshers' week sexism, and the damage it does",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/the-womens-blog-with-jane-martinson/2013/sep/19/freshers-week-sexism-women",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/the-womens-blog-with-jane-martinson/2013/sep/19/freshers-week-sexism-women",
+      "fields":{
+        "trailText":"<p><strong>Laura Bates:</strong> The first term of college is many young women's first experience of leaving home and adult life, which makes the #freshersweeksexism of laddish university culture so hard to stand</p>",
+        "headline":"Freshers' week sexism, and the damage it does",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3tqjn",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601219888/Students-at-freshers-week-005.jpg",
+        "wordcount":"906",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/laura-bates",
+        "type":"contributor",
+        "webTitle":"Laura Bates",
+        "webUrl":"http://www.theguardian.com/profile/laura-bates",
+        "apiUrl":"http://content.guardianapis.com/profile/laura-bates",
+        "bio":"<p>Laura Bates is the founder of the <a href=\"http://www.everydaysexism.com/\">Everyday Sexism Project</a>, a collection of over 10,000 women's daily experiences of gender inequality</p>",
+        "r2ContributorId":"54862",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/3/7/1362678319287/Laura-Bates.jpg",
+        "references":[]
+      },{
+        "id":"lifeandstyle/the-womens-blog-with-jane-martinson",
+        "type":"blog",
+        "webTitle":"The women's blog with Jane Martinson",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/the-womens-blog-with-jane-martinson",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/the-womens-blog-with-jane-martinson",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"education/students",
+        "type":"keyword",
+        "webTitle":"Students",
+        "webUrl":"http://www.theguardian.com/education/students",
+        "apiUrl":"http://content.guardianapis.com/education/students",
+        "sectionId":"education",
+        "sectionName":"Education",
+        "references":[]
+      },{
+        "id":"education/freshers",
+        "type":"keyword",
+        "webTitle":"Freshers",
+        "webUrl":"http://www.theguardian.com/education/freshers",
+        "apiUrl":"http://content.guardianapis.com/education/freshers",
+        "sectionId":"education",
+        "sectionName":"Education",
+        "references":[]
+      },{
+        "id":"education/higher-education",
+        "type":"keyword",
+        "webTitle":"Higher education",
+        "webUrl":"http://www.theguardian.com/education/higher-education",
+        "apiUrl":"http://content.guardianapis.com/education/higher-education",
+        "sectionId":"education",
+        "sectionName":"Education",
+        "references":[]
+      },{
+        "id":"education/education",
+        "type":"keyword",
+        "webTitle":"Education",
+        "webUrl":"http://www.theguardian.com/education/education",
+        "apiUrl":"http://content.guardianapis.com/education/education",
+        "sectionId":"education",
+        "sectionName":"Education",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-417768162",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601215020/Students-at-freshers-week-002.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"54",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601216584/Students-at-freshers-week-003.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"340",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601218158/Students-at-freshers-week-004.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"130",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601219888/Students-at-freshers-week-005.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"84",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601221976/Students-at-freshers-week-006.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"132",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601224266/Students-at-freshers-week-007.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"168",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601225871/Students-at-freshers-week-008.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"180",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601227419/Students-at-freshers-week-009.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"228",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601229117/Students-at-freshers-week-010.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"276",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601230739/Students-at-freshers-week-011.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"372",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601229117/Students-at-freshers-week-010.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"276",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-417768163",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/19/1379601219888/Students-at-freshers-week-005.jpg",
+          "typeData":{
+            "source":"Martin Godwin for the Guardian",
+            "altText":"Students at freshers' week",
+            "height":"84",
+            "credit":"Martin Godwin for the Guardian",
+            "caption":"Students at the freshers' week fair at the University of Sussex in Brighton. Photograph: Martin Godwin for the Guardian",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/sep/19/kenya-mindy-budgor-masai-mara",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-09-19T14:21:26Z",
+      "webTitle":"Mindy's Masai Mara adventure is an insult to us all",
+      "webUrl":"http://www.theguardian.com/world/2013/sep/19/kenya-mindy-budgor-masai-mara",
+      "apiUrl":"http://content.guardianapis.com/world/2013/sep/19/kenya-mindy-budgor-masai-mara",
+      "fields":{
+        "trailText":"<p>American woman who claims to be the first female Masai warrior is perpetuating troubling stereotypes for personal gain, says <strong>Sitinga Kachipande</strong></p>",
+        "headline":"Mindy's Masai Mara adventure is an insult to us all",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3tqgy",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/9/6/1378460564036/Mindy-003.jpg",
+        "wordcount":"1035",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/kenya",
+        "type":"keyword",
+        "webTitle":"Kenya",
+        "webUrl":"http://www.theguardian.com/world/kenya",
+        "apiUrl":"http://content.guardianapis.com/world/kenya",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/indigenous-peoples",
+        "type":"keyword",
+        "webTitle":"Indigenous peoples",
+        "webUrl":"http://www.theguardian.com/world/indigenous-peoples",
+        "apiUrl":"http://content.guardianapis.com/world/indigenous-peoples",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"travel/travel",
+        "type":"keyword",
+        "webTitle":"Travel",
+        "webUrl":"http://www.theguardian.com/travel/travel",
+        "apiUrl":"http://content.guardianapis.com/travel/travel",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"world/series/guardian-africa-network",
+        "type":"series",
+        "webTitle":"Guardian Africa network",
+        "webUrl":"http://www.theguardian.com/world/series/guardian-africa-network",
+        "apiUrl":"http://content.guardianapis.com/world/series/guardian-africa-network",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/africa",
+        "type":"keyword",
+        "webTitle":"Africa",
+        "webUrl":"http://www.theguardian.com/world/africa",
+        "apiUrl":"http://content.guardianapis.com/world/africa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"tone/analysis",
+        "type":"tone",
+        "webTitle":"Analysis",
+        "webUrl":"http://www.theguardian.com/tone/analysis",
+        "apiUrl":"http://content.guardianapis.com/tone/analysis",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-417771604",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/9/5/1378396450690/Mindy-Budgor-with-Masai-008.jpg",
+          "typeData":{
+            "source":"Mindy Budgor",
+            "altText":"Mindy Budgor with Masai",
+            "height":"276",
+            "credit":"Mindy Budgor",
+            "caption":"Mindy Budgor with Masai in Kenya. Photograph courtesy Mindy Budgor",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-417771605",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/9/6/1378460564036/Mindy-003.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Mindy",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Mindy Budgor with tribesmen in Kenya during her training as a Maasai warrior",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-417771606",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Late_offers/pictures/2013/9/5/1378411003927/Mindy-with-Maasai-guide-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Mindy with Maasai guide",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Mindy Budgor with a guide during her 'training'.",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/sep/19/joe-biden-mexico-enrique-pena-nieto",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-09-19T12:30:00Z",
+      "webTitle":"Biden's visit to Mexico: what you should know, Joe | John Ackerman",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/sep/19/joe-biden-mexico-enrique-pena-nieto",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/sep/19/joe-biden-mexico-enrique-pena-nieto",
+      "fields":{
+        "trailText":"<p><strong>John Ackerman:</strong> Mexico's president, Enrique Peña Nieto, was billed as a bold reformer. In reality, he acts like a corrupt, authoritarian oligarch</p>",
+        "headline":"Biden's visit to Mexico: what you should know, Joe",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3tq3p",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2012/12/2/1354425016209/Mexican-police-charge-dow-003.jpg",
+        "wordcount":"1252",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"world/enrique-pena-nieto",
+        "type":"keyword",
+        "webTitle":"Enrique Peña Nieto",
+        "webUrl":"http://www.theguardian.com/world/enrique-pena-nieto",
+        "apiUrl":"http://content.guardianapis.com/world/enrique-pena-nieto",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/joebiden",
+        "type":"keyword",
+        "webTitle":"Joe Biden",
+        "webUrl":"http://www.theguardian.com/world/joebiden",
+        "apiUrl":"http://content.guardianapis.com/world/joebiden",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/mexico",
+        "type":"keyword",
+        "webTitle":"Mexico",
+        "webUrl":"http://www.theguardian.com/world/mexico",
+        "apiUrl":"http://content.guardianapis.com/world/mexico",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/protest",
+        "type":"keyword",
+        "webTitle":"Protest",
+        "webUrl":"http://www.theguardian.com/world/protest",
+        "apiUrl":"http://content.guardianapis.com/world/protest",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/usimmigration",
+        "type":"keyword",
+        "webTitle":"US immigration",
+        "webUrl":"http://www.theguardian.com/world/usimmigration",
+        "apiUrl":"http://content.guardianapis.com/world/usimmigration",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/obama-administration",
+        "type":"keyword",
+        "webTitle":"Obama administration",
+        "webUrl":"http://www.theguardian.com/world/obama-administration",
+        "apiUrl":"http://content.guardianapis.com/world/obama-administration",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/barack-obama",
+        "type":"keyword",
+        "webTitle":"Barack Obama",
+        "webUrl":"http://www.theguardian.com/world/barack-obama",
+        "apiUrl":"http://content.guardianapis.com/world/barack-obama",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/drugs-trade",
+        "type":"keyword",
+        "webTitle":"Drugs trade",
+        "webUrl":"http://www.theguardian.com/world/drugs-trade",
+        "apiUrl":"http://content.guardianapis.com/world/drugs-trade",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/unions",
+        "type":"keyword",
+        "webTitle":"Unions",
+        "webUrl":"http://www.theguardian.com/world/unions",
+        "apiUrl":"http://content.guardianapis.com/world/unions",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"profile/john-ackerman",
+        "type":"contributor",
+        "webTitle":"John Ackerman",
+        "webUrl":"http://www.theguardian.com/profile/john-ackerman",
+        "apiUrl":"http://content.guardianapis.com/profile/john-ackerman",
+        "bio":"<p>John M. Ackerman is a professor at the Institute for Legal Research at the National Autonomous University of Mexico (UNAM), Editor-in-Chief of the Mexican Law Review and a columnist for Proceso magazine and La Jornada newspaper. Read his <a href=\" http://johnackerman.blogspot.com/\">blog</a> and follow him on twitter <a href=\"https://twitter.com/JohnMAckerman\">@JohnMAckerman</a></p>",
+        "r2ContributorId":"30325",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Global/content/icons/2011/11/10/1320945106989/johnackerman_140x140.jpg",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-417677242",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2012/12/2/1354425032425/Mexican-police-charge-dow-008.jpg",
+          "typeData":{
+            "source":"Reuters",
+            "altText":"Mexican police charge down protesters against Enrique Peña Nieto, who has taken office as president.",
+            "height":"276",
+            "credit":"Reuters",
+            "caption":"Police charge down protesters against Enrique Peña Nieto, Mexico's new president. Photograph: Reuters",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-417677243",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2012/12/2/1354425016209/Mexican-police-charge-dow-003.jpg",
+          "typeData":{
+            "source":"Reuters",
+            "altText":"Mexican police charge down protesters against Enrique Peña Nieto, who has taken office as president.",
+            "height":"84",
+            "credit":"Reuters",
+            "caption":"Mexican police charge down protesters against Enrique Peña Nieto, who has taken office as president. Photograph: Reuters",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/sep/19/sex-selective-abortion-womans-right",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-09-19T11:40:36Z",
+      "webTitle":"Why women have a right to sex-selective abortion | Sarah Ditum",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/sep/19/sex-selective-abortion-womans-right",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/sep/19/sex-selective-abortion-womans-right",
+      "fields":{
+        "trailText":"<p><strong>Sarah Ditum: </strong>As far as I'm concerned, it doesn't matter why any woman wants to end her pregnancy. If it's to select for sex, that's her choice</p>",
+        "headline":"Why women have a right to sex-selective abortion",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3tqc6",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/9/19/1379587874329/Ann-Furedi-003.jpg",
+        "wordcount":"638",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"world/abortion",
+        "type":"keyword",
+        "webTitle":"Abortion",
+        "webUrl":"http://www.theguardian.com/world/abortion",
+        "apiUrl":"http://content.guardianapis.com/world/abortion",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/health",
+        "type":"keyword",
+        "webTitle":"Health",
+        "webUrl":"http://www.theguardian.com/society/health",
+        "apiUrl":"http://content.guardianapis.com/society/health",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/sarah-ditum",
+        "type":"contributor",
+        "webTitle":"Sarah Ditum",
+        "webUrl":"http://www.theguardian.com/profile/sarah-ditum",
+        "apiUrl":"http://content.guardianapis.com/profile/sarah-ditum",
+        "bio":"<p>Sarah Ditum is a freelance writer on politics, culture and lifestyle. She lives in Bath and blogs at <a href=\"http://sarahditum.com/\">Paperhouse</a></p>",
+        "r2ContributorId":"31955",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2012/2/29/1330519293276/Sarah_Ditum.jpg",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"lifeandstyle/the-womens-blog-with-jane-martinson",
+        "type":"blog",
+        "webTitle":"The women's blog with Jane Martinson",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/the-womens-blog-with-jane-martinson",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/the-womens-blog-with-jane-martinson",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-417816745",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/9/19/1379587920812/Ann-Furedi-008.jpg",
+          "typeData":{
+            "source":"Getty Images",
+            "photographer":"Bwp Media",
+            "altText":"Ann Furedi",
+            "height":"276",
+            "credit":"Bwp Media/Getty Images",
+            "caption":"'Ann Furedi of BPAS ... has won outraged headlines simply by saying that abortion on the grounds of sex selection may be within the terms of the 1967 Abortion Act Photograph: Bwp Media/Getty Images",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-417816746",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/9/19/1379587874329/Ann-Furedi-003.jpg",
+          "typeData":{
+            "source":"Getty Images",
+            "photographer":"Bwp Media",
+            "altText":"Ann Furedi",
+            "height":"84",
+            "credit":"Bwp Media/Getty Images",
+            "caption":"'Ann Furedi of BPAS ... has won outraged headlines simply by saying that abortion on the grounds of sex selection may be within the terms of the 1967 Abortion Act Photograph: Bwp Media/Getty Images",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"news/video/2013/sep/19/stephen-hawking-history-time-simple-video",
+      "sectionId":"science",
+      "sectionName":"Science",
+      "webPublicationDate":"2013-09-19T10:04:00Z",
+      "webTitle":"Stephen Hawking's big ideas ... made simple - video animation",
+      "webUrl":"http://www.theguardian.com/news/video/2013/sep/19/stephen-hawking-history-time-simple-video",
+      "apiUrl":"http://content.guardianapis.com/news/video/2013/sep/19/stephen-hawking-history-time-simple-video",
+      "fields":{
+        "trailText":"<p>Learn about black holes, Hawking radiation, the big bang and creation of the universe in just two and a half minutes</p>",
+        "headline":"Stephen Hawking's big ideas ... made simple - video animation",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3tq9n",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583038269/Stephen-Hawkings-black-ho-026.jpg",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"science/hawking",
+        "type":"keyword",
+        "webTitle":"Stephen Hawking",
+        "webUrl":"http://www.theguardian.com/science/hawking",
+        "apiUrl":"http://content.guardianapis.com/science/hawking",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"news/series/made-simple",
+        "type":"series",
+        "webTitle":"Made simple",
+        "webUrl":"http://www.theguardian.com/news/series/made-simple",
+        "apiUrl":"http://content.guardianapis.com/news/series/made-simple",
+        "sectionId":"news",
+        "sectionName":"News",
+        "references":[]
+      },{
+        "id":"science/black-holes",
+        "type":"keyword",
+        "webTitle":"Black holes",
+        "webUrl":"http://www.theguardian.com/science/black-holes",
+        "apiUrl":"http://content.guardianapis.com/science/black-holes",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"science/space",
+        "type":"keyword",
+        "webTitle":"Space",
+        "webUrl":"http://www.theguardian.com/science/space",
+        "apiUrl":"http://content.guardianapis.com/science/space",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"science/astronomy",
+        "type":"keyword",
+        "webTitle":"Astronomy",
+        "webUrl":"http://www.theguardian.com/science/astronomy",
+        "apiUrl":"http://content.guardianapis.com/science/astronomy",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"science/physics",
+        "type":"keyword",
+        "webTitle":"Physics",
+        "webUrl":"http://www.theguardian.com/science/physics",
+        "apiUrl":"http://content.guardianapis.com/science/physics",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"science/science",
+        "type":"keyword",
+        "webTitle":"Science",
+        "webUrl":"http://www.theguardian.com/science/science",
+        "apiUrl":"http://content.guardianapis.com/science/science",
+        "sectionId":"science",
+        "sectionName":"Science",
+        "references":[]
+      },{
+        "id":"profile/alokjha",
+        "type":"contributor",
+        "webTitle":"Alok Jha",
+        "webUrl":"http://www.theguardian.com/profile/alokjha",
+        "apiUrl":"http://content.guardianapis.com/profile/alokjha",
+        "bio":"<p>Alok Jha is a science correspondent at the Guardian. In addition to writing news and comment, he presents the <a href=\"http://www.theguardian.com/science/series/science\">Science Weekly podcast</a>. A physics graduate from Imperial College London, he has been at the Guardian since the launch of the science supplement, Life, in 2003. He is the author of <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9780857386120\">The Doomsday Handbook: 50 Ways to the End of the World </a> and <a href=\"http://www.amazon.co.uk/How-Live-Forever-Interesting-Science/dp/1849164827\">How To Live Forever And 34 Other Really Interesting Uses for Science</a>, both published by Quercus. You can find him on Twitter at  <a href=\"https://twitter.com/alokjha\">@alokjha</a> and his personal website is at <a href=\"http://www.alokjha.com\">alokjha.com </a></p>",
+        "rcsId":"GNL006494",
+        "r2ContributorId":"15338",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/26/alok_jha_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/matt-hill",
+        "type":"contributor",
+        "webTitle":"Matt Hill",
+        "webUrl":"http://www.theguardian.com/profile/matt-hill",
+        "apiUrl":"http://content.guardianapis.com/profile/matt-hill",
+        "r2ContributorId":"51656",
+        "references":[]
+      },{
+        "id":"profile/paul-boyd",
+        "type":"contributor",
+        "webTitle":"Paul Boyd",
+        "webUrl":"http://www.theguardian.com/profile/paul-boyd",
+        "apiUrl":"http://content.guardianapis.com/profile/paul-boyd",
+        "bio":"<p>Paul Boyd is the multimedia editor for specialist subjects and professional networks at the Guardian</p>",
+        "r2ContributorId":"56133",
+        "references":[]
+      },{
+        "id":"type/video",
+        "type":"type",
+        "webTitle":"Video",
+        "webUrl":"http://www.theguardian.com/video",
+        "apiUrl":"http://content.guardianapis.com/video",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-video-417725296",
+        "relation":"main",
+        "type":"video",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583003871/Stephen-Hawkings-black-ho-001.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"360",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"640"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583020789/Stephen-Hawkings-black-ho-012.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"372",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583022007/Stephen-Hawkings-black-ho-013.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"90",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"120"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583023259/Stephen-Hawkings-black-ho-014.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"225",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583024463/Stephen-Hawkings-black-ho-015.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"360",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583025825/Stephen-Hawkings-black-ho-016.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"340",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583027063/Stephen-Hawkings-black-ho-017.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"54",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583028291/Stephen-Hawkings-black-ho-018.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"130",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583030832/Stephen-Hawkings-black-ho-020.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"132",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583032028/Stephen-Hawkings-black-ho-021.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"168",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583033306/Stephen-Hawkings-black-ho-022.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"180",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583034541/Stephen-Hawkings-black-ho-023.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"228",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583035767/Stephen-Hawkings-black-ho-024.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"276",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583036981/Stephen-Hawkings-black-ho-025.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"230",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583038269/Stephen-Hawkings-black-ho-026.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"84",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"140"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/webm",
+          "file":"http://cdn.theguardian.tv/webM/640/2013/9/19/130919StevenHawking_vpx.webm",
+          "typeData":{
+            "source":"Scriberia",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/19/130919StevenHawking_8092453.jpg",
+            "height":"360",
+            "durationMinutes":"2",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/19/130919StevenHawking_8092453.jpg",
+            "width":"480",
+            "durationSeconds":"44"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4:720",
+          "file":"http://cdn.theguardian.tv/connectedTV/1280/2013/9/19/130919StevenHawking-720.mp4",
+          "typeData":{
+            "source":"Scriberia",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/19/130919StevenHawking_8092453.jpg",
+            "height":"360",
+            "durationMinutes":"2",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/19/130919StevenHawking_8092453.jpg",
+            "width":"480",
+            "durationSeconds":"44"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/9/19/130919StevenHawking-16x9.mp4",
+          "typeData":{
+            "source":"Scriberia",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/19/130919StevenHawking_8092453.jpg",
+            "height":"360",
+            "durationMinutes":"2",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/19/130919StevenHawking_8092453.jpg",
+            "width":"480",
+            "durationSeconds":"44"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/9/19/130919StevenHawking_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"Scriberia",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/19/130919StevenHawking_8092453.jpg",
+            "height":"360",
+            "durationMinutes":"2",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/19/130919StevenHawking_8092453.jpg",
+            "width":"480",
+            "durationSeconds":"44"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/9/19/130919StevenHawking_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"Scriberia",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/19/130919StevenHawking_8092453.jpg",
+            "height":"360",
+            "durationMinutes":"2",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/19/130919StevenHawking_8092453.jpg",
+            "width":"480",
+            "durationSeconds":"44"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/9/19/130919StevenHawking/130919StevenHawking.m3u8",
+          "typeData":{
+            "source":"Scriberia",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/19/130919StevenHawking_8092453.jpg",
+            "height":"360",
+            "durationMinutes":"2",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/19/130919StevenHawking_8092453.jpg",
+            "width":"480",
+            "durationSeconds":"44"
+          }
+        }]
+      },{
+        "id":"gu-image-417774239",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/19/1379583038269/Stephen-Hawkings-black-ho-026.jpg",
+          "typeData":{
+            "source":"Scriberia",
+            "altText":"Stephen Hawking's black hole theory",
+            "height":"84",
+            "credit":"Scriberia",
+            "caption":"Stephen Hawking's black hole theory Photograph: Scriberia",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/video/2013/sep/18/seven-man-kick-off-red-bull-leipzig-video",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-09-18T08:35:59Z",
+      "webTitle":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under 10 seconds - video",
+      "webUrl":"http://www.theguardian.com/football/video/2013/sep/18/seven-man-kick-off-red-bull-leipzig-video",
+      "apiUrl":"http://content.guardianapis.com/football/video/2013/sep/18/seven-man-kick-off-red-bull-leipzig-video",
+      "fields":{
+        "trailText":"<p>Red Bull Leipzig line up with seven men on the halfway line to start a German second division game against Stuttgart II</p>",
+        "headline":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under 10 seconds - video",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3tpvq",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433015693/Seven-man-attacking-kick--005.jpg",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"football/europeanfootball",
+        "type":"keyword",
+        "webTitle":"European club football",
+        "webUrl":"http://www.theguardian.com/football/europeanfootball",
+        "apiUrl":"http://content.guardianapis.com/football/europeanfootball",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/series/amazing-world-of-sport",
+        "type":"series",
+        "webTitle":"The amazing world of sport",
+        "webUrl":"http://www.theguardian.com/sport/series/amazing-world-of-sport",
+        "apiUrl":"http://content.guardianapis.com/sport/series/amazing-world-of-sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"type/video",
+        "type":"type",
+        "webTitle":"Video",
+        "webUrl":"http://www.theguardian.com/video",
+        "apiUrl":"http://content.guardianapis.com/video",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-video-417545114",
+        "relation":"main",
+        "type":"video",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433010311/Seven-man-attacking-kick--002.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"54",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433011801/Seven-man-attacking-kick--003.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"340",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433013393/Seven-man-attacking-kick--004.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"130",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433015693/Seven-man-attacking-kick--005.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"84",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433017683/Seven-man-attacking-kick--006.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"132",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433019133/Seven-man-attacking-kick--007.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"168",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433020713/Seven-man-attacking-kick--008.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"180",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433022220/Seven-man-attacking-kick--009.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"228",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433023691/Seven-man-attacking-kick--010.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"276",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433025381/Seven-man-attacking-kick--011.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"372",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433026865/Seven-man-attacking-kick--012.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"360",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"640"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433028440/Seven-man-attacking-kick--013.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"90",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"120"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433029970/Seven-man-attacking-kick--014.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"225",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433031711/Seven-man-attacking-kick--015.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"360",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433033834/Seven-man-attacking-kick--016.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"230",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"300"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/9/17/130917flyingkick-16x9.mp4",
+          "typeData":{
+            "source":"YouTube",
+            "embeddable":"true",
+            "blockAds":"true",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/17/130917flyingkick_8085498.jpg",
+            "height":"360",
+            "durationMinutes":"0",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/17/130917flyingkick_8085498.jpg",
+            "width":"480",
+            "durationSeconds":"43"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/9/17/130917flyingkick_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"YouTube",
+            "embeddable":"true",
+            "blockAds":"true",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/17/130917flyingkick_8085498.jpg",
+            "height":"360",
+            "durationMinutes":"0",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/17/130917flyingkick_8085498.jpg",
+            "width":"480",
+            "durationSeconds":"43"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/9/17/130917flyingkick_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"YouTube",
+            "embeddable":"true",
+            "blockAds":"true",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/17/130917flyingkick_8085498.jpg",
+            "height":"360",
+            "durationMinutes":"0",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/17/130917flyingkick_8085498.jpg",
+            "width":"480",
+            "durationSeconds":"43"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/9/17/130917flyingkick/130917flyingkick.m3u8",
+          "typeData":{
+            "source":"YouTube",
+            "embeddable":"true",
+            "blockAds":"true",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/17/130917flyingkick_8085498.jpg",
+            "height":"360",
+            "durationMinutes":"0",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/17/130917flyingkick_8085498.jpg",
+            "width":"480",
+            "durationSeconds":"43"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4:720",
+          "file":"http://cdn.theguardian.tv/connectedTV/1280/2013/9/17/130917flyingkick-720.mp4",
+          "typeData":{
+            "source":"YouTube",
+            "embeddable":"true",
+            "blockAds":"true",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/17/130917flyingkick_8085498.jpg",
+            "height":"360",
+            "durationMinutes":"0",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/17/130917flyingkick_8085498.jpg",
+            "width":"480",
+            "durationSeconds":"43"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/webm",
+          "file":"http://cdn.theguardian.tv/webM/640/2013/9/17/130917flyingkick_vpx.webm",
+          "typeData":{
+            "source":"YouTube",
+            "embeddable":"true",
+            "blockAds":"true",
+            "thumbnailImageUrl":"http://cdn.theguardian.tv/mainwebsite/thumb/2013/9/17/130917flyingkick_8085498.jpg",
+            "height":"360",
+            "durationMinutes":"0",
+            "stillImageUrl":"http://cdn.theguardian.tv/mainwebsite/poster/2013/9/17/130917flyingkick_8085498.jpg",
+            "width":"480",
+            "durationSeconds":"43"
+          }
+        }]
+      },{
+        "id":"gu-image-417597086",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/9/17/1379433015693/Seven-man-attacking-kick--005.jpg",
+          "typeData":{
+            "source":"YouTube",
+            "photographer":"YouTube",
+            "altText":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video",
+            "height":"84",
+            "credit":"YouTube/YouTube",
+            "caption":"Seven-man attacking kick-off results in goal for Red Bull Leipzig in under ten seconds - video Photograph: YouTube",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"culture/australia-culture-blog/video/2013/sep/18/wagners-ring-cycle-2-mins-video",
+      "sectionId":"culture",
+      "sectionName":"Culture",
+      "webPublicationDate":"2013-09-18T01:45:34Z",
+      "webTitle":"Wagner's 15-hour Ring Cycle … in two and a half minutes - video",
+      "webUrl":"http://www.theguardian.com/culture/australia-culture-blog/video/2013/sep/18/wagners-ring-cycle-2-mins-video",
+      "apiUrl":"http://content.guardianapis.com/culture/australia-culture-blog/video/2013/sep/18/wagners-ring-cycle-2-mins-video",
+      "fields":{
+        "trailText":"<p>A short animation, with appropriately rousing musical accompaniment, which manages to condense Wagner's magnificent 15-hour epic, Ring Cycle – complete with gods, heroes, dragons, a castle in the sky, love triangles, magic swords and Valkyries – into a succinct, coffee-break friendly two and a half minutes. Get it? Got it? Good!</p>",
+        "headline":"Wagner's 15-hour Ring Cycle … in two and a half minutes – video",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3tzd2",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/17/1379392161811/Ring-Cycle-in-2-mins-009.jpg",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"culture/australia-culture-blog",
+        "type":"blog",
+        "webTitle":"Australia culture blog",
+        "webUrl":"http://www.theguardian.com/culture/australia-culture-blog",
+        "apiUrl":"http://content.guardianapis.com/culture/australia-culture-blog",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"music/richard-wagner",
+        "type":"keyword",
+        "webTitle":"Richard Wagner",
+        "webUrl":"http://www.theguardian.com/music/richard-wagner",
+        "apiUrl":"http://content.guardianapis.com/music/richard-wagner",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"travel/sydneyoperahouse",
+        "type":"keyword",
+        "webTitle":"Sydney Opera House, Sydney, Australia",
+        "webUrl":"http://www.theguardian.com/travel/sydneyoperahouse",
+        "apiUrl":"http://content.guardianapis.com/travel/sydneyoperahouse",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"type/video",
+        "type":"type",
+        "webTitle":"Video",
+        "webUrl":"http://www.theguardian.com/video",
+        "apiUrl":"http://content.guardianapis.com/video",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-video-417472828",
+        "relation":"main",
+        "type":"video",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/17/1379392161811/Ring-Cycle-in-2-mins-009.jpg",
+          "typeData":{
+            "source":"Sydney Symphony",
+            "altText":"Ring Cycle in 2 mins",
+            "height":"84",
+            "credit":"Sydney Symphony",
+            "caption":"Ring Cycle in 2 mins Photograph: Sydney Symphony",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/17/1379392178015/Ring-Cycle-in-2-mins-016.jpg",
+          "typeData":{
+            "source":"Sydney Symphony",
+            "altText":"Ring Cycle in 2 mins",
+            "height":"360",
+            "credit":"Sydney Symphony",
+            "caption":"Ring Cycle in 2 mins Photograph: Sydney Symphony",
+            "width":"640"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/17/1379392145327/Ring-Cycle-in-2-mins-002.jpg",
+          "typeData":{
+            "source":"Sydney Symphony",
+            "altText":"Ring Cycle in 2 mins",
+            "height":"90",
+            "credit":"Sydney Symphony",
+            "caption":"Ring Cycle in 2 mins Photograph: Sydney Symphony",
+            "width":"120"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/17/1379392149118/Ring-Cycle-in-2-mins-003.jpg",
+          "typeData":{
+            "source":"Sydney Symphony",
+            "altText":"Ring Cycle in 2 mins",
+            "height":"225",
+            "credit":"Sydney Symphony",
+            "caption":"Ring Cycle in 2 mins Photograph: Sydney Symphony",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/17/1379392151764/Ring-Cycle-in-2-mins-004.jpg",
+          "typeData":{
+            "source":"Sydney Symphony",
+            "altText":"Ring Cycle in 2 mins",
+            "height":"360",
+            "credit":"Sydney Symphony",
+            "caption":"Ring Cycle in 2 mins Photograph: Sydney Symphony",
+            "width":"480"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/9/17/130917ring_FromGAus-16x9.mp4",
+          "typeData":{
+            "source":"Sydney Symphony Orchestra",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942306387/Guardian-Video-Holding-Im-003.jpg",
+            "height":"360",
+            "durationMinutes":"3",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942308989/Guardian-Video-Holding-Im-005.jpg",
+            "width":"480",
+            "durationSeconds":"1"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/9/17/130917ring_FromGAus_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"Sydney Symphony Orchestra",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942306387/Guardian-Video-Holding-Im-003.jpg",
+            "height":"360",
+            "durationMinutes":"3",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942308989/Guardian-Video-Holding-Im-005.jpg",
+            "width":"480",
+            "durationSeconds":"1"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/9/17/130917ring_FromGAus_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"Sydney Symphony Orchestra",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942306387/Guardian-Video-Holding-Im-003.jpg",
+            "height":"360",
+            "durationMinutes":"3",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942308989/Guardian-Video-Holding-Im-005.jpg",
+            "width":"480",
+            "durationSeconds":"1"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/9/17/130917ring_FromGAus/130917ring_FromGAus.m3u8",
+          "typeData":{
+            "source":"Sydney Symphony Orchestra",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942306387/Guardian-Video-Holding-Im-003.jpg",
+            "height":"360",
+            "durationMinutes":"3",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942308989/Guardian-Video-Holding-Im-005.jpg",
+            "width":"480",
+            "durationSeconds":"1"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/webm",
+          "file":"http://cdn.theguardian.tv/webM/640/2013/9/17/130917ring_FromGAus_vpx.webm",
+          "typeData":{
+            "source":"Sydney Symphony Orchestra",
+            "embeddable":"true",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942306387/Guardian-Video-Holding-Im-003.jpg",
+            "height":"360",
+            "durationMinutes":"3",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2013/1/23/1358942308989/Guardian-Video-Holding-Im-005.jpg",
+            "width":"480",
+            "durationSeconds":"1"
+          }
+        }]
+      },{
+        "id":"gu-image-417475543",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/17/1379392161811/Ring-Cycle-in-2-mins-009.jpg",
+          "typeData":{
+            "source":"Sydney Symphony",
+            "altText":"Ring Cycle in 2 mins",
+            "height":"84",
+            "credit":"Sydney Symphony",
+            "caption":"Ring Cycle in 2 mins Photograph: Sydney Symphony",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    }]
+  }
+}

--- a/football/app/views/fragments/competitionsBody.scala.html
+++ b/football/app/views/fragments/competitionsBody.scala.html
@@ -27,8 +27,8 @@
     @renderFilter(comp)
 }
 
-@fragments.footballNav("/football")
-
 <div class="box-indent article-zone-no-indent">
+    @fragments.footballNav("/football")
+
     @fragments.mostPopularPlaceholder("sport")
 </div>

--- a/football/app/views/fragments/footballMatchBody.scala.html
+++ b/football/app/views/fragments/footballMatchBody.scala.html
@@ -2,63 +2,61 @@
 @import feed._
 @import implicits.Football._
 
-    <div class="article-wrapper monocolumn-wrapper">
+<div class="article-wrapper monocolumn-wrapper">
+    <div class="article-v2__inner">
+        <h2 class="article-zone type-1">
+            <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
+        </h2>
+    </div>
+    <article class="article football-article @if(page.theMatch.isLive){is-live}" role="main">
         <div class="article-v2__inner">
-            <h2 class="article-zone type-1">
-                <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
-            </h2>
+            <header class="article__head">
+                <p class="dateline type-11">
+                    @fragments.status(page.theMatch)
+                    <time data-timestamp="@page.theMatch.date.getMillis">
+                        @Format(page.theMatch.date, "EEEE d MMMM y HH.mm z")
+                    </time>
+                </p>
+                <div class="match-summary" data-match-id="@page.theMatch.id">
+                    @fragments.matchSummary(page.theMatch)
+                </div>
+            </header>
+            <div class="after-header">
+                @* this 'Stats' header gets replaced by the match navigation tabs (if available) *@
+                @if(page.matchStarted){
+                    <h3 class="type-2 section-divider">Stats</h3>
+                }
+            </div>
         </div>
-        <article class="article football-article @if(page.theMatch.isLive){is-live}" role="main">
-            <div class="article-v2__inner">
-                <header class="article__head">
-                    <p class="dateline type-11">
-                        @fragments.status(page.theMatch)
-                        <time data-timestamp="@page.theMatch.date.getMillis">
-                            @Format(page.theMatch.date, "EEEE d MMMM y HH.mm z")
-                        </time>
-                    </p>
-                    <div class="match-summary" data-match-id="@page.theMatch.id">
-                        @fragments.matchSummary(page.theMatch)
+        <div class="article-v2__columning-wrapper">
+            <div class="article-v2__main-column">
+                <div class="js-article__container article__container u-cf">
+
+                @if(page.theMatch.isLive) {
+                    <div class="live-toolbar">
+                        <div class="update update-live-matches update-match-stats" data-link-name="autoupdate"></div>
                     </div>
-                </header>
-                <div class="after-header">
-                    @* this 'Stats' header gets replaced by the match navigation tabs (if available) *@
-                    @if(page.matchStarted){
-                        <h3 class="type-2 section-divider">Stats</h3>
-                    }
+                }
+                <div class="match-stats">
+                    @fragments.matchStats(page)
+                </div>
                 </div>
             </div>
-            <div class="article-v2__columning-wrapper">
-                <div class="article-v2__main-column">
-                    <div class="js-article__container article__container u-cf">
-
-                    @if(page.theMatch.isLive) {
-                        <div class="live-toolbar">
-                            <div class="update update-live-matches update-match-stats" data-link-name="autoupdate"></div>
-                        </div>
-                    }
-                    <div class="match-stats">
-                        @fragments.matchStats(page)
-                    </div>
-                    </div>
-                </div>
-                <div class="article-v2__secondary-column" aria-hidden="true">
-                    <div class="article-v2__secondary-column__inner">
-                        <div class="u-table">
-                            <div class="u-table__row">
-                                <div class="u-table__cell u-table__cell--top">
-                                    @fragments.social(page, "next to content")
-                                </div>
+            <div class="article-v2__secondary-column" aria-hidden="true">
+                <div class="article-v2__secondary-column__inner">
+                    <div class="u-table">
+                        <div class="u-table__row">
+                            <div class="u-table__cell u-table__cell--top">
+                                @fragments.social(page, "next to content")
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </article>
-        <div class="article-v2__inner">
-            @fragments.footballNav("/football", None, None)
-            @fragments.mostPopularPlaceholder("sport")
         </div>
+    </article>
+    <div class="article-v2__inner">
+        @fragments.footballNav("/football", None, None)
+        @fragments.mostPopularPlaceholder("sport")
     </div>
-
-
+</div>

--- a/football/app/views/fragments/footballMatchBody.scala.html
+++ b/football/app/views/fragments/footballMatchBody.scala.html
@@ -2,47 +2,63 @@
 @import feed._
 @import implicits.Football._
 
-<div class="article-wrapper monocolumn-wrapper">
-    <h2 class="article-zone type-1">
-        <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
-    </h2>
-
-    <article class="article football-article @if(page.theMatch.isLive){is-live}" role="main">
-        <header class="article__head">
-            <p class="dateline type-11">
-                @fragments.status(page.theMatch)
-                <time data-timestamp="@page.theMatch.date.getMillis">
-                    @Format(page.theMatch.date, "EEEE d MMMM y HH.mm z")
-                </time>
-            </p>
-            <div class="match-summary" data-match-id="@page.theMatch.id">
-                @fragments.matchSummary(page.theMatch)
-            </div>
-        </header>
-
-        <div class="after-header">
-            @* this 'Stats' header gets replaced by the match navigation tabs (if available) *@
-            @if(page.matchStarted){
-                <h3 class="type-2 section-divider">Stats</h3>
-            }
+    <div class="article-wrapper monocolumn-wrapper">
+        <div class="article-v2__inner">
+            <h2 class="article-zone type-1">
+                <a class="zone-color" data-link-name="article section" href="@LinkTo{/football}">Football</a>
+            </h2>
         </div>
-        <div class="article__main-column">
-            @if(page.theMatch.isLive) {
-                <div class="live-toolbar">
-                    <div class="update update-live-matches update-match-stats" data-link-name="autoupdate"></div>
+        <article class="article football-article @if(page.theMatch.isLive){is-live}" role="main">
+            <div class="article-v2__inner">
+                <header class="article__head">
+                    <p class="dateline type-11">
+                        @fragments.status(page.theMatch)
+                        <time data-timestamp="@page.theMatch.date.getMillis">
+                            @Format(page.theMatch.date, "EEEE d MMMM y HH.mm z")
+                        </time>
+                    </p>
+                    <div class="match-summary" data-match-id="@page.theMatch.id">
+                        @fragments.matchSummary(page.theMatch)
+                    </div>
+                </header>
+                <div class="after-header">
+                    @* this 'Stats' header gets replaced by the match navigation tabs (if available) *@
+                    @if(page.matchStarted){
+                        <h3 class="type-2 section-divider">Stats</h3>
+                    }
                 </div>
-            }
-            <div class="match-stats">
-                @fragments.matchStats(page)
             </div>
+            <div class="article-v2__columning-wrapper">
+                <div class="article-v2__main-column">
+                    <div class="js-article__container article__container u-cf">
+
+                    @if(page.theMatch.isLive) {
+                        <div class="live-toolbar">
+                            <div class="update update-live-matches update-match-stats" data-link-name="autoupdate"></div>
+                        </div>
+                    }
+                    <div class="match-stats">
+                        @fragments.matchStats(page)
+                    </div>
+                    </div>
+                </div>
+                <div class="article-v2__secondary-column" aria-hidden="true">
+                    <div class="article-v2__secondary-column__inner">
+                        <div class="u-table">
+                            <div class="u-table__row">
+                                <div class="u-table__cell u-table__cell--top">
+                                    @fragments.social(page, "next to content")
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </article>
+        <div class="article-v2__inner">
+            @fragments.footballNav("/football", None, None)
+            @fragments.mostPopularPlaceholder("sport")
         </div>
-    </article>
-</div>
+    </div>
 
-<div id="js-related"></div>
 
-@fragments.footballNav("/football", None, None)
-
-<div class="article__main-column article-zone-no-indent">
-    @fragments.mostPopularPlaceholder("sport")
-</div>

--- a/football/app/views/fragments/matchesBody.scala.html
+++ b/football/app/views/fragments/matchesBody.scala.html
@@ -36,8 +36,8 @@
 
 </div>
 
-@fragments.footballNav(model.urlBase, model.comp.map(c => c.fullName), model.comp.map(c => c.url))
-
 <div class="box-indent article-zone-no-indent">
+    @fragments.footballNav(model.urlBase, model.comp.map(c => c.fullName), model.comp.map(c => c.url))
+
     @fragments.mostPopularPlaceholder("sport")
 </div>

--- a/football/app/views/fragments/tablesBody.scala.html
+++ b/football/app/views/fragments/tablesBody.scala.html
@@ -59,8 +59,8 @@
     }
 </ol>
 
-@fragments.footballNav(model.urlBase, model.comp.map(c => c.fullName), model.comp.map(c => c.url))
-
 <div class="box-indent article-zone-no-indent">
+    @fragments.footballNav(model.urlBase, model.comp.map(c => c.fullName), model.comp.map(c => c.url))
+
     @fragments.mostPopularPlaceholder("sport")
 </div>

--- a/football/app/views/fragments/teamFixturesBody.scala.html
+++ b/football/app/views/fragments/teamFixturesBody.scala.html
@@ -23,8 +23,8 @@
     }
 </div>
 
-@fragments.footballNav("/football")
-
 <div class="box-indent article-zone-no-indent">
+    @fragments.footballNav("/football")
+
     @fragments.mostPopularPlaceholder("sport")
 </div>

--- a/football/app/views/fragments/teamlistBody.scala.html
+++ b/football/app/views/fragments/teamlistBody.scala.html
@@ -28,8 +28,8 @@
     @renderTeamList(comp)
 }
 
-@fragments.footballNav("/football")
-
 <div class="box-indent article-zone-no-indent">
+    @fragments.footballNav("/football")
+
     @fragments.mostPopularPlaceholder("sport")
 </div>


### PR DESCRIPTION
One of those days…
- Football results layout fixes
- Replace `js-popular` in CSS by a normal class (not `js-` prefixed)
- Refactor `headline-list__title`

The PR contains tons of code stuff (sorry), but what is important is this:
## Before

![eintracht frankfurt 3 - 0 bordeaux](https://f.cloud.github.com/assets/85783/1181489/03932f4c-220a-11e3-957e-426011c97523.png)
## After

![valencia 0 - 3 swansea](https://f.cloud.github.com/assets/85783/1181663/b4c9da3e-220c-11e3-969c-1132228cd0d1.png)

![ ](http://s1.developerslife.ru/public/images/gifs/d729f6e5-1d1d-4d76-89b2-bf462dccd41d.gif)
