### PR TITLE
Fix position of football fixtures 'show more' button

### DIFF
--- a/common/app/assets/javascripts/modules/expandable.js
+++ b/common/app/assets/javascripts/modules/expandable.js
@@ -4,16 +4,19 @@
 */
 define([
     'common',
-    'bean'
+    'bean',
+    'bonzo'
 ], function (
     common,
-    bean
+    bean,
+    bonzo
 ) {
     /*
         @param {Object} options hash of configuration options:
-            dom         : DOM element to convert
-            expanded    : {Boolean} Whether the component should init in an expanded state
-            showCount   : {Boolean} Whether to display the count in the CTA
+            dom           : DOM element to convert
+            expanded      : {Boolean} Whether the component should init in an expanded state
+            showCount     : {Boolean} Whether to display the count in the CTA
+            buttonAfterEl : {Element} Element to add the button after (defaults to last child of dom)
     */
     var Expandable = function (options) {
 
@@ -27,9 +30,9 @@ define([
             showCount = (opts.showCount === false) ? false : true;
 
         // View
-        
+
         var view = {
-           
+
             updateCallToAction: function () {
                 var text = 'Show ';
                 if (showCount) {
@@ -40,7 +43,7 @@ define([
                 cta.setAttribute('data-link-name', 'Show ' + ((expanded) ? 'more' : 'fewer'));
                 cta.setAttribute('data-is-ajax', '1');
             },
-            
+
             renderState: function () {
                 if(expanded) {
                     dom.removeClass('shut');
@@ -48,13 +51,17 @@ define([
                     dom.addClass('shut');
                 }
             },
-            
+
             renderCallToAction: function () {
                 bean.add(cta, 'click', function (e) {
                     model.toggleExpanded();
                 });
                 cta.className = 'cta';
-                dom[0].appendChild(cta);
+                if (opts.buttonAfterEl) {
+                    bonzo(opts.buttonAfterEl).after(cta);
+                } else {
+                    dom[0].appendChild(cta);
+                }
                 view.updateCallToAction();
             },
 
@@ -67,11 +74,11 @@ define([
                 }
             }
         };
-        
+
         // Model
 
         var model = {
-        
+
             toggleExpanded: function () {
                 expanded = (expanded) ? false : true;
                 view.renderState();
@@ -103,6 +110,6 @@ define([
     };
 
     return Expandable;
-   
+
 });
 

--- a/common/app/assets/javascripts/modules/footballfixtures.js
+++ b/common/app/assets/javascripts/modules/footballfixtures.js
@@ -39,6 +39,7 @@ define([
                 if(options.expandable) {
                     var expandable = new Expandable({
                         dom: '.front-competition-fixtures',
+                        buttonAfterEl: document.querySelector('.front-competition-fixtures .panel'),
                         expanded: false
                     });
                     expandable.init();

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -195,8 +195,14 @@
             border-style: none;
             border-top: 2px solid $c-newsAccent;
         }
+        .matches {
+            margin-bottom: 0;
+        }
         .match-desc__result {
             width: 20%;
+        }
+        .cta {
+            margin-bottom: 0;
         }
         .cta-small {
             padding-bottom: 0;


### PR DESCRIPTION
Move it above the link, below the table

![fixtures-button-2](https://f.cloud.github.com/assets/74132/1493174/3d6189cc-47ca-11e3-92eb-df9a4ec93d88.jpg)
