### PR TITLE
Simple view of the views over sessions data on the dashboard

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -50,4 +50,9 @@ object RadiatorController extends Controller with Logging with AuthLogging {
         Ok(Json.toJson(response.body))
       }
   }
+  
+  def liveStats() = Authenticated { implicit request =>
+    val graphs = CloudWatch.liveStats
+    Ok(views.html.liveStats(graphs, Configuration.environment.stage))
+  }
 }

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -96,6 +96,23 @@ trait CloudWatch {
         asyncHandler)
     )
   }.toSeq
+  
+  private val liveStatsMetrics = List(
+    ("Responsive views over sessions", "viewsOverSessions.responsive")
+  )
+ 
+  def liveStats = liveStatsMetrics.map{ case (name, metric) =>
+    new LiveStatsGraph( name, metric, 
+      cloudClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+        .withStartTime(new DateTime().minusHours(6).toDate)
+        .withEndTime(new DateTime().toDate)
+        .withPeriod(120)
+        .withStatistics("Average")
+        .withNamespace("Diagnostics")
+        .withMetricName(metric),
+        asyncHandler)
+      )
+  }.toSeq
 
   // charges are only available from the 'default' region
   private lazy val defaultCloudClient = new AmazonCloudWatchAsyncClient(Configuration.aws.credentials)

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -248,6 +248,18 @@ case class FastlyMetricGraph(
   )
 }
 
+case class LiveStatsGraph(
+  name: String,
+  metric: String,
+  metricResults: Future[GetMetricStatisticsResult]) extends Chart {
+    override lazy val labels = Seq("Time", metric)
+    override lazy val yAxis = Some(metric)
+    private lazy val datapoints = metricResults.get().getDatapoints.sortBy(_.getTimestamp.getTime).toSeq
+    override lazy val dataset = datapoints.map(d => DataPoint(
+      new DateTime(d.getTimestamp.getTime).toString("HH:mm"), Seq(d.getAverage))
+    )
+}
+
 case class CostMetric(costMetric: Future[GetMetricStatisticsResult]) {
   lazy val cost = costMetric.get().getDatapoints.headOption.map(_.getMaximum.toInt).getOrElse(0)
 }

--- a/admin/app/views/liveStats.scala.html
+++ b/admin/app/views/liveStats.scala.html
@@ -1,5 +1,6 @@
 @(charts: Seq[tools.Chart], env: String)
 
+<!DOCTYPE html>
 <html>
   <head>
         <meta http-equiv="refresh" content="60">
@@ -16,8 +17,7 @@
                 display: table;
                 width: 50%;
                 float: left;
-                min-height: 100%;
-                max-height: 100%;
+                min-height: 100vh;
                 font-size: 100px;
             }
             .display span {

--- a/admin/app/views/liveStats.scala.html
+++ b/admin/app/views/liveStats.scala.html
@@ -31,16 +31,17 @@
                 font-size: 30px;
                 text-align: center;
                 width: 50%;
+                font-weight: normal;
             }
             .desktop {
-                background-color: black;
+                background-color: #FF1493;
                 color: white;
                 text-shadow: 1px 1px #ccc;
             } 
             .responsive {
-                background-color: white;
+                background-color: #40E0D0;
                 color: black;
-                text-shadow: 1px 1px #ccc;
+                text-shadow: 1px 1px #666;
             }
         </style>
   </head>

--- a/admin/app/views/liveStats.scala.html
+++ b/admin/app/views/liveStats.scala.html
@@ -1,0 +1,63 @@
+@(charts: Seq[tools.Chart], env: String)
+
+<html>
+  <head>
+        <meta http-equiv="refresh" content="60">
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>theguardian.com livestats</title>
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+                font-family: Georgia, serif;
+            }
+            .display {
+                display: table;
+                width: 50%;
+                float: left;
+                min-height: 100%;
+                max-height: 100%;
+                font-size: 100px;
+            }
+            .display span {
+                display: table-cell;
+                vertical-align: middle;
+                text-align: center;
+            }
+            .display h2 {
+                position: absolute;
+                top: 10px;
+                font-size: 30px;
+                text-align: center;
+                width: 50%;
+            }
+            .desktop {
+                background-color: black;
+                color: white;
+                text-shadow: 1px 1px #ccc;
+            } 
+            .responsive {
+                background-color: white;
+                color: black;
+                text-shadow: 1px 1px #ccc;
+            }
+        </style>
+  </head>
+  <body>
+        <div class="display desktop">
+            <h2>desktop</h2>
+            <span>-</span>
+        </div>
+        <div class="display responsive">
+            <h2>responsive</h2>
+            <span>
+                @charts.map{ chart =>
+                    @{"%.2f".format(chart.dataset.last.values.head)}
+                }
+            </span>
+        </div>
+
+
+  </body>
+</html>

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -51,6 +51,7 @@ GET           /metrics/fastly                  controllers.admin.FastlyControlle
 GET           /radiator                        controllers.admin.RadiatorController.renderRadiator()
 GET           /radiator/pingdom                controllers.admin.RadiatorController.pingdom()
 GET           /radiator/commit/*hash           controllers.admin.RadiatorController.commitDetail(hash)
+GET           /radiator/livestats              controllers.admin.RadiatorController.liveStats()
 
 # Football Troubleshooter
 GET           /troubleshoot/football           controllers.admin.FootballTroubleshooterController.renderFootballTroubleshooter()


### PR DESCRIPTION
Some big stupid numbers we can all coo at during the alpha testing. We'll put this up on the spare iMac.

_Views over sessions_ is the ratio of users arriving with new sessions to the number of page views over the course of 60 seconds. It approximates page views p/visitor. The higher, the better.

![desktop-vs-responsive](https://f.cloud.github.com/assets/84996/1487586/c028b108-4736-11e3-8f6c-cb99f5687495.png)

Hopefully @kaelig won't pick too much at the CSS as it's temporary :astonished: 
