### PR TITLE
Tweaks to most read headline lists

### DIFF
--- a/common/app/assets/stylesheets/module/_headline-list.scss
+++ b/common/app/assets/stylesheets/module/_headline-list.scss
@@ -2,7 +2,7 @@
     li {
         display: block;
         overflow: auto;
-        border-bottom: 1px solid $c-neutral4;
+        border-bottom: 1px solid $c-neutral6;
         padding: $baseline 0 $baseline*5;
 
         &:last-child {

--- a/common/app/assets/stylesheets/module/_headline-list.scss
+++ b/common/app/assets/stylesheets/module/_headline-list.scss
@@ -37,6 +37,10 @@
         float: left;
         color: $c-neutral4;
         width: 12px;
+
+        @include mq(tablet) {
+            @include fs-bodyCopy(3, true);
+        }
     }
 }
 


### PR DESCRIPTION
Small styling fixes for headline lists:
- Make count number font-size scale with headline at wider breakpoints
- Change colour of keyline dividers to match trails `$c-neutral6`
#### Before

![google chrome](https://f.cloud.github.com/assets/80089/1267643/96778e26-2cc7-11e3-956e-5b02e5e2a0a1.png)
#### After

![google chrome 9](https://f.cloud.github.com/assets/80089/1267645/a73e0f1e-2cc7-11e3-9408-db0a2081c8ad.jpg)
