### PR TITLE
Fix broken header height since navigation refactor

### DIFF
--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -55,15 +55,12 @@
                 background-color: $c-neutral7;
                 border-bottom: 1px solid $c-neutral5;
             }
-
-            .header__inner {
-                height: 60px;
-            }
         }
     }
 }
     .header__inner {
         background-color: $c-brandBlue;
+        height: $headerHeight;
     }
 
 .guardian-logo-wrapper {


### PR DESCRIPTION
Fix header height overspill since navigation refactor (#2184), breaking on Identity pages implementing distraction-free variation (no sections menu).
