### PR TITLE
exclude admin casper tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -388,7 +388,7 @@ module.exports = function (grunt) {
     grunt.registerTask('test:integration:article',  ['env:casperjs', 'casperjs:article']);
     grunt.registerTask('test:integration:front',  ['env:casperjs', 'casperjs:front']);
     grunt.registerTask('test:integration:corenavigation',  ['env:casperjs', 'casperjs:corenavigation']);
-     grunt.registerTask('test:integration:allexceptadmin',  ['env:casperjs', 'casperjs:allexceptadmin']);
+    grunt.registerTask('test:integration:allexceptadmin',  ['env:casperjs', 'casperjs:allexceptadmin']);
 
 
     grunt.registerTask('test', ['jshint:common', 'test:unit', 'test:integration']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,6 +129,9 @@ module.exports = function (grunt) {
             corenavigation: {
                 src: ['integration-tests/casper/tests/core-navigation/*.js']
             },
+            allexceptadmin: {
+                src: ['integration-tests/casper/tests/!(*admin)/*.spec.js']
+            },
             },
 
         jasmine: {
@@ -385,6 +388,8 @@ module.exports = function (grunt) {
     grunt.registerTask('test:integration:article',  ['env:casperjs', 'casperjs:article']);
     grunt.registerTask('test:integration:front',  ['env:casperjs', 'casperjs:front']);
     grunt.registerTask('test:integration:corenavigation',  ['env:casperjs', 'casperjs:corenavigation']);
+     grunt.registerTask('test:integration:allexceptadmin',  ['env:casperjs', 'casperjs:allexceptadmin']);
+
 
     grunt.registerTask('test', ['jshint:common', 'test:unit', 'test:integration']);
 


### PR DESCRIPTION
Made a new grunt option:
test:integration:allexceptadmin
which runs all tests except admin. This is so we can have a passing build by excluding the admin test which currently fails due to authentication issues.

This option will make it easier to spot legitimately failing tests.

cc/ @ironsidevsquincy 
