### PR TITLE
Facia metrics

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -286,13 +286,6 @@ object FaciaToolMetrics {
     "Number of expired requests coming into an endpoint using ExpiringAuthAction"
   )
 
-  object LoginCount extends CountMetric(
-    "facia-api",
-    "facia-auth-logins",
-    "Facia auth logins",
-    "Number of logins"
-  )
-
   object DraftPublishCount extends CountMetric(
     "facia-api",
     "facia-draft-publish",
@@ -302,7 +295,7 @@ object FaciaToolMetrics {
 
   val all: Seq[Metric] = Seq(
     ApiUsageCount, ProxyCount, ExpiredRequestCount,
-    LoginCount, DraftPublishCount
+    DraftPublishCount
   )
 }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -249,6 +249,20 @@ object FootballMetrics {
   )
 }
 
+object FaciaMetrics {
+
+  object JsonParsingErrorCount extends CountMetric(
+    "facia-front",
+    "facia-json-error",
+    "Facia JSON parsing errors",
+    "Number of errors whilst parsing JSON out of S3"
+  )
+
+  val all: Seq[Metric] = Seq(
+    JsonParsingErrorCount
+  )
+}
+
 object FaciaToolMetrics {
 
   object ApiUsageCount extends CountMetric(
@@ -301,6 +315,7 @@ object Metrics {
 
   lazy val discussion = DiscussionMetrics.all
   lazy val admin = AdminMetrics.all
+  lazy val facia = FaciaMetrics.all
   lazy val faciaTool = FaciaToolMetrics.all
   lazy val porter = PorterMetrics.all
   lazy val coreNavigation = CoreNavivationMetrics.all

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -251,7 +251,45 @@ object FootballMetrics {
 
 object FaciaToolMetrics {
 
-  val all: Seq[Metric] = Nil
+  object ApiUsageCount extends CountMetric(
+    "facia-api",
+    "facia-api-usage",
+    "Facia API usage count",
+    "Number of requests to the Facia API from clients (The tool)"
+  )
+
+  object ProxyCount extends CountMetric(
+    "facia-api",
+    "facia-proxy-usage",
+    "Facia proxy usage count",
+    "Number of requests to the Facia proxy endpoints (Ophan and Content API) from clients"
+  )
+
+  object ExpiredRequestCount extends CountMetric(
+    "facia-api",
+    "facia-auth-expired",
+    "Facia auth endpoints expired requests",
+    "Number of expired requests coming into an endpoint using ExpiringAuthAction"
+  )
+
+  object LoginCount extends CountMetric(
+    "facia-api",
+    "facia-auth-logins",
+    "Facia auth logins",
+    "Number of logins"
+  )
+
+  object DraftPublishCount extends CountMetric(
+    "facia-api",
+    "facia-draft-publish",
+    "Facia draft publish count",
+    "Number of drafts that have been published"
+  )
+
+  val all: Seq[Metric] = Seq(
+    ApiUsageCount, ProxyCount, ExpiredRequestCount,
+    LoginCount, DraftPublishCount
+  )
 }
 
 

--- a/facia-tool/app/controllers/FaciaContentApiProxy.scala
+++ b/facia-tool/app/controllers/FaciaContentApiProxy.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import conf.Configuration
-import common.{ExecutionContexts, Logging}
+import common.{FaciaToolMetrics, ExecutionContexts, Logging}
 import implicits.Strings
 import play.api.mvc._
 import play.api.libs.ws.WS
@@ -9,6 +9,7 @@ import play.api.libs.ws.WS
 object FaciaContentApiProxy extends Controller with Logging with AuthLogging with ExecutionContexts with Strings {
 
   def proxy(path: String) = AjaxExpiringAuthentication.async { request =>
+    FaciaToolMetrics.ProxyCount.increment()
     val queryString = request.queryString.map { p =>
        "%s=%s".format(p._1, p._2.head.urlEncoded)
     }.mkString("&")
@@ -23,6 +24,7 @@ object FaciaContentApiProxy extends Controller with Logging with AuthLogging wit
   }
 
   def json(url: String) = AjaxExpiringAuthentication.async { request =>
+    FaciaToolMetrics.ProxyCount.increment()
     log("Proxying json request to: %s" format url, request)
 
     WS.url(url).get().map { response =>

--- a/facia-tool/app/controllers/FaciaOphanApiController.scala
+++ b/facia-tool/app/controllers/FaciaOphanApiController.scala
@@ -2,12 +2,13 @@ package controllers
 
 import play.api.mvc._
 import services.OphanApi
-import common.ExecutionContexts
+import common.{FaciaToolMetrics, ExecutionContexts}
 
 
 object FaciaOphanApiController extends Controller with ExecutionContexts {
 
   def pageViews(path: String) = AjaxExpiringAuthentication.async { request =>
+    FaciaToolMetrics.ProxyCount.increment()
     OphanApi.getBreakdown(path) map (body => Ok(body) as "application/json")
   }
 

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -4,7 +4,7 @@ import frontsapi.model._
 import frontsapi.model.UpdateList
 import play.api.mvc.{AnyContent, Action, Controller}
 import play.api.libs.json._
-import common.{ExecutionContexts, Logging}
+import common.{FaciaToolMetrics, ExecutionContexts, Logging}
 import conf.Configuration
 import tools.FaciaApi
 import services.S3FrontsApi
@@ -21,20 +21,24 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
   }
 
   def listCollections = AjaxExpiringAuthentication { request =>
+    FaciaToolMetrics.ApiUsageCount.increment()
     Ok(Json.toJson(S3FrontsApi.listCollectionIds))
   }
 
   def listConfigs = AjaxExpiringAuthentication { request =>
+    FaciaToolMetrics.ApiUsageCount.increment()
     Ok(Json.toJson(S3FrontsApi.listConfigsIds))
   }
 
   def readBlock(id: String) = AjaxExpiringAuthentication { request =>
+    FaciaToolMetrics.ApiUsageCount.increment()
     S3FrontsApi.getBlock(id) map { json =>
       Ok(json).as("application/json")
     } getOrElse NotFound
   }
 
   def getConfig(id: String) = AjaxExpiringAuthentication { request =>
+    FaciaToolMetrics.ApiUsageCount.increment()
     S3FrontsApi.getConfig(id) map {json =>
       Ok(json).as("application/json")
     } getOrElse NotFound
@@ -42,6 +46,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
 
 
   def updateBlock(id: String): Action[AnyContent] = AjaxExpiringAuthentication { request =>
+    FaciaToolMetrics.ApiUsageCount.increment()
     request.body.asJson flatMap JsonExtract.build map {
       case update: UpdateList if update.item == update.position.getOrElse("") => Conflict
       case update: UpdateList => {
@@ -80,6 +85,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
   }
 
   def deleteTrail(id: String) = AjaxExpiringAuthentication { request =>
+    FaciaToolMetrics.ApiUsageCount.increment()
     request.body.asJson flatMap JsonExtract.build map {
       case update: UpdateList => {
         val identity = Identity(request).get

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -59,6 +59,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
         val identity = Identity(request).get
         blockAction.publish.filter {_ == true}
           .map { _ =>
+            FaciaToolMetrics.DraftPublishCount.increment()
             FaciaApi.publishBlock(id, identity)
             Ok
           }

--- a/facia/app/conf/context.scala
+++ b/facia/app/conf/context.scala
@@ -10,7 +10,7 @@ class SwitchBoardPlugin(app: PlayApp) extends SwitchBoardAgent(Configuration)
 
 object Management extends GuManagement {
   val applicationName = "frontend-facia"
-  val metrics = Metrics.contentApi ++ Metrics.common ++ Metrics.front
+  val metrics = Metrics.facia ++ Metrics.contentApi ++ Metrics.common ++ Metrics.front
 
   lazy val pages = List(
     new ManifestPage,


### PR DESCRIPTION
Add some facia metrics and logging:

FaciaTool:
- `ApiUsageCount` - Everything from updates to deletes
- `ProxyUsageCount` - Expose how many requests are going through the proxy controllers (Ophan and ContentApi)
- `ExpiredRequestCount` - How many requests have failed the auth expiry constraint that we use in facia tool
- `DraftPublishCount` - Number of requests to publish a draft collection

Facia:
- `JsonParsingErrorCount` - Expose problems with JSON coming from S3

Give me the graphs.

@stephanfowler
