### PR TITLE
Add football nav to applications index page

### DIFF
--- a/applications/app/views/indexFacia.scala.html
+++ b/applications/app/views/indexFacia.scala.html
@@ -7,5 +7,9 @@
 
         @fragments.collections.container(index.page, Config(index.page.id, None, Some(index.page.webTitle)), Collection(index.trails, None), Container("news"), containerIndex = 0)
 
+        <section class="collection">
+            @fragments.footballNav(index.page)
+        </section>
+
     </div>
 }


### PR DESCRIPTION
This wraps the football nav in a `section` element with class `collection`, as `Popular` is appended with the selector `.collection:last-child`

![footballnav](https://f.cloud.github.com/assets/445472/1262464/38ba0684-2c3f-11e3-9980-df1083b7d049.png)
