### PR TITLE
Expose more metadata

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -39,7 +39,7 @@ class Content protected (val delegate: ApiContent) extends Trail with Tags with 
   // Inherited from Trail
   override lazy val webPublicationDate: DateTime = delegate.webPublicationDate
   override lazy val linkText: String = webTitle
-  override lazy val headline: String = fields("headline")
+  override def headline: String = fields("headline")
   override lazy val url: String = SupportedUrl(delegate)
   override lazy val trailText: Option[String] = fields.get("trailText")
   override lazy val section: String = delegate.sectionId.getOrElse("")

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -135,9 +135,9 @@ object Content {
     }
   }
 
-  def apply(delegate: ApiContent, headline: Option[String]): Content = {
-    headline match {
-      case Some(title) => new ContentWithHeadline(delegate, title)
+  def apply(delegate: ApiContent, metaData: Option[Map[String, String]]): Content = {
+    metaData match {
+      case Some(metaData) => new ContentWithMetaData(delegate, metaData)
       case _ => apply(delegate)
     }
   }
@@ -266,6 +266,7 @@ class ImageContent(content: ApiContent) extends Content(content) {
   ) ++ mainPicture.flatMap(_.largestImage.map( "twitter:image:src" -> _.path ))
 }
 
-class ContentWithHeadline(content: ApiContent, title: String) extends Content(content) {
-  override lazy val headline: String = title
+class ContentWithMetaData(content: ApiContent, metaData: Map[String, String]) extends Content(content) {
+  override lazy val headline: String = metaData.get("headline").getOrElse(super.headline)
+  override lazy val group: Option[String] = None//metaData.get("group")
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -268,5 +268,5 @@ class ImageContent(content: ApiContent) extends Content(content) {
 
 class ContentWithMetaData(content: ApiContent, metaData: Map[String, String]) extends Content(content) {
   override lazy val headline: String = metaData.get("headline").getOrElse(super.headline)
-  override lazy val group: Option[String] = None//metaData.get("group")
+  override lazy val group: Option[String] = metaData.get("group")
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -26,7 +26,8 @@ trait Trail extends Elements with Tags {
   def isClosedForComments: Boolean = false
   def leadingParagraphs: List[org.jsoup.nodes.Element] = Nil
   def byline: Option[String] = None
-  def trailType: Option[String] = None
+  def trailType: Option[String] = None  //Facia tool values
+  def group: Option[String] = None
 }
 
 case class Trailblock(description: TrailblockDescription, trails: Seq[Trail])

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -12,7 +12,7 @@ import services.S3FrontsApi
 import views.support.Style
 
 
-trait Trail extends Elements with Tags {
+trait Trail extends Elements with Tags with FaciaFields {
   def webPublicationDate: DateTime
   def linkText: String
   def headline: String
@@ -26,7 +26,11 @@ trait Trail extends Elements with Tags {
   def isClosedForComments: Boolean = false
   def leadingParagraphs: List[org.jsoup.nodes.Element] = Nil
   def byline: Option[String] = None
-  def trailType: Option[String] = None  //Facia tool values
+  def trailType: Option[String] = None
+}
+
+//Facia tool values
+trait FaciaFields {
   def group: Option[String] = None
 }
 


### PR DESCRIPTION
This passes along a `Map[String, String]`, allowing you to pull anything you need out of the metadata key coming from the fronts api `JSON`.

@ironsidevsquincy Has mentioned that there is no way to retrieve the original headline. This is intentional, as the object `ContentWithMetadata` is only used in the `Facia` project. If and when we need it, we can easily add it to `Trail`.
