### PR TITLE
Add tables link to all competitions

### DIFF
--- a/common/app/model/FootballNavigation.scala
+++ b/common/app/model/FootballNavigation.scala
@@ -43,6 +43,7 @@ object FootballNavigation {
     )
   } else {
     Seq(
+      Link(s"$competition/table", "tables", "Tables"), // note if there is no table for this comp it will redirect to /football/tables
       Link(s"$competition/live", "livescores", "Live scores"),
       Link(s"$competition/fixtures", "fixtures", "Fixtures"),
       Link(s"$competition/results", "results", "Results"),


### PR DESCRIPTION
We were missing some (e.g. Champions League).

Note that if a competition does not have a table it will redirect to /football/tables (e.g. www.theguardian.com/football/capital-one-cup/table)
