### PR TITLE
Adding mobile image size

### DIFF
--- a/common/app/assets/javascripts/modules/facia/image-upgrade.js
+++ b/common/app/assets/javascripts/modules/facia/image-upgrade.js
@@ -5,8 +5,11 @@ define(['common', 'bonzo', 'modules/detect'], function (common, bonzo, detect) {
         this.upgrade = function() {
             if (detect.getConnectionSpeed() !== 'low' && bonzo(imageContainer).css('display') !== 'none') {
                 var $image = common.$g('.item__image', imageContainer),
-                    src = $image.attr(isMain ? 'data-src-main' : 'data-src');
-                    $image.attr('src', src);
+                    srcDataAttr = isMain ? 'data-src-main' : 'data-src';
+                if (detect.getBreakpoint() === 'mobile') {
+                    srcDataAttr += '-mobile';
+                }
+                $image.attr('src', $image.attr(srcDataAttr));
             }
         };
 

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -37,7 +37,9 @@
         @trail.mainPicture.map{ mainPicture =>
             <div class="item__image-container">
                 <a href="@LinkTo{@trail.url}" class="item__link">
-                    <img class="item__image" alt="" data-src="@ImgSrc(mainPicture, FrontItem)" data-src-main="@ImgSrc(mainPicture, FrontItemMain)" />
+                    <img class="item__image" alt=""
+                         data-src="@ImgSrc(mainPicture, FrontItem)" data-src-main="@ImgSrc(mainPicture, FrontItemMain)"
+                         data-src-mobile="@ImgSrc(mainPicture, FrontItemMobile)" data-src-main-mobile="@ImgSrc(mainPicture, FrontItemMainMobile)" />
                 </a>
             </div>
         }

--- a/common/app/views/support/images.scala
+++ b/common/app/views/support/images.scala
@@ -14,13 +14,15 @@ object GallerySmallTrail extends Profile("gst", Some(280), Some(168), 70) {}
 object FeaturedTrail extends Profile("f", Some(640), None, 70) {}
 object ArticleMainPicture extends Profile("a", Some(640), None, 70) {}
 object FrontItem extends Profile("fi", Some(300), None, 70) {}
+object FrontItemMobile extends Profile("fi-mobile", Some(140), None, 70) {}
 object FrontItemMain extends Profile("fim", Some(620), None, 70) {}
+object FrontItemMainMobile extends Profile("fim-mobile", Some(300), None, 70) {}
 
 // Just degrade the image quality without adjusting the width/height
 object Naked extends Profile("n", None, None, 70) {}
 
 object Profile {
-  lazy val all = Seq(Contributor, GalleryLargeTrail, GallerySmallTrail, FeaturedTrail, Naked, ArticleMainPicture, FrontItem, FrontItemMain)
+  lazy val all = Seq(Contributor, GalleryLargeTrail, GallerySmallTrail, FeaturedTrail, Naked, ArticleMainPicture, FrontItem, FrontItemMobile, FrontItemMain, FrontItemMainMobile)
 }
 
 


### PR DESCRIPTION
Pull in smaller image on mobile

Note, the way the breakpoints are set up (and consequently `getBreakpoint`), get mobile-sized images also on devices >= mobile and < tablet; will need revisiting
