### PR TITLE
sessionStorage

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -227,7 +227,7 @@ define([
 
                         var viewData = {};
 
-                        var audsci = storage.get('gu.ads.audsci');
+                        var audsci = storage.local.get('gu.ads.audsci');
                         if (audsci) {
                             viewData.audsci_json = JSON.stringify(audsci);
                         }

--- a/common/app/assets/javascripts/modules/adverts/audience-science.js
+++ b/common/app/assets/javascripts/modules/adverts/audience-science.js
@@ -3,7 +3,7 @@ define(['modules/cookies', 'modules/storage'], function(Cookies, storage) {
     var revenueScienceUrl = "js!http://js.revsci.net/gateway/gw.js?csid=E05516";
 
     function getSegments() {
-        var segments = storage.get("gu.ads.audsci");
+        var segments = storage.local.get("gu.ads.audsci");
         return (segments) ? segments : [];
     }
 
@@ -22,7 +22,7 @@ define(['modules/cookies', 'modules/storage'], function(Cookies, storage) {
             }
         };
         window.DM_onSegsAvailable = function(segments, id) {
-            storage.set("gu.ads.audsci", processSegments(segments));
+            storage.local.set("gu.ads.audsci", processSegments(segments));
             // Kill any legacy cookies
             Cookies.cleanUp(["rsi_segs"]);
         };

--- a/common/app/assets/javascripts/modules/adverts/userAdTargeting.js
+++ b/common/app/assets/javascripts/modules/adverts/userAdTargeting.js
@@ -2,15 +2,15 @@ define(['modules/storage', 'modules/id', 'modules/time' ], function(storage, id,
     var userSegmentsKey = "gu.ads.userSegmentsData";
 
     function getUserSegments() {
-        if(storage.isAvailable()) {
-            var userSegmentsData = storage.get(userSegmentsKey);
+        if(storage.local.isAvailable()) {
+            var userSegmentsData = storage.local.get(userSegmentsKey);
             var userCookieData = id.getUserFromCookie();
 
             if(userSegmentsData) {
                 if( userCookieData && ( userSegmentsData.userHash === ( userCookieData.id % 9999 ) ) ) {
                     return userSegmentsData.segments;
                 } else {
-                    storage.remove(userSegmentsKey);
+                    storage.local.remove(userSegmentsKey);
                 }
             }
         }
@@ -19,7 +19,7 @@ define(['modules/storage', 'modules/id', 'modules/time' ], function(storage, id,
     }
 
     function requestUserSegmentsFromId() {
-        if(storage.isAvailable() && (storage.get(userSegmentsKey) === null)) {
+        if(storage.local.isAvailable() && (storage.local.get(userSegmentsKey) === null)) {
             if(id.getUserFromCookie()) {
                 id.getUserFromApi(
                     function(user) {
@@ -28,7 +28,7 @@ define(['modules/storage', 'modules/id', 'modules/time' ], function(storage, id,
                             for(var key in user.adData) {
                                 userSegments.push(key + user.adData[key]);
                             }
-                            storage.set(
+                            storage.local.set(
                                 userSegmentsKey,
                                 {
                                     'segments' : userSegments,

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -57,7 +57,7 @@ define([
                     tag: spec.tag,
                     time: new Date().getTime()
                 };
-                storage.set(storagePrefix + 'referrerVars', storeObj);
+                storage.session.set(storagePrefix + 'referrerVars', storeObj);
             } else {
                 that.populateEventProperties(spec.tag);
                 // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
@@ -174,7 +174,7 @@ define([
             }
 
             /* Retrieve navigation interaction data, incl. swipe */
-            var ni = storage.get('gu.analytics.referrerVars');
+            var ni = storage.session.get('gu.analytics.referrerVars');
             if (ni) {
                 var d = new Date().getTime();
                 if (d - ni.time < 60 * 1000) { // One minute
@@ -182,7 +182,7 @@ define([
                     s.eVar37 = ni.tag;
                     s.events   = 'event37';
                 }
-                storage.remove('gu.analytics.referrerVars');
+                storage.session.remove('gu.analytics.referrerVars');
             } else if (config.swipe) {
                 s.referrer = config.swipe.referrer;
                 s.eVar24   = config.swipe.referrerPageName;

--- a/common/app/assets/javascripts/modules/commercial/commercial-components.js
+++ b/common/app/assets/javascripts/modules/commercial/commercial-components.js
@@ -18,7 +18,7 @@ define([
         this.options        = common.extend(this.DEFAULTS, options);
         this.keywords       = this.options.config.page.keywords.split(',');
         this.keywordsParams = documentWrite.getKeywords(this.options.config.page);
-        this.userSegments   = 'seg=' + (storage.get('gu.history').length <= 1 ? 'new' : 'repeat');
+        this.userSegments   = 'seg=' + (storage.local.get('gu.history').length <= 1 ? 'new' : 'repeat');
     };
 
 

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -26,7 +26,7 @@ define([
         participationsKey = 'gu.ab.participations';
 
     function getParticipations() {
-        return store.get(participationsKey) || {};
+        return store.local.get(participationsKey) || {};
     }
 
     function isParticipating(test) {
@@ -39,17 +39,17 @@ define([
         participations[test.id] = {
             variant: variantId
         };
-        store.set(participationsKey, participations);
+        store.local.set(participationsKey, participations);
     }
 
     function removeParticipation(test) {
         var participations = getParticipations();
         delete participations[test.id];
-        store.set(participationsKey, participations);
+        store.local.set(participationsKey, participations);
     }
 
     function clearParticipations() {
-        return store.remove(participationsKey);
+        return store.local.remove(participationsKey);
     }
 
     function getActiveTests() {

--- a/common/app/assets/javascripts/modules/fonts.js
+++ b/common/app/assets/javascripts/modules/fonts.js
@@ -42,7 +42,7 @@ define(['ajax', 'common', 'modules/storage'], function (ajax, common, storage) {
                                 var nameAndCacheKey = getNameAndCacheKey(style);
 
                                 that.clearFont(nameAndCacheKey[0]);
-                                storage.set(storagePrefix + nameAndCacheKey[0] + '.' + nameAndCacheKey[1], json.css);
+                                storage.local.set(storagePrefix + nameAndCacheKey[0] + '.' + nameAndCacheKey[1], json.css);
                                 common.mediator.emit('modules:fonts:loaded', [json.name]);
                             };
                         }(style))
@@ -61,11 +61,11 @@ define(['ajax', 'common', 'modules/storage'], function (ajax, common, storage) {
         };
 
         this.clearFont = function(name) {
-            storage.clearByPrefix(storagePrefix + name);
+            storage.local.clearByPrefix(storagePrefix + name);
         };
 
         this.clearAllFontsFromStorage = function() {
-            storage.clearByPrefix(storagePrefix);
+            storage.local.clearByPrefix(storagePrefix);
         };
 
         function getNameAndCacheKey(style) {
@@ -77,9 +77,9 @@ define(['ajax', 'common', 'modules/storage'], function (ajax, common, storage) {
         function fontIsRequired(style) {
             // A final check for storage (is it full, disabled, any other error).
             // Because it would be horrible if people downloaded fonts and then couldn't cache them.
-            if (storage.isAvailable()) {
+            if (storage.local.isAvailable()) {
                 var nameAndCacheKey =  getNameAndCacheKey(style);
-                var cachedValue = storage.get(storagePrefix + nameAndCacheKey[0] + '.' + nameAndCacheKey[1]);
+                var cachedValue = storage.local.get(storagePrefix + nameAndCacheKey[0] + '.' + nameAndCacheKey[1]);
 
                 var widthMatches = true;
                 var minWidth = style.getAttribute('data-min-width');

--- a/common/app/assets/javascripts/modules/onward/history.js
+++ b/common/app/assets/javascripts/modules/onward/history.js
@@ -28,11 +28,11 @@ define([
     };
 
     History.prototype.set = function(data) {
-        return storage.set(this.config.storageKey, data);
+        return storage.local.set(this.config.storageKey, data);
     };
 
     History.prototype.get = function() {
-        var hist = storage.get(this.config.storageKey);
+        var hist = storage.local.get(this.config.storageKey);
         return (hist === null) ? [] : hist;
     };
 

--- a/common/app/assets/javascripts/modules/onward/sequence.js
+++ b/common/app/assets/javascripts/modules/onward/sequence.js
@@ -15,6 +15,7 @@ define([
     ){
 
     var context,
+        store = storage.session,
         sequence = [],
         prefixes = {
             context: 'gu.context',
@@ -22,17 +23,17 @@ define([
         };
 
     function set(type, item) {
-        storage.set(prefixes[type], item);
+        store.set(prefixes[type], item);
         mediator.emit('modules:sequence:'+ type +':loaded', item);
     }
 
     function get(type) {
-        return storage.get(prefixes[type]);
+        return store.get(prefixes[type]);
     }
 
     function getSequence() { return get('sequence'); }
     function getContext() { return get('context'); }
-    function removeContext() { return storage.remove(prefixes.context); }
+    function removeContext() { return store.remove(prefixes.context); }
 
     function dedupeSequence(sequence) {
         return _difference(sequence, new History({}).get().map(function(i){

--- a/common/app/assets/javascripts/modules/storage.js
+++ b/common/app/assets/javascripts/modules/storage.js
@@ -6,98 +6,101 @@ define(['utils/mediator'], function (mediator) {
     
     var w = window;
     
-    var storage = {
-            
-        _setWindow: function(window) {
-            w = window;
-        },
-            
-        isAvailable: function(data) {
-            var testKey = 'local-storage-module-test',
-                d = data || 'test';
-            try {
-                // to fully test, need to set item
-                // http://stackoverflow.com/questions/9077101/iphone-localstorage-quota-exceeded-err-issue#answer-12976988
-                w.localStorage.setItem(testKey, d);
-                w.localStorage.removeItem(testKey);
-                return true;
-            } catch (e) {
-                mediator.emit('module:error', 'Unable to save to local storage: ' + e.message, 'modules/storage.js');
-                return false;
-            }
-        },
-        
-        /**
-         * @param {String}  key
-         * @param {Any}     data
-         * @param {Object} [options]
-         *     {Date} expires - When should the storage expire
-         */
-        set: function(key, data, options) {
-            var opts = options || {},
-                value = JSON.stringify({
-                    'value': data,
-                    'expires': opts.expires
-                });
-            if (!storage.isAvailable(value)) {
-                return false;
-            }
-            return w.localStorage.setItem(key, value);
-        },
-        
-        get: function(key) {
-            var data = w.localStorage.getItem(key);
-            if (data === null) {
-                return null;
-            }
-            
-            // try and parse the data
-            var dataParsed;
-            try{
-                dataParsed = JSON.parse(data);
-            } catch (e) {
-                // remove the key
-                storage.remove(key);
-                return null;
-            }
-            
-            // has it expired?
-            if (dataParsed.expires && new Date() > new Date(dataParsed.expires)) {
-                storage.remove(key);
-                return null;
-            }
-
-            return dataParsed.value;
-        },
-        
-        remove: function(key) {
-            return w.localStorage.removeItem(key);
-        },
-        
-        removeAll: function() {
-            return w.localStorage.clear();
-        },
-        
-        length: function() {
-            return w.localStorage.length;
-        },
-        
-        getKey: function(i) {
-            return w.localStorage.key(i);
-        },
-
-        clearByPrefix: function(prefix) {
-            // Loop in reverse because storage indexes will change as you delete items.
-            for (var i = storage.length() - 1; i > -1; --i) {
-                var name = storage.getKey(i);
-                if (name.indexOf(prefix) === 0) {
-                    storage.remove(name);
-                }
-            }
-        }
-            
+    var Storage = function(type) {
+        this.type = type;
     };
     
-    return storage;
+    Storage.prototype.setWindow = function(window) {
+        w = window;
+    };
+            
+    Storage.prototype.isAvailable = function(data) {
+        var testKey = 'local-storage-module-test',
+            d = data || 'test';
+        try {
+            // to fully test, need to set item
+            // http://stackoverflow.com/questions/9077101/iphone-localstorage-quota-exceeded-err-issue#answer-12976988
+            w[this.type].setItem(testKey, d);
+            w[this.type].removeItem(testKey);
+            return true;
+        } catch (e) {
+            mediator.emit('module:error', 'Unable to save to local storage: ' + e.message, 'modules/storage.js');
+            return false;
+        }
+    };
+    
+    /**
+     * @param {String}  key
+     * @param {Any}     data
+     * @param {Object} [options]
+     *     {Date} expires - When should the storage expire
+     */
+    Storage.prototype.set = function(key, data, options) {
+        var opts = options || {},
+            value = JSON.stringify({
+                'value': data,
+                'expires': opts.expires
+            });
+        if (!this.isAvailable(value)) {
+            return false;
+        }
+        return w[this.type].setItem(key, value);
+    };
+        
+    Storage.prototype.get = function(key) {
+        var data = w[this.type].getItem(key);
+        if (data === null) {
+            return null;
+        }
+        
+        // try and parse the data
+        var dataParsed;
+        try{
+            dataParsed = JSON.parse(data);
+        } catch (e) {
+            // remove the key
+            this.remove(key);
+            return null;
+        }
+        
+        // has it expired?
+        if (dataParsed.expires && new Date() > new Date(dataParsed.expires)) {
+            this.remove(key);
+            return null;
+        }
+
+        return dataParsed.value;
+    };
+        
+    Storage.prototype.remove = function(key) {
+        return w[this.type].removeItem(key);
+    };
+        
+    Storage.prototype.removeAll = function() {
+        return w[this.type].clear();
+    };
+    
+    Storage.prototype.length = function() {
+        return w[this.type].length;
+    };
+    
+    Storage.prototype.getKey = function(i) {
+        return w[this.type].key(i);
+    };
+
+    Storage.prototype.clearByPrefix = function(prefix) {
+        // Loop in reverse because storage indexes will change as you delete items.
+        for (var i = this.length() - 1; i > -1; --i) {
+            var name = this.getKey(i);
+            if (name.indexOf(prefix) === 0) {
+                this.remove(name);
+            }
+        }
+    };
+    
+    return {
+        local: new Storage('localStorage'),
+        session: new Storage('sessionStorage')
+    };
 
 });

--- a/common/app/assets/javascripts/modules/swipe/swipenav.js
+++ b/common/app/assets/javascripts/modules/swipe/swipenav.js
@@ -236,10 +236,10 @@ define([
             // data-link-context was from a click within this app
             linkContext = undefined;
         } else {
-            sequenceUrl = storage.get(storePrefix + 'linkContext');
+            sequenceUrl = storage.session.get(storePrefix + 'linkContext');
             if (sequenceUrl) {
                 // data-link-context was set by a click on a previous page
-                storage.remove(storePrefix + 'linkContext');
+                storage.session.remove(storePrefix + 'linkContext');
             } else {
                 // No data-link-context, so infer the section/tag component from the url,
                 if("page" in config) {
@@ -508,7 +508,7 @@ define([
                     }
 
                 } else if (clickSpec.linkContext) {
-                    storage.set(storePrefix + 'linkContext', clickSpec.linkContext, {
+                    storage.session.set(storePrefix + 'linkContext', clickSpec.linkContext, {
                         expires: 10000 + (new Date()).getTime()
                     });
                 }

--- a/common/app/assets/javascripts/modules/userPrefs.js
+++ b/common/app/assets/javascripts/modules/userPrefs.js
@@ -1,7 +1,7 @@
 define(['modules/storage'], function(storage) {
 
     var storagePrefix = 'gu.prefs.',
-        store = storage;
+        store = storage.local;
 
     function set(name, value) {
         store.set(storagePrefix + name, value);

--- a/common/test/assets/javascripts/spec/Omniture.spec.js
+++ b/common/test/assets/javascripts/spec/Omniture.spec.js
@@ -20,7 +20,7 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
         });
 
         afterEach(function(){
-            localStorage.removeItem('gu.analytics.referrerVars')
+            sessionStorage.removeItem('gu.analytics.referrerVars')
         });
 
         it("should correctly set the Omniture account", function(){
@@ -186,7 +186,7 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
             o.go(config);
             runs(function() {
                 common.mediator.emit('module:clickstream:click', clickSpec);
-                expect(JSON.parse(localStorage.getItem('gu.analytics.referrerVars')).value.tag).toEqual('tag in localstorage')
+                expect(JSON.parse(sessionStorage.getItem('gu.analytics.referrerVars')).value.tag).toEqual('tag in localstorage')
             });
 
         });

--- a/common/test/assets/javascripts/spec/Sequence.spec.js
+++ b/common/test/assets/javascripts/spec/Sequence.spec.js
@@ -1,4 +1,4 @@
-define(['common', 'ajax', 'modules/onward/sequence'], function(common, ajax, sequence) {
+define(['utils/mediator', 'ajax', 'modules/onward/sequence'], function(mediator, ajax, sequence) {
 
     describe("Sequence", function() {
         var sequenceLoadedCallback,
@@ -12,8 +12,8 @@ define(['common', 'ajax', 'modules/onward/sequence'], function(common, ajax, seq
                 ]
             });
 
-        var setStorageItem = function(key, item) {
-            window.localStorage.setItem('gu.' + key, JSON.stringify({
+        var setStorageItem = function(key, item, type) {
+            window[type].setItem('gu.' + key, JSON.stringify({
                 'value' : item
             }));
         };
@@ -24,20 +24,21 @@ define(['common', 'ajax', 'modules/onward/sequence'], function(common, ajax, seq
                 edition: "UK"
             }});
             sequenceLoadedCallback = sinon.stub();
-            common.mediator.on('modules:sequence:sequence:loaded', sequenceLoadedCallback);
+            mediator.on('modules:sequence:sequence:loaded', sequenceLoadedCallback);
+            mediator.on('modules:sequence:sequence:loaded', function() { console.log(Array.prototype.slice.call(arguments)); });
             //Set up fake server
             server = sinon.fakeServer.create();
             server.autoRespond = true;
             server.autoRespondAfter = 20;
             server.respondWith('/world.json?_edition=UK', [200, {}, response]);
             //Set up storage
-            setStorageItem('context', 'world');
-            setStorageItem('history', [{"id":"/p/3k43n"}]);
+            setStorageItem('context', 'world', 'sessionStorage');
+            setStorageItem('history', [{"id":"/p/3k43n"}], 'localStorage');
         });
 
         afterEach(function () {
             server.restore();
-            window.localStorage.removeItem('gu.context');
+            window.sessionStorage.removeItem('gu.context');
             window.localStorage.removeItem('gu.sequence');
         });
 

--- a/common/test/assets/javascripts/spec/Storage.spec.js
+++ b/common/test/assets/javascripts/spec/Storage.spec.js
@@ -1,4 +1,4 @@
-define(['common', 'modules/storage'], function(common, storage) {
+define(['utils/mediator', 'modules/storage'], function(mediator, storage) {
 
     describe('Storage', function() {
 
@@ -10,7 +10,7 @@ define(['common', 'modules/storage'], function(common, storage) {
         };
 
         beforeEach(function() {
-            sinon.spy(common.mediator, 'emit');
+            sinon.spy(mediator, 'emit');
            date = new Date;
         });
 
@@ -21,30 +21,30 @@ define(['common', 'modules/storage'], function(common, storage) {
                     window.localStorage[prop].restore();
                 }
             }
-            storage._setWindow(window);
-            common.mediator.emit.restore();
+            storage.local.setWindow(window);
+            mediator.emit.restore();
         });
-        
+
         function setWindowLocalStorage(winLocalStorage) {
-            storage._setWindow({localStorage: winLocalStorage})
+            storage.local.setWindow({localStorage: winLocalStorage})
         }
-        
+
         function testSetAndGet(key, data, dataAsString) {
             setWindowLocalStorage({
                 setItem: sinon.stub().withArgs(key, dataAsString).returns(true),
                 getItem: sinon.stub().withArgs(key).returns(dataAsString),
                 removeItem: sinon.stub().withArgs(dataAsString)
             });
-            expect(storage.set(key, data)).toBeTruthy();
-            expect(storage.get(key)).toEqual(data);
+            expect(storage.local.set(key, data)).toBeTruthy();
+            expect(storage.local.get(key)).toEqual(data);
         }
 
         it('shouldn\'t be available if can\'t set data', function() {
             setWindowLocalStorage({
                 setItem: sinon.stub().throws()
             });
-            expect(storage.isAvailable()).toBeFalsy();
-            expect(common.mediator.emit).toHaveBeenCalledWith('module:error', 'Unable to save to local storage: Error', 'modules/storage.js');
+            expect(storage.local.isAvailable()).toBeFalsy();
+            expect(mediator.emit).toHaveBeenCalledWith('module:error', 'Unable to save to local storage: Error', 'modules/storage.js');
         });
 
         it('should save and retrieve data', function() {
@@ -52,9 +52,9 @@ define(['common', 'modules/storage'], function(common, storage) {
         });
 
         it('should not save if local storage unavailavble', function() {
-            sinon.stub(storage, 'isAvailable').returns(false);
-            expect(storage.set('foo', 'bar')).toBeFalsy();
-            storage.isAvailable.restore();
+            sinon.stub(storage.local, 'isAvailable').returns(false);
+            expect(storage.local.set('foo', 'bar')).toBeFalsy();
+            storage.local.isAvailable.restore();
         });
 
         it('should be able to remove item', function() {
@@ -62,35 +62,35 @@ define(['common', 'modules/storage'], function(common, storage) {
             setWindowLocalStorage({
                 removeItem: sinon.stub().withArgs(key).returns(true)
             });
-            expect(storage.remove(key)).toBeTruthy();
+            expect(storage.local.remove(key)).toBeTruthy();
         });
 
         it('should be able to clear data', function() {
             setWindowLocalStorage({
                 clear: sinon.stub().returns(true)
             });
-            expect(storage.removeAll()).toBeTruthy();
+            expect(storage.local.removeAll()).toBeTruthy();
         });
 
         it('should return if key not set', function() {
             setWindowLocalStorage({
                 getItem: sinon.stub().returns(null)
             });
-            expect(storage.get('foo')).toBe(null);
+            expect(storage.local.get('foo')).toBe(null);
         });
 
         it('should return number of items in storage', function() {
-            storage.removeAll();
-            storage.set('foo',' bar');
-            expect(storage.length()).toBe(1);
-            storage.set('foo2',' bar2');
-            expect(storage.length()).toBe(2);
+            storage.local.removeAll();
+            storage.local.set('foo',' bar');
+            expect(storage.local.length()).toBe(1);
+            storage.local.set('foo2',' bar2');
+            expect(storage.local.length()).toBe(2);
         });
 
         it('should return item by index', function() {
-            storage.removeAll();
-            storage.set('foo',' bar');
-            expect(storage.getKey(0)).toBe('foo');
+            storage.local.removeAll();
+            storage.local.set('foo',' bar');
+            expect(storage.local.getKey(0)).toBe('foo');
         });
 
         it('should handle migrating non-stringified data', function() {
@@ -98,9 +98,9 @@ define(['common', 'modules/storage'], function(common, storage) {
                 getItem: sinon.stub().withArgs('foo').returns('bar|string'),
                 removeItem: sinon.stub().withArgs('foo')
             });
-            expect(storage.get('foo')).toBeNull();
+            expect(storage.local.get('foo')).toBeNull();
         });
-        
+
         describe('Expiration', function() {
 
             it('should delete if expired', function() {
@@ -116,10 +116,10 @@ define(['common', 'modules/storage'], function(common, storage) {
                     removeItem: removeItemSpy
                 });
 
-                storage.set(key, value, {expires: expires});
+                storage.local.set(key, value, {expires: expires});
 
                 // expectations
-                expect(storage.get(key)).toBeNull();
+                expect(storage.local.get(key)).toBeNull();
                 expect(setItemSpy).toHaveBeenCalledWith(key, storedData);
                 expect(removeItemSpy).toHaveBeenCalledWith(key);
             });
@@ -134,10 +134,10 @@ define(['common', 'modules/storage'], function(common, storage) {
                     removeItem: removeItemSpy
                 });
 
-                storage.set(key, value, {expires: expires});
+                storage.local.set(key, value, {expires: expires});
 
                 // expectations
-                expect(storage.get(key)).toBe(value);
+                expect(storage.local.get(key)).toBe(value);
                 expect(removeItemSpy).not.toHaveBeenCalledWith(key);
             });
 


### PR DESCRIPTION
As discussed with @jamesgorrie and @stephanfowler this refactors our `storage.js` module to also abstract the sessionStorage api. 

storage.js is now a singleton object which contains two instances of the Storage class, one for session and one for local. The api of the class remains the same. 
### Example

``` JavaScript
define(['storage'], function(storage) {

    var foo = 'bar';

    //Set the key 'foo' in localStorage
    storage.local.set('foo', foo);

   //get the key bar  from sessionStorage
    storage.session.get(foo);

});
```
