### PR TITLE
Prevent witness embeds from being picture cleaned

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -165,7 +165,7 @@ case class PictureCleaner(contentImages: List[ImageElement]) extends HtmlCleaner
 
   def clean(body: Document): Document = {
     body.getElementsByTag("figure").foreach { fig =>
-      if(!fig.hasClass("element-comment")) {
+      if(!fig.hasClass("element-comment") && !fig.hasClass("element-witness")) {
         fig.attr("itemprop", "associatedMedia")
         fig.attr("itemscope", "")
         fig.attr("itemtype", "http://schema.org/ImageObject")


### PR DESCRIPTION
We recently changed the way we manage/style inline images below 400px, this was affecting witness embeds with low quality user generated uploads. This simply prevents witness embeds from being picture cleaned.
#### Before

![google chrome](https://f.cloud.github.com/assets/80089/1277667/9ff37724-2ed6-11e3-9987-826ac3f820a5.png)
#### After

![google chrome](https://f.cloud.github.com/assets/80089/1277668/a2e8c024-2ed6-11e3-9ad6-f262ba7fe29d.png)
