### PR TITLE
Fix stomping bug in admin switchboard

### DIFF
--- a/admin/app/controllers/SwitchboardController.scala
+++ b/admin/app/controllers/SwitchboardController.scala
@@ -13,44 +13,58 @@ object SwitchboardController extends Controller with AuthLogging with Logging wi
 
   val SwitchPattern = """([a-z\d-]+)=(on|off)""".r
 
-  def render() = AuthAction { request =>
+  def render() = AuthAction { implicit request =>
     log("loaded Switchboard", request)
 
-    val promiseOfSwitches = Akka future { Store.getSwitches }
+    val promiseOfSwitches = Akka future { Store.getSwitchesWithLastModified }
 
     Async {
-      promiseOfSwitches map { configuration =>
-        val nextStateLookup = Properties(configuration getOrElse "")
+      promiseOfSwitches map { switchesWithLastModified =>
+          val configuration = switchesWithLastModified.map(_._1)
+          val nextStateLookup = Properties(configuration getOrElse "")
 
-        Switches.all foreach { switch =>
-          nextStateLookup.get(switch.name) foreach {
-            case "on" => switch.switchOn()
-            case _ => switch.switchOff()
+          Switches.all foreach {
+            switch =>
+              nextStateLookup.get(switch.name) foreach {
+                case "on" => switch.switchOn()
+                case _ => switch.switchOff()
+              }
           }
-        }
 
-        Ok(views.html.switchboard(Configuration.environment.stage))
+          val lastModified = switchesWithLastModified.map(_._2).map(_.getMillis).getOrElse(System.currentTimeMillis)
+          Ok(views.html.switchboard(Configuration.environment.stage, lastModified))
       }
     }
   }
 
-  def save() = AuthAction { request =>
-    log("saving switchboard", request)
+  def save() = AuthAction { implicit request =>
 
-    val requester = Identity(request).get.fullName
-    val updates = request.body.asFormUrlEncoded.map { params =>
-      Switches.all map { switch =>
-        switch.name + "=" + params.get(switch.name).map(v => "on").getOrElse("off")
+      val form = request.body.asFormUrlEncoded
+
+      val localLastModified = form.get("lastModified").head.toLong
+      val remoteLastModified = Store.getSwitchesLastModified
+
+      if (remoteLastModified.exists(_.getMillis > localLastModified)) {
+        Redirect(routes.SwitchboardController.render()).flashing("error" -> "Stomp! Try Again.")
+      } else {
+
+        log("saving switchboard", request)
+
+        val requester = Identity(request).get.fullName
+        val updates = request.body.asFormUrlEncoded.map { params =>
+            Switches.all map { switch =>
+                switch.name + "=" + params.get(switch.name).map(v => "on").getOrElse("off")
+            }
+        }.get
+
+        val promiseOfSavedSwitches = Akka.future {
+          saveSwitchesOrError(requester, updates)
+        }
+
+        Async {
+          promiseOfSavedSwitches
+        }
       }
-    }.get
-
-    val promiseOfSavedSwitches = Akka.future {
-      saveSwitchesOrError(requester, updates)
-    }
-
-    Async {
-      promiseOfSavedSwitches
-    }
   }
 
   private def saveSwitchesOrError(requester: String, updates: List[String]) = try {

--- a/admin/app/controllers/SwitchboardController.scala
+++ b/admin/app/controllers/SwitchboardController.scala
@@ -45,7 +45,7 @@ object SwitchboardController extends Controller with AuthLogging with Logging wi
       val remoteLastModified = Store.getSwitchesLastModified
 
       if (remoteLastModified.exists(_.getMillis > localLastModified)) {
-        Redirect(routes.SwitchboardController.render()).flashing("error" -> "Stomp! Try Again.")
+        Redirect(routes.SwitchboardController.render()).flashing("error" -> "A more recent change to the switch has been found, please refresh and try again.")
       } else {
 
         log("saving switchboard", request)

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -13,6 +13,8 @@ trait Store extends Logging {
   def putConfig(config: String) { S3.putPublic(configKey, config, "application/json") }
 
   def getSwitches = S3.get(switchesKey)
+  def getSwitchesWithLastModified = S3.getWithLastModified(switchesKey)
+  def getSwitchesLastModified = S3.getLastModified(switchesKey)
   def putSwitches(config: String) { S3.putPublic(switchesKey, config, "text/plain") }
 
   def getTopStories = S3.get(topStoriesKey)

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -1,9 +1,10 @@
-@(env: String)
+@(env: String, lastModified: Long)(implicit flash: Flash)
 
 @admin_main("Switchboard", env, isAuthed = true) {
+@if(flash.get("error").isDefined) { <h1 style="color:#bd362f">@flash.get("error").get</h1> }
 <div class="row">
     <form id="switchboard" action="/dev/switchboard" method="POST">
-
+        <input type="hidden" name="lastModified" value="@lastModified" />
         @Switches.grouped.map { case (group, switches) =>
             <h4>@group</h4>
             <div class="well">


### PR DESCRIPTION
An attempt to fix this scenario, which has occurred several times:
if user 1 renders page, user 2 renders page, user 2 saves and then user 1 saves, user 2's changes will be lost.
