### PR TITLE
Fix localstorage write issues in most-popular-facebook

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/most-popular-from-facebook.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/most-popular-from-facebook.js
@@ -14,7 +14,8 @@ define(['common', 'bonzo', 'modules/popular', 'modules/storage'], function (comm
 
             var isArticle = config.page && config.page.contentType === "Article",
                 isFromFacebook = document.referrer.indexOf('facebook.com') !== -1,
-                hasBeenFromFacebook = storage.get('gu.ab.participations')[this.id],
+                participations = storage.get('gu.ab.participations'),
+                hasBeenFromFacebook = participations ? participations[this.id] : false,
                 isTest = /#dev-fbpopular/.test(window.location.hash);
 
             return isArticle && (isFromFacebook || hasBeenFromFacebook || isTest);


### PR DESCRIPTION
This fixes a runtime error that was preventing JS to run in Safari private mode.

We also learnt that browsing privately is the normal behaviour for half of the editorial department.

/cc @kaelig @indeox @commuterjoy 
