### PR TITLE
Redirect old match stats to results page

### DIFF
--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -63,6 +63,7 @@ object MatchController extends Controller with Football with Requests with Loggi
       }
     }
 
-    response.getOrElse(Future { NotFound })
+    // we do not keep historical data, so just redirect old stuff to the results page
+    response.getOrElse(Future { Found("/football/results") })
   }
 }

--- a/sport/test/controllers/MatchControllerTest.scala
+++ b/sport/test/controllers/MatchControllerTest.scala
@@ -7,7 +7,7 @@ import test.{TestRequest, Fake}
 
 class MatchControllerTest extends FlatSpec with Matchers {
   
-  "MatchController" should "redirect when content match is not found" in Fake {
+  "MatchController" should "redirect to results when match is not found" in Fake {
     val result = football.controllers.MatchController.renderMatchId("12345")(TestRequest())
     status(result) should be(302)
     header("Location", result).head should be ("/football/results")

--- a/sport/test/controllers/MatchControllerTest.scala
+++ b/sport/test/controllers/MatchControllerTest.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import play.api.test.Helpers._
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+import test.{TestRequest, Fake}
+
+class MatchControllerTest extends FlatSpec with Matchers {
+  
+  "MatchController" should "redirect when content match is not found" in Fake {
+    val result = football.controllers.MatchController.renderMatchId("12345")(TestRequest())
+    status(result) should be(302)
+    header("Location", result).head should be ("/football/results")
+  }
+}


### PR DESCRIPTION
We do not keep old match data, so if we cannot find the match simply redirect to /football/results
