### PR TITLE
Remove itemref on body

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -12,7 +12,7 @@
     @head
 
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top" itemscope itemtype="http://schema.org/WebPage">
 
     @fragments.releaseMessage(metaData)
     @fragments.header(metaData)


### PR DESCRIPTION
Not sure why we had this attribute on the body.

Fixes #1942 

![ ](http://s1.developerslife.ru/public/images/gifs/df68b188-704b-4c48-a854-773679a20721.gif)
