### PR TITLE
Removes Orphaned A/B tests from localStorage

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -52,6 +52,17 @@ define([
         return store.remove(participationsKey);
     }
 
+    function cleanParticipations(config) {
+        // Removes any tests from localstorage that have been
+        // renamed/deleted from the backend
+        var participations = getParticipations();
+        Object.keys(participations).forEach(function (k) {
+            if (typeof(config.switches['ab' + k]) === 'undefined') {
+                removeParticipation({ id: k });
+            }
+        });
+    }
+
     function getActiveTests() {
         return TESTS.filter(function(test) {
             var expired = (new Date() - new Date(test.expiry)) > 0;
@@ -159,6 +170,8 @@ define([
 
         run: function(config, context, options) {
             var opts = options || {};
+
+            cleanParticipations(config);
 
             getActiveTests().forEach(function(test) {
                 run(test, config, context);

--- a/common/test/assets/javascripts/spec/Ab.spec.js
+++ b/common/test/assets/javascripts/spec/Ab.spec.js
@@ -110,6 +110,12 @@ define(['modules/experiments/ab', 'fixtures/ab-test'], function(ab, ABTest) {
                 expect(localStorage.getItem(participationsKey)).toBe('{"value":{"DummyTest2":{"variant":"foo"}}}');
             });
 
+            it('should remove participation from tests that have been removed/renamed', function () {
+                localStorage.setItem(participationsKey, '{ "value": { "DummyTest": { "variant": "foo" }, "DummyTestDeleted": { "variant": "bar" } } }');
+                ab.run(switches.test_one_on);
+                expect(localStorage.getItem(participationsKey)).toBe('{"value":{"DummyTest":{"variant":"foo"}}}');
+            })
+
             it('should allow the forcing of users in to a given test and variant', function () {
                 ab.forceSegment('DummyTest', 'bar');
                 expect(getItem('DummyTest').variant).toBe('bar');


### PR DESCRIPTION
Fixes JS error "**Cannot read property 'expiry' of undefined**" caused by tests that have been renamed/removed, but are still in the client's localStorage.

Can cause Omniture not to fire when **makeOmnitureTag()** gets called.
