### PR TITLE
Initial implementation of CallToAction component.

### DIFF
--- a/call-to-action/app/Global.scala
+++ b/call-to-action/app/Global.scala
@@ -1,0 +1,19 @@
+import common.Logging
+import cta.conf.Configuration
+import play.api.{Application, GlobalSettings}
+import play.api.mvc.{Handler, RequestHeader}
+
+object Global extends GlobalSettings with Logging {
+
+   override def beforeStart(app: Application) {
+     assert(Configuration.ctaHostName.isDefined, "cta-host property not set. Please check the environment specific application property file")
+   }
+
+  override def onRouteRequest(req: RequestHeader): Option[Handler] = {
+    log.debug("Received request to host:'%s', path:'%s', headers:'%s'".format(req.host, req.path, req.headers.toMap))
+    Option(req.host) match {
+      case Configuration.ctaHostName => cta.Routes.routes.lift(req)
+      case _   =>  super.onRouteRequest(req)
+    }
+  }
+}

--- a/call-to-action/app/conf/Configuration.scala
+++ b/call-to-action/app/conf/Configuration.scala
@@ -1,0 +1,15 @@
+package cta.conf
+
+import com.gu.conf.ConfigurationFactory
+
+object Configuration {
+
+  lazy private val configuration = ConfigurationFactory("call-to-action", "env")
+
+  lazy val ctaHostName = configuration.getStringProperty("cta-host")
+
+  lazy val cacheControlMaxAge = configuration.getIntegerProperty("cache-control", 3600)
+}
+
+
+

--- a/call-to-action/app/controllers/CallToActionController.scala
+++ b/call-to-action/app/controllers/CallToActionController.scala
@@ -1,0 +1,74 @@
+package controllers
+
+import common.{ExecutionContexts, Logging}
+import play.api.mvc.{Action, Controller}
+import scala.concurrent._
+import play.api.libs.json.{JsValue, Json}
+import cta.conf.Configuration
+
+object CallToActionController extends CallToActionController
+
+trait CallToActionController extends Controller with Logging with ExecutionContexts {
+
+  def forArticle(articleId: String) = Action.async {
+    request =>
+      getBody map {Ok(_).withHeaders(CACHE_CONTROL -> getMaxAge)}
+  }
+
+  private def getMaxAge = "max-age=" + Configuration.cacheControlMaxAge
+
+  private def getBody(): Future[JsValue] = {
+    future {
+      Json.parse(
+        """
+          |
+          |{
+          |    "status": "ok",
+          |    "endPoint": "http://cta.guardian.com/article/p/1234",
+          |    "components": [
+          |        {
+          |            "type": "top-comments-for-article",
+          |            "discussionMetadata": {
+          |                "key": "/p/323gn",
+          |                "webUrl": "http://www.theguardian.com/commentisfree/2011/sep/21/you-tell-us",
+          |                "apiUrl": "http://discussion.guardianapis.com/discussion-api/discussion//p/323gn",
+          |                "title": "Ideas for September 21-22"
+          |            },
+          |            "comments": [
+          |                {
+          |                    "apiUrl": "http://discussion.guardianapis.com/discussion-api/comment/28656413",
+          |                    "body": "<p>In terms of the diversity and originality of his work as well as his lasting influence, it's probably Aristotle. Marx's ideas and arguments have only been around for 160 years, and have been thoroughly critiqued in theory and practice. Aristotle not only founded most of our academic disciplines, but his ideas on logic, epistemology, metaphysics, physics, biology, ethics, psychology, the nature of God, poetry, rhetoric, and more, were the generally accepted view of things in the West for over 1,600 years. He was also pretty influential in the Islamic world, too.</p>",
+          |                    "date": "07 November 2013 11:59am",
+          |                    "id": 28656413,
+          |                    "isHighlighted": true,
+          |                    "isoDateTime": "2013-11-07T11:59:46Z",
+          |                    "numRecommends": 8,
+          |                    "numResponses": 1,
+          |                    "status": "visible",
+          |                    "userProfile": {
+          |                        "apiUrl": "http://discussion.guardianapis.com/discussion-api/profile/4235958",
+          |                        "avatar": "http://static.guim.co.uk/sys-images/discussion/avatars/2010/09/23/JamesDavid/0663561f-c609-43e2-a713-0c0006c1ec45/60x60.png",
+          |                        "badge": [ ],
+          |                        "displayName": "JamesDavid",
+          |                        "secureAvatarUrl": "https://static-secure.guim.co.uk/sys-images/discussion/avatars/2010/09/23/JamesDavid/0663561f-c609-43e2-a713-0c0006c1ec45/60x60.png",
+          |                        "userId": "4235958",
+          |                        "webUrl": "http://www.theguardian.com/discussion/user/id/4235958"
+          |                    },
+          |                    "webUrl": "http://discussion.theguardian.com/comment-permalink/28656413"
+          |                }
+          |            ]
+          |        },
+          |        {
+          |            "type": "discussion-prompt",
+          |            "content": {}
+          |        }
+          |    ]
+          |}
+          |
+        """.stripMargin)
+    }
+  }
+
+
+}
+

--- a/call-to-action/conf/cta.routes
+++ b/call-to-action/conf/cta.routes
@@ -1,0 +1,1 @@
+GET	/forarticle/*articleId		controllers.CallToActionController.forArticle(articleId)

--- a/call-to-action/conf/env/CODE.properties
+++ b/call-to-action/conf/env/CODE.properties
@@ -1,0 +1,3 @@
+
+cta-host: cta.code.dev-theguardian.com
+cache-control : 3600

--- a/call-to-action/conf/env/DEV.properties
+++ b/call-to-action/conf/env/DEV.properties
@@ -1,0 +1,3 @@
+
+cta-host: cta.theguardian.com
+cache-control : 3600

--- a/call-to-action/conf/env/DEVINFRA.properties
+++ b/call-to-action/conf/env/DEVINFRA.properties
@@ -1,0 +1,3 @@
+
+cta-host: cta.theguardian.com
+cache-control : 3600

--- a/call-to-action/conf/env/PROD.properties
+++ b/call-to-action/conf/env/PROD.properties
@@ -1,0 +1,3 @@
+
+cta-host: cta.theguardian.com
+cache-control : 3600

--- a/call-to-action/test/cta/CTARouterTest.scala
+++ b/call-to-action/test/cta/CTARouterTest.scala
@@ -1,0 +1,56 @@
+package cta
+
+import org.scalatest.{ShouldMatchers, FreeSpec}
+import play.api.test.Helpers._
+import play.api.test.{FakeApplication, FakeRequest}
+import akka.util.Timeout
+
+class CTARouterTest extends FreeSpec with ShouldMatchers {
+
+  "The Router" - {
+
+    "Should return 200 for valid request to cta.theguardian.com host" in {
+      running(FakeApplication()) {
+        val request = FakeRequest(GET, "/forarticle/p/1a3d").withHeaders(("Host", "cta.theguardian.com"))
+
+        val Some(result) = route(request)
+
+        status(result) should be(200)
+      }
+    }
+
+    "Should return 404 if the host header is not cta.guardian.com" in {
+      running(FakeApplication()) {
+        val requestOnLocalhost = FakeRequest(GET, "/forarticle/p/1a3d").withHeaders(("host", "localhost"))
+
+        val result = route(requestOnLocalhost)
+
+        result should be(None)
+      }
+    }
+
+    "Should return 404 if the articleId is missing" in {
+      running(FakeApplication()) {
+        val request = FakeRequest(GET, "/forarticle").withHeaders(("host", "cta.theguardian.com"))
+
+        val result = route(request)
+
+        result should be(None)
+      }
+    }
+
+  }
+
+  "The Controller" - {
+
+    "Should return the right caching headers" in {
+      running(FakeApplication()) {
+        val request = FakeRequest(GET, "/forarticle/p/1a3d").withHeaders(("Host", "cta.theguardian.com"))
+
+        val Some(result) = route(request)
+
+        headers(result)(Timeout(2000L))("Cache-Control") should be("max-age=3600")
+      }
+    }
+  }
+}

--- a/call-to-action/test/resources/logback-test.xml
+++ b/call-to-action/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%coloredLevel %logger{15} - %message%n%xException{5}</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="play" level="DEBUG" />
+    <logger name="application" level="DEBUG" />
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -58,6 +58,8 @@ object Frontend extends Build with Prototypes {
     templatesImport ++= Seq("discussion._", "discussion.model._")
   )
 
+  val callToAction = application("call-to-action").dependsOn(commonWithTests).aggregate(common)
+
   val router = application("router")
 
   val diagnostics = application("diagnostics").dependsOn(commonWithTests).aggregate(common).settings(
@@ -133,6 +135,7 @@ object Frontend extends Build with Prototypes {
       sport,
       coreNavigation,
       discussion,
+      callToAction,
       router,
       diagnostics,
       identity,
@@ -149,6 +152,7 @@ object Frontend extends Build with Prototypes {
     coreNavigation,
     image,
     discussion,
+    callToAction,
     router,
     diagnostics,
     admin,


### PR DESCRIPTION
- In prod, this will be available at cta.theguardian.com
- For now, just returns stub data
- Includes router that will work based on the host name
- If cta-host property not set, application will fail-fast and will not start
