### PR TITLE
Commercial: Segment Users By New Or Repeat Visitors

### DIFF
--- a/commercial/app/controllers/commercial/TravelOffers.scala
+++ b/commercial/app/controllers/commercial/TravelOffers.scala
@@ -3,7 +3,7 @@ package controllers.commercial
 import play.api.mvc._
 import common.ExecutionContexts
 import model.commercial.travel.OffersAgent
-import scala.util.Random
+import model.commercial.Segment
 
 object TravelOffers extends Controller with ExecutionContexts {
 
@@ -15,10 +15,12 @@ object TravelOffers extends Controller with ExecutionContexts {
 
   def listOffers = Action {
     implicit request =>
-      val keywords = request.queryString.get("k")
-      val offers = keywords map (OffersAgent.offers(_)) getOrElse OffersAgent.allOffers
+
+      def expectedParam(paramName: String): Seq[String] = request.queryString.get(paramName) getOrElse Nil
+
+      val segment = Segment(expectedParam("k"), expectedParam("seg"))
+      val offers = OffersAgent.offers(segment)
       if (offers.size > 1) {
-        val shuffled = Random.shuffle(offers.indices.toList)
         val view = views.html.fragments.travelOffer(offers)
         Ok(view) withHeaders ("Cache-Control" -> "max-age=60")
       } else {

--- a/commercial/app/controllers/commercial/TravelOffers.scala
+++ b/commercial/app/controllers/commercial/TravelOffers.scala
@@ -7,12 +7,6 @@ import model.commercial.Segment
 
 object TravelOffers extends Controller with ExecutionContexts {
 
-  def refresh = Action {
-    implicit request =>
-      OffersAgent.refresh()
-      Ok("OK") withHeaders ("Cache-Control" -> "max-age=0")
-  }
-
   def listOffers = Action {
     implicit request =>
 

--- a/commercial/app/model/commercial/Segment.scala
+++ b/commercial/app/model/commercial/Segment.scala
@@ -1,0 +1,7 @@
+package model.commercial
+
+
+case class Segment(keywords: Seq[String], userSegments: Seq[String]) {
+
+  def isRepeatVisitor = userSegments contains "repeat"
+}

--- a/commercial/app/model/commercial/travel/OffersAgent.scala
+++ b/commercial/app/model/commercial/travel/OffersAgent.scala
@@ -3,7 +3,7 @@ package model.commercial.travel
 import common.{AkkaAgent, ExecutionContexts, Logging}
 import scala.concurrent.Future
 import conf.ContentApi
-import model.commercial.Keyword
+import model.commercial.{Segment, Keyword}
 
 object OffersAgent extends Logging with ExecutionContexts {
 
@@ -11,9 +11,11 @@ object OffersAgent extends Logging with ExecutionContexts {
 
   def allOffers: List[Offer] = agent()
 
-  def offers(keywords: Seq[String], offersToChooseFrom: List[Offer] = allOffers) = {
-    offersToChooseFrom.filter {
-      offer => (keywords.map(_.toLowerCase).toSet & offer.keywords.map(_.name.toLowerCase).toSet).size > 0
+  def offers(segment: Segment, offersToChooseFrom: List[Offer] = allOffers) = {
+    offersToChooseFrom filter {
+      offer => (segment.keywords.map(_.toLowerCase).toSet & offer.keywords.map(_.name.toLowerCase).toSet).size > 0
+    } filter {
+      offer => segment.isRepeatVisitor
     }
   }
 

--- a/commercial/test/model/commercial/travel/OffersAgentTest.scala
+++ b/commercial/test/model/commercial/travel/OffersAgentTest.scala
@@ -2,14 +2,17 @@ package model.commercial.travel
 
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
+import model.commercial.Segment
 
 class OffersAgentTest extends FlatSpec with Matchers {
+
+  private def segment(keywords: Seq[String]) = Segment(keywords, Seq("repeat"))
 
   "offers" should "give offers associated with given keywords" in {
     val keywords = List("france")
     val allOffers = Fixtures.offers
 
-    val offers = OffersAgent.offers(keywords, allOffers)
+    val offers = OffersAgent.offers(segment(keywords), allOffers)
 
     offers should be(List(Fixtures.offers(2)))
   }
@@ -18,7 +21,7 @@ class OffersAgentTest extends FlatSpec with Matchers {
     val keywords = List("argentina")
     val allOffers = Fixtures.offers
 
-    val offers = OffersAgent.offers(keywords, allOffers)
+    val offers = OffersAgent.offers(segment(keywords), allOffers)
 
     offers should be(Nil)
   }
@@ -27,7 +30,7 @@ class OffersAgentTest extends FlatSpec with Matchers {
     val keywords = List("france")
     val allOffers = Nil
 
-    val offers = OffersAgent.offers(keywords, allOffers)
+    val offers = OffersAgent.offers(segment(keywords), allOffers)
 
     offers should be(Nil)
   }

--- a/common/app/assets/javascripts/modules/commercial/commercial-components.js
+++ b/common/app/assets/javascripts/modules/commercial/commercial-components.js
@@ -3,19 +3,22 @@ define([
     'qwery',
     'bonzo',
     'bean',
-    'modules/adverts/document-write'
+    'modules/adverts/document-write',
+    'modules/storage'
 ], function (
     common,
     qwery,
     bonzo,
     bean,
-    documentWrite
+    documentWrite,
+    storage
 ) {
 
     var Commercial = function(options) {
         this.options        = common.extend(this.DEFAULTS, options);
         this.keywords       = this.options.config.page.keywords.split(',');
         this.keywordsParams = documentWrite.getKeywords(this.options.config.page);
+        this.userSegments   = 'seg=' + (storage.get('gu.history').length <= 1 ? 'new' : 'repeat');
     };
 
 
@@ -26,10 +29,10 @@ define([
         mediumAdWidth: 600
     };
 
-    Commercial.prototype.init = function(options) {
+    Commercial.prototype.init = function() {
         var self = this;
 
-        bean.on(window, 'resize', common.debounce(function(e) {
+        bean.on(window, 'resize', common.debounce(function() {
             self.applyClassnames();
         }, 250));
 

--- a/common/app/assets/javascripts/modules/experiments/tests/commercial-components.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/commercial-components.js
@@ -37,6 +37,7 @@ define([
 
                     loadComponents({
                         keywordsParams: c.keywordsParams,
+                        userSegments: c.userSegments,
                         context: context
                     });
 
@@ -57,7 +58,7 @@ define([
     function loadComponents(opts) {
 
         var slotTargets = {
-            ".article__main-column": "/commercial/travel/offers?" + opts.keywordsParams,
+            ".article__main-column": "/commercial/travel/offers?" + opts.keywordsParams + "&" + opts.userSegments,
             ".js-mpu-ad-slot":       "/commercial/masterclasses?" + opts.keywordsParams
         };
 

--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -37,7 +37,8 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
     // these params are only whitelisted on dev machines, they will not make it through the CDN
     "view",
     "_edition", //allows us to spoof edition in tests
-    "k" // keywords in ad requests
+    "k", // keywords in commercial component requests
+    "seg" // user segments in commercial component requests
   )
 
   override def onRouteRequest(request: RequestHeader) = {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -119,7 +119,6 @@ GET         /troubleshoot/football                                              
 
 # Commercial
 GET         /commercial/travel/offers                                                                        controllers.commercial.TravelOffers.listOffers
-GET         /commercial/travel/devload                                                                       controllers.commercial.TravelOffers.refresh
 GET         /commercial/jobs                                                                                 controllers.commercial.JobAds.jobs
 GET         /commercial/$advert<(soulmates|masterclasses)>                                                   controllers.commercial.SimpleAdvert.render(advert)
 


### PR DESCRIPTION
This is a first attempt to include user segments in the choice of commercial component to display.  It uses the history from local storage to segment users until we have more sophisticated data from Vlad.
