### PR TITLE
Refactor of commenting to allow for cookie user state checking

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/discussion.js
+++ b/common/app/assets/javascripts/modules/discussion/discussion.js
@@ -43,7 +43,12 @@ define([
             loadingCommentsHtml   = '<div class="preload-msg">Loading comments…<div class="is-updating"></div></div>',
             currentPage           = 0,
             actionsTemplate       = '<button class="js-show-more-comments cta" data-link-name="Show more comments">Show more comments</button>' +
-                                    '<div class="d-actions"><a href="#article" class="top" data-link-name="Discussion: Return to article">Return to article</a></div>',
+                                    '<div class="d-actions">'+
+                                        '<a data-link-name="Comment on desktop" class="d-actions__link" href="/'+ config.page.pageId +'?view=desktop#start-of-comments">'+
+                                            'Want our fully featured commenting experience? Head to our old site.'+
+                                        '</a>'+
+                                        '<a href="#article" class="top" data-link-name="Discussion: Return to article">Return to article</a>'+
+                                    '</div>',
             clickstream           = new ClickStream({ addListener: false }),
             apiRoot               = config.page.discussionApiRoot,
             user                  = Id.getUserFromCookie(),
@@ -247,6 +252,10 @@ define([
                     $topBoxElem = bonzo(bonzo.create(html)),
                     $bottomBoxElem = bonzo(bonzo.create(html));
 
+                // This comes in useful later
+                user.privateFields = userFields;
+                user.avata = resp.userProfile.avatar;
+
                 if (!userFields.isPremoderated) {
                     bonzo($topBoxElem[0].querySelector('.d-comment-box__premod')).remove();
                     bonzo($bottomBoxElem[0].querySelector('.d-comment-box__premod')).remove();
@@ -269,9 +278,6 @@ define([
                 });
                 bottomBox.attachTo($bottomBoxElem[0]);
                 bottomBox.on('post:success', self.addComment.bind(self, true));
-
-                $bottomBoxElem.after('<a data-link-name="Comment on desktop" class="d-actions__link" href="/' + config.page.pageId + '?view=desktop#start-of-comments">' +
-                    'Want our fully featured commenting experience? Head to our old site.</a>');
             },
 
             addComment: function(takeToTop, resp) {
@@ -283,7 +289,7 @@ define([
                     $datetime = bonzo($comment.querySelector('time')),
                     $author = bonzo($comment.querySelector('.d-comment__author')),
                     $body = bonzo($comment.querySelector('.d-comment__body')),
-                    $avatar = bonzo($comment.querySelector('.d-comment__avatar'))[0];
+                    $avatar = bonzo($comment.querySelector('.d-comment__avatar'));
 
                 $comment.id = 'comment-'+ resp.id;
                 $author.html(user.displayName);
@@ -299,7 +305,7 @@ define([
 
                 // This is stored in the DOM like so
                 // To spare us another call to the discussion API
-                $avatar.src = qwery('.js-avatar-url', discussionContainerNode)[0].getAttribute('data-avatar-url');
+                $avatar[0].src = user.avatar;
             },
 
             showMoreReplies: function(el) {

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -38,7 +38,7 @@ id.webapp.url=https://id.code.dev-theguardian.com
 guardian.page.omnitureAccount=guardiangu-frontend-dev
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 guardian.page.fbAppId=180444840287
-guardian.page.discussionApiRoot=http://discussion.release.dev-guardianapis.com/discussion-api
+guardian.page.discussionApiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
 guardian.page.host=http://m.code.dev-theguardian.com
 guardian.page.idApiJsClientToken=frontend-code-js-client-token
 

--- a/discussion/app/views/fragments/commentBox.scala.html
+++ b/discussion/app/views/fragments/commentBox.scala.html
@@ -1,6 +1,5 @@
 @(premod: Boolean = false, avatarUrl: String)(implicit request: RequestHeader)
 <form class="component js-comment-box d-comment-box">
-    <div class="js-avatar-url" data-avatar-url="@avatarUrl"></div>
     <label for="body" class="d-comment-box__add-comment js-show-comment-box cta">Add your comment</label>
 
     <div class="d-comment-box__content">

--- a/discussion/app/views/fragments/commentBox.scala.html
+++ b/discussion/app/views/fragments/commentBox.scala.html
@@ -5,7 +5,7 @@
 
     <div class="d-comment-box__content">
         <div class="d-comment-box__messages"></div>
-        @if(premod){<div class="d-comment-box__error">Your comments are currently being pre-moderated (<a href="/community-faqs#311" target="_blank">why?</a>)</div>}
+        @if(premod){<div class="d-comment-box__error d-comment-box__premod">Your comments are currently being pre-moderated (<a href="/community-faqs#311" target="_blank">why?</a>)</div>}
         <textarea name="body" class="d-comment-box__body" placeholder="Join the discussion…"></textarea>
         <button type="submit" class="submit-input d-comment-box__submit">Post comment</button>
     </div>

--- a/discussion/app/views/fragments/commentsBody.scala.html
+++ b/discussion/app/views/fragments/commentsBody.scala.html
@@ -11,3 +11,6 @@
 	    }
 	</ul>
 </div>
+
+<script type="text/template" id="tmpl-comment-box">@fragments.commentBox(true, "")</script>
+<script type="text/template" id="tmpl-banned-user">@fragments.cannotComment()</script>


### PR DESCRIPTION
We've had problems sending cookies from our play app to the Discussion API. Dang.
We have a work around of hitting the Discussion API directly.

We are using the `<script type="text/template">`.

This is by no means the way we are going to do things in the future, but the next step is to refactor the discussion modules, as this feature has proven, it's becoming a bit of a God Object.

![God-Zilla!](http://stream1.gifsoup.com/view/752790/godzilla-s-dance-o.gif)
