### PR TITLE
Article keywords list: filter out section tags

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -82,7 +82,7 @@
 
                 @fragments.standfirst(gallery)
 
-                @if(gallery.keywords.nonEmpty && ArticleKeywordsSwitch.isSwitchedOn){
+                @if(ArticleKeywordsSwitch.isSwitchedOn){
                     <div class="article__keywords" data-link-name="gallery keywords">
                         @fragments.keywordList(gallery.keywords)
                     </div>

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -38,7 +38,7 @@
                         @fragments.standfirst(video)
                     </div>
 
-                    @if(video.keywords.nonEmpty && ArticleKeywordsSwitch.isSwitchedOn){
+                    @if(ArticleKeywordsSwitch.isSwitchedOn){
                         <div class="article__keywords" data-link-name="video keywords">
                             @fragments.keywordList(video.keywords)
                         </div>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -58,7 +58,7 @@
                         </div>
                     </div>
 
-                    @if(article.keywords.nonEmpty && ArticleKeywordsSwitch.isSwitchedOn){
+                    @if(ArticleKeywordsSwitch.isSwitchedOn){
                         <div class="article__keywords" data-link-name="article keywords">
                             @fragments.keywordList(article.keywords)
                         </div>

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -84,7 +84,7 @@
                         </div>
                     </div>
 
-                    @if(article.keywords.nonEmpty && ArticleKeywordsSwitch.isSwitchedOn){
+                    @if(ArticleKeywordsSwitch.isSwitchedOn){
                         <div class="article__keywords" data-link-name="live blog keywords">
                             @fragments.keywordList(article.keywords)
                         </div>

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -2,7 +2,7 @@
 
 <ul class="inline-list" itemprop="keywords">
     <li class="inline-list__item">Tags:</li>
-    @keywords.take(visibleKeywords).zipWithRowInfo.map{ case(keyword, row) =>
+    @keywords.filterNot(_.isSectionTag).take(visibleKeywords).zipWithRowInfo.map{ case(keyword, row) =>
         <li class="inline-list__item"><a href="@LinkTo(keyword.url)" data-link-name="keyword: @keyword.id">@keyword.name</a>@if(!row.isLast){, }</li>
     }
 </ul>


### PR DESCRIPTION
In this PR, we make sure we don't link to section tags (eg `uk/uk` or `world/world`).

Meaning we can turn the article keywords switch back on.

Thanks @gklopper!

![ ](http://s2.developerslife.ru/public/images/gifs/1472c79b-f58f-4ec4-ac19-10cf59152b87.gif)
