### PR TITLE
Remove double border below local nav in articles

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_localnav.scss
+++ b/common/app/assets/stylesheets/module/nav/_localnav.scss
@@ -39,7 +39,9 @@
             display: block;
         }
     }
-
+    .article__headline {
+        border-top: 0;
+    }
 }
 
 

--- a/common/app/assets/stylesheets/module/trails/_trailblock.scss
+++ b/common/app/assets/stylesheets/module/trails/_trailblock.scss
@@ -16,9 +16,6 @@
         margin-left: 0;
         margin-right: 0;
     }
-    .has-local-nav & {
-        border-top: 0;
-    }
 
     > ul {
         margin-bottom: 0;


### PR DESCRIPTION
One too many borders in:
http://www.theguardian.com/music/musicblog/2013/nov/04/wooden-shjips-back-to-land-album-stream

Thanks to Chris P for flagging this.
## Before

![screen shot 2013-11-04 at 13 07 03](https://f.cloud.github.com/assets/85783/1464754/09826c72-4552-11e3-91aa-90d27a5c2b5f.PNG)
## After

![screen shot 2013-11-04 at 13 07 23](https://f.cloud.github.com/assets/85783/1464758/125d66a8-4552-11e3-9711-e765ff1915ad.PNG)

![ ](http://4.bp.blogspot.com/-hs-waeEqHN4/UnKZnHRmMlI/AAAAAAABArY/B6Dl8wgFDKU/s1600/1.gif)
