### PR TITLE
Show right hand card for first item in story package if avaliable

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -94,7 +94,7 @@
                                 <div class="u-table__cell u-table__cell--collapse u-table__cell--bottom">
                                     <div class="js-sticky-lower" data-id="mpu-ad-slot"></div>
                                     @if(storyPackage.nonEmpty) {
-                                      @fragments.cards.card(storyPackage.last, "right", "More on this story", "Story package card", "visible")
+                                      @fragments.cards.card(storyPackage.head, "right", "More on this story", "Story package card", "visible")
                                     }
                                 </div>
                             </div>
@@ -110,7 +110,7 @@
             }
             @if(storyPackage.nonEmpty) {
                 <aside role="complementary" data-link-context="@article.section">
-                    @fragments.relatedTrails(storyPackage.dropRight(1), heading = "More on this story", visibleTrails = 5)
+                    @fragments.relatedTrails(storyPackage.drop(1), heading = "More on this story", visibleTrails = 5)
                 </aside>
             } else {
                 <aside class="js-related" role="complementary" data-link-context="related@article.url"></aside>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -93,6 +93,9 @@
                             <div class="u-table__row">
                                 <div class="u-table__cell u-table__cell--collapse u-table__cell--bottom">
                                     <div class="js-sticky-lower" data-id="mpu-ad-slot"></div>
+                                    @if(storyPackage.nonEmpty) {
+                                      @fragments.cards.card(storyPackage.last, "right", "More on this story", "Story package card", "visible")
+                                    }
                                 </div>
                             </div>
                         </div>
@@ -107,7 +110,7 @@
             }
             @if(storyPackage.nonEmpty) {
                 <aside role="complementary" data-link-context="@article.section">
-                    @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 5)
+                    @fragments.relatedTrails(storyPackage.dropRight(1), heading = "More on this story", visibleTrails = 5)
                 </aside>
             } else {
                 <aside class="js-related" role="complementary" data-link-context="related@article.url"></aside>

--- a/common/app/views/fragments/cards/card.scala.html
+++ b/common/app/views/fragments/cards/card.scala.html
@@ -11,8 +11,8 @@
             </h3>
         </div>
 
-        <div class="card__meta">
-            @fragments.relativeDate(trail.webPublicationDate, trail.isLive)
+        <div class="card__meta dateline">
+            <div class="dateline"><i class="i i-clock-grey relative-timestamp__icon"></i><time datetime="@trail.webPublicationDate" class="js-timestamp"></time></div>
         </div>
 
         @trail.thumbnailPath.map{ thumbnailPath =>


### PR DESCRIPTION
This re-introduces the right hand cards by default on article pages if the piece of content has a curated story package.

As discussed with @kungpochicken this is to gather some usage data whilst we start work on new onward journeys.

![screenshot from 2013-10-22 17 03 54](https://f.cloud.github.com/assets/80089/1382850/c906bb76-3b33-11e3-8993-a1de92e59558.png)

![Table tennis shipping](http://uberpong.com/wp-content/uploads/2012/10/Slow-motion-ping-pong-shot.gif)
