### PR TITLE
Added discussion analytics with extra oomph

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/discussion.js
+++ b/common/app/assets/javascripts/modules/analytics/discussion.js
@@ -12,7 +12,7 @@ define(['common', 'modules/id'], function(common, Id) {
             'prop4', 'prop6', 'prop8', 'prop10', 'prop13',
             'prop19', 'prop31', 'prop51', 'prop75',
             'eVar7', 'eVar8',  'eVar19', 'eVar31',
-            'eVar51', 'eVar66', 'eVar67'];
+            'eVar51', 'eVar66'];
 
         return linkTrackVars.concat(extras).join(',');
     };
@@ -31,7 +31,7 @@ define(['common', 'modules/id'], function(common, Id) {
         s.eVar65 = 'recommendation';
         s.eVar66 = Id.getUserFromCookie().id;
         s.eVar67 = e.userId;
-        s.linkTrackVars = this.getLinkTrackVars(['eVar65']);
+        s.linkTrackVars = this.getLinkTrackVars(['eVar65', 'eVar67']);
         s.linkTrackEvents = 'event72';
         s.tl(true, 'o', 'Recommend a comment');
     };

--- a/common/app/assets/javascripts/modules/analytics/discussion.js
+++ b/common/app/assets/javascripts/modules/analytics/discussion.js
@@ -1,11 +1,27 @@
 define(['common', 'modules/id'], function(common, Id) {
     function Track() {}
 
+    /**
+     * @param {Array.<string>}
+     * @return {string}
+     */
+    Track.prototype.getLinkTrackVars = function(extras) {
+        extra = extras || [];
+        var linkTrackVars = [
+            'events',
+            'prop4', 'prop6', 'prop8', 'prop10', 'prop13',
+            'prop19', 'prop31', 'prop51', 'prop75',
+            'eVar7', 'eVar8',  'eVar19', 'eVar31',
+            'eVar51', 'eVar66', 'eVar67'];
+
+        return linkTrackVars.concat(extras).join(',');
+    };
+
     Track.prototype.comment = function() {
         s.events = 'event51';
         s.eVar66 = Id.getUserFromCookie().id;
         s.eVar68 = 'comment';
-        s.linkTrackVars = 'events,prop51,eVar51,eVar7,eVar66,eVar67,eVar68,prop19';
+        s.linkTrackVars = this.getLinkTrackVars(['eVar68']);
         s.linkTrackEvents = 'event51';
         s.tl(true, 'o', 'comment');
     };
@@ -15,7 +31,7 @@ define(['common', 'modules/id'], function(common, Id) {
         s.eVar65 = 'recommendation';
         s.eVar66 = Id.getUserFromCookie().id;
         s.eVar67 = e.userId;
-        s.linkTrackVars = 'events,prop51,eVar51,eVar7,eVar65,eVar66,eVar67,prop19';
+        s.linkTrackVars = this.getLinkTrackVars(['eVar65']);
         s.linkTrackEvents = 'event72';
         s.tl(true, 'o', 'Recommend a comment');
     };
@@ -23,8 +39,8 @@ define(['common', 'modules/id'], function(common, Id) {
 
     var init = function() {
         var track = new Track();
-        common.mediator.on('discussion:commentbox:post:success', track.comment);
-        common.mediator.on('discussion:comment:recommend:success', track.recommend);
+        common.mediator.on('discussion:commentbox:post:success', track.comment.bind(track));
+        common.mediator.on('discussion:comment:recommend:success', track.recommend.bind(track));
     };
 
     return { init: init };


### PR DESCRIPTION
We needed some meta-info to come along with the discussion requests.

What we are sending to the server is:
## Recommend

```
SiteCatalyst Server Call #2 (1162 chars)
CUSTOM LINK        : Recommend a comment
Report Suite ID    : guardiangu-frontend-dev
Page Name          : GFE:science:Article:3
Current URL        : http://m.thegulocal.com/science/grrlscientist/2012/aug/07/3#comments
Events             : event72
eVar19             : frontend
eVar31             : registered user
eVar51             : AB | AlphaAdvertsData | notintest
eVar65             : recommendation
eVar66             : 11800127
eVar67             : 11800127
prop4              : Science
prop6              : GrrlScientist
prop8              : 1782564
prop10             : Blogposts
prop19             : frontend
prop31             : registered user
prop51             : AB | AlphaAdvertsData | notintest
Currency Code      : GBP
Char Set           : UTF-8
Screen Resolution  : 1920x1080
Color Depth        : 24
JavaScript Version : 1.6
JavaScript Enabled : Y
Cookies Supported  : Y
Browser Width      : 636
Browser Height     : 933
Version of Code    : H.25.3
Data Centre        : hits.theguardian.com
```
## Comment

```
SiteCatalyst Server Call #3 (1214 chars)
CUSTOM LINK        : comment
Report Suite ID    : guardiangu-frontend-dev
Page Name          : GFE:science:Article:3
Current URL        : http://m.thegulocal.com/science/grrlscientist/2012/aug/07/3#comments
Events             : event51
eVar19             : frontend
eVar31             : registered user
eVar51             : AB | AlphaAdvertsData | notintest
eVar66             : 11800127
eVar67             : 11800127
eVar68             : comment
prop4              : Science
prop6              : GrrlScientist
prop8              : 1782564
prop10             : Blogposts
prop19             : frontend
prop31             : registered user
prop51             : AB | AlphaAdvertsData | notintest
Currency Code      : GBP
Char Set           : UTF-8
Screen Resolution  : 1920x1080
Color Depth        : 24
JavaScript Version : 1.6
JavaScript Enabled : Y
Cookies Supported  : Y
Browser Width      : 636
Browser Height     : 933
Version of Code    : H.25.3
Data Centre        : hits.theguardian.com
```
