### PR TITLE
Sticky MPU with CSS

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -85,7 +85,7 @@
                             </div>
 
                             <div class="u-table__row">
-                                <div class="u-table__cell u-table__cell--bottom">
+                                <div class="u-table__cell u-table__cell--collapse u-table__cell--bottom">
                                     <div class="js-sticky-lower" data-id="mpu-ad-slot"></div>
                                 </div>
                             </div>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -74,10 +74,12 @@
                         <div class="u-table">
                             <div class="u-table__row">
                                 <div class="u-table__cell u-table__cell--top">
-                                    <div class="mpu-container js-mpu-ad-slot">
-                                        <h2 class="article__meta-heading tone-colour">Share this article</h2>
-                                        @fragments.social(article, "next to content")
-                                        @fragments.adSlot(id="mpu-banner-ad", baseSlot="", medianSlot="Middle1", extendedSlot="Middle1")
+                                    <div class="mpu-context">
+                                        <div class="mpu-container js-mpu-ad-slot">
+                                            <h2 class="article__meta-heading tone-colour">Share this article</h2>
+                                            @fragments.social(article, "next to content")
+                                            @fragments.adSlot(id="mpu-banner-ad", baseSlot="", medianSlot="Middle1", extendedSlot="Middle1")
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/common/app/assets/javascripts/modules/adverts/sticky.js
+++ b/common/app/assets/javascripts/modules/adverts/sticky.js
@@ -11,7 +11,10 @@ define([
         this.$el = bonzo(this.el);
         this.top =  bonzo(this.options.context.querySelector(".js-sticky-upper[data-id=" + this.options.id + "]")).offset().top;
         this.bottom = bonzo(this.options.context.querySelector(".js-sticky-lower[data-id=" + this.options.id + "]")).offset().top - 250;
-        this.bindListeners();
+
+        if (!detect.hasCSSSupport('position', 'sticky') && detect.hasCSSSupport('position', 'fixed', true)) {
+            this.bindListeners();
+        }
     };
 
     Sticky.prototype.DEFAULTS = {
@@ -25,26 +28,20 @@ define([
     Sticky.prototype.bindListeners = function () {
         var self = this;
 
-        var e = detect.hasTouchScreen() ? 'touchmove' : 'scroll';
-        
-        if (detect.hasCSSSupport('position', 'sticky')) {
-            this.el.classList.add(this.options.stickCls);
-        } else if (detect.hasCSSSupport('position', 'fixed', true)) {
-            bean.on(window, 'scroll', function(){
-                common.requestAnimationFrame(function(){
-                    self.checkPosition.call(self);
-                });
+        bean.on(window, 'scroll', function(){
+            common.requestAnimationFrame(function(){
+                self.checkPosition.call(self);
             });
-        }
+        });
     };
 
     Sticky.prototype.checkPosition = function () {
         var scrollTop = bonzo(document.body).scrollTop();
 
         if(scrollTop > this.top && scrollTop < this.bottom) {
-            this.el.classList.add(this.options.affixCls);
+            bonzo(this.el).addClass(this.options.affixCls);
         } else {
-            this.el.classList.remove(this.options.affixCls);
+            bonzo(this.el).removeClass(this.options.affixCls);
         }
 
     };

--- a/common/app/assets/javascripts/modules/adverts/sticky.js
+++ b/common/app/assets/javascripts/modules/adverts/sticky.js
@@ -21,7 +21,6 @@ define([
         context: document,
         elCls: 'ad-slot--mpu-banner-ad',
         affixCls: 'is-affixed',
-        stickCls: 'is-sticked',
         id: 'Middle1'
     };
 

--- a/common/app/assets/javascripts/modules/adverts/sticky.js
+++ b/common/app/assets/javascripts/modules/adverts/sticky.js
@@ -18,6 +18,7 @@ define([
         context: document,
         elCls: 'ad-slot--mpu-banner-ad',
         affixCls: 'is-affixed',
+        stickCls: 'is-sticked',
         id: 'Middle1'
     };
 
@@ -25,11 +26,16 @@ define([
         var self = this;
 
         var e = detect.hasTouchScreen() ? 'touchmove' : 'scroll';
-        bean.on(window, 'scroll', function(){
-            common.requestAnimationFrame(function(){
-                self.checkPosition.call(self);
+        
+        if (detect.hasCSSSupport('position', 'sticky')) {
+            this.el.classList.add(this.options.stickCls);
+        } else if (detect.hasCSSSupport('position', 'fixed', true)) {
+            bean.on(window, 'scroll', function(){
+                common.requestAnimationFrame(function(){
+                    self.checkPosition.call(self);
+                });
             });
-        });
+        }
     };
 
     Sticky.prototype.checkPosition = function () {

--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -164,7 +164,7 @@ define(['modules/userPrefs', 'common'], function (userPrefs, common) {
         } else {
             mStyle.cssText = prop + value;
         }
-        return mStyle[ property ].indexOf( value ) !== -1;
+        return mStyle[property].indexOf(value) !== -1;
     }
 
     function hasTouchScreen() {

--- a/common/app/assets/javascripts/modules/detect.js
+++ b/common/app/assets/javascripts/modules/detect.js
@@ -152,6 +152,21 @@ define(['modules/userPrefs', 'common'], function (userPrefs, common) {
         return !!document.createElementNS && !!document.createElementNS(ns.svg, 'svg').createSVGRect;
     }
 
+    function hasCSSSupport(property, value, noPrefixes) {
+        // Thanks Modernizr: https://github.com/filamentgroup/fixed-sticky/blob/master/fixedsticky.js
+        // and Filament Group: https://github.com/filamentgroup/fixed-sticky/blob/master/fixedsticky.js
+        var prop = property + ':',
+            el = document.createElement('test'),
+            mStyle = el.style;
+
+        if (!noPrefixes) {
+            mStyle.cssText = prop + ['-webkit-', '-moz-', '-ms-', '-o-', ''].join(value + ';' + prop) + value + ';';
+        } else {
+            mStyle.cssText = prop + value;
+        }
+        return mStyle[ property ].indexOf( value ) !== -1;
+    }
+
     function hasTouchScreen() {
         return ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
     }
@@ -305,6 +320,7 @@ define(['modules/userPrefs', 'common'], function (userPrefs, common) {
         getFontFormatSupport: getFontFormatSupport,
         getVideoFormatSupport: getVideoFormatSupport,
         hasSvgSupport: hasSvgSupport,
+        hasCSSSupport: hasCSSSupport,
         hasTouchScreen: hasTouchScreen,
         hasPushStateSupport: hasPushStateSupport,
         getOrientation: getOrientation,

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -96,6 +96,10 @@
 .u-table__cell--bottom {
     vertical-align: bottom;
 }
+.u-table__cell--collapse {
+    // Cell / row will only take the height it needs
+    height: 1px;
+}
 
 
 /**

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -84,17 +84,14 @@
     height: 100%;
 }
 .mpu-container {
-    position: static;
+    position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
+    position: sticky;
+    top: $baseline*4;
+
     &.is-affixed {
         position: fixed;
-        top: $baseline*4;
-    }
-    &.is-sticked {
-        position: -webkit-sticky;
-        position: -moz-sticky;
-        position: -ms-sticky;
-        position: sticky;
-        top: $baseline*4;
     }
 }
 

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -16,7 +16,6 @@
         margin: 0 auto;
     }
 }
-
 .ad-container {
     display: inline-block;
     width: auto;
@@ -80,10 +79,21 @@
         padding-right: $gs-gutter;
     }
 }
+.mpu-context {
+    // Provides context to sticky positioned blocks
+    height: 100%;
+}
 .mpu-container {
     position: static;
     &.is-affixed {
         position: fixed;
+        top: $baseline*4;
+    }
+    &.is-sticked {
+        position: -webkit-sticky;
+        position: -moz-sticky;
+        position: -ms-sticky;
+        position: sticky;
         top: $baseline*4;
     }
 }

--- a/common/test/assets/javascripts/spec/Detect.spec.js
+++ b/common/test/assets/javascripts/spec/Detect.spec.js
@@ -103,6 +103,15 @@ define(['modules/detect', 'bonzo'], function(detect, bonzo) {
 
     });
 
+    describe("CSS support", function() {
+
+        it("should determine CSS support for any property", function() {
+            expect(detect.hasCSSSupport('position', 'relative', true)).toBe(true);
+            expect(detect.hasCSSSupport('position', 'sixtynine')).toBe(false);
+        });
+
+    });
+
     describe("Breakpoint", function() {
 
         var breakpointName = 'a-breakpoint',


### PR DESCRIPTION
- [new] detect CSS support of a property through `detect.hasCSSSupport(property, value, noPrefixes)`
- [new] If sticky position is supported, fix the position of sticky MPUs with CSS
- [fixed] sticky MPUs getting out of bounds in iOS7 

Should fix https://github.com/guardian/frontend/issues/2063

@marcjones can you have a look at this branch?

![ ](http://media.tumblr.com/7f827996c10ca52baafdb31319de00b8/tumblr_inline_mu9m6d53Fn1raprkq.gif)
