### PR TITLE
Article casper tests

### DIFF
--- a/integration-tests/casper/tests/article/article.spec.js
+++ b/integration-tests/casper/tests/article/article.spec.js
@@ -10,33 +10,6 @@
 casper.start(host + "business/2010/feb/08/fsa-european-directive-hedge-funds?view=mobile");
 
 casper.then(function() {
-
-	casper.test.begin("Article head", function(test) {
-		test.assertVisible('a[data-link-name="article section"]', 'Section link visible');
-		test.assertVisible('.article__head h1.article__headline', 'Headline visible');
-		test.assertVisible('.article__head p.article__standfirst', 'Standfirst visible');
-		test.assertVisible('.article__head p.article__dateline time', 'Publish date visible');
-		test.assertVisible('.article__head p.article__dateline a.commentcount', 'Comment count visible');
-		test.done();
-	});
-
-	casper.test.begin("Article main content", function(test) {
-		test.assertVisible('img.main-image', 'Article main image visible');
-		test.assertVisible('figcaption.main-caption', 'Main image caption visible');
-		test.assertVisible('.article__meta-container p.byline', 'Byline visible');
-		test.assertVisible('.js-article__container .article-body', 'Article body visible');
-		test.assertVisible('.article__keywords ul.inline-list', 'Keyword list visible');
-		test.done();
-	});
-
-	casper.test.begin("Article share links", function(test) {
-		test.assertVisible('.article-v2__main-column a.social__action--email', 'Email share link visible');
-		test.assertVisible('.article-v2__main-column a.social__action--facebook', 'Facebook share link visible');
-		test.assertVisible('.article-v2__main-column a.social__action--twitter', 'Twitter share link visible');
-		test.assertVisible('.article-v2__main-column a.social__action--gplus', 'Google+ share link visible');
-		test.done();
-	});
-
 	casper.test.begin("Related content", function(test) {
 		test.assertVisible('.js-related', 'Related content trailblock visible');
 		test.assertExists('.js-related .related-trails.shut', 'Additional related trails hidden on page load');

--- a/integration-tests/casper/tests/article/article.spec.js
+++ b/integration-tests/casper/tests/article/article.spec.js
@@ -7,21 +7,47 @@
  *
  **/
 
-var casper = require('casper').create();
-
 casper.start(host + "business/2010/feb/08/fsa-european-directive-hedge-funds?view=mobile");
 
-casper.test.begin("Display related content", function(test) {
-    casper.waitForText('Related content', function() {
-        casper.click('.js-related button');
-        test.assertEquals(document.querySelectorAll('.js-related .related-trails.shut').length, 0, 'Button shows more related trails');
-        test.done();
-    }, function timeout() {
-        test.fail('Failed to transclude related content');
-    });
-});
+casper.then(function() {
 
+	casper.test.begin("Article head", function(test) {
+		test.assertVisible('a[data-link-name="article section"]', 'Section link visible');
+		test.assertVisible('.article__head h1.article__headline', 'Headline visible');
+		test.assertVisible('.article__head p.article__standfirst', 'Standfirst visible');
+		test.assertVisible('.article__head p.article__dateline time', 'Publish date visible');
+		test.assertVisible('.article__head p.article__dateline a.commentcount', 'Comment count visible');
+		test.done();
+	});
+
+	casper.test.begin("Article main content", function(test) {
+		test.assertVisible('img.main-image', 'Article main image visible');
+		test.assertVisible('figcaption.main-caption', 'Main image caption visible');
+		test.assertVisible('.article__meta-container p.byline', 'Byline visible');
+		test.assertVisible('.js-article__container .article-body', 'Article body visible');
+		test.assertVisible('.article__keywords ul.inline-list', 'Keyword list visible');
+		test.done();
+	});
+
+	casper.test.begin("Article share links", function(test) {
+		test.assertVisible('.article-v2__main-column a.social__action--email', 'Email share link visible');
+		test.assertVisible('.article-v2__main-column a.social__action--facebook', 'Facebook share link visible');
+		test.assertVisible('.article-v2__main-column a.social__action--twitter', 'Twitter share link visible');
+		test.assertVisible('.article-v2__main-column a.social__action--gplus', 'Google+ share link visible');
+		test.done();
+	});
+
+	casper.test.begin("Related content", function(test) {
+		test.assertVisible('.js-related', 'Related content trailblock visible');
+		test.assertExists('.js-related .related-trails.shut', 'Additional related trails hidden on page load');
+    	casper.click('.js-related button');
+    	test.assertDoesntExist('.js-related .related-trails.shut', 'Button shows more related trails');
+    	test.done();
+	});
+});
 
 casper.run(function() {
     this.test.renderResults(true, 0, this.cli.get("xunit") + "article.xml");
 });
+
+

--- a/integration-tests/casper/tests/article/article.spec.js
+++ b/integration-tests/casper/tests/article/article.spec.js
@@ -49,5 +49,3 @@ casper.then(function() {
 casper.run(function() {
     this.test.renderResults(true, 0, this.cli.get("xunit") + "article.xml");
 });
-
-

--- a/integration-tests/casper/tests/article/article.spec.js
+++ b/integration-tests/casper/tests/article/article.spec.js
@@ -40,9 +40,9 @@ casper.then(function() {
 	casper.test.begin("Related content", function(test) {
 		test.assertVisible('.js-related', 'Related content trailblock visible');
 		test.assertExists('.js-related .related-trails.shut', 'Additional related trails hidden on page load');
-    	casper.click('.js-related button');
-    	test.assertDoesntExist('.js-related .related-trails.shut', 'Button shows more related trails');
-    	test.done();
+		casper.click('.js-related button');
+		test.assertDoesntExist('.js-related .related-trails.shut', 'Button shows more related trails');
+		test.done();
 	});
 });
 


### PR DESCRIPTION
This will hopefully fix intermittent failures by wrapping tests in `casper.then` to stop casper trying to execute tests before the page has loaded.

Also removed unnecessary defining of casper variable.
