### PR TITLE
Don't show a tag list if there are no keywords in it

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -443,6 +443,19 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with ShouldMatch
         $(".article__keywords a").size should be (5)
       }
     }
+
+    scenario("Don't show keywords in an article with only section tags (eg info/info) or no keywords"){
+      Given("I am on an article entitled 'Removed: Eyeball-licking: the fetish that is making Japanese teenagers sick'")
+
+      ArticleKeywordsSwitch.switchOn
+
+      HtmlUnit("/info/2013/aug/26/2"){ browser =>
+        import browser._
+
+        Then("I should not see a keywords list")
+        $(".article__keywords *").size should be (0)
+      }
+    }
     
     scenario("Twitter cards"){
       Given("I am on an article entitled 'Iran's Rouhani may meet Obama at UN after American president reaches out'")

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -1,8 +1,12 @@
 @(keywords: Seq[Tag], visibleKeywords: Int = 5)(implicit request: RequestHeader)
 
-<ul class="inline-list" itemprop="keywords">
-    <li class="inline-list__item">Tags:</li>
-    @keywords.filterNot(_.isSectionTag).take(visibleKeywords).zipWithRowInfo.map{ case(keyword, row) =>
-        <li class="inline-list__item"><a href="@LinkTo(keyword.url)" data-link-name="keyword: @keyword.id">@keyword.name</a>@if(!row.isLast){, }</li>
+@defining(keywords.filterNot(_.isSectionTag).take(visibleKeywords)) { keywordsList => 
+    @if(keywordsList.size > 0) {
+        <ul class="inline-list" itemprop="keywords">
+            <li class="inline-list__item">Tags:</li>
+            @keywordsList.zipWithRowInfo.map{ case(keyword, row) =>
+                <li class="inline-list__item"><a href="@LinkTo(keyword.url)" data-link-name="keyword: @keyword.id">@keyword.name</a>@if(!row.isLast){, }</li>
+            }
+        </ul>
     }
-</ul>
+}

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -1,7 +1,7 @@
 @(keywords: Seq[Tag], visibleKeywords: Int = 5)(implicit request: RequestHeader)
 
 @defining(keywords.filterNot(_.isSectionTag).take(visibleKeywords)) { keywordsList => 
-    @if(keywordsList.size > 0) {
+    @if(keywordsList.nonEmpty) {
         <ul class="inline-list" itemprop="keywords">
             <li class="inline-list__item">Tags:</li>
             @keywordsList.zipWithRowInfo.map{ case(keyword, row) =>

--- a/data/database/5c01032e9d7241bef7bb3ecfe59e64272346b64e
+++ b/data/database/5c01032e9d7241bef7bb3ecfe59e64272346b64e
@@ -1,0 +1,44 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":1,
+    "content":{
+      "id":"info/2013/aug/26/2",
+      "sectionId":"info",
+      "sectionName":"Info",
+      "webPublicationDate":"2013-08-26T10:02:13Z",
+      "webTitle":"Removed: Eyeball-licking: the fetish that is making Japanese teenagers sick",
+      "webUrl":"http://www.theguardian.com/info/2013/aug/26/2",
+      "apiUrl":"http://content.guardianapis.com/info/2013/aug/26/2",
+      "fields":{
+        "trailText":"<p>Removed: Eyeball-licking: the fetish that is making Japanese teenagers sick</p>",
+        "headline":"Removed: Eyeball-licking: the fetish that is making Japanese teenagers sick",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3tavq",
+        "wordcount":"21",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"info/info",
+        "type":"keyword",
+        "webTitle":"Information",
+        "webUrl":"http://www.theguardian.com/info/info",
+        "apiUrl":"http://content.guardianapis.com/info/info",
+        "sectionId":"info",
+        "sectionName":"Info",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[],
+      "references":[]
+    },
+    "storyPackage":[]
+  }
+}

--- a/data/database/6262a3afd34a7089fcb7c0514622980257730bbd
+++ b/data/database/6262a3afd34a7089fcb7c0514622980257730bbd
@@ -1,0 +1,57 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":1,
+    "content":{
+      "id":"info/2013/aug/26/2",
+      "sectionId":"info",
+      "sectionName":"Info",
+      "webPublicationDate":"2013-08-26T10:02:13Z",
+      "webTitle":"Removed: Eyeball-licking: the fetish that is making Japanese teenagers sick",
+      "webUrl":"http://www.theguardian.com/info/2013/aug/26/2",
+      "apiUrl":"http://content.guardianapis.com/info/2013/aug/26/2",
+      "fields":{
+        "trailText":"<p>Removed: Eyeball-licking: the fetish that is making Japanese teenagers sick</p>",
+        "headline":"Removed: Eyeball-licking: the fetish that is making Japanese teenagers sick",
+        "body":"<p>This blog was taken down on 26 August 2013 as it has been discovered to have been based on a hoax. </p><!-- Guardian Watermark: internal-code/content/415848123|2013-10-16T15:17:42Z|63f61a9c31d939713187cb196160abbbb4241290 -->",
+        "showInRelatedContent":"false",
+        "lastModified":"2013-08-26T10:02:13Z",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3tavq",
+        "wordcount":"21",
+        "commentable":"false",
+        "internalContentCode":"415848123",
+        "allowUgc":"false",
+        "isPremoderated":"false",
+        "publication":"theguardian.com",
+        "internalPageCode":"1955933",
+        "productionOffice":"UK",
+        "shouldHideAdverts":"false",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-08-29T10:02:13Z"
+      },
+      "tags":[{
+        "id":"info/info",
+        "type":"keyword",
+        "webTitle":"Information",
+        "webUrl":"http://www.theguardian.com/info/info",
+        "apiUrl":"http://content.guardianapis.com/info/info",
+        "sectionId":"info",
+        "sectionName":"Info",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[],
+      "references":[],
+      "isExpired":"false"
+    },
+    "storyPackage":[]
+  }
+}


### PR DESCRIPTION
Not convinced this is a very elegant way of doing it, any Scala experts could review this?
## Before

![screen shot 2013-10-16 at 16 19 54](https://f.cloud.github.com/assets/85783/1343654/74c837f4-3676-11e3-8e51-7c9ee489e28a.PNG)
## After

![screen shot 2013-10-16 at 16 19 43](https://f.cloud.github.com/assets/85783/1343656/78c48a42-3676-11e3-9f23-4922745e6dc4.PNG)

![ ](http://i.imgur.com/0kuLwdM.gif)
