### PR TITLE
Create main template for Identity pages

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -111,7 +111,7 @@ define([
                 sections = new Sections(config),
                 search = new Search(config),
                 editions = new EditionSwitch(),
-                header = document.body,
+                header = document.body.querySelector('#header'),
                 profile;
 
             if (config.switches.idProfileNavigation) {

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -111,7 +111,7 @@ define([
                 sections = new Sections(config),
                 search = new Search(config),
                 editions = new EditionSwitch(),
-                header = document.body.querySelector('#header'),
+                header = document.getElementById('header'),
                 profile;
 
             if (config.switches.idProfileNavigation) {

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -7,8 +7,10 @@ $headerHeight: 58px;
     @include gs-container;
     clear: both;
     margin-top: $headerHeight;
+}
 
-    @include mq(tablet) {
+@include mq(tablet) {
+    #header.has-nav + #preloads {
         margin-top: 104px;
     }
 }
@@ -48,17 +50,22 @@ $headerHeight: 58px;
             background-color: $c-brandBlue;
         }
 
-        &:after {
-            top: $headerHeight;
-            height: 40px;
-            background-color: $c-neutral7;
-            border-bottom: 1px solid $c-neutral5;
+        &.has-nav {
+            &:after {
+                top: $headerHeight;
+                height: 40px;
+                background-color: $c-neutral7;
+                border-bottom: 1px solid $c-neutral5;
+            }
+
+            .header__inner {
+                height: 60px;
+            }
         }
     }
 }
     .header__inner {
         background-color: $c-brandBlue;
-        height: 60px;
     }
 
 .guardian-logo-wrapper {

--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -1,29 +1,4 @@
 
-/* Global header and navigation
-   ========================================================================== */
-
-.zone-identity {
-    /* Hide sections menu for Identity pages */
-    #header {
-        .nav-container,
-        .nav-popup-sections,
-        .control--sections,
-        &:after {
-            display: none;
-        }
-    }
-
-    /* Position in absence of section menu */
-    #preloads {
-        margin-top: 58px;
-    }
-
-    /* Ads aren't served */
-    .ad-slot {
-        display: none;
-    }
-}
-
 /* Identity and registration
    ========================================================================== */
 

--- a/common/app/assets/stylesheets/module/nav/_control.scss
+++ b/common/app/assets/stylesheets/module/nav/_control.scss
@@ -223,6 +223,10 @@ span.control__menu.i-menu {
         top: 0;
         right: 178px;
         white-space: nowrap;
+
+        &.control--profile-right {
+            right: 0;
+        }
     }
 }
 

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -1,0 +1,9 @@
+@(metaData: MetaData, switches: Seq[com.gu.management.Switchable], projectName: Option[String] = None, head: Html)(implicit request: RequestHeader)
+
+<meta charset="utf-8" />
+<title>@Html(metaData.webTitle)</title>
+@fragments.metaData(metaData)
+@fragments.commonCssSetup(projectName)
+@fragments.commonJavaScriptSetup(metaData, "app", switches)
+
+@head

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,7 +1,7 @@
 @(page: MetaData)(implicit request: RequestHeader)
 @import conf.Switches.{SearchSwitch, ReleaseMessageSwitch, IdentityProfileNavigationSwitch}
 
-<header id="header" role="banner" data-link-name="global navigation: header" itemscope itemtype="http://schema.org/Organization">
+<header id="header" class="has-nav" role="banner" data-link-name="global navigation: header" itemscope itemtype="http://schema.org/Organization">
     <div class="header__inner gs-container u-cf">
         <meta itemprop="logo" content="http://static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png" />
         <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="guardian-logo-wrapper" itemprop="url">

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -3,14 +3,7 @@
 <!DOCTYPE html>
 <html class="js-off" lang="en-GB">
 <head>
-    <meta charset="utf-8" />
-    <title>@Html(metaData.webTitle)</title>
-    @fragments.metaData(metaData)
-    @fragments.commonCssSetup(projectName)
-    @fragments.commonJavaScriptSetup(metaData, "app", switches)
-
-    @head
-
+    @fragments.head(metaData, switches, projectName, head)
 </head>
 <body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
 

--- a/identity/app/views/fragments/identityHeader.scala.html
+++ b/identity/app/views/fragments/identityHeader.scala.html
@@ -1,0 +1,28 @@
+@(page: MetaData)(implicit request: RequestHeader)
+@import conf.Switches.{SearchSwitch, ReleaseMessageSwitch, IdentityProfileNavigationSwitch}
+
+<header id="header" role="banner" data-link-name="global navigation: header" itemscope itemtype="http://schema.org/Organization">
+    <div class="header__inner gs-container u-cf">
+        <meta itemprop="logo" content="http://static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png" />
+        <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="guardian-logo-wrapper" itemprop="url">
+            <span class="h">The Guardian</span>
+            <i class="i i-guardian-logo"></i>
+        </a>
+
+        <span class="release">Alpha</span>
+
+        @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
+        <div class="js-profile-nav js-hidden">
+            <a href="@Configuration.id.url/signin" data-link-name="User profile" data-toggle="nav-popup-profile"
+               class="control control--profile control--profile-right">
+                <span class="js-profile-info control__info">Sign in</span>
+                <i class="i i-profile"></i>
+            </a>
+        </div>
+        }
+
+        @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
+        <div class="nav-popup-profile js-profile-nav-popup nav-popup nav-popup--box is-off"></div>
+        }
+    </div>
+ </header>

--- a/identity/app/views/identityMain.scala.html
+++ b/identity/app/views/identityMain.scala.html
@@ -1,0 +1,26 @@
+@(metaData: MetaData, switches: Seq[com.gu.management.Switchable], projectName: Option[String] = None)(head: Html)(body: Html)(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+<html class="js-off" lang="en-GB">
+<head>
+    @fragments.head(metaData, switches, projectName, head)
+</head>
+<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+
+    @fragments.releaseMessage(metaData)
+    @fragments.identityHeader(metaData)
+
+    <div id="preloads">
+        <div id="preload-1">
+            @body
+        </div>
+    </div>
+
+    @fragments.footer(metaData)
+
+    @fragments.loadCss()
+
+    @fragments.analytics(metaData)
+    @fragments.debug()
+</body>
+</html>

--- a/identity/app/views/password/email_sent.scala.html
+++ b/identity/app/views/password/email_sent.scala.html
@@ -2,7 +2,7 @@
 
 @import views.html.fragments.registrationFooter
 
-@main(page, Switches.all){
+@identityMain(page, Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Now check your email</h1>

--- a/identity/app/views/password/password_reset_confirmation.scala.html
+++ b/identity/app/views/password/password_reset_confirmation.scala.html
@@ -2,7 +2,7 @@
 
 @import views.html.fragments.registrationFooter
 
-@main(page, Switches.all){
+@identityMain(page, Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Your password has been changed</h1>

--- a/identity/app/views/password/request_password_reset.scala.html
+++ b/identity/app/views/password/request_password_reset.scala.html
@@ -5,7 +5,7 @@
 @import views.html.fragments.registrationFooter
 @import client.Error
 
-@main(page, Switches.all) {
+@identityMain(page, Switches.all) {
 }{
 <div class="identity-wrapper">
     <h1>Forgotten or need to reset your password?</h1>

--- a/identity/app/views/password/reset_error.scala.html
+++ b/identity/app/views/password/reset_error.scala.html
@@ -2,7 +2,7 @@
 
 @import views.html.fragments.registrationFooter
 
-@main(page, Switches.all){
+@identityMain(page, Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Sorry, there's a problem with our servers. Our techies have been notified.</h1>

--- a/identity/app/views/password/reset_password.scala.html
+++ b/identity/app/views/password/reset_password.scala.html
@@ -6,7 +6,7 @@
 
 @emailAddress = @{ resetPasswordForm("email-address").value }
 
-@main(page, Switches.all){
+@identityMain(page, Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Please enter your new password for @emailAddress</h1>

--- a/identity/app/views/password/reset_password_request_new_token.scala.html
+++ b/identity/app/views/password/reset_password_request_new_token.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.form.idInput
 @import views.html.fragments.registrationFooter
 
-@main(page, Switches.all){
+@identityMain(page, Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Oh no! The reset password link has expired</h1>

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -5,7 +5,7 @@
 @import views.html.fragments.registrationFooter
 @import views.html.fragments.socialSignin
 
-@main(page, conf.Switches.all){
+@identityMain(page, conf.Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Create your Guardian account</h1>

--- a/identity/app/views/registration_confirmation.scala.html
+++ b/identity/app/views/registration_confirmation.scala.html
@@ -2,7 +2,7 @@
 
 @import views.html.fragments.registrationFooter
 
-@main(page, Switches.all){
+@identityMain(page, Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Now check your email</h1>

--- a/identity/app/views/signin.scala.html
+++ b/identity/app/views/signin.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.form.{idInput, idCheckbox}
 @import views.html.fragments.socialSignin
 
-@main(page, conf.Switches.all){
+@identityMain(page, conf.Switches.all){
 }{
 <div class="identity-wrapper">
     <h1>Sign in to the Guardian</h1>


### PR DESCRIPTION
Following conversation with @phamann and @gklopper:
- Create a new Identity main template (variant of `main.scala.html`)
- This shares the `<head>` but a different body structure - namely no ads and stripped down swipe containers. Note, these can't be entirely removed, some [dependencies remain](https://github.com/guardian/frontend/blob/identity-main/common/app/assets/javascripts/bootstraps/app.js#L107).
- Also creates a new Identity header template (variant of `header.scala.html`)
- This is a distraction-free version, removing the section navigation, top stories and search controls. Since the navigation styles are hooked on more than the `nav-container`, this also adds a `.has-nav` class to the existing header and styles in `_layout.scss`.
