### PR TITLE
Speech bubble bug fix

### DIFF
--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -249,7 +249,8 @@
         left: 6px;
         border-width: 0 0 8px 8px;
         border-style: solid;
-        border-color: transparent inherit;
+        border-color: transparent;
+        border-left-color: inherit;
     }
 }
 


### PR DESCRIPTION
Two `border-color`s seems to burst Firefox's bubble.
One after the other seems to do it.

![Bubble = burst](http://devilsfoe.com/wp-content/uploads/2012/06/funny-animated-gifs-big-bubble.gif)
