### PR TITLE
Prevent XSS iframe exploit

### DIFF
--- a/facia-tool/public/javascripts/models/common.js
+++ b/facia-tool/public/javascripts/models/common.js
@@ -7,10 +7,10 @@ define([
 ) {
     return {
         config: {
-            previewUrlBase: {
+            viewer: {
                 dev:  'http://localhost:9000/responsive-viewer#',
-                code: 'http://code.preview.guardianapps.co.uk/responsive-viewer#http://m.code.dev-theguardian.com',
-                prod: 'http://preview.guardianapps.co.uk/responsive-viewer#http://www.theguardian.com'
+                code: 'http://code.preview.guardianapps.co.uk/responsive-viewer#',
+                prod: 'http://preview.guardianapps.co.uk/responsive-viewer#'
             },
             filterTypes: {
                 section: { display: 'in section:', param: "section", path: "sections", placeholder: "e.g. news" },

--- a/facia-tool/public/javascripts/models/common.js
+++ b/facia-tool/public/javascripts/models/common.js
@@ -8,9 +8,9 @@ define([
     return {
         config: {
             viewer: {
-                dev:  'http://localhost:9000/responsive-viewer#',
-                code: 'http://code.preview.guardianapps.co.uk/responsive-viewer#',
-                prod: 'http://preview.guardianapps.co.uk/responsive-viewer#'
+                dev:  'http://localhost:9000',
+                code: 'http://code.preview.guardianapps.co.uk',
+                prod: 'http://preview.guardianapps.co.uk'
             },
             filterTypes: {
                 section: { display: 'in section:', param: "section", path: "sections", placeholder: "e.g. news" },

--- a/facia-tool/public/javascripts/modules/listManager.js
+++ b/facia-tool/public/javascripts/modules/listManager.js
@@ -68,7 +68,7 @@ define([
         }
 
         model.previewUrl = ko.computed(function() {
-            return common.config.viewer[Config.env] + 'env=' + Config.env + '&url=' + model.config() + encodeURIComponent('?view=mobile');
+            return common.config.viewer[Config.env] + '/responsive-viewer#env=' + Config.env + '&url=' + model.config() + encodeURIComponent('?view=mobile');
         })
 
         function fetchConfigsList() {

--- a/facia-tool/public/javascripts/modules/listManager.js
+++ b/facia-tool/public/javascripts/modules/listManager.js
@@ -68,7 +68,7 @@ define([
         }
 
         model.previewUrl = ko.computed(function() {
-            return common.config.previewUrlBase[Config.env] + '/' + model.config() + '?view=mobile';
+            return common.config.viewer[Config.env] + 'env=' + Config.env + '&url=' + model.config() + encodeURIComponent('?view=mobile');
         })
 
         function fetchConfigsList() {

--- a/facia/app/views/fragments/responsiveViewer.scala.html
+++ b/facia/app/views/fragments/responsiveViewer.scala.html
@@ -2,12 +2,17 @@
 <html>
     <head>
         <script>
-            breakpoints = [
-                { width:  320,  height: 480,  name: "Mobile" },
-                { width:  1295, height: 1024, name: "Desktop" },
-                { width:  768,  height: 1024, name: "Tablet portrait" },
-                { width:  1024, height: 768,  name: "Tablet landscape" }
-            ]
+            var breakpoints = [
+                    { width:  320,  height: 480,  name: "Mobile" },
+                    { width:  1295, height: 1024, name: "Desktop" },
+                    { width:  768,  height: 1024, name: "Tablet portrait" },
+                    { width:  1024, height: 768,  name: "Tablet landscape" }
+                ],
+
+                base = {
+                    code: 'http://m.code.dev-theguardian.com',
+                    prod: 'http://www.theguardian.com'
+                };
         </script>
         <style>
             iframe {
@@ -26,20 +31,25 @@
     <body>
         <div class="frames"></div>
         <script>
+            function hashArgs() {
+                var obj = {};
+                window.location.hash.substring(1).split('&').forEach(function(kv) {
+                    obj[kv.split('=')[0]] = kv.split('=')[1] === undefined ? '' : decodeURIComponent(kv.split('=')[1]);
+                });
+                return obj;
+            }
+
             function init() {
-                var url = window.location.hash.substring(1),
-                    sbWidth = 15, // scrollbar width
+                var sbWidth = 15, // scrollbar width
                     html = '',
                     leftAcc = 0;
-
-                if (!url) { return; }
 
                 breakpoints.forEach(function(bp) {
                     html +=
                         '<div style="left:' + leftAcc + 'px">' +
                             '<h2>' + bp.name + '</h2>' +
                             '<iframe sandbox="allow-same-origin allow-forms allow-scripts" seamless ' +
-                                'src="' + url + '" ' +
+                                'src="' + (base[hashArgs().env] || '') + '/' + (hashArgs().url || '').replace(/^(\/|https?:\/\/)/, '') + '" ' +
                                 'width="' + (bp.width + sbWidth) + '" ' +
                                 'height="' + bp.height + '"></iframe>' +
                         '</div>';
@@ -50,7 +60,6 @@
             }
 
             init();
-            window.onhashchange = init;
         </script>
     </body>
 </html>

--- a/facia/app/views/fragments/responsiveViewer.scala.html
+++ b/facia/app/views/fragments/responsiveViewer.scala.html
@@ -60,6 +60,7 @@
             }
 
             init();
+            window.onhashchange = init;
         </script>
     </body>
 </html>


### PR DESCRIPTION
The responsive viewer took an absolute url as an query arg, for its iframe src. Make this a relative url, with the hostname keyed indirectly by an arg. To prevent naughty URLs being passed in.
