### PR TITLE
Dedupe tweaks

### DIFF
--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -18,6 +18,9 @@ class TemplateDeduping extends implicits.Collections {
 
   def apply(numberWanted: Int, collection: Collection): Collection = take(numberWanted, collection)
   def apply(collection: Collection): Collection = take(collection.items.length, collection)
+
+  def apply(numberWanted: Int, items: Seq[Trail]): Seq[Trail] = take(numberWanted, items)
+  def apply(items: Seq[Trail]): Seq[Trail] = take(items.length, items)
 }
 
 object TemplateDeduping {

--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -5,7 +5,6 @@ import scala.collection.mutable
 
 class TemplateDeduping extends implicits.Collections {
   private val alreadyUsed: mutable.HashSet[String] = new mutable.HashSet[String]()
-  private val defaultTake: Int = 20
 
   def take(numberWanted: Int, items: Seq[Trail]): Seq[Trail] = {
     val thisRound = items filterNot (t => alreadyUsed.contains(t.url)) take numberWanted
@@ -18,7 +17,7 @@ class TemplateDeduping extends implicits.Collections {
     collection.copy(items = take(numberWanted, collection.items))
 
   def apply(numberWanted: Int, collection: Collection): Collection = take(numberWanted, collection)
-  def apply(collection: Collection): Collection = take(defaultTake, collection)
+  def apply(collection: Collection): Collection = take(collection.items.length, collection)
 }
 
 object TemplateDeduping {

--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -7,15 +7,12 @@ class TemplateDeduping extends implicits.Collections {
   private val alreadyUsed: mutable.HashSet[String] = new mutable.HashSet[String]()
   private val defaultTake: Int = 20
 
-  def take(numberWanted: Int, items: Seq[Trail]): Seq[Trail] =
-    items
-      .distinctBy{_.url}
-      .filterNot(t => alreadyUsed.contains(t.url))
-      .take(numberWanted)
-      .map {trail =>
-        alreadyUsed += trail.url
-        trail
-      }
+  def take(numberWanted: Int, items: Seq[Trail]): Seq[Trail] = {
+    val thisRound = items filterNot (t => alreadyUsed.contains(t.url)) take numberWanted
+    val returnList = thisRound ++ {thisRound.lastOption.map(t => items.dropWhile(_ != t).drop(1)).getOrElse(Nil)}
+    thisRound foreach (alreadyUsed += _.url)
+    returnList.distinctBy(_.url)
+  }
 
   def take(numberWanted: Int, collection: Collection): Collection =
     collection.copy(items = take(numberWanted, collection.items))

--- a/common/test/views/support/TemplateDedupingTest.scala
+++ b/common/test/views/support/TemplateDedupingTest.scala
@@ -82,12 +82,10 @@ class TemplateDedupingTest extends FlatSpec with Matchers with BeforeAndAfter {
     newTrailsOne.items should be (Seq(trailOne, trailTwo, trailThree, trailFour))
 
     val newTrailsTwo = dedupe.take(1, Collection(trails))
-    println("BeforeTestOne: " + newTrailsTwo.items.map(_.url).mkString(","))
     newTrailsTwo.items.length should be (3)
     newTrailsTwo.items should be (Seq(trailTwo, trailThree, trailFour))
 
     val newTrailsThree = dedupe.take(1, Collection(trails))
-    println("BeforeTestTwo: " + newTrailsThree.items.map(_.url).mkString(","))
     newTrailsThree.items.length should be (2)
     newTrailsThree.items should be (Seq(trailThree, trailFour))
 

--- a/common/test/views/support/TemplateDedupingTest.scala
+++ b/common/test/views/support/TemplateDedupingTest.scala
@@ -96,6 +96,14 @@ class TemplateDedupingTest extends FlatSpec with Matchers with BeforeAndAfter {
     val newTrailsFive = dedupe.take(1, Collection(trails))
     newTrailsFive.items.length should be (0)
   }
+
+  it should "preserve order" in {
+    val newTrailsOne = dedupe.take(1, Seq(trailThree))
+    newTrailsOne.length should be (1)
+
+    val newTrailsTwo = dedupe.take(3, Seq(trailOne, trailThree, trailFour))
+    newTrailsTwo should be (Seq(trailOne, trailFour))
+  }
 }
 
 case class TestTrail(url: String) extends Trail {

--- a/common/test/views/support/TemplateDedupingTest.scala
+++ b/common/test/views/support/TemplateDedupingTest.scala
@@ -1,0 +1,117 @@
+package views.support
+
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import model.{Collection, Trail}
+import org.joda.time.DateTime
+import com.gu.openplatform.contentapi.model.{Content => ApiContent}
+
+class TemplateDedupingTest extends FlatSpec with Matchers with BeforeAndAfter {
+
+  val trailOne = new TestTrail("uk/news/one")
+  val trailTwo = new TestTrail("uk/news/two")
+  val trailThree = new TestTrail("uk/news/three")
+  val trailFour = new TestTrail("uk/news/four")
+  val trails = Seq(trailOne, trailTwo, trailThree, trailFour)
+
+  val trailFive = new TestTrail("uk/news/five")
+
+  var dedupe: TemplateDeduping = null
+  before {
+    dedupe = new TemplateDeduping
+  }
+
+  "Trails" should "equal each other" in {
+    val tempTrailOne = TestTrail("one/two/three")
+    val tempTrailTwo = TestTrail("one/two/three")
+
+    tempTrailOne shouldEqual tempTrailTwo
+  }
+
+  "TemplateDeduping" should "remove duplicates" in {
+    val duplicateTrail = TestTrail("uk/news/two")
+    val newTrails = dedupe.take(5, trails :+ duplicateTrail)
+
+    newTrails.length should be (4)
+    newTrails(1) shouldEqual trailTwo
+    newTrails(3) shouldEqual trailFour
+  }
+
+  it should "not remove duplicates if it was not within what was asked" in {
+    val newTrailsOne = dedupe.take(2, trails)
+    newTrailsOne.length should be (4)
+    newTrailsOne should be (trails)
+
+    val newTrailsTwo = dedupe.take(2, trails)
+    newTrailsTwo.length should be (2)
+    newTrailsTwo(0) shouldEqual trailThree
+    newTrailsTwo(1) shouldEqual trailFour
+  }
+
+  it should "dedupe all of the trails passed by default" in {
+    val newTrailsOne = dedupe.apply(Collection(trails))
+    newTrailsOne.items.length should be (4)
+
+    val newTrailsTwo = dedupe.apply(Collection(trails))
+    newTrailsTwo.items.length should be (0)
+  }
+
+  it should "respect deduping boundaries" in {
+    val newTrailsOne = dedupe.take(1, Collection(trails))
+    newTrailsOne.items.length should be (4)
+    newTrailsOne.items should be (Seq(trailOne, trailTwo, trailThree, trailFour))
+
+    val newTrailsTwo = dedupe.take(1, Collection(trails))
+    newTrailsTwo.items.length should be (3)
+    newTrailsTwo.items should be (Seq(trailTwo, trailThree, trailFour))
+
+    //trailTwo and trailOne have been deduped above, but are not in the deduping zone here
+    //so they should not be deduped and we should get 4 back
+    val newTrailSeq = Seq(trailFour, trailThree, trailTwo, trailOne)
+    val newTrailsThree = dedupe.take(2, newTrailSeq)
+    newTrailsThree.length should be (4)
+    newTrailsThree should be (Seq(trailFour, trailThree, trailTwo, trailOne))
+
+    val newTrailSeqTwo = Seq(trailFive) ++ newTrailSeq
+    val newTrailsFour = dedupe.take(1, newTrailSeqTwo)
+    newTrailsFour.length should be (5)
+  }
+
+  it should "not return anything in the end" in {
+    val newTrailsOne = dedupe.take(1, Collection(trails))
+    newTrailsOne.items.length should be (4)
+    newTrailsOne.items should be (Seq(trailOne, trailTwo, trailThree, trailFour))
+
+    val newTrailsTwo = dedupe.take(1, Collection(trails))
+    println("BeforeTestOne: " + newTrailsTwo.items.map(_.url).mkString(","))
+    newTrailsTwo.items.length should be (3)
+    newTrailsTwo.items should be (Seq(trailTwo, trailThree, trailFour))
+
+    val newTrailsThree = dedupe.take(1, Collection(trails))
+    println("BeforeTestTwo: " + newTrailsThree.items.map(_.url).mkString(","))
+    newTrailsThree.items.length should be (2)
+    newTrailsThree.items should be (Seq(trailThree, trailFour))
+
+    val newTrailsFour = dedupe.take(1, Collection(trails))
+    newTrailsFour.items.length should be (1)
+    newTrailsFour.items should be (Seq(trailFour))
+
+    val newTrailsFive = dedupe.take(1, Collection(trails))
+    newTrailsFive.items.length should be (0)
+  }
+}
+
+case class TestTrail(url: String) extends Trail {
+  def webPublicationDate: DateTime = DateTime.now
+  def linkText: String = ""
+  def headline: String = ""
+  def trailText: Option[String] = None
+  def section: String = ""
+  def sectionName: String = ""
+  def isLive: Boolean = true
+
+  override def delegate = ApiContent("foo/2012/jan/07/bar", None, None, new DateTime, "Some trail",
+    "http://www.guardian.co.uk/foo/2012/jan/07/bar",
+    "http://content.guardianapis.com/foo/2012/jan/07/bar",
+    elements = None,
+    fields = None)
+}

--- a/common/test/views/support/TemplateDedupingTest.scala
+++ b/common/test/views/support/TemplateDedupingTest.scala
@@ -36,7 +36,7 @@ class TemplateDedupingTest extends FlatSpec with Matchers with BeforeAndAfter {
     newTrails(3) shouldEqual trailFour
   }
 
-  it should "not remove duplicates if it was not within what was asked" in {
+  it should "correctly dedupe items not already deduped" in {
     val newTrailsOne = dedupe.take(2, trails)
     newTrailsOne.length should be (4)
     newTrailsOne should be (trails)

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -6,10 +6,10 @@
             @faciaTrailblock.collections.zipWithIndex.map{ case(block, index) =>
                 @if(block._2.items.nonEmpty){
                     @FindStyle(faciaTrailblock.id, block._1) match {
-                        case Masthead           => { @collections.masthead(block._1, dedupe(4, block._2), Masthead, index) }
-                        case style: Container   => { @collections.container(front, block._1,  dedupe(block._2), style, index) }
-                        case style: SectionZone => { @collections.sectionZone(block._1,  dedupe(block._2), style, index) }
-                        case style              => { @collections.masthead(block._1,  dedupe(block._2), style, index) }
+                        case Masthead           => { @collections.masthead(block._1, dedupe(5, block._2), Masthead, index) }
+                        case style: Container   => { @collections.container(front, block._1,  dedupe(5, block._2), style, index) }
+                        case style: SectionZone => { @collections.sectionZone(block._1,  dedupe(5, block._2), style, index) }
+                        case style              => { @collections.masthead(block._1,  dedupe(5, block._2), style, index) }
                     }
                 }
             }


### PR DESCRIPTION
Deduping now behaves differently:
- If no number supplied while deduping then the whole list is deduped
- Only deduped what was asked
- By default each template coming through `facia` now dedupes only the top 5 items.

If an item has been deduped in the past and is within the deduping bounds, it will never show again in further down the list if it appears within the deduping bounds. If an item is outside the deduping bounds then it will always show, deduped in the past or not.

I have also added tests around deduping.

@ironsidevsquincy 
