### PR TITLE
Update Sass from 3.2.10 to 3.2.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "sass", "3.2.10"
+gem "sass", "3.2.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    sass (3.2.10)
+    sass (3.2.11)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  sass (= 3.2.10)
+  sass (= 3.2.11)


### PR DESCRIPTION
- Fix `@extend`’s semantics with respect to pseudo-elements. They are no longer treated identically to pseudo-classes.
- A more understandable error is now provided when the `-E` option is passed to the Sass command line in ruby 1.8
- Fixed a bug in the output of lists containing unary plus or minus operations during sass <=> scss conversion.
- Avoid the IE7 content: counter bug with content: counters as well.
- Fix some thread-safety issues.

![ ](http://s2.developerslife.ru/public/images/gifs/131ae7f2-0bc3-424b-b611-f0698f1676eb.gif)
