### PR TITLE
Add Identity to CORS origin property

### DIFF
--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -23,7 +23,7 @@ football.api.host=http://football-stats-stub.appspot.com/2012-10-20/16-05
 ajax.url=http://code.api.nextgen.guardianapps.co.uk
 
 # no spaces
-ajax.cors.origin=http://m.code.dev-theguardian.com
+ajax.cors.origin=http://m.code.dev-theguardian.com,https://profile.code.dev-theguardian.com
 
 # Admin switches
 admin.config.file=CODE/config/front.json

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -20,7 +20,7 @@ front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/CODE/config/fr
 
 # uncomment to test cors locally
 #ajax.url=http://localhost:9000
-#ajax.cors.origin=http://m.random.com,http://127.0.0.1:9000,http://www.random.com
+#ajax.cors.origin=http://m.random.com,http://127.0.0.1:9000,http://www.random.com,https://profile.thegulocal.com
 
 # Admin switches
 admin.config.file=DEV/config/front.json

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -20,7 +20,7 @@ guardian.page.fbAppId=180444840287
 ajax.url=http://api.nextgen.guardianapps.co.uk
 
 # no spaces
-ajax.cors.origin=http://www.theguardian.com,http://m.guardian.co.uk,http://m.guardiannews.com
+ajax.cors.origin=http://www.theguardian.com,http://m.guardian.co.uk,http://m.guardiannews.com,https://profile.theguardian.com
 
 # Admin switches
 admin.config.file=PROD/config/front.json


### PR DESCRIPTION
To prevent "origin is not allowed" errors from Identity pages
