### PR TITLE
Fonts files should have json endpoint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
         webfontjson: {
             WebAgateSansWoff: {
                 options: {
-                    "filename": staticTargetDir + "fonts/WebAgateSans.woff.js",
+                    "filename": staticTargetDir + "fonts/WebAgateSans.woff.json",
                     "callback": "guFont",
                     "fonts": [
                         {
@@ -88,7 +88,7 @@ module.exports = function (grunt) {
             },
             WebAgateSansTtf: {
                 options: {
-                    "filename": staticTargetDir + "fonts/WebAgateSans.ttf.js",
+                    "filename": staticTargetDir + "fonts/WebAgateSans.ttf.json",
                     "callback": "guFont",
                     "fonts": [
                         {
@@ -101,7 +101,7 @@ module.exports = function (grunt) {
             },
             WebEgyptianWoff: {
                 options: {
-                    "filename": staticTargetDir + "fonts/WebEgyptian.woff.js",
+                    "filename": staticTargetDir + "fonts/WebEgyptian.woff.json",
                     "callback": "guFont",
                     "fonts": [
                         {
@@ -146,7 +146,7 @@ module.exports = function (grunt) {
             },
             WebEgyptianTtf: {
                 options: {
-                    "filename": staticTargetDir + "fonts/WebEgyptian.ttf.js",
+                    "filename": staticTargetDir + "fonts/WebEgyptian.ttf.json",
                     "callback": "guFont",
                     "fonts": [
                         {

--- a/common/app/assets/javascripts/modules/fonts.js
+++ b/common/app/assets/javascripts/modules/fonts.js
@@ -69,7 +69,7 @@ define(['ajax', 'common', 'modules/storage'], function (ajax, common, storage) {
         };
 
         function getNameAndCacheKey(style) {
-            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.js$/);
+            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.json$/);
             nameAndCacheKey.shift();
             return nameAndCacheKey;
         }

--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -26,5 +26,5 @@
     <link rel="stylesheet" type="text/css" href="@Static("stylesheets/old-ie.global.css")" />
 <![endif]-->
 
-<style class="initial" data-cache-name="WebEgyptian" data-cache-file-woff="@Static("fonts/WebEgyptian.woff.js")" data-cache-file-ttf="@Static("fonts/WebEgyptian.ttf.js")"></style>
-<style class="initial" data-cache-name="WebAgateSans" data-min-width="980" data-cache-file-woff="@Static("fonts/WebAgateSans.woff.js")" data-cache-file-ttf="@Static("fonts/WebAgateSans.ttf.js")"></style>
+<style class="initial" data-cache-name="WebEgyptian" data-cache-file-woff="@Static("fonts/WebEgyptian.woff.json")" data-cache-file-ttf="@Static("fonts/WebEgyptian.ttf.json")"></style>
+<style class="initial" data-cache-name="WebAgateSans" data-min-width="980" data-cache-file-woff="@Static("fonts/WebAgateSans.woff.json")" data-cache-file-ttf="@Static("fonts/WebAgateSans.ttf.json")"></style>

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -84,7 +84,7 @@
                 var styleNodes = document.querySelectorAll('[data-cache-name]');
                 for (var i = 0, j = styleNodes.length; i<j; ++i) {
                     var style = styleNodes[i],
-                        nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.js$/),
+                        nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.json$/),
                         cachedCss = localStorage.getItem('gu.fonts.' + nameAndCacheKey[1] + '.' + nameAndCacheKey[2]);
                         @* try to parse it (should really use the storage module) *@
                         try {


### PR DESCRIPTION
As we lock down javascript requests, with a callback param, to only .json extensions

https://github.com/guardian/frontend/blob/master/dev-build/app/Global.scala#L39
