### PR TITLE
Fix article-zone margins and refactor football match markup

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -27,17 +27,17 @@
     }
 
     @include mq(rightCol) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
+        margin-left: $gs-gutter;
+        margin-right: $gs-gutter;
         max-width: none;
     }
 
     @include mq(leftCol) {
-        padding-left: $a-leftCol-width + $gs-gutter*2;
+        padding-left: $a-leftCol-width + $gs-gutter;
     }
 
     @include mq(wide) {
-        padding-left:  gs-span(3) + $gs-gutter*2;
+        padding-left:  gs-span(3);
         padding-right: $a-rightCol-width + gs-span(1) + $gs-gutter*2;
     }
 

--- a/sport/app/football/views/fragments/footballMatchBody.scala.html
+++ b/sport/app/football/views/fragments/footballMatchBody.scala.html
@@ -2,12 +2,10 @@
 @import feed._
 @import implicits.Football._
 
+<h2 class="article-zone">
+    <a class="tone-colour" data-link-name="article section" href="@LinkTo{/football}">football</a>
+</h2>
 <div class="article-wrapper monocolumn-wrapper">
-    <div class="article-v2__inner">
-        <h2 class="article-zone type-1">
-            <a class="tone-colour" data-link-name="article section" href="@LinkTo{/football}">football</a>
-        </h2>
-    </div>
     <article class="article football-article @if(page.theMatch.isLive){is-live}" role="main">
         <div class="article-v2__inner">
             <header class="article__head">


### PR DESCRIPTION
- Simple fix to `article-zone` object to correctly align the top border with the navigation.
- Refactor football match page markup to display header correctly
#### Before

![google chrome](https://f.cloud.github.com/assets/80089/1277582/fec0b700-2ecf-11e3-9060-5045f978eba1.png)
#### After

![google chrome](https://f.cloud.github.com/assets/80089/1277584/07d48024-2ed0-11e3-899f-3376306e9434.png)
