### PR TITLE
Fix binary hashing

### DIFF
--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -1,21 +1,24 @@
 package dev
 
+import common.ExecutionContexts
 import java.io.File
-import org.apache.commons.io.IOUtils
 import play.api.libs.MimeTypes
 import play.api.mvc._
+import play.api.libs.iteratee.Enumerator
 
-object DevAssetsController extends Controller {
+object DevAssetsController extends Controller with ExecutionContexts {
 
   def at(path: String): Action[AnyContent] = Action {
-    val resolved = new File(s"static/target/hashed/$path").toURI.toURL
-    val body = IOUtils.toString(resolved)
-
     val contentType: Option[String] = MimeTypes.forFileName(path) map { mime =>
       // Add charset for text types
       if (MimeTypes.isText(mime)) s"${mime}; charset=utf-8" else mime
     }
 
-    Ok(body).withHeaders(CONTENT_TYPE -> contentType.getOrElse(BINARY))
+    val resolved = new File(s"static/target/hashed/$path").toURI.toURL
+
+    SimpleResult(
+      ResponseHeader(OK, Map(CONTENT_TYPE -> contentType.getOrElse(BINARY))),
+      Enumerator.fromStream(resolved.openStream())
+    )
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "moment": "~2.1.0",
     "grunt-mkdir": "~0.1.1",
     "grunt-contrib-imagemin": "~0.3.0",
-    "grunt-hash": "~0.4.0",
+    "grunt-hash": "git://github.com/guardian/grunt-hash.git",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3"
   },


### PR DESCRIPTION
This ensures that newly created files during hashing process are saved with their correct file type (binary or text) rather than treating everything as text.

A side effect of this is that we have had to fork the grunt task to a guardian repo. This shall only be temporary until we create a PR back to the original repo with our changes.

/cc @daithiocrualaoich 
