### PR TITLE
Fronts tool: fixable titles

### DIFF
--- a/admin/app/views/fronts.scala.html
+++ b/admin/app/views/fronts.scala.html
@@ -2,7 +2,7 @@
 
 @admin_main("Fronts editor", env, isAuthed = true) {
 
-    <div class="splash" data-bind="visible: false">Loading Editor...</div> 
+    <div class="splash" data-bind="visible: false">Loading Editor...</div>
 
     <div class="fronts" data-bind="visible: true, makeDropabble: true" style="display: none">
         <header>
@@ -67,14 +67,20 @@
                         <span class="list-header__edition" data-bind="text: edition"></span>
                         <span class="list-header__section" data-bind="text: section"></span>
                         <span class="list-header__role"    data-bind="text: configMeta.roleName"></span>
-                        <span data-bind="visible: !state.editingConfig()">
-                            : <a class="list-header__display" data-bind="
+                        <span data-bind="visible: !state.editingConfig()"> :
+                            <a class="list-header__display" data-bind="
+                                visible: typeof configMeta.displayName() === 'undefined',
                                 css: { 'list-header__display--is-set': !!collectionMeta.displayName() },
-                                text: collectionMeta.displayName() || 'Add Title',
-                                click: toggleEditingConfig"></a></span>
+                                text: collectionMeta.displayName() || 'Set Title',
+                                click: toggleEditingConfig"></a>
 
-                        <span class="list-header__role__description">
-                            : <span data-bind="text: configMeta.roleDescription"></span>
+                            <span class="list-header__display list-header__display--is-set" data-bind="
+                                visible: typeof configMeta.displayName() !== 'undefined',
+                                text: configMeta.displayName"></a>
+                        </span>
+
+                        <span class="list-header__role__description"> :
+                            <span data-bind="text: configMeta.roleDescription"></span>
                         </span>
                     </div>
 
@@ -92,7 +98,7 @@
                                 active: state.liveMode()
                             }">
                             <span class="list-header__status__live__title" data-bind="click: setLiveMode">LIVE</span>
-                        </div>                    
+                        </div>
                         <div class="list-header__status__draft" data-bind="
                             css: {
                                 'active':   !state.liveMode(),
@@ -120,7 +126,7 @@
                 </div>
 
                 <div class="needs-more" data-bind="if: needsMore">
-                    Needs at least <span class="needs-more__num" data-bind="text: configMeta.min"></span> 
+                    Needs at least <span class="needs-more__num" data-bind="text: configMeta.min"></span>
                     article<span data-bind="text: configMeta.min() > 1 ? 's' : ''"></span>
                 </div>
                 <div class="connectedList persisted" data-bind="
@@ -129,7 +135,7 @@
                     },
                     css: {
                         'pending': state.loadIsPending,
-                        'is-live': state.liveMode() 
+                        'is-live': state.liveMode()
                     },
                     template: {name: 'template_article', foreach: state.liveMode() ? live : draft}"></div>
             </div>
@@ -172,11 +178,11 @@
             <!-- /ko -->
 
             <a class="webTitle" target="_blank" data-bind="
-                html: meta.webTitle, 
+                html: meta.webTitle,
                 attr: {href: 'http://www.theguardian.com/' + meta.id()}"></a>
 
         </div>
     </script>
-    
+
     <script src="@routes.Assets.at("javascripts/fronts.js")"></script>
 }

--- a/admin/public/javascripts/models/fronts/list.js
+++ b/admin/public/javascripts/models/fronts/list.js
@@ -21,6 +21,8 @@ define([
 
         opts = opts || {};
 
+        console.log(opts);
+
         if (!opts.id) { return; }
 
         this.id      = opts.id;
@@ -32,6 +34,7 @@ define([
 
         // properties from the config, about this collection
         this.configMeta   = common.util.asObservableProps([
+            'displayName',
             'min',
             'max',
             'roleName',
@@ -39,7 +42,7 @@ define([
         common.util.populateObservables(this.configMeta, opts);
 
         // properties from the collection itself
-        this.collectionMeta = common.util.asObservableProps([ 
+        this.collectionMeta = common.util.asObservableProps([
             'displayName',
             'lastUpdated',
             'updatedBy',
@@ -166,8 +169,8 @@ define([
 
                 self.state.hasDraft(_.isArray(resp.draft));
 
-                if (opts.isRefresh && (self.state.loadIsPending() || resp.lastUpdated === self.collectionMeta.lastUpdated())) { 
-                    // noop    
+                if (opts.isRefresh && (self.state.loadIsPending() || resp.lastUpdated === self.collectionMeta.lastUpdated())) {
+                    // noop
                 } else {
                     self.populateLists(resp);
                 }
@@ -179,7 +182,7 @@ define([
 
                 self.decorate();
 
-                if (_.isFunction(opts.callback)) { opts.callback(); } 
+                if (_.isFunction(opts.callback)) { opts.callback(); }
             }
         );
     };
@@ -242,7 +245,7 @@ define([
             method: 'post',
             type: 'json',
             contentType: 'application/json',
-            data: JSON.stringify({ 
+            data: JSON.stringify({
                 config: {
                     displayName: this.collectionMeta.displayName()
                 }

--- a/admin/public/javascripts/models/fronts/list.js
+++ b/admin/public/javascripts/models/fronts/list.js
@@ -21,8 +21,6 @@ define([
 
         opts = opts || {};
 
-        console.log(opts);
-
         if (!opts.id) { return; }
 
         this.id      = opts.id;


### PR DESCRIPTION
If there's a `config.displayName` it'll override `collection.displayName` and be non-editable. This prevents editors from renaming collections as sneaky way of reordering them.
