### PR TITLE
Do not escape title in containter.scala.html

### DIFF
--- a/common/app/views/fragments/collections/container.scala.html
+++ b/common/app/views/fragments/collections/container.scala.html
@@ -8,7 +8,7 @@
     @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
         @if(title.nonEmpty) {
             <h2 class="collection__title tone-background tone-border">
-                <a data-link-name="section heading" href="@LinkTo{/@if(!config.section.equals("news")){@config.section}}">@title</a>
+                <a data-link-name="section heading" href="@LinkTo{/@if(!config.section.equals("news")){@config.section}}">@Html(title)</a>
             </h2>
         }
     }

--- a/common/app/views/fragments/collections/masthead.scala.html
+++ b/common/app/views/fragments/collections/masthead.scala.html
@@ -7,7 +7,7 @@
 
     @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
         @if(title.nonEmpty) {
-            <h2 class="collection__title">@title</h2>
+            <h2 class="collection__title">@Html(title)</h2>
         }
     }
 

--- a/common/app/views/fragments/collections/sectionZone.scala.html
+++ b/common/app/views/fragments/collections/sectionZone.scala.html
@@ -8,7 +8,7 @@
     @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
         @if(title.nonEmpty) {
             <h2 class="collection__title tone-background tone-border">
-                <a data-link-name="section heading" href="@LinkTo{/@config.section}">@title</a>
+                <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
             </h2>
         }
     }


### PR DESCRIPTION
This comes out of the content API already escaped, and we are escaping it early in the tool also.
