### PR TITLE
Serve hinted fonts to Windows Desktop only

### DIFF
--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -122,7 +122,7 @@
         var connectionClass = 'connection--' + (isConnectionLow() ? '' : 'not-') + 'low';
         document.documentElement.className += connectionClass;
 
-        guardian.platformsGettingHintedFonts = /Windows/;
+        guardian.platformsGettingHintedFonts = /W(indows(?!( Phone|PDesktop)))/;
 
         if (guardian.platformsGettingHintedFonts.test(navigator.userAgent)) {
             loadFontsAsynchronously();

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -122,9 +122,11 @@
         var connectionClass = 'connection--' + (isConnectionLow() ? '' : 'not-') + 'low';
         document.documentElement.className += connectionClass;
 
-        guardian.platformsGettingHintedFonts = /W(indows(?!( Phone|PDesktop)))/;
+        guardian.platformsGettingHintedFonts = /Windows/;
+        guardian.platformsNotGettingHintedFonts = /W(indows Phone|PDesktop)/; // exceptions
 
-        if (guardian.platformsGettingHintedFonts.test(navigator.userAgent)) {
+        if (guardian.platformsGettingHintedFonts.test(navigator.userAgent) &&
+            !! guardian.platformsNotGettingHintedFonts.test(navigator.userAgent)) {
             loadFontsAsynchronously();
         } else {
             loadFontsFromStorage();


### PR DESCRIPTION
One of the performance issues in Windows Phones may have been caused by the non hinted version of the fonts, that also happen to be served in a rather blunt way.

This PR restricts hinted fonts to Desktop windows only.

Are excluded:
- Windows phone
- Windows phone in desktop mode

See http://stackoverflow.com/questions/9926504/how-do-i-check-windows-phone-useragent-with-javascript for the bit about the WPDesktop user agent.

Related to #2127

![ ](http://media.tumblr.com/7ef0237c00bbd397c5ac392375d212bd/tumblr_inline_muzu5lCkAo1raprkq.gif)
