### PR TITLE
Responsive viewer

### DIFF
--- a/facia-dev-build/conf/routes
+++ b/facia-dev-build/conf/routes
@@ -106,6 +106,8 @@ GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)
 GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>/trails                    controllers.FaciaController.renderTrails(path)
 GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>/trails.json               controllers.FaciaController.renderTrailsJson(path)
 
+GET        /responsive-viewer                                                                               controllers.FaciaController.renderResponsiveViewer()
+
 # Applications
 GET        /sections                                                                                        controllers.SectionsController.renderSections()
 GET        /sections.json                                                                                   controllers.SectionsController.renderSectionsJson()
@@ -123,8 +125,8 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                        
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                         controllers.IndexController.render(path)
 GET        /$leftSide<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>+$rightSide<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>        controllers.IndexController.renderCombiner(leftSide, rightSide)
 
-GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json                          controllers.InteractiveController.renderInteractiveJson(path) 
-GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>                               controllers.InteractiveController.renderInteractive(path) 
+GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json                          controllers.InteractiveController.renderInteractiveJson(path)
+GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>                               controllers.InteractiveController.renderInteractive(path)
 
 # Articles
 GET        /*path.json                                                                                      controllers.ArticleController.renderLatest(path, lastUpdate: Option[String])

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -190,6 +190,10 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
     }.getOrElse(NotFound)
   }
 
+  def renderResponsiveViewer() = Action {
+    Ok(views.html.fragments.responsiveViewer())
+  }
+
 }
 
 object FaciaController extends FaciaController

--- a/facia/app/views/fragments/responsiveViewer.scala.html
+++ b/facia/app/views/fragments/responsiveViewer.scala.html
@@ -43,7 +43,7 @@
                                 'width="' + (bp.width + sbWidth) + '" ' +
                                 'height="' + bp.height + '"></iframe>' +
                         '</div>';
-                    leftAcc += bp.width + sbWidth + 13;
+                    leftAcc += bp.width + sbWidth + 15;
                 })
 
                 document.querySelector('.frames').innerHTML = html;

--- a/facia/app/views/fragments/responsiveViewer.scala.html
+++ b/facia/app/views/fragments/responsiveViewer.scala.html
@@ -1,0 +1,56 @@
+@()<!DOCTYPE html>
+<html>
+    <head>
+        <script>
+            breakpoints = [
+                { width:  320,  height: 480,  name: "Mobile" },
+                { width:  1295, height: 1024, name: "Desktop" },
+                { width:  768,  height: 1024, name: "Tablet portrait" },
+                { width:  1024, height: 768,  name: "Tablet landscape" }
+            ]
+        </script>
+        <style>
+            iframe {
+                border: 1px solid #999999;
+                border-radius: 4px;
+            }
+            h2 {
+                font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+                font-size: 16px;
+                margin-bottom: 5px;
+            }
+            .frames { position: relative; }
+            .frames > div { position: absolute; }
+        </style>
+    </head>
+    <body>
+        <div class="frames"></div>
+        <script>
+            function init() {
+                var url = window.location.hash.substring(1),
+                    sbWidth = 15, // scrollbar width
+                    html = '',
+                    leftAcc = 0;
+
+                if (!url) { return; }
+
+                breakpoints.forEach(function(bp) {
+                    html +=
+                        '<div style="left:' + leftAcc + 'px">' +
+                            '<h2>' + bp.name + '</h2>' +
+                            '<iframe sandbox="allow-same-origin allow-forms allow-scripts" seamless ' +
+                                'src="' + url + '" ' +
+                                'width="' + (bp.width + sbWidth) + '" ' +
+                                'height="' + bp.height + '"></iframe>' +
+                        '</div>';
+                    leftAcc += bp.width + sbWidth + 13;
+                })
+
+                document.querySelector('.frames').innerHTML = html;
+            }
+
+            init();
+            window.onhashchange = init;
+        </script>
+    </body>
+</html>

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -12,3 +12,5 @@ GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)
 GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json               controllers.FaciaController.renderEditionSectionFrontJson(path)
 GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>/trails             controllers.FaciaController.renderTrails(path)
 GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>/trails.json        controllers.FaciaController.renderTrailsJson(path)
+
+GET        /responsive-viewer                                                                        controllers.FaciaController.renderResponsiveViewer()


### PR DESCRIPTION
Moved to facia app, because of SSL issues with having it in facia-tool. Specify a target page with the url hash, e.g. `/responsive-viewer#http://www.theguardian.com/uk`

Also needs: https://github.com/guardian/platform/pull/248

![fronts-tool](https://f.cloud.github.com/assets/1147913/1327453/7131432a-34ef-11e3-92bf-370f35e03b74.png)
