### PR TITLE
Reinstate the Imagemin plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -267,16 +267,6 @@ module.exports = function (grunt) {
             compile: {
                 files: [{
                     expand: true,
-                    cwd: 'common/app/assets/images/',
-                    src: ['**/*.png'],
-                    dest: 'static/target/compiled/images/'
-                },{
-                    expand: true,
-                    cwd: 'static/target/generated/images/',
-                    src: ['**/*.{png,gif,jpg}'],
-                    dest: 'static/target/compiled/images/'
-                },{
-                    expand: true,
                     cwd: 'common/app/assets/images',
                     src: ['**/*.ico'],
                     dest: 'static/target/compiled/images'
@@ -573,6 +563,7 @@ module.exports = function (grunt) {
         'shell:webfontjson',
         'webfontjson',
         'shell:icons',
+        'imagemin:compile',
         'copy:compile',
         'hash'
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -549,6 +549,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-mkdir');
     grunt.loadNpmTasks('grunt-s3');
     grunt.loadNpmTasks('grunt-contrib-jasmine');
+    grunt.loadNpmTasks('grunt-contrib-imagemin');
     grunt.loadNpmTasks('grunt-hash');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-watch');

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt-s3": "~0.2.0-alpha.2",
     "moment": "~2.1.0",
     "grunt-mkdir": "~0.1.1",
+    "grunt-contrib-imagemin": "git://github.com/guardian/grunt-contrib-imagemin#master",
     "grunt-hash": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",


### PR DESCRIPTION
We have had problems with some of imagemin's dependencies. So this change uses the forked grunt plugin, which has fixed-version dependencies.
