### PR TITLE
Facia popular bug

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -154,7 +154,7 @@ define('bootstraps/app', [
                     Tag.init(config, context);
                 }
 
-                if (config.page.contentType === "Section") {
+                if (config.page.contentType === "Section" && !config.page.isFront) {
                     Section.init(config, context);
                 }
 

--- a/common/app/assets/javascripts/modules/facia/popular.js
+++ b/common/app/assets/javascripts/modules/facia/popular.js
@@ -15,7 +15,7 @@ define([
             });
         },
         collectionTmpl =
-            '<section class="collection collection--popular tone-news" data-collection-type="container" data-section="popular">' +
+            '<section class="collection collection--popular tone-news" data-type="popular">' +
                 '<h2 class="collection__title tone-background tone-accent-border">Popular</h2>' +
             '</section>',
         itemTmpl  = function(trail) {

--- a/common/app/views/fragments/collections/container.scala.html
+++ b/common/app/views/fragments/collections/container.scala.html
@@ -3,7 +3,7 @@
 @if(collection.items.nonEmpty) {
     <section class="collection collection--@style.className @if(style.containerType != "news"){js-collection--display-toggle} collection--@style.containerType tone-@style.tone"
              data-link-name="block | @config.id"
-             data-id="@config.id",
+             data-id="@config.id"
              data-type="@style.containerType">
 
         @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>

--- a/common/test/assets/javascripts/spec/facia/popular.spec.js
+++ b/common/test/assets/javascripts/spec/facia/popular.spec.js
@@ -65,6 +65,19 @@ define(['modules/facia/popular', 'bonzo', 'common', 'bean', 'helpers/fixtures', 
             }, 'popular collection to be rendered', 100);
         });
 
+        it('should have a "data-type" attribute of value "popular"', function() {
+            server.respondWith([200, {}, response]);
+            popular.render({});
+
+            waitsFor(function() {
+                return common.$g('.collection--popular').length;
+            }, 'popular collection to be rendered', 100);
+
+            runs(function() {
+                expect(common.$g('.collection--popular').attr('data-type')).toEqual('popular');
+            });
+        });
+
         it('should call correct most-read endpoint', function() {
             var section = 'sport';
             server.respondWith('/most-read/' + section + '.json?_edition=UK', [200, {}, response]);

--- a/integration-tests/casper/tests/facia/network-front.spec.js
+++ b/integration-tests/casper/tests/facia/network-front.spec.js
@@ -1,6 +1,3 @@
-/* global window, document */
-'use strict';
-
 var collection = '.collection--sport',
     button = collection + ' .collection__display-toggle';
 

--- a/integration-tests/casper/tests/facia/network-front.spec.js
+++ b/integration-tests/casper/tests/facia/network-front.spec.js
@@ -127,6 +127,7 @@ casper.test.begin('Items display their comment count', function(test) {
 casper.test.begin('Popular collection appears at the bottom of the page', function(test) {
     casper.waitForSelector('.collection--popular', function(){
         test.assertExists('.collection--popular', 'popular collection displayed');
+        test.assertElementCount('.collection--popular .item:nth-child(-n+3):not(.u-h)', 3, 'first three items visible');
     });
 
     casper.run(function() {

--- a/integration-tests/casper/tests/facia/section-front.spec.js
+++ b/integration-tests/casper/tests/facia/section-front.spec.js
@@ -1,0 +1,25 @@
+/**
+ *
+ * Network front feature tests
+ *
+ **/
+casper.test.setUp(function() {
+    casper.start(host + 'uk/culture?view=mobile', function() {
+        clearLocalStorage();
+    });
+});
+
+/**
+* Scenario: Popular collection appears at the bottom of the page
+*    Given I visit the network front
+*    Then I should see the popular collection
+**/
+casper.test.begin('Popular collection appears at the bottom of the page', function(test) {
+    casper.waitForSelector('.collection--popular', function(){
+        test.assertElementCount('.collection--popular', 1, 'exactly one popular collection should be displayed');
+    });
+
+    casper.run(function() {
+        test.done();
+    })
+});


### PR DESCRIPTION
Was only showing two popular items on network front, and displaying two popular collections on section fronts
