### PR TITLE
Change Admin ID to use http in dev and permit parameters in callback

### DIFF
--- a/admin/app/controllers/authentication.scala
+++ b/admin/app/controllers/authentication.scala
@@ -2,7 +2,7 @@ package controllers.admin
 
 import common.ExecutionContexts
 import conf.Configuration
-import controllers.{AuthAction, LoginController, NonAuthAction}
+import controllers.{AuthAction, LoginController}
 import play.api.mvc._
 
 object Authenticated extends AuthAction(routes.Login.login.url)
@@ -16,9 +16,9 @@ object Login extends LoginController with Controller with ExecutionContexts {
     routes.Login.openIDCallback.absoluteURL(secure && Configuration.environment.stage != "dev")
   }
 
-  def login = NonAuthAction {
+  def login = Action {
     request =>
       val error = request.flash.get("error")
-      Ok(views.html.auth.login(request, error, Configuration.environment.stage))
+      Ok(views.html.auth.login(error, Configuration.environment.stage))
   }
 }

--- a/admin/app/controllers/authentication.scala
+++ b/admin/app/controllers/authentication.scala
@@ -2,9 +2,8 @@ package controllers.admin
 
 import common.ExecutionContexts
 import conf.Configuration
-import controllers.{AuthAction, Identity, LoginController, NonAuthAction}
+import controllers.{AuthAction, LoginController, NonAuthAction}
 import play.api.mvc._
-import play.api.libs.openid.OpenID
 
 object Authenticated extends AuthAction(routes.Login.login.url)
 
@@ -13,7 +12,9 @@ object Login extends LoginController with Controller with ExecutionContexts {
   val loginUrl: String = routes.Login.login.url
   val baseUrl: String = "/admin"
 
-  def openIdCallback(secure: Boolean)(implicit request: RequestHeader): String = routes.Login.openIDCallback.absoluteURL(secure)
+  def openIdCallback(secure: Boolean)(implicit request: RequestHeader): String = {
+    routes.Login.openIDCallback.absoluteURL(secure && Configuration.environment.stage != "dev")
+  }
 
   def login = NonAuthAction {
     request =>

--- a/admin/app/views/auth/login.scala.html
+++ b/admin/app/views/auth/login.scala.html
@@ -1,4 +1,4 @@
-@(request: controllers.AuthenticatedRequest[AnyContent], error: Option[String] = None, env: String)
+@(error: Option[String] = None, env: String)
 
 @admin_main("Login", env) {
         @if(error.isDefined) {

--- a/common/app/common/authentication.scala
+++ b/common/app/common/authentication.scala
@@ -90,7 +90,7 @@ class AuthAction(loginUrl: String) extends ExecutionContexts {
 
   def apply(f: Request[AnyContent] => SimpleResult): Action[AnyContent] = async(request => Future { f(request) })
 
-  def async(f: Request[AnyContent] => Future[SimpleResult]): Action[AnyContent] = Action.async { _ match {
+  def async(f: Request[AnyContent] => Future[SimpleResult]): Action[AnyContent] = Action.async { req: Request[AnyContent] => req match {
     case authenticatedRequest: AuthenticatedRequest[_] => f(authenticatedRequest)
 
     case request if Play.isTest =>
@@ -134,6 +134,8 @@ trait LoginController extends ExecutionContexts { self: Controller =>
   }
 
   def openIDCallback = Action.async { implicit request =>
+    val output = "ok"
+    println("ok")
     OpenID.verifiedId.map { info =>
       val credentials = Identity(
         info.id,

--- a/common/app/common/authentication.scala
+++ b/common/app/common/authentication.scala
@@ -5,7 +5,6 @@ import net.liftweb.json.{ Serialization, NoTypeHints }
 import net.liftweb.json.Serialization.{ read, write }
 import play.api.mvc._
 import play.api.mvc.Results._
-import play.api.mvc.BodyParsers._
 import play.api.Play
 import scala.concurrent.Future
 import play.api.libs.openid.OpenID
@@ -27,48 +26,21 @@ object Identity {
 
   def readJson(json: String) = read[Identity](json)
 
-  def apply(request: Request[Any]): Option[Identity] = request match {
-    case authenticated: AuthenticatedRequest[_] => authenticated.identity
-    case _ => request.session.get(KEY).map(credentials => Identity.readJson(credentials))
+  def apply(request: Request[Any]): Option[Identity] = {
+    request.session.get(KEY).map(credentials => Identity.readJson(credentials))
   }
 }
 
-object AuthenticatedRequest {
-  def apply[A](request: Request[A]) = {
-    new AuthenticatedRequest(Identity(request), request)
-  }
-}
-
-class AuthenticatedRequest[A](val identity: Option[Identity], request: Request[A]) extends WrappedRequest(request) {
-  lazy val isAuthenticated = identity.isDefined
-}
+class AuthenticatedRequest(val identity: Identity, request: Request[AnyContent]) extends WrappedRequest(request)
 
 trait AuthLogging {
   self: Logging =>
   def log(msg: String, request: Request[AnyContent]) {
     request match {
-      case auth: AuthenticatedRequest[_] => auth.identity.foreach(id => log.info(id.email + ": " + msg))
+      case auth: AuthenticatedRequest => log.info(auth.identity.email + ": " + msg)
       case _ => throw new IllegalStateException("Expected an authenticated request")
     }
   }
-}
-
-object NonAuthAction {
-
-  def apply[A](p: BodyParser[A])(f: AuthenticatedRequest[A] => Result) = {
-    Action(p) {
-      implicit request => f(AuthenticatedRequest(request))
-    }
-  }
-
-  def apply(f: AuthenticatedRequest[AnyContent] => Result): Action[AnyContent] = {
-    this.apply(parse.anyContent)(f)
-  }
-
-  def apply(block: => Result): Action[AnyContent] = {
-    this.apply(_ => block)
-  }
-
 }
 
 class ExpiringAuthAction(loginUrl: String) extends AuthAction(loginUrl) with implicits.Dates {
@@ -90,22 +62,17 @@ class AuthAction(loginUrl: String) extends ExecutionContexts {
 
   def apply(f: Request[AnyContent] => SimpleResult): Action[AnyContent] = async(request => Future { f(request) })
 
-  def async(f: Request[AnyContent] => Future[SimpleResult]): Action[AnyContent] = Action.async { req: Request[AnyContent] => req match {
-    case authenticatedRequest: AuthenticatedRequest[_] => f(authenticatedRequest)
+  def async(f: Request[AnyContent] => Future[SimpleResult]): Action[AnyContent] = Action.async {
 
-    case request if Play.isTest =>
-      val stubbedIdentity = new AuthenticatedRequest(Some(Identity("1234", "foo@bar.com", "John", "Smith")), request)
-      f(stubbedIdentity)
+      request: Request[AnyContent] =>
 
-    case request =>
-      val authenticatedRequest = Identity(request) map { id => f(new AuthenticatedRequest(Some(id), request)) }
-      authenticatedRequest getOrElse {
-        Future {
-          Redirect(loginUrl).withSession(request.session + ("loginFromUrl", request.uri))
-        }
+      val identity: Option[Identity] = Identity(request)
+      identity match {
+        case Some(id) => f(new AuthenticatedRequest(id, request))
+        case _ if Play.isTest => f(new AuthenticatedRequest(Identity("1234", "foo@bar.com", "John", "Smith"), request))
+        case _ => Future(Redirect(loginUrl).withSession(request.session + ("loginFromUrl", request.uri)))
       }
     }
-  }
 }
 
 trait LoginController extends ExecutionContexts { self: Controller =>
@@ -134,8 +101,6 @@ trait LoginController extends ExecutionContexts { self: Controller =>
   }
 
   def openIDCallback = Action.async { implicit request =>
-    val output = "ok"
-    println("ok")
     OpenID.verifiedId.map { info =>
       val credentials = Identity(
         info.id,

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -33,7 +33,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
     val stage = apply("STAGE", "unknown")
 
-    lazy val isNonProd = List("dev", "code", "gudev").contains(stage.toLowerCase)
+    lazy val isNonProd = List("dev", "code", "gudev").contains(stage)
   }
 
   object switches {

--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -48,7 +48,6 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
         val illegalParams = request.queryString.keySet.filterNot(allowedParams.contains(_))
         if (illegalParams.nonEmpty) {
           // it is pretty hard to spot what is happening in tests without this println
-          println(request.uri)
           println(s"\n\nILLEGAL PARAMETER(S) FOUND : ${illegalParams.mkString(",")}\n\n")
           throw new RuntimeException(s"illegal parameter(s) found ${illegalParams.mkString(",")}")
         }

--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -43,10 +43,12 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
 
     Play.maybeApplication.foreach{ implicit application =>
       // json requests have no SEO implication but will affect caching
-      if (!isProd && !request.isJson) {
+
+      if (!isProd && !request.isJson && !request.uri.startsWith("/openIDCallback")) {
         val illegalParams = request.queryString.keySet.filterNot(allowedParams.contains(_))
         if (illegalParams.nonEmpty) {
           // it is pretty hard to spot what is happening in tests without this println
+          println(request.uri)
           println(s"\n\nILLEGAL PARAMETER(S) FOUND : ${illegalParams.mkString(",")}\n\n")
           throw new RuntimeException(s"illegal parameter(s) found ${illegalParams.mkString(",")}")
         }

--- a/common/test/model/UrlsTest.scala
+++ b/common/test/model/UrlsTest.scala
@@ -84,23 +84,3 @@ class UrlsTest extends FlatSpec with ShouldMatchers {
     id = id, `type` = "type", webTitle = name, webUrl = "", apiUrl = ""
   )
 }
-
-/*
-
-
-
-  [error] Failed tests:
-[error] 	test.TagControllerTest
-[info] No tests to run for diagnostics/test:test
-[error] Failed tests:
-[error] 	test.FrontFeatureTest
-[info] No tests to run for router/test:test
-[error] Failed tests:
-[error] 	test.RelatedControllerTest
-
-
-
-
-
-
-*/


### PR DESCRIPTION
This should stop us from having problems logging in to the Admin app locally. I tried to minimise the code that handles the Open ID callback and identity. @janua works as we guessed!
