### PR TITLE
Change grunt-hash dependency back to origin repo v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "moment": "~2.1.0",
     "grunt-mkdir": "~0.1.1",
     "grunt-contrib-imagemin": "~0.3.0",
-    "grunt-hash": "git://github.com/guardian/grunt-hash.git#0.4.2",
+    "grunt-hash": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
     "mkdirp": "~0.3.5"


### PR DESCRIPTION
They merged our PR yesterday so we can go back to using the NPM version rather than our forked.

/cc @daithiocrualaoich 
