### PR TITLE
Do not show empty collections in container, masthead and sectionZone

### DIFF
--- a/common/app/views/fragments/collections/container.scala.html
+++ b/common/app/views/fragments/collections/container.scala.html
@@ -1,24 +1,26 @@
 @(page: model.MetaData, config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
 
-<section class="collection collection--@style.className @if(style.section != "news"){js-collection--display-toggle} collection--@style.section zone-@config.section.split("/").headOption"
-         data-link-name="block | @collection.displayName.getOrElse(config.id)"
-         data-collection-type="@style.className"
-         data-section="@config.section">
+@if(collection.items.nonEmpty) {
+    <section class="collection collection--@style.className @if(style.section != "news"){js-collection--display-toggle} collection--@style.section zone-@config.section.split("/").headOption"
+             data-link-name="block | @collection.displayName.getOrElse(config.id)"
+             data-collection-type="@style.className"
+             data-section="@config.section">
 
-    @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
-        @if(title.nonEmpty) {
-            <h2 class="collection__title tone-background tone-border">
-                <a data-link-name="section heading" href="@LinkTo{/@if(!config.section.equals("news")){@config.section}}">@Html(title)</a>
-            </h2>
+        @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
+            @if(title.nonEmpty) {
+                <h2 class="collection__title tone-background tone-border">
+                    <a data-link-name="section heading" href="@LinkTo{/@if(!config.section.equals("news")){@config.section}}">@Html(title)</a>
+                </h2>
+            }
         }
-    }
 
-    @fragments.contributor(page)
+        @fragments.contributor(page)
 
-    <ul class="unstyled items item-count-@collection.items.size @if(style.showMore){js-items--show-more} items--cards items--without-sport-stats">
-        @collection.items.zipWithIndex.map{ case (trail, index) =>
-            @fragments.items.standard(trail, index, mainItem = containerIndex == 0 && index == 0)
-        }
-    </ul>
+        <ul class="unstyled items item-count-@collection.items.size @if(style.showMore){js-items--show-more} items--cards items--without-sport-stats">
+            @collection.items.zipWithIndex.map{ case (trail, index) =>
+                @fragments.items.standard(trail, index, mainItem = containerIndex == 0 && index == 0)
+            }
+        </ul>
 
-</section>
+    </section>
+}

--- a/common/app/views/fragments/collections/masthead.scala.html
+++ b/common/app/views/fragments/collections/masthead.scala.html
@@ -1,52 +1,54 @@
 @(config: Config, collection: Collection, style: Style)(implicit request: RequestHeader)
 
-<section class="collection collection--@style.className collection--@{config.section}-section"
-         data-link-name="block | @collection.displayName.getOrElse(config.id)"
-         data-collection-type="@style.className"
-         data-section="@config.section">
+@if(collection.items.nonEmpty) {
+    <section class="collection collection--@style.className collection--@{config.section}-section"
+             data-link-name="block | @collection.displayName.getOrElse(config.id)"
+             data-collection-type="@style.className"
+             data-section="@config.section">
 
-    @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
-        @if(title.nonEmpty) {
-            <h2 class="collection__title">@Html(title)</h2>
+        @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
+            @if(title.nonEmpty) {
+                <h2 class="collection__title">@Html(title)</h2>
+            }
         }
-    }
 
-    <ul class="unstyled items item-count-@collection.items.size">
-        @collection.items.zipWithIndex.map{ case (trail, index) =>
-            <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
-                @trail.discussionId.map{ id => data-discussion-id="@id" }>
-                <h2 class="item__title">
-                    <a href="@LinkTo{@trail.url}" class="item__link">
-                        @RemoveOuterParaHtml(trail.headline)
-                    </a>
-                </h2>
-                @trail.trailText.map { text =>
-                    <div class="item__standfirst">
-                        <p>@cleanTrailText(text)(Edition(request))</p>
-                    </div>
-                }
-                <div class="item__meta">
-                    <time class="item__timestamp js-item__timestamp"
-                          itemprop="datePublished"
-                          datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-                          data-timestamp="@trail.webPublicationDate.getMillis">
-                        <i class="i"></i>
-                        <span class="timestamp__text"><span class="u-h">Published: </span>@Format(trail.webPublicationDate, "d MMM y")</span>
-                    </time>
-                </div>
-                @trail match {
-                    case trail: Video => {
-                        <span class="item__duration"><i class="i"></i><span class="u-h">Duration: </span>@{trail.duration/60}: @{trail.duration%60}</span>
+        <ul class="unstyled items item-count-@collection.items.size">
+            @collection.items.zipWithIndex.map{ case (trail, index) =>
+                <li class="item @trail.trailType.map("item--" + _) @trail.mainPicture(620).map{image => item--with-image}.getOrElse{item--without-image}" data-link-name="trail | @{index + 1}"
+                    @trail.discussionId.map{ id => data-discussion-id="@id" }>
+                    <h2 class="item__title">
+                        <a href="@LinkTo{@trail.url}" class="item__link">
+                            @RemoveOuterParaHtml(trail.headline)
+                        </a>
+                    </h2>
+                    @trail.trailText.map { text =>
+                        <div class="item__standfirst">
+                            <p>@cleanTrailText(text)(Edition(request))</p>
+                        </div>
                     }
-                    case _ => {}
-                }
-                @trail.mainPicture(620).map{ mainPicture =>
-                    <div class="item__image-container">
-                        <img class="item__image" alt="" data-src="@ImgSrc(mainPicture, FrontItem)" data-src-main="@ImgSrc(mainPicture, FrontItemMain)" />
+                    <div class="item__meta">
+                        <time class="item__timestamp js-item__timestamp"
+                              itemprop="datePublished"
+                              datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                              data-timestamp="@trail.webPublicationDate.getMillis">
+                            <i class="i"></i>
+                            <span class="timestamp__text"><span class="u-h">Published: </span>@Format(trail.webPublicationDate, "d MMM y")</span>
+                        </time>
                     </div>
-                }
-            </li>
-        }
-    </ul>
+                    @trail match {
+                        case trail: Video => {
+                            <span class="item__duration"><i class="i"></i><span class="u-h">Duration: </span>@{trail.duration/60}: @{trail.duration%60}</span>
+                        }
+                        case _ => {}
+                    }
+                    @trail.mainPicture(620).map{ mainPicture =>
+                        <div class="item__image-container">
+                            <img class="item__image" alt="" data-src="@ImgSrc(mainPicture, FrontItem)" data-src-main="@ImgSrc(mainPicture, FrontItemMain)" />
+                        </div>
+                    }
+                </li>
+            }
+        </ul>
 
-</section>
+    </section>
+}

--- a/common/app/views/fragments/collections/sectionZone.scala.html
+++ b/common/app/views/fragments/collections/sectionZone.scala.html
@@ -1,22 +1,24 @@
 @(config: Config, collection: Collection, style: SectionZone, containerIndex: Int)(implicit request: RequestHeader)
 
-<section class="collection collection--@style.className js-collection--display-toggle zone-@config.section.split("/").headOption"
-         data-link-name="block | @collection.displayName.getOrElse(config.id)"
-         data-collection-type="@style.className"
-         data-section="@config.section">
+@if(collection.items.nonEmpty) {
+    <section class="collection collection--@style.className js-collection--display-toggle zone-@config.section.split("/").headOption"
+             data-link-name="block | @collection.displayName.getOrElse(config.id)"
+             data-collection-type="@style.className"
+             data-section="@config.section">
 
-    @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
-        @if(title.nonEmpty) {
-            <h2 class="collection__title tone-background tone-border">
-                <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
-            </h2>
+        @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
+            @if(title.nonEmpty) {
+                <h2 class="collection__title tone-background tone-border">
+                    <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
+                </h2>
+            }
         }
-    }
 
-    <ul class="unstyled items item-count-@collection.items.size js-items--show-more items--cards items--without-sport-stats">
-        @collection.items.zipWithIndex.map{ case (trail, index) =>
-            @fragments.items.standard(trail, index, mainItem = containerIndex == 0 && index == 0)
-        }
-    </ul>
+        <ul class="unstyled items item-count-@collection.items.size js-items--show-more items--cards items--without-sport-stats">
+            @collection.items.zipWithIndex.map{ case (trail, index) =>
+                @fragments.items.standard(trail, index, mainItem = containerIndex == 0 && index == 0)
+            }
+        </ul>
 
-</section>
+    </section>
+}


### PR DESCRIPTION
@ironsidevsquincy Ping!

This now will not show a section tag in each template (`masthead`, `sectionZone` and `container`) if the `Collection` coming in has got no items in it.

The diff is a bit crazy, all it is really doing is wrapping each `section` with an `@if(collections.items.nonEmpty)` and indenting all the code.
