### PR TITLE
Add geolocation to idapi registration calls

### DIFF
--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -18,7 +18,8 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
                                      api: IdApiClient,
                                      idRequestParser : IdRequestParser,
                                      idUrlBuilder : IdentityUrlBuilder,
-                                     signinService : PlaySigninService  ) extends Controller with ExecutionContexts with SafeLogging  {
+                                     signinService : PlaySigninService  )
+  extends Controller with ExecutionContexts with SafeLogging with RemoteAddress {
 
 
   val page = new IdentityPage("/register", "Register", "register")
@@ -53,7 +54,7 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
         case(email, username, password, gnmMarketing, thirdPartyMarketing) => {
           val user = userCreationService.createUser(email, username, password, gnmMarketing, thirdPartyMarketing)
           Async {
-            api.register(user, omnitureData, Some(request.remoteAddress)) map ( _ match {
+            api.register(user, omnitureData, clientIp(request)) map ( _ match {
               case Left(errors) => {
                 val formWithError = errors.foldLeft(boundForm) {  (form, error) =>
                   error match {

--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -5,7 +5,7 @@ import services._
 import idapiclient.IdApiClient
 import play.api.mvc._
 import common.ExecutionContexts
-import utils.SafeLogging
+import utils.{RemoteAddress, SafeLogging}
 import javax.inject.Singleton
 import model.IdentityPage
 import play.api.data._
@@ -20,7 +20,6 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
                                      idUrlBuilder : IdentityUrlBuilder,
                                      signinService : PlaySigninService  )
   extends Controller with ExecutionContexts with SafeLogging with RemoteAddress {
-
 
   val page = new IdentityPage("/register", "Register", "register")
 

--- a/identity/app/services/RemoteAddress.scala
+++ b/identity/app/services/RemoteAddress.scala
@@ -1,12 +1,12 @@
 package services
 
-import play.api.mvc.{Request, AnyContent}
+import play.api.mvc.RequestHeader
 import common.Logging
 
 trait RemoteAddress extends Logging {
   private val Ip = """(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})""".r
 
-  def clientIp(request: Request[AnyContent]): Option[String] = {
+  def clientIp(request: RequestHeader): Option[String] = {
     request.headers.get("X-Forwarded-For").flatMap { xForwardedFor =>
       xForwardedFor.split(", ").find {  // leftmost non-private IP from header is client
         case Ip(a, b, c, d) => {

--- a/identity/app/utils/RemoteAddress.scala
+++ b/identity/app/utils/RemoteAddress.scala
@@ -1,4 +1,4 @@
-package services
+package utils
 
 import play.api.mvc.RequestHeader
 import common.Logging

--- a/identity/test/utils/RemoteAddressTest.scala
+++ b/identity/test/utils/RemoteAddressTest.scala
@@ -1,4 +1,4 @@
-package services
+package utils
 
 import org.scalatest.FunSuite
 import play.api.test.FakeRequest


### PR DESCRIPTION
I've tested the solution provided in the RemoteAddress trait and it works nicely, so I'm enabling it in the RegistrationController (rather than the old remoteAddress approach which only picks up the ELB's IP).

A little tidying as well, while I was in there.
