### PR TITLE
Static compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ local.sbt
 
 node_modules
 
-common/conf/assets/assets.map
+common/conf/assets
 
 dev/gems
 dev/casperjs

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,29 +19,20 @@ module.exports = function (grunt) {
 
         sass: {
             compile: {
-                files: {
-                    // head css must go where Play can find it from resources at runtime,
-                    // Everything else goes into frontend-static bundling.
-                    'common/conf/assets/head.min.css': 'common/app/assets/stylesheets/head.scss',
-                    'common/conf/assets/head.facia.min.css': 'common/app/assets/stylesheets/head.facia.scss',
-                    'common/conf/assets/head.identity.min.css': 'common/app/assets/stylesheets/head.identity.scss',
-                    'static/target/compiled/stylesheets/global.min.css': 'common/app/assets/stylesheets/global.scss',
-                    'static/target/compiled/stylesheets/football.min.css': 'common/app/assets/stylesheets/football.scss',
-                    'static/target/compiled/stylesheets/gallery.min.css': 'common/app/assets/stylesheets/gallery.scss',
-                    'static/target/compiled/stylesheets/video.min.css': 'common/app/assets/stylesheets/video.scss',
-                    'static/target/compiled/stylesheets/old-ie.head.min.css': 'common/app/assets/stylesheets/old-ie.head.scss',
-                    'static/target/compiled/stylesheets/old-ie.head.identity.min.css': 'common/app/assets/stylesheets/old-ie.head.identity.scss',
-                    'static/target/compiled/stylesheets/old-ie.global.min.css': 'common/app/assets/stylesheets/old-ie.global.scss',
-                    'static/target/compiled/stylesheets/webfonts.min.css': 'common/app/assets/stylesheets/webfonts.scss'
-                },
-
+                files: [{
+                    expand: true,
+                    cwd: 'common/app/assets/stylesheets',
+                    src: ['*.scss', '!_*'],
+                    dest: 'static/target/compiled/stylesheets/',
+                    rename: function(dest, src) {
+                        return dest + src.replace('scss', 'min.css');
+                    }
+                }],
                 options: {
-                    check: false,
-                    quiet: true,
+                    style: 'compressed',
+                    sourcemap: false,
                     noCache: (isDev) ? false : true,
-                    debugInfo: (isDev) ? true : false,
-                    style: (isDev) ? 'nested' : 'compressed',
-                    sourcemap: (isDev) ? true : false,
+                    quiet: (isDev) ? false : true,
                     loadPath: [
                         'common/app/assets/stylesheets/components/sass-mq',
                         'common/app/assets/stylesheets/components/pasteup/sass/layout',
@@ -282,6 +273,14 @@ module.exports = function (grunt) {
                     src: ['**/*.swf'],
                     dest: 'static/target/compiled/flash'
                 }]
+            },
+            headCss: {
+                files: [{
+                    expand: true,
+                    cwd: 'static/target/compiled/stylesheets',
+                    src: ['**/*.css'],
+                    dest: 'common/app/assets/stylesheets'
+                }]
             }
         },
 
@@ -293,7 +292,7 @@ module.exports = function (grunt) {
                 srcBasePath: 'static/target/compiled',
                 destBasePath: 'static/target/hashed',
                 flatten: false,
-                hashLength: 32
+                hashLength: (isDev) ? 0 : 32
             },
 
             files: {
@@ -301,7 +300,11 @@ module.exports = function (grunt) {
                 cwd: 'static/target/compiled/',
                 src: '**/*',
                 filter: 'isFile',
-                dest: 'static/target/hashed/'
+                dest: 'static/target/hashed/',
+                rename: function(dest, src) {
+                    // remove .. when hash length is 0
+                    return dest + src.split('/').slice(0, -1).join('/');
+                }
             }
         },
 
@@ -539,7 +542,7 @@ module.exports = function (grunt) {
             },
             sass: {
                 files: ['common/**/*.scss'],
-                tasks: ['sass:compile', 'hash'],
+                tasks: ['sass:compile', 'copy:headCss', 'hash'],
                 options: {
                     spawn: false
                 }
@@ -581,6 +584,7 @@ module.exports = function (grunt) {
         'shell:icons',
         'imagemin:compile',
         'copy:compile',
+        'copy:headCss',
         'hash'
     ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
                     src: ['*.scss', '!_*'],
                     dest: 'static/target/compiled/stylesheets/',
                     rename: function(dest, src) {
-                        return dest + src.replace('scss', 'min.css');
+                        return dest + src.replace('scss', 'css');
                     }
                 }],
                 options: {
@@ -279,7 +279,7 @@ module.exports = function (grunt) {
                     expand: true,
                     cwd: 'static/target/compiled/stylesheets',
                     src: ['**/*.css'],
-                    dest: 'common/app/assets/stylesheets'
+                    dest: 'common/conf/assets'
                 }]
             }
         },

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -48,9 +48,9 @@ class Assets(base: String, assetMap: String = "assets/assets.map") extends Loggi
     private def css(project: String): String = {
 
       val suffix = project match {
-        case "facia" => "facia.min.css"
-        case "identity" => "identity.min.css"
-        case default => "min.css"
+        case "facia" => "facia.css"
+        case "identity" => "identity.css"
+        case default => "css"
       }
       val url = Play.classloader(Play.current).getResource(s"assets/head.$suffix")
 
@@ -65,8 +65,8 @@ class Assets(base: String, assetMap: String = "assets/assets.map") extends Loggi
     }
 
     def oldIePath: String = Configuration.environment.projectName match {
-      case "identity" => "stylesheets/old-ie.head.identity.min.css"
-      case _ => "stylesheets/old-ie.head.min.css"
+      case "identity" => "stylesheets/old-ie.head.identity.css"
+      case _ => "stylesheets/old-ie.head.css"
     }
   }
 }

--- a/common/app/assets/javascripts/modules/fonts.js
+++ b/common/app/assets/javascripts/modules/fonts.js
@@ -63,13 +63,13 @@ define(['ajax', 'common', 'modules/storage'], function (ajax, common, storage) {
         this.clearFont = function(name) {
             storage.clearByPrefix(storagePrefix + name);
         };
-        
+
         this.clearAllFontsFromStorage = function() {
             storage.clearByPrefix(storagePrefix);
         };
 
         function getNameAndCacheKey(style) {
-            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff\.(.*)\.js$/);
+            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.js$/);
             nameAndCacheKey.shift();
             return nameAndCacheKey;
         }

--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -1,8 +1,12 @@
 @(projectName: Option[String])(implicit request: RequestHeader)
 <!--[if (gt IE 8) | (IEMobile)]><!-->
-<style type="text/css">
-    @Html(Static.css.head(projectName))
-</style>
+@if(play.Play.isDev()) {
+    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse("") + ".min.css")" />
+} else {
+    <style type="text/css">
+        @Html(Static.css.head(projectName))
+    </style>
+}
 <!--<![endif]-->
 <!--[if (lt IE 9) & (!IEMobile)]>
     <link rel="stylesheet" type="text/css" href="@Static("stylesheets/webfonts.min.css")" />

--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -1,7 +1,7 @@
 @(projectName: Option[String])(implicit request: RequestHeader)
 <!--[if (gt IE 8) | (IEMobile)]><!-->
 @if(play.Play.isDev()) {
-    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse("") + ".min.css")" />
+    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse("") + ".css")" />
 } else {
     <style type="text/css">
         @Html(Static.css.head(projectName))
@@ -9,7 +9,7 @@
 }
 <!--<![endif]-->
 <!--[if (lt IE 9) & (!IEMobile)]>
-    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/webfonts.min.css")" />
+    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/webfonts.css")" />
     <link rel="stylesheet" type="text/css" href="@Static(Static.css.oldIePath)" />
 <![endif]-->
 
@@ -22,7 +22,7 @@
 </style>
 
 <!--[if (lt IE 9) & (!IEMobile)]>
-    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/old-ie.global.min.css")" />
+    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/old-ie.global.css")" />
 <![endif]-->
 
 <style class="initial" data-cache-name="WebEgyptian" data-cache-file-woff="@Static("fonts/WebEgyptian.woff.js")" data-cache-file-ttf="@Static("fonts/WebEgyptian.ttf.js")"></style>

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -83,7 +83,7 @@
                 var styleNodes = document.querySelectorAll('[data-cache-name]');
                 for (var i = 0, j = styleNodes.length; i<j; ++i) {
                     var style = styleNodes[i],
-                        nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff\.(.*)\.js$/),
+                        nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.js$/),
                         cachedCss = localStorage.getItem('gu.fonts.' + nameAndCacheKey[1] + '.' + nameAndCacheKey[2]);
                         @* try to parse it (should really use the storage module) *@
                         try {

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -21,9 +21,9 @@
         ),
         css: {
             loaded: false,
-            football: '@Static("stylesheets/football.min.css")',
-            gallery: '@Static("stylesheets/gallery.min.css")',
-            video: '@Static("stylesheets/video.min.css")'
+            football: '@Static("stylesheets/football.css")',
+            gallery: '@Static("stylesheets/gallery.css")',
+            video: '@Static("stylesheets/video.css")'
         }
     },
     curl = {
@@ -41,7 +41,7 @@
 
         @if(CssFromStorageSwitch.isSwitchedOn) {
             function loadCssFromStorage() {
-                var c = localStorage.getItem('gu.css.@Static("stylesheets/global.min.css").md5Key'), s, sc;
+                var c = localStorage.getItem('gu.css.@Static("stylesheets/global.css").md5Key'), s, sc;
                 if(c) {
                     s = document.createElement('style');
                     sc = document.getElementsByTagName('script')[0];
@@ -58,7 +58,7 @@
             x = document.getElementById('gu');
             f = document.createElement('link');
             f.rel = 'stylesheet';
-            f.href = '@Static("stylesheets/webfonts.min.css")';
+            f.href = '@Static("stylesheets/webfonts.css")';
             window.setTimeout(function() {
                 x.parentNode.insertBefore(f, x);
             }, 0);

--- a/common/app/views/fragments/loadCss.scala.html
+++ b/common/app/views/fragments/loadCss.scala.html
@@ -5,7 +5,7 @@
 
     <noscript>
         <!--[if (gt IE 8) | (IEMobile)]><!-->
-            <link rel="stylesheet" id="global-css" type="text/css" href="@Static("stylesheets/global.min.css")" />
+            <link rel="stylesheet" id="global-css" type="text/css" href="@Static("stylesheets/global.css")" />
         <!--<![endif]-->
     </noscript>
     <script>
@@ -27,7 +27,7 @@
                     if(key.match(/^gu.css./g)) { localStorage.removeItem(key); }
                 });
                 try {
-                    localStorage.setItem('gu.css.@Static("stylesheets/global.min.css").md5Key', c);
+                    localStorage.setItem('gu.css.@Static("stylesheets/global.css").md5Key', c);
                 } catch(e) {
 
                 }
@@ -37,13 +37,13 @@
                 var l = document.createElement('link');
 
                 l.rel = "stylesheet"; l.type = 'text/css';
-                l.href = '@Static("stylesheets/global.min.css")';
+                l.href = '@Static("stylesheets/global.css")';
                 injectElement(l);
             }
 
             function loadCssWithAjax() {
                 var xhr = new XMLHttpRequest();
-                xhr.open('GET', '@Static("stylesheets/global.min.css")?type=ajax');
+                xhr.open('GET', '@Static("stylesheets/global.css")?type=ajax');
                 xhr.onreadystatechange = function() {
                     if (xhr.readyState === 4) {
                         if(xhr.status === 200) {
@@ -74,7 +74,7 @@
 } else {
 
     <!--[if (gt IE 8) | (IEMobile)]><!-->
-        <link rel="stylesheet" id="global-css" type="text/css" href="@Static("stylesheets/global.min.css")" />
+        <link rel="stylesheet" id="global-css" type="text/css" href="@Static("stylesheets/global.css")" />
     <!--<![endif]-->
 
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "moment": "~2.1.0",
     "grunt-mkdir": "~0.1.1",
     "grunt-contrib-imagemin": "git://github.com/guardian/grunt-contrib-imagemin#master",
-    "grunt-hash": "~0.4.1",
+    "grunt-hash": "git://github.com/guardian/grunt-hash.git#master",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
     "mkdirp": "~0.3.5"


### PR DESCRIPTION
PR goes towards not re-compiling app on static asset changes. Mainly
- On dev, include `head` css externally, not inline, and don't add a hash to the static filenames
- Tidy up the filenames produced by the `hash` task, so we can use `sass --watch`, e.g.

```
sass -I common/app/assets/stylesheets/components/normalize-scss/ -I common/app/assets/stylesheets/components/sass-mq/  --watch common/app/assets/stylesheets:static/target/hashed/stylesheets
```
