### PR TITLE
Prevent list and quote icon from overlapping - Fixes #2026

### DIFF
--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -134,13 +134,21 @@
                 text-indent: 40px;
 
                 @include mq(tablet) {
-                    text-indent: 42px;
+                    text-indent: 44px;
                 }
             }
 
             @include mq(tablet) {
                 @include fs-headline(2, true);
                 line-height: inherit;
+            }
+        }
+        > ul:first-child {
+            // Fix list and quote icon overlap - #2026
+            margin-left: 40px;
+
+            @include mq(tablet) {
+                margin-left: 44px;
             }
         }
     }


### PR DESCRIPTION
## Before

![screen shot 2013-11-02 at 15 33 01](https://f.cloud.github.com/assets/85783/1459400/14f66542-43d4-11e3-8544-5bed81ddfcfa.PNG)
## After

![screen shot 2013-11-02 at 15 27 10](https://f.cloud.github.com/assets/85783/1459395/e829abbe-43d3-11e3-9dad-29c2d8aad14f.PNG)

![ ](http://media.giphy.com/media/iVDo6InQKyW8o/giphy.gif)
