### PR TITLE
Styling tweaks to football match pages

### DIFF
--- a/common/app/assets/stylesheets/module/_tabs.scss
+++ b/common/app/assets/stylesheets/module/_tabs.scss
@@ -39,7 +39,7 @@
         min-height: $gs-column-height;
         text-align: left;
         color: inherit;
-        padding: $baseline $gs-gutter/2 0;
+        padding: $baseline 8px 0;
         display: block;
         text-decoration: none;
         background-color: $c-neutral6;
@@ -50,9 +50,13 @@
             text-decoration: none;
         }
 
-        @include mq($to: 300px) {
+        @include mq($to: tablet) {
             font-size: 14px;
             font-size: 1.4rem;
+        }
+
+        @include mq(tablet) {
+            padding: $baseline $gs-gutter/2 0;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -1,30 +1,36 @@
 .match-summary {
     padding-top: 5px;
     padding-bottom: $baseline*3;
+}
 
-    h2 {
-        @include fs-headline(3);
-        margin-bottom: $baseline;
-    }
+.match-summary__team {
+    @include fs-headline(3);
+    margin-bottom: $baseline;
+}
 
-    p:nth-child(3) {
-        margin-bottom: $baseline*2;
-    }
+.match-summary__score {
+    display:inline-block;
+    margin-left: $gs-gutter;
+}
 
-    .away-team {
-        border-top: 1px solid $c-neutral7;
-        padding-top: $baseline;
-        margin-top: $baseline*5;
-    }
+.match-summary__team--away {
+    border-top: 1px solid $c-neutral7;
+    padding-top: $baseline;
+    margin-top: $baseline*5;
+}
 
-    .home-scorers {
-        margin-bottom: $baseline*2;
-    }
+.match-summary__scorers {
+    @include fs-data(3);
+    margin-bottom: $baseline*2;
+}
 
-    .match-comment {
-        text-align: left;
-        border-top: 1px solid #F4F4EE;
-        margin-top: $baseline*2;
-        padding-top: 5px;
-    }
+.match-summary__comment {
+    text-align: left;
+    border-top: 1px solid #F4F4EE;
+    margin-top: $baseline*2;
+    padding-top: 5px;
+}
+
+.match-summary__aggregate {
+    margin-bottom: $baseline*2;
 }

--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -9,7 +9,7 @@
 }
 
 .match-summary__score {
-    display:inline-block;
+    display: inline-block;
     margin-left: $gs-gutter;
 }
 

--- a/common/app/views/fragments/footballNavLinks.scala.html
+++ b/common/app/views/fragments/footballNavLinks.scala.html
@@ -1,7 +1,7 @@
 @(headerLink: model.Link, links: Seq[model.Link])(implicit request: RequestHeader)
 @import common.LinkTo
 <div class="tone-news">
-    <h3 class="article-zone article-zone--sport tone-accent-border">
+    <h3 class="article__sub-head tone-colour">
         <a class="tone-colour" href="@headerLink.url" data-link-name="football index @headerLink.linkName">@headerLink.linkText.toLowerCase</a>
     </h3>
     <div class="sections u-cf football-nav" data-link-name="football bottom nav">

--- a/common/app/views/fragments/footballNavLinks.scala.html
+++ b/common/app/views/fragments/footballNavLinks.scala.html
@@ -1,7 +1,7 @@
 @(headerLink: model.Link, links: Seq[model.Link])(implicit request: RequestHeader)
 @import common.LinkTo
 <div class="tone-news">
-    <h3 class="article-zone tone-accent-border">
+    <h3 class="article-zone article-zone--sport tone-accent-border">
         <a class="tone-colour" href="@headerLink.url" data-link-name="football index @headerLink.linkName">@headerLink.linkText.toLowerCase</a>
     </h3>
     <div class="sections u-cf football-nav" data-link-name="football bottom nav">

--- a/sport/app/football/views/fragments/matchSummary.scala.html
+++ b/sport/app/football/views/fragments/matchSummary.scala.html
@@ -7,22 +7,28 @@
 
 @defining((theMatch.homeTeam, theMatch.awayTeam)){ case (homeTeam, awayTeam) =>
   @if(theMatch.isLive || theMatch.isResult){
-    <h2 class="type-3">@homeTeam.name @homeTeam.score</h2>
+    <h2 class="match-summary__team">
+        @homeTeam.name
+        <span class="match-summary__score">@homeTeam.score</span>
+    </h2>
     @if(homeTeam.hasScored){
-        <p class="home-scorers type-11">@cleanScorers(homeTeam.scorers)</p>
+        <p class="match-summary__scorers match-summary__scorers--home">@cleanScorers(homeTeam.scorers)</p>
     }
-    <h2 class="away-team type-3">@awayTeam.name @awayTeam.score</h2>
 
+    <h2 class="match-summary__team match-summary__team--away">
+        @awayTeam.name
+        <span class="match-summary__score">@awayTeam.score</span>
+    </h2>
     @if(awayTeam.hasScored){
-        <p class="type-11">@cleanScorers(awayTeam.scorers)</p>
+        <p class="match-summary__scorers match-summary__scorers--home">@cleanScorers(awayTeam.scorers)</p>
     }
   } else {
-    <h2 class="type-3">@homeTeam.name v @awayTeam.name</h2>
+    <h2 class="match-summary__team">@homeTeam.name v @awayTeam.name</h2>
   }
 
     @if(theMatch.homeTeam.aggregateScore){
-        <p class="match-aggregate type-10"><span>(agg. <span>@theMatch.homeTeam.aggregateScore-@theMatch.awayTeam.aggregateScore</span>)</span></p>
+        <p class="match-summary__aggregate"><span>(agg. <span>@theMatch.homeTeam.aggregateScore-@theMatch.awayTeam.aggregateScore</span>)</span></p>
     }
 
-    @theMatch.comments.map{ comments => <h5 class="match-comment type-5">@comments.replace("(", "").replace(")", "")</h5>}
+    @theMatch.comments.map{ comments => <h5 class="match-summary__comment">@comments.replace("(", "").replace(")", "")</h5>}
 }

--- a/sport/app/football/views/fragments/matchSummary.scala.html
+++ b/sport/app/football/views/fragments/matchSummary.scala.html
@@ -27,7 +27,7 @@
   }
 
     @if(theMatch.homeTeam.aggregateScore){
-        <p class="match-summary__aggregate"><span>(agg. <span>@theMatch.homeTeam.aggregateScore-@theMatch.awayTeam.aggregateScore</span>)</span></p>
+        <p class="match-summary__aggregate">(agg. <span>@theMatch.homeTeam.aggregateScore-@theMatch.awayTeam.aggregateScore</span>)</p>
     }
 
     @theMatch.comments.map{ comments => <h5 class="match-summary__comment">@comments.replace("(", "").replace(")", "")</h5>}


### PR DESCRIPTION
A few minor tweaks to football match pages noticed by various people since lanuch of bacon
- Refactor and BEMify match summary markup
- Apply margin right to match score
- Reduce tab font-size and padding at smaller breakpoints
- Change heading style on football nav
#### Before

![google chrome](https://f.cloud.github.com/assets/80089/1290685/01141360-3035-11e3-8f58-9db63adc58a3.png)
#### After

![google chrome](https://f.cloud.github.com/assets/80089/1290686/05c4db1a-3035-11e3-961f-f34077a68330.png)
