### PR TITLE
Updated Play Akka settings to default for Async apps.

### DIFF
--- a/admin/conf/application.conf
+++ b/admin/conf/application.conf
@@ -21,35 +21,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-

--- a/applications/conf/application.conf
+++ b/applications/conf/application.conf
@@ -20,34 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }

--- a/article/conf/application.conf
+++ b/article/conf/application.conf
@@ -21,34 +21,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }

--- a/core-navigation/conf/application.conf
+++ b/core-navigation/conf/application.conf
@@ -20,35 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-

--- a/dev-build/conf/application.conf
+++ b/dev-build/conf/application.conf
@@ -20,36 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-
-

--- a/diagnostics/conf/application.conf
+++ b/diagnostics/conf/application.conf
@@ -20,35 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-

--- a/discussion/conf/application.conf
+++ b/discussion/conf/application.conf
@@ -20,35 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-

--- a/facia-dev-build/conf/application.conf
+++ b/facia-dev-build/conf/application.conf
@@ -20,36 +20,22 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-
 

--- a/facia-tool/conf/application.conf
+++ b/facia-tool/conf/application.conf
@@ -21,35 +21,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-

--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -20,34 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }

--- a/front/conf/application.conf
+++ b/front/conf/application.conf
@@ -20,34 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -20,34 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }

--- a/image/conf/application.conf
+++ b/image/conf/application.conf
@@ -20,26 +20,31 @@ logger: {
 #default timeout for promises
 promise.akka.actor.typed.timeout=5s
 
+##################################################################
+#
+# Threadpool config
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
+#
+##################################################################
+
+################################################################
+#
+#  NOTE - this app is Highly Synchronous - hence 300 parallelism
+#  (see docs link above)
+#
+################################################################
+
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 12.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 300.0
+          parallelism-max = 300
         }
-
+      }
     }
-
+  }
 }

--- a/interactive/conf/application.conf
+++ b/interactive/conf/application.conf
@@ -21,34 +21,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }

--- a/porter/conf/application.conf
+++ b/porter/conf/application.conf
@@ -21,35 +21,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-

--- a/router/conf/application.conf
+++ b/router/conf/application.conf
@@ -20,34 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }

--- a/sport/conf/application.conf
+++ b/sport/conf/application.conf
@@ -20,35 +20,21 @@ logger: {
 ############################################################
 #
 # Threadpool config
-# see http://www.playframework.com/documentation/2.1.1/ThreadPools
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
 #
 ############################################################
 
-
-#default timeout for promises
-promise.akka.actor.typed.timeout=5s
-
 play {
-
-    akka {
-        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-        loglevel = WARNING
-
-        actor {
-            retrieveBodyParserTimeout = 1 second
-
-            default-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 2.0
-                    parallelism-max = 24
-                }
-                throughput-deadline-time = 2000ms
-                throughput = 100
-            }
-
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
         }
-
+      }
     }
-
+  }
 }
-


### PR DESCRIPTION
When we started this adventure we made some of our decisions based on Fear, Uncertainty and Doubt.

There was actually no reason for messing with default Play settings other than we did not really know what we were doing.

Our Apps (apart from image) are 100% async and thus should just use the default Play configuration.

The other settings like `throughput-deadline-time` never worked for us (did I mention we did not know what we were doing).

![jansen](https://f.cloud.github.com/assets/76709/1252800/ec5a73dc-2b53-11e3-8052-d78855080633.gif)
