### PR TITLE
Facia tool: bust cache for ajax

### DIFF
--- a/facia-tool/public/javascripts/models/authedAjax.js
+++ b/facia-tool/public/javascripts/models/authedAjax.js
@@ -1,7 +1,11 @@
 define([], function () {
     return function (opts) {
         return $.ajax(
-            _.extend({}, opts, {dataType: 'json', contentType: 'application/json'})
+            _.extend({}, opts, {
+                dataType: 'json',
+                contentType: 'application/json',
+                cache: false
+            })
         ).fail(function(xhr) {
             if (xhr.status === 403) {
                 window.location.href = window.location.href;


### PR DESCRIPTION
Fixes IE9 issue : https://github.com/guardian/frontend/issues/1303
