### PR TITLE
Upgrade images on resize/oreientation change

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -1,13 +1,16 @@
 /*global Imager:true */
 define([
     //Commmon libraries
-    'common',
+    '$',
+    'utils/mediator',
+    'utils/deferToLoad',
     'ajax',
     'modules/userPrefs',
     //Vendor libraries
     'domReady',
     'bonzo',
     'bean',
+    'lodash/functions/debounce',
     //Modules
     'modules/storage',
     'modules/detect',
@@ -40,13 +43,16 @@ define([
     "modules/onward/history",
     "modules/onward/sequence"
 ], function (
-    common,
+    $,
+    mediator,
+    deferToLoadEvent,
     ajax,
     userPrefs,
 
     domReady,
     bonzo,
     bean,
+    debounce,
 
     storage,
     detect,
@@ -84,20 +90,21 @@ define([
     var modules = {
 
         upgradeImages: function () {
-            faciaImages.upgrade();
+            // upgrade images, and add listeners on completion
+            faciaImages.upgrade(document, faciaImages.listen);
 
             var images = new Images();
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 images.upgrade(context);
             });
-            common.mediator.on('fragment:ready:images', function(context) {
+            mediator.on('fragment:ready:images', function(context) {
                 images.upgrade(context);
             });
-            common.mediator.on('modules:related:loaded', function(config, context) {
+            mediator.on('modules:related:loaded', function(config, context) {
                 images.upgrade(context);
             });
-            common.mediator.on('modules:images:upgrade', function() {
-                common.$g('body').addClass('images-upgraded');
+            mediator.on('modules:images:upgrade', function() {
+                $('body').addClass('images-upgraded');
             });
         },
 
@@ -121,20 +128,20 @@ define([
         },
 
         transcludeRelated: function () {
-            common.mediator.on("page:common:ready", function(config, context){
+            mediator.on("page:common:ready", function(config, context){
                 related(config, context);
             });
         },
 
         transcludePopular: function () {
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 popular(config, context);
             });
         },
 
         showTabs: function() {
             var tabs = new Tabs();
-            common.mediator.on('modules:popular:loaded', function(el) {
+            mediator.on('modules:popular:loaded', function(el) {
                 tabs.init(el);
             });
         },
@@ -142,17 +149,17 @@ define([
         showToggles: function() {
             var toggles = new Toggles();
             toggles.init(document);
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 toggles.reset();
             });
         },
 
         showRelativeDates: function () {
             var dates = RelativeDates;
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 dates.init(context);
             });
-            common.mediator.on('fragment:ready:dates', function(el) {
+            mediator.on('fragment:ready:dates', function(el) {
                 dates.init(el);
             });
         },
@@ -162,29 +169,29 @@ define([
         },
 
         transcludeCommentCounts: function () {
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 CommentCount.init(context);
             });
         },
 
         initLightboxGalleries: function () {
             var thisPageId;
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 var galleries = new LightboxGallery(config, context);
                 thisPageId = config.page.pageId;
                 galleries.init();
             });
 
             // Register as a page view if invoked from elsewhere than its gallery page (like a trailblock)
-            common.mediator.on('module:lightbox-gallery:loaded', function(config, context) {
+            mediator.on('module:lightbox-gallery:loaded', function(config, context) {
                 if (thisPageId !== config.page.pageId) {
-                    common.mediator.emit('page:common:deferred:loaded', config, context);
+                    mediator.emit('page:common:deferred:loaded', config, context);
                 }
             });
         },
 
         runAbTests: function () {
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 ab.run(config, context);
             });
         },
@@ -192,7 +199,7 @@ define([
         loadAnalytics: function () {
             var omniture = new Omniture();
 
-            common.mediator.on('page:common:deferred:loaded:omniture', function(config, context) {
+            mediator.on('page:common:deferred:loaded:omniture', function(config, context) {
                 omniture.go(config, function(){
                     // callback:
 
@@ -212,9 +219,9 @@ define([
                 });
             });
 
-            common.mediator.on('page:common:deferred:loaded', function(config, context) {
+            mediator.on('page:common:deferred:loaded', function(config, context) {
 
-                common.mediator.emit('page:common:deferred:loaded:omniture', config, context);
+                mediator.emit('page:common:deferred:loaded:omniture', config, context);
 
                 require(config.page.ophanUrl, function (Ophan) {
 
@@ -254,19 +261,19 @@ define([
 
         loadAdverts: function () {
             if (!userPrefs.isOff('adverts')){
-                common.mediator.on('page:common:deferred:loaded', function(config, context) {
+                mediator.on('page:common:deferred:loaded', function(config, context) {
                     if (config.switches && config.switches.adverts && !config.page.blockAds) {
                         Adverts.init(config, context);
                     }
                 });
-                common.mediator.on('modules:adverts:docwrite:loaded', function(){
+                mediator.on('modules:adverts:docwrite:loaded', function(){
                     Adverts.loadAds();
                 });
             }
         },
 
         loadVideoAdverts: function(config) {
-            common.mediator.on('page:common:ready', function(config, context) {
+            mediator.on('page:common:ready', function(config, context) {
                 if(config.switches.videoAdverts && !config.page.blockAds) {
                     Array.prototype.forEach.call(context.querySelectorAll('video'), function(el) {
                         var support = detect.getVideoFormatSupport();
@@ -278,7 +285,7 @@ define([
                         }).init(config.page);
                     });
                 } else {
-                    common.mediator.emit("video:ads:finished", config, context);
+                    mediator.emit("video:ads:finished", config, context);
                 }
             });
         },
@@ -301,13 +308,13 @@ define([
             var alreadyOptedIn = !!userPrefs.get('releaseMessage'),
                 releaseMessage = {
                     show: function () {
-                        common.$g('#header').addClass('js-site-message');
-                        common.$g('.site-message').removeClass('u-h');
+                        $('#header').addClass('js-site-message');
+                        $('.site-message').removeClass('u-h');
                     },
                     hide: function () {
                         userPrefs.set('releaseMessage', true);
-                        common.$g('#header').removeClass('js-site-message');
-                        common.$g('.site-message').addClass('u-h');
+                        $('#header').removeClass('js-site-message');
+                        $('.site-message').addClass('u-h');
                     }
                 };
 
@@ -328,15 +335,15 @@ define([
             if (config.switches.swipeNav && detect.canSwipe() && !userPrefs.isOff('swipe') || userPrefs.isOn('swipe-dev')) {
                 var swipe = swipeNav(config, contextHtml);
 
-                common.mediator.on('module:swipenav:navigate:next', function(){ swipe.gotoNext(); });
-                common.mediator.on('module:swipenav:navigate:prev', function(){ swipe.gotoPrev(); });
+                mediator.on('module:swipenav:navigate:next', function(){ swipe.gotoNext(); });
+                mediator.on('module:swipenav:navigate:prev', function(){ swipe.gotoPrev(); });
             } else {
                 delete this.contextHtml;
                 return;
             }
             if (config.switches.swipeNav && detect.canSwipe()) {
                 bonzo(document.body).addClass('can-swipe');
-                common.mediator.on('module:clickstream:click', function(clickSpec){
+                mediator.on('module:clickstream:click', function(clickSpec){
                     if (clickSpec.tag.indexOf('switch-swipe-on') > -1) {
                         userPrefs.switchOn('swipe');
                         window.location.reload();
@@ -350,7 +357,7 @@ define([
         },
 
         logReadingHistory : function() {
-            common.mediator.on('page:common:ready', function(config) {
+            mediator.on('page:common:ready', function(config) {
                  if(/Article|Video|Gallery|Interactive/.test(config.page.contentType)) {
                     new History().log({
                         id: '/' + config.page.pageId,
@@ -362,12 +369,24 @@ define([
                 }
                 sequence.init();
             });
+        },
+
+        windowEventListeners: function() {
+            bean.on(window, 'resize', debounce(function(e) {
+                mediator.emitEvent('window:resize', [e]);
+            }, 200));
+            bean.on(window, 'scroll', debounce(function(e) {
+                mediator.emitEvent('window:scroll', [e]);
+            }, 200));
+            bean.on(window, 'orientationchange', debounce(function(e) {
+                mediator.emitEvent('window:orientationchange', [e]);
+            }, 200));
         }
     };
 
     var deferrable = function (config, context) {
         var self = this;
-        common.deferToLoadEvent(function() {
+        deferToLoadEvent(function() {
             if (!self.initialisedDeferred) {
                 self.initialisedDeferred = true;
                 modules.loadAdverts();
@@ -378,13 +397,14 @@ define([
                 // TODO: make these run in event 'page:common:deferred:loaded'
                 modules.cleanupCookies(context);
             }
-            common.mediator.emit("page:common:deferred:loaded", config, context);
+            mediator.emit("page:common:deferred:loaded", config, context);
         });
     };
 
     var ready = function (config, context, contextHtml) {
         if (!this.initialised) {
             this.initialised = true;
+            modules.windowEventListeners();
             modules.upgradeImages();
             modules.showTabs();
             modules.initialiseNavigation(config);
@@ -405,7 +425,7 @@ define([
             modules.displayReleaseMessage(config);
             modules.logReadingHistory();
         }
-        common.mediator.emit("page:common:ready", config, context);
+        mediator.emit("page:common:ready", config, context);
     };
 
     var init = function (config, context, contextHtml) {

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -372,15 +372,19 @@ define([
         },
 
         windowEventListeners: function() {
-            bean.on(window, 'resize', debounce(function(e) {
-                mediator.emitEvent('window:resize', [e]);
-            }, 200));
-            bean.on(window, 'scroll', debounce(function(e) {
-                mediator.emitEvent('window:scroll', [e]);
-            }, 200));
-            bean.on(window, 'orientationchange', debounce(function(e) {
-                mediator.emitEvent('window:orientationchange', [e]);
-            }, 200));
+            var events = {
+                    resize: 'window:resize',
+                    scroll: 'window:scroll',
+                    orientationchange: 'window:orientationchange'
+                },
+                emitEvent = function(eventName) {
+                    return function(e) {
+                        mediator.emit(eventName, e);
+                    };
+                };
+            for (var event in events) {
+                bean.on(window, event, debounce(emitEvent(events[event]), 200));
+            }
         }
     };
 

--- a/common/app/assets/javascripts/modules/commercial/commercial-components.js
+++ b/common/app/assets/javascripts/modules/commercial/commercial-components.js
@@ -1,12 +1,16 @@
 define([
-    'common',
+    '$',
+    'utils/mediator',
+    'lodash/objects/assign',
     'qwery',
     'bonzo',
     'bean',
     'modules/adverts/document-write',
     'modules/storage'
 ], function (
-    common,
+    $,
+    mediator,
+    extend,
     qwery,
     bonzo,
     bean,
@@ -15,7 +19,7 @@ define([
 ) {
 
     var Commercial = function(options) {
-        this.options        = common.extend(this.DEFAULTS, options);
+        this.options        = extend(this.DEFAULTS, options);
         this.keywords       = this.options.config.page.keywords.split(',');
         this.keywordsParams = documentWrite.getKeywords(this.options.config.page);
         this.userSegments   = 'seg=' + (storage.local.get('gu.history').length <= 1 ? 'new' : 'repeat');
@@ -32,11 +36,11 @@ define([
     Commercial.prototype.init = function() {
         var self = this;
 
-        bean.on(window, 'resize', common.debounce(function() {
+        mediator.addListener('window:resize', function() {
             self.applyClassnames();
-        }, 250));
+        });
 
-        common.mediator.on('modules:commercial:loaded', function() {
+        mediator.on('modules:commercial:loaded', function() {
             self.applyClassnames();
         });
 
@@ -50,7 +54,7 @@ define([
         var self = this,
             classname = this.options.elCls;
 
-        common.$g('.' + classname, this.options.context).each(function() {
+        $('.' + classname, this.options.context).each(function() {
             var $node = bonzo(this),
                 width = $node.dim().width;
 

--- a/common/app/assets/javascripts/modules/experiments/inline-link-card.js
+++ b/common/app/assets/javascripts/modules/experiments/inline-link-card.js
@@ -3,15 +3,15 @@
     Description: Load in data from the linked page and display in sidebar
 */
 define([
-    'common',
+    '$',
+    'utils/mediator',
     'modules/detect',
-    'ajax',
-    'bean'
+    'ajax'
 ], function (
-    common,
+    $,
+    mediator,
     detect,
-    ajax,
-    bean
+    ajax
 ) {
     /**
      * @param {DOMElement} link        The link to transform
@@ -21,16 +21,16 @@ define([
     function InlineLinkCard(link, linkContext, title) {
         this.link = link;
         this.title = title || false;
-        this.$linkContext = common.$g(linkContext);
+        this.$linkContext = $(linkContext);
     }
 
     InlineLinkCard.prototype.init = function() {
         var self = this;
         self.loadCard();
 
-        bean.on(window, 'resize', common.debounce(function(e){
+        mediator.addListener('window:resize', function(e) {
             self.loadCard();
-        }, 200));
+        });
     };
 
     InlineLinkCard.prototype.loadCard = function() {
@@ -95,7 +95,7 @@ define([
               '</div>';
 
         self.$linkContext.before(tpl);
-        common.mediator.emit('fragment:ready:dates');
+        mediator.emit('fragment:ready:dates');
     };
 
     function stripHost(url) {
@@ -122,7 +122,7 @@ define([
                 self.prependCard(href, resp, self.title);
             },
             function(req) {
-                common.mediator.emit('module:error', 'Failed to cardify in body link: ' + req.statusText, 'modules/inline-link-card.js');
+                mediator.emit('module:error', 'Failed to cardify in body link: ' + req.statusText, 'modules/inline-link-card.js');
             }
         );
     };

--- a/common/app/assets/javascripts/modules/facia/images.js
+++ b/common/app/assets/javascripts/modules/facia/images.js
@@ -1,15 +1,15 @@
 /*global Imager:true */
-define(['common', 'bonzo'], function (common, bonzo) {
+define(['$', 'utils/to-array', 'bonzo', 'utils/mediator'], function ($, toArray, bonzo, mediator) {
 
-    return {
+    var images = {
 
-        upgrade: function(context) {
-            if (common.$g('html').hasClass('connection--low')) {
+        upgrade: function(context, callback) {
+            if ($('html').hasClass('connection--low')) {
                 return;
             }
             require(['js!imager'], function() {
                 context = context || document;
-                var images = common.toArray(document.getElementsByClassName('item__image-container')).filter(function(img) {
+                var images = toArray(document.getElementsByClassName('item__image-container')).filter(function(img) {
                         return bonzo(img).css('display') !== 'none';
                     }),
                     options = {
@@ -18,9 +18,21 @@ define(['common', 'bonzo'], function (common, bonzo) {
                         replacementDelay: 0
                     };
                 Imager.init(images, options);
+                if (callback) {
+                    callback(images);
+                }
+            });
+        },
+
+        listen: function() {
+            mediator.addListeners({
+                'window:resize': images.upgrade,
+                'window:orientationchange': images.upgrade
             });
         }
 
     };
+
+    return images;
 
 });

--- a/common/app/assets/javascripts/modules/inview.js
+++ b/common/app/assets/javascripts/modules/inview.js
@@ -1,4 +1,4 @@
-define(["common", "bean"], function (common, bean) {
+define(["utils/mediator", 'utils/to-array', 'utils/request-animation-frame', "bean"], function (mediator, toArray, requestAnimationFrame, bean) {
 
     function Inview(selector, context) {
         var self = this;
@@ -8,15 +8,16 @@ define(["common", "bean"], function (common, bean) {
         this.refresh();
         this.checkForVisibleNodes();
 
-        bean.on(window, 'scroll', common.debounce(function() {
-            common.requestAnimationFrame(function(){
+        mediator.addListener('window:scroll', function() {
+            requestAnimationFrame(function(){
                 self.checkForVisibleNodes();
             });
-        }, 200));
+        });
     }
 
+
     Inview.prototype.refresh = function() {
-        this.inviewNodes = common.toArray(this.context.querySelectorAll(this.selector));
+        this.inviewNodes = toArray(this.context.querySelectorAll(this.selector));
     };
 
     Inview.prototype.checkForVisibleNodes = function() {
@@ -25,7 +26,7 @@ define(["common", "bean"], function (common, bean) {
             if (!el._inviewHasFired && self.isVisible(el)) {
                 // Element is visible
                 bean.fire(el, 'inview');
-                common.mediator.emit('modules:inview:visible', el);
+                mediator.emit('modules:inview:visible', el);
                 el._inviewHasFired = true;
             }
         });

--- a/common/app/assets/javascripts/modules/lightbox-gallery.js
+++ b/common/app/assets/javascripts/modules/lightbox-gallery.js
@@ -1,5 +1,7 @@
-define(["bean",
-        "common",
+define(['$',
+        "bean",
+        "utils/mediator",
+        'lodash/functions/debounce',
         "ajax",
         "bonzo",
         "qwery",
@@ -8,8 +10,10 @@ define(["bean",
         "modules/overlay"
         ],
     function (
+        $,
         bean,
-        common,
+        mediator,
+        debounce,
         ajax,
         bonzo,
         qwery,
@@ -44,7 +48,7 @@ define(["bean",
 
             if (config.switches.lightboxGalleries || self.opts.overrideSwitch) {
                 // Apply tracking to links
-                common.$g(self.selector + ' a', context).attr('data-is-ajax', '1');
+                $(self.selector + ' a', context).attr('data-is-ajax', '1');
 
                 bean.on(context, 'click', self.selector + ' a', function(e) {
                     e.preventDefault();
@@ -96,7 +100,7 @@ define(["bean",
                     var currentItemEl = qwery('.js-gallery-item-'+currentImage, galleryNode)[0],
                         captionAreaHit = false;
 
-                    common.$g('.gallerycaption, .captioncontrol', currentItemEl).each(function(el) {
+                    $('.gallerycaption, .captioncontrol', currentItemEl).each(function(el) {
                         if (bonzo.isAncestor(el, e.target)) {
                             captionAreaHit = true;
                         }
@@ -132,18 +136,18 @@ define(["bean",
                 self.goTo(index);
             });
 
-            bean.on(window, 'orientationchange', common.debounce(function() {
+            mediator.addListener('window:orientationchange', function() {
                 self.layout();
                 if (detect.getOrientation() === 'landscape') {
                     self.jumpToContent();
                 }
-            }));
+            });
 
-            bean.on(window, 'resize', common.debounce(function() {
+            mediator.addListener('window:resize', function() {
                 self.layout();
-            }));
+            });
 
-            common.mediator.on('modules:overlay:close', function() {
+            mediator.on('modules:overlay:close', function() {
                 // Remove events
                 bean.off(overlay.toolbarNode, 'click');
                 bean.off(overlay.bodyNode, 'click touchmove touchend');
@@ -176,7 +180,7 @@ define(["bean",
                     // Remove keyboard handlers
                     bean.off(document.body, 'keydown', self.handleKeyEvents);
 
-                    common.mediator.emit('module:clickstream:interaction', 'Lightbox Gallery - Back button exit');
+                    mediator.emit('module:clickstream:interaction', 'Lightbox Gallery - Back button exit');
                 }
             });
         };
@@ -216,8 +220,8 @@ define(["bean",
                     overlay.setBody(response.html);
 
                     galleryNode  = qwery('.gallery--lightbox', overlay.bodyNode)[0];
-                    $navArrows   = common.$g('.gallery__nav', galleryNode);
-                    $images      = common.$g('.gallery__img', galleryNode);
+                    $navArrows   = $('.gallery__nav', galleryNode);
+                    $images      = $('.gallery__img', galleryNode);
                     totalImages  = parseInt(galleryNode.getAttribute('data-total'), 10);
 
                     // Save the first state of the gallery
@@ -241,7 +245,7 @@ define(["bean",
                     bean.on(document.body, 'keydown', self.handleKeyEvents);
 
                     // Register this as a page view
-                    common.mediator.emit('module:lightbox-gallery:loaded', response.config, galleryNode);
+                    mediator.emit('module:lightbox-gallery:loaded', response.config, galleryNode);
                 },
                 error: function() {
                     var errorMsg = '<div class="preload-msg">Error loading gallery' +
@@ -278,7 +282,7 @@ define(["bean",
             overlay.toolbarNode.querySelector('.js-stop-slideshow').style.display  = 'none';
         };
 
-        this.removeOverlay = common.debounce(function(e){
+        this.removeOverlay = debounce(function(e){
             // Needs a delay to give time for analytics to fire before DOM removal
             overlay.remove();
             return true;
@@ -320,7 +324,7 @@ define(["bean",
                 index = totalImages;
             }
 
-            common.$g('.gallery__item', overlay.bodyNode).each(function(el) {
+            $('.gallery__item', overlay.bodyNode).each(function(el) {
                 var itemIndex = parseInt(el.getAttribute('data-index'), 10);
 
                 if (itemIndex === index) {
@@ -358,7 +362,7 @@ define(["bean",
             bonzo(galleryNode).removeClass('gallery--fullimage-mode').addClass('gallery--grid-mode');
 
             // Switch all images back to thumbnail versions
-            common.$g('.gallery__img', overlay.bodyNode).each(function(el) {
+            $('.gallery__img', overlay.bodyNode).each(function(el) {
                 el.src = el.getAttribute('data-src');
             });
 
@@ -419,8 +423,8 @@ define(["bean",
             }
 
             // We query for the images here, as the swipe lib can rewrite the DOM, which loses the references
-            $images = common.$g('.gallery__img', galleryNode);
-            var $items = common.$g('.gallery__item', galleryNode);
+            $images = $('.gallery__img', galleryNode);
+            var $items = $('.gallery__item', galleryNode);
 
 
             if (mode === 'fullimage') {
@@ -503,7 +507,7 @@ define(["bean",
 
         // send custom (eg non-link) interactions to omniture
         this.trackInteraction = function (str) {
-            common.mediator.emit('module:clickstream:interaction', str);
+            mediator.emit('module:clickstream:interaction', str);
         };
 
 

--- a/common/app/assets/javascripts/modules/live-summary.js
+++ b/common/app/assets/javascripts/modules/live-summary.js
@@ -3,13 +3,13 @@
     Description: Display latest summary to the user
 */
 define([
-    'common',
-    'bonzo',
-    'bean'
+    'utils/mediator',
+    'utils/to-array',
+    'bonzo'
 ], function (
-    common,
-    bonzo,
-    bean
+    mediator,
+    toArray,
+    bonzo
 ) {
     'use strict';
 
@@ -18,10 +18,10 @@ define([
         this.maxSummaryHeight = 250;
         this.expandableClass = 'live-summary--expandable';
         this.articleContainer = this.context.getElementsByClassName('js-article__container')[0];
-        this.summaries = common.toArray(this.articleContainer.getElementsByClassName('is-summary'));
-        this.summaryContainers = common.toArray(this.context.getElementsByClassName('js-article__summary'));
-        this.hiddenSummaryContainers = common.toArray(this.context.querySelectorAll('.js-article__summary.is-hidden'));
-        this.placeholders = common.toArray(this.context.getElementsByClassName('js-summary-placeholder'));
+        this.summaries = toArray(this.articleContainer.getElementsByClassName('is-summary'));
+        this.summaryContainers = toArray(this.context.getElementsByClassName('js-article__summary'));
+        this.hiddenSummaryContainers = toArray(this.context.querySelectorAll('.js-article__summary.is-hidden'));
+        this.placeholders = toArray(this.context.getElementsByClassName('js-summary-placeholder'));
     }
 
     Summary.prototype.init = function() {
@@ -30,15 +30,16 @@ define([
         this.deportLatest();
         this.render();
 
-        common.mediator.on('modules:autoupdate:loaded', function() {
+        mediator.on('modules:autoupdate:loaded', function() {
             self.deportLatest.call(self);
             self.render.call(self);
         });
-        bean.on(window, 'resize', common.debounce(function() {
+
+        mediator.addListener('window:resize', function() {
             self.summaryContainers.forEach(function(element, index) {
                 self.expandable(element, self.maxSummaryHeight, self.expandableClass);
             });
-        }, 100));
+        });
     };
 
     Summary.prototype.render = function() {

--- a/common/app/assets/javascripts/modules/navigation/sections.js
+++ b/common/app/assets/javascripts/modules/navigation/sections.js
@@ -1,13 +1,13 @@
 define([
     'common',
     'bonzo',
-    'bean',
+    'utils/mediator',
     'modules/detect',
     'modules/userPrefs'
 ], function (
     common,
     bonzo,
-    bean,
+    mediator,
     detect,
     userPrefs
 ) {
@@ -78,7 +78,7 @@ define([
                     return;
                 }
 
-                bean.on(window, 'resize', common.debounce(function(e){
+                mediator.addListener('window:resize', function(e) {
                     hasCrossedBreakpoint(function(layoutMode) {
 
                         bonzo(sectionsHeader).addClass(className);
@@ -92,7 +92,7 @@ define([
                             that.view.showColumns(sectionsHeader, sectionsNav);
                         }
                     });
-                }, 200));
+                });
 
                 if(detect.getLayoutMode() !== 'mobile') {
                     that.view.hideColumns(sectionsHeader, sectionsNav);


### PR DESCRIPTION
Ostensibly the title, achieved by proxying `window` events (`resize`, `scroll`, `orientationchange`) through event emitter. 

https://github.com/guardian/frontend/compare/window-resize-images?expand=1#diff-1fc34d3571eb5e604f148c59d69a1e18R374

Now, instead of each module creating their own `bean` listener, they can now listen to the `mediator`

https://github.com/guardian/frontend/compare/window-resize-images?expand=1#diff-c787f5386a82fc95c76d71485ac9b67aR31

Also started to move over to requiring the exact modules used, rather than just `common`
