### PR TITLE
Improve Gathering of A/B Test Results

### DIFF
--- a/admin/app/tools/charts/ABTestResultGraph.scala
+++ b/admin/app/tools/charts/ABTestResultGraph.scala
@@ -41,9 +41,26 @@ trait ABTestResultGraph extends Chart with implicits.Dates {
    */
   def buildDataset(data: List[(Int, String, Double)]) = {
 
-    val groupedData = data groupBy {
+    val dataByDay = data groupBy {
       case (day, _, _) => day
-    } mapValues {
+    }
+
+    val allVariants = extractLabels(data) filterNot (_ == "Date")
+
+    val missingData = for {
+      variant <- allVariants
+      day <- dataByDay.keys
+      variantsForDay = dataByDay.get(day).get.map(_._2)
+      if !variantsForDay.contains(variant)
+    } yield (day, variant)
+
+    val filledInData = missingData.foldLeft(dataByDay)((acc, missingDatum) => {
+      val day = missingDatum._1
+      val variant = missingDatum._2
+      acc - day + (day -> (acc.get(day).get :+(day, variant, 0.0)))
+    })
+
+    val groupedData = filledInData mapValues {
       _.sortWith {
         case ((_, variant1, _), (_, variant2, _)) => compareVariants(variant1, variant2)
       }.map {

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -16,6 +16,7 @@
             <li><a href="@routes.AnalyticsController.kpis()">KPIs</a></li>
             <li><a href="@routes.AnalyticsController.pageviews()">Pageviews</a></li>
             <li><a href="@routes.AnalyticsController.browsers()">Browser support tables</a></li>
+            <li><a href="@routes.AnalyticsController.abtests()">A/B Test Results</a></li>
         </ul>
     </div>
     <div class="row">

--- a/admin/test/tools/charts/ABTestResultGraphTest.scala
+++ b/admin/test/tools/charts/ABTestResultGraphTest.scala
@@ -44,7 +44,8 @@ class ABTestResultGraphTest extends FeatureSpec with ShouldMatchers {
       (1526, "A", 45.4554),
       (1527, "A", 54167.3),
       (1527, "B", 1687.3),
-      (1523, "A", 12.1234)
+      (1523, "A", 12.1234),
+      (1538, "A", 2.341)
     )
 
     scenario("Labels") {
@@ -62,7 +63,8 @@ class ABTestResultGraphTest extends FeatureSpec with ShouldMatchers {
         DataPoint("15/03", List(17.3, 7.3, 27.3)),
         DataPoint("16/03", List(3.234, 3.2345, 23.234)),
         DataPoint("17/03", List(451.4554, 45.4554, 45.45541)),
-        DataPoint("18/03", List(34167.3, 54167.3, 1687.3)))
+        DataPoint("18/03", List(34167.3, 54167.3, 1687.3)),
+        DataPoint("19/03", List(0, 2.341, 0)))
       testGraph.buildDataset(data) should equal(dataset)
     }
   }

--- a/common/app/assets/javascripts/modules/experiments/tests/most-popular-from-facebook.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/most-popular-from-facebook.js
@@ -5,7 +5,7 @@ define(['common', 'bonzo', 'modules/popular', 'modules/storage'], function (comm
         var _config;
 
         this.id = 'MostPopularFromFacebook';
-        this.expiry = '2013-09-30';
+        this.expiry = '2013-10-08';
         this.audience = 0.5;
         this.description = 'Tests whether showing Most Popular for visitors referred from Facebook to visitors referred from Facebook increases clickthrough';
         this.events = ['most popular'];


### PR DESCRIPTION
This change is primarily to fix a bug where if a day has no data in a particular variant it causes a JS error in the result graph.  This scenario is most likely to happen on first and last days of test, depending on when data snapshot is taken.
