### PR TITLE
Left align article header

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -1,10 +1,11 @@
 @(gallery: Gallery, storyPackage: List[Trail], index: Int, trail: Boolean)(implicit request: RequestHeader)
 @import conf.Switches._
 
-<h2 class="article-zone tone-@VisualTone(gallery) tone-accent-border">
-    <a class="tone-colour" data-link-name="article section" href="/@gallery.section">@Html(gallery.sectionName.toLowerCase)</a>
+<h2 class="article-zone left-col-deport tone-@VisualTone(gallery) tone-accent-border">
+    <span class="left-col-deport__body">
+        <a class="tone-colour" data-link-name="article section" href="/@gallery.section">@Html(gallery.sectionName.toLowerCase)</a>
+    </span>
 </h2>
-
 <div class="article-wrapper monocolumn-wrapper tone-@VisualTone(gallery)">
     <article class="js-gallery article gallery-page" itemprop="mainContentOfPage"
          itemscope itemtype="@gallery.schemaType" role="main">

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -2,10 +2,11 @@
 @import conf.Switches._
 
 @defining((page.image, page.storyPackage)) { case (image, storyPackage) =>
-    <h2 class="article-zone tone-@VisualTone(image) tone-accent-border">
-        <a class="tone-colour" data-link-name="article section" href="/@image.section">@Html(image.sectionName.toLowerCase)</a>
+    <h2 class="article-zone left-col-deport tone-@VisualTone(image) tone-accent-border">
+        <span class="left-col-deport__body">
+            <a class="tone-colour" data-link-name="article section" href="/@image.section">@Html(image.sectionName.toLowerCase)</a>
+        </span>
     </h2>
-
     <div class="article-wrapper monocolumn-wrapper tone-@VisualTone(image)">
         <article id="article" class="article"
                  itemprop="mainContentOfPage" itemscope itemtype="@image.schemaType" role="main">

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -2,8 +2,10 @@
 @import conf.Switches._
 
 @defining(page.video){ video =>
-    <h2 class="article-zone tone-@VisualTone(video) tone-accent-border">
-        <a class="tone-colour tone-border" data-link-name="article section" href="/@LinkTo(video.section)">@Html(video.sectionName.toLowerCase)</a>
+    <h2 class="article-zone left-col-deport tone-@VisualTone(video) tone-accent-border">
+        <span class="left-col-deport__body">
+            <a class="tone-colour tone-border" data-link-name="article section" href="/@LinkTo(video.section)">@Html(video.sectionName.toLowerCase)</a>
+        </span>
     </h2>
     <div class="article-wrapper monocolumn-wrapper tone-@VisualTone(video)">
 

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -2,8 +2,10 @@
 @import conf.Switches._
 
 @defining((model.article, model.storyPackage)) { case (article, storyPackage) =>
-    <h2 class="article-zone tone-@VisualTone(article) tone-accent-border">
-        <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>
+    <h2 class="article-zone left-col-deport tone-@VisualTone(article) tone-accent-border">
+        <span class="left-col-deport__body">
+            <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>
+        </span>
     </h2>
     <div class="article-wrapper monocolumn-wrapper tone-@VisualTone(article)">
         <article id="article" class="article @if(article.isLive){is-live}"

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -2,8 +2,10 @@
 @import conf.Switches._
 
 @defining((model.article, model.storyPackage)) {  case (article, storyPackage) =>
-    <h2 class="article-zone tone-@VisualTone(article) tone-accent-border">
-        <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>
+    <h2 class="article-zone left-col-deport tone-@VisualTone(article) tone-accent-border">
+        <span class="left-col-deport__body">
+            <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>
+        </span>
     </h2>
     <div class="article-wrapper monocolumn-wrapper tone-@VisualTone(article)">
         <article id="article" class="article @if(article.isLive){is-live}"

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -37,10 +37,11 @@ $trailblockImgWidthLarge: 140px;
 @import 'layout/_grid-system';
 
 // Article breakpoints
-$a-rightCol-width:   gs-span(4);
-$a-rightCol-trigger: gs-span(11) + $gs-gutter*2; // 900px
-$a-leftCol-width:    gs-span(2); // Grows to 3 columns on wide viewports
-$a-leftCol-trigger:  gs-span(13) + $gs-gutter*2; // 1060px
+$a-rightCol-width:    gs-span(4);
+$a-rightCol-trigger:  gs-span(11) + $gs-gutter*2; // 900px
+$a-leftCol-width:     gs-span(2); // Grows to 3 columns on wide viewports
+$a-leftCol-trigger:   gs-span(13) + $gs-gutter*2; // 1060px
+$a-leftColWide-width: gs-span(3); // Grows to 3 columns on wide viewports
 
 $mq-breakpoints: (
     (mobile  gs-span(4)  + $gs-gutter)   // 320px

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -18,7 +18,7 @@
 
     @include mq(tablet) {
         min-height: 0;
-        padding: $baseline*3 0;
+        padding: $baseline*4 0 $baseline*3;
         border-top: 1px dotted $c-neutral5 !important; // Disable tone colour
 
         max-width: gs-span(8);
@@ -37,7 +37,7 @@
     }
 
     @include mq(wide) {
-        padding-left:  gs-span(3) + $gs-gutter;
+        padding-left:  $a-leftColWide-width + $gs-gutter;
         padding-right: $a-rightCol-width + gs-span(1) + $gs-gutter*2;
     }
 
@@ -50,6 +50,7 @@
         padding-left: 0 !important;
         padding-right: 0;
         margin-left: 0;
+        margin-right: 0;
     }
 }
 
@@ -70,6 +71,28 @@
         padding-right: 0;
         margin-left: auto;
         margin-right: auto;
+    }
+}
+
+.left-col-deport {
+    @include mq(leftCol) {
+        padding: 0 0 $baseline;
+    }
+}
+.left-col-deport__body {
+    @include mq(leftCol) {
+        float: left;
+        padding-top: $baseline*4;
+        margin-left: 0;
+        width: $a-leftCol-width;
+
+        // Makes the block actionable
+        // when out of the flow
+        position: relative;
+        z-index: 1;
+    }
+    @include mq(wide) {
+        width: $a-leftColWide-width;
     }
 }
 
@@ -241,8 +264,8 @@
     }
 
     @include mq(wide) {
-        margin-left: (gs-span(3) + $gs-gutter)*-1;
-        width: gs-span(3);
+        margin-left: ($a-leftColWide-width + $gs-gutter)*-1;
+        width: $a-leftColWide-width;
     }
 }
 
@@ -468,7 +491,7 @@ video {
 @include mq(wide) {
     .article-v2__inner,
     .article-v2__main-column {
-        padding-left: gs-span(3) + $gs-gutter;
+        padding-left: $a-leftColWide-width + $gs-gutter;
     }
     .article-v2__main-column {
         padding-right: gs-span(1) + $gs-gutter*2;

--- a/common/app/views/fragments/expiredBody.scala.html
+++ b/common/app/views/fragments/expiredBody.scala.html
@@ -1,7 +1,9 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
-<h2 class="article-zone tone-@VisualTone(content) tone-accent-border">
-    <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@content.section}">@Html(content.sectionName.toLowerCase)</a>
+<h2 class="article-zone left-col-deport tone-@VisualTone(content) tone-accent-border">
+    <span class="left-col-deport__body">
+        <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@content.section}">@Html(content.sectionName.toLowerCase)</a>
+    </span>
 </h2>
 <div class="article-wrapper monocolumn-wrapper tone-@VisualTone(content)">
     <article id="article" class="article" itemprop="mainContentOfPage" role="main">

--- a/sport/app/football/views/fragments/footballMatchBody.scala.html
+++ b/sport/app/football/views/fragments/footballMatchBody.scala.html
@@ -2,8 +2,10 @@
 @import feed._
 @import implicits.Football._
 
-<h2 class="article-zone tone-news tone-accent-border">
-    <a class="tone-colour" data-link-name="article section" href="@LinkTo{/football}">football</a>
+<h2 class="article-zone left-col-deport tone-news tone-accent-border">
+    <span class="left-col-deport__body">
+        <a class="tone-colour" data-link-name="article section" href="@LinkTo{/football}">football</a>
+    </span>
 </h2>
 <div class="article-wrapper monocolumn-wrapper tone-news">
     <article class="article football-article @if(page.theMatch.isLive){is-live}" role="main">

--- a/sport/app/football/views/fragments/teamFixturesBody.scala.html
+++ b/sport/app/football/views/fragments/teamFixturesBody.scala.html
@@ -14,9 +14,9 @@
 
     <div class="matches-container component" role="main">
         @fixtures.map{ fixture =>
-            <h2 class="competitions-date type-4">@fixture.fixture.date.toString("EEEE d MMMM yyyy")</h2>
+            <h2 class="competitions-date type-7">@fixture.fixture.date.toString("EEEE d MMMM yyyy")</h2>
 
-            <a class="competition-title football-table-link tone-colour type-4" href="@fixture.competition.url" data-link-name="view competition">
+            <a class="competition-title football-table-link tone-colour type-7" href="@fixture.competition.url" data-link-name="view competition">
                 @fixture.competition.fullName<i class="i i-sport-arrow"></i>
             </a>
             <ol class="matches unstyled">


### PR DESCRIPTION
- [new] Article zone is deported in the left column
- [new] `$a-leftColWide-width` as an abstraction for the widest state of the left column
- [fix] article-zone in sports has the right width (had 20 px too much on the right)
- [unrelated fix] Team fixtures text size is the same as the rest of the sports tables

![screen shot 2013-10-24 at 17 20 01](https://f.cloud.github.com/assets/85783/1400620/373738ce-3cc8-11e3-98de-5ddd55ccea8c.PNG)

![ ](http://1.bp.blogspot.com/-MqijOIFQltM/UmjeTQTzY4I/AAAAAAABAiM/8bSFSlBuAhY/s1600/Honda+Illusions.gif)
