### PR TITLE
Fix headers in non-mq compliant browers

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -25,19 +25,27 @@ $c-live: #e81818;
     @include fs-header(5, $size-only: true);
     border-top-style: solid;
     border-top-color: $c-newsAccent;
-    @include mq($to: tablet) {
-        padding: $gs-baseline/3 $gs-gutter/5;
-        min-height: gs-height(1) - $gs-baseline*(2/3);
-        color: #ffffff !important;
-        border-top-width: $gs-baseline/3;
-        background-color: $c-newsDefault;
-
-    }
+    padding: $gs-baseline/3 $gs-gutter/5;
+    border-top-width: $gs-baseline/3;
+    background-color: $c-newsDefault;
+    min-height: gs-height(1) - $gs-baseline*(2/3);
+    color: #ffffff;
     @include mq(tablet) {
+        min-height: 0;
+        padding: 0;
         margin-bottom: $gs-baseline;
         border-top-width: $item-top-border-height;
         background-color: transparent !important;
         line-height: 1em;
+        .tone-news & {
+            color: $c-newsDefault;
+        }
+        .tone-comment & {
+            color: $c-commentDefault;
+        }
+        .tone-feature & {
+            color: $c-featureDefault;
+        }
     }
 }
 .container__title a {

--- a/common/app/views/fragments/containers/comment.scala.html
+++ b/common/app/views/fragments/containers/comment.scala.html
@@ -8,7 +8,7 @@
 
         @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-colour tone-background tone-accent-border">
+                <h2 class="container__title tone-background tone-accent-border">
                     <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                 </h2>
             }

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -8,7 +8,7 @@
 
         @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-colour tone-background tone-accent-border">
+                <h2 class="container__title tone-background tone-accent-border">
                     <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                 </h2>
             }

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -9,7 +9,7 @@
 
         @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-colour tone-background tone-accent-border">
+                <h2 class="container__title tone-background tone-accent-border">
                     <a data-link-name="section heading" href="@LinkTo{/@if(!config.section.equals("news")){@config.section}}">@Html(title)</a>
                 </h2>
             }

--- a/common/app/views/fragments/containers/section.scala.html
+++ b/common/app/views/fragments/containers/section.scala.html
@@ -8,7 +8,7 @@
 
         @Seq(config.displayName, collection.displayName).find(_.nonEmpty).flatten.map { title =>
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-colour tone-background tone-accent-border">
+                <h2 class="container__title tone-background tone-accent-border">
                     <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                 </h2>
             }


### PR DESCRIPTION
Headline text was invisible, as `color: $ffffff...` wan't being called

![blackberr](https://f.cloud.github.com/assets/74132/1523481/d12e5014-4bb6-11e3-8a40-f88ee780c8b6.jpg)
