### PR TITLE
Local nav text wrapping issues

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -303,6 +303,7 @@
 
 .localnav__title {
     @extend .section-head;
+    width: 100%;
     float: left;
     border: 0 !important;
     height: $gs-column-height + $baseline !important;


### PR DESCRIPTION
This fixes text wrapping issues on local nav
#### Before

![screenshot_2013-10-04-07-41-41](https://f.cloud.github.com/assets/80089/1267687/9cd53484-2cc8-11e3-81e5-438d7f99570b.png)
#### After

![screenshot_2013-10-04-08-40-35](https://f.cloud.github.com/assets/80089/1267688/a4c5beb6-2cc8-11e3-81a9-060ac28311a4.png)
