### PR TITLE
Refactored 'row-start' mixin

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_comment.scss
+++ b/common/app/assets/stylesheets/module/containers/_comment.scss
@@ -55,11 +55,9 @@
                 @include fs-header(4, $size-only: true);
             }
         }
-        .item:nth-child(3n+2) {
-            @include row-start;
-        }
     }
     @include mq(desktop) {
+        @include first-row(3);
         .item:first-child {
             @include card-double-width;
         }
@@ -69,10 +67,6 @@
         .item:nth-child(2),
         .item:nth-child(3) {
             @include card-image;
-        }
-        @include first-row(3);
-        .item:nth-child(4n+6) {
-            @include row-start;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/containers/_comment.scss
+++ b/common/app/assets/stylesheets/module/containers/_comment.scss
@@ -35,16 +35,17 @@
             }
         }
     }
-    @include mq(tablet, desktop) {
-        .item:first-child {
-            @include card-full-width;
-        }
+    @include mq(tablet) {
         .item:nth-child(n+2) {
             @include card;
         }
-        .item:nth-child(2),
-        .item:nth-child(4) {
+        .item:nth-child(2) {
             @include card-image;
+        }
+    }
+    @include mq(tablet, desktop) {
+        .item:first-child {
+            @include card-full-width;
         }
         .item:nth-child(3) {
             min-height: gs-height(6) - $metaHeight;
@@ -55,16 +56,15 @@
                 @include fs-header(4, $size-only: true);
             }
         }
+        .item:nth-child(4) {
+            @include card-image;
+        }
     }
     @include mq(desktop) {
         @include first-row(3);
         .item:first-child {
             @include card-double-width;
         }
-        .item:nth-child(n+2) {
-            @include card;
-        }
-        .item:nth-child(2),
         .item:nth-child(3) {
             @include card-image;
         }

--- a/common/app/assets/stylesheets/module/containers/_features.scss
+++ b/common/app/assets/stylesheets/module/containers/_features.scss
@@ -8,9 +8,6 @@
         .item:nth-child(3) {
             @include card-half-width($with-image: true);
         }
-        .item:nth-child(2) {
-            @include row-start;
-        }
         .item:nth-child(n+4) {
             @include card-headline;
         }
@@ -30,10 +27,6 @@
         .item:nth-child(n+2):nth-child(-n+4)  {
             @include card-image;
         }
-        @include first-row(1);
-        .item:nth-child(3n+2) {
-            @include row-start;
-        }
     }
     @include mq(desktop) {
         .item:first-child {
@@ -45,10 +38,6 @@
         .item:nth-child(2),
         .item:nth-child(3) {
             @include card-image;
-        }
-        @include first-row(2);
-        .item:nth-child(4n+4) {
-            @include row-start;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/containers/_features.scss
+++ b/common/app/assets/stylesheets/module/containers/_features.scss
@@ -17,27 +17,27 @@
             }
         }
     }
-    @include mq(tablet, desktop) {
-        .item:first-child {
-            @include card-full-width-feature;
-        }
-        .item:nth-child(n+2) {
-            @include card;
-        }
-        .item:nth-child(n+2):nth-child(-n+4)  {
-            @include card-image;
-        }
-    }
-    @include mq(desktop) {
-        .item:first-child {
-            @include card-triple-width;
-        }
+    @include mq(tablet) {
         .item:nth-child(n+2) {
             @include card;
         }
         .item:nth-child(2),
         .item:nth-child(3) {
             @include card-image;
+        }
+    }
+    @include mq(tablet, desktop) {
+        .item:first-child {
+            @include card-full-width-feature;
+        }
+        .item:nth-child(4)  {
+            @include card-image;
+        }
+    }
+    @include mq(desktop) {
+        @include first-row(2);
+        .item:first-child {
+            @include card-triple-width;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -93,7 +93,7 @@
     }
     .competition-table {
         padding-top: 0;
-        border-style: none;
+        border-bottom-style: none;
         border-top: 2px solid $c-newsAccent;
     }
     @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -20,10 +20,6 @@
                     border-top: 1px dotted $c-neutral5;
                 }
             }
-            .item:nth-child(2),
-            .item:nth-child(4) {
-                @include row-start;
-            }
         }
         .collection--with-sport-stats {
             .item:nth-child(n+3):nth-child(-n+6) {
@@ -41,10 +37,6 @@
                     border-top: 1px dotted $c-neutral5;
                 }
             }
-            .item:nth-child(3),
-            .item:nth-child(5) {
-                @include row-start;
-            }
         }
     }
     @include mq(tablet) {
@@ -53,10 +45,6 @@
         }
         &:nth-of-type(even) .item:first-child {
             float: right;
-
-            &:before {
-                display: block !important;
-            }
         }
         .item:nth-child(n+2) {
             @include card;
@@ -75,88 +63,21 @@
                 @include card-image;
             }
         }
-        &:nth-of-type(odd) {
-            .collection--without-sport-stats {
-                .item:nth-child(3n+1) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(3n+3) {
-                    @include row-start;
-                }
-            }
-        }
-        &:nth-of-type(even) {
-            .collection--without-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(3),
-                .item:nth-child(3n+4) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(3n+3) {
-                    @include row-start;
-                }
-            }
-        }
     }
     @include mq(desktop) {
         @include first-row(3);
+        .item:nth-child(3) {
+            @include card-image;
+        }
         .collection--without-sport-stats {
-            .item:nth-child(2),
-            .item:nth-child(3) {
+            .item:nth-child(2) {
                 @include card-image;
-            }
-        }
-        .collection--with-sport-stats {
-            .item:nth-child(3) {
-                @include card-image;
-            }
-        }
-        &:nth-of-type(odd) {
-            .collection--without-sport-stats {
-                .item:nth-child(4n+6) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(4n+5) {
-                    @include row-start;
-                }
-            }
-        }
-        &:nth-of-type(even) {
-            .collection--without-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(4),
-                .item:nth-child(4n+6) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(4n+5) {
-                    @include row-start;
-                }
             }
         }
     }
 
     .item--sport-stats {
         padding-bottom: 0 !important;
-        @include mq($to: tablet) {
-            width: 100% !important;
-            padding-left: 0 !important;
-            border-left-style: none !important;
-        }
-        .competition-table {
-            padding-top: 0;
-            border-style: none;
-            border-top: 2px solid $c-newsAccent;
-        }
         .match-desc__result {
             width: 20%;
         }
@@ -166,12 +87,11 @@
     }
     .item--sport-table {
         width: 100% !important;
-        padding-left: 0;
-        padding-right: 0;
-        border-left-style: none;
     }
-    .front-competition-table {
+    .competition-table {
+        padding-top: 0;
         border-style: none;
+        border-top: 2px solid $c-newsAccent;
     }
     @include mq(tablet) {
         .item--sport-stats-tall {

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -20,10 +20,6 @@
                     border-top: 1px dotted $c-neutral5;
                 }
             }
-            .item:nth-child(2),
-            .item:nth-child(4) {
-                @include row-start;
-            }
         }
         .collection--with-sport-stats {
             .item:nth-child(n+3):nth-child(-n+6) {
@@ -41,10 +37,6 @@
                     border-top: 1px dotted $c-neutral5;
                 }
             }
-            .item:nth-child(3),
-            .item:nth-child(5) {
-                @include row-start;
-            }
         }
     }
     @include mq(tablet) {
@@ -53,10 +45,6 @@
         }
         &:nth-of-type(even) .item:first-child {
             float: right;
-
-            &:before {
-                display: block !important;
-            }
         }
         .item:nth-child(n+2) {
             @include card;
@@ -75,91 +63,21 @@
                 @include card-image;
             }
         }
-        &:nth-of-type(odd) {
-            .collection--without-sport-stats {
-                .item:nth-child(3n+1) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(3n+3) {
-                    @include row-start;
-                }
-            }
-        }
-        &:nth-of-type(even) {
-            .collection--without-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(3),
-                .item:nth-child(3n+4) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(3n+3) {
-                    @include row-start;
-                }
-            }
-        }
     }
     @include mq(desktop) {
         @include first-row(3);
+        .item:nth-child(3) {
+            @include card-image;
+        }
         .collection--without-sport-stats {
-            .item:nth-child(2),
-            .item:nth-child(3) {
+            .item:nth-child(2) {
                 @include card-image;
-            }
-        }
-        .collection--with-sport-stats {
-            .item:nth-child(3) {
-                @include card-image;
-            }
-        }
-        &:nth-of-type(odd) {
-            .collection--without-sport-stats {
-                .item:nth-child(4n+6) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(4n+5) {
-                    @include row-start;
-                }
-            }
-        }
-        &:nth-of-type(even) {
-            .collection--without-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(4),
-                .item:nth-child(4n+6) {
-                    @include row-start;
-                }
-            }
-            .collection--with-sport-stats {
-                .item:nth-child(2),
-                .item:nth-child(4n+5) {
-                    @include row-start;
-                }
             }
         }
     }
 
     .item--sport-stats {
         padding-bottom: 0 !important;
-        @include mq($to: tablet) {
-            width: 100% !important;
-            padding-left: 0 !important;
-            border-left-style: none !important;
-        }
-        .competition-table {
-            padding-top: 0;
-            border-style: none;
-            border-top: 2px solid $c-newsAccent;
-        }
-        .matches {
-            margin-bottom: 0;
-        }
         .match-desc__result {
             width: 20%;
         }
@@ -172,12 +90,11 @@
     }
     .item--sport-table {
         width: 100% !important;
-        padding-left: 0;
-        padding-right: 0;
-        border-left-style: none;
     }
-    .front-competition-table {
+    .competition-table {
+        padding-top: 0;
         border-style: none;
+        border-top: 2px solid $c-newsAccent;
     }
     @include mq(tablet) {
         .item--sport-stats-tall {

--- a/common/app/assets/stylesheets/module/containers/_popular.scss
+++ b/common/app/assets/stylesheets/module/containers/_popular.scss
@@ -36,13 +36,13 @@
         }
     }
     @include mq(tablet, desktop) {
-        @include row(3);
+        @include first-row(3);
         .item:nth-child(-n+3) {
             @include card-image;
         }
     }
     @include mq(desktop) {
-        @include row(4);
+        @include first-row(4);
         .item:nth-child(-n+4) {
             @include card-image;
         }

--- a/common/app/assets/stylesheets/module/containers/_section.scss
+++ b/common/app/assets/stylesheets/module/containers/_section.scss
@@ -1,6 +1,6 @@
 .container--section {
     @include mq($to: tablet) {
-        @include row(2);
+        @include first-row(2);
         .item:nth-child(-n+2) {
             @include card-half-width($with-image: true);
         }
@@ -19,13 +19,13 @@
         }
     }
     @include mq(tablet, desktop) {
-        @include row(3);
+        @include first-row(3);
         .item:nth-child(-n+3) {
             @include card-image;
         }
     }
     @include mq(desktop) {
-        @include row(4);
+        @include first-row(4);
         .item:nth-child(-n+4) {
             @include card-image;
         }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -3,10 +3,7 @@ $c-live: #e81818;
 .container {
     position: relative;
     overflow: hidden;
-    @include mq($to: tablet) {
-        margin-top: $gs-baseline;
-
-    }
+    margin-top: $gs-baseline;
     @include mq(tablet) {
         margin-top: $gs-baseline*2;
     }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -2,6 +2,17 @@ $c-live: #e81818;
 
 .container {
     position: relative;
+    overflow: hidden;
+    @include mq($to: tablet) {
+        margin-top: $gs-baseline;
+
+    }
+    @include mq(tablet) {
+        margin-top: $gs-baseline*2;
+    }
+}
+.container:first-child {
+    margin-top: 0;
 }
 .container--rolled-up {
     .collection,
@@ -17,20 +28,15 @@ $c-live: #e81818;
     @include fs-header(5, $size-only: true);
     border-top-style: solid;
     border-top-color: $c-newsAccent;
-    .container:first-child & {
-        margin-top: 0;
-    }
     @include mq($to: tablet) {
         padding: $gs-baseline/3 $gs-gutter/5;
         min-height: gs-height(1) - $gs-baseline*(2/3);
         color: #ffffff !important;
-        margin-top: $gs-baseline;
         border-top-width: $gs-baseline/3;
         background-color: $c-newsDefault;
 
     }
     @include mq(tablet) {
-        margin-top: $gs-baseline*2;
         margin-bottom: $gs-baseline;
         border-top-width: $item-top-border-height;
         background-color: transparent !important;
@@ -108,12 +114,19 @@ $c-live: #e81818;
     @include mq(tablet) {
         display: inline-block;
         vertical-align: top;
-        @include item-separator-vertical;
     }
-}
-.item:first-child {
-    clear: left;
-    @include hide-item-separator-vertical;
+
+    &:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px dotted $c-neutral5;
+    }
 }
 .item__link {
     display: block;

--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -16,37 +16,6 @@ $item-top-border-height: 2px;
         }
     }
 }
-@mixin item-separator-vertical {
-    &:before {
-        content: '';
-        display: block;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: 1px;
-        height: 100%;
-        border-left: 1px dotted $c-neutral5;
-    }
-}
-@mixin hide-item-separator-vertical {
-    &:before {
-        display: none !important;
-    }
-}
-@mixin row-start {
-    clear: left;
-    @include hide-item-separator-vertical;
-}
-@mixin row($row-size, $first-row-size: $row-size) {
-    // styling for first row
-    @include first-row($row-size);
-    // stylings for begining and end of rows
-    .item:first-child,
-    .item:nth-child(#{$row-size}n+#{$first-row-size + 1}) {
-        @include row-start;
-    }
-}
 
 $metaHeight: 14px;
 @mixin card-mobile($with-image: false) {
@@ -102,7 +71,6 @@ $metaHeight: 14px;
     min-height: gs-height(3);
     padding-bottom: $metaHeight;
     float: left;
-    @include item-separator-vertical;
 
     .item__title {
         @include fs-headline(1, $size-only: true);


### PR DESCRIPTION
Adding `overflow: hidden` to container, so no need to remove border on first items in a row
