### PR TITLE
Football headers

### DIFF
--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -6,7 +6,7 @@
 
 .competitions-date {
     background-color: $c-sportMid;
-    color: $c-neutral1;
+    color: #ffffff;
     margin-top: $baseline*2;
     margin-bottom: $baseline;
     padding: 9px $gutter/2;
@@ -14,6 +14,7 @@
 
 .team-fixtures .competitions-date,
 .team-results .competitions-date {
+    color: $c-neutral1;
     background-color: $c-sportBright;
 }
 


### PR DESCRIPTION
The dark text on dark blue background on football headers will fail accessibility. This changes the text to white. Needs design review.
#### Before

![google chrome](https://f.cloud.github.com/assets/80089/1267737/378be224-2cca-11e3-8ed4-6635cc1ebcd7.png)
#### After

![google chrome](https://f.cloud.github.com/assets/80089/1267740/42c2725c-2cca-11e3-866d-0c3527cdd7a7.png)
