### PR TITLE
Check for HTTPS ajax URL before making absolute

### DIFF
--- a/common/app/assets/javascripts/ajax.js
+++ b/common/app/assets/javascripts/ajax.js
@@ -18,7 +18,7 @@ define(["reqwest"], function (reqwest) {
 
         params = appendEdition(params);
 
-        if(params.url.lastIndexOf("http://", 0)!==0){
+        if (!params.url.match('^https?://')) {
             params.url = makeAbsolute(params.url);
         }
         return ajax.reqwest(params);


### PR DESCRIPTION
To allow HTTPS ajax calls, tweak the method to check whether URLs start with either before prepending full url.
