### PR TITLE
Prevent optimization of windows 8 icon - needs to be a PNG32 (fixes #1917)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -210,7 +210,7 @@ module.exports = function (grunt) {
                 },{
                     expand: true,
                     cwd: 'common/app/public/images/',
-                    src: ['**/*.{png,gif,jpg}'],
+                    src: ['**/*.{png,gif,jpg}', '!favicons/windows_tile_144_b.png'],
                     dest: 'static/target/compiled/images/'
                 }]
             }


### PR DESCRIPTION
![ ](http://s1.developerslife.ru/public/images/gifs/94e8b576-baf7-4431-b99d-421a93e2c08f.gif)
