### PR TITLE
Cookie secure flag

### DIFF
--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -1,0 +1,12 @@
+import java.io.File
+import play.api._
+
+object Global extends GlobalSettings {
+
+  lazy val devConfig = Configuration.from(Map("session.secure" -> "false"))
+
+  override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration = {
+    val newConfig: Configuration = if (mode == Mode.Dev) config ++ devConfig else config
+    super.onLoadConfig(newConfig, path, classloader, mode)
+  }
+}

--- a/facia-tool/conf/application.conf
+++ b/facia-tool/conf/application.conf
@@ -7,6 +7,8 @@ application: {
     secret: ${APP_SECRET}
     langs: "en"
 }
+#If you are on a dev machine, this is set to false in Global.scala
+session.secure=true
 
 logger: {
     # Even though we configure logback using conf/logger.xml, Play still inherits a standard logback configuration


### PR DESCRIPTION
Turn on the secure cookie flag for `facia-tool`.

Turn off if you are in `Mode.DEV`.
