### PR TITLE
Fix .json and trails.json endpoints on facia

### DIFF
--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -1,10 +1,10 @@
 package views.support
 
-import scala.collection.mutable.HashSet
 import model.{Collection, Trail}
+import scala.collection.mutable
 
 class TemplateDeduping extends implicits.Collections {
-  private var alreadyUsed: HashSet[String] = new HashSet[String]()
+  private var alreadyUsed: mutable.LinkedHashSet[String] = new mutable.LinkedHashSet[String]()
   private val defaultTake: Int = 20
 
   def take(numberWanted: Int, items: Seq[Trail]): Seq[Trail] =

--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -4,7 +4,7 @@ import model.{Collection, Trail}
 import scala.collection.mutable
 
 class TemplateDeduping extends implicits.Collections {
-  private var alreadyUsed: mutable.LinkedHashSet[String] = new mutable.LinkedHashSet[String]()
+  private var alreadyUsed: mutable.HashSet[String] = new mutable.HashSet[String]()
   private val defaultTake: Int = 20
 
   def take(numberWanted: Int, items: Seq[Trail]): Seq[Trail] =
@@ -22,8 +22,6 @@ class TemplateDeduping extends implicits.Collections {
 
   def apply(numberWanted: Int, collection: Collection): Collection = take(numberWanted, collection)
   def apply(collection: Collection): Collection = take(defaultTake, collection)
-
-  def getTrailIds: Seq[String] = alreadyUsed.toList
 }
 
 object TemplateDeduping {

--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -22,6 +22,8 @@ class TemplateDeduping extends implicits.Collections {
 
   def apply(numberWanted: Int, collection: Collection): Collection = take(numberWanted, collection)
   def apply(collection: Collection): Collection = take(defaultTake, collection)
+
+  def getTrailIds: Seq[String] = alreadyUsed.toList
 }
 
 object TemplateDeduping {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -5,7 +5,6 @@ import front._
 import model._
 import conf._
 import play.api.mvc._
-import views.support.TemplateDeduping
 import play.api.libs.json.Json
 
 // TODO, this needs a rethink, does not seem elegant

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -148,11 +148,10 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
             Redirect(editionalisedPath)
           } else {
             if (request.isJson) {
-              val templateDeduping: TemplateDeduping = TemplateDeduping()
-              val html = views.html.fragments.frontBody(frontPage, faciaPage, Some(templateDeduping))
+              val html = views.html.fragments.frontBody(frontPage, faciaPage)
               JsonComponent(
                 "html" -> html,
-                "trails" -> templateDeduping.getTrailIds,
+                "trails" -> faciaPage.collections.filter(_._1.contentApiQuery.isDefined).take(1).flatMap(_._2.items.map(_.url)).toList,
                 "config" -> Json.parse(views.html.fragments.javaScriptConfig(frontPage, Switches.all).body)
               )
             }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -170,7 +170,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
     FrontPage(editionalisedPath).map{ frontPage =>
 
       // get the first trailblock
-      val collection: Option[(Config, Collection)] = front(editionalisedPath).flatMap(_.collections.headOption)
+      val collection: Option[(Config, Collection)] = front(editionalisedPath).flatMap(_.collections.filter(_._2.items.nonEmpty).headOption)
 
       if (path != editionalisedPath) {
         Redirect(editionalisedPath)

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,8 +1,8 @@
-@(front: FrontPage, faciaTrailblock: FaciaPage)(implicit request: RequestHeader)
+@(front: FrontPage, faciaTrailblock: FaciaPage, templateDeduping: Option[TemplateDeduping] = None)(implicit request: RequestHeader)
 
 @if(faciaTrailblock.collections.nonEmpty) {
     <div class="facia-container monocolumn-wrapper monocolumn-wrapper--no-limit" data-link-name="Front" role="main">
-        @defining {TemplateDeduping()} { dedupe: TemplateDeduping =>
+        @defining {templateDeduping.getOrElse(TemplateDeduping())} { dedupe: TemplateDeduping =>
             @faciaTrailblock.collections.zipWithIndex.map{ case(block, index) =>
                 @if(block._2.items.nonEmpty){
                     @FindStyle(faciaTrailblock.id, block._1) match {

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,8 +1,8 @@
-@(front: FrontPage, faciaTrailblock: FaciaPage, templateDeduping: Option[TemplateDeduping] = None)(implicit request: RequestHeader)
+@(front: FrontPage, faciaTrailblock: FaciaPage)(implicit request: RequestHeader)
 
 @if(faciaTrailblock.collections.nonEmpty) {
     <div class="facia-container monocolumn-wrapper monocolumn-wrapper--no-limit" data-link-name="Front" role="main">
-        @defining {templateDeduping.getOrElse(TemplateDeduping())} { dedupe: TemplateDeduping =>
+        @defining {TemplateDeduping()} { dedupe: TemplateDeduping =>
             @faciaTrailblock.collections.zipWithIndex.map{ case(block, index) =>
                 @if(block._2.items.nonEmpty){
                     @FindStyle(faciaTrailblock.id, block._1) match {


### PR DESCRIPTION
This fixes both the <section>.json and <section>/trails.json endpoints in facia, and adds back in the `trails` key that was used for swipe.

The `trails` key that is returned in the `.json` endpoint is now the items of the first collection in the list to define a `contentApiQuery`. I thought this would be more reasonable than searching explicitly for medium stories.

The `trails.json` endpoint returns the same HTML structure as fronts does, except it finds the first collection in the list that has items. @ironsidevsquincy Maybe this should instead do the same think as .json and take the first collection that has defined a contentApiQuery?

@stephanfowler 
