### PR TITLE
Make sure IE8 displays little dots in password fields

### DIFF
--- a/common/app/assets/stylesheets/base/_forms.scss
+++ b/common/app/assets/stylesheets/base/_forms.scss
@@ -1,6 +1,13 @@
 /* Base form styles
    ========================================================================== */
 
+@if $old-ie {
+   // IE 8 won't display webfonts in password fields…
+   [type=password] {
+      font-family: sans-serif !important;
+   }
+}
+
 .form {
     margin-top: $baseline*6;
     margin-bottom: $baseline*6;


### PR DESCRIPTION
See the effect of webfonts on password fields in IE8:
http://blog.kaelig.fr/post/19578237411/ie-champ-mot-de-passe-et-webfonts

![ ](http://s2.developerslife.ru/public/images/gifs/0cf792b6-5715-4445-916d-a47146c3215d.gif)
