### PR TITLE
Ab test for number of items to initially show in news container

### DIFF
--- a/common/app/assets/javascripts/bootstraps/facia.js
+++ b/common/app/assets/javascripts/bootstraps/facia.js
@@ -63,7 +63,7 @@ define([
                         if (hiddenCollection) {
                             var $items = common.$g('.item:nth-last-child(-n+2)', $collection[0])
                                             .remove();
-                            hiddenCollection.extraItems.unshift($items[0], $items[1]);
+                            hiddenCollection.addExtraItems($items);
                         }
                     });
                     new FootballFixtures({

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -7,6 +7,7 @@ define([
     'modules/experiments/tests/live-blog-show-more',
     'modules/experiments/tests/alpha-adverts',
     'modules/experiments/tests/commercial-components',
+    'modules/experiments/tests/initial-show-more'
 ], function (
     common,
     store,
@@ -14,7 +15,8 @@ define([
     Aa,
     LiveBlogShowMore,
     AlphaAdverts,
-    CommercialComponentsTest
+    CommercialComponentsTest,
+    InitialShowMore
     ) {
 
     var TESTS = [
@@ -22,6 +24,7 @@ define([
             new LiveBlogShowMore(),
             new AlphaAdverts(),
             new CommercialComponentsTest(),
+            new InitialShowMore()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
@@ -4,7 +4,7 @@ define(['utils/mediator'], function(mediator) {
 
         this.id = 'InitialShowMore';
         this.expiry = '2013-11-30';
-        this.audience = 0.2;
+        this.audience = 0.02;
         this.description = 'Test how many items to initially show in the news container';
         this.canRun = function(config) {
             return config.page.contentType === 'Network Front';

--- a/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
@@ -1,0 +1,27 @@
+define([], function() {
+
+    return function() {
+
+        this.id = 'InitialShowMore';
+        this.expiry = '2013-11-30';
+        this.audience = 1;
+        this.description = 'Test how many items to initially show in the news container';
+        this.canRun = function(config) {
+            return config.page.contentType === 'Network Front';
+        };
+        this.variants = [
+//            {
+//                id: 'control',
+//                test: function () {
+//                    return true;
+//                }
+//            },
+            {
+                id: 'initial-show-more',
+                test: function (context) {
+                }
+            }
+        ];
+    };
+
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
@@ -1,4 +1,4 @@
-define([], function() {
+define(['utils/mediator'], function(mediator) {
 
     return function() {
 
@@ -10,15 +10,18 @@ define([], function() {
             return config.page.contentType === 'Network Front';
         };
         this.variants = [
-//            {
-//                id: 'control',
-//                test: function () {
-//                    return true;
-//                }
-//            },
+            {
+                id: 'control',
+                test: function () {
+                    return true;
+                }
+            },
             {
                 id: 'initial-show-more',
                 test: function (context) {
+                    mediator.addOnceListener('modules:collectionShowMore:renderButton', function(collectionShowMore) {
+                        collectionShowMore.showMore();
+                    });
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
@@ -4,7 +4,7 @@ define(['utils/mediator'], function(mediator) {
 
         this.id = 'InitialShowMore';
         this.expiry = '2013-11-30';
-        this.audience = 0.1;
+        this.audience = 0.2;
         this.description = 'Test how many items to initially show in the news container';
         this.canRun = function(config) {
             return config.page.contentType === 'Network Front';

--- a/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/initial-show-more.js
@@ -4,7 +4,7 @@ define(['utils/mediator'], function(mediator) {
 
         this.id = 'InitialShowMore';
         this.expiry = '2013-11-30';
-        this.audience = 1;
+        this.audience = 0.1;
         this.description = 'Test how many items to initially show in the news container';
         this.canRun = function(config) {
             return config.page.contentType === 'Network Front';
@@ -17,7 +17,7 @@ define(['utils/mediator'], function(mediator) {
                 }
             },
             {
-                id: 'initial-show-more',
+                id: 'show-first-page',
                 test: function (context) {
                     mediator.addOnceListener('modules:collectionShowMore:renderButton', function(collectionShowMore) {
                         collectionShowMore.showMore();

--- a/common/app/assets/javascripts/modules/facia/collection-show-more.js
+++ b/common/app/assets/javascripts/modules/facia/collection-show-more.js
@@ -129,7 +129,7 @@ define([
                 var that = this;
                 // listen to the clickstream, as happens later, before removing
                 mediator.on('module:clickstream:click', function(clickSpec) {
-                    if (bonzo(clickSpec.target)[0] === that._$button[0]) {
+                    if (qwery(clickSpec.target)[0] === that._$button[0]) {
                         that._$button.remove();
                     }
                 });

--- a/common/app/assets/javascripts/modules/facia/collection-show-more.js
+++ b/common/app/assets/javascripts/modules/facia/collection-show-more.js
@@ -1,5 +1,6 @@
 define([
-    'common',
+    '$',
+    'utils/mediator',
     'bonzo',
     'bean',
     'qwery',
@@ -7,118 +8,136 @@ define([
     'modules/relativedates',
     'modules/facia/images',
     'modules/discussion/commentCount'
-], function (common, bonzo, bean, qwery, detect, relativeDates, faciaImages, commentCount) {
+], function ($, mediator, bonzo, bean, qwery, detect, relativeDates, faciaImages, commentCount) {
+
+    var buttonText = 'Show more',
+        getInitialShowSize = function (collectionType) {
+            var breakpointOptions = {
+                wide: {
+                    default: 4,
+                    news: 5,
+                    comment: 5,
+                    features: 3
+                },
+                desktop: {
+                    default: 4,
+                    news: 5,
+                    comment: 5,
+                    features: 3
+                },
+                tablet: {
+                    default: 3,
+                    news: 6,
+                    comment: 4,
+                    features: 4
+                },
+                mobile: {
+                    default: 2,
+                    news: 5,
+                    comment: 3,
+                    features: 3,
+                    popular: 5
+                }
+            }[detect.getBreakpoint()];
+            return breakpointOptions[collectionType] || breakpointOptions['default'];
+        },
+        getShowMoreSize = function() {
+            return {
+                wide: 8,
+                desktop: 8,
+                tablet: 6,
+                mobile: 5
+            }[detect.getBreakpoint()];
+        },
+        showMore = function($collection, $extraItems, count, upgradeImages) {
+            var $items = $extraItems.splice(0, count);
+            if (!$items.length) {
+                return;
+            }
+            // NOTE: wrapping in div so can be passed to commentCount, relativeDates, etc.
+            var wrappedItems = bonzo(bonzo.create('<div></div>'))
+                                   .append($items)[0];
+            relativeDates.init(wrappedItems);
+            commentCount.init(wrappedItems);
+            if (upgradeImages === true) {
+                faciaImages.upgrade(wrappedItems);
+            }
+            $collection.append($items);
+        };
 
     return function(collection) {
 
-        var _getInitialShowSize = function (collectionType) {
-                var breakpointOptions = {
-                    wide: {
-                        default: 4,
-                        news: 5,
-                        comment: 5,
-                        features: 3
-                    },
-                    desktop: {
-                        default: 4,
-                        news: 5,
-                        comment: 5,
-                        features: 3
-                    },
-                    tablet: {
-                        default: 3,
-                        news: 6,
-                        comment: 4,
-                        features: 4
-                    },
-                    mobile: {
-                        default: 2,
-                        news: 5,
-                        comment: 3,
-                        features: 3,
-                        popular: 5
-                    }
-                }[detect.getBreakpoint()];
-                return breakpointOptions[collectionType] || breakpointOptions['default'];
-            },
-            _getShowMoreSize = function() {
-                return {
-                    wide: 8,
-                    desktop: 8,
-                    tablet: 6,
-                    mobile: 5
-                }[detect.getBreakpoint()];
-            },
-            _showMore = function($collection, extraItems, count, upgradeImages) {
-                var items = extraItems.splice(0, count);
-                if (!items.length) {
-                    return;
-                }
-                // NOTE: wrapping in div so can be passed to commentCount, relativeDates, etc.
-                var wrappedItems = bonzo(bonzo.create('<div></div>'))
-                                       .append(items)[0];
-                relativeDates.init(wrappedItems);
-                commentCount.init(wrappedItems);
-                if (upgradeImages === true) {
-                    faciaImages.upgrade(wrappedItems);
-                }
-                $collection.append(items);
-            },
-            _renderToggle = function($collection, extraItems) {
-                var buttonText = 'Show more',
-                    $button = bonzo(bonzo.create(
-                                        '<button class="collection__show-more tone-background" data-link-name="' + buttonText + ' | 0">' +
-                                            '<span class="i i-arrow-white-large">' +
-                                                buttonText +
-                                            '</span>' +
-                                        '</button>'
-                                    ))
-                                  .insertAfter($collection);
-                bean.on($button[0], 'click', function(e) {
-                    // increment button counter
-                    var newDataAttr = $button.attr('data-link-name').replace(/^(.* | )(\d+)$/, function(match, prefix, count) {
-                        // http://nicolaasmatthijs.blogspot.co.uk/2009/05/missing-radix-parameter.html
-                        return prefix + (parseInt(count, 10) + 1);
-                    });
-                    $button.attr('data-link-name', newDataAttr);
+        this._collection = collection;
 
-                    // show x more, depending on current breakpoint
-                    _showMore($collection, extraItems, _getShowMoreSize());
+        this._$collection = bonzo(collection);
 
-                    if (extraItems.length === 0) {
-                        // listen to the clickstream, as happens later, before removing
-                        common.mediator.on('module:clickstream:click', function(clickSpec) {
-                            if (bonzo(clickSpec.target)[0] === $button[0]) {
-                                $button.remove();
-                            }
-                        });
-                    }
-                });
-            };
+        this._$button = bonzo(bonzo.create(
+            '<button class="collection__show-more tone-background" data-link-name="' + buttonText + ' | 0">' +
+                '<span class="i i-arrow-white-large">' +
+                    buttonText +
+                '</span>' +
+            '</button>'
+        ));
 
-        this.extraItems = bonzo.create(
-            common.$g('.collection--template', collection).html()
+        this._$extraItems = bonzo.create(
+            $('.collection--template', collection).html()
         );
 
+        this._renderButton = function() {
+            this._$collection.after(this._$button);
+            var that = this;
+            bean.on(this._$button[0], 'click', function() {
+                that.showMore();
+            });
+            mediator.emitEvent('modules:collectionShowMore:renderButton', [this]);
+        };
+
         this.addShowMore = function() {
-            var $collection = bonzo(collection).removeClass('js-collection--show-more'),
-                initalShowSize = _getInitialShowSize($collection.parent().attr('data-type'));
+            var initalShowSize = getInitialShowSize(this._$collection.parent().attr('data-type'));
+
+            this._$collection.removeClass('js-collection--show-more');
 
             // remove extras from dom
-            common.$g('.collection--template', collection).remove();
+            $('.collection--template', this._collection).remove();
 
             // if we are showing more items than necessary, store them
-            var excess = qwery('.item:nth-child(n+' + (initalShowSize + 1) + ')', collection);
-            this.extraItems = excess.concat(this.extraItems);
+            var excess = qwery('.item:nth-child(n+' + (initalShowSize + 1) + ')', this._collection);
+            this._$extraItems = excess.concat(this._$extraItems);
             bonzo(excess).remove();
 
             // if we are showing less items than necessary, show more
-            _showMore($collection, this.extraItems, initalShowSize - qwery('.item', collection).length, true);
+            showMore(this._$collection, this._$extraItems, initalShowSize - qwery('.item',this._collection).length, true);
 
             // add toggle button, if they are extra items left to show
-            if (this.extraItems.length) {
-                _renderToggle($collection, this.extraItems);
+            if (this._$extraItems.length) {
+                this._renderButton();
             }
+        };
+
+        this.showMore = function() {
+            // increment button counter
+            var newDataAttr = this._$button.attr('data-link-name').replace(/^(.* | )(\d+)$/, function(match, prefix, count) {
+                // http://nicolaasmatthijs.blogspot.co.uk/2009/05/missing-radix-parameter.html
+                return prefix + (parseInt(count, 10) + 1);
+            });
+            this._$button.attr('data-link-name', newDataAttr);
+
+            // show x more, depending on current breakpoint
+            showMore(this._$collection, this._$extraItems, getShowMoreSize());
+
+            if (this._$extraItems.length === 0) {
+                var that = this;
+                // listen to the clickstream, as happens later, before removing
+                mediator.on('module:clickstream:click', function(clickSpec) {
+                    if (bonzo(clickSpec.target)[0] === that._$button[0]) {
+                        that._$button.remove();
+                    }
+                });
+            }
+        };
+
+        this.addExtraItems = function($items) {
+            this._$extraItems.concat($items);
         };
 
     };

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -83,7 +83,7 @@ object Switches extends Collections {
   val AdSlotImpressionStatsSwitch = Switch("Analytics", "adslot-impression-stats",
     "Track when adslots (and possible ad slots) are scrolled into view.",
     safeState = Off)
-  
+
   val LiveStatsSwitch = Switch("Analytics", "live-stats",
     "Turns on our real-time KPIs",
     safeState = On)
@@ -117,7 +117,7 @@ object Switches extends Collections {
     safeState = Off)
 
   // Feature Switches
-  
+
   val ReleaseMessageSwitch = Switch("Feature Switches", "release-message",
     "If this is switched on users will be messaged that they are inside the alpha/beta/whatever release",
     safeState = Off)
@@ -174,7 +174,7 @@ object Switches extends Collections {
   val ArticleKeywordsSwitch = Switch("Feature Switches", "article-keywords",
     "If this is switched on then keywords will be shown at the end of articles.",
     safeState = Off)
-  
+
   val ClientSideErrorSwitch = Switch("Feature Switches", "client-side-errors",
     "If this is switch on the the browser will log JavaScript errors to the server (via a beacon)",
     safeState = Off)
@@ -207,6 +207,10 @@ object Switches extends Collections {
 
   val ABCommercialComponents = Switch("A/B Tests", "ab-commercial-components",
     "If this is switched on an AB test runs to test the new commercial components",
+    safeState = Off)
+
+  val ABInitialShowMore = Switch("A/B Tests", "ab-initial-show-more",
+    "If this is switched on an AB test runs to test how many items to initially show in news container",
     safeState = Off)
 
   // Sport Switch
@@ -286,7 +290,8 @@ object Switches extends Collections {
     ArticleKeywordsSwitch,
     ABAlphaAdverts,
     ABCommercialComponents,
-    EditionRedirectLoggingSwitch
+    EditionRedirectLoggingSwitch,
+    ABInitialShowMore
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/test/assets/javascripts/spec/facia/collection-show-more.spec.js
+++ b/common/test/assets/javascripts/spec/facia/collection-show-more.spec.js
@@ -1,4 +1,4 @@
-define(['modules/facia/collection-show-more', 'bonzo', 'common', 'bean'], function(CollectionShowMore, bonzo, common, bean) {
+define(['modules/facia/collection-show-more', 'bonzo', '$', 'utils/mediator', 'bean'], function(CollectionShowMore, bonzo, $, mediator, bean) {
 
     describe('Collection Show More', function() {
 
@@ -17,8 +17,8 @@ define(['modules/facia/collection-show-more', 'bonzo', 'common', 'bean'], functi
                     '</ul>' +
                 '</section>'
             )[0];
-            collection = common.$g('ul', container)[0];
-            $template = common.$g('.collection--template', collection);
+            collection = $('ul', container)[0];
+            $template = $('.collection--template', collection);
             // add collection
             var i = 10;
             while(i--) {
@@ -34,7 +34,7 @@ define(['modules/facia/collection-show-more', 'bonzo', 'common', 'bean'], functi
 
         afterEach(function() {
             $style.remove();
-            common.mediator.off(clickstreamEvent);
+            mediator.removeAllListeners();
         });
 
         it('should be able to initialise', function() {
@@ -52,60 +52,67 @@ define(['modules/facia/collection-show-more', 'bonzo', 'common', 'bean'], functi
         });
 
         it('should not append button if displaying all collection', function() {
-            common.$g('.item:nth-child(n+2)', container).remove();
+            $('.item:nth-child(n+2)', container).remove();
             // create again, after culling fixture data
             var collectionShowMore = new CollectionShowMore(collection);
             collectionShowMore.addShowMore();
-            expect(common.$g('button', container).length).toEqual(0);
+            expect($('button', container).length).toEqual(0);
         });
 
         it('should show collection when button clicked', function() {
             collectionShowMore.addShowMore();
-            bean.fire(common.$g('button', container)[0], 'click');
-            expect(common.$g('.item', collection).hasClass('u-h')).toBeFalsy();
+            bean.fire($('button', container)[0], 'click');
+            expect($('.item', collection).hasClass('u-h')).toBeFalsy();
         });
 
         it('should update "data-link-name" after click', function() {
             collectionShowMore.addShowMore();
-            var $button = common.$g('button', container);
+            var $button = $('button', container);
             bean.fire($button[0], 'click');
             expect($button.attr('data-link-name')).toEqual('Show more | 1');
         });
 
         it('should remove button if no more collection, after clickstream event', function() {
             collectionShowMore.addShowMore();
-            var button = common.$g('button', container)[0];
+            var button = $('button', container)[0];
             bean.fire(button, 'click');
             bean.fire(button, 'click');
-            common.mediator.emit(clickstreamEvent, {target: button});
-            expect(common.$g('button', container).length).toEqual(0);
+            mediator.emit(clickstreamEvent, {target: button});
+            expect($('button', container).length).toEqual(0);
         });
 
         it('should not remove button if more collection', function() {
             $style.html('body:after { content: "mobile"; }');
             collectionShowMore.addShowMore();
-            bean.fire(common.$g('button', container)[0], 'click');
-            expect(common.$g('button', container).length).toEqual(1);
+            bean.fire($('button', container)[0], 'click');
+            expect($('button', container).length).toEqual(1);
         });
 
         it('should initially show 2 collection at mobile breakpoint', function() {
             $style.html('body:after { content: "mobile"; }');
             collectionShowMore.addShowMore();
-            expect(common.$g('.item', collection).length).toEqual(2);
+            expect($('.item', collection).length).toEqual(2);
         });
 
         it('should initially 5 collection in the "news" container at mobile breakpoint', function() {
             $style.html('body:after { content: "mobile"; }');
             bonzo(container).attr('data-type', 'news');
             collectionShowMore.addShowMore();
-            expect(common.$g('.item', collection).length).toEqual(5);
+            expect($('.item', collection).length).toEqual(5);
         });
 
         it('should show 5 more at mobile breakpoint', function() {
             $style.html('body:after { content: "mobile"; }');
             collectionShowMore.addShowMore();
-            bean.fire(common.$g('button', container)[0], 'click');
-            expect(common.$g('.item', collection).length).toEqual(7);
+            bean.fire($('button', container)[0], 'click');
+            expect($('.item', collection).length).toEqual(7);
+        });
+
+        it('should emit "modules:collectionShowMore:renderButton" on render of button', function() {
+            var emitSpy = sinon.spy(mediator, 'emitEvent');
+            collectionShowMore.addShowMore();
+            expect(emitSpy).toHaveBeenCalledWith('modules:collectionShowMore:renderButton', [collectionShowMore]);
+            emitSpy.restore();
         });
 
     });


### PR DESCRIPTION
If in test, effectively displays as if the 'show more' button was pressed once
## Hypothesis

Click through of stories that would have been hidden will increase (compared to when they are hidden)

Plus this will have no (or comparatively no) negative effect on click through to articles further down

Also moved over related js files to use the new smaller common modules (`utils/mediator`, `$`, etc)
