### PR TITLE
Ensure right-hand-card adheres to sort ordering

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -96,7 +96,7 @@
                                 <div class="u-table__cell u-table__cell--collapse u-table__cell--bottom">
                                     <div class="js-sticky-lower" data-id="mpu-ad-slot"></div>
                                     @if(storyPackage.nonEmpty) {
-                                      @fragments.cards.card(storyPackage.last, "right", "More on this story", "Story package card", "visible")
+                                        @fragments.cards.card(storyPackage.sortBy(-_.webPublicationDate.getMillis).head, "right", "More on this story", "Story package card", "visible")
                                     }
                                 </div>
                             </div>


### PR DESCRIPTION
This ensures that the right hand card trail adheres to the same ordering the main story package has applied to it. This prevents duplication errors.

After discussing with @rich-nguyen story-packages should really be filtered/sorted much higher up the chain, for example inside the Content model. Though that re-factoring is out of the scope of this simple fix.
#### Before

![screenshot from 2013-11-12 13 50 07](https://f.cloud.github.com/assets/80089/1522142/f3d55af4-4ba2-11e3-9071-2b4638a7f1cf.png)
#### After

![screenshot from 2013-11-12 13 47 27](https://f.cloud.github.com/assets/80089/1522144/f920abee-4ba2-11e3-8a62-6f8664b70f8b.png)
