### PR TITLE
Facia tests

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -1,7 +1,7 @@
 package common
 
 import play.api.templates.Html
-import play.api.mvc.RequestHeader
+import play.api.mvc.{SimpleResult, AnyContent, Request, RequestHeader}
 import conf.Configuration
 import model.MetaData
 
@@ -28,6 +28,13 @@ trait LinkTo extends Logging {
 
   private def urlFor(path: String, edition: Edition) = s"$host/${Editionalise(path, edition)}"
 
+  def redirectWithParameters(request: Request[AnyContent], realPath: String): SimpleResult = {
+    val params = if (request.hasParameters) s"?${request.rawQueryString}" else ""
+    Redirect(request.path.endsWith(".json") match {
+      case true => s"/$realPath.json$params"
+      case _ => s"/$realPath$params"
+    })
+  }
 }
 
 object LinkTo extends LinkTo

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -156,7 +156,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
         val faciaPageOption: Option[FaciaPage] = front(editionalisedPath)
         faciaPageOption map { faciaPage =>
           if (path != editionalisedPath) {
-            Redirect(editionalisedPath)
+            LinkTo.redirectWithParameters(request, editionalisedPath)
           } else {
             if (request.isJson) {
               val html = views.html.fragments.frontBody(frontPage, faciaPage)

--- a/facia/app/controllers/front/Front.scala
+++ b/facia/app/controllers/front/Front.scala
@@ -38,6 +38,15 @@ class Front extends Logging {
     }) ++ pageFrontAgent().values.map{ agent => () => agent.refresh() }
 
   def apply(path: String): Option[FaciaPage] = pageFrontAgent().get(path).flatMap(pageFront => pageFront())
+
+  def hasItems(pageFronts: Iterable[PageFront]): Boolean = pageFronts.exists( pageFront =>
+    pageFront.apply().exists( faciaPage =>
+      faciaPage.collections.map(_._2).exists( collection =>
+        collection.items.nonEmpty
+      )
+    )
+  )
+  def hasItems(path: String): Boolean = hasItems(pageFrontAgent.get().values.filter(_.id == path))
 }
 
 object Front extends Front

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -21,7 +21,6 @@ class FaciaControllerTest extends FlatSpec with ShouldMatchers {
 
     val result = controllers.FaciaController.renderFront("")(responsiveRequest.withHeaders("X-GU-Edition" -> "US"))
     status(result) should be(303)
-    //TODO: Fronts returns /us this returns us
     header("Location", result) should be (Some("/us"))
 
     val result2 = controllers.FaciaController.renderFront("culture")(responsiveRequest.withHeaders("X-GU-Edition" -> "AU"))

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -1,0 +1,98 @@
+package test
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.FlatSpec
+
+class FaciaControllerTest extends FlatSpec with ShouldMatchers {
+
+  val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"
+  val callbackName = "aFunction"
+
+  val responsiveRequest = FakeRequest().withHeaders("host" -> "www.theguardian.com")
+
+  "Facia Controller" should "200 when content type is front" in Fake {
+    val result = controllers.FaciaController.renderEditionFront("uk")(TestRequest())
+    status(result) should be(200)
+  }
+
+  it should "redirect base page to edition page if on www.theguardian.com" in Fake {
+
+    val result = controllers.FaciaController.renderFront("")(responsiveRequest.withHeaders("X-GU-Edition" -> "US"))
+    status(result) should be(303)
+    //TODO: Fronts returns /us this returns us
+    header("Location", result) should be (Some("us"))
+
+    val result2 = controllers.FaciaController.renderFront("culture")(responsiveRequest.withHeaders("X-GU-Edition" -> "AU"))
+    status(result2) should be(303)
+    header("Location", result2) should be (Some("au/culture"))
+
+  }
+
+  it should "understand the editionalised network front" in Fake {
+    val result2 = controllers.FaciaController.renderEditionFront("uk")(TestRequest())
+    status(result2) should be(200)
+  }
+
+  it should "understand editionalised section fronts" in Fake {
+    val result2 = controllers.FaciaController.renderEditionSectionFront("uk/culture")(TestRequest())
+    status(result2) should be(200)
+  }
+
+  it should "return JSONP when callback is supplied to front" in Fake {
+    val fakeRequest = FakeRequest(GET, s"?callback=$callbackName")
+      .withHeaders("host" -> "localhost:9000")
+
+    val result = controllers.FaciaController.renderEditionFront("uk")(fakeRequest)
+    status(result) should be(200)
+    contentType(result).get should be("application/javascript")
+    contentAsString(result) should startWith(s"""$callbackName({\"html\"""")
+  }
+
+  it should "return JSON when .json format is supplied to front" in Fake {
+    val fakeRequest = FakeRequest("GET", ".json")
+      .withHeaders("Host" -> "localhost:9000")
+      .withHeaders("Origin" -> "http://www.theorigin.com")
+
+    val result = controllers.FaciaController.renderEditionFrontJson("uk")(fakeRequest)
+    status(result) should be(200)
+    contentType(result).get should be("application/json")
+    contentAsString(result) should startWith("{\"html\"")
+  }
+
+  it should "200 when content type is front trails" in Fake {
+    //Fronts never redirected, this redirects if you hit naked slash
+    val result = controllers.FaciaController.renderTrails("")(TestRequest())
+    status(result) should be(303)
+
+    val result2 = controllers.FaciaController.renderTrails("uk")(TestRequest())
+    status(result2) should be(200)
+  }
+
+  it should "return JSONP when callback is supplied to front trails" in Fake {
+    val fakeRequest = FakeRequest(GET, s"/culture/trails?callback=$callbackName")
+      .withHeaders("host" -> "localhost:9000")
+
+    val result = controllers.FaciaController.renderTrails("uk")(fakeRequest)
+    status(result) should be(200)
+    contentType(result).get should be("application/javascript")
+    contentAsString(result) should startWith(s"""$callbackName({\"html\"""")
+  }
+
+  it should "return JSON when .json format is supplied to front trails" in Fake {
+    val fakeRequest = FakeRequest("GET", "/culture/trails.json")
+      .withHeaders("Host" -> "localhost:9000")
+      .withHeaders("Origin" -> "http://www.theorigin.com")
+
+    val result = controllers.FaciaController.renderTrails("uk")(fakeRequest)
+    status(result) should be(200)
+    contentType(result).get should be("application/json")
+    contentAsString(result) should startWith("{\"html\"")
+  }
+
+  it should "200 when hitting the front" in Fake {
+    val result = controllers.FaciaController.renderEditionFront("uk")(TestRequest())
+    status(result) should be(200)
+  }
+}

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -22,11 +22,11 @@ class FaciaControllerTest extends FlatSpec with ShouldMatchers {
     val result = controllers.FaciaController.renderFront("")(responsiveRequest.withHeaders("X-GU-Edition" -> "US"))
     status(result) should be(303)
     //TODO: Fronts returns /us this returns us
-    header("Location", result) should be (Some("us"))
+    header("Location", result) should be (Some("/us"))
 
     val result2 = controllers.FaciaController.renderFront("culture")(responsiveRequest.withHeaders("X-GU-Edition" -> "AU"))
     status(result2) should be(303)
-    header("Location", result2) should be (Some("au/culture"))
+    header("Location", result2) should be (Some("/au/culture"))
 
   }
 

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -1,0 +1,57 @@
+package test
+
+import org.fluentlenium.core.domain.FluentWebElement
+import play.api.GlobalSettings
+import controllers.front.{Front, FrontLifecycle}
+import dev.DevParametersLifecycle
+import common.{AkkaAsync, FrontMetrics, Jobs}
+import concurrent.duration._
+
+object FaciaTestGlobal extends GlobalSettings with FrontLifecycle with DevParametersLifecycle {
+
+  override def onStart(app: play.api.Application) {
+    super.onStart(app)
+    Jobs.deschedule("FrontRefreshJob")
+    Jobs.schedule("FrontRefreshJob", "0 * * * * ?", FrontMetrics.FrontLoadTimingMetric) {
+      // stagger refresh jobs to avoid dogpiling the api
+      Front.refreshJobs().zipWithIndex.foreach{ case (job, index) =>
+        val sec = (index * 2) % 60
+        AkkaAsync.after(sec.seconds){
+          job()
+        }
+      }
+    }
+
+    Front.refresh()
+
+    val start = System.currentTimeMillis
+
+    //Our tests use things from uk, us and au. Lets wait for these three fronts (60 seconds)
+    while (!Front.hasItems("uk") || !Front.hasItems("us") || !Front.hasItems("au")) {
+      // ensure we don't get in an endless loop if test data changes
+      if (System.currentTimeMillis - start > 60000) throw new RuntimeException("front should have loaded by now")
+    }
+  }
+
+  override def onStop(app: play.api.Application) {
+    // do not stop the agents
+    Jobs.deschedule("FrontRefreshJob")
+    super.onStop(app)
+  }
+}
+
+object `package` {
+
+  object Fake extends FakeApp {
+    override val globalSettingsOverride = Some(FaciaTestGlobal)
+  }
+
+  object HtmlUnit extends EditionalisedHtmlUnit {
+    override val globalSettingsOverride = Some(FaciaTestGlobal)
+  }
+
+  implicit class WebElement2rich(element: FluentWebElement) {
+    lazy val href = element.getAttribute("href")
+    def hasAttribute(name: String) = element.getAttribute(name) != null
+  }
+}

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -7,48 +7,11 @@ import dev.DevParametersLifecycle
 import common.{AkkaAsync, FrontMetrics, Jobs}
 import concurrent.duration._
 
-object FaciaTestGlobal extends GlobalSettings with FrontLifecycle with DevParametersLifecycle {
-
-  override def onStart(app: play.api.Application) {
-    super.onStart(app)
-    Jobs.deschedule("FrontRefreshJob")
-    Jobs.schedule("FrontRefreshJob", "0 * * * * ?", FrontMetrics.FrontLoadTimingMetric) {
-      // stagger refresh jobs to avoid dogpiling the api
-      Front.refreshJobs().zipWithIndex.foreach{ case (job, index) =>
-        val sec = (index * 2) % 60
-        AkkaAsync.after(sec.seconds){
-          job()
-        }
-      }
-    }
-
-    Front.refresh()
-
-    val start = System.currentTimeMillis
-
-    //Our tests use things from uk, us and au. Lets wait for these three fronts (60 seconds)
-    while (!Front.hasItems("uk") || !Front.hasItems("us") || !Front.hasItems("au")) {
-      // ensure we don't get in an endless loop if test data changes
-      if (System.currentTimeMillis - start > 60000) throw new RuntimeException("front should have loaded by now")
-    }
-  }
-
-  override def onStop(app: play.api.Application) {
-    // do not stop the agents
-    Jobs.deschedule("FrontRefreshJob")
-    super.onStop(app)
-  }
-}
-
 object `package` {
 
-  object Fake extends FakeApp {
-    override val globalSettingsOverride = Some(FaciaTestGlobal)
-  }
+  object Fake extends FakeApp
 
-  object HtmlUnit extends EditionalisedHtmlUnit {
-    override val globalSettingsOverride = Some(FaciaTestGlobal)
-  }
+  object HtmlUnit extends EditionalisedHtmlUnit
 
   implicit class WebElement2rich(element: FluentWebElement) {
     lazy val href = element.getAttribute("href")

--- a/front/app/controllers/FrontController.scala
+++ b/front/app/controllers/FrontController.scala
@@ -164,7 +164,7 @@ class FrontController extends Controller with Logging with JsonTrails with Execu
         }
 
         if (path != realPath) {
-          redirectWithParameters(request, realPath)
+          LinkTo.redirectWithParameters(request, realPath)
         } else if (trailblocks.isEmpty) {
           InternalServerError
         } else {
@@ -184,14 +184,6 @@ class FrontController extends Controller with Logging with JsonTrails with Execu
 
       }.getOrElse(NotFound) //TODO is 404 the right thing here
     }
-  }
-
-  private def redirectWithParameters(request: Request[AnyContent], realPath: String): SimpleResult = {
-    val params = if (request.hasParameters) s"?${request.rawQueryString}" else ""
-    Redirect(request.path.endsWith(".json") match {
-      case true => s"/$realPath.json$params"
-      case _ => s"/$realPath$params"
-    })
   }
 
   def renderTrailsJson(path: String) = renderTrails(path)


### PR DESCRIPTION
This introduces:
- Add `redirectWithParameters` to `LinkTo` so that redirects in both Facia and Front are the same
- Add `hasItems` to `Front` in Facia, to check if a path has anything in it
- Add `FaciaControllerTest`, initial tests for Facia

This differs from the tests in Front in that I am using the `BeforeAndAfterAll` mixin to wait for up to `1 minute` for each main front (`UK`, `US`, `AU`) to have items in them.

In Front, a global object `FrontTestGlobal` is used with the mixin `GlobalSettings`, which then the `onStart` is overridden to wait for the front to load. This doesn't work for Facia as it needs more than one refresh, which can take up to one minute, and waiting for one minute would be bad in `onStart` as this was running before every test.

This is very initial. If we see any trouble in teamcity with the Front object, we may either need to change how long the `beforeAll` waits for the `Front` to load, or use Akka scheduling to schedule the refresh more often.
