### PR TITLE
Facia tool update auth endpoints

### DIFF
--- a/common/app/common/authentication.scala
+++ b/common/app/common/authentication.scala
@@ -74,9 +74,11 @@ object NonAuthAction {
 class ExpiringAuthAction(loginUrl: String) extends AuthAction(loginUrl) with implicits.Dates {
   import Play.current
 
-  override def apply(f: Request[AnyContent] => SimpleResult): Action[AnyContent] = async { request =>
+  override def apply(f: Request[AnyContent] => SimpleResult) = async(request => Future.apply(f(request)))
+
+  override def async(f: Request[AnyContent] => Future[SimpleResult]): Action[AnyContent] = super.async { request =>
     if (withinAllowedTime(request) || Play.isTest)
-      Future { f(request).withSession(request.session + (Configuration.cookies.lastSeenKey , DateTime.now.toString)) }
+      f(request).map(_.withSession(request.session + (Configuration.cookies.lastSeenKey , DateTime.now.toString)))
     else
       Future { Redirect(loginUrl).withSession(("loginFromUrl", request.uri)) }
   }

--- a/facia-tool/app/controllers/FaciaContentApiProxy.scala
+++ b/facia-tool/app/controllers/FaciaContentApiProxy.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WS
 
 object FaciaContentApiProxy extends Controller with Logging with AuthLogging with ExecutionContexts with Strings {
 
-  def proxy(path: String, callback: String) = Authenticated.async { request =>
+  def proxy(path: String, callback: String) = ExpiringAuthentication.async { request =>
     val queryString = request.queryString.map { p =>
        "%s=%s".format(p._1, p._2.head.urlEncoded)
     }.mkString("&")
@@ -22,7 +22,7 @@ object FaciaContentApiProxy extends Controller with Logging with AuthLogging wit
     }
   }
 
-  def tag(q: String, callback: String) = Authenticated.async { request =>
+  def tag(q: String, callback: String) = ExpiringAuthentication.async { request =>
     val url = "%s/tags?format=json&page-size=50&api-key=%s&callback=%s&q=%s".format(
       Configuration.contentApi.host,
       Configuration.contentApi.key,
@@ -37,7 +37,7 @@ object FaciaContentApiProxy extends Controller with Logging with AuthLogging wit
     }
   }
 
-  def item(path: String, callback: String) = Authenticated.async { request =>
+  def item(path: String, callback: String) = ExpiringAuthentication.async { request =>
     val url = "%s/%s?format=json&page-size=1&api-key=%s&callback=%s".format(
       Configuration.contentApi.host,
       path.javascriptEscaped.urlEncoded,
@@ -52,7 +52,7 @@ object FaciaContentApiProxy extends Controller with Logging with AuthLogging wit
     }
   }
 
-  def json(url: String) = Authenticated.async { request =>
+  def json(url: String) = ExpiringAuthentication.async { request =>
     log("Proxying json request to: %s" format url, request)
 
     WS.url(url).get().map { response =>

--- a/facia-tool/app/controllers/FaciaOphanApiController.scala
+++ b/facia-tool/app/controllers/FaciaOphanApiController.scala
@@ -7,11 +7,11 @@ import common.ExecutionContexts
 
 object FaciaOphanApiController extends Controller with ExecutionContexts {
 
-  def pageViews(path: String) = Authenticated.async { request =>
+  def pageViews(path: String) = ExpiringAuthentication.async { request =>
     OphanApi.getBreakdown(path) map (body => Ok(body) as "application/json")
   }
 
-  def platformPageViews = Authenticated.async { request =>
+  def platformPageViews = ExpiringAuthentication.async { request =>
     OphanApi.getBreakdown(platform = "next-gen", hours = 2) map (body => Ok(body) as "application/json")
   }
 


### PR DESCRIPTION
This changes the proxy endpoints that Facia Tool uses to make calls to both the Content API and Ophan so that it updates the cookie to keep the user logged in.

Before this, if a user opens the facia tool and does not open a collection, the tool can get into a broken state as the requests it was constantly making were not updating the cookie, and when a user finally went into a collection, these requests would be `303` to login.

@stephanfowler 
