### PR TITLE
Add wait for related content transclusion and increase wait timeout

### DIFF
--- a/integration-tests/casper/tests/article/article.spec.js
+++ b/integration-tests/casper/tests/article/article.spec.js
@@ -9,7 +9,9 @@
 
 casper.start(host + "business/2010/feb/08/fsa-european-directive-hedge-funds?view=mobile");
 
-casper.then(function() {
+casper.options.waitTimeout = 10000;
+
+casper.waitUntilVisible('.js-related.lazyloaded', function() {
 	casper.test.begin("Related content", function(test) {
 		test.assertVisible('.js-related', 'Related content trailblock visible');
 		test.assertExists('.js-related .related-trails.shut', 'Additional related trails hidden on page load');


### PR DESCRIPTION
Okay, looks like I was wrong and we do need to make casper wait for the related content trailblock to be transcluded after page load. It was failing before as the wait was timing out. The default wait timeout is 5 seconds, so I've also increased this to 10 seconds. The test usually completes in under 10 seconds, but it seemed that 5 seconds was not always long enough for the wait timeout.
