### PR TITLE
Defend against non existing previous siblings of in body links

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/left-hand-card.js
+++ b/common/app/assets/javascripts/modules/experiments/left-hand-card.js
@@ -67,7 +67,7 @@ define([
 
             function hasImageSibling(el) {
                 var prevSibling = el.previousElementSibling;
-                if (prevSibling.length) {
+                if (prevSibling) {
                     return (/img-extended/).test(prevSibling.className);
                 }
                 return false;

--- a/common/app/assets/javascripts/modules/experiments/left-hand-card.js
+++ b/common/app/assets/javascripts/modules/experiments/left-hand-card.js
@@ -66,7 +66,11 @@ define([
             }
 
             function hasImageSibling(el) {
-                return (/img-extended/).test(el.previousElementSibling.className);
+                var prevSibling = el.previousElementSibling;
+                if (prevSibling.length) {
+                    return (/img-extended/).test(prevSibling.className);
+                }
+                return false;
             }
 
             function cardifyRelatedInBodyLink(link) {


### PR DESCRIPTION
Inline link card JavaScript was throwing an error when trying to detect if the first paragraph had an image preceding it.

This may fix #1999

![ ](http://s1.developerslife.ru/public/images/gifs/84c10ece-d0cf-4d4d-b2f1-6459d924604d.gif)
