### PR TITLE
Fix sections module running without required context

### DIFF
--- a/common/app/assets/javascripts/modules/navigation/sections.js
+++ b/common/app/assets/javascripts/modules/navigation/sections.js
@@ -72,9 +72,11 @@ define([
                 contexts[id] = true;
 
                 var sectionsHeader = context.querySelector('.nav-popup-sections'),
-                    sectionsNav    = context.querySelector('.nav--global'),
-                    subSectionsNav = context.querySelector('.nav--local'),
-                    $sectionsHeader = bonzo(sectionsHeader);
+                    sectionsNav    = context.querySelector('.nav--global');
+
+                if (!sectionsHeader || !sectionsNav) {
+                    return;
+                }
 
                 bean.on(window, 'resize', common.debounce(function(e){
                     hasCrossedBreakpoint(function(layoutMode) {


### PR DESCRIPTION
Without `sectionsHeader` or `sectionsNav` found, queries were selecting all matching `nav` elements on the page.
