### PR TITLE
Alpha Adverts test - Impression fix

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -1,3 +1,4 @@
+/*global s_i_guardian:true */
 define([
     'common',
     'modules/detect',
@@ -225,6 +226,9 @@ define([
             // Can be used as a way to prevent other events to fire earlier than the pageview
             var self = this;
             var checkForPageViewInterval = setInterval(function() {
+                // s_i_guardian is a globally defined Image() object created by Omniture
+                // It does not sit in the DOM tree, and seems to be the only surefire way
+                // to check if the intial beacon has been successfully sent
                 if (typeof(s_i_guardian) !== 'undefined' &&
                     (s_i_guardian.complete === true || s_i_guardian.width + s_i_guardian.height > 0)) {
                     clearInterval(checkForPageViewInterval);

--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts-data.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts-data.js
@@ -1,11 +1,12 @@
 /*global guardian */
 define([
+    'common',
     'qwery',
     'bonzo',
     'modules/detect',
     'modules/analytics/adverts',
     'modules/adverts/sticky'
-], function (qwery, bonzo, detect, inview, Sticky) {
+], function (common, qwery, bonzo, detect, inview, Sticky) {
 
     var AlphaAdvertsData = function () {
 
@@ -44,7 +45,14 @@ define([
                             'data-extended' : 'Middle'
                         }).addClass(cls).insertAfter(this);
                     });
-                    inview(document);
+
+                    // Don't setup the listener here when the 'Both' variant is running
+                    if (!isBoth) {
+                        common.mediator.on('module:analytics:omniture:pageview:sent', function(config, context) {
+                            inview(document);
+                        });
+                    }
+
                     return true;
                 }
             },
@@ -76,7 +84,14 @@ define([
                             });
                         }
                     }
-                    inview(document);
+
+                    // Don't setup the listener here when the 'Both' variant is running
+                    if (!isBoth) {
+                        common.mediator.on('module:analytics:omniture:pageview:sent', function(config, context) {
+                            inview(document);
+                        });
+                    }
+
                     return true;
                 }
             },
@@ -88,6 +103,10 @@ define([
                         if(variant.id === 'Inline' || variant.id === 'Adhesive') {
                             variant.test.call(self, {}, true);
                         }
+                    });
+
+                    common.mediator.on('module:analytics:omniture:pageview:sent', function(config, context) {
+                        inview(document);
                     });
 
                     // This needs to be last as the previous calls set their own variant hosts

--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts-data.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts-data.js
@@ -46,9 +46,9 @@ define([
                         }).addClass(cls).insertAfter(this);
                     });
 
-                    // Don't setup the listener here when the 'Both' variant is running
+                    // The listener for the 'Both' variant is setup only once in the variant itself
                     if (!isBoth) {
-                        common.mediator.on('module:analytics:omniture:pageview:sent', function(config, context) {
+                        common.mediator.on('module:analytics:omniture:pageview:sent', function() {
                             inview(document);
                         });
                     }
@@ -85,9 +85,9 @@ define([
                         }
                     }
 
-                    // Don't setup the listener here when the 'Both' variant is running
+                    // The listener for the 'Both' variant is setup only once in the variant itself
                     if (!isBoth) {
-                        common.mediator.on('module:analytics:omniture:pageview:sent', function(config, context) {
+                        common.mediator.on('module:analytics:omniture:pageview:sent', function() {
                             inview(document);
                         });
                     }
@@ -105,7 +105,7 @@ define([
                         }
                     });
 
-                    common.mediator.on('module:analytics:omniture:pageview:sent', function(config, context) {
+                    common.mediator.on('module:analytics:omniture:pageview:sent', function() {
                         inview(document);
                     });
 


### PR DESCRIPTION
This provides an Omniture hook that confirms the pageview beacon. Used to prevent events from firing before the main pageview tracking event.

Also fixes the Alpha Advert test firing twice when inside the 'Both' variant
