### PR TITLE
Only make gallery out of largest crop available for each element

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -46,7 +46,7 @@
 
                     <div class="js-gallery-holder gallery-container">
                         <ul class="unstyled">
-                        @gallery.crops.zipWithRowInfo.map{ case(image, row) =>
+                        @gallery.largestCrops.zipWithRowInfo.map{ case(image, row) =>
                             @if(row.rowNum == index) {
                                 <li class="js-gallery-item-@row.rowNum js-current-gallery-slide" data-image="true"
                                 data-index="@row.rowNum" data-total="@gallery.size">

--- a/applications/app/views/fragments/lightboxGalleryBody.scala.html
+++ b/applications/app/views/fragments/lightboxGalleryBody.scala.html
@@ -3,7 +3,7 @@
 
 <div class="gallery gallery--lightbox" data-total="@gallery.size" data-link-name="Lightbox gallery">
     <ul class="gallery__images unstyled">
-        @gallery.crops.zipWithRowInfo.map{ case(image, row) =>
+        @gallery.largestCrops.zipWithRowInfo.map{ case(image, row) =>
             <li class="js-gallery-item-@row.rowNum gallery__item @if(image.width >= image.height){gallery__item--landscape} else {gallery__item--portrait}"
                 data-index="@row.rowNum">
                     <figure itemprop="associatedMedia" itemtype="http://schema.org/ImageObject" itemscope>

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -25,7 +25,7 @@ trait Formats {
   implicit val galleryFormat: Writes[Gallery] = new Writes[Gallery] {
     def writes(gallery: Gallery): JsValue = toJson(
       Map(
-        "pictures" -> gallery.crops.map(toJson(_))
+        "pictures" -> gallery.largestCrops.map(toJson(_))
       )
     )
   }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -68,11 +68,12 @@ trait Elements {
   private lazy val imageElements: List[ImageContainer] = (images ++ videos).sortBy(_.index)
   // Find the the lowest index imageContainer.
   private lazy val mainImageElement: Option[ImageContainer] = imageElements.find(!_.largestImage.isEmpty)
-  lazy val crops: List[ImageAsset] = imageElements.flatMap(_.imageCrops)
+  private lazy val crops: List[ImageAsset] = imageElements.flatMap(_.imageCrops)
   lazy val videoAssets: List[VideoAsset] = videos.flatMap(_.videoAssets)
 
   // Return the biggest main picture crop.
   lazy val largestMainPicture: Option[ImageAsset] = mainImageElement.flatMap(_.largestImage)
+  lazy val largestCrops: List[ImageAsset] = imageElements.flatMap(_.largestImage)
 }
 
 trait Tags {

--- a/common/test/model/ElementsTest.scala
+++ b/common/test/model/ElementsTest.scala
@@ -79,6 +79,21 @@ class ElementsTest extends FlatSpec with ShouldMatchers {
     images.largestMainPicture.get.caption should be(Some("biggest main picture"))
   }
 
+  it should "find the biggest crops of all the pictures" in {
+    val images = new Elements {
+      override def images = List(
+                        image("test-image-0","body", 0, List(asset("smaller picture 1",50), asset("biggest picture 1",100))),
+                        image("test-image-1","body", 1, "a single picture 2", 200))
+      override def videos = Nil
+      override def thumbnail = None
+      override def mainPicture = None
+      override def mainVideo = None
+    }
+
+    images.largestCrops(0).caption should be(Some("biggest picture 1"))
+    images.largestCrops(1).caption should be(Some("a single picture 2"))
+  }
+
   it should "get a crop of the main pic of a specific size" in {
 
     val images = new Elements {


### PR DESCRIPTION
Upcoming composer galleries have several image crops per element. We only want the largest one, which is what this does.
