### PR TITLE
Fix football match nav selected state

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -39,7 +39,7 @@ define([
                         var url = "/football/api/match-nav/" +
                                   config.webPublicationDateAsUrlPart() + "/" +
                                   teamIds[0] + "/" + teamIds[1] +
-                                  "?currentPage=" + encodeURIComponent(config.page.pageId);
+                                  "?page=" + encodeURIComponent(config.page.pageId);
 
                         matchNav.load(url, context);
                     }

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -31,7 +31,7 @@ define([
         matchNav: function(config, context){
             if (config.page.footballMatch) {
                 var url =  "/football/api/match-nav/" + config.page.footballMatch.id;
-                    url += "?currentPage=" + encodeURIComponent(config.page.pageId);
+                    url += "?page=" + encodeURIComponent(config.page.pageId);
                 new MatchNav().load(url, context);
             }
         },

--- a/common/app/assets/javascripts/modules/matchnav.js
+++ b/common/app/assets/javascripts/modules/matchnav.js
@@ -1,4 +1,4 @@
-define(['common', 'ajax', 'modules/pad'], function (common, ajax, Pad) {
+define(['common', 'ajax'], function (common, ajax) {
 
     function MatchNav() {
 

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -88,7 +88,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
     val minByMin = related.find { c => c.webPublicationDate.toDateMidnight == matchDate && c.matchReport && c.minByMin }
     val stats: Trail = theMatch
 
-    val currentPage = request.getParameter("currentPage").flatMap { pageId =>
+    val currentPage = request.getParameter("page").flatMap { pageId =>
       (stats :: List(matchReport, minByMin).flatten).find(_.url.endsWith(pageId))
     }
 

--- a/sport/app/football/views/fragments/matchNav.scala.html
+++ b/sport/app/football/views/fragments/matchNav.scala.html
@@ -4,7 +4,7 @@
 
 @report(trail: Trail, text: String) = {
     @if(component.currentPage.exists(_.url == trail.url)){
-        <li class="tabs__tab tabs__tab--selected"><a href="#">@text</a></li>
+        <li class="tabs__tab tabs__tab--selected tone-colour tone-accent-border"><a href="#">@text</a></li>
     } else {
         <li class="tabs__tab"><a href="@LinkTo{@trail.url}" data-link-name="@text">@text</a></li>
     }


### PR DESCRIPTION
This fixes #1875 

The ajaxed football match day navigation no longer highlights the current active tab. This is because the component uses an unsupported url parameter `currentPage` to determine which to highlight. We strip out query strings not in our whitelist at the CDN level and thus was not reaching the controller.

This was annoying me so I went with the simple solution and renamed the query string to `page` which is in our whitelist and therefore doesn't add extra complexity and polution of our URLs.
#### Before

![Before](https://f.cloud.github.com/assets/80089/1277602/b48471d4-2ed1-11e3-9615-d25b0d7ea9e1.png)
#### After

![After](https://f.cloud.github.com/assets/80089/1277603/bb197e2c-2ed1-11e3-92a3-7873c45ecd9e.png)
