### PR TITLE
Ensure we adhere to storypackage source ordering

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -95,8 +95,8 @@
                             <div class="u-table__row">
                                 <div class="u-table__cell u-table__cell--collapse u-table__cell--bottom">
                                     <div class="js-sticky-lower" data-id="mpu-ad-slot"></div>
-                                    @if(storyPackage.nonEmpty) {
-                                        @fragments.cards.card(storyPackage.head, "right", "More on this story", "Story package card", "visible")
+                                    @storyPackage.headOption.map{ item =>
+                                        @fragments.cards.card(item, "right", "More on this story", "Story package card", "visible")
                                     }
                                 </div>
                             </div>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -96,7 +96,7 @@
                                 <div class="u-table__cell u-table__cell--collapse u-table__cell--bottom">
                                     <div class="js-sticky-lower" data-id="mpu-ad-slot"></div>
                                     @if(storyPackage.nonEmpty) {
-                                        @fragments.cards.card(storyPackage.sortBy(-_.webPublicationDate.getMillis).head, "right", "More on this story", "Story package card", "visible")
+                                        @fragments.cards.card(storyPackage.head, "right", "More on this story", "Story package card", "visible")
                                     }
                                 </div>
                             </div>

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -269,23 +269,6 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers  w
 
     }
 
-    scenario("Story package ordered by date published") {
-
-      Given("I'm on an article entitled 'Iraq war logs reveal 15,000 previously unlisted civilian deaths'")
-
-      HtmlUnit("/world/2010/oct/22/true-civilian-body-count-iraq") { browser =>
-        import browser._
-
-        Then("I should see the related content ordered")
-        val relatedContent = $("[itemprop=relatedLink]")
-        relatedContent.get(0).getText should be("Iraq war logs: experts' views")
-        relatedContent.get(1).getText should be("Iraq war logs: media reaction around the world")
-        relatedContent.get(2).getText should be("Iraq war logs: 'The US was part of the Wolf Brigade operation against us'")
-        relatedContent.get(3).getText should be("Iraq war logs: Prisoner beaten to death days after British handover to police")
-        relatedContent.get(4).getText should be("Iraq war logs: These crimes were not secret, they were tolerated")
-      }
-    }
-
     scenario("Direct link to paragraph") {
 
       Given("I have clicked a direct link to paragrah 16 on the article 'Eurozone crisis live: Fitch downgrades Greece on euro exit fears'")

--- a/common/app/views/fragments/relatedTrails.scala.html
+++ b/common/app/views/fragments/relatedTrails.scala.html
@@ -8,9 +8,9 @@
         role="complementary"
         aria-labelledby="related-content-head">
         @* order the related trails by date *@
-        @fragments.trailblocks.thumbnail(trails.sortBy(-_.webPublicationDate.getMillis), numItemsVisible = visibleTrails, related = true, headingLevel = 3)
+        @fragments.trailblocks.thumbnail(trails, numItemsVisible = visibleTrails, related = true, headingLevel = 3)
         @if(trails.size > visibleTrails) {
-            @fragments.trailblocks.headline(trails.sortBy(-_.webPublicationDate.getMillis).drop(visibleTrails), numItemsVisible = trails.size - visibleTrails, related = true, isPanel = true, headingLevel = 3)
+            @fragments.trailblocks.headline(trails.drop(visibleTrails), numItemsVisible = trails.size - visibleTrails, related = true, isPanel = true, headingLevel = 3)
         }
     </div>
 }

--- a/core-navigation/app/controllers/RelatedController.scala
+++ b/core-navigation/app/controllers/RelatedController.scala
@@ -13,7 +13,7 @@ object RelatedController extends Controller with Related with Logging with Execu
     val edition = Edition(request)
     related(edition, path) map {
       case Nil => JsonNotFound()
-      case trails => renderRelated(trails)
+      case trails => renderRelated(trails.sortBy(-_.webPublicationDate.getMillis))
     }
   }
 

--- a/data/database/23b6b726b78b3950a9c8902ead1a2a35f4f5ada2
+++ b/data/database/23b6b726b78b3950a9c8902ead1a2a35f4f5ada2
@@ -1,0 +1,6212 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":1,
+    "mostViewed":[{
+      "id":"lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Why you won't catch me queuing for a burger",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "fields":{
+        "trailText":"<p><strong>Jay Rayner:</strong> Waiting two hours in a line for beef in a bun was never going to be a good idea</p>",
+        "headline":"Why you won't catch me queuing for a burger",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k6zt",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+        "wordcount":"567",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T12:00:02Z"
+      },
+      "tags":[{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fast-food",
+        "type":"keyword",
+        "webTitle":"Fast food",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fast-food",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fast-food",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Observer Food Monthly recipes & features",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly/features",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly/features",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly",
+        "type":"newspaper-book",
+        "webTitle":"Observer Food Monthly",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"lifeandstyle/series/happy-eater",
+        "type":"series",
+        "webTitle":"Happy eater",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/happy-eater",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/happy-eater",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/jayrayner",
+        "type":"contributor",
+        "webTitle":"Jay Rayner",
+        "webUrl":"http://www.theguardian.com/profile/jayrayner",
+        "apiUrl":"http://content.guardianapis.com/profile/jayrayner",
+        "bio":"<p>Jay Rayner is the Observer's restaurant critic and a novelist. His latest book is the Oyster House Siege</p>",
+        "rcsId":"GNL258574",
+        "r2ContributorId":"15803",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2008/06/02/jay_rayner_140x140.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theobserver",
+        "type":"publication",
+        "webTitle":"The Observer",
+        "webUrl":"http://www.theguardian.com/theobserver/all",
+        "apiUrl":"http://content.guardianapis.com/theobserver/all",
+        "sectionId":"theobserver",
+        "sectionName":"From the Observer",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422287525",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259303137/burger-and-fries-from-sha-007.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"276",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about self-denial\". Photograph: Radharc Images/Alamy",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422287526",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"84",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about \nself-denial\". Photograph: Radharc Images /Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T12:58:39Z",
+      "webTitle":"It was hard to stomach David Cameron preaching austerity from a golden throne | Ruth Hardy",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "fields":{
+        "trailText":"<strong>Ruth Hardy: </strong>As a waitress at the lord mayor's banquet, the contrast between what Cameron was saying and where he was saying it felt particularly chilling",
+        "headline":"It was hard to stomach David Cameron preaching austerity from a golden throne",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbyq",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+        "wordcount":"738",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T12:58:39Z"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"politics/davidcameron",
+        "type":"keyword",
+        "webTitle":"David Cameron",
+        "webUrl":"http://www.theguardian.com/politics/davidcameron",
+        "apiUrl":"http://content.guardianapis.com/politics/davidcameron",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/conservatives",
+        "type":"keyword",
+        "webTitle":"Conservatives",
+        "webUrl":"http://www.theguardian.com/politics/conservatives",
+        "apiUrl":"http://content.guardianapis.com/politics/conservatives",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"society/public-sector-cuts",
+        "type":"keyword",
+        "webTitle":"Public sector cuts",
+        "webUrl":"http://www.theguardian.com/society/public-sector-cuts",
+        "apiUrl":"http://content.guardianapis.com/society/public-sector-cuts",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/policy",
+        "type":"keyword",
+        "webTitle":"Public services policy",
+        "webUrl":"http://www.theguardian.com/society/policy",
+        "apiUrl":"http://content.guardianapis.com/society/policy",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/public-finance",
+        "type":"keyword",
+        "webTitle":"Public finance",
+        "webUrl":"http://www.theguardian.com/society/public-finance",
+        "apiUrl":"http://content.guardianapis.com/society/public-finance",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"business/austerity",
+        "type":"keyword",
+        "webTitle":"Austerity",
+        "webUrl":"http://www.theguardian.com/business/austerity",
+        "apiUrl":"http://content.guardianapis.com/business/austerity",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/economics",
+        "type":"keyword",
+        "webTitle":"Economics",
+        "webUrl":"http://www.theguardian.com/business/economics",
+        "apiUrl":"http://content.guardianapis.com/business/economics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"profile/ruth-hardy",
+        "type":"contributor",
+        "webTitle":"Ruth Hardy",
+        "webUrl":"http://www.theguardian.com/profile/ruth-hardy",
+        "apiUrl":"http://content.guardianapis.com/profile/ruth-hardy",
+        "bio":"<p>Ruth Hardy is a freelance writer and recent graduate in philosophy at King's College London. You can follow her on Twitter <a href=\"https://twitter.com/ruthhardy22\">here</a></p>",
+        "r2ContributorId":"56147",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Education/Pix/pictures/2013/4/24/1366808642483/Ruth-Hardy-student-blogge-002.jpg",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422382150",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344632805/David-Cameron-at-Lord-May-001.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"54",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344634858/David-Cameron-at-Lord-May-002.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"130",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344637355/David-Cameron-at-Lord-May-004.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"132",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344638596/David-Cameron-at-Lord-May-005.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"168",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344639804/David-Cameron-at-Lord-May-006.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"180",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344641041/David-Cameron-at-Lord-May-007.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"228",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422382151",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T14:44:00Z",
+      "webTitle":"MI6 spy found dead in bag probably locked himself inside, Met says",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "fields":{
+        "trailText":"Three-year investigation by Scotland Yard concludes Gareth Williams probably died as a result of tragic accident",
+        "headline":"MI6 spy found dead in bag probably locked himself inside, Met says",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjj",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+        "wordcount":"962",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:18:14Z"
+      },
+      "tags":[{
+        "id":"uk/gareth-williams",
+        "type":"keyword",
+        "webTitle":"Gareth Williams",
+        "webUrl":"http://www.theguardian.com/uk/gareth-williams",
+        "apiUrl":"http://content.guardianapis.com/uk/gareth-williams",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/mi6",
+        "type":"keyword",
+        "webTitle":"MI6",
+        "webUrl":"http://www.theguardian.com/uk/mi6",
+        "apiUrl":"http://content.guardianapis.com/uk/mi6",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uksecurity",
+        "type":"keyword",
+        "webTitle":"UK security and counter-terrorism",
+        "webUrl":"http://www.theguardian.com/uk/uksecurity",
+        "apiUrl":"http://content.guardianapis.com/uk/uksecurity",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/josh-halliday",
+        "type":"contributor",
+        "webTitle":"Josh Halliday",
+        "webUrl":"http://www.theguardian.com/profile/josh-halliday",
+        "apiUrl":"http://content.guardianapis.com/profile/josh-halliday",
+        "bio":"<p><a href=\"http://twitter.com/JoshHalliday\">Josh Halliday</a> is a media and technology reporter. Josh has a keen interest in digital media and privacy. Dislikes insufferable enthusiasm. Bradfordian via Wearside</p>",
+        "r2ContributorId":"38624",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/7/14/1279118930047/Josh-Halliday.jpg",
+        "references":[]
+      },{
+        "id":"uk/metropolitan-police",
+        "type":"keyword",
+        "webTitle":"Metropolitan police",
+        "webUrl":"http://www.theguardian.com/uk/metropolitan-police",
+        "apiUrl":"http://content.guardianapis.com/uk/metropolitan-police",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/uk/london",
+        "apiUrl":"http://content.guardianapis.com/uk/london",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379877",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341447432/Gareth-Williams-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"54",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341448835/Gareth-Williams-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"340",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341450089/Gareth-Williams-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"130",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341452580/Gareth-Williams-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"132",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341453889/Gareth-Williams-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"168",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341455246/Gareth-Williams-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"180",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341456514/Gareth-Williams-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"228",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341459093/Gareth-Williams-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"372",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379878",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-12T15:34:27Z",
+      "webTitle":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "fields":{
+        "trailText":"Rolling Jubilee spent $400,000 to purchase debt cheaply from banks before 'abolishing' it, freeing individuals from their bills",
+        "headline":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb4g",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+        "wordcount":"1",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-15T15:30:25Z"
+      },
+      "tags":[{
+        "id":"world/occupy-movement",
+        "type":"keyword",
+        "webTitle":"Occupy movement",
+        "webUrl":"http://www.theguardian.com/world/occupy-movement",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-movement",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/occupy-wall-street",
+        "type":"keyword",
+        "webTitle":"Occupy Wall Street",
+        "webUrl":"http://www.theguardian.com/world/occupy-wall-street",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-wall-street",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/debt-relief",
+        "type":"keyword",
+        "webTitle":"Debt relief",
+        "webUrl":"http://www.theguardian.com/world/debt-relief",
+        "apiUrl":"http://content.guardianapis.com/world/debt-relief",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"money/us-personal-finance",
+        "type":"keyword",
+        "webTitle":"US personal finance",
+        "webUrl":"http://www.theguardian.com/money/us-personal-finance",
+        "apiUrl":"http://content.guardianapis.com/money/us-personal-finance",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"money/mortgages-us",
+        "type":"keyword",
+        "webTitle":"US mortgages",
+        "webUrl":"http://www.theguardian.com/money/mortgages-us",
+        "apiUrl":"http://content.guardianapis.com/money/mortgages-us",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"business/useconomy",
+        "type":"keyword",
+        "webTitle":"US economy",
+        "webUrl":"http://www.theguardian.com/business/useconomy",
+        "apiUrl":"http://content.guardianapis.com/business/useconomy",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"money/money",
+        "type":"keyword",
+        "webTitle":"Money",
+        "webUrl":"http://www.theguardian.com/money/money",
+        "apiUrl":"http://content.guardianapis.com/money/money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/adam-gabbatt",
+        "type":"contributor",
+        "webTitle":"Adam Gabbatt",
+        "webUrl":"http://www.theguardian.com/profile/adam-gabbatt",
+        "apiUrl":"http://content.guardianapis.com/profile/adam-gabbatt",
+        "bio":"<p>Adam Gabbatt is a reporter and live blogger for the Guardian, based in New York. He won a journalism bursary from the Scott Trust, the company that owns the Guardian, in 2008, and began writing for the newspaper and website in 2009. He was highly commended in the young journalist of the year category at the British Press Awards in 2011</p>",
+        "r2ContributorId":"33854",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/1/24/1359039911843/AdamGabbatt.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"276",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"'Our primary purpose was to spread information about the workings of this secondary debt market,' said Andrew Ross.&nbsp;Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"84",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"The Occupy movement began in Wall Street in November 2011 when protesters attempted to shut down the New York stock exchange. Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T01:25:32Z",
+      "webTitle":"ITV news presenter hits back after abuse for not wearing poppy",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "fields":{
+        "trailText":"Charlene White faced racist and sexist abuse which, she said, acted against all the goals that the fallen soldiers fought for",
+        "headline":"ITV news presenter hits back after abuse for not wearing poppy",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbfc",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+        "wordcount":"504",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T01:25:32Z"
+      },
+      "tags":[{
+        "id":"uk/remembranceday",
+        "type":"keyword",
+        "webTitle":"Remembrance Day",
+        "webUrl":"http://www.theguardian.com/uk/remembranceday",
+        "apiUrl":"http://content.guardianapis.com/uk/remembranceday",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"media/itv1",
+        "type":"keyword",
+        "webTitle":"ITV channel",
+        "webUrl":"http://www.theguardian.com/media/itv1",
+        "apiUrl":"http://content.guardianapis.com/media/itv1",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/television",
+        "type":"keyword",
+        "webTitle":"Television industry",
+        "webUrl":"http://www.theguardian.com/media/television",
+        "apiUrl":"http://content.guardianapis.com/media/television",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/media",
+        "type":"keyword",
+        "webTitle":"Media",
+        "webUrl":"http://www.theguardian.com/media/media",
+        "apiUrl":"http://content.guardianapis.com/media/media",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"tv-and-radio/tv-news",
+        "type":"keyword",
+        "webTitle":"The news on TV",
+        "webUrl":"http://www.theguardian.com/tv-and-radio/tv-news",
+        "apiUrl":"http://content.guardianapis.com/tv-and-radio/tv-news",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"culture/television",
+        "type":"keyword",
+        "webTitle":"Television",
+        "webUrl":"http://www.theguardian.com/culture/television",
+        "apiUrl":"http://content.guardianapis.com/culture/television",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"profile/shane-hickey",
+        "type":"contributor",
+        "webTitle":"Shane Hickey",
+        "webUrl":"http://www.theguardian.com/profile/shane-hickey",
+        "apiUrl":"http://content.guardianapis.com/profile/shane-hickey",
+        "r2ContributorId":"55396",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422347763",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305766581/Poppies-001.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"54",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305768729/Poppies-002.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"340",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305770017/Poppies-003.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"130",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305772726/Poppies-005.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"132",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305773964/Poppies-006.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"168",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305775328/Poppies-007.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"180",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305776636/Poppies-008.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"228",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305779302/Poppies-010.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"372",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422347764",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "sectionId":"society",
+      "sectionName":"Society",
+      "webPublicationDate":"2013-11-13T12:10:00Z",
+      "webTitle":"Hamzah Khan: minister has 'deep concerns' over review findings",
+      "webUrl":"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "apiUrl":"http://content.guardianapis.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "fields":{
+        "trailText":"Edward Timpson criticises review into death of child who starved to death while DfE source describes report as 'risible'",
+        "headline":"Hamzah Khan: minister has 'deep concerns' over review findings",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kby3",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+        "wordcount":"579",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:49:22Z"
+      },
+      "tags":[{
+        "id":"society/childprotection",
+        "type":"keyword",
+        "webTitle":"Child protection",
+        "webUrl":"http://www.theguardian.com/society/childprotection",
+        "apiUrl":"http://content.guardianapis.com/society/childprotection",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/children",
+        "type":"keyword",
+        "webTitle":"Children",
+        "webUrl":"http://www.theguardian.com/society/children",
+        "apiUrl":"http://content.guardianapis.com/society/children",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/social-care",
+        "type":"keyword",
+        "webTitle":"Social care",
+        "webUrl":"http://www.theguardian.com/society/social-care",
+        "apiUrl":"http://content.guardianapis.com/society/social-care",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/localgovernment",
+        "type":"keyword",
+        "webTitle":"Local government",
+        "webUrl":"http://www.theguardian.com/society/localgovernment",
+        "apiUrl":"http://content.guardianapis.com/society/localgovernment",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"uk/bradford",
+        "type":"keyword",
+        "webTitle":"Bradford",
+        "webUrl":"http://www.theguardian.com/uk/bradford",
+        "apiUrl":"http://content.guardianapis.com/uk/bradford",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/helenpidd",
+        "type":"contributor",
+        "webTitle":"Helen Pidd",
+        "webUrl":"http://www.theguardian.com/profile/helenpidd",
+        "apiUrl":"http://content.guardianapis.com/profile/helenpidd",
+        "bio":"<p>Helen Pidd is northern editor of the Guardian, based in Manchester. She joined the paper in 2004 to edit the now defunct Office Hours and was a commissioning editor on G2 before joining the home news team in 2007, going on to spend 2011 in Germany as Berlin correspondent followed by a stint in Delhi. She is the author of <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490530\">Bicycle – The Complete<br />Guide to Everyday Cycling</a>.</p>",
+        "r2ContributorId":"19855",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/6/22/1277217764498/Helen-Pidd-byline.-003.jpg",
+        "references":[]
+      },{
+        "id":"profile/haroonsiddique",
+        "type":"contributor",
+        "webTitle":"Haroon Siddique",
+        "webUrl":"http://www.theguardian.com/profile/haroonsiddique",
+        "apiUrl":"http://content.guardianapis.com/profile/haroonsiddique",
+        "bio":"<p>Haroon Siddique is a news reporter on the Guardian website. He previously worked for North London institution the Ham&amp;High, and before pursuing his passion for journalism he was a commodity trader in the City</p>",
+        "r2ContributorId":"19136",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/haroon_siddique.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379573",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343315052/Hamzah-Khan-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"54",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343317421/Hamzah-Khan-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"340",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343318751/Hamzah-Khan-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"130",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343321335/Hamzah-Khan-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"132",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343322756/Hamzah-Khan-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"168",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343324035/Hamzah-Khan-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"180",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343325436/Hamzah-Khan-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"228",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343328488/Hamzah-Khan-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"372",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379574",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T09:50:29Z",
+      "webTitle":"Lily Allen does not represent all feminism – and nor should she | Ellie Mae O'Hagan",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "fields":{
+        "trailText":"<p><strong>Ellie Mae O'Hagan:</strong> Instead of critiquing whether Allen's new video is feminist or not, we should ask why there is such a weight of expectation on one woman</p>",
+        "headline":"Lily Allen does not represent all feminism – and nor should she",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbhf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+        "wordcount":"909",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T09:50:00Z"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"world/feminism",
+        "type":"keyword",
+        "webTitle":"Feminism",
+        "webUrl":"http://www.theguardian.com/world/feminism",
+        "apiUrl":"http://content.guardianapis.com/world/feminism",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"music/lilyallen",
+        "type":"keyword",
+        "webTitle":"Lily Allen",
+        "webUrl":"http://www.theguardian.com/music/lilyallen",
+        "apiUrl":"http://content.guardianapis.com/music/lilyallen",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/ellie-mae-o-hagan",
+        "type":"contributor",
+        "webTitle":"Ellie Mae O'Hagan",
+        "webUrl":"http://www.theguardian.com/profile/ellie-mae-o-hagan",
+        "apiUrl":"http://content.guardianapis.com/profile/ellie-mae-o-hagan",
+        "bio":"<p>Ellie Mae O'Hagan is a regular columnist for Comment is free. She has also written for the Times, the New Statesman, Red Pepper, False Economy, New Left Project and Union News. She currently works with the Centre for Labour and Social Studies, a think for left debate and discussion originating in the trade union movement. She is also an active member of UK Uncut. She  tweets as <a href=\"http://twitter.com/#!/MissEllieMae\">@MissEllieMae</a></p>",
+        "r2ContributorId":"43367",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/3/22/1300821538131/EllieMaeOHagan.jpg",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388300",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Lily Allen",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Lily Allen",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T10:06:25Z",
+      "webTitle":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "fields":{
+        "trailText":"Ranjit Sinha, chief of India's Central Bureau of Investigation, apologises for remark that causes outrage across country",
+        "headline":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbhz",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+        "wordcount":"273",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T10:06:25Z"
+      },
+      "tags":[{
+        "id":"world/india",
+        "type":"keyword",
+        "webTitle":"India",
+        "webUrl":"http://www.theguardian.com/world/india",
+        "apiUrl":"http://content.guardianapis.com/world/india",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"society/rape",
+        "type":"keyword",
+        "webTitle":"Rape",
+        "webUrl":"http://www.theguardian.com/society/rape",
+        "apiUrl":"http://content.guardianapis.com/society/rape",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"law/law",
+        "type":"keyword",
+        "webTitle":"Law",
+        "webUrl":"http://www.theguardian.com/law/law",
+        "apiUrl":"http://content.guardianapis.com/law/law",
+        "sectionId":"law",
+        "sectionName":"Law",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422369576",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337123909/Ranjit-Sinha-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"54",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337125231/Ranjit-Sinha-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"340",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337126586/Ranjit-Sinha-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"130",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337129092/Ranjit-Sinha-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"132",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337130310/Ranjit-Sinha-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"168",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337131559/Ranjit-Sinha-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"180",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337132902/Ranjit-Sinha-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"228",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337135575/Ranjit-Sinha-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"372",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422369577",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T11:18:52Z",
+      "webTitle":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "fields":{
+        "trailText":"Roberto Di Matteo is reportedly still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago",
+        "headline":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjb",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+        "wordcount":"140",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:18:52Z"
+      },
+      "tags":[{
+        "id":"football/roberto-di-matteo",
+        "type":"keyword",
+        "webTitle":"Roberto Di Matteo",
+        "webUrl":"http://www.theguardian.com/football/roberto-di-matteo",
+        "apiUrl":"http://content.guardianapis.com/football/roberto-di-matteo",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/chelsea",
+        "type":"keyword",
+        "webTitle":"Chelsea",
+        "webUrl":"http://www.theguardian.com/football/chelsea",
+        "apiUrl":"http://content.guardianapis.com/football/chelsea",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/4"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422374804",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341239071/Roberto-Di-Matteo-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"54",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341242197/Roberto-Di-Matteo-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"340",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341243440/Roberto-Di-Matteo-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"130",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341244752/Roberto-Di-Matteo-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"720",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341246531/Roberto-Di-Matteo-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341249682/Roberto-Di-Matteo-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"132",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341250911/Roberto-Di-Matteo-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"168",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341252176/Roberto-Di-Matteo-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"180",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341253497/Roberto-Di-Matteo-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"228",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341256016/Roberto-Di-Matteo-012.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"372",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341257472/Roberto-Di-Matteo-013.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1116",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1860"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341259557/Roberto-Di-Matteo-014.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2560"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422374805",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/4"
+      }]
+    },{
+      "id":"film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "sectionId":"film",
+      "sectionName":"Film",
+      "webPublicationDate":"2013-11-12T10:01:00Z",
+      "webTitle":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+      "webUrl":"http://www.theguardian.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "apiUrl":"http://content.guardianapis.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "fields":{
+        "trailText":"<p>Unable to cut his sexually explicit film down from five hours, Danish director opts to let someone else cut the movie down to two, two-hour chunks – both including explicit footage</p>",
+        "headline":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kakf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+        "wordcount":"343",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-15T10:01:00Z"
+      },
+      "tags":[{
+        "id":"film/lars-von-trier",
+        "type":"keyword",
+        "webTitle":"Lars von Trier",
+        "webUrl":"http://www.theguardian.com/film/lars-von-trier",
+        "apiUrl":"http://content.guardianapis.com/film/lars-von-trier",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"culture/charlotte-gainsbourg",
+        "type":"keyword",
+        "webTitle":"Charlotte Gainsbourg",
+        "webUrl":"http://www.theguardian.com/culture/charlotte-gainsbourg",
+        "apiUrl":"http://content.guardianapis.com/culture/charlotte-gainsbourg",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"profile/benchild",
+        "type":"contributor",
+        "webTitle":"Ben Child",
+        "webUrl":"http://www.theguardian.com/profile/benchild",
+        "apiUrl":"http://content.guardianapis.com/profile/benchild",
+        "bio":"<p>Ben Child is a journalist, DJ and producer whose main interests lie in the worlds of film and music</p>",
+        "r2ContributorId":"24984",
+        "references":[]
+      },{
+        "id":"film/drama",
+        "type":"keyword",
+        "webTitle":"Drama",
+        "webUrl":"http://www.theguardian.com/film/drama",
+        "apiUrl":"http://content.guardianapis.com/film/drama",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"culture/pornography",
+        "type":"keyword",
+        "webTitle":"Pornography",
+        "webUrl":"http://www.theguardian.com/culture/pornography",
+        "apiUrl":"http://content.guardianapis.com/culture/pornography",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"world/denmark",
+        "type":"keyword",
+        "webTitle":"Denmark",
+        "webUrl":"http://www.theguardian.com/world/denmark",
+        "apiUrl":"http://content.guardianapis.com/world/denmark",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422284236",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244020710/Nymphomaniac-chapter-one--008.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"276",
+            "credit":"Christian Geisnaes",
+            "caption":"One of the few fully-clothed stills from Nymphomaniac. Photograph: Christian Geisnaes",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422284237",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"84",
+            "credit":"Christian Geisnaes",
+            "caption":"Nymphomaniac chapter one still Photograph: Christian Geisnaes",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:04:31Z",
+      "webTitle":"Jack Monroe's frozen yoghurt recipe",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "fields":{
+        "trailText":"<p>This simple dessert is a great way to stretch fresh berries, but it works brilliantly with cheaper frozen fruit, too</p>",
+        "headline":"Jack Monroe's frozen yoghurt recipe",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbka",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+        "wordcount":"222",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T12:04:31Z"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "type":"series",
+        "webTitle":"Jack Monroe's low-cost recipes",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/dessert",
+        "type":"keyword",
+        "webTitle":"Dessert",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/dessert",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/dessert",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fruit",
+        "type":"keyword",
+        "webTitle":"Fruit",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fruit",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fruit",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"money/saving-money",
+        "type":"keyword",
+        "webTitle":"Saving money",
+        "webUrl":"http://www.theguardian.com/money/saving-money",
+        "apiUrl":"http://content.guardianapis.com/money/saving-money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"profile/jack-monroe",
+        "type":"contributor",
+        "webTitle":"Jack Monroe",
+        "webUrl":"http://www.theguardian.com/profile/jack-monroe",
+        "apiUrl":"http://content.guardianapis.com/profile/jack-monroe",
+        "bio":"<p>Jack Monroe blogs at <a href=\"http://agirlcalledjack.com/\">A Girl Called Jack</a> and is author of the forthcoming A Girl Called Jack recipe book</p>",
+        "r2ContributorId":"57609",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/10/1378813805813/Jack-Monroe.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381337",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344202019/Jack-Monroes-frozen-yoghu-009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"276",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381338",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"84",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "sectionId":"news",
+      "sectionName":"News",
+      "webPublicationDate":"2013-11-13T07:30:00Z",
+      "webTitle":"The daily quiz, 13 November 2013",
+      "webUrl":"http://www.theguardian.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "apiUrl":"http://content.guardianapis.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "fields":{
+        "trailText":"<p>From murder mysteries to famous lakes and luxury goods purveyors to the rules of boxing, 10 questions to test you</p>",
+        "headline":"The daily quiz, 13 November 2013",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k2vg",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T07:30:00Z"
+      },
+      "tags":[{
+        "id":"news/series/the-daily-quiz",
+        "type":"series",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/news/series/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/news/series/the-daily-quiz",
+        "sectionId":"news",
+        "sectionName":"News",
+        "references":[]
+      },{
+        "id":"profile/the-daily-quiz",
+        "type":"contributor",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/profile/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/profile/the-daily-quiz",
+        "bio":"<p>A daily general knowledge quiz from theguardian.com. Email: daily.quiz@theguardian.com</p>",
+        "r2ContributorId":"57817",
+        "references":[]
+      },{
+        "id":"type/quiz",
+        "type":"type",
+        "webTitle":"Quiz",
+        "webUrl":"http://www.theguardian.com/quizzes",
+        "apiUrl":"http://content.guardianapis.com/quizzes",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-421318129",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Sinibomb Images",
+            "altText":"Pac-Man",
+            "height":"84",
+            "credit":"Sinibomb Images/Alamy",
+            "caption":"Despite our video games knowledge being prehistoric, we decided such a huge part of the entertainment world would be ignored at our peril. Photograph: Sinibomb Images/Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:55:00Z",
+      "webTitle":"How to make the perfect onion bhajis",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "fields":{
+        "trailText":"<p>Can another member of the fritter family beat the onion bhaji, do you eat them as a starter or a snack, and what do you serve with them?</p>",
+        "headline":"How to make the perfect onion bhajis",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbnh",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+        "wordcount":"1130",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-20T12:55:00Z"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/how-to-cook-the-perfect",
+        "type":"series",
+        "webTitle":"How to cook the perfect ...",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/indian",
+        "type":"keyword",
+        "webTitle":"Indian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/indian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/indian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/starter",
+        "type":"keyword",
+        "webTitle":"Starter",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/starter",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/starter",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/snacks",
+        "type":"keyword",
+        "webTitle":"Snacks",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/snacks",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/snacks",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/vegetarian",
+        "type":"keyword",
+        "webTitle":"Vegetarian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/vegetarian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/vegetarian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/wordofmouth",
+        "type":"blog",
+        "webTitle":"Word of Mouth blog",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/felicity-cloake",
+        "type":"contributor",
+        "webTitle":"Felicity Cloake",
+        "webUrl":"http://www.theguardian.com/profile/felicity-cloake",
+        "apiUrl":"http://content.guardianapis.com/profile/felicity-cloake",
+        "bio":"<p>Felicity Cloake is a writer specialising in food and drink and winner of the 2011 Guild of Food Writers awards for Food Journalist of the Year and New Media of the Year. Her first recipe book, <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490837\">Perfect</a>, is published by Fig Tree. She likes to think she'd try any food once – although an eyeball recently caused her to question this gung-ho gastronomic philosophy</p>",
+        "r2ContributorId":"32433",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/5/1370451580801/Felicity-Cloake.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422395580",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346619304/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photographs: Felicity Cloake for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422395581",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"84",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photograph: Felicity Cloake for the Guardian",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422395582",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"SImon Majumdar's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Simon Majumdar's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395583",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Flavours of Gujarat's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Flavours of Gujarat's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395584",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Nikita Gulhane's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Nikita Gulhane's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395585",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Alfred Prasad's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Alfred Prasad's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395586",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Cyrus Todiwala's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Cyrus Todiwala's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395587",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis.",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"books/2013/nov/13/autobiography-by-morrissey-review",
+      "sectionId":"books",
+      "sectionName":"Books",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Autobiography by Morrissey – review",
+      "webUrl":"http://www.theguardian.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "apiUrl":"http://content.guardianapis.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "fields":{
+        "trailText":"<p>This book is superb: Mozzer is so devastatingly articulate he could win the Booker, argues <strong>Terry Eagleton</strong></p>",
+        "headline":"Autobiography by Morrissey – review",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kann",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+        "wordcount":"1264",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-12-27T11:39:00Z"
+      },
+      "tags":[{
+        "id":"books/autobiography-and-memoir",
+        "type":"keyword",
+        "webTitle":"Autobiography and memoir",
+        "webUrl":"http://www.theguardian.com/books/autobiography-and-memoir",
+        "apiUrl":"http://content.guardianapis.com/books/autobiography-and-memoir",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/morrissey",
+        "type":"keyword",
+        "webTitle":"Morrissey",
+        "webUrl":"http://www.theguardian.com/music/morrissey",
+        "apiUrl":"http://content.guardianapis.com/music/morrissey",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"books/books",
+        "type":"keyword",
+        "webTitle":"Books",
+        "webUrl":"http://www.theguardian.com/books/books",
+        "apiUrl":"http://content.guardianapis.com/books/books",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"tone/reviews",
+        "type":"tone",
+        "webTitle":"Reviews",
+        "webUrl":"http://www.theguardian.com/tone/reviews",
+        "apiUrl":"http://content.guardianapis.com/tone/reviews",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview/saturdayreviewsfeatres",
+        "type":"newspaper-book-section",
+        "webTitle":"Features & reviews",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview",
+        "type":"newspaper-book",
+        "webTitle":"Guardian review",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/smiths",
+        "type":"keyword",
+        "webTitle":"The Smiths",
+        "webUrl":"http://www.theguardian.com/music/smiths",
+        "apiUrl":"http://content.guardianapis.com/music/smiths",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/indie",
+        "type":"keyword",
+        "webTitle":"Indie",
+        "webUrl":"http://www.theguardian.com/music/indie",
+        "apiUrl":"http://content.guardianapis.com/music/indie",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"uk/manchester",
+        "type":"keyword",
+        "webTitle":"Manchester",
+        "webUrl":"http://www.theguardian.com/uk/manchester",
+        "apiUrl":"http://content.guardianapis.com/uk/manchester",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/terryeagleton",
+        "type":"contributor",
+        "webTitle":"Terry Eagleton",
+        "webUrl":"http://www.theguardian.com/profile/terryeagleton",
+        "apiUrl":"http://content.guardianapis.com/profile/terryeagleton",
+        "bio":"<p>Terry Eaglton is a literary critic, writer and chair in English literature in Lancaster University's department of English and creative writing. His latest book is The Event of Literature</p>",
+        "r2ContributorId":"22184",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/11/3/1320333646305/Terry-Eagleton.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381626",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256764062/Morrissey-at-book-signing-001.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"54",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256766657/Morrissey-at-book-signing-002.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"340",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256768272/Morrissey-at-book-signing-003.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"130",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256771724/Morrissey-at-book-signing-005.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"132",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256773421/Morrissey-at-book-signing-006.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"168",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256775059/Morrissey-at-book-signing-007.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"180",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256776719/Morrissey-at-book-signing-008.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"228",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256780785/Morrissey-at-book-signing-010.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"372",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel/TT/EPA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381627",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "sectionId":"business",
+      "sectionName":"Business",
+      "webPublicationDate":"2013-11-13T15:14:55Z",
+      "webTitle":"Bank of England: UK recovery has finally taken hold - live",
+      "webUrl":"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "apiUrl":"http://content.guardianapis.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "fields":{
+        "trailText":"UK central bank has upgraded its forecasts for growth and unemployment today, with governor Mark Carney telling reporters that the recovery looks more solid",
+        "headline":"Bank of England: UK recovery has finally taken hold - live",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+        "wordcount":"1",
+        "liveBloggingNow":"true",
+        "commentCloseDate":"2013-11-16T07:45:55Z"
+      },
+      "tags":[{
+        "id":"business/series/guardian-business-live",
+        "type":"series",
+        "webTitle":"Guardian business live",
+        "webUrl":"http://www.theguardian.com/business/series/guardian-business-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/guardian-business-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/debt-crisis",
+        "type":"keyword",
+        "webTitle":"Eurozone crisis",
+        "webUrl":"http://www.theguardian.com/business/debt-crisis",
+        "apiUrl":"http://content.guardianapis.com/business/debt-crisis",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/series/eurozone-crisis-live",
+        "type":"series",
+        "webTitle":"Eurozone crisis live",
+        "webUrl":"http://www.theguardian.com/business/series/eurozone-crisis-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/eurozone-crisis-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/euro",
+        "type":"keyword",
+        "webTitle":"Euro",
+        "webUrl":"http://www.theguardian.com/business/euro",
+        "apiUrl":"http://content.guardianapis.com/business/euro",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/bankofenglandgovernor",
+        "type":"keyword",
+        "webTitle":"Bank of England",
+        "webUrl":"http://www.theguardian.com/business/bankofenglandgovernor",
+        "apiUrl":"http://content.guardianapis.com/business/bankofenglandgovernor",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/mark-carney",
+        "type":"keyword",
+        "webTitle":"Mark Carney",
+        "webUrl":"http://www.theguardian.com/business/mark-carney",
+        "apiUrl":"http://content.guardianapis.com/business/mark-carney",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/unemployment-and-employment-statistics",
+        "type":"keyword",
+        "webTitle":"Unemployment and employment statistics",
+        "webUrl":"http://www.theguardian.com/business/unemployment-and-employment-statistics",
+        "apiUrl":"http://content.guardianapis.com/business/unemployment-and-employment-statistics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/minutebyminute",
+        "type":"tone",
+        "webTitle":"Minute by minutes",
+        "webUrl":"http://www.theguardian.com/tone/minutebyminute",
+        "apiUrl":"http://content.guardianapis.com/tone/minutebyminute",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"profile/graemewearden",
+        "type":"contributor",
+        "webTitle":"Graeme Wearden",
+        "webUrl":"http://www.theguardian.com/profile/graemewearden",
+        "apiUrl":"http://content.guardianapis.com/profile/graemewearden",
+        "bio":"<p>Graeme Wearden is a <a href=\"http://www.guardian.co.uk/business\">business</a> reporter on guardian.co.uk and writes breaking City news plus the occasional blog. Previously he worked as a technology journalist at CNET Networks</p>",
+        "r2ContributorId":"19202",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/01/graeme_wearden_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/nickfletcher",
+        "type":"contributor",
+        "webTitle":"Nick Fletcher",
+        "webUrl":"http://www.theguardian.com/profile/nickfletcher",
+        "apiUrl":"http://content.guardianapis.com/profile/nickfletcher",
+        "bio":"<p>Nick Fletcher is a Guardian columnist and writer of the Market Forces column</p>",
+        "rcsId":"GNL023406",
+        "r2ContributorId":"16178",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/03/nick_fletcher_140x140.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"84",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"276",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"132",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"612",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"180",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"324",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"68",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"228",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"372",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"620"
+          }
+        }]
+      },{
+        "id":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"251",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"453",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"386",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"117",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"318",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"184",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"68",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"68"
+          }
+        }]
+      },{
+        "id":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"184",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"233",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"282",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"380",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1261",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"68",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"331",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"625",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"768",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"86",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"135",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"159",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"448",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"101",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1490",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"333",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"275",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"738",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"68",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1536",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"217",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"390",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"768",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"360",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"133",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"284",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"401",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"423"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"209",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"310",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"586",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"356",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"768",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"355",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"309",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"256",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"346",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"167",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"78",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"123",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"212",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"301",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"134",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"86",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"330",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"232",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"379",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"281",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"183",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"121",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"253",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"77",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"340",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"209",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"296",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"165",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"161",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"66",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"185",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"68",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"90",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"114",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"137",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"42",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"211",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"706"
+          }
+        }]
+      },{
+        "id":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"680",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"93",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1374",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"147",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"68",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1536",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"307",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"200",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"253",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"768",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"413",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"360",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"540"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T08:30:00Z",
+      "webTitle":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "fields":{
+        "trailText":"<p>Thousands storm rice warehouse in the devastated central Philippines while Haiyan relief effort flounders</p>",
+        "headline":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgx",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+        "wordcount":"1488",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T04:25:00Z"
+      },
+      "tags":[{
+        "id":"world/typhoon-haiyan",
+        "type":"keyword",
+        "webTitle":"Typhoon Haiyan",
+        "webUrl":"http://www.theguardian.com/world/typhoon-haiyan",
+        "apiUrl":"http://content.guardianapis.com/world/typhoon-haiyan",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/philippines",
+        "type":"keyword",
+        "webTitle":"Philippines",
+        "webUrl":"http://www.theguardian.com/world/philippines",
+        "apiUrl":"http://content.guardianapis.com/world/philippines",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/natural-disasters",
+        "type":"keyword",
+        "webTitle":"Natural disasters and extreme weather",
+        "webUrl":"http://www.theguardian.com/world/natural-disasters",
+        "apiUrl":"http://content.guardianapis.com/world/natural-disasters",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/asia-pacific",
+        "type":"keyword",
+        "webTitle":"Asia Pacific",
+        "webUrl":"http://www.theguardian.com/world/asia-pacific",
+        "apiUrl":"http://content.guardianapis.com/world/asia-pacific",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/taniabranigan",
+        "type":"contributor",
+        "webTitle":"Tania Branigan",
+        "webUrl":"http://www.theguardian.com/profile/taniabranigan",
+        "apiUrl":"http://content.guardianapis.com/profile/taniabranigan",
+        "bio":"<p>Tania Branigan is <a href=\"http://www.guardian.co.uk/world/china\">China correspondent</a> for the Guardian</p>",
+        "rcsId":"GNL004773",
+        "r2ContributorId":"16507",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/tania_branigan_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/kate-hodal",
+        "type":"contributor",
+        "webTitle":"Kate Hodal",
+        "webUrl":"http://www.theguardian.com/profile/kate-hodal",
+        "apiUrl":"http://content.guardianapis.com/profile/kate-hodal",
+        "r2ContributorId":"47767",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422364488",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Bullit Marquez",
+            "altText":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban",
+            "height":"84",
+            "credit":"Bullit Marquez/AP",
+            "caption":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban. Photograph: Bullit Marquez/AP",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-video-422358527",
+        "relation":"body",
+        "type":"video",
+        "assets":[{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "sectionId":"travel",
+      "sectionName":"Travel",
+      "webPublicationDate":"2013-11-13T14:06:00Z",
+      "webTitle":"Top 10 budget restaurants and cafes in central London",
+      "webUrl":"http://www.theguardian.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "apiUrl":"http://content.guardianapis.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "fields":{
+        "trailText":"<p>Updating his last budget eats guide to central London, Tony Naylor discovers that, particularly in and around Soho, the capital is home to a thriving casual dining scene</p>",
+        "headline":"Top 10 budget restaurants and cafes in central London",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbp6",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+        "wordcount":"1573",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T14:06:00Z"
+      },
+      "tags":[{
+        "id":"travel/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/travel/london",
+        "apiUrl":"http://content.guardianapis.com/travel/london",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/travel/restaurants",
+        "apiUrl":"http://content.guardianapis.com/travel/restaurants",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/series/britains-best-budget-eats",
+        "type":"series",
+        "webTitle":"Britain's best budget eats",
+        "webUrl":"http://www.theguardian.com/travel/series/britains-best-budget-eats",
+        "apiUrl":"http://content.guardianapis.com/travel/series/britains-best-budget-eats",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"profile/tonynaylor",
+        "type":"contributor",
+        "webTitle":"Tony Naylor",
+        "webUrl":"http://www.theguardian.com/profile/tonynaylor",
+        "apiUrl":"http://content.guardianapis.com/profile/tonynaylor",
+        "bio":"<p>Tony Naylor lives in the north of England. He likes Greggs pasties, molecular gastronomy and lots of things in between. Outside of filling his face his interests include any licensed establishments, Manchester City, electronic music and some other stuff which could look a bit pretentious in print</p>",
+        "rcsId":"GNL009141",
+        "r2ContributorId":"16542",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/tony_naylor.jpg",
+        "references":[]
+      },{
+        "id":"travel/travel",
+        "type":"keyword",
+        "webTitle":"Travel",
+        "webUrl":"http://www.theguardian.com/travel/travel",
+        "apiUrl":"http://content.guardianapis.com/travel/travel",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/travelfoodanddrink",
+        "type":"keyword",
+        "webTitle":"Food and drink",
+        "webUrl":"http://www.theguardian.com/travel/travelfoodanddrink",
+        "apiUrl":"http://content.guardianapis.com/travel/travelfoodanddrink",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"travel/uk",
+        "type":"keyword",
+        "webTitle":"United Kingdom",
+        "webUrl":"http://www.theguardian.com/travel/uk",
+        "apiUrl":"http://content.guardianapis.com/travel/uk",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/europe",
+        "type":"keyword",
+        "webTitle":"Europe",
+        "webUrl":"http://www.theguardian.com/travel/europe",
+        "apiUrl":"http://content.guardianapis.com/travel/europe",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/england",
+        "type":"keyword",
+        "webTitle":"England",
+        "webUrl":"http://www.theguardian.com/travel/england",
+        "apiUrl":"http://content.guardianapis.com/travel/england",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/budget",
+        "type":"keyword",
+        "webTitle":"Budget travel",
+        "webUrl":"http://www.theguardian.com/travel/budget",
+        "apiUrl":"http://content.guardianapis.com/travel/budget",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397454",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349264516/Koshari-Street-London-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Koshari Street's twist on Egyptian street food",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397455",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Koshari Street, London",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422397456",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg",
+          "typeData":{
+            "source":"Heloise Faure",
+            "photographer":"Heloise Faure",
+            "altText":"Honey & Co Cafe, Soho, London",
+            "height":"276",
+            "credit":"Heloise Faure/Heloise Faure",
+            "caption":"Photograph: Heloise Faure",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397457",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg",
+          "typeData":{
+            "source":"Ming Tang-Evans",
+            "photographer":"Ming Tang-Evans",
+            "altText":"Attendant cafe-restaurant, London",
+            "height":"276",
+            "credit":"Ming Tang-Evans/Ming Tang-Evans",
+            "caption":"Photograph: Ming Tang-Evans",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397458",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Scandinavian kitchen, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397459",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Honest Burger",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397460",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Foxcroft and Ginger, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397461",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg",
+          "typeData":{
+            "source":"Paul Winch-Furness",
+            "photographer":"Paul Winch-Furness",
+            "altText":"Pizza Pilgrims, Soho, London",
+            "height":"277",
+            "credit":"Paul Winch-Furness/Paul Winch-Furness",
+            "caption":"Photograph: Paul Winch-Furness",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397462",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Chettinad lunch box, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397463",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Bi Bim Bap Soho ",
+            "height":"277",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-12T15:43:09Z",
+      "webTitle":"Jennifer Lawrence is striking a blow for healthy, sweaty women | Muireann Carey-Campbell",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "fields":{
+        "trailText":"<p><strong>Muireann Carey-Campbell:</strong> Shock, horror – a female film star says she wants to be 'fit and strong'. But the more women she gets into the gym the better</p>",
+        "headline":"Jennifer Lawrence is striking a blow for healthy, sweaty women",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb44",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+        "wordcount":"572",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-15T15:43:00Z"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"film/jennifer-lawrence",
+        "type":"keyword",
+        "webTitle":"Jennifer Lawrence",
+        "webUrl":"http://www.theguardian.com/film/jennifer-lawrence",
+        "apiUrl":"http://content.guardianapis.com/film/jennifer-lawrence",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/body-image",
+        "type":"keyword",
+        "webTitle":"Body image",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/body-image",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/body-image",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fitness",
+        "type":"keyword",
+        "webTitle":"Fitness",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fitness",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fitness",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"lifeandstyle/health-and-wellbeing",
+        "type":"keyword",
+        "webTitle":"Health & wellbeing",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/health-and-wellbeing",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/health-and-wellbeing",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/health",
+        "type":"keyword",
+        "webTitle":"Health",
+        "webUrl":"http://www.theguardian.com/society/health",
+        "apiUrl":"http://content.guardianapis.com/society/health",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/muireann-carey-campbell",
+        "type":"contributor",
+        "webTitle":"Muireann Carey-Campbell",
+        "webUrl":"http://www.theguardian.com/profile/muireann-carey-campbell",
+        "apiUrl":"http://content.guardianapis.com/profile/muireann-carey-campbell",
+        "bio":"<p>Muireann Carey-Campbell is a fashion, lifestyle and fitness blogger based in London. She is an advocate for empowering women through exercise and edits <a href-\"http://spikesandheels.com\">spikesandheels.com</a> and <a href=\"http://www./pikesandheels.com\">bangsandabun.com</a></p>",
+        "r2ContributorId":"59569",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384260881751/Muireann-Carey-Campbell.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422318972",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269380150/Jennifer-Lawrence-with-Jo-001.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"54",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269383552/Jennifer-Lawrence-with-Jo-002.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"130",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269387034/Jennifer-Lawrence-with-Jo-004.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"132",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269388680/Jennifer-Lawrence-with-Jo-005.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"168",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269390391/Jennifer-Lawrence-with-Jo-006.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"180",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269392235/Jennifer-Lawrence-with-Jo-007.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"228",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/Lionsgate/Sportsphoto Ltd",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422318973",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "sectionId":"technology",
+      "sectionName":"Technology",
+      "webPublicationDate":"2013-11-13T11:29:00Z",
+      "webTitle":"PS4: the 10 key launch titles",
+      "webUrl":"http://www.theguardian.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "apiUrl":"http://content.guardianapis.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "fields":{
+        "trailText":"<p>As the Sony PlayStation 4's US launch looms, here are the best initial titles, from Killzone: Shadow Fall to Call of Duty: Ghosts. By <strong>Keith Stuart</strong></p>",
+        "headline":"PS4: the 10 key launch titles",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kb3x",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+        "wordcount":"964",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:29:00Z"
+      },
+      "tags":[{
+        "id":"technology/playstation-4",
+        "type":"keyword",
+        "webTitle":"PlayStation 4",
+        "webUrl":"http://www.theguardian.com/technology/playstation-4",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation-4",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/playstation",
+        "type":"keyword",
+        "webTitle":"PlayStation",
+        "webUrl":"http://www.theguardian.com/technology/playstation",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/sony",
+        "type":"keyword",
+        "webTitle":"Sony",
+        "webUrl":"http://www.theguardian.com/technology/sony",
+        "apiUrl":"http://content.guardianapis.com/technology/sony",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/games",
+        "type":"keyword",
+        "webTitle":"Games",
+        "webUrl":"http://www.theguardian.com/technology/games",
+        "apiUrl":"http://content.guardianapis.com/technology/games",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/technology",
+        "type":"keyword",
+        "webTitle":"Technology",
+        "webUrl":"http://www.theguardian.com/technology/technology",
+        "apiUrl":"http://content.guardianapis.com/technology/technology",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"profile/keithstuart",
+        "type":"contributor",
+        "webTitle":"Keith Stuart",
+        "webUrl":"http://www.theguardian.com/profile/keithstuart",
+        "apiUrl":"http://content.guardianapis.com/profile/keithstuart",
+        "bio":"<p>Keith Stuart is a veteran video game and technology writer, who is also a regular contributor to Edge magazine</p>",
+        "rcsId":"GNL007878",
+        "r2ContributorId":"15953",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Media/Columnists/Columnists/2013/11/8/1383915413362/Keith-Stuart--003.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388207",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288957309/KZ4_Blast3_main.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Killzone: Shadow Fall – a graphical showcase for Sony's next-gen PS4 console",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422388208",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"84",
+            "credit":"PR",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T13:54:18Z",
+      "webTitle":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "fields":{
+        "trailText":"Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol<br />",
+        "headline":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbqd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+        "wordcount":"247",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T13:54:18Z"
+      },
+      "tags":[{
+        "id":"football/martin-jol",
+        "type":"keyword",
+        "webTitle":"Martin Jol",
+        "webUrl":"http://www.theguardian.com/football/martin-jol",
+        "apiUrl":"http://content.guardianapis.com/football/martin-jol",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/fulham",
+        "type":"keyword",
+        "webTitle":"Fulham",
+        "webUrl":"http://www.theguardian.com/football/fulham",
+        "apiUrl":"http://content.guardianapis.com/football/fulham",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/55"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397529",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350779268/Ren--Meulensteen-001.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"54",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350781955/Ren--Meulensteen-002.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"130",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350783658/Ren--Meulensteen-003.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"84",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350785345/Ren--Meulensteen-004.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"132",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350787149/Ren--Meulensteen-005.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"168",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350788867/Ren--Meulensteen-006.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"180",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350790688/Ren--Meulensteen-007.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"228",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350792437/Ren--Meulensteen-008.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"276",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351652017/Martin-Jol-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"276",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by the newly appointed head coach René Meulensteen (right) at Fulham. Photographs: PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397530",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"84",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by new head coach René Meulensteen (right) at Fulham. Photograph: PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/55"
+      }]
+    }],
+    "storyPackage":[]
+  }
+}

--- a/data/database/31794ea179a3e9600290d952fed2ac7430b915a2
+++ b/data/database/31794ea179a3e9600290d952fed2ac7430b915a2
@@ -1,0 +1,6212 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":1,
+    "mostViewed":[{
+      "id":"lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Why you won't catch me queuing for a burger",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "fields":{
+        "trailText":"<p><strong>Jay Rayner:</strong> Waiting two hours in a line for beef in a bun was never going to be a good idea</p>",
+        "headline":"Why you won't catch me queuing for a burger",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k6zt",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+        "wordcount":"567",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T12:00:02Z"
+      },
+      "tags":[{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fast-food",
+        "type":"keyword",
+        "webTitle":"Fast food",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fast-food",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fast-food",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Observer Food Monthly recipes & features",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly/features",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly/features",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly",
+        "type":"newspaper-book",
+        "webTitle":"Observer Food Monthly",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"lifeandstyle/series/happy-eater",
+        "type":"series",
+        "webTitle":"Happy eater",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/happy-eater",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/happy-eater",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/jayrayner",
+        "type":"contributor",
+        "webTitle":"Jay Rayner",
+        "webUrl":"http://www.theguardian.com/profile/jayrayner",
+        "apiUrl":"http://content.guardianapis.com/profile/jayrayner",
+        "bio":"<p>Jay Rayner is the Observer's restaurant critic and a novelist. His latest book is the Oyster House Siege</p>",
+        "rcsId":"GNL258574",
+        "r2ContributorId":"15803",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2008/06/02/jay_rayner_140x140.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theobserver",
+        "type":"publication",
+        "webTitle":"The Observer",
+        "webUrl":"http://www.theguardian.com/theobserver/all",
+        "apiUrl":"http://content.guardianapis.com/theobserver/all",
+        "sectionId":"theobserver",
+        "sectionName":"From the Observer",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422287525",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259303137/burger-and-fries-from-sha-007.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"276",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about self-denial\". Photograph: Radharc Images/Alamy",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422287526",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"84",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about \nself-denial\". Photograph: Radharc Images /Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T12:58:39Z",
+      "webTitle":"It was hard to stomach David Cameron preaching austerity from a golden throne | Ruth Hardy",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "fields":{
+        "trailText":"<strong>Ruth Hardy: </strong>As a waitress at the lord mayor's banquet, the contrast between what Cameron was saying and where he was saying it felt particularly chilling",
+        "headline":"It was hard to stomach David Cameron preaching austerity from a golden throne",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbyq",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+        "wordcount":"738",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T12:58:39Z"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"politics/davidcameron",
+        "type":"keyword",
+        "webTitle":"David Cameron",
+        "webUrl":"http://www.theguardian.com/politics/davidcameron",
+        "apiUrl":"http://content.guardianapis.com/politics/davidcameron",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/conservatives",
+        "type":"keyword",
+        "webTitle":"Conservatives",
+        "webUrl":"http://www.theguardian.com/politics/conservatives",
+        "apiUrl":"http://content.guardianapis.com/politics/conservatives",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"society/public-sector-cuts",
+        "type":"keyword",
+        "webTitle":"Public sector cuts",
+        "webUrl":"http://www.theguardian.com/society/public-sector-cuts",
+        "apiUrl":"http://content.guardianapis.com/society/public-sector-cuts",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/policy",
+        "type":"keyword",
+        "webTitle":"Public services policy",
+        "webUrl":"http://www.theguardian.com/society/policy",
+        "apiUrl":"http://content.guardianapis.com/society/policy",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/public-finance",
+        "type":"keyword",
+        "webTitle":"Public finance",
+        "webUrl":"http://www.theguardian.com/society/public-finance",
+        "apiUrl":"http://content.guardianapis.com/society/public-finance",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"business/austerity",
+        "type":"keyword",
+        "webTitle":"Austerity",
+        "webUrl":"http://www.theguardian.com/business/austerity",
+        "apiUrl":"http://content.guardianapis.com/business/austerity",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/economics",
+        "type":"keyword",
+        "webTitle":"Economics",
+        "webUrl":"http://www.theguardian.com/business/economics",
+        "apiUrl":"http://content.guardianapis.com/business/economics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"profile/ruth-hardy",
+        "type":"contributor",
+        "webTitle":"Ruth Hardy",
+        "webUrl":"http://www.theguardian.com/profile/ruth-hardy",
+        "apiUrl":"http://content.guardianapis.com/profile/ruth-hardy",
+        "bio":"<p>Ruth Hardy is a freelance writer and recent graduate in philosophy at King's College London. You can follow her on Twitter <a href=\"https://twitter.com/ruthhardy22\">here</a></p>",
+        "r2ContributorId":"56147",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Education/Pix/pictures/2013/4/24/1366808642483/Ruth-Hardy-student-blogge-002.jpg",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422382150",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344632805/David-Cameron-at-Lord-May-001.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"54",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344634858/David-Cameron-at-Lord-May-002.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"130",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344637355/David-Cameron-at-Lord-May-004.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"132",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344638596/David-Cameron-at-Lord-May-005.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"168",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344639804/David-Cameron-at-Lord-May-006.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"180",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344641041/David-Cameron-at-Lord-May-007.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"228",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422382151",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T14:44:00Z",
+      "webTitle":"MI6 spy found dead in bag probably locked himself inside, Met says",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "fields":{
+        "trailText":"Three-year investigation by Scotland Yard concludes Gareth Williams probably died as a result of tragic accident",
+        "headline":"MI6 spy found dead in bag probably locked himself inside, Met says",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjj",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+        "wordcount":"962",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:18:14Z"
+      },
+      "tags":[{
+        "id":"uk/gareth-williams",
+        "type":"keyword",
+        "webTitle":"Gareth Williams",
+        "webUrl":"http://www.theguardian.com/uk/gareth-williams",
+        "apiUrl":"http://content.guardianapis.com/uk/gareth-williams",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/mi6",
+        "type":"keyword",
+        "webTitle":"MI6",
+        "webUrl":"http://www.theguardian.com/uk/mi6",
+        "apiUrl":"http://content.guardianapis.com/uk/mi6",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uksecurity",
+        "type":"keyword",
+        "webTitle":"UK security and counter-terrorism",
+        "webUrl":"http://www.theguardian.com/uk/uksecurity",
+        "apiUrl":"http://content.guardianapis.com/uk/uksecurity",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/josh-halliday",
+        "type":"contributor",
+        "webTitle":"Josh Halliday",
+        "webUrl":"http://www.theguardian.com/profile/josh-halliday",
+        "apiUrl":"http://content.guardianapis.com/profile/josh-halliday",
+        "bio":"<p><a href=\"http://twitter.com/JoshHalliday\">Josh Halliday</a> is a media and technology reporter. Josh has a keen interest in digital media and privacy. Dislikes insufferable enthusiasm. Bradfordian via Wearside</p>",
+        "r2ContributorId":"38624",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/7/14/1279118930047/Josh-Halliday.jpg",
+        "references":[]
+      },{
+        "id":"uk/metropolitan-police",
+        "type":"keyword",
+        "webTitle":"Metropolitan police",
+        "webUrl":"http://www.theguardian.com/uk/metropolitan-police",
+        "apiUrl":"http://content.guardianapis.com/uk/metropolitan-police",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/uk/london",
+        "apiUrl":"http://content.guardianapis.com/uk/london",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379877",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341447432/Gareth-Williams-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"54",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341448835/Gareth-Williams-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"340",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341450089/Gareth-Williams-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"130",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341452580/Gareth-Williams-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"132",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341453889/Gareth-Williams-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"168",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341455246/Gareth-Williams-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"180",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341456514/Gareth-Williams-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"228",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341459093/Gareth-Williams-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"372",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379878",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-12T15:34:27Z",
+      "webTitle":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "fields":{
+        "trailText":"Rolling Jubilee spent $400,000 to purchase debt cheaply from banks before 'abolishing' it, freeing individuals from their bills",
+        "headline":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb4g",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+        "wordcount":"1",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-15T15:30:25Z"
+      },
+      "tags":[{
+        "id":"world/occupy-movement",
+        "type":"keyword",
+        "webTitle":"Occupy movement",
+        "webUrl":"http://www.theguardian.com/world/occupy-movement",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-movement",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/occupy-wall-street",
+        "type":"keyword",
+        "webTitle":"Occupy Wall Street",
+        "webUrl":"http://www.theguardian.com/world/occupy-wall-street",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-wall-street",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/debt-relief",
+        "type":"keyword",
+        "webTitle":"Debt relief",
+        "webUrl":"http://www.theguardian.com/world/debt-relief",
+        "apiUrl":"http://content.guardianapis.com/world/debt-relief",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"money/us-personal-finance",
+        "type":"keyword",
+        "webTitle":"US personal finance",
+        "webUrl":"http://www.theguardian.com/money/us-personal-finance",
+        "apiUrl":"http://content.guardianapis.com/money/us-personal-finance",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"money/mortgages-us",
+        "type":"keyword",
+        "webTitle":"US mortgages",
+        "webUrl":"http://www.theguardian.com/money/mortgages-us",
+        "apiUrl":"http://content.guardianapis.com/money/mortgages-us",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"business/useconomy",
+        "type":"keyword",
+        "webTitle":"US economy",
+        "webUrl":"http://www.theguardian.com/business/useconomy",
+        "apiUrl":"http://content.guardianapis.com/business/useconomy",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"money/money",
+        "type":"keyword",
+        "webTitle":"Money",
+        "webUrl":"http://www.theguardian.com/money/money",
+        "apiUrl":"http://content.guardianapis.com/money/money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/adam-gabbatt",
+        "type":"contributor",
+        "webTitle":"Adam Gabbatt",
+        "webUrl":"http://www.theguardian.com/profile/adam-gabbatt",
+        "apiUrl":"http://content.guardianapis.com/profile/adam-gabbatt",
+        "bio":"<p>Adam Gabbatt is a reporter and live blogger for the Guardian, based in New York. He won a journalism bursary from the Scott Trust, the company that owns the Guardian, in 2008, and began writing for the newspaper and website in 2009. He was highly commended in the young journalist of the year category at the British Press Awards in 2011</p>",
+        "r2ContributorId":"33854",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/1/24/1359039911843/AdamGabbatt.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"276",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"'Our primary purpose was to spread information about the workings of this secondary debt market,' said Andrew Ross.&nbsp;Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"84",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"The Occupy movement began in Wall Street in November 2011 when protesters attempted to shut down the New York stock exchange. Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T01:25:32Z",
+      "webTitle":"ITV news presenter hits back after abuse for not wearing poppy",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "fields":{
+        "trailText":"Charlene White faced racist and sexist abuse which, she said, acted against all the goals that the fallen soldiers fought for",
+        "headline":"ITV news presenter hits back after abuse for not wearing poppy",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbfc",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+        "wordcount":"504",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T01:25:32Z"
+      },
+      "tags":[{
+        "id":"uk/remembranceday",
+        "type":"keyword",
+        "webTitle":"Remembrance Day",
+        "webUrl":"http://www.theguardian.com/uk/remembranceday",
+        "apiUrl":"http://content.guardianapis.com/uk/remembranceday",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"media/itv1",
+        "type":"keyword",
+        "webTitle":"ITV channel",
+        "webUrl":"http://www.theguardian.com/media/itv1",
+        "apiUrl":"http://content.guardianapis.com/media/itv1",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/television",
+        "type":"keyword",
+        "webTitle":"Television industry",
+        "webUrl":"http://www.theguardian.com/media/television",
+        "apiUrl":"http://content.guardianapis.com/media/television",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/media",
+        "type":"keyword",
+        "webTitle":"Media",
+        "webUrl":"http://www.theguardian.com/media/media",
+        "apiUrl":"http://content.guardianapis.com/media/media",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"tv-and-radio/tv-news",
+        "type":"keyword",
+        "webTitle":"The news on TV",
+        "webUrl":"http://www.theguardian.com/tv-and-radio/tv-news",
+        "apiUrl":"http://content.guardianapis.com/tv-and-radio/tv-news",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"culture/television",
+        "type":"keyword",
+        "webTitle":"Television",
+        "webUrl":"http://www.theguardian.com/culture/television",
+        "apiUrl":"http://content.guardianapis.com/culture/television",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"profile/shane-hickey",
+        "type":"contributor",
+        "webTitle":"Shane Hickey",
+        "webUrl":"http://www.theguardian.com/profile/shane-hickey",
+        "apiUrl":"http://content.guardianapis.com/profile/shane-hickey",
+        "r2ContributorId":"55396",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422347763",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305766581/Poppies-001.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"54",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305768729/Poppies-002.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"340",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305770017/Poppies-003.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"130",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305772726/Poppies-005.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"132",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305773964/Poppies-006.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"168",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305775328/Poppies-007.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"180",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305776636/Poppies-008.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"228",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305779302/Poppies-010.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"372",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422347764",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "sectionId":"society",
+      "sectionName":"Society",
+      "webPublicationDate":"2013-11-13T12:10:00Z",
+      "webTitle":"Hamzah Khan: minister has 'deep concerns' over review findings",
+      "webUrl":"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "apiUrl":"http://content.guardianapis.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "fields":{
+        "trailText":"Edward Timpson criticises review into death of child who starved to death while DfE source describes report as 'risible'",
+        "headline":"Hamzah Khan: minister has 'deep concerns' over review findings",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kby3",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+        "wordcount":"579",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:49:22Z"
+      },
+      "tags":[{
+        "id":"society/childprotection",
+        "type":"keyword",
+        "webTitle":"Child protection",
+        "webUrl":"http://www.theguardian.com/society/childprotection",
+        "apiUrl":"http://content.guardianapis.com/society/childprotection",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/children",
+        "type":"keyword",
+        "webTitle":"Children",
+        "webUrl":"http://www.theguardian.com/society/children",
+        "apiUrl":"http://content.guardianapis.com/society/children",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/social-care",
+        "type":"keyword",
+        "webTitle":"Social care",
+        "webUrl":"http://www.theguardian.com/society/social-care",
+        "apiUrl":"http://content.guardianapis.com/society/social-care",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/localgovernment",
+        "type":"keyword",
+        "webTitle":"Local government",
+        "webUrl":"http://www.theguardian.com/society/localgovernment",
+        "apiUrl":"http://content.guardianapis.com/society/localgovernment",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"uk/bradford",
+        "type":"keyword",
+        "webTitle":"Bradford",
+        "webUrl":"http://www.theguardian.com/uk/bradford",
+        "apiUrl":"http://content.guardianapis.com/uk/bradford",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/helenpidd",
+        "type":"contributor",
+        "webTitle":"Helen Pidd",
+        "webUrl":"http://www.theguardian.com/profile/helenpidd",
+        "apiUrl":"http://content.guardianapis.com/profile/helenpidd",
+        "bio":"<p>Helen Pidd is northern editor of the Guardian, based in Manchester. She joined the paper in 2004 to edit the now defunct Office Hours and was a commissioning editor on G2 before joining the home news team in 2007, going on to spend 2011 in Germany as Berlin correspondent followed by a stint in Delhi. She is the author of <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490530\">Bicycle – The Complete<br />Guide to Everyday Cycling</a>.</p>",
+        "r2ContributorId":"19855",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/6/22/1277217764498/Helen-Pidd-byline.-003.jpg",
+        "references":[]
+      },{
+        "id":"profile/haroonsiddique",
+        "type":"contributor",
+        "webTitle":"Haroon Siddique",
+        "webUrl":"http://www.theguardian.com/profile/haroonsiddique",
+        "apiUrl":"http://content.guardianapis.com/profile/haroonsiddique",
+        "bio":"<p>Haroon Siddique is a news reporter on the Guardian website. He previously worked for North London institution the Ham&amp;High, and before pursuing his passion for journalism he was a commodity trader in the City</p>",
+        "r2ContributorId":"19136",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/haroon_siddique.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379573",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343315052/Hamzah-Khan-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"54",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343317421/Hamzah-Khan-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"340",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343318751/Hamzah-Khan-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"130",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343321335/Hamzah-Khan-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"132",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343322756/Hamzah-Khan-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"168",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343324035/Hamzah-Khan-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"180",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343325436/Hamzah-Khan-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"228",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343328488/Hamzah-Khan-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"372",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379574",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T09:50:29Z",
+      "webTitle":"Lily Allen does not represent all feminism – and nor should she | Ellie Mae O'Hagan",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "fields":{
+        "trailText":"<p><strong>Ellie Mae O'Hagan:</strong> Instead of critiquing whether Allen's new video is feminist or not, we should ask why there is such a weight of expectation on one woman</p>",
+        "headline":"Lily Allen does not represent all feminism – and nor should she",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbhf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+        "wordcount":"909",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T09:50:00Z"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"world/feminism",
+        "type":"keyword",
+        "webTitle":"Feminism",
+        "webUrl":"http://www.theguardian.com/world/feminism",
+        "apiUrl":"http://content.guardianapis.com/world/feminism",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"music/lilyallen",
+        "type":"keyword",
+        "webTitle":"Lily Allen",
+        "webUrl":"http://www.theguardian.com/music/lilyallen",
+        "apiUrl":"http://content.guardianapis.com/music/lilyallen",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/ellie-mae-o-hagan",
+        "type":"contributor",
+        "webTitle":"Ellie Mae O'Hagan",
+        "webUrl":"http://www.theguardian.com/profile/ellie-mae-o-hagan",
+        "apiUrl":"http://content.guardianapis.com/profile/ellie-mae-o-hagan",
+        "bio":"<p>Ellie Mae O'Hagan is a regular columnist for Comment is free. She has also written for the Times, the New Statesman, Red Pepper, False Economy, New Left Project and Union News. She currently works with the Centre for Labour and Social Studies, a think for left debate and discussion originating in the trade union movement. She is also an active member of UK Uncut. She  tweets as <a href=\"http://twitter.com/#!/MissEllieMae\">@MissEllieMae</a></p>",
+        "r2ContributorId":"43367",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/3/22/1300821538131/EllieMaeOHagan.jpg",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388300",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Lily Allen",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Lily Allen",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T10:06:25Z",
+      "webTitle":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "fields":{
+        "trailText":"Ranjit Sinha, chief of India's Central Bureau of Investigation, apologises for remark that causes outrage across country",
+        "headline":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbhz",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+        "wordcount":"273",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T10:06:25Z"
+      },
+      "tags":[{
+        "id":"world/india",
+        "type":"keyword",
+        "webTitle":"India",
+        "webUrl":"http://www.theguardian.com/world/india",
+        "apiUrl":"http://content.guardianapis.com/world/india",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"society/rape",
+        "type":"keyword",
+        "webTitle":"Rape",
+        "webUrl":"http://www.theguardian.com/society/rape",
+        "apiUrl":"http://content.guardianapis.com/society/rape",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"law/law",
+        "type":"keyword",
+        "webTitle":"Law",
+        "webUrl":"http://www.theguardian.com/law/law",
+        "apiUrl":"http://content.guardianapis.com/law/law",
+        "sectionId":"law",
+        "sectionName":"Law",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422369576",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337123909/Ranjit-Sinha-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"54",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337125231/Ranjit-Sinha-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"340",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337126586/Ranjit-Sinha-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"130",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337129092/Ranjit-Sinha-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"132",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337130310/Ranjit-Sinha-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"168",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337131559/Ranjit-Sinha-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"180",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337132902/Ranjit-Sinha-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"228",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337135575/Ranjit-Sinha-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"372",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422369577",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T11:18:52Z",
+      "webTitle":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "fields":{
+        "trailText":"Roberto Di Matteo is reportedly still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago",
+        "headline":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjb",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+        "wordcount":"140",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:18:52Z"
+      },
+      "tags":[{
+        "id":"football/roberto-di-matteo",
+        "type":"keyword",
+        "webTitle":"Roberto Di Matteo",
+        "webUrl":"http://www.theguardian.com/football/roberto-di-matteo",
+        "apiUrl":"http://content.guardianapis.com/football/roberto-di-matteo",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/chelsea",
+        "type":"keyword",
+        "webTitle":"Chelsea",
+        "webUrl":"http://www.theguardian.com/football/chelsea",
+        "apiUrl":"http://content.guardianapis.com/football/chelsea",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/4"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422374804",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341239071/Roberto-Di-Matteo-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"54",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341242197/Roberto-Di-Matteo-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"340",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341243440/Roberto-Di-Matteo-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"130",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341244752/Roberto-Di-Matteo-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"720",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341246531/Roberto-Di-Matteo-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341249682/Roberto-Di-Matteo-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"132",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341250911/Roberto-Di-Matteo-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"168",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341252176/Roberto-Di-Matteo-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"180",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341253497/Roberto-Di-Matteo-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"228",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341256016/Roberto-Di-Matteo-012.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"372",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341257472/Roberto-Di-Matteo-013.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1116",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1860"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341259557/Roberto-Di-Matteo-014.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2560"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422374805",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/4"
+      }]
+    },{
+      "id":"film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "sectionId":"film",
+      "sectionName":"Film",
+      "webPublicationDate":"2013-11-12T10:01:00Z",
+      "webTitle":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+      "webUrl":"http://www.theguardian.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "apiUrl":"http://content.guardianapis.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "fields":{
+        "trailText":"<p>Unable to cut his sexually explicit film down from five hours, Danish director opts to let someone else cut the movie down to two, two-hour chunks – both including explicit footage</p>",
+        "headline":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kakf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+        "wordcount":"343",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-15T10:01:00Z"
+      },
+      "tags":[{
+        "id":"film/lars-von-trier",
+        "type":"keyword",
+        "webTitle":"Lars von Trier",
+        "webUrl":"http://www.theguardian.com/film/lars-von-trier",
+        "apiUrl":"http://content.guardianapis.com/film/lars-von-trier",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"culture/charlotte-gainsbourg",
+        "type":"keyword",
+        "webTitle":"Charlotte Gainsbourg",
+        "webUrl":"http://www.theguardian.com/culture/charlotte-gainsbourg",
+        "apiUrl":"http://content.guardianapis.com/culture/charlotte-gainsbourg",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"profile/benchild",
+        "type":"contributor",
+        "webTitle":"Ben Child",
+        "webUrl":"http://www.theguardian.com/profile/benchild",
+        "apiUrl":"http://content.guardianapis.com/profile/benchild",
+        "bio":"<p>Ben Child is a journalist, DJ and producer whose main interests lie in the worlds of film and music</p>",
+        "r2ContributorId":"24984",
+        "references":[]
+      },{
+        "id":"film/drama",
+        "type":"keyword",
+        "webTitle":"Drama",
+        "webUrl":"http://www.theguardian.com/film/drama",
+        "apiUrl":"http://content.guardianapis.com/film/drama",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"culture/pornography",
+        "type":"keyword",
+        "webTitle":"Pornography",
+        "webUrl":"http://www.theguardian.com/culture/pornography",
+        "apiUrl":"http://content.guardianapis.com/culture/pornography",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"world/denmark",
+        "type":"keyword",
+        "webTitle":"Denmark",
+        "webUrl":"http://www.theguardian.com/world/denmark",
+        "apiUrl":"http://content.guardianapis.com/world/denmark",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422284236",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244020710/Nymphomaniac-chapter-one--008.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"276",
+            "credit":"Christian Geisnaes",
+            "caption":"One of the few fully-clothed stills from Nymphomaniac. Photograph: Christian Geisnaes",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422284237",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"84",
+            "credit":"Christian Geisnaes",
+            "caption":"Nymphomaniac chapter one still Photograph: Christian Geisnaes",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:04:31Z",
+      "webTitle":"Jack Monroe's frozen yoghurt recipe",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "fields":{
+        "trailText":"<p>This simple dessert is a great way to stretch fresh berries, but it works brilliantly with cheaper frozen fruit, too</p>",
+        "headline":"Jack Monroe's frozen yoghurt recipe",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbka",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+        "wordcount":"222",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T12:04:31Z"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "type":"series",
+        "webTitle":"Jack Monroe's low-cost recipes",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/dessert",
+        "type":"keyword",
+        "webTitle":"Dessert",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/dessert",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/dessert",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fruit",
+        "type":"keyword",
+        "webTitle":"Fruit",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fruit",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fruit",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"money/saving-money",
+        "type":"keyword",
+        "webTitle":"Saving money",
+        "webUrl":"http://www.theguardian.com/money/saving-money",
+        "apiUrl":"http://content.guardianapis.com/money/saving-money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"profile/jack-monroe",
+        "type":"contributor",
+        "webTitle":"Jack Monroe",
+        "webUrl":"http://www.theguardian.com/profile/jack-monroe",
+        "apiUrl":"http://content.guardianapis.com/profile/jack-monroe",
+        "bio":"<p>Jack Monroe blogs at <a href=\"http://agirlcalledjack.com/\">A Girl Called Jack</a> and is author of the forthcoming A Girl Called Jack recipe book</p>",
+        "r2ContributorId":"57609",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/10/1378813805813/Jack-Monroe.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381337",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344202019/Jack-Monroes-frozen-yoghu-009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"276",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381338",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"84",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "sectionId":"news",
+      "sectionName":"News",
+      "webPublicationDate":"2013-11-13T07:30:00Z",
+      "webTitle":"The daily quiz, 13 November 2013",
+      "webUrl":"http://www.theguardian.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "apiUrl":"http://content.guardianapis.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "fields":{
+        "trailText":"<p>From murder mysteries to famous lakes and luxury goods purveyors to the rules of boxing, 10 questions to test you</p>",
+        "headline":"The daily quiz, 13 November 2013",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k2vg",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T07:30:00Z"
+      },
+      "tags":[{
+        "id":"news/series/the-daily-quiz",
+        "type":"series",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/news/series/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/news/series/the-daily-quiz",
+        "sectionId":"news",
+        "sectionName":"News",
+        "references":[]
+      },{
+        "id":"profile/the-daily-quiz",
+        "type":"contributor",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/profile/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/profile/the-daily-quiz",
+        "bio":"<p>A daily general knowledge quiz from theguardian.com. Email: daily.quiz@theguardian.com</p>",
+        "r2ContributorId":"57817",
+        "references":[]
+      },{
+        "id":"type/quiz",
+        "type":"type",
+        "webTitle":"Quiz",
+        "webUrl":"http://www.theguardian.com/quizzes",
+        "apiUrl":"http://content.guardianapis.com/quizzes",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-421318129",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Sinibomb Images",
+            "altText":"Pac-Man",
+            "height":"84",
+            "credit":"Sinibomb Images/Alamy",
+            "caption":"Despite our video games knowledge being prehistoric, we decided such a huge part of the entertainment world would be ignored at our peril. Photograph: Sinibomb Images/Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:55:00Z",
+      "webTitle":"How to make the perfect onion bhajis",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "fields":{
+        "trailText":"<p>Can another member of the fritter family beat the onion bhaji, do you eat them as a starter or a snack, and what do you serve with them?</p>",
+        "headline":"How to make the perfect onion bhajis",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbnh",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+        "wordcount":"1130",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-20T12:55:00Z"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/how-to-cook-the-perfect",
+        "type":"series",
+        "webTitle":"How to cook the perfect ...",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/indian",
+        "type":"keyword",
+        "webTitle":"Indian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/indian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/indian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/starter",
+        "type":"keyword",
+        "webTitle":"Starter",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/starter",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/starter",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/snacks",
+        "type":"keyword",
+        "webTitle":"Snacks",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/snacks",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/snacks",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/vegetarian",
+        "type":"keyword",
+        "webTitle":"Vegetarian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/vegetarian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/vegetarian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/wordofmouth",
+        "type":"blog",
+        "webTitle":"Word of Mouth blog",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/felicity-cloake",
+        "type":"contributor",
+        "webTitle":"Felicity Cloake",
+        "webUrl":"http://www.theguardian.com/profile/felicity-cloake",
+        "apiUrl":"http://content.guardianapis.com/profile/felicity-cloake",
+        "bio":"<p>Felicity Cloake is a writer specialising in food and drink and winner of the 2011 Guild of Food Writers awards for Food Journalist of the Year and New Media of the Year. Her first recipe book, <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490837\">Perfect</a>, is published by Fig Tree. She likes to think she'd try any food once – although an eyeball recently caused her to question this gung-ho gastronomic philosophy</p>",
+        "r2ContributorId":"32433",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/5/1370451580801/Felicity-Cloake.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422395580",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346619304/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photographs: Felicity Cloake for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422395581",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"84",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photograph: Felicity Cloake for the Guardian",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422395582",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"SImon Majumdar's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Simon Majumdar's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395583",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Flavours of Gujarat's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Flavours of Gujarat's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395584",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Nikita Gulhane's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Nikita Gulhane's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395585",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Alfred Prasad's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Alfred Prasad's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395586",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Cyrus Todiwala's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Cyrus Todiwala's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395587",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis.",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"books/2013/nov/13/autobiography-by-morrissey-review",
+      "sectionId":"books",
+      "sectionName":"Books",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Autobiography by Morrissey – review",
+      "webUrl":"http://www.theguardian.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "apiUrl":"http://content.guardianapis.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "fields":{
+        "trailText":"<p>This book is superb: Mozzer is so devastatingly articulate he could win the Booker, argues <strong>Terry Eagleton</strong></p>",
+        "headline":"Autobiography by Morrissey – review",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kann",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+        "wordcount":"1264",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-12-27T11:39:00Z"
+      },
+      "tags":[{
+        "id":"books/autobiography-and-memoir",
+        "type":"keyword",
+        "webTitle":"Autobiography and memoir",
+        "webUrl":"http://www.theguardian.com/books/autobiography-and-memoir",
+        "apiUrl":"http://content.guardianapis.com/books/autobiography-and-memoir",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/morrissey",
+        "type":"keyword",
+        "webTitle":"Morrissey",
+        "webUrl":"http://www.theguardian.com/music/morrissey",
+        "apiUrl":"http://content.guardianapis.com/music/morrissey",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"books/books",
+        "type":"keyword",
+        "webTitle":"Books",
+        "webUrl":"http://www.theguardian.com/books/books",
+        "apiUrl":"http://content.guardianapis.com/books/books",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"tone/reviews",
+        "type":"tone",
+        "webTitle":"Reviews",
+        "webUrl":"http://www.theguardian.com/tone/reviews",
+        "apiUrl":"http://content.guardianapis.com/tone/reviews",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview/saturdayreviewsfeatres",
+        "type":"newspaper-book-section",
+        "webTitle":"Features & reviews",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview",
+        "type":"newspaper-book",
+        "webTitle":"Guardian review",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/smiths",
+        "type":"keyword",
+        "webTitle":"The Smiths",
+        "webUrl":"http://www.theguardian.com/music/smiths",
+        "apiUrl":"http://content.guardianapis.com/music/smiths",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/indie",
+        "type":"keyword",
+        "webTitle":"Indie",
+        "webUrl":"http://www.theguardian.com/music/indie",
+        "apiUrl":"http://content.guardianapis.com/music/indie",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"uk/manchester",
+        "type":"keyword",
+        "webTitle":"Manchester",
+        "webUrl":"http://www.theguardian.com/uk/manchester",
+        "apiUrl":"http://content.guardianapis.com/uk/manchester",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/terryeagleton",
+        "type":"contributor",
+        "webTitle":"Terry Eagleton",
+        "webUrl":"http://www.theguardian.com/profile/terryeagleton",
+        "apiUrl":"http://content.guardianapis.com/profile/terryeagleton",
+        "bio":"<p>Terry Eaglton is a literary critic, writer and chair in English literature in Lancaster University's department of English and creative writing. His latest book is The Event of Literature</p>",
+        "r2ContributorId":"22184",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/11/3/1320333646305/Terry-Eagleton.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381626",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256764062/Morrissey-at-book-signing-001.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"54",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256766657/Morrissey-at-book-signing-002.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"340",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256768272/Morrissey-at-book-signing-003.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"130",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256771724/Morrissey-at-book-signing-005.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"132",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256773421/Morrissey-at-book-signing-006.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"168",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256775059/Morrissey-at-book-signing-007.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"180",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256776719/Morrissey-at-book-signing-008.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"228",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256780785/Morrissey-at-book-signing-010.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"372",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel/TT/EPA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381627",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "sectionId":"business",
+      "sectionName":"Business",
+      "webPublicationDate":"2013-11-13T15:14:55Z",
+      "webTitle":"Bank of England: UK recovery has finally taken hold - live",
+      "webUrl":"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "apiUrl":"http://content.guardianapis.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "fields":{
+        "trailText":"UK central bank has upgraded its forecasts for growth and unemployment today, with governor Mark Carney telling reporters that the recovery looks more solid",
+        "headline":"Bank of England: UK recovery has finally taken hold - live",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+        "wordcount":"1",
+        "liveBloggingNow":"true",
+        "commentCloseDate":"2013-11-16T07:45:55Z"
+      },
+      "tags":[{
+        "id":"business/series/guardian-business-live",
+        "type":"series",
+        "webTitle":"Guardian business live",
+        "webUrl":"http://www.theguardian.com/business/series/guardian-business-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/guardian-business-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/debt-crisis",
+        "type":"keyword",
+        "webTitle":"Eurozone crisis",
+        "webUrl":"http://www.theguardian.com/business/debt-crisis",
+        "apiUrl":"http://content.guardianapis.com/business/debt-crisis",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/series/eurozone-crisis-live",
+        "type":"series",
+        "webTitle":"Eurozone crisis live",
+        "webUrl":"http://www.theguardian.com/business/series/eurozone-crisis-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/eurozone-crisis-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/euro",
+        "type":"keyword",
+        "webTitle":"Euro",
+        "webUrl":"http://www.theguardian.com/business/euro",
+        "apiUrl":"http://content.guardianapis.com/business/euro",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/bankofenglandgovernor",
+        "type":"keyword",
+        "webTitle":"Bank of England",
+        "webUrl":"http://www.theguardian.com/business/bankofenglandgovernor",
+        "apiUrl":"http://content.guardianapis.com/business/bankofenglandgovernor",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/mark-carney",
+        "type":"keyword",
+        "webTitle":"Mark Carney",
+        "webUrl":"http://www.theguardian.com/business/mark-carney",
+        "apiUrl":"http://content.guardianapis.com/business/mark-carney",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/unemployment-and-employment-statistics",
+        "type":"keyword",
+        "webTitle":"Unemployment and employment statistics",
+        "webUrl":"http://www.theguardian.com/business/unemployment-and-employment-statistics",
+        "apiUrl":"http://content.guardianapis.com/business/unemployment-and-employment-statistics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/minutebyminute",
+        "type":"tone",
+        "webTitle":"Minute by minutes",
+        "webUrl":"http://www.theguardian.com/tone/minutebyminute",
+        "apiUrl":"http://content.guardianapis.com/tone/minutebyminute",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"profile/graemewearden",
+        "type":"contributor",
+        "webTitle":"Graeme Wearden",
+        "webUrl":"http://www.theguardian.com/profile/graemewearden",
+        "apiUrl":"http://content.guardianapis.com/profile/graemewearden",
+        "bio":"<p>Graeme Wearden is a <a href=\"http://www.guardian.co.uk/business\">business</a> reporter on guardian.co.uk and writes breaking City news plus the occasional blog. Previously he worked as a technology journalist at CNET Networks</p>",
+        "r2ContributorId":"19202",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/01/graeme_wearden_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/nickfletcher",
+        "type":"contributor",
+        "webTitle":"Nick Fletcher",
+        "webUrl":"http://www.theguardian.com/profile/nickfletcher",
+        "apiUrl":"http://content.guardianapis.com/profile/nickfletcher",
+        "bio":"<p>Nick Fletcher is a Guardian columnist and writer of the Market Forces column</p>",
+        "rcsId":"GNL023406",
+        "r2ContributorId":"16178",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/03/nick_fletcher_140x140.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"84",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"276",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"132",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"612",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"180",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"324",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"68",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"228",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"372",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"620"
+          }
+        }]
+      },{
+        "id":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"251",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"453",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"386",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"117",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"318",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"184",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"68",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"68"
+          }
+        }]
+      },{
+        "id":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"184",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"233",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"282",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"380",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1261",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"68",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"331",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"625",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"768",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"86",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"135",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"159",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"448",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"101",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1490",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"333",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"275",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"738",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"68",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1536",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"217",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"390",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"768",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"360",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"133",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"284",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"401",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"423"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"209",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"310",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"586",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"356",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"768",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"355",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"309",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"256",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"346",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"167",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"78",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"123",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"212",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"301",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"134",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"86",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"330",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"232",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"379",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"281",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"183",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"121",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"253",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"77",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"340",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"209",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"296",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"165",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"161",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"66",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"185",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"68",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"90",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"114",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"137",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"42",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"211",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"706"
+          }
+        }]
+      },{
+        "id":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"680",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"93",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1374",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"147",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"68",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1536",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"307",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"200",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"253",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"768",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"413",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"360",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"540"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T08:30:00Z",
+      "webTitle":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "fields":{
+        "trailText":"<p>Thousands storm rice warehouse in the devastated central Philippines while Haiyan relief effort flounders</p>",
+        "headline":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgx",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+        "wordcount":"1488",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T04:25:00Z"
+      },
+      "tags":[{
+        "id":"world/typhoon-haiyan",
+        "type":"keyword",
+        "webTitle":"Typhoon Haiyan",
+        "webUrl":"http://www.theguardian.com/world/typhoon-haiyan",
+        "apiUrl":"http://content.guardianapis.com/world/typhoon-haiyan",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/philippines",
+        "type":"keyword",
+        "webTitle":"Philippines",
+        "webUrl":"http://www.theguardian.com/world/philippines",
+        "apiUrl":"http://content.guardianapis.com/world/philippines",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/natural-disasters",
+        "type":"keyword",
+        "webTitle":"Natural disasters and extreme weather",
+        "webUrl":"http://www.theguardian.com/world/natural-disasters",
+        "apiUrl":"http://content.guardianapis.com/world/natural-disasters",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/asia-pacific",
+        "type":"keyword",
+        "webTitle":"Asia Pacific",
+        "webUrl":"http://www.theguardian.com/world/asia-pacific",
+        "apiUrl":"http://content.guardianapis.com/world/asia-pacific",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/taniabranigan",
+        "type":"contributor",
+        "webTitle":"Tania Branigan",
+        "webUrl":"http://www.theguardian.com/profile/taniabranigan",
+        "apiUrl":"http://content.guardianapis.com/profile/taniabranigan",
+        "bio":"<p>Tania Branigan is <a href=\"http://www.guardian.co.uk/world/china\">China correspondent</a> for the Guardian</p>",
+        "rcsId":"GNL004773",
+        "r2ContributorId":"16507",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/tania_branigan_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/kate-hodal",
+        "type":"contributor",
+        "webTitle":"Kate Hodal",
+        "webUrl":"http://www.theguardian.com/profile/kate-hodal",
+        "apiUrl":"http://content.guardianapis.com/profile/kate-hodal",
+        "r2ContributorId":"47767",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422364488",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Bullit Marquez",
+            "altText":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban",
+            "height":"84",
+            "credit":"Bullit Marquez/AP",
+            "caption":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban. Photograph: Bullit Marquez/AP",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-video-422358527",
+        "relation":"body",
+        "type":"video",
+        "assets":[{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "sectionId":"travel",
+      "sectionName":"Travel",
+      "webPublicationDate":"2013-11-13T14:06:00Z",
+      "webTitle":"Top 10 budget restaurants and cafes in central London",
+      "webUrl":"http://www.theguardian.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "apiUrl":"http://content.guardianapis.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "fields":{
+        "trailText":"<p>Updating his last budget eats guide to central London, Tony Naylor discovers that, particularly in and around Soho, the capital is home to a thriving casual dining scene</p>",
+        "headline":"Top 10 budget restaurants and cafes in central London",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbp6",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+        "wordcount":"1573",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T14:06:00Z"
+      },
+      "tags":[{
+        "id":"travel/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/travel/london",
+        "apiUrl":"http://content.guardianapis.com/travel/london",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/travel/restaurants",
+        "apiUrl":"http://content.guardianapis.com/travel/restaurants",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/series/britains-best-budget-eats",
+        "type":"series",
+        "webTitle":"Britain's best budget eats",
+        "webUrl":"http://www.theguardian.com/travel/series/britains-best-budget-eats",
+        "apiUrl":"http://content.guardianapis.com/travel/series/britains-best-budget-eats",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"profile/tonynaylor",
+        "type":"contributor",
+        "webTitle":"Tony Naylor",
+        "webUrl":"http://www.theguardian.com/profile/tonynaylor",
+        "apiUrl":"http://content.guardianapis.com/profile/tonynaylor",
+        "bio":"<p>Tony Naylor lives in the north of England. He likes Greggs pasties, molecular gastronomy and lots of things in between. Outside of filling his face his interests include any licensed establishments, Manchester City, electronic music and some other stuff which could look a bit pretentious in print</p>",
+        "rcsId":"GNL009141",
+        "r2ContributorId":"16542",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/tony_naylor.jpg",
+        "references":[]
+      },{
+        "id":"travel/travel",
+        "type":"keyword",
+        "webTitle":"Travel",
+        "webUrl":"http://www.theguardian.com/travel/travel",
+        "apiUrl":"http://content.guardianapis.com/travel/travel",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/travelfoodanddrink",
+        "type":"keyword",
+        "webTitle":"Food and drink",
+        "webUrl":"http://www.theguardian.com/travel/travelfoodanddrink",
+        "apiUrl":"http://content.guardianapis.com/travel/travelfoodanddrink",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"travel/uk",
+        "type":"keyword",
+        "webTitle":"United Kingdom",
+        "webUrl":"http://www.theguardian.com/travel/uk",
+        "apiUrl":"http://content.guardianapis.com/travel/uk",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/europe",
+        "type":"keyword",
+        "webTitle":"Europe",
+        "webUrl":"http://www.theguardian.com/travel/europe",
+        "apiUrl":"http://content.guardianapis.com/travel/europe",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/england",
+        "type":"keyword",
+        "webTitle":"England",
+        "webUrl":"http://www.theguardian.com/travel/england",
+        "apiUrl":"http://content.guardianapis.com/travel/england",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/budget",
+        "type":"keyword",
+        "webTitle":"Budget travel",
+        "webUrl":"http://www.theguardian.com/travel/budget",
+        "apiUrl":"http://content.guardianapis.com/travel/budget",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397454",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349264516/Koshari-Street-London-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Koshari Street's twist on Egyptian street food",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397455",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Koshari Street, London",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422397456",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg",
+          "typeData":{
+            "source":"Heloise Faure",
+            "photographer":"Heloise Faure",
+            "altText":"Honey & Co Cafe, Soho, London",
+            "height":"276",
+            "credit":"Heloise Faure/Heloise Faure",
+            "caption":"Photograph: Heloise Faure",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397457",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg",
+          "typeData":{
+            "source":"Ming Tang-Evans",
+            "photographer":"Ming Tang-Evans",
+            "altText":"Attendant cafe-restaurant, London",
+            "height":"276",
+            "credit":"Ming Tang-Evans/Ming Tang-Evans",
+            "caption":"Photograph: Ming Tang-Evans",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397458",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Scandinavian kitchen, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397459",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Honest Burger",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397460",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Foxcroft and Ginger, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397461",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg",
+          "typeData":{
+            "source":"Paul Winch-Furness",
+            "photographer":"Paul Winch-Furness",
+            "altText":"Pizza Pilgrims, Soho, London",
+            "height":"277",
+            "credit":"Paul Winch-Furness/Paul Winch-Furness",
+            "caption":"Photograph: Paul Winch-Furness",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397462",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Chettinad lunch box, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397463",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Bi Bim Bap Soho ",
+            "height":"277",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-12T15:43:09Z",
+      "webTitle":"Jennifer Lawrence is striking a blow for healthy, sweaty women | Muireann Carey-Campbell",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "fields":{
+        "trailText":"<p><strong>Muireann Carey-Campbell:</strong> Shock, horror – a female film star says she wants to be 'fit and strong'. But the more women she gets into the gym the better</p>",
+        "headline":"Jennifer Lawrence is striking a blow for healthy, sweaty women",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb44",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+        "wordcount":"572",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-15T15:43:00Z"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"film/jennifer-lawrence",
+        "type":"keyword",
+        "webTitle":"Jennifer Lawrence",
+        "webUrl":"http://www.theguardian.com/film/jennifer-lawrence",
+        "apiUrl":"http://content.guardianapis.com/film/jennifer-lawrence",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/body-image",
+        "type":"keyword",
+        "webTitle":"Body image",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/body-image",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/body-image",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fitness",
+        "type":"keyword",
+        "webTitle":"Fitness",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fitness",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fitness",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"lifeandstyle/health-and-wellbeing",
+        "type":"keyword",
+        "webTitle":"Health & wellbeing",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/health-and-wellbeing",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/health-and-wellbeing",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/health",
+        "type":"keyword",
+        "webTitle":"Health",
+        "webUrl":"http://www.theguardian.com/society/health",
+        "apiUrl":"http://content.guardianapis.com/society/health",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/muireann-carey-campbell",
+        "type":"contributor",
+        "webTitle":"Muireann Carey-Campbell",
+        "webUrl":"http://www.theguardian.com/profile/muireann-carey-campbell",
+        "apiUrl":"http://content.guardianapis.com/profile/muireann-carey-campbell",
+        "bio":"<p>Muireann Carey-Campbell is a fashion, lifestyle and fitness blogger based in London. She is an advocate for empowering women through exercise and edits <a href-\"http://spikesandheels.com\">spikesandheels.com</a> and <a href=\"http://www./pikesandheels.com\">bangsandabun.com</a></p>",
+        "r2ContributorId":"59569",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384260881751/Muireann-Carey-Campbell.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422318972",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269380150/Jennifer-Lawrence-with-Jo-001.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"54",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269383552/Jennifer-Lawrence-with-Jo-002.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"130",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269387034/Jennifer-Lawrence-with-Jo-004.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"132",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269388680/Jennifer-Lawrence-with-Jo-005.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"168",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269390391/Jennifer-Lawrence-with-Jo-006.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"180",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269392235/Jennifer-Lawrence-with-Jo-007.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"228",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/Lionsgate/Sportsphoto Ltd",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422318973",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "sectionId":"technology",
+      "sectionName":"Technology",
+      "webPublicationDate":"2013-11-13T11:29:00Z",
+      "webTitle":"PS4: the 10 key launch titles",
+      "webUrl":"http://www.theguardian.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "apiUrl":"http://content.guardianapis.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "fields":{
+        "trailText":"<p>As the Sony PlayStation 4's US launch looms, here are the best initial titles, from Killzone: Shadow Fall to Call of Duty: Ghosts. By <strong>Keith Stuart</strong></p>",
+        "headline":"PS4: the 10 key launch titles",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kb3x",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+        "wordcount":"964",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T11:29:00Z"
+      },
+      "tags":[{
+        "id":"technology/playstation-4",
+        "type":"keyword",
+        "webTitle":"PlayStation 4",
+        "webUrl":"http://www.theguardian.com/technology/playstation-4",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation-4",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/playstation",
+        "type":"keyword",
+        "webTitle":"PlayStation",
+        "webUrl":"http://www.theguardian.com/technology/playstation",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/sony",
+        "type":"keyword",
+        "webTitle":"Sony",
+        "webUrl":"http://www.theguardian.com/technology/sony",
+        "apiUrl":"http://content.guardianapis.com/technology/sony",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/games",
+        "type":"keyword",
+        "webTitle":"Games",
+        "webUrl":"http://www.theguardian.com/technology/games",
+        "apiUrl":"http://content.guardianapis.com/technology/games",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/technology",
+        "type":"keyword",
+        "webTitle":"Technology",
+        "webUrl":"http://www.theguardian.com/technology/technology",
+        "apiUrl":"http://content.guardianapis.com/technology/technology",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"profile/keithstuart",
+        "type":"contributor",
+        "webTitle":"Keith Stuart",
+        "webUrl":"http://www.theguardian.com/profile/keithstuart",
+        "apiUrl":"http://content.guardianapis.com/profile/keithstuart",
+        "bio":"<p>Keith Stuart is a veteran video game and technology writer, who is also a regular contributor to Edge magazine</p>",
+        "rcsId":"GNL007878",
+        "r2ContributorId":"15953",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Media/Columnists/Columnists/2013/11/8/1383915413362/Keith-Stuart--003.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388207",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288957309/KZ4_Blast3_main.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Killzone: Shadow Fall – a graphical showcase for Sony's next-gen PS4 console",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422388208",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"84",
+            "credit":"PR",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T13:54:18Z",
+      "webTitle":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "fields":{
+        "trailText":"Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol<br />",
+        "headline":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbqd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+        "wordcount":"247",
+        "liveBloggingNow":"false",
+        "commentCloseDate":"2013-11-16T13:54:18Z"
+      },
+      "tags":[{
+        "id":"football/martin-jol",
+        "type":"keyword",
+        "webTitle":"Martin Jol",
+        "webUrl":"http://www.theguardian.com/football/martin-jol",
+        "apiUrl":"http://content.guardianapis.com/football/martin-jol",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/fulham",
+        "type":"keyword",
+        "webTitle":"Fulham",
+        "webUrl":"http://www.theguardian.com/football/fulham",
+        "apiUrl":"http://content.guardianapis.com/football/fulham",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/55"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397529",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350779268/Ren--Meulensteen-001.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"54",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350781955/Ren--Meulensteen-002.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"130",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350783658/Ren--Meulensteen-003.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"84",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350785345/Ren--Meulensteen-004.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"132",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350787149/Ren--Meulensteen-005.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"168",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350788867/Ren--Meulensteen-006.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"180",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350790688/Ren--Meulensteen-007.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"228",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350792437/Ren--Meulensteen-008.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"276",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351652017/Martin-Jol-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"276",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by the newly appointed head coach René Meulensteen (right) at Fulham. Photographs: PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397530",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"84",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by new head coach René Meulensteen (right) at Fulham. Photograph: PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/55"
+      }]
+    }],
+    "storyPackage":[]
+  }
+}

--- a/data/database/516ea6e302684c35fc42df012545710d5c3ba364
+++ b/data/database/516ea6e302684c35fc42df012545710d5c3ba364
@@ -1,0 +1,6211 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":1,
+    "mostViewed":[{
+      "id":"lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Why you won't catch me queuing for a burger",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "fields":{
+        "trailText":"<p><strong>Jay Rayner:</strong> Waiting two hours in a line for beef in a bun was never going to be a good idea</p>",
+        "headline":"Why you won't catch me queuing for a burger",
+        "body":"<p>I'm all for delayed gratification. I will book theatre tickets six months ahead. I will take a shoulder of lamb, stud it with anchovies and garlic and half-submerge it in a broth of red wine, stock and piggy bits, so that it looks like the ravaged island of Dr Moreau, shove it in the oven and know it will have nothing of any interest to say to me for at least seven hours.</p><p>What I won't do is <a href=\"http://www.theguardian.com/lifeandstyle/2013/nov/03/eat-out-queue-for-table\" title=\"\">queue for a hamburger</a>. In this, it seems, I am peculiar. Recently London's Covent Garden has seen the opening of the US operations Shake Shack and Five Guys. We also have home-grown outfits like Meat Liquor, and Burger and Lobster, which seem to regard reservation policies as bourgeois affectations. In the sense that bookable tables suit people with jobs, interesting lives and places they need to be which don't include standing dead-eyed and wet-lipped on a chilly pavement for the running time of <em>The Godfather Part III</em>, I suppose they are. And yes, it's not entirely new. The Hard Rock Cafe has long been famous for its queue, but that was so odd it was a tourist attraction, something people pointed and laughed at. The new queueing has got completely out of hand. It's taken for granted. I have wandered past these places on numerous occasions and been baffled. What in God's name possesses anyone to stand in an endless line – I've been quoted more than two hours for Burger and Lobster – for a lump of ground beef between two sugary buns?</p><p>Of course it's not just a lump of ground beef, is it? Over at the Shake Shack it's \"our proprietary Shack blend\" which makes it sound less like lunch and more like a haemorrhoid ointment; at Five Guys it's \"hand formed burgers cooked to perfection\". Really? Whose version of perfection, given that Westminster Council is trying to outlaw any burger served less than medium? Or completely buggered, as it's known.</p><p>I'll go that extra 10 miles to eat well. I'll cross London to secure an ingredient, take a flight to eat at the right restaurant. But queue? That's not an expression of greed. It's stamp-collecting. It's trainspotting. It's eating out as spectator sport. Except the only thing the queue has to spectate upon is itself, and there it finds validation: standing in line for a hamburger must be entirely reasonable; just look at all the other people doing it.</p><p>The counter-argument involves the P word: patience, and my total lack of it. Apparently patience is a virtue. Really? If everybody was patient, nothing would ever get done. The world depends on restless, impatient people. I should also point out that patience is one of the seven great Christian virtues. Nobody with an appetite should ever sign up to those. Obviously some are OK. I believe fully in humility. I am brilliant at that, do it better than anybody else. But chastity and temperance? Don't be silly. That's the point. Queuing for a burger is not about eating. It's about self-denial. And doing the restaurant's marketing for them by standing outside.</p><p>Me? I will go somewhere that serves a slightly less impressive burger and in so doing, trade a little of the perceived quality of the Shake Shack object of desire, for living more of my life. I've only got one of those, and I'm not wasting it in a queue.</p><!-- Guardian Watermark: internal-code/content/421828691|2013-11-13T15:50:01Z|4b3ef3429e53b630d10c1f8a057f6a070b28ee4f -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k6zt",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+        "wordcount":"567",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fast-food",
+        "type":"keyword",
+        "webTitle":"Fast food",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fast-food",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fast-food",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Observer Food Monthly recipes & features",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly/features",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly/features",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly",
+        "type":"newspaper-book",
+        "webTitle":"Observer Food Monthly",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"lifeandstyle/series/happy-eater",
+        "type":"series",
+        "webTitle":"Happy eater",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/happy-eater",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/happy-eater",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/jayrayner",
+        "type":"contributor",
+        "webTitle":"Jay Rayner",
+        "webUrl":"http://www.theguardian.com/profile/jayrayner",
+        "apiUrl":"http://content.guardianapis.com/profile/jayrayner",
+        "bio":"<p>Jay Rayner is the Observer's restaurant critic and a novelist. His latest book is the Oyster House Siege</p>",
+        "rcsId":"GNL258574",
+        "r2ContributorId":"15803",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2008/06/02/jay_rayner_140x140.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theobserver",
+        "type":"publication",
+        "webTitle":"The Observer",
+        "webUrl":"http://www.theguardian.com/theobserver/all",
+        "apiUrl":"http://content.guardianapis.com/theobserver/all",
+        "sectionId":"theobserver",
+        "sectionName":"From the Observer",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422287525",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259303137/burger-and-fries-from-sha-007.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"276",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about self-denial\". Photograph: Radharc Images/Alamy",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422287526",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"84",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about \nself-denial\". Photograph: Radharc Images /Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T12:58:39Z",
+      "webTitle":"It was hard to stomach David Cameron preaching austerity from a golden throne | Ruth Hardy",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "fields":{
+        "trailText":"<strong>Ruth Hardy: </strong>As a waitress at the lord mayor's banquet, the contrast between what Cameron was saying and where he was saying it felt particularly chilling",
+        "headline":"It was hard to stomach David Cameron preaching austerity from a golden throne",
+        "body":"<p>At a state banquet for the new Lord Mayor on Monday, David Cameron gave a <a href=\"http://www.theguardian.com/politics/2013/nov/11/david-cameron-policy-shift-leaner-efficient-state\" title=\"\">speech about his commitment to the cause of permanent austerity</a>. He stood up to speak from a golden chair, and read his notes from a golden lectern.</p><p></p><p>As it happens, I was at the banquet too and heard the news about permanent spending cutbacks for myself. Sadly I was not there as a dignitary, a foreign diplomat, a captain of industry or the director of a big City firm. I was there as a waitress. The contrast between what he was saying and where he was saying it seemed initially almost too laughable to get worked up about. But actually, it reflected something chilling in Cameron's attitude towards the people he purports to be working for.</p><p></p><p>I work evenings and weekends at an events company. The company is great and the hours are flexible, which allows me to combine it with my main job of an internship. It's tough, and I've been in a state of semi-tiredness for the last two months. I do get to work at interesting events, though, and the fanciness of the Guildhall banquet was breathtaking. Although, as one of my colleagues said: \"I thought Boris Johnson was the lord mayor, that's the only reason I agreed to work!\"</p><p></p><p>The guests enjoyed a champagne reception, and then were served a starter (\"a celebration of British mushrooms\"), a fish course and main course of fillet of beef, all served with wine of course. In the break before dessert, coffee, dessert wine, port, brandy and whisky were served, Cameron gave his speech. We retreated downstairs to a steam-filled kitchen, where we polished the cutlery. Most of us were exhausted by this point. Dinner service is physically demanding, and I am by no means the only person who combines two or three jobs. The contrast of the two worlds was striking; someone said it was like a scene from Downton Abbey.</p><p></p><p>Maybe Cameron didn't see the irony; perhaps he forgot about the army of waiting staff, cleaners, chefs and porters who were also present at the banquet. Perhaps he thought he was in a room of similarly rich people, who understood the necessity for austerity. Perhaps it didn't occur to him that this message might not be as easily comprehended by those who hadn't just enjoyed a four-course meal. Perhaps he forgot about those of us, disabled or unemployed or on the minimum wage, for whom austerity has had a catastrophic and wounding effect.</p><p></p><p>In his speech, Cameron talked about a \"leaner, more efficient, more affordable state\". He argued that austerity could be a permanent government policy; a way of trimming down the administrative excesses of some public services. He framed it in the context of the current tough living conditions – a minimising of state spending, as it \"comes out of the pockets of the same taxpayers whose living standards we want to see improve\".</p><p></p><p>No word yet, of course, on what changes will be made to the state-funded banquet he was speaking at. Perhaps next year there will only be three courses, or the dessert wine will be ruthlessly culled.</p><p></p><p>I wonder how Cameron and his government can do these things. Aside from the idiocy of calling for cuts while wearing a white tie – has the man never heard of Twitter – does he not see what welfare cuts are doing to the vulnerable in society? He enjoys a banquet, while the number of people using food banks has tripled in the past year. As someone on the shift with me said, \"It gets annoying that we always serve free food to the people who really don't need free food.\"</p><p></p><p>The political content of what Cameron is saying is obviously more important than where he was saying it, but I don't think the latter is irrelevant. I have a fundamental problem with a man who sits on a golden throne and lectures us about spending less, like a modern-day, white-tie clad sheriff of Nottingham. And all around him, the insidious stain of austerity creeps across the country, manifesting in the bedroom tax, rising tuition fees and the closure of public services that vulnerable people depend on.</p><p></p><p>Each of us has just one chance at existence, and so many people's lives are being blighted by these cuts. If this is the cruel and damaging reality of permanent austerity, then we should be telling Mr Cameron we don't want it.</p><!-- Guardian Watermark: internal-code/content/422381235|2013-11-13T15:50:01Z|a39e5393ad4fbfe9cb5ea9291bf9c8c72f35b051 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbyq",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+        "wordcount":"738",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"politics/davidcameron",
+        "type":"keyword",
+        "webTitle":"David Cameron",
+        "webUrl":"http://www.theguardian.com/politics/davidcameron",
+        "apiUrl":"http://content.guardianapis.com/politics/davidcameron",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/conservatives",
+        "type":"keyword",
+        "webTitle":"Conservatives",
+        "webUrl":"http://www.theguardian.com/politics/conservatives",
+        "apiUrl":"http://content.guardianapis.com/politics/conservatives",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"society/public-sector-cuts",
+        "type":"keyword",
+        "webTitle":"Public sector cuts",
+        "webUrl":"http://www.theguardian.com/society/public-sector-cuts",
+        "apiUrl":"http://content.guardianapis.com/society/public-sector-cuts",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/policy",
+        "type":"keyword",
+        "webTitle":"Public services policy",
+        "webUrl":"http://www.theguardian.com/society/policy",
+        "apiUrl":"http://content.guardianapis.com/society/policy",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/public-finance",
+        "type":"keyword",
+        "webTitle":"Public finance",
+        "webUrl":"http://www.theguardian.com/society/public-finance",
+        "apiUrl":"http://content.guardianapis.com/society/public-finance",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"business/austerity",
+        "type":"keyword",
+        "webTitle":"Austerity",
+        "webUrl":"http://www.theguardian.com/business/austerity",
+        "apiUrl":"http://content.guardianapis.com/business/austerity",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/economics",
+        "type":"keyword",
+        "webTitle":"Economics",
+        "webUrl":"http://www.theguardian.com/business/economics",
+        "apiUrl":"http://content.guardianapis.com/business/economics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"profile/ruth-hardy",
+        "type":"contributor",
+        "webTitle":"Ruth Hardy",
+        "webUrl":"http://www.theguardian.com/profile/ruth-hardy",
+        "apiUrl":"http://content.guardianapis.com/profile/ruth-hardy",
+        "bio":"<p>Ruth Hardy is a freelance writer and recent graduate in philosophy at King's College London. You can follow her on Twitter <a href=\"https://twitter.com/ruthhardy22\">here</a></p>",
+        "r2ContributorId":"56147",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Education/Pix/pictures/2013/4/24/1366808642483/Ruth-Hardy-student-blogge-002.jpg",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422382150",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344632805/David-Cameron-at-Lord-May-001.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"54",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344634858/David-Cameron-at-Lord-May-002.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"130",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344637355/David-Cameron-at-Lord-May-004.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"132",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344638596/David-Cameron-at-Lord-May-005.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"168",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344639804/David-Cameron-at-Lord-May-006.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"180",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344641041/David-Cameron-at-Lord-May-007.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"228",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422382151",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T14:44:00Z",
+      "webTitle":"MI6 spy found dead in bag probably locked himself inside, Met says",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "fields":{
+        "trailText":"Three-year investigation by Scotland Yard concludes Gareth Williams probably died as a result of tragic accident",
+        "headline":"MI6 spy found dead in bag probably locked himself inside, Met says",
+        "body":"<p></p><p>The MI6 spy found dead in a bag three years ago probably locked himself in the holdall and died as a result of a tragic accident, Scotland Yard has said.</p><p>Outlining the results of a three-year investigation on Wednesday, the Metropolitan police said that Gareth Williams was most likely to have died alone in his flat.</p><p>However, Detective Assistant Commissioner Martin Hewitt said the police could not \"fundamentally and beyond doubt\" rule out the possibility that a third-party was involved in his  death.</p><p>The naked body of Williams was found in the padlocked bag, with the keys discovered under his body, in the otherwise empty bath in his flat in Pimlico, London, in August 2010.</p><p>Last year, a coroner concluded that Williams was probably unlawfully killed and his death the result of a criminal act. Following an eight-day inquest, the Westminster coroner, Dr Fiona Wilcox, said he was probably either suffocated or poisoned, before a third-party locked and placed the bag in the bath.</p><p></p><p>However, Hewitt said Scotland Yard's three-year inquiry had come to a different conclusion and that Williams was \"most probably\" alone when he died.</p><p>\"Despite all of this considerable effort, it is still the case that there is insufficient evidence to be definitive on the circumstances that led to Gareth's death,\" he said.</p><p></p><p>\"Rather, what we are left with is either individual pieces of evidence, or a lack of such evidence, that can logically support one of a number of hypotheses.\"</p><p></p><p></p><p></p><p>Hewitt added that the investigation had added \"some clarity and detail\" to the case, but that \"no evidence has been identified to establish the full circumstances of Gareth's death beyond all reasonable doubt\".</p><p></p><p>A forensic examination of Williams's flat, a security service safe house, has concluded that there was no sign of forced entry or DNA that pointed to a third-party present at the time of the spy's death.</p><p></p><p>Scotland Yard's inquiry also found no evidence of Williams's fingerprints on the padlock of the bag or the rim of the bath, which the coroner last year said supported her assertion of \"third-party involvement\" in the death.</p><p></p><p>However, Hewitt said it was theoretically possible for Williams to lower himself into the holdall without touching the rim of the bath.</p><p></p><p>Winding down the lengthy investigation, which has drawn interviews and statements from 27 of Williams's colleagues in MI6 and GCHQ, Hewitt said the death remained a tragedy that would be kept under review by detectives.</p><p></p><p>In a statement, Williams's family said they were  disappointed with the police findings and that they agreed with the coroner's conclusions that he was most likely killed unlawfully.</p><p></p><p>\"We are naturally disappointed that it is still not possible to state with certainty how Gareth died and the fact that the circumstances of his death are still unknown adds to our grief,\" the  family said.</p><p></p><p>\"We note that the investigation has been conducted with further interviews upon some of the witnesses who gave evidence at the inquest and that the investigation team were at last able to interview directly members of GCHQ and SIS [MI6].</p><p></p><p>\"We consider that on the basis of the facts at present known the coroner's verdict accurately reflects the circumstances of Gareth's death.\"</p><p></p><p>In a press briefing at Scotland Yard, Hewitt admitted it was \"a cause of some regret\" that the police were not able to definitively explain the circumstances surrounding the 31-year-old's death.</p><p></p><p>He rejected suggestions that the security services had \"pulled the wool\" over his eyes, following concerns over how MI6 and counter-terrorism officers had handled some evidence during the initial investigation. It emerged on Wednesday that police only gained access to Williams's spy agency personnel and vetting files after the coroner's inquest ended last May.</p><p></p><p>Williams, a maths prodigy and fitness enthusiast originally from Anglesey, was a private person with few other close friends aside from his family, police said. In interviews, MI6 and GCHQ colleagues described him as a \"conscientious and decent man\" and detectives were unable to identify anyone with any animosity towards him or a motive for causing him harm.</p><p></p><p>As part of the fresh investigation, a forensic sweep of Williams's flat discovered 10 to 15 unidentified traces of DNA, which are being kept under examination, but none on the North Face holdall or around the bath area of the en-suite bathroom of the flat's main bedroom. There was also no evidence of a \"deep clean\" of the flat to wipe all trace of DNA.</p><p></p><p>Hewitt said: \"There are really three hypotheses that you can use here. One is that Gareth, for whatever reason, got himself into that bag and then was unable to get himself out and died as a result of that.</p><p></p><p>\"One is that Gareth, with someone else, got into the bag consensually then something went wrong and he died as a result of that. The third is that someone murdered Gareth by putting him in that bag. I would argue that any physical absence [of evidence of] a third party being present tends to make the hypotheses that there is a third party present less likely.\"</p><p></p><p>He added: \"The coroner drew an inference. I am now drawing a different inference.\"</p><p></p><p>At the coroner's inquest, two experts tried 400 times to lock themselves into the 32-inch by 19-inch holdall without success, with one remarking that even Harry Houdini \"would have struggled\" to squeeze himself inside. But days after the inquest footage emerged of a retired Army sergeant climbing into the bag and locking it from the inside.</p><p></p><p>Hewitt said it was now established that it was theoretically possible for a person to climb into the bag and that it was \"more probable\" that Williams did this before suffocating as a result of the accident. It emerged during the inquest that Williams had an interest in escapology, but the police said it would be speculation to link his death to a failed attempt to escape from the locked holdall.</p><!-- Guardian Watermark: internal-code/content/422374658|2013-11-13T15:50:01Z|2fd9134acad4628a73f05b72533e71cb4f6ef04d -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjj",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+        "wordcount":"962",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"uk/gareth-williams",
+        "type":"keyword",
+        "webTitle":"Gareth Williams",
+        "webUrl":"http://www.theguardian.com/uk/gareth-williams",
+        "apiUrl":"http://content.guardianapis.com/uk/gareth-williams",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/mi6",
+        "type":"keyword",
+        "webTitle":"MI6",
+        "webUrl":"http://www.theguardian.com/uk/mi6",
+        "apiUrl":"http://content.guardianapis.com/uk/mi6",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uksecurity",
+        "type":"keyword",
+        "webTitle":"UK security and counter-terrorism",
+        "webUrl":"http://www.theguardian.com/uk/uksecurity",
+        "apiUrl":"http://content.guardianapis.com/uk/uksecurity",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/josh-halliday",
+        "type":"contributor",
+        "webTitle":"Josh Halliday",
+        "webUrl":"http://www.theguardian.com/profile/josh-halliday",
+        "apiUrl":"http://content.guardianapis.com/profile/josh-halliday",
+        "bio":"<p><a href=\"http://twitter.com/JoshHalliday\">Josh Halliday</a> is a media and technology reporter. Josh has a keen interest in digital media and privacy. Dislikes insufferable enthusiasm. Bradfordian via Wearside</p>",
+        "r2ContributorId":"38624",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/7/14/1279118930047/Josh-Halliday.jpg",
+        "references":[]
+      },{
+        "id":"uk/metropolitan-police",
+        "type":"keyword",
+        "webTitle":"Metropolitan police",
+        "webUrl":"http://www.theguardian.com/uk/metropolitan-police",
+        "apiUrl":"http://content.guardianapis.com/uk/metropolitan-police",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/uk/london",
+        "apiUrl":"http://content.guardianapis.com/uk/london",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379877",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341447432/Gareth-Williams-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"54",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341448835/Gareth-Williams-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"340",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341450089/Gareth-Williams-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"130",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341452580/Gareth-Williams-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"132",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341453889/Gareth-Williams-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"168",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341455246/Gareth-Williams-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"180",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341456514/Gareth-Williams-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"228",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341459093/Gareth-Williams-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"372",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379878",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-12T15:34:27Z",
+      "webTitle":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "fields":{
+        "trailText":"Rolling Jubilee spent $400,000 to purchase debt cheaply from banks before 'abolishing' it, freeing individuals from their bills",
+        "headline":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+        "body":"<p>A group of Occupy Wall Street activists has bought almost $15m of Americans' personal debt over the last year as part of the Rolling Jubilee project to help people pay off their outstanding credit.</p> <p><a href=\"http://rollingjubilee.org/\">Rolling Jubilee</a>,&nbsp;set up by Occupy's <a href=\"http://www.theguardian.com/world/2012/nov/15/occupy-rolling-jubilee-debt-forgiveness\">Strike Debt group</a>&nbsp;following the street protests that swept the world in 2011, launched on 15 November 2012. The group purchases personal debt cheaply from banks before \"abolishing\" it, freeing individuals from their bills.</p> <p>By purchasing the debt at knockdown prices the group has managed to free $14,734,569.87 of personal debt, mainly medical debt, spending only $400,000.</p> <p>\"We thought that the ratio would be about 20 to 1,\" said Andrew Ross, a member of Strike Debt and professor of social and cultural analysis at New York University. He said the team initially envisaged raising $50,000, which would have enabled it to buy $1m in debt.</p> <p>\"In fact we've been able to buy debt a lot more cheaply than that.\"</p> <p>The group is able to buy debt so cheaply due to the nature of the \"secondary debt market\". If individuals consistently fail to pay bills from credit cards, loans, or medical insurance the bank or lender that issued the funds will eventually cut its losses by selling that debt to a third party. These sales occur for a fraction of the debt&rsquo;s true values &ndash; typically for five cents on the dollar &ndash; and debt-buying companies then attempt to recoup the debt from the individual debtor and thus make a profit.</p> <p>The Rolling Jubilee project was mostly conceived as a \"public education project\", Ross said.</p> <p>\"We're under no illusions that $15m is just a tiny drop in the secondary debt market. It doesn't make a dent in the amount of debt.</p> <p>\"Our purpose in doing this, aside from helping some people along the way &ndash; there's certainly many, many people who are very thankful that their debts are abolished &ndash; our primary purpose was to spread information about the workings of this secondary debt market.\"</p> <p>The group has focussed on buying medical debt, and has acquired the $14.7m in three separate purchases, most recently&nbsp;purchasing the value of&nbsp;$13.5m on medical debt owed by 2,693 people across 45 states and Puerto Rico, Rolling Jubilee said in a press release.</p> <p>&ldquo;No one should have to go into debt or bankruptcy because they get sick,&rdquo; said Laura Hanna, an organiser with the group. Hanna said 62% of all personal bankruptcies have medical debt as a contributing factor.</p> <p>Due to the nature of the debt market, the group is unable to specify whose debt it purchases, taking on the amounts before it discovers individuals&rsquo; identities. When Rolling Jubilee has bought the debt they send notes to their debtors &ldquo;telling them they&rsquo;re off the hook&rdquo;, Ross said.</p> <p>Ross, whose book, <a href=\"http://www.orbooks.com/catalog/creditocracy/\">Creditocracy</a> and the case for debt refusal, outlines the problems of the debt industry and calls for a &ldquo;debtors&rsquo; movement&rdquo; to resist credit, said the group had received letters from people whose debt they had lifted thanking them for the service. But the real victory was in spreading knowledge of the nature of the debt industry, he said.</p> <p>\"Very few people know how cheaply their debts have been bought by collectors. It changes the psychology of the debtor, knowing this.</p> <p>&ldquo;So when you get called up by the debt collector, and you're being asked to pay the full amount of your debt, you now know that the debt collector has bought your debt very, very cheaply. As cheaply as we bought it. And that gives you moral ammunition to have a different conversation with the debt collector.\"</p><!-- Guardian Watermark: internal-code/content/422309147|2013-11-13T15:50:02Z|54fde1a29219bce7813ff3897428d2ce48607b5f -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb4g",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+        "wordcount":"1",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/occupy-movement",
+        "type":"keyword",
+        "webTitle":"Occupy movement",
+        "webUrl":"http://www.theguardian.com/world/occupy-movement",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-movement",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/occupy-wall-street",
+        "type":"keyword",
+        "webTitle":"Occupy Wall Street",
+        "webUrl":"http://www.theguardian.com/world/occupy-wall-street",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-wall-street",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/debt-relief",
+        "type":"keyword",
+        "webTitle":"Debt relief",
+        "webUrl":"http://www.theguardian.com/world/debt-relief",
+        "apiUrl":"http://content.guardianapis.com/world/debt-relief",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"money/us-personal-finance",
+        "type":"keyword",
+        "webTitle":"US personal finance",
+        "webUrl":"http://www.theguardian.com/money/us-personal-finance",
+        "apiUrl":"http://content.guardianapis.com/money/us-personal-finance",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"money/mortgages-us",
+        "type":"keyword",
+        "webTitle":"US mortgages",
+        "webUrl":"http://www.theguardian.com/money/mortgages-us",
+        "apiUrl":"http://content.guardianapis.com/money/mortgages-us",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"business/useconomy",
+        "type":"keyword",
+        "webTitle":"US economy",
+        "webUrl":"http://www.theguardian.com/business/useconomy",
+        "apiUrl":"http://content.guardianapis.com/business/useconomy",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"money/money",
+        "type":"keyword",
+        "webTitle":"Money",
+        "webUrl":"http://www.theguardian.com/money/money",
+        "apiUrl":"http://content.guardianapis.com/money/money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/adam-gabbatt",
+        "type":"contributor",
+        "webTitle":"Adam Gabbatt",
+        "webUrl":"http://www.theguardian.com/profile/adam-gabbatt",
+        "apiUrl":"http://content.guardianapis.com/profile/adam-gabbatt",
+        "bio":"<p>Adam Gabbatt is a reporter and live blogger for the Guardian, based in New York. He won a journalism bursary from the Scott Trust, the company that owns the Guardian, in 2008, and began writing for the newspaper and website in 2009. He was highly commended in the young journalist of the year category at the British Press Awards in 2011</p>",
+        "r2ContributorId":"33854",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/1/24/1359039911843/AdamGabbatt.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"276",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"'Our primary purpose was to spread information about the workings of this secondary debt market,' said Andrew Ross.&nbsp;Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"84",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"The Occupy movement began in Wall Street in November 2011 when protesters attempted to shut down the New York stock exchange. Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T01:25:32Z",
+      "webTitle":"ITV news presenter hits back after abuse for not wearing poppy",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "fields":{
+        "trailText":"Charlene White faced racist and sexist abuse which, she said, acted against all the goals that the fallen soldiers fought for",
+        "headline":"ITV news presenter hits back after abuse for not wearing poppy",
+        "body":"<p>An ITV news presenter who has been subject to racist and sexist abuse for her decision not to wear a Remembrance Day poppy said she made her decision in order to be \"neutral and impartial on-screen\".</p><p>Charlene White, a presenter on ITV News London, received insults on social media after she appeared on screen without the poppy, with many of the jibes focusing on her race.</p><p><a href=\"http://www.itv.com/news/2013-11-12/itv-news-presenter-defends-decision-to-not-wear-a-poppy-on-air/\" title=\"\">In a statement on the ITV website</a>, the journalist said she had made the decision not to wear a poppy a number of years ago but the backlash this year had been the worst so far.</p><p>She said she supported the armed forces, in which her father and uncle had served, but chose to remain impartial on screen.</p><p>\"I support and am patron of a number of charities and I am uncomfortable with giving one of those charities more on-screen time than others,\" she said. \"I prefer to be neutral and impartial on screen so that one of those charities doesn't feel less favoured than another.  Offscreen in my private life – it's different.</p><p>\"I wear a red ribbon at the start of December for World Aids Day, a pink ribbon in October during breast cancer awareness month, a badge in April during Bowel Cancer Awareness month, and yes – a poppy on Armistice Day.</p><p>\"I respect and hold in high esteem those in the armed forces, both my father and my uncle have served in the RAF and the army.  Every year I donate to the Poppy Appeal because above all else it is a charity that needs donations, so that it can continue to help support serving and ex-service men and women and their families.\"</p><p>The abuse directed at her on Twitter included racist jibes that her family would not have been able to settle in Britain but for the deaths of soldiers.  \"Without all those fallen soldiers, Hitler would've taken over Britain and your family would never have been allowed here...,\" user @alhaurincraig wrote.  Another crudely superimposed a picture of a poppy on to an image of the presenter with a banner saying 'Sack the Slag'.</p><p>White said the racist and sexist abuse acted against all of the goals that the fallen soldiers had fought for. \"The messages of \"go back to where you came from\" have been interesting to read, as have the 'fat s--g' comments, and the repeated use of the phrase 'black c--t',\" she said.  \"Mostly because it flies in the face of everything that millions of British men and women and those in the Commonwealth have fought for for generations, and continue to fight for: the right to choose, and the right of freedom of speech and expression.\"</p><p>Google has also been the subject of criticism because it used only a small Remembrance Day poppy on its website. Labour MP Gerry Sutcliffe said it was \"demeaning not to have something spectacular\".</p><p>The search engine said it tried to be sensitive in not putting sombre occasions into one of their trademark doodles but instead featuring them in some way on their homepage.</p><!-- Guardian Watermark: internal-code/content/422347727|2013-11-13T15:50:02Z|89439d0c4b7d39bea2cc0a546381366a0ed0a071 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbfc",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+        "wordcount":"504",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"uk/remembranceday",
+        "type":"keyword",
+        "webTitle":"Remembrance Day",
+        "webUrl":"http://www.theguardian.com/uk/remembranceday",
+        "apiUrl":"http://content.guardianapis.com/uk/remembranceday",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"media/itv1",
+        "type":"keyword",
+        "webTitle":"ITV channel",
+        "webUrl":"http://www.theguardian.com/media/itv1",
+        "apiUrl":"http://content.guardianapis.com/media/itv1",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/television",
+        "type":"keyword",
+        "webTitle":"Television industry",
+        "webUrl":"http://www.theguardian.com/media/television",
+        "apiUrl":"http://content.guardianapis.com/media/television",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/media",
+        "type":"keyword",
+        "webTitle":"Media",
+        "webUrl":"http://www.theguardian.com/media/media",
+        "apiUrl":"http://content.guardianapis.com/media/media",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"tv-and-radio/tv-news",
+        "type":"keyword",
+        "webTitle":"The news on TV",
+        "webUrl":"http://www.theguardian.com/tv-and-radio/tv-news",
+        "apiUrl":"http://content.guardianapis.com/tv-and-radio/tv-news",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"culture/television",
+        "type":"keyword",
+        "webTitle":"Television",
+        "webUrl":"http://www.theguardian.com/culture/television",
+        "apiUrl":"http://content.guardianapis.com/culture/television",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"profile/shane-hickey",
+        "type":"contributor",
+        "webTitle":"Shane Hickey",
+        "webUrl":"http://www.theguardian.com/profile/shane-hickey",
+        "apiUrl":"http://content.guardianapis.com/profile/shane-hickey",
+        "r2ContributorId":"55396",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422347763",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305766581/Poppies-001.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"54",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305768729/Poppies-002.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"340",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305770017/Poppies-003.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"130",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305772726/Poppies-005.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"132",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305773964/Poppies-006.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"168",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305775328/Poppies-007.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"180",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305776636/Poppies-008.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"228",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305779302/Poppies-010.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"372",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422347764",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "sectionId":"society",
+      "sectionName":"Society",
+      "webPublicationDate":"2013-11-13T12:10:00Z",
+      "webTitle":"Hamzah Khan: minister has 'deep concerns' over review findings",
+      "webUrl":"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "apiUrl":"http://content.guardianapis.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "fields":{
+        "trailText":"Edward Timpson criticises review into death of child who starved to death while DfE source describes report as 'risible'",
+        "headline":"Hamzah Khan: minister has 'deep concerns' over review findings",
+        "body":"<p>The children's minister Edward Timpson has said he has deep concerns over <a href=\"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-social-services-warning-signs\" title=\"\">the serious case review by the Bradford safeguarding children board into the death of four-year-old Hamzah Khan</a>, who was starved to death by his mother in Bradford.</p><p>A source from the Department for Education (DfE) used even stronger language, describing the review as \"risible\", but a source at the council accused the government of \"social worker bashing\".</p><p>Hamzah's partially mummified body was found clothed in a Babygro meant for a child aged six to nine months in September 2011, almost two years after his death in December 2009.</p><p><a href=\"http://www.theguardian.com/society/2013/oct/03/hamzah-khan-starved-to-death-amanda-hutton\" title=\"\">His mother, Amanda Hutton, 44, was last month found guilty of his manslaughter</a> and of neglecting six of her eight children.</p><p><a href=\"http://www.theguardian.com/society/interactive/2013/nov/13/hamzah-khan-serious-case-review\" title=\"\">The serious case review (SCR)</a>, commissioned by Bradford safeguarding children board (BSCB), concluded that while social services missed signs that, had they been put together, could have warned that Hamzah and his seven siblings were at risk, his death was \"not predictable\". That appears to have not gone far enough for the DfE.</p><p>In a letter to Nick Frost, chair of BSCB, Edward Timpson, the minister for children and families, wrote: \"I am concerned that it [the SCR] fails to explain sufficiently clearly the actions taken, or not taken, by children's social care when problems in the Khan family were brought to their attention on a number of occasions.\"</p><p>The letter sets out a number of questions, which Timpson says relate to \"missed opportunities to protect the children in the house\".</p><p>He continues: \"It is tragic beyond words that by the time a health visitor did trigger concerns about the whereabouts of the younger children in the household, who were missing from health and education services altogether, Hamzah Khan was already dead.\"</p><p>Frost said in a statement: \"The SCR is very clear that Hamzah's death could not have been predicted but finds that systems, many of them national systems, let Hamzah down both before and following his death.\"</p><p>The DfE's criticism provoked an angry response at Bradford council, with a source claiming that the education secretary, Michael Gove, had initially been ready to accept the SCR's findings.</p><p>The source said: \"Forty-eight hours ago all the indications were that the DfE were going to accept the report but Gove appears to have had a change of heart.\"</p><p>The council accused the education secretary of changing his mind because there was \"not enough social worker bashing\".  It is understood Gove thinks there has been a failure of all agencies in Bradford to accept any responsibility.</p><p>The authors of the SCR make 50 recommendations for \"learning\", which have been accepted by BSCB without blaming any one agency for failing Hamzah. The panel found that the agencies focused their efforts on Hutton as a victim of domestic violence, rather than her children. The experts report that while much help was offered to Hamzah's mother, who was beaten up by her partner for much of their 22-year relationship, not enough focus was put on whether her children were safe and well.</p><p>Annie Hudson, chief executive of the College of Social Work, said the SCR \"brings into sharp focus why there must be strong, joined-up and effective systems in place to keep in contact with, and track, children at risk.</p><p>\"No child should ever fall off the radar or become invisible to child protection agencies and society as a whole.\"</p><p>The NSPCC said it highlighted the need for a red flag when children miss key appointments so youngsters such as Hamzah do not \"slip off the radar of society\".</p><!-- Guardian Watermark: internal-code/content/422378691|2013-11-13T15:50:01Z|d7c3b400464ae84bc4d38dfc68bb6ce1b96a13d1 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kby3",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+        "wordcount":"579",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"society/childprotection",
+        "type":"keyword",
+        "webTitle":"Child protection",
+        "webUrl":"http://www.theguardian.com/society/childprotection",
+        "apiUrl":"http://content.guardianapis.com/society/childprotection",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/children",
+        "type":"keyword",
+        "webTitle":"Children",
+        "webUrl":"http://www.theguardian.com/society/children",
+        "apiUrl":"http://content.guardianapis.com/society/children",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/social-care",
+        "type":"keyword",
+        "webTitle":"Social care",
+        "webUrl":"http://www.theguardian.com/society/social-care",
+        "apiUrl":"http://content.guardianapis.com/society/social-care",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/localgovernment",
+        "type":"keyword",
+        "webTitle":"Local government",
+        "webUrl":"http://www.theguardian.com/society/localgovernment",
+        "apiUrl":"http://content.guardianapis.com/society/localgovernment",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"uk/bradford",
+        "type":"keyword",
+        "webTitle":"Bradford",
+        "webUrl":"http://www.theguardian.com/uk/bradford",
+        "apiUrl":"http://content.guardianapis.com/uk/bradford",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/helenpidd",
+        "type":"contributor",
+        "webTitle":"Helen Pidd",
+        "webUrl":"http://www.theguardian.com/profile/helenpidd",
+        "apiUrl":"http://content.guardianapis.com/profile/helenpidd",
+        "bio":"<p>Helen Pidd is northern editor of the Guardian, based in Manchester. She joined the paper in 2004 to edit the now defunct Office Hours and was a commissioning editor on G2 before joining the home news team in 2007, going on to spend 2011 in Germany as Berlin correspondent followed by a stint in Delhi. She is the author of <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490530\">Bicycle – The Complete<br />Guide to Everyday Cycling</a>.</p>",
+        "r2ContributorId":"19855",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/6/22/1277217764498/Helen-Pidd-byline.-003.jpg",
+        "references":[]
+      },{
+        "id":"profile/haroonsiddique",
+        "type":"contributor",
+        "webTitle":"Haroon Siddique",
+        "webUrl":"http://www.theguardian.com/profile/haroonsiddique",
+        "apiUrl":"http://content.guardianapis.com/profile/haroonsiddique",
+        "bio":"<p>Haroon Siddique is a news reporter on the Guardian website. He previously worked for North London institution the Ham&amp;High, and before pursuing his passion for journalism he was a commodity trader in the City</p>",
+        "r2ContributorId":"19136",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/haroon_siddique.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379573",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343315052/Hamzah-Khan-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"54",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343317421/Hamzah-Khan-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"340",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343318751/Hamzah-Khan-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"130",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343321335/Hamzah-Khan-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"132",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343322756/Hamzah-Khan-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"168",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343324035/Hamzah-Khan-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"180",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343325436/Hamzah-Khan-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"228",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343328488/Hamzah-Khan-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"372",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379574",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T09:50:29Z",
+      "webTitle":"Lily Allen does not represent all feminism – and nor should she | Ellie Mae O'Hagan",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "fields":{
+        "trailText":"<p><strong>Ellie Mae O'Hagan:</strong> Instead of critiquing whether Allen's new video is feminist or not, we should ask why there is such a weight of expectation on one woman</p>",
+        "headline":"Lily Allen does not represent all feminism – and nor should she",
+        "body":"<p>As soon as <a href=\"http://www.theguardian.com/music/musicblog/2013/nov/12/lily-allen-hard-out-here\" title=\"\">Lily Allen released a music video</a> that was purportedly a new feminist anthem, I anticipated that a slew of blogs and commentary would follow. I was right – I've read four on the subject already. Nevertheless, it is my policy to leave no bandwagon unjumped, and so here's my contribution to the unfolding brouhaha.</p><p>I can't deny I enjoyed watching Lily Allen poke fun at the notoriously sexist music industry, and in many ways I thought she was spot on. The presence of a besuited old white man in her music video who encourages her to fellate a banana was pretty revealing. Behind the dancing girls and schmaltzy lyrics that usually characterise pop songs, these men act as the all-oppressing eye of the industry: telling female singers that weight loss and sexual objectification are the only feasible routes to stardom; stripping down women in music videos to their underwear while leaving their male counterparts untouched. Allen was right to identify these shadowy white men as the source of the problem, for though sexism is a structural thing, it does usually manifest itself in the actual men in charge dictating how women should present themselves and their bodies in order to achieve some kind of validation.</p><p>But the video is problematic too. For one thing, it's unclear whether Allen is reserving scorn solely for the rich white men she satirises, or whether some women (like <a href=\"http://www.theguardian.com/commentisfree/2013/nov/07/pop-stars-sexy-netmums-parents-miley-cyrus\" title=\"\">Miley Cyrus</a> – who presumably has also been taught that sexualisation is the route to success) don't cop some too. To twerk or not to twerk may be the zeitgeist question, but whatever answer you come up with, you're still telling women how they should present their own bodies. Then there's the issue of <a href=\"http://www.theguardian.com/commentisfree/2013/nov/10/black-women-music-industry-sex\" title=\"\">race in the video</a>. On a surface level, Allen attempts to mock the way black women are treated as nothing more than sexual objects in music videos – yet she also posits herself as separate from the black women that feature in hers. At the end of the song, she pointedly sashays off, while they remain behind as simply semi-nude backing dancers. <a href=\"http://www.voice-online.co.uk/article/music-videos-exploiting-black-womens-bodies\" title=\"\">Sarah Greene of the End Violence Against Women Coalition recently told the Voice</a>, \"In a particular Calvin Harris video [Drinking from the Bottle ft Tinie Tempah], there is kind of a sea of black women's bottoms. You never even see their faces … young black women say it makes them feel hated.\" In that respect, it's difficult to see Allen's anthem as little more than same old same old, and it's probably why I ultimately feel she misses the mark. As the <a href=\"https://twitter.com/Okwonga/status/400367983299940352\" title=\"\">journalist Musa Okwonga put it</a>, \"She should've swapped the female dancers for a bunch of twerking middle-aged men.\"</p><p>In my mind though, the wider question is not whether or not Lily Allen's feminist song is a success or not; it's why is it that one single music video containing some fairly cursory observations on sexism is able to stir up such a reaction in the feminist movement. One explanation lies in a comment made by the blogger Glosswitch recently (<a href=\"http://glosswatch.com/\" title=\"\">and I recommend you read her piece in full</a>): \"I'd say one objective of feminism should be to help women's decisions become less loaded. It's oppressive to have to represent a whole sex in everything you do.\" Unfortunately for Allen and everybody else, her music video seems unable to stand in and of itself, representing only her opinions, but is instead being seen as some kind of expression of all feminism – and by extension all women. This is part and parcel of being in an oppressed group: women are routinely dehumanised and homogenised, so that every act we undertake in public tends to reflect on all women, instead of our own individual character. It's a problem men just don't have. And feminism is so marginalised as a strain of political thought, that when one feminist woman makes it into the mainstream, a flurry of panic and excitement will inevitably follow simply because there are so few feminist voices in the public sphere. Feminism is an extremely broad church, but I often think feminists are guilty of expecting every single prominent feminist to reflect their exact politics because there aren't enough opinions in the mainstream to choose from – and all too often the feminists that do make it big are white and middle class.</p><p>Perhaps the most helpful response we feminists can have to Lily Allen's video is not to tear it down because of its flaws (although they should be addressed), but to look at feminism itself and discuss how to realise its potential as a political movement. Instead of admonishing or praising Allen, we should ask why there is such a weight of expectation upon something so small, and what we can do to rectify that. There are already exciting projects attempting to do this, like the <a href=\"http://ukfeminista.org.uk/event-details/summer-school-2013/\" title=\"\">UK Feminista summer school</a>, the <a href=\"http://www.theguardian.com/lifeandstyle/the-womens-blog-with-jane-martinson/2013/apr/16/everyday-sexism-project-shouting-back\" title=\"\">Everyday Sexism Project</a>, <a href=\"http://www.southallblacksisters.org.uk/\" title=\"\">Southall Black Sisters</a>, or the indispensable work of the <a href=\"http://www.fawcettsociety.org.uk/\" title=\"\">Fawcett Society</a>. I don't pretend to have a grand feminist plan, and in any case feminists should probably decide on such a plan together, but I do know that if we focus on organising ourselves into a political force and supporting each other in the struggle against patriarchy, the time will come when we care less about what Lily Allen has to say – because the fate of feminism won't seem to rest upon the strengths and weaknesses of one music video.</p><!-- Guardian Watermark: internal-code/content/422367349|2013-11-13T15:50:02Z|515745560af7b3a1b18f3c2e4634a1dc86313d53 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbhf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+        "wordcount":"909",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"world/feminism",
+        "type":"keyword",
+        "webTitle":"Feminism",
+        "webUrl":"http://www.theguardian.com/world/feminism",
+        "apiUrl":"http://content.guardianapis.com/world/feminism",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"music/lilyallen",
+        "type":"keyword",
+        "webTitle":"Lily Allen",
+        "webUrl":"http://www.theguardian.com/music/lilyallen",
+        "apiUrl":"http://content.guardianapis.com/music/lilyallen",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/ellie-mae-o-hagan",
+        "type":"contributor",
+        "webTitle":"Ellie Mae O'Hagan",
+        "webUrl":"http://www.theguardian.com/profile/ellie-mae-o-hagan",
+        "apiUrl":"http://content.guardianapis.com/profile/ellie-mae-o-hagan",
+        "bio":"<p>Ellie Mae O'Hagan is a regular columnist for Comment is free. She has also written for the Times, the New Statesman, Red Pepper, False Economy, New Left Project and Union News. She currently works with the Centre for Labour and Social Studies, a think for left debate and discussion originating in the trade union movement. She is also an active member of UK Uncut. She  tweets as <a href=\"http://twitter.com/#!/MissEllieMae\">@MissEllieMae</a></p>",
+        "r2ContributorId":"43367",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/3/22/1300821538131/EllieMaeOHagan.jpg",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388300",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Lily Allen",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Lily Allen",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T10:06:25Z",
+      "webTitle":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "fields":{
+        "trailText":"Ranjit Sinha, chief of India's Central Bureau of Investigation, apologises for remark that causes outrage across country",
+        "headline":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+        "body":"<p>India's top police official has apologised for saying: \"If you can't prevent rape, you enjoy it,\" – a remark that has outraged the country.</p><p>Ranjit Sinha, chief of India's Central Bureau of Investigation, made the remark on Tuesday during a conference about illegal sports betting and the need to legalise gambling. The CBI, the country's premier investigative agency, is India's equivalent of the FBI.</p><p>Sinha said at the conference that if the state could not stop gambling, it could at least make some revenue by legalising it.</p><p>\"If you cannot enforce the ban on betting, it is like saying: 'If you can't prevent rape, you enjoy it,'\" he said.</p><p>The remarks have caused outrage across India, which in the past year has been hit by widespread protests following the<a href=\"http://www.theguardian.com/world/2013/sep/13/delhi-gang-rape-relief-india-men-sentenced-death\" title=\"\"> fatal gang-rape</a> of a 23-year-old woman on a bus in New Delhi.</p><p>On Wednesday, Sinha said  his comments had been taken out of context and misinterpreted, and that he was sorry if he had caused hurt. Angry activists, however, called for his resignation.</p><p>Brinda Karat, leader of the Communist party of India (Marxist), said Sinha's comments were offensive to women everywhere.</p><p>\"It is sickening that a man who is in charge of several rape investigations should use such an analogy,\" Karat told reporters. \"He should be prosecuted for degrading and insulting women.\"</p><p>The New Delhi attack on the young woman last December caused nationwide outrage and forced the government to change rape laws and create fast-track courts for rape cases.</p><p>Laws introduced after the attack make stalking, voyeurism and sexual harassment a crime. They also provide for the death penalty for repeat offenders or for rape attacks that lead to the victim's death.</p><!-- Guardian Watermark: internal-code/content/422368950|2013-11-13T15:50:02Z|9a2e5d5c81e79e624c9022d8c135bb3776c5b9a0 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbhz",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+        "wordcount":"273",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/india",
+        "type":"keyword",
+        "webTitle":"India",
+        "webUrl":"http://www.theguardian.com/world/india",
+        "apiUrl":"http://content.guardianapis.com/world/india",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"society/rape",
+        "type":"keyword",
+        "webTitle":"Rape",
+        "webUrl":"http://www.theguardian.com/society/rape",
+        "apiUrl":"http://content.guardianapis.com/society/rape",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"law/law",
+        "type":"keyword",
+        "webTitle":"Law",
+        "webUrl":"http://www.theguardian.com/law/law",
+        "apiUrl":"http://content.guardianapis.com/law/law",
+        "sectionId":"law",
+        "sectionName":"Law",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422369576",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337123909/Ranjit-Sinha-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"54",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337125231/Ranjit-Sinha-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"340",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337126586/Ranjit-Sinha-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"130",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337129092/Ranjit-Sinha-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"132",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337130310/Ranjit-Sinha-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"168",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337131559/Ranjit-Sinha-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"180",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337132902/Ranjit-Sinha-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"228",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337135575/Ranjit-Sinha-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"372",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422369577",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T11:18:52Z",
+      "webTitle":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "fields":{
+        "trailText":"Roberto Di Matteo is reportedly still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago",
+        "headline":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+        "body":"<p>Roberto Di Matteo is still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago, according to reports.</p><p>The former manager did not agree a pay-off settlement when he was axed as manager last season, and <a href=\"http://www.dailymail.co.uk/sport/football/article-2503321/Chelsea-paying-Roberto-Di-Matteo-130-000-week.html\" title=\"\">the Daily Mail reports</a> the Italian will continue to be paid in full until June 2014 unless he takes another job before then.</p><p>That, however, seems unlikely given Di Matteo has reportedly turned down several offers both in the Premier League and from abroad since his departure, while there are few clubs who could match the lucrative £6.76m annual salary he was earning at Stamford Bridge.</p><p>Di Matteo was <a href=\"http://www.theguardian.com/football/2013/sep/23/roberto-di-matteo-gus-poyet-sunderland\" title=\"\">linked with the Sunderland job</a> before Gus Poyet's appointment and he is seen as a possible replacement for Martin Jol at Fulham should the Dutch manager leave Craven Cottage.</p><!-- Guardian Watermark: internal-code/content/422374266|2013-11-13T15:50:02Z|020959d3b6559e918939baaa9dd61595bc87d634 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjb",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+        "wordcount":"140",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"football/roberto-di-matteo",
+        "type":"keyword",
+        "webTitle":"Roberto Di Matteo",
+        "webUrl":"http://www.theguardian.com/football/roberto-di-matteo",
+        "apiUrl":"http://content.guardianapis.com/football/roberto-di-matteo",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/chelsea",
+        "type":"keyword",
+        "webTitle":"Chelsea",
+        "webUrl":"http://www.theguardian.com/football/chelsea",
+        "apiUrl":"http://content.guardianapis.com/football/chelsea",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/4"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422374804",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341239071/Roberto-Di-Matteo-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"54",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341242197/Roberto-Di-Matteo-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"340",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341243440/Roberto-Di-Matteo-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"130",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341244752/Roberto-Di-Matteo-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"720",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341246531/Roberto-Di-Matteo-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341249682/Roberto-Di-Matteo-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"132",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341250911/Roberto-Di-Matteo-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"168",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341252176/Roberto-Di-Matteo-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"180",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341253497/Roberto-Di-Matteo-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"228",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341256016/Roberto-Di-Matteo-012.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"372",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341257472/Roberto-Di-Matteo-013.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1116",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1860"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341259557/Roberto-Di-Matteo-014.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2560"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422374805",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/4"
+      }]
+    },{
+      "id":"film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "sectionId":"film",
+      "sectionName":"Film",
+      "webPublicationDate":"2013-11-12T10:01:00Z",
+      "webTitle":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+      "webUrl":"http://www.theguardian.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "apiUrl":"http://content.guardianapis.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "fields":{
+        "trailText":"<p>Unable to cut his sexually explicit film down from five hours, Danish director opts to let someone else cut the movie down to two, two-hour chunks – both including explicit footage</p>",
+        "headline":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+        "body":"<p>Lars Von Trier has abandoned plans to release a softcore version of his sex epic Nymphomaniac. The film's two-part four-hour cut, which is due to debut in Copenhagen on Christmas Day, will now contain explicit scenes. </p><p>The release of Nymphomaniac will see the Danish director give up final cut for the first time in his career. The decision was apparently taken after Von Trier said he was unwilling to trim the two-part film's current five and a half hour running time himself. Nymphomaniac's strange fate is detailed in an extended making-of feature in the Danish film magazine Filmmagasinet Ekko which was picked up by <a href=\"http://www.hollywoodreporter.com/news/lars-von-trier-gives-up-655155\">the Hollywood Reporter</a>. </p><p>\"The short version is against Lars' own will, but he accepts it because he understands market mechanisms,\" says Von Trier's long-term producing partner Peter Aalbaek Jensen in the magazine article. \"You cannot make a film for more than 60 million kroners (about $11 million or £6.9 million) that is so lengthy. Five and a half hours is so extreme that it reduces market value so radically that investors would have felt they had bought a pig in a poke.\"</p><p>It is extremely unusual a director of the artistic clout of Von Trier to allow somebody else to complete their vision, particularly on such a singular project as Nymphomaniac. It is not known if the longer five-and-a-half-hour cut will ever be released, and Jensen refused to confirm if Von Trier would take it to next year's Cannes film festival.</p><p>Nymphomaniac, which stars the film-maker's regular muse Charlotte Gainsbourg in the lead, has been billed as an exploration of the erotic life of a woman from infancy to middle age. Digital trickery and body doubles have reportedly been used to portray famous stars such as Uma Thurman, Stellan Skarsgård, Christian Slater, Jamie Bell and Shia LaBeouf having sex.</p><p>A teaser trailer for the much anticipated film was briefly <a href=\"http://www.theguardian.com/film/2013/nov/04/nymphomiac-youtube-shia-labeouf-lars-von-trier-clip-removed\">removed from YouTube earlier this month</a> after apparently falling foul of the site's rules on nudity and sexual content.</p><h2>More on Nymphomaniac</h2><p>• <a href=\"http://www.theguardian.com/film/2013/nov/04/nymphomiac-youtube-shia-labeouf-lars-von-trier-clip-removed\">Nymphomaniac clip removed from Youtube</a><br />• <a href=\"http://www.theguardian.com/film/poll/2013/oct/10/nymphomaniac-orgasm-posters-vote-favourite\">Vote for your favourite Nymphomaniac orgasm poster</a></p><!-- Guardian Watermark: internal-code/content/422267679|2013-11-13T15:50:02Z|ffcd9c752fa3609600cfc5eda4c7f85a9552f666 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kakf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+        "wordcount":"343",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"film/lars-von-trier",
+        "type":"keyword",
+        "webTitle":"Lars von Trier",
+        "webUrl":"http://www.theguardian.com/film/lars-von-trier",
+        "apiUrl":"http://content.guardianapis.com/film/lars-von-trier",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"culture/charlotte-gainsbourg",
+        "type":"keyword",
+        "webTitle":"Charlotte Gainsbourg",
+        "webUrl":"http://www.theguardian.com/culture/charlotte-gainsbourg",
+        "apiUrl":"http://content.guardianapis.com/culture/charlotte-gainsbourg",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"profile/benchild",
+        "type":"contributor",
+        "webTitle":"Ben Child",
+        "webUrl":"http://www.theguardian.com/profile/benchild",
+        "apiUrl":"http://content.guardianapis.com/profile/benchild",
+        "bio":"<p>Ben Child is a journalist, DJ and producer whose main interests lie in the worlds of film and music</p>",
+        "r2ContributorId":"24984",
+        "references":[]
+      },{
+        "id":"film/drama",
+        "type":"keyword",
+        "webTitle":"Drama",
+        "webUrl":"http://www.theguardian.com/film/drama",
+        "apiUrl":"http://content.guardianapis.com/film/drama",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"culture/pornography",
+        "type":"keyword",
+        "webTitle":"Pornography",
+        "webUrl":"http://www.theguardian.com/culture/pornography",
+        "apiUrl":"http://content.guardianapis.com/culture/pornography",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"world/denmark",
+        "type":"keyword",
+        "webTitle":"Denmark",
+        "webUrl":"http://www.theguardian.com/world/denmark",
+        "apiUrl":"http://content.guardianapis.com/world/denmark",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422284236",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244020710/Nymphomaniac-chapter-one--008.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"276",
+            "credit":"Christian Geisnaes",
+            "caption":"One of the few fully-clothed stills from Nymphomaniac. Photograph: Christian Geisnaes",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422284237",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"84",
+            "credit":"Christian Geisnaes",
+            "caption":"Nymphomaniac chapter one still Photograph: Christian Geisnaes",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:04:31Z",
+      "webTitle":"Jack Monroe's frozen yoghurt recipe",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "fields":{
+        "trailText":"<p>This simple dessert is a great way to stretch fresh berries, but it works brilliantly with cheaper frozen fruit, too</p>",
+        "headline":"Jack Monroe's frozen yoghurt recipe",
+        "body":"<p>I first made these berry desserts with foraged blackberries and a few things from the fridge, but any berries will do. You can often get bags of mixed frozen berries far cheaper than their fresh counterparts, which are perfect for this simple dessert.</p><p><strong><em>(Makes 4 ramekins or lolly moulds)</em></strong> <em>34p a portion</em><br /><strong>100g white chocolate, </strong><em>30p</em><br /><strong>100g mixed frozen berries, </strong><em>33p</em><br /><strong>150g soft cream cheese, </strong><em>40p</em><br /><strong>300g low fat natural yoghurt, </strong><em>33p</em></p><p>Break up the chocolate and melt it gently in a mixing bowl over a pan containing a couple of inches of boiling water. Make sure the water doesn't touch the bowl, as too much heat will make the chocolate bitter.</p><p>Remove the bowl from the heat, using a tea towel or oven glove.</p><p>Add the berries, cream cheese and yoghurt and stir well to combine until smooth – the cheese will soften into the chocolate and yoghurt.</p><p>Spoon into ramekin dishes or lolly moulds, and freeze for at least two hours.</p><p>The lollies can be served as they are; ramekin dishes should be removed from the freezer 20 minutes before eating to thaw, or pinged in the microwave for a minute to soften.</p><h2>Jack's tip</h2><p>Replace the white chocolate with lemon curd for a sweet, zesty dessert. Dark chocolate and fresh chopped mint works well too.</p><p><em>• For more recipe ideas, including using up remaining ingredients, see <a href=\"http://agirlcalledjack.com/\">agirlcalledjack.com</a> or follow <a href=\"https://twitter.com/MsJackMonroe\">@MsJackMonroe</a> on Twitter.</em></p><!-- Guardian Watermark: internal-code/content/422376870|2013-11-13T15:50:01Z|97ef9d51bfc30f2ea9fd96125522f0c9a9d2232a -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbka",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+        "wordcount":"222",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "type":"series",
+        "webTitle":"Jack Monroe's low-cost recipes",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/dessert",
+        "type":"keyword",
+        "webTitle":"Dessert",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/dessert",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/dessert",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fruit",
+        "type":"keyword",
+        "webTitle":"Fruit",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fruit",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fruit",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"money/saving-money",
+        "type":"keyword",
+        "webTitle":"Saving money",
+        "webUrl":"http://www.theguardian.com/money/saving-money",
+        "apiUrl":"http://content.guardianapis.com/money/saving-money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"profile/jack-monroe",
+        "type":"contributor",
+        "webTitle":"Jack Monroe",
+        "webUrl":"http://www.theguardian.com/profile/jack-monroe",
+        "apiUrl":"http://content.guardianapis.com/profile/jack-monroe",
+        "bio":"<p>Jack Monroe blogs at <a href=\"http://agirlcalledjack.com/\">A Girl Called Jack</a> and is author of the forthcoming A Girl Called Jack recipe book</p>",
+        "r2ContributorId":"57609",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/10/1378813805813/Jack-Monroe.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381337",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344202019/Jack-Monroes-frozen-yoghu-009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"276",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381338",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"84",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "sectionId":"news",
+      "sectionName":"News",
+      "webPublicationDate":"2013-11-13T07:30:00Z",
+      "webTitle":"The daily quiz, 13 November 2013",
+      "webUrl":"http://www.theguardian.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "apiUrl":"http://content.guardianapis.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "fields":{
+        "trailText":"<p>From murder mysteries to famous lakes and luxury goods purveyors to the rules of boxing, 10 questions to test you</p>",
+        "headline":"The daily quiz, 13 November 2013",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k2vg",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"news/series/the-daily-quiz",
+        "type":"series",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/news/series/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/news/series/the-daily-quiz",
+        "sectionId":"news",
+        "sectionName":"News",
+        "references":[]
+      },{
+        "id":"profile/the-daily-quiz",
+        "type":"contributor",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/profile/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/profile/the-daily-quiz",
+        "bio":"<p>A daily general knowledge quiz from theguardian.com. Email: daily.quiz@theguardian.com</p>",
+        "r2ContributorId":"57817",
+        "references":[]
+      },{
+        "id":"type/quiz",
+        "type":"type",
+        "webTitle":"Quiz",
+        "webUrl":"http://www.theguardian.com/quizzes",
+        "apiUrl":"http://content.guardianapis.com/quizzes",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-421318129",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Sinibomb Images",
+            "altText":"Pac-Man",
+            "height":"84",
+            "credit":"Sinibomb Images/Alamy",
+            "caption":"Despite our video games knowledge being prehistoric, we decided such a huge part of the entertainment world would be ignored at our peril. Photograph: Sinibomb Images/Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:55:00Z",
+      "webTitle":"How to make the perfect onion bhajis",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "fields":{
+        "trailText":"<p>Can another member of the fritter family beat the onion bhaji, do you eat them as a starter or a snack, and what do you serve with them?</p>",
+        "headline":"How to make the perfect onion bhajis",
+        "body":"<p>The onion bhaji was probably my first introduction to the joys of Indian food back in the late 80s, so I feel I owe this simple snack a considerable debt of thanks. The word \"bhajia\" means fritter – in fact, they're just one small part of the wider pakora family, which encompasses all manner of good things (<a href=\"http://adventurefoodie.blogspot.co.uk/2011/06/bheja-fry-goat-brain-fritters.html\" title=\"\">goat brain pakora</a> stands out in my memory) fried in chickpea batter, but in Britain, a land never known for its subtle taste, the pungent onion variety rules supreme.</p><p>Usually served <a href=\"http://www.greatbritishchefs.com/community/origins-onion-bhaji\" title=\"\">as a snack in its homeland</a>, generally with a nice cup of chai, bhajis are the stalwart of the starter selection here: a deep-fried appetite whetter for the myriad joys to come. At their best, they're almost ethereally light and addictively crisp. At their worst, they're stodgy and bland – as chef Cyrus Todiwala observes in his new book, <a href=\"http://nr11blog.wordpress.com/tag/onion-bhaji-recipe/\" title=\"\">Mr Todiwala's Bombay</a>: \"What you see in stores and supermarkets does not always represent the bhajia we Indians know.\" So just how do you guarantee great results?</p><h2>Onion</h2><figure data-media-id='gu-image-422395582'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg' alt='SImon Majumdar's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Simon Majumdar's onion bhajis.</figcaption></figure><p>Often lost in mass-produced versions, the bulk of the bhaji should be onion, rather than dough. Most recipes use yellow onion, sliced very thinly so it cooks through quickly, but <a href=\"http://www.simonmajumdar.com/recipes/onion-bhaji/\" title=\"\">food writer Simon Majumdar</a> specifies white and <a href=\"http://www.greatbritishchefs.com/recipes/onion-bhaji-recipe\" title=\"\">Alfred Prasad, executive chef at the Michelin-starred Tamarind</a>, goes for red. I find white too mild, and although I like the sweetness of the red versions, I miss the yellow onion's pungent flavour, so I'm going to stick with that.</p><h2>Batter</h2><figure data-media-id='gu-image-422395583'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg' alt='Flavours of Gujarat's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Flavours of Gujarat's onion bhajis.</figcaption></figure><p>Onions are onions, but where bhaji recipes diverge is in the batter that binds the slices together. Gram, or chickpea flour, is fairly standard, but Prasad and a brilliant little book called Flavours of Gujarat (which has been sitting on my parents' bookshelf for more than 20 years, waiting for this moment) recommend adding rice flour, presumably to make the batter crisper. For me, the difference between a great bhaji and a merely adequate one is in the crunch – as with all deep-fried foods, it should fight back – and Prasad's are particularly fiesty, so I'm going to adopt his 2:1 ratio of gram to rice flour.</p><p>Perhaps more important is the liquid used, both in type and quantity. Water is obviously the first choice, <a href=\"http://uktv.co.uk/food/recipe/aid/653916\" title=\"\">but Nikita Gulhane</a>, whose bhaji recipe features in Madhur Jaffrey's Curry Nation, also adds plain yoghurt, and Prasad stirs in a little melted butter. I like the rich tanginess of Gulhane's yoghurt, but I find it makes the batter a bit thick and gloopy, so I'm going to use Prasad's butter, plus Todiwala's lemon juice for flavour.</p><figure data-media-id='gu-image-422395584'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg' alt='Nikita Gulhane's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Nikita Gulhane's onion bhajis.</figcaption></figure><p>The batters vary enormously in consistency: Gulhane's is a thick paste, while Majumdar counsels aiming for the texture of double cream. This makes all the difference to the finished result: the two thickest batters, from Gulhane and Flavours of Gujarat, produce rather doughy bhajis that seem to be more about the batter than the onion. They're tasty enough, but I prefer the more delicate coating of Todiwala, Prasad and Majumdar's versions. The guiding principle is that it should be thick enough to cling to the onion, but not firm enough to form clumps of its own.</p><p>Majumdar suggests letting the batter rest for an hour before use, much like a yorkshire pudding, presumably to allow the flours to absorb the moisture in the batter. I don't think this is desirable here, though: his coating is tough, but not particularly crisp, and one taster likens it (approvingly, I must add) to a Woolworths onion ring.</p><h2>Spices</h2><figure data-media-id='gu-image-422395585'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg' alt='Alfred Prasad's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Alfred Prasad's onion bhajis.</figcaption></figure><p>The gram flour gives the batter a subtle nutty flavour, but subtle isn't what we're looking for here. Chillies are a popular addition, with Prasad and Todiwala plumping for fresh green chillies, and Prasad, Todiwala, Majumdar and Flavours of Gujarat sticking in dried chilli powder too. I prefer the cleaner, greener flavour of the fresh variety. Turmeric is also fairly standard, as much for colour as flavour.</p><p>Gulhane and Prasad both add garlic and ginger to the batter, which lend it a pleasing and more interesting sweetness than Majumdar's sugar – as do Prasad's unusual, but very welcome, fennel seeds, which I prefer to Todiwala's sharper ajwain, or lovage seeds. I love the earthiness of his cumin seeds with the onion, though. Sesame seeds, as used in Flavours of Gujarat, seem an unnecessary addition.</p><p>Fresh coriander, used by everyone but Majumdar, adds an attractive colour and a fresh, clean flavour to the batter, while curry leaves, as used by Prasad and Gulhane, contribute a herbal note. They're only worth buying fresh though, so if you can't find them, leave them out.</p><h2>Cooking</h2><figure data-media-id='gu-image-422395586'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg' alt='Cyrus Todiwala's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Cyrus Todiwala's onion bhajis.</figcaption></figure><p>It is very important to get the temperature of the oil right, as Todiwala explains: \"Too hot [and] they will fry too fast and remain raw inside and gooey. Too cold and the results will be oily and soft.\" The fairly standard 180C seems about right – most recipes suggest dropping a piece of batter in there to test the heat, but if you do have a food thermometer, use it – it is far more reliable than the sizzle test if you're after perfect results.</p><h2>The perfect onion bhajis</h2><figure data-media-id='gu-image-422395587'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg' alt='Felicity Cloake's perfect onion bhajis' width='460' height='276' class='gu-image'/><figcaption>Felicity Cloake's perfect onion bhajis.</figcaption></figure><p><strong><em>(Makes 8)</em></strong><br /><strong>60g gram flour</strong><br /><strong>30g rice flour</strong><br /><strong>1 tbsp ghee or butter, melted </strong><br /><strong>Juice of ¼ lemon</strong><br /><strong>½ tsp turmeric</strong><br /><strong>1 tsp cumin seeds, coarsely chopped</strong><br /><strong>¼ tsp fennel seeds</strong><br /><strong>1-2 hot green chillies (to taste), finely minced</strong><br /><strong>2 tsp root ginger, finely grated </strong><br /><strong>2 cloves of garlic, finely chopped</strong><br /><strong>Small bunch of coriander, chopped</strong><br /><strong>2 fresh curry leaves, chopped (optional)</strong><br /><strong>2 onions, halved, core removed and thinly sliced</strong><br /><strong>Vegetable oil, to cook</strong></p><p>Sift the flours into a mixing bowl, then stir in the ghee and lemon juice and just enough cold water to bring it to the consistency of double cream. Stir in the spices, aromatics and herbs and add salt to taste. Stir in the onions so they are well coated.</p><p>Heat the oil in a deep-fat fryer to 180C, or fill a large pan a third full with oil and heat – a drop of batter should sizzle as it hits the oil, then float. Meanwhile, put a bowl of cold water next to the hob, and a plate lined with kitchen paper. Put the oven on a low heat.</p><p>Once the oil is up to temperature, wet your hands and shape tablespoon-sized amounts of the mixture into balls. Drop into the oil, being careful not to overcrowd the pan, then stir carefully to stop them sticking. Cook for about four minutes, turning occasionally, until crisp and golden, then drain on the paper and put in the oven to keep warm while you cook the next batch. Serve with chutney or pickle.</p><p><strong>Bhajis – where do you stand: a great curry house starter, or a fabulous teatime treat? Which other members of the pakora family do you rate – and what do you like to serve with them? (For me, aubergine pickle takes some bettering.)</strong></p><!-- Guardian Watermark: internal-code/content/422384559|2013-11-13T15:50:01Z|f51a9b2b64f187bce77f10fd85178b2aabe50b5a -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbnh",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+        "wordcount":"1130",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/how-to-cook-the-perfect",
+        "type":"series",
+        "webTitle":"How to cook the perfect ...",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/indian",
+        "type":"keyword",
+        "webTitle":"Indian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/indian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/indian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/starter",
+        "type":"keyword",
+        "webTitle":"Starter",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/starter",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/starter",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/snacks",
+        "type":"keyword",
+        "webTitle":"Snacks",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/snacks",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/snacks",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/vegetarian",
+        "type":"keyword",
+        "webTitle":"Vegetarian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/vegetarian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/vegetarian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/wordofmouth",
+        "type":"blog",
+        "webTitle":"Word of Mouth blog",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/felicity-cloake",
+        "type":"contributor",
+        "webTitle":"Felicity Cloake",
+        "webUrl":"http://www.theguardian.com/profile/felicity-cloake",
+        "apiUrl":"http://content.guardianapis.com/profile/felicity-cloake",
+        "bio":"<p>Felicity Cloake is a writer specialising in food and drink and winner of the 2011 Guild of Food Writers awards for Food Journalist of the Year and New Media of the Year. Her first recipe book, <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490837\">Perfect</a>, is published by Fig Tree. She likes to think she'd try any food once – although an eyeball recently caused her to question this gung-ho gastronomic philosophy</p>",
+        "r2ContributorId":"32433",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/5/1370451580801/Felicity-Cloake.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422395580",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346619304/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photographs: Felicity Cloake for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422395581",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"84",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photograph: Felicity Cloake for the Guardian",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422395582",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"SImon Majumdar's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Simon Majumdar's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395583",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Flavours of Gujarat's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Flavours of Gujarat's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395584",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Nikita Gulhane's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Nikita Gulhane's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395585",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Alfred Prasad's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Alfred Prasad's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395586",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Cyrus Todiwala's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Cyrus Todiwala's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395587",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis.",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"books/2013/nov/13/autobiography-by-morrissey-review",
+      "sectionId":"books",
+      "sectionName":"Books",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Autobiography by Morrissey – review",
+      "webUrl":"http://www.theguardian.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "apiUrl":"http://content.guardianapis.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "fields":{
+        "trailText":"<p>This book is superb: Mozzer is so devastatingly articulate he could win the Booker, argues <strong>Terry Eagleton</strong></p>",
+        "headline":"Autobiography by Morrissey – review",
+        "body":"<p>Not content with being voted the greatest northern male ever, the second greatest living British icon (he lost out to David Attenborough) and granted the freedom of the city of Tel Aviv, Morrissey is now out to demonstrate that he can write the kind of burnished prose no other singer on the planet could aspire to. There are, to be sure, a&nbsp;few painfully florid patches in this superb autobiography (\"Headmaster Mr Coleman rumbles with grumpiness in a rambling stew of hate\"), but it would be hard to imagine Ronnie Wood or <a href=\"http://www.theguardian.com/music/ericclapton\" title=\"\">Eric Clapton</a> portraying the \"Duchess of nothing\" Sarah Ferguson as \"a little bundle of orange crawling out of a frothy dress, the drone of Sloane, blessed with two daughters of Queen Victoria pot-dog pudginess\".</p><p><a href=\"http://www.theguardian.com/music/morrissey\" title=\"\">Morrissey</a> despises most of the people he meets, often with excellent reason. He is scurrilous, withdrawn and disdainful, an odd mixture of shyness and vitriol. The dreamy, heart-throbbish photo on the cover of the book, the nose rakishly tilted above the&nbsp;Cupid's-bow lips, belies what a mean old bastard he is. He finds an image of himself in (of all people) the minor Georgian poet <a href=\"http://books.theguardian.com/review/story/0,,1788971,00.html\" title=\"\">AE Housman</a>, who preferred art to humanity and whose ascetic, spiritually tortured life seems to echo Morrissey's own. He admires wayward, bloody-minded types much like himself, and takes a&nbsp;sadistic delight in discomforting interviewers. \"Why did you mention Battersea in that song?\" a journalist asks him. \"Because it rhymes with fatty,\" he replies. Taken by his father at the age of eight to watch <a href=\"http://www.theguardian.com/books/2013/oct/04/immortal-biography-george-best-hamilton-review\" title=\"\">George Best</a> play at Old Trafford, he swoons at the sight of such artistry combined with such rebelliousness. Years later, others will swoon at his own mixing of the two.</p><p>Some of his bloody-mindedness springs from a damaged childhood. Born into a working-class Irish-Mancunian family, Steven Patrick Morrissey sang his way out of what struck him as a soulless environment, as other working-class Irish Mancunians have written or acted their way out. The vitriol started to flow early: his bleak mausoleum of a Catholic primary school was ruled by Mother Peter, \"a&nbsp;bearded nun who beat children from&nbsp;dawn to dusk\", and by the time he was 17 he was already emotionally exhausted. Manchester, still in its pre-cool days, was a \"barbaric place where only savages can survive … There are no sexual guidelines, and I see myself naked only by appointment.\" His eloquent contempt for his fellow citizens is terrifying: \"non-human sewer-rats with missing eyes; the loudly insane with indecipherable speech patterns; the mad poor of Manchester's armpit.\" The final indignity is to be turned down for a job&nbsp;as a postman at the local sorting office. At the hour of the birth of the Smiths, which gave him the exit from Manchester he craved, he felt himself dying of boredom, loneliness and disgust. \"I would talk myself through each day,\" he writes, \"as one would nurse a dying friend.\"</p><p>Not long afterwards, hordes of young people throughout the world are&nbsp;wearing his face on their chests. He returns to the streets where he grew up, now with a police escort, to sing to 17,000 fans from a stage overlooking an odious Inland Revenue office where he once worked. Having failed to find love from one man or woman, he can now find it from thousands. <a href=\"http://www.theguardian.com/music/mick-jagger\" title=\"\">Mick Jagger</a> and <a href=\"http://www.theguardian.com/music/elton-john\" title=\"\">Elton John</a> are eager to shake his hand. He enjoys his celebrity, but the sardonic self-irony of the book seeks to&nbsp;persuade us otherwise. There is a relish and energy about its prose that undercuts his misanthropy. Its lyrical quality suggests that beneath the hard-bitten scoffer there lurks a romantic softie, while beneath that again lies a hard-bitten scoffer. Implausibly, he claims to be \"chilled\" by road signs reading \"Morrissey Concert, Next Left\". It's true, however, that having spent years yearning to be seen, he now spends years longing to be invisible. Living in Hollywood is hardly the best place for that. He deals with his own egocentricity by being wryly amusing about it: his birth almost killed his mother, he comments, because even then his head was too&nbsp;big.</p><p>Even so, he remains for the most part icily unillusioned, like a monk passing through a whorehouse. His contempt for the music industry is visceral, and he prefers to spend his time reading <a href=\"http://www.theguardian.com/books/whauden\" title=\"\">Auden</a> and <a href=\"http://www.theguardian.com/books/jamesbaldwin\" title=\"\">James Baldwin</a>. (Spotting Baldwin in a Barcelona hotel, he decides not to approach him, since even the mildest rejection would apparently mean he would have to go and hang himself.) The solution to all problems, he tells us, \"is the goodness of privacy in a warm room with books\". <a href=\"http://www.theguardian.com/music/davidbowie\" title=\"\">David Bowie</a> tells him that he's had so much sex and drugs that he's surprised he is still alive, to which Morrissey replies that he's had so little of both that he feels much the same. <a href=\"http://www.theguardian.com/film/tomhanks\" title=\"\">Tom Hanks</a> comes backstage to say hello, but Morrissey doesn't know who he is. The press lie that he is a racist, that he opened the door to a journalist wearing a tutu, that he hung around public toilets as a youth and that he would welcome the assassination of Margaret Thatcher. The Guardian runs a disapproving piece on him adorned with a photo of somebody else. When he discovers that a Smiths record released in Japan includes a track by Sandie Shaw, he begs the people around him to kill him. \"Many rush forward,\" he adds.</p><p>\"Although a passable human creature on the outside,\" he comments of himself, \"the swirling&nbsp;soul within seemed to speak up for the most awkward people on the planet\", of whom he himself ranks among the most adept. He is one of the great curmudgeons and contrarians of our time. He&nbsp;even puts in a&nbsp;good word for the Kray brothers.</p><p>Surprisingly, he goes easy on his passion for animal rights, but observes no such restraint when it comes to <a href=\"http://www.theguardian.com/world/george-bush\" title=\"\">George Bush</a> (\"the world's most famous active terrorist\") and <a href=\"http://www.theguardian.com/politics/tonyblair\" title=\"\">Tony Blair</a>, at whose feet he lays the London deaths of 2005. At least the vindictive music industry has taught him how to&nbsp;hate, though one suspects he didn't&nbsp;need much tutoring. The music impresario <a href=\"http://www.theguardian.com/music/tonywilson\" title=\"\">Tony Wilson</a> \"managed a lengthy and slow decline which some thought was actually an ongoing career\". There is a cameo of Julie Burchill of such sublime savagery that&nbsp;one expects the page to ignite. The&nbsp;former Smiths who took him to court are subjected to 50 pages of devastatingly articulate venom.</p><p>Though he is careful to inform us that he drives a sky-blue Jag, fame hasn't changed him much. He is still the same miserable old Mozzer he always was. The death of friends leads him to wonder movingly whether life isn't \"all too burdensome, with so much loss taking its root in the heart, as the body goes spinning on towards a&nbsp;dreadful cessation\". It isn't the kind of sentence Robbie Williams would come up with. His interest in the dead, his father warns him, outstrips his affection for the living. He sees a ghost on Saddleworth Moor, burial ground of&nbsp;the Moors murders, and narrowly avoids being kidnapped in Mexico. Everywhere he looks he sees violence: \"military science whaling, nuclear weapons, armed combat, the abattoir, holy war … riot police assaulting innocent civilians.\" When a small, flightless bird comes to live in his back garden, he fences it in with boxes to ward off predators. He has quite a few such boxes of his own.</p><p>Perhaps the time has come for a new&nbsp;career. If he could get treatment for his addiction to alliteration and stop using phrases like \"for you and I\", this prodigiously talented \"small boy of 52\", as he described himself two years ago, could walk away with the Booker prize.</p><!-- Guardian Watermark: internal-code/content/422279954|2013-11-13T15:50:01Z|42551f72bd3fa99ac491fea86fb610ea14c72160 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kann",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+        "wordcount":"1264",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"books/autobiography-and-memoir",
+        "type":"keyword",
+        "webTitle":"Autobiography and memoir",
+        "webUrl":"http://www.theguardian.com/books/autobiography-and-memoir",
+        "apiUrl":"http://content.guardianapis.com/books/autobiography-and-memoir",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/morrissey",
+        "type":"keyword",
+        "webTitle":"Morrissey",
+        "webUrl":"http://www.theguardian.com/music/morrissey",
+        "apiUrl":"http://content.guardianapis.com/music/morrissey",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"books/books",
+        "type":"keyword",
+        "webTitle":"Books",
+        "webUrl":"http://www.theguardian.com/books/books",
+        "apiUrl":"http://content.guardianapis.com/books/books",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"tone/reviews",
+        "type":"tone",
+        "webTitle":"Reviews",
+        "webUrl":"http://www.theguardian.com/tone/reviews",
+        "apiUrl":"http://content.guardianapis.com/tone/reviews",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview/saturdayreviewsfeatres",
+        "type":"newspaper-book-section",
+        "webTitle":"Features & reviews",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview",
+        "type":"newspaper-book",
+        "webTitle":"Guardian review",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/smiths",
+        "type":"keyword",
+        "webTitle":"The Smiths",
+        "webUrl":"http://www.theguardian.com/music/smiths",
+        "apiUrl":"http://content.guardianapis.com/music/smiths",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/indie",
+        "type":"keyword",
+        "webTitle":"Indie",
+        "webUrl":"http://www.theguardian.com/music/indie",
+        "apiUrl":"http://content.guardianapis.com/music/indie",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"uk/manchester",
+        "type":"keyword",
+        "webTitle":"Manchester",
+        "webUrl":"http://www.theguardian.com/uk/manchester",
+        "apiUrl":"http://content.guardianapis.com/uk/manchester",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/terryeagleton",
+        "type":"contributor",
+        "webTitle":"Terry Eagleton",
+        "webUrl":"http://www.theguardian.com/profile/terryeagleton",
+        "apiUrl":"http://content.guardianapis.com/profile/terryeagleton",
+        "bio":"<p>Terry Eaglton is a literary critic, writer and chair in English literature in Lancaster University's department of English and creative writing. His latest book is The Event of Literature</p>",
+        "r2ContributorId":"22184",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/11/3/1320333646305/Terry-Eagleton.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381626",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256764062/Morrissey-at-book-signing-001.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"54",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256766657/Morrissey-at-book-signing-002.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"340",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256768272/Morrissey-at-book-signing-003.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"130",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256771724/Morrissey-at-book-signing-005.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"132",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256773421/Morrissey-at-book-signing-006.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"168",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256775059/Morrissey-at-book-signing-007.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"180",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256776719/Morrissey-at-book-signing-008.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"228",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256780785/Morrissey-at-book-signing-010.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"372",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel/TT/EPA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381627",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "sectionId":"business",
+      "sectionName":"Business",
+      "webPublicationDate":"2013-11-13T15:14:55Z",
+      "webTitle":"Bank of England: UK recovery has finally taken hold - live",
+      "webUrl":"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "apiUrl":"http://content.guardianapis.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "fields":{
+        "trailText":"UK central bank has upgraded its forecasts for growth and unemployment today, with governor Mark Carney telling reporters that the recovery looks more solid",
+        "headline":"Bank of England: UK recovery has finally taken hold - live",
+        "body":"<div id=\"block-52839521e4b06f50dbc6f580\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T15:09:28.623Z\">3.09pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Euro drops as ECB hints at possible negative rates or QE</h2> <div class=\"block-elements\"> <p><strong>The euro has come under pressure after an ECB board member hinted the central bank could authorise negative interest rates or buying assets from banks to hit its inflation target.</strong> Peter Praet <a href=\"http://online.wsj.com/news/articles/SB10001424052702304243904579195631017906684\">told the Wall Street Journal</a>:</p> <blockquote class=\"quoted\"> <p>If our mandate is at risk we are going to take all the measures that we think we should take to fulfil that mandate. That's a very clear signal.&nbsp;The balance sheet capacity of the central bank can also be used. This includes outright purchases that any central bank can do.</p> </blockquote> <p>The ECB cut interest rates to 0.25% last week and kept the deposit rate at zero. Praet said:</p> <blockquote class=\"quoted\"> <p>On standard measures, interest rates, we still have room and that would also include the deposit facility.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/IGSquawk/statuses/400637632176480256\"> <blockquote class=\"twitter-tweet\"><p><a href=\"https://twitter.com/search?q=%24EURUSD&amp;src=ctag\">$EURUSD</a> has fallen 40pips since 14:30 and dropped below the 1.34 handle. ECB not ruling out QE according to WSJ - <a href=\"http://t.co/gZbr2p290S\">http://t.co/gZbr2p290S</a>. AB</p>— IGSquawk (@IGSquawk) <a href=\"https://twitter.com/IGSquawk/statuses/400637632176480256\">November 13, 2013</a></blockquote> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T15:14:55.959Z\">at 3.14pm GMT</time></p> </div> <div id=\"block-528391f3e4b04416f8fd691f\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T15:01:35.421Z\">3.01pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Over in Ireland, some good employment news.</strong> Henry McDonald, Ireland Correspondent, writes:</p> <blockquote class=\"quoted\"> <p>Belfast's iconic shipbuilding firm that constructed the Titanic has given Northern Ireland's economy a temporary boost with the creation of 600 short term skilled jobs.<br />Harland and Wolff, whose giant yellow cranes dominate the Belfast skyline, announced today that they are recruiting the extra skilled tradesmen to work on one of the largest oil rigs ever built in its shipyard.<br />The 360 ft tall Blackford Dolphin offshore drill platform is currently on its way from Brazil to Belfast where it will undergo maintenance work at the yard where the Titanic was made.</p> </blockquote> <figure class=\"element element-image\" data-media-id=\"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg\" alt=\"Belfast Harbour. Photo: Belfast Harbour/PA\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption>Belfast Harbour. Photo: Belfast Harbour/PA</figcaption> </figure> <blockquote class=\"quoted\"> <p>David McVeigh, head of sales and marketing at Harland and Wolff, said the contract was on such a large scale and completed within such a tight time frame, that the 600 additional workers had to be found in a relatively short period of time.</p> <p>&quot;Harland and Wolff continues to compete successfully in a sector which has seen competition grow,&quot; said McVeigh.</p> <p>&quot;Apart from being able to exceed stringent health and safety element requirements for such contracts, H&amp;W is also capable of great flexibility which means we can put 600 contractors from electrical, welding, engineering and painting disciplines in place in a short time.&quot;</p> <p>The shipyard now concentrates on maintaining and repairing oil rigs rather than ships. Its giant Samson and Goliath cranes will have to be moved out of their current positions along tracks to the end of the building dock for the estimated 50 days of work on the Blackford Dolphin rig.</p> </blockquote> </div> </div> <div id=\"block-52838fc0e4b0839b692756a5\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:49:37.980Z\">2.49pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Our <strong><a href=\"http://www.theguardian.com/data\">Data Blog</a></strong> has pulled together statistics on the unemployment figures:</p> <blockquote class=\"quoted\"> <p>The unemployment rate dropped from 7.8% in the three months to June to 7.6% – its <a href=\"http://www.theguardian.com/business/2013/nov/13/unemployment-rate-falls-bank-of-england-interest-rate-target\">lowest level in four years</a>, but what has happened to the claimant count? Using the October 2013 figures from <a href=\"http://www.nomisweb.co.uk/\">Nomis</a>, the map shows the numbers by each local authority.</p> </blockquote> <p>The data is here:</p> <h2><a href=\"http://www.theguardian.com/news/datablog/interactive/2013/nov/13/uk-unemployment-mapped-adult-youth\">UK unemployment mapped</a></h2> </div> </div> <div id=\"block-528388a6e4b04416f8fd6915\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:22:22.515Z\">2.22pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The FTSE 100 is on course for its worse one day fall in months.</strong> It is 105 points or 1.57% lower which would be its biggest drop since 20 June, if it ends like this. On Wall Street, the Dow Jones Industrial Average is forecast to open around 90 points lower, so there will be no help for the bulls from that direction.</p> <p>The falls are being driven by the feeling that central banks could finally start switching off the money taps, which have been providing support for the markets for what seems like forever. On Tuesday US Federal Reserve member Dennis Lockhart - seen as being in the centre as far as the policy debate goes - suggested there was a possibility the bank could reduce its $85bn a month bond buying programme at its December meeting. Most observers had still been banking on no change to the stimulus programme until next year.</p> <p>Meanwhile, as we have been reporting this morning, the Bank of England may also raise rates sooner than had been anticipated.</p> </div> </div> <div id=\"block-528384a1e4b031056a8eeebe\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:06:24.127Z\">2.06pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Back to the Bank of England....</h2> <div class=\"block-elements\"> <p><strong>On the Bank of England's raised growth forecasts, our economics correspondent Phillip Inman reports:</strong></p> <blockquote class=\"quoted\"> <p>The&nbsp;Bank of England&nbsp;expects to consider raising&nbsp;interest rates&nbsp;in 2015, a year earlier than expected, following a sharp fall in unemployment.</p> <p>But the bank tempered expectations of an early increase with the warning that the recovery remained fragile and rates could still remain low for several years.</p> <p>Governor&nbsp;Mark Carney&nbsp;said he expected growth to remain modest over the next couple of years while the economy continues to be hampered by a weak banking sector and stumbling overseas markets.</p> <p>Speaking after publication of the central bank's quarterly inflation report, Carney played down concerns that the current 0.5% base rate would rise before real incomes begin to rise and the recovery is secured.</p> <p>&quot;The economy is growing robustly as lifting uncertainty and thawing credit conditions start to unlock pent-up demand. But significant headwinds – both at home and abroad – remain, and there is a long way to go before the aftermath of the financial crisis has cleared and economic conditions normalise,&quot; he said in the report.</p> <p>&quot;That underpins the monetary policy committee's (MPC) intention to maintain the exceptionally stimulative stance of monetary policy until there has been a substantial reduction in the degree of economic slack.&quot;</p> <p>In August the BoE said as part of its new policy of forward guidance that it would not consider raising interest rates before unemployment fell to 7%. MPC members agreed that unemployment was a strong indicator of slack in the economy. Figures for August show that rate has fallen to 7.6% following an unexpectedly sharp rise in job recruitment over the previous three months.</p> <p>In response the BoE said there was now a three in five chance that the UK unemployment rate would hit 7% in mid-2015 compared to a previous prediction of late 2016.</p> <p>Deputy governor Charlie Bean said forward guidance was still pointing to a rate rise later rather than sooner. He said: &quot;The key message is that policy is not going to be related to growth rates but the elimination of slack.&quot;</p> </blockquote> <h2>Here's the full story:&nbsp;<a href=\"http://www.theguardian.com/business/2013/nov/13/interest-rates-could-rise-2015\">Interest rates could rise in 2015 – BoE</a></h2> <p>The other big news story of the day is the drop in UK unemployment, to a four-year low of 7.6%.</p> <p><strong>Economics editor Larry Elliott writes:</strong></p> <blockquote class=\"quoted\"> <p>Britain's rising population means that a record number of people – 29.95 million – are in work but the employment rate remains lower than it was before the deep recession of 2008-09. The current rate of 71.8% compares with 73% at the peak in early 2008 but above the trough of 70.8% reached in 2011.</p> <p>The bulk of the jobs created in the latest three months were full time but a record 1.46 million people were working part time because they could not find a full-time job. Unemployment as measured by the number of people out of work and claiming eligible benefits dropped by 41,700 in September to 1.3 million.</p> </blockquote> <h2>More here:&nbsp;<a href=\"http://www.theguardian.com/business/2013/nov/13/unemployment-rate-falls-bank-of-england-interest-rate-target\">Jobless rate moves towards Bank of England target</a></h2> <p><em>And that's a good moment to hand over <strong>Nick Fletcher</strong>, before trading begins on Wall Street. Shares are still lower in London, with the FTSE 100 down 107 points... </em><strong>GW</strong></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T14:07:41.474Z\">at 2.07pm GMT</time></p> </div> <div id=\"block-528380e8e4b01a80f661c25a\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:45:06.789Z\">1.45pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>As well as the departure of Sir Hector Sants, Barclays has also reported that chief operations and technology officer,&nbsp;Shaygan Kheradpir, is leaving the company.</strong></p> <p>Here's the bank's statement:</p> <blockquote class=\"quoted\"> <p>Hector Sants has been on sick leave since the beginning of October, suffering from stress and exhaustion. He has concluded that he will not be able to return to work in the near term. Consequently he has decided to resign from Barclays and not return from sick leave.</p> <p>Shaygan Kheradpir, Chief Operations and Technology Officer, is leaving Barclays to take on a role as CEO for a company based in the United States.</p> <p>An internal and external search will be launched for both posts. In the meantime Allen Meyer, Head of Compliance, Corporate and Investment Banking will act as Interim Head of Compliance and Government and Regulatory Relations. Darryl West, Barclays’ Chief Information Officer, will act as Interim Group Chief Operations and Technology Officer. In these posts both will join the Executive Committee and report to Group Chief Executive, Antony Jenkins.</p> </blockquote> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:46:41.132Z\">at 1.46pm GMT</time></p> </div> <div id=\"block-52837ee7e4b01a80f661c259\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:33:57.694Z\">1.33pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Sants leaves Barclays</h2> <div class=\"block-elements\"> <p><strong>Sir Hector Sants</strong>, the former head of the UK's Financial Services Authority, has stepped down from his role as head of compliance at Barclays, my colleague <strong>Jill Treanor</strong> reports.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/jilltreanor/statuses/400613343108411392\"> <blockquote class=\"twitter-tweet\"><p>Barclays says Sir Hector Sants has quit as head of compliance</p>— Jill Treanor (@jilltreanor) <a href=\"https://twitter.com/jilltreanor/statuses/400613343108411392\">November 13, 2013</a></blockquote> </figure> <p><a href=\"http://www.theguardian.com/business/2013/oct/15/hector-sants-barclays-exhaustion\"><strong>This comes a month after Sants began a &quot;leave of absence&quot; after being diagnosed with exhaustion and stress</strong></a>.&nbsp;</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:34:44.051Z\">at 1.34pm GMT</time></p> </div> <div id=\"block-528376d2e4b01a80f661c258\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:29:57.899Z\">1.29pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">EC begins review of German trade surplus</h2> <div class=\"block-elements\"> <p><strong>Over in Brussels, the European Commission has - as anticipated - launched an inquiry into the German trade surplus.</strong></p> <p><a href=\"http://ec.europa.eu/europe2020/pdf/2014/amr2014_en.pdf\"><strong>In a new report</strong></a>, the EC said it would launch an &quot;in-depth review&quot; of both&nbsp;Germany and Luxembourg.</p> <p>It plans to:</p> <blockquote class=\"quoted\"> <p>better scrutinise&nbsp;their external position and analyse internal developments, and assess whether any of these countries is experiencing imbalances.</p> </blockquote> <p>It explained that the&nbsp;German trade surplus has exceeded the EC's 'threshold' (6% of national GDP)&nbsp;each year since 2007, so it clearly isn't a short-term problem.</p> <p>This means Germany becomes one of 16 Member States who are being probed for imbalances (many others face questions over&nbsp;current account&nbsp;deficits, losses of competitiveness and debt and deficit levels).</p> <p>This chart shows the differences between EU member states:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png\" alt=\"Eurozone current account data\" width=\"460\" height=\"386\" class=\"gu-image\" /> <figcaption>Photograph: EC</figcaption> </figure> <p>Germany's defenders say it should not be blamed for running a successful export sector, and suggest that other countries could learn a few lessons.</p> <p>Commission president&nbsp;Jos&eacute; Manuel Barroso sounded conciliatory at a press briefing in Brussels, saying:</p> <blockquote class=\"quoted\"> <p>Europe needs more Germanys.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/OpenEurope/statuses/400603967698108416\"> <blockquote class=\"twitter-tweet\"><p>Barroso: what we are launching here is an indepth review, which is almost automatic as Germany exceeded the threshold of 4 indicators</p>— Open Europe (@OpenEurope) <a href=\"https://twitter.com/OpenEurope/statuses/400603967698108416\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/OpenEurope/statuses/400604259462295554\"> <blockquote class=\"twitter-tweet\"><p>Barroso: this should not be seen as Europe being perceived at odds with German competitiveness...exercise to judge the consequences</p>— Open Europe (@OpenEurope) <a href=\"https://twitter.com/OpenEurope/statuses/400604259462295554\">November 13, 2013</a></blockquote> </figure> <p>Bundesbank presiden<strong>t Jens Weidmann</strong>&nbsp;has already warned that Germany shouldn't be penalised, according to this Reuters newsflash:</p> <p><strong>• WEIDMANN SAYS ANSWER TO GERMANY'S CURRENT ACCOUNT SURPLUS CANNOT BE TO MAKE GERMAN COMPANIES LESS COMPETITIVE&nbsp;</strong></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:34:27.612Z\">at 1.34pm GMT</time></p> </div> <div id=\"block-528376bae4b01a80f661c257\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:55:35.845Z\">12.55pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg\" alt=\"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.\" width=\"460\" height=\"282\" class=\"gu-image\" /> <figcaption>Photograph: TOBY MELVILLE/AFP/Getty Images</figcaption> </figure> </div> </div> <div id=\"block-52837335e4b0f37bee4ff653\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:53:14.524Z\">12.53pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England's report: What the experts say</h2> <div class=\"block-elements\"> <p>Here's some economist reaction:</p> <p><strong>David Kern, chief economist at the British Chambers of Commerce:</strong></p> <blockquote class=\"quoted\"> <p>We support Governor&nbsp;Carney’s statement that the pressure on living standards can only be addressed when productivity increases. Simply raising wages before this happens would make businesses uncompetitive and threaten the recovery.</p> </blockquote> <p><strong>Howard Archer of IHS Global Insight:</strong></p> <blockquote class=\"quoted\"> <p>The message coming loud and clear from the Bank of England is that it remains in no hurry at all to raise interest rates despite the economy’s improved performance and a likely significantly faster fall in unemployment than the central bank had previously expected.</p> <p>It is clear that&nbsp;the Bank of England wants to give the economy every chance to develop sustainable decent growth and not to risk choking it off by any premature increasing of interest rates.</p> </blockquote> <p><strong>Rob Wood of&nbsp;Berenberg Bank:</strong></p> <blockquote class=\"quoted\"> <p>The BoE signalled its first rate hike might come in 2015, rather than late 2016 as it had previously said, in its quarterly forecast update this morning.....</p> <p>We see a 70% chance that unemployment falls to the 7% threshold by Q3 2015, compared to the BoE’s 50% chance.</p> <p>So while they have moved towards our view and the market, they still have some way to go. The risks are probably that the BoE is underestimating the speed at which the economy can recover. With loose policy, falling uncertainty and booming house prices, the recovery could snowball and more than 3% growth next year is not impossible. There are downside risks too of course, that we should not forget, but they seem to be diminishing.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/FGoria/statuses/400592336935485440\"> <blockquote class=\"twitter-tweet\"><p>Schroders now expects BoE to raise rates at beginning of 2016, previously expected BoE rate increase at end of 2016</p>— Fabrizio Goria (@FGoria) <a href=\"https://twitter.com/FGoria/statuses/400592336935485440\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52836f78e4b0f37bee4ff64c\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:40:13.804Z\">12.40pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Market reaction</h2> <div class=\"block-elements\"> <p>The pound has rallied by around 0.5% today, following the Bank of England's new forecasts and this morning's drop in UK unemployment (<a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283464ce4b0f37bee4ff61c\"><strong>see 9.30am onwards)</strong></a>.</p> <p>It's gained three quarters of a cent, against the US dollar to $1.5977.</p> <p>Shares, though, are down in London as traders anticipate monetary policy being tightened more quickly.</p> <p><strong>The FTSE 100 has dropped by 93 points, or 1.39%, to 6633.</strong></p> <p>Financial stocks are among the fallers -- with RSA Insurance down 3.8%, Standard Chartered down 3.4% and Barclays losing 3.1%.</p> </div> </div> <div id=\"block-528368dde4b0312d704c1180\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:24:19.055Z\">12.24pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England quarterly inflation report, a summary</h2> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg\" alt=\"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.\" width=\"460\" height=\"333\" class=\"gu-image\" /> <figcaption>Photograph: Toby Melville/POOL/EPA</figcaption> </figure> <p>So, to quickly recap.</p> <p>•<strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52835455e4b0b9c05d8a3466\">The Bank of England has raised its economic forecasts</a>, concluding that Britain's output will rise faster than expected this year and in 2014.</strong>&nbsp;This will help to pull down the UK unemployment rate, with a roughly 40% chance that it will be 7% by the end of next year.</p> <p>•&nbsp;<strong>Governor Mark Carney said the UK recovery had <a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-528359cfe4b0312d704c1179\">&quot;finally taken hold&quot;</a>,</strong>&nbsp;but warned that it needs to become &quot;strong and sustained&quot; to get more people into work, and to drive wages higher.</p> <blockquote class=\"quoted\"> <p>For the first time in a long time you don't have to be an optimist to see the glass is half full. The recovery has finally taken hold.</p> </blockquote> <p>This chart shows how the BoE sees more chance of the jobless rate hitting 7% soon:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png\" alt=\"Bank of England unemployment forecasts\" width=\"423\" height=\"401\" class=\"gu-image\" /> <figcaption>Photograph: Bank of England</figcaption> </figure> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-528357c1e4b0312d704c1177\">Carney defended his 'forward guidance' on interest rates</a>, which states that borrowing costs won't rise until the jobless rate has hit 7%.</strong> He said the pledge had helped to sustain the recovery, and did not mean that a rate rise was inevitable once the 7% rate has been hit.</p> <p>He said:</p> <blockquote class=\"quoted\"> <p>There was always going to be movement in the timing of when potentially the unemployment threshold was reached .. but what's important is two things.</p> <p>One is what we learn between now and when that threshold is achieved, what we learn about the economy, what we learn about how much extra slack there is in the economy. And secondly what the conditions are when it's achieved and we're providing the confidence to businesses and households that we will not even begin to think about moving interest rates until that threshold is achieved.</p> </blockquote> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52835d8ee4b07aa4168b4b14\">Carney was also asked about the UK housing market,</a> and concerns of a bubble in London</strong>. He replied that the Bank is setting policy for the whole country, not <strong><a href=\"http://cdn.london-insider.co.uk/wp-content/uploads/2009/11/LondonTubeTrainMap2010.jpg\">&quot;inside the Circle Line&quot;</a>, </strong>adding:</p> <blockquote class=\"quoted\"> <p>In terms of housing valuation there are clearly areas in the country where valuation is very elevated. What we are seeing across the UK is the greatest price momentum is for houses that are towards the upper end of the valuation spectrum.</p> <p>The bank, through the Financial Policy Committee, will be vigilant about potential risks there but we need to put the pickup in housing activity in perspective. Activity levels, while they've picked up, are still running at between two thirds or three quarters of historic averages in terms of whether its transactions or approvals, homebuilding, so there is some room for that to further pickup and that's the initial phase of this recovery.</p> </blockquote> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52836023e4b0b9c05d8a346f\">And the Bank is still cautious about the situation in the eurozone</a>, even though the 'pall' of uncertainty over the future of the euro has mostly lifted.</strong> Carney said the UK central bank isn't expecting a big pick-up in demand from Europe.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T12:54:06.834Z\">at 12.54pm GMT</time></p> </div> <div id=\"block-528365f7e4b0b9c05d8a3477\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:47:39.873Z\">11.47am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>And that's the end of the press conference - cue a brief burst of Beethoven* on the webcast feed.</p> <p>* - <a href=\"https://www.youtube.com/watch?v=iwIvS4yIThU\"><em>9th Symphony,&nbsp;2nd movement, rather awesome</em></a></p> </div> </div> <div id=\"block-528363a6e4b0312d704c117e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:42:25.732Z\">11.42am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Several questions on the government's Help to Buy mortgage subsidy scheme.</p> <p><strong>Observer economics editor Heather Stewart</strong> asks about the Treasury Select Committee's concerns (<a href=\"http://www.theguardian.com/business/2013/nov/09/help-to-buy-scrutiny-bank-of-england-mark-carney\"><em>they want the Bank of England to clarify its role in the scheme</em></a>).</p> <p>Carney says that the issue will be considered at the next meeting of the Financial Policy Committee (responsible for ensuring economic stability). He adds that the Bank has a range of ways to influence the housing market.</p> </div> </div> <div id=\"block-5283625fe4b0b9c05d8a3473\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:33:53.080Z\">11.33am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Kathryn Hopkins of The Times raises the issue of gender targets (<em>the Bank of England's senior ranks are dominated by men</em>).</strong></p> <p>Mark Carney replies that &quot;it is an objective of this institution to increase the diversity of our junior ranks, and senior ranks&quot;.</p> <p>Appointments to the senior ranks are made by others, he points out (<em>the Treasury picks the governor, and the members of the rate-setting Monetary Policy Committee</em>), but the Bank can increase diversity at all levels.</p> <p>A review of the Bank's talent management and recruitment policies is underway, he adds, though he won't prejudge its conclusions</p> </div> </div> <div id=\"block-52836023e4b0b9c05d8a346f\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:28:09.358Z\">11.28am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Asked about the eurozone, Mark Carney says that the Bank of England only expects &quot;quite modest demand growth&quot; in this major export market.</p> <p>We do expect the removal, or reduction, of the pall of uncertainty that hung over businesses over the future of the eurozone, he adds.</p> <p>But Threadneedle Street is not&nbsp;relying on any meaningful recovery in Europe to drive this forwards.</p> <p>And that's why the GDP growth forecasts remain relatively modest compared to previous recoveries, he adds.</p> </div> </div> <div id=\"block-528361c5e4b0b9c05d8a3472\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:26:44.887Z\">11.26am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png\" alt=\"Mark Carney\" width=\"460\" height=\"264\" class=\"gu-image\" /> <figcaption>Mark Carney speaking today. Photograph: Bank of England</figcaption> </figure> </div> </div> <div id=\"block-5283607ae4b0312d704c117c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:25:09.673Z\">11.25am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>How much credit does Mark Carney take for the recent pick-up in the UK economy, asks Channel 4's Faisal Islam.</strong></p> <p>Governor Carney says that &quot;our view is that forward guidance is helpful to sustain the recovery, that's why we did it.&quot;</p> <p>You only see the value of it at events like today, and in meetings with people around the country. People understand that the Bank of England &quot;needs to see sustained momentum and the slack picked up&quot; before we would tighten monetary policy.</p> <p>The government's Funding for Lending scheme is also helping to support the recovery and provide support for bank balance sheets, Carney adds.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T11:26:30.294Z\">at 11.26am GMT</time></p> </div> <div id=\"block-52835d8ee4b07aa4168b4b14\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:18:54.159Z\">11.18am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>Should the Bank's Financial Policy Committee&nbsp;act on the house price levels in London, the main topic of conversation at dinner parties in the capital?</em>&nbsp;</p> <p>Carney says the Bank is looking at the bigger picture:</p> <blockquote class=\"quoted\"> <p>We don't make policy for inside the Circle Line, we make it for the entire United Kingdom.</p> </blockquote> <p>And at this stage, the Bank isn't very worried about the housing market.</p> <p>He argues that expectations of future earnings can drive increased consumption levels, rather than the fact that people's houses are worth more (<em>which doesn't deliver a real 'wealth effect' unless people can unlock the value</em>).&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/EdConwaySky/statuses/400581840303828992\"> <blockquote class=\"twitter-tweet\"><p>Carney says for a 2nd time: &quot;We have a good line of sight to dynamics in the housing market&quot;. No idea what it means, but it sure sounds good</p>— Ed Conway (@EdConwaySky) <a href=\"https://twitter.com/EdConwaySky/statuses/400581840303828992\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835cf9e4b0b9c05d8a346d\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:07:19.425Z\">11.07am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>What would a more normal economy look like?</em>&nbsp;</p> <p>Mark Carney says that as the economy 'heals', the natural rate of unemployment should return to the pre-crisis levels of around 5%.</p> <p>But to be a sustainable, we need to see growth in real wages (ie, pay rises need to beat inflation not lag behind it) to sustain consumption growth.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T11:07:41.682Z\">at 11.07am GMT</time></p> </div> <div id=\"block-52835b50e4b0f37bee4ff635\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:05:13.895Z\">11.05am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Our economics editor Larry Elliott calls the Bank of England's forecasting record to account.</strong></p> <p>&nbsp;<strong>Larry asks:</strong></p> <blockquote class=\"quoted\"> <p>You failed to spot the recession in 2008, you&nbsp;failed to spot the flat-lining economy in 2010, and now you've failed to spot the stronger recovery. How can we have any faith in the forecasts that underpin forward guidance?</p> </blockquote> <p>Carney defends the Bank's record, says that it's confident that it's predictions are on the right path. He adds, though, that he's trying to make the forecasts more transparent to that doubters can better understand the bank's thinking.</p> <p>He then bats the question over to chief economist Spencer Dale -- who says that weaker global demand was one reason the Bank's UK growth forecasts were too optimistic in the past.</p> <p>Dale also argues that the real power of forward guidance is that people understand the Bank's approach to monetary policy, rather than its forecasts.</p> </div> </div> <div id=\"block-52835a24e4b0312d704c117a\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:58:17.730Z\">10.58am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Carney defends forward guidance</h2> <div class=\"block-elements\"> <p><em><strong>What on earth is the point of forward guidance on interest rates, asks Chris Giles of the FT, given the dramatic changes in the Bank of England's predictions.</strong></em>&nbsp;</p> <p>Imagine a world without forward guidance, replies Mark Carney.&nbsp;We've had an unexpectedly strong recovery - stronger than most analysts expected.</p> <p>If forward guidance wasn't introduced in August, the discussion would be 'is the Bank going to raise interest rates today'. No-one is asking that question today...</p> <p><strong>...and rightly so, Carney adds. A rate rise would mean the bank would &quot;take a recovery that has finally taken hold and pull the rug out from under it&quot;.</strong></p> </div> </div> <div id=\"block-528359cfe4b0312d704c1179\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:53:20.798Z\">10.53am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England: the recovery is finally taken hold</h2> <div class=\"block-elements\"> <p><strong>Here's the key quote from the Bank of England's report, declaring that the British recovery is, at last, underway:</strong></p> <blockquote class=\"quoted\"> <p>In the United Kingdom, recovery has finally taken hold. The economy is growing robustly as lifting&nbsp;uncertainty and thawing credit conditions start to unlock pent-up demand.</p> <p>But significant&nbsp;headwinds — both at home and abroad — remain, and there is a long way to go before the&nbsp;aftermath of the financial crisis has cleared and economic conditions normalise. That underpins the&nbsp;MPC’s intention to maintain the exceptionally stimulative stance of monetary policy until there has&nbsp;been a substantial reduction in the degree of economic slack.&nbsp;</p> <p>The pace at which that slack is eroded, and the durability of the recovery, will depend on the extent&nbsp;to which productivity picks up alongside demand. Productivity growth has risen in recent quarters,&nbsp;although unemployment has fallen by slightly more than expected on the back of strong output&nbsp;growth.</p> </blockquote> </div> </div> <div id=\"block-52835981e4b0b9c05d8a346a\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:50:50.503Z\">10.50am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><a href=\"http://www.bankofengland.co.uk/publications/Pages/inflationreport/2013/ir1304.aspx\"><strong>The full quarterly inflation report is online here</strong></a>.</p> </div> </div> <div id=\"block-5283584ee4b0b9c05d8a3469\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:50:07.913Z\">10.50am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>What can the Bank of England do to close the gap between wages and inflation, asks Sky's Ed Conway.</em></p> <p>Carney replies that it is important that the recovery persists, and &quot;we need a pickup in business investment&quot; too.</p> <p>The Bank's pledge to keep interest rates at record lows at least until the jobless rate is 7% will also help, he adds.</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png\" alt=\"Mark Carney\" width=\"460\" height=\"264\" class=\"gu-image\" /> <figcaption>Photograph: Sky News</figcaption> </figure> </div> </div> <div id=\"block-528357c1e4b0312d704c1177\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:45:19.433Z\">10.45am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>As expected, Mark Carney is having to defend his forward guidance policy on interest rates.</strong></p> <p>Asked how people and businesses are supposed to plan for the future if the bank's forecasts change so much, governor Carney explains that his priority is to &quot;provide confidence&quot; that borrowing costs won't rise until the recovery is secured.</p> <p>Interest rates won't immediately rise when the jobless rate hits 7%, he insists.</p> </div> </div> <div id=\"block-52835773e4b07aa4168b4b0c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:43:03.177Z\">10.43am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><a href=\"http://streamstudio.world-television.com/CCUIv3/frameset.aspx?ticket=117-118-13642&amp;target=en-default-&amp;status=live&amp;browser=ns-0-0-0-11-0&amp;stream=flash-video-400\"><strong>The Bank of England's Q&amp;A is being webcast here</strong></a>.</p> </div> </div> <div id=\"block-52835651e4b0312d704c1175\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:41:52.871Z\">10.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Mark Carney is telling reporters in London that:</strong></p> <blockquote class=\"quoted\"> <p><strong>For the first time in a long time, you don't need to be an optimist to see that the glass is half full.&nbsp;</strong><strong>The recovery has taken hold.</strong></p> </blockquote> <p>He's explaining that the Bank of England's job is to help secure the recovery, and make it strong enough to get more people back into work.&nbsp;</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T10:47:49.645Z\">at 10.47am GMT</time></p> </div> <div id=\"block-5283566be4b0b9c05d8a3468\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:39:05.299Z\">10.39am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The Bank of England has also raised its growth forecasts.</strong></p> <p>It expects GDP to rise by 1.6% for 2013 as a whole, up from 1.4%.</p> <p>In 2014, it expects growth of 2.8%, up from 2.5% in the August report.</p> <p>It still expects growth of 2.3% in 2015.</p> </div> </div> <div id=\"block-52835455e4b0b9c05d8a3466\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:36:13.581Z\">10.36am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England releases quarterly inflation report</h2> <div class=\"block-elements\"> <p><strong>The Bank of England has just released its latest quarterly report on the UK economy.</strong></p> <p>And it's raised its economic forecasts, saying that the unemployment rate will fall faster than it expected three months ago. There is a &quot;two in five chance&quot; that it could be 7% at the end of 2014, Mark Carney says.</p> <p>However, that doesn't mean interest rates would immediately rise (<em>7% being the target in the Bank's forward guidance</em>).&nbsp;</p> <p>It also believes that the inflation rate will fall to the 2% target faster than it thought in August.</p> <p>Here's the Reuters newsflashes:&nbsp;</p> <p><strong>• BANK OF ENGLAND NOV INFLATION REPORT - UK RECOVERY HAS FINALLY TAKEN HOLD, ECONOMY GROWING ROBUSTLY BUT SIGNIFICANT HEADWINDS REMAIN&nbsp;</strong></p> <p><strong>• BOE - MPC INTENDS TO KEEP EXCEPTIONALLY STIMULATIVE POLICY STANCE UNTIL SLACK HAS REDUCED SUBSTANTIALLY&nbsp;13-Nov-2013 </strong></p> <p><strong>• BOE - UNEMPLOYMENT LIKELY TO FALL MORE QUICKLY THAN FORECAST IN AUGUST, HITTING 7 PCT THRESHOLD WILL NOT NECESSARILY TRIGGER RATE RISE&nbsp;</strong></p> <p><strong>• BOE INFLATION REPORT SAYS MPC SEES 41 PCT CHANCE OF 7 PCT UNEMPLOYMENT AT END-2014, 57 PCT AT END-2015, 68 PCT AT END-2016 BASED ON MARKET INTEREST RATES&nbsp;</strong></p> </div> </div> <div id=\"block-528354a4e4b0312d704c1174\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:29:58.205Z\">10.29am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/notayesmansecon/statuses/400570702014590976\"> <blockquote class=\"twitter-tweet\"><p>Will somebody please point out the 7.1% September UK unemployment number at the Bank of England press conference?! <a href=\"https://twitter.com/search?q=%23ForwardGuidance&amp;src=hash\">#ForwardGuidance</a> <a href=\"https://twitter.com/search?q=%23BoE&amp;src=hash\">#BoE</a></p>— Shaun Richards (@notayesmansecon) <a href=\"https://twitter.com/notayesmansecon/statuses/400570702014590976\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835369e4b0b9c05d8a3464\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:28:19.259Z\">10.28am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The recovery in the UK unemployment rate comes as the Bank of England prepares to release its latest Quarterly Inflation Report (</strong><em>in just a couple of minute<strong>s).</strong></em></p> <p>Having pinned UK interest rates to the jobless rate, will Mark Carney now say that the recovery is accelerating faster than he expected? <em>We're about to find out....</em></p> </div> </div> <div id=\"block-528352bde4b0f37bee4ff631\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:24:08.394Z\">10.24am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment: what the politicians say</h2> <div class=\"block-elements\"> <p>Here's the political reaction to the news that Britain's unemployment rate has fallen to 7.6%, but that pay remains well below inflation (<strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283464ce4b0f37bee4ff61c\">see 9.31am onwards for all the details</a></strong>).</p> <h2>Minister for Employment Esther McVey</h2> <blockquote class=\"quoted\"> <p>This Government is delivering on its promise to rebalance the economy, promote job creation, and support people to get off benefits and into work.</p> <p>Today's figures show that the number of people in work has risen by more than a million under this Government, with the growth driven by full-time private sector jobs.&nbsp;</p> <p>At the same time, the number of people claiming the main out-of-work benefits has fallen by almost half a million. There's more work to do, and we are not complacent, but these are all very positive signs.</p> </blockquote> <h2><strong>Rachel Reeves MP, Labour’s Shadow Work and Pensions Secretary</strong></h2> <blockquote class=\"quoted\"> <p>Today’s fall in unemployment is welcome, but families facing a cost-of-living crisis need a recovery that benefits them, and these figures show we are still far from achieving that.</p> <p>Prices have now risen much faster than wages for 40 of the 41 months since David Cameron became Prime Minister. On average working people are now over &pound;1,600 a year worse off under this out-of-touch Government.</p> <p>The employment figures give no cause for complacency. The number of people who want to work full-time but are stuck on part-time hours is at a record high. And youth unemployment is still at unacceptable and unaffordable levels with almost a million young people still out of work, while the number of young people unemployed for a year or more has gone up by 7,000 this quarter.</p> <p>The Tory-led Government’s Work Programme and Youth Contract are failing – they should adopt Labour’s compulsory jobs guarantee, funded by repeating the tax on bank bonuses, and limiting pension tax relief for the very highest earners. This would guarantee real paid work for young people unemployed for a year, or adults unemployed for two years – work they would have to take or lose benefits.</p> </blockquote> </div> </div> <div id=\"block-52835239e4b07aa4168b4b07\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:21:02.918Z\">10.21am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Incidentally, we've just learned that September was a less cheery month for the eurozone. Factory output fell by 0.5%, rather worse than expected.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BBCGavinHewitt/statuses/400567118460362752\"> <blockquote class=\"twitter-tweet\"><p>Industrial production in euro-zone fell in Sept more than expected. In Portugal it fell 11.2%. in Germany down 0.8%. V fragile recovery.</p>— Gavin Hewitt (@BBCGavinHewitt) <a href=\"https://twitter.com/BBCGavinHewitt/statuses/400567118460362752\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-528350e4e4b0312d704c1173\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:19:20.525Z\">10.19am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Now this is interesting....</strong> the ONS has also released an unofficial snapshot of the UK labour market just for September.</p> <p>It's more informal than the official data -- &quot;not designated as National Statistics&quot; as the jargon has it.</p> <p>But with that caveat duly noted.... the data shows that the jobless rate was just 7.1% in September itself (compared to 7.6% for the July-September quarter). <a href=\"http://www.ons.gov.uk/ons/dcp171766_334875.pdf\"><strong>It's online here....</strong></a></p> <p>That's much closer to the 7% target which the Bank of England has set as a milestone before interest rates could rise.&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/JonPrynn/statuses/400561002107768833\"> <blockquote class=\"twitter-tweet\"><p>Hold on to your hats. The unofficial &quot;one month&quot; measure shows unemployment at just 7.1%. Rate rise for 2014? <a href=\"http://t.co/61oS2mW10V\">http://t.co/61oS2mW10V</a></p>— Jonathan Prynn (@JonPrynn) <a href=\"https://twitter.com/JonPrynn/statuses/400561002107768833\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835028e4b0f37bee4ff62d\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:13:27.217Z\">10.13am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Rob Wood of Berenberg Bank says unemployment is falling faster than economists, or the Bank of England, expected -- but he is also concerned that wage growth is so weak.</strong></p> <p>Wood comments:</p> <blockquote class=\"quoted\"> <p>There is a lot of good news in this release for the UK economy. Stonking job gains show the UK is recovering rapidly.</p> <p>At the same time those jobs gains are not cutting unemployment as fast as might be expected because the workforce is rising rapidly.</p> <p>Unlike in the US, the UK participation rate is rising. People are competing for jobs rather than giving up and leaving the workforce. That is keeping wage growth very subdued.</p> </blockquote> </div> </div> <div id=\"block-528349ade4b0f37bee4ff622\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:10:39.584Z\">10.10am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">The wage squeeze continues....</h2> <div class=\"block-elements\"> <p>Many analysts concerned by the lack of progress in pay (with total weekly earnings up just 0.7% annually).</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/jamestplunkett/statuses/400563344840470528\"> <blockquote class=\"twitter-tweet\"><p>Wages have now been falling in real terms for four years. Uncharted waters. <a href=\"http://t.co/sIfsQolJe0\">pic.twitter.com/sIfsQolJe0</a></p>— James Plunkett (@jamestplunkett) <a href=\"https://twitter.com/jamestplunkett/statuses/400563344840470528\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/faisalislam/statuses/400562487692500992\"> <blockquote class=\"twitter-tweet\"><p>... and pay is still falling well short of prices, particularly now the 50p bonus-tax shifts have stopped: <a href=\"http://t.co/WpmQHq6V5K\">pic.twitter.com/WpmQHq6V5K</a></p>— Faisal Islam (@faisalislam) <a href=\"https://twitter.com/faisalislam/statuses/400562487692500992\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52834dd5e4b0f37bee4ff62c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:07:10.738Z\">10.07am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>As this graph shows, the UK unemployment rate has now dropped to its lowest in over four years - it hit 7.6% in&nbsp;May 2009, during the recession sparked by the financial crisis:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png\" alt=\"Unemployment: the unemployment rate to September 2013\" width=\"460\" height=\"256\" class=\"gu-image\" /> <figcaption>Photograph: ONS</figcaption> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T10:07:40.171Z\">at 10.07am GMT</time></p> </div> <div id=\"block-52834c71e4b0312d704c1171\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:56:34.562Z\">9.56am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>This chart shows how the rise in the labour force was split between men and women, and between full-timer and part-time staff:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png\" alt=\"Unemployment; The 177,000 rise in the labour force in July-September 2013\" width=\"460\" height=\"281\" class=\"gu-image\" /> <figcaption>Photograph: ONS</figcaption> </figure> </div> </div> <div id=\"block-52834b22e4b0312d704c1170\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:54:01.797Z\">9.54am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>At 29.95 million people, the UK workforce is now at a record high having jumped by 177,000 in the July-September quarter.&nbsp;</p> <p>However, this partly reflects increased population levels.<strong> The&nbsp;</strong><strong>employment rate of 71.8% is not at a record high</strong> -- as this graph shows, it's still below its pre-crisis levels:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png\" alt=\"Unemployment: UK employment rate to September 2013\" width=\"460\" height=\"253\" class=\"gu-image\" /> <figcaption>Unemployment: UK employment rate to September 2013 Photograph: /ONS</figcaption> </figure> <p><em>It's moving the right way, though....</em></p> </div> </div> <div id=\"block-52834a2ee4b07aa4168b4b02\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:49:17.013Z\">9.49am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>While the fall in the headline jobless rate is clearly welcome, the detail of the ONS report paints a more sober picture.</p> <p>For example, the number of people working part-time because they can't get full-time employment is at a record high.</p> <p><strong>According to the ONS&nbsp;there were 1.46 million employees and self-employed people who&nbsp;were working part-time because they could not find a full-time job, the highest figure since records&nbsp;began in 1992.</strong></p> </div> </div> <div id=\"block-5283497fe4b0f37bee4ff621\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:43:02.831Z\">9.43am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>The full report from the Office for National Statistics is online here:</p> <h2><a href=\"http://www.ons.gov.uk/ons/dcp171778_332467.pdf\">Labour Market Statistics, November&nbsp;2013</a></h2> </div> </div> <div id=\"block-52834838e4b07aa4168b4b00\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:41:29.326Z\">9.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>But while unemployment is down, pay packets are not yet feeling the benefits.</strong></p> <p>Total pay, including bonuses, rose by 0.7% annually in September -- down from 0.8% in August. That's dwarfed by the 2.2% rise in inflation over the last year in Britain.</p> <p>Average pay fell year-on-year in the public sector.</p> <p>The ONS reported:</p> <blockquote class=\"quoted\"> <p>Average weekly earnings for the private sector increased&nbsp;by 1.1% but average weekly earnings for the public sector fell by 0.4%.&nbsp;</p> <p>In September 2013 average pay including bonus payments in the private sector was &pound;473 a week,&nbsp;&pound;14 a week lower than the public sector figure of &pound;487 a week. However, excluding publicly owned&nbsp;financial corporations, average weekly pay in the public sector was only &pound;3 a week higher than for&nbsp;the private sector, at &pound;476 a week.</p> </blockquote> </div> </div> <div id=\"block-52834798e4b07aa4168b4aff\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:36:43.015Z\">9.36am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The UK claimant count is also down -- dropping by 41,700 people in October. </strong>That takes the claimant count rate down to 3.9%.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T09:36:51.658Z\">at 9.36am GMT</time></p> </div> <div id=\"block-5283473ee4b0312d704c116e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:33:52.032Z\">9.33am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>The total number of people in work across the UK rose by 177,000 in the three months to September, taking the total to 29.953 million. That's the biggest jump since the June to August quarter.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T09:34:01.700Z\">at 9.34am GMT</time></p> </div> <div id=\"block-5283464ce4b0f37bee4ff61c\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:31:39.669Z\">9.31am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment rate falls</h2> <div class=\"block-elements\"> <p><strong>Breaking: the UK unemployment rate has fallen to 7.6% in the three months to September.</strong></p> <p>The number of people out of work fell by 48,000 to 2.466m in the quarter, which Reuters says is the lowest level in three years.</p> <p><em><strong>More to follow....</strong></em></p> </div> </div> <div id=\"block-52833ed7e4b0312d704c116d\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:17:55.081Z\">9.17am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment data due soon</h2> <div class=\"block-elements\"> <p>We get the latest UK unemployment data in less than 15 minutes time. As mentioned at the start, economists expect:</p> <p><strong>• a drop in the claimant count of around 30,000 people in October (compared with 41k last month)&nbsp;</strong></p> <p><strong>• a rise in the number of people in work in the three months to September, of around&nbsp;113,000 </strong></p> <p><strong>• No change to the unemployment rate, of 7.7% [<em>which is crucial to UK monetary policy given the Bank of England's pledge not to raise rates till it hits 7%</em>]&nbsp;</strong></p> <p><strong>• Another fall in real pay, with average weekly earnings expected to have risen by just 0.7% over the last year.</strong></p> <p>In other words, some signs of recovery in the labour market, but no relief to the squeeze on living standards and wages.</p> <p>The youth unemployment data will also be scrutinised, with <a href=\"http://www.presstv.ir/detail/2013/11/13/334472/uk-youth-unemployment-rises-report/\"><strong>a new report warning that the jobless rate among young people has still risen despite the UK economy returning to growth</strong></a>.</p> </div> </div> <div id=\"block-52834019e4b07aa4168b4afa\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:05:22.339Z\">9.05am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Bad economic data from the Netherlands -- retail sales tumbled by 6.1% year-on-year in September.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/lexvandam/statuses/400544001645752320\"> <blockquote class=\"twitter-tweet\"><p>Shocking: NETHERLANDS SEPT RETAIL SALES Y/Y: -6.1% V -0.7% PRIOR</p>— Lex van Dam (@lexvandam) <a href=\"https://twitter.com/lexvandam/statuses/400544001645752320\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52833b63e4b0b9c05d8a345e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:54:03.704Z\">8.54am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png\" alt=\"European stock markets, early trading, November 13 2013\" width=\"460\" height=\"137\" class=\"gu-image\" /> <figcaption>European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters</figcaption> </figure> <p>European stock markets are in the red this morning, with the FTSE 100 shedding 47 points or 0.7%.</p> <p>Traders are blaming nervousness ahead of <a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283235be4b0312d704c116a\"><strong>the Bank of England's inflation report</strong></a>&nbsp;(<em>what will Mark Carney say about growth prospects and rate rises?</em>), and another bout of jitters over when the US Federal Reserve will start to slow its own stimulus programme.</p> <p>There's also a knock-on effect from Asia. China's stock market shed 2% following the conclusion of the Beijing government's Plenary meeting where <a href=\"http://www.theguardian.com/world/2013/nov/12/china-markets-decisive-role-economy\"><strong>leaders pledged to give the markets a &quot;decisive role&quot; in the country's economic future</strong></a>.</p> <p><a href=\"https://twitter.com/Accendo_Mike\"><strong>Mike van Dulken of Accendo Markets</strong></a> says traders are</p> <blockquote class=\"quoted\"> <p>disappointed&nbsp;by the rather general/vague&nbsp;Chinese statement&nbsp;in terms of its plan for the next decade.</p> </blockquote> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T08:54:21.368Z\">at 8.54am GMT</time></p> </div> <div id=\"block-52833755e4b0b9c05d8a345c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:41:50.014Z\">8.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>In the corporate world, Sainsbury's is getting into the early festive spirit with a 7% jump in profits, the top of analyst forecasts.</strong></p> <p>The supermarket chain also reported that its market share was at its highest for a decade, but remained cautious about UK economic prospects.</p> <p>Phil Dorrell, director of the retail consultants Retail Remedy, reckons &quot;The fairytale continues at Sainsbury's&quot;, and predicts it will do well this Christmas.</p> <h2>More here: <a href=\"http://www.theguardian.com/business/2013/nov/13/sainsburys-rise-7-percent-own-brand-online-sales\">Sainsbury's profit rise 7% as own-brand and online sales thrive</a></h2> </div> </div> <div id=\"block-52833971e4b0f37bee4ff615\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:39:02.545Z\">8.39am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Robin Bew</strong> of the&nbsp;Economist Intelligence Unit tweets that <a href=\"http://www.theguardian.com/business/2013/nov/12/inflation-fall-welcomed-by-government\"><strong>yesterday's drop in UK inflation, to 2.2%</strong></a>, gives Mark Carney and colleagues a little more room to&nbsp;manoeuvre.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/RobinBew/statuses/400513462440566784\"> <blockquote class=\"twitter-tweet\"><p>Lower <a href=\"https://twitter.com/search?q=%23UK&amp;src=hash\">#UK</a> inflation data means <a href=\"https://twitter.com/search?q=%23BoE&amp;src=hash\">#BoE</a> faces better growth/price mix than expected. Gives them a bit more policy flexibility</p>— Robin Bew (@RobinBew) <a href=\"https://twitter.com/RobinBew/statuses/400513462440566784\">November 13, 2013</a></blockquote> </figure> <p>And as our economics editor Larry Elliott wrote yesterday, spending power is on the wane in many countries.</p> <h2><a href=\"http://www.theguardian.com/business/2013/nov/12/inflation-fall-spending-power-squeeze-uk\">Inflation fall shows effects of spending power squeeze</a></h2> </div> </div> <div id=\"block-528330a5e4b0f37bee4ff613\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:21:27.995Z\">8.21am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Speaking of the eurozone, we get also industrial production data for September at 10am -- economists expect a 0.3% drop month-on-month.</strong></p> <p>Germany's top central banker, Jens Weidmann, is giving a speech around noon GMT. Let's hope he comments on last week's ECB interest rate cut, given the Bundesbank chief is understood to have opposed it.</p> <p>Greece's finance minister, Yannis Stournaras, meanwhile is reported to be in Brussels - perhaps preparing for tomorrow's Eurogroup meeting of finance ministers.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BloombergAthens/statuses/400527179475214337\"> <blockquote class=\"twitter-tweet\"><p>Greek Finance Minister Yannis Stournaras in Brussels</p>— Bloomberg Athens (@BloombergAthens) <a href=\"https://twitter.com/BloombergAthens/statuses/400527179475214337\">November 13, 2013</a></blockquote> </figure> <p>Yesterday, Stournaras denied that the Athens government and its troika inspectors were &quot;miles&quot; apart in their assessment of Greece's performance against its bailout programme. <a href=\"http://www.ekathimerini.com/4dcgi/_w_articles_wsite1_1_12/11/2013_527556\"><strong>It's just meters, he insisted</strong></a>.&nbsp;</p> </div> </div> <div id=\"block-52833237e4b0b9c05d8a345b\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:13:11.498Z\">8.13am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Spain reports deflation in October</h2> <div class=\"block-elements\"> <p><strong>Spain's annual inflation rate turned negative last month, according to new data that will heighten concerns that parts of the eurozone are slipping into deflation</strong>.</p> <p>The latest inflation data showed that the Spanish consumer prices index <strong>fell by 0.1% in October</strong>, on an annual basis. On a monthly basis, the CPI rose by 0.4%.&nbsp;</p> <p>On an 'EU harmonised basis', prices were flat year-on-year.&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/minefornothing/statuses/400534375164825600\"> <blockquote class=\"twitter-tweet\"><p>Spanish CPI drops to -0.1% YoY in October <a href=\"https://twitter.com/search?q=%23deflation&amp;src=hash\">#deflation</a></p>— MineForNothing (@minefornothing) <a href=\"https://twitter.com/minefornothing/statuses/400534375164825600\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BBCGavinHewitt/statuses/400535222162579456\"> <blockquote class=\"twitter-tweet\"><p>Further indication of weak demand in euro-zone. Spanish consumer prices fell 0.1% compared to October last year - the first fall in 4 years.</p>— Gavin Hewitt (@BBCGavinHewitt) <a href=\"https://twitter.com/BBCGavinHewitt/statuses/400535222162579456\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/ReutersJamie/statuses/400535572650807296\"> <blockquote class=\"twitter-tweet\"><p>Spain in deflation. Annual CPI -0.1% in Oct. It was +3.5% only a year ago: <a href=\"http://t.co/x5f5Z9iEcr\">pic.twitter.com/x5f5Z9iEcr</a></p>— Jamie McGeever (@ReutersJamie) <a href=\"https://twitter.com/ReutersJamie/statuses/400535572650807296\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/fwred/statuses/400536877502971904\"> <blockquote class=\"twitter-tweet\"><p>Spanish HICP inflation revised down to 0.0% YoY in October (vs. preliminary estimate of +0.1%). <a href=\"https://twitter.com/search?q=%23Dword&amp;src=hash\">#Dword</a></p>— Frederik Ducrozet (@fwred) <a href=\"https://twitter.com/fwred/statuses/400536877502971904\">November 13, 2013</a></blockquote> </figure> <p>We have seen a steady stream of low inflation rates recently (German's CPI fell to 1.2%), while <a href=\"http://www.reuters.com/article/2013/11/08/greece-inflation-idUSEMS1C747020131108\">the cost of living fell by 2.0% in Greece last month</a>. <em>Understandable, given sluggish demand, weak European growth and cash-strapped consumers.</em></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T08:24:37.877Z\">at 8.24am GMT</time></p> </div> <div id=\"block-52833020e4b0312d704c116b\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:56:12.818Z\">7.56am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>City traders are predicting the blue-chip Footsie index will drop by around 0.6%, when trading begins in a few minutes.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/DavidJones_IG/statuses/400529358357798912\"> <blockquote class=\"twitter-tweet\"><p>Quite a weak start forecast for the FTSE this morning- currently expected to open -45 at 6682.</p>— David Jones (@DavidJones_IG) <a href=\"https://twitter.com/DavidJones_IG/statuses/400529358357798912\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52832e69e4b0b9c05d8a3459\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:52:46.164Z\">7.52am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Much was made of Mark Carney's Canadian background when he was named as Sir Mervyn King's successor. The FT has now discovered that he's also the proud holder of Irish citizenship too:</p> <p>Chris Giles reports:</p> <blockquote class=\"quoted\"> <p>Since his arrival as governor of the Bank of England in July Mark Carney has had the luck of the Irish, enjoying rising growth, falling unemployment and rapidly moderating inflation.</p> <p>That cannot have been much of a surprise to the BoE or Treasury as on Tuesday night both confirmed that the Canadian running the old Lady of Threadneedle Street has also held Irish citizenship since 1988 when he started working for Goldman Sachs in London.</p> </blockquote> <h2>More here:&nbsp;<a href=\"http://www.ft.com/cms/s/0/ee169c30-4bc6-11e3-a02f-00144feabdc0.html?siteedition=uk#axzz2kQ6dOH6F\"><strong>Mark Carney brings luck of the Irish to BoE</strong></a></h2> <p>And on the FT's front page:</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/suttonnick/statuses/400384504235184128\"> <blockquote class=\"twitter-tweet\"><p>Wednesday's FT front page - &quot;Forex probe widens to at least 15 big banks&quot; <a href=\"https://twitter.com/search?q=%23tomorrowspaperstoday&amp;src=hash\">#tomorrowspaperstoday</a> <a href=\"https://twitter.com/search?q=%23bbcpapers&amp;src=hash\">#bbcpapers</a> <a href=\"http://t.co/YQkIpAjAkY\">pic.twitter.com/YQkIpAjAkY</a></p>— Nick Sutton (@suttonnick) <a href=\"https://twitter.com/suttonnick/statuses/400384504235184128\">November 12, 2013</a></blockquote> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T07:52:56.198Z\">at 7.52am GMT</time></p> </div> <div id=\"block-5283235be4b0312d704c116a\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:31:30.171Z\">7.31am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England and UK unemployment data</h2> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg\" alt=\"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.\" width=\"460\" height=\"307\" class=\"gu-image\" /> <figcaption>Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS</figcaption> </figure> <p><strong>Good morning, and welcome to our rolling coverage of events across the economy, the financial markets, the eurozone and the business world.</strong></p> <p>UK economics is centre-stage today, with the release of fresh unemployment data (<strong>at 9.30am</strong>) followed by the Bank of England's quarterly inflation report (<strong>from 10.30am</strong>).&nbsp;</p> <p><strong>And what a difference three months makes.</strong> Back on August 7, governor Mark Carney pushed the Bank of England into a bold new era by <a href=\"http://www.theguardian.com/business/2013/aug/07/bank-of-engand-links-interest-rates-jobless-target\"><strong>setting 'forward guidance' on interest rates</strong></a>. Effectively he pledged that borrowing costs won't rise until the UK jobless rate drops to 7% (<em>from 7.7% a month ago</em>), which Carney didn't see happening until 2016.</p> <p>Since then, a rich seam of solid economic data has shown that Britain's economy is performing better than most analysts thought in August. So the Bank is likely to upgrade its growth forecasts, and could also predict that unemployment will fall faster than previously expected.</p> <p><strong>And that could fuel predictions that UK interest rates will finally rise from their record low of 0.5% somewhat earlier than 2016</strong>.</p> <p>The unemployment data, meanwhile, is expected to show another drop in the number of people signing on for the Jobseeker's Allowance in October. The headline jobless rate is expected to stay at 7.7% for the three months to September.</p> <p>Michael Hewson of CMC helpfully rounds up the recent figures:</p> <blockquote class=\"quoted\"> <p>The latest&nbsp;unemployment&nbsp;numbers look set to show the&nbsp;ILO September&nbsp;unemployment&nbsp;rate stuck at 7.7%&nbsp;despite double digit falls in jobless claims numbers for the last four months.</p> <p>Claims numbers for October&nbsp;are expected to show another&nbsp;double digit decline of 33k, following on from declines of 41.7k, 32.6k, 29.2k and 21.2k, in previous months.</p> </blockquote> <p>But with pay still lagging behind inflation (which fell to 2.2% yesterday), it may not feel like a recovery to many.</p> <p><em><strong>We'll be tracking all the events through the day...</strong></em></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T07:42:19.086Z\">at 7.42am GMT</time></p> </div><!-- Guardian Watermark: internal-code/content/422360318|2013-11-13T15:50:01Z|c26f4ab4f6e13790bb78440fbf15a02fc58d90e8 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+        "wordcount":"1",
+        "liveBloggingNow":"true"
+      },
+      "tags":[{
+        "id":"business/series/guardian-business-live",
+        "type":"series",
+        "webTitle":"Guardian business live",
+        "webUrl":"http://www.theguardian.com/business/series/guardian-business-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/guardian-business-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/debt-crisis",
+        "type":"keyword",
+        "webTitle":"Eurozone crisis",
+        "webUrl":"http://www.theguardian.com/business/debt-crisis",
+        "apiUrl":"http://content.guardianapis.com/business/debt-crisis",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/series/eurozone-crisis-live",
+        "type":"series",
+        "webTitle":"Eurozone crisis live",
+        "webUrl":"http://www.theguardian.com/business/series/eurozone-crisis-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/eurozone-crisis-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/euro",
+        "type":"keyword",
+        "webTitle":"Euro",
+        "webUrl":"http://www.theguardian.com/business/euro",
+        "apiUrl":"http://content.guardianapis.com/business/euro",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/bankofenglandgovernor",
+        "type":"keyword",
+        "webTitle":"Bank of England",
+        "webUrl":"http://www.theguardian.com/business/bankofenglandgovernor",
+        "apiUrl":"http://content.guardianapis.com/business/bankofenglandgovernor",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/mark-carney",
+        "type":"keyword",
+        "webTitle":"Mark Carney",
+        "webUrl":"http://www.theguardian.com/business/mark-carney",
+        "apiUrl":"http://content.guardianapis.com/business/mark-carney",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/unemployment-and-employment-statistics",
+        "type":"keyword",
+        "webTitle":"Unemployment and employment statistics",
+        "webUrl":"http://www.theguardian.com/business/unemployment-and-employment-statistics",
+        "apiUrl":"http://content.guardianapis.com/business/unemployment-and-employment-statistics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/minutebyminute",
+        "type":"tone",
+        "webTitle":"Minute by minutes",
+        "webUrl":"http://www.theguardian.com/tone/minutebyminute",
+        "apiUrl":"http://content.guardianapis.com/tone/minutebyminute",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"profile/graemewearden",
+        "type":"contributor",
+        "webTitle":"Graeme Wearden",
+        "webUrl":"http://www.theguardian.com/profile/graemewearden",
+        "apiUrl":"http://content.guardianapis.com/profile/graemewearden",
+        "bio":"<p>Graeme Wearden is a <a href=\"http://www.guardian.co.uk/business\">business</a> reporter on guardian.co.uk and writes breaking City news plus the occasional blog. Previously he worked as a technology journalist at CNET Networks</p>",
+        "r2ContributorId":"19202",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/01/graeme_wearden_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/nickfletcher",
+        "type":"contributor",
+        "webTitle":"Nick Fletcher",
+        "webUrl":"http://www.theguardian.com/profile/nickfletcher",
+        "apiUrl":"http://content.guardianapis.com/profile/nickfletcher",
+        "bio":"<p>Nick Fletcher is a Guardian columnist and writer of the Market Forces column</p>",
+        "rcsId":"GNL023406",
+        "r2ContributorId":"16178",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/03/nick_fletcher_140x140.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"84",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"276",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"132",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"612",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"180",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"324",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"68",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"228",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"372",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"620"
+          }
+        }]
+      },{
+        "id":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"251",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"453",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"386",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"117",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"318",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"184",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"68",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"68"
+          }
+        }]
+      },{
+        "id":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"184",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"233",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"282",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"380",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1261",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"68",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"331",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"625",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"768",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"86",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"135",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"159",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"448",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"101",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1490",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"333",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"275",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"738",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"68",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1536",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"217",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"390",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"768",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"360",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"133",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"284",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"401",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"423"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"209",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"310",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"586",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"356",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"768",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"355",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"309",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"256",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"346",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"167",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"78",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"123",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"212",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"301",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"134",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"86",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"330",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"232",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"379",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"281",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"183",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"121",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"253",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"77",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"340",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"209",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"296",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"165",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"161",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"66",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"185",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"68",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"90",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"114",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"137",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"42",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"211",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"706"
+          }
+        }]
+      },{
+        "id":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"680",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"93",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1374",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"147",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"68",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1536",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"307",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"200",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"253",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"768",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"413",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"360",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"540"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T08:30:00Z",
+      "webTitle":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "fields":{
+        "trailText":"<p>Thousands storm rice warehouse in the devastated central Philippines while Haiyan relief effort flounders</p>",
+        "headline":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+        "body":"<video data-media-id=\"gu-video-422358527\" class=\"gu-video\" controls=\"controls\" poster=\"\">\n        <source src=\"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4\"></source><source src=\"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp\"></source><source src=\"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp\"></source><source src=\"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8\"></source>\n      </video><p>Eight people have been killed in the typhoon-ravaged central Philippines after thousands of Haiyan survivors stormed a government-owned rice warehouse seeking food supplies.</p><p>The Philippines National Food Authority said police and soldiers stood by helpless as people streamed into the warehouse in Alangalang, Leyte province – an area where hunger and desperation are running high after Haiyan made landfall early on Friday morning, ravaging vast swaths of Leyte and Samar islands. The security forces could only watch as more than 100,000 sacks of rice were carried away. </p><p>The eight were crushed to death when a wall in the warehouse collapsed, spokesman Rex Estoperez told the Associated Press. Other rice warehouses were dotted around the region, he said, refusing to give their locations for security reasons.</p><p>The Philippines government has come under fire for failing to deliver aid adequately or quickly enough, with growing frustration in the hardest hit areas, such as Tacloban, the capital of Leyte province where dead bodies have piled up on the streets and residents have resorted to looting to find food.</p><p>A military official told the Guardian on Wednesday that the government was aiming to double its relief efforts within the next two days. Attempts to provide help were buoyed by the expected arrival of two extra US military C-130 planes and one additional Australian air force plane.</p><p>Three relief distribution points were being set up in the Leyte island towns of Tacloban, Guiuan and Ormoc, the official said, with the main aid effort operating out of neighbouring Cebu instead of Manila, the capital, which is 360 miles to the north.</p><p>More than 10,000 people are feared to have been killed in the Philippines due to Haiyan, most of them in Leyte province, with aid workers suggesting that number may rise significantly. As many as 29 municipalities have still not been reached due to impassable roads and downed telecommunications. </p><p>President Benigno Aquino III said on Tuesday that he believed the number killed to be far lower – around 2,500 – and told CNN that the 10,000 figure may have come from an \"emotional\" official, with government figures alleging that the death toll stands at 2,275. The UN has said more than 670,000 people have been displaced and a total of 11.3 million people directly affected by the super storm.</p><p>International relief efforts intensified with the launch of a UN appeal and the dispatch of American, British and Japanese troops to the affected regions. But minimal amounts of aid have reached the worst‑hit areas.</p><p>More than 3,000 people surged on to the tarmac of Tacloban airport on Tuesday morning in the hope of flying out on the two Philippine air force planes that had just arrived.</p><p>Babies and sick or elderly people were given priority but only a few hundred were able to leave. Others were held back by soldiers and police. Many had walked for hours and camped at the base overnight.</p><p>\"I was pleading with the soldiers. I was kneeling and begging because I have diabetes,\" said Helen Cordial as she lay on a stretcher, shaking. \"Do they want me to die in this airport? They are stone-hearted,\" she told the Associated Press.</p><p>Dean Smith, an Australian who has been living with his family near Palo, Leyte province, for the last five years, told the Guardian that he waited eight hours to be able to get one of the first commercial flights out of Tacloban to Cebu. On the way to the airport he said he saw \"horrifying things that I know I have seen but my brain hasn't processed yet\". </p><p>He described scenes of chaos in the city centre, where police were stealing money from the local cashpoints, people in cars were refusing to drive the injured to get help, and the bloated body of a man floating in dirty water was being gnawed at by a dog.</p><p>\"What people have gone through, what they have seen – there is going to be a lot of post-traumatic stress after this event I assure you,\" he said shakily. \"No one has ever seen anything like this.\"</p><p>Having arrived on Tuesday in Cebu, Smith was planning to stock up on food, medicine and water and take it back to his Palo home, where his wife, six children, a 92-year-old grandmother and a pregnant nanny were all desperately awaiting supplies. He departed for Tacloban early on Wednesday morning.</p><p>Domestic and international relief efforts were being hampered by wet weather, poor communications and damaged infrastructure, with aircraft only able to land in Tacloban during daylight hours because the air control tower had been destroyed by Haiyan. Unsubstantiated reports of aid convoys being attacked by hungry victims circulated, with the Telegraph reporting that communist rebels had been killed whilst <a href=\"http://www.telegraph.co.uk/news/worldnews/asia/philippines/10445615/Typhoon-Haiyan-aid-convoys-come-under-fire-as-relief-operation-becomes-logistical-nightmare.html\">trying to intercept a Red Cross convoy</a> destined for the island of Samar.</p><p>Still, Corizon Soliman, secretary of the Philippine department of social welfare and development, said aid had so far reached a third of the city's 45,000 families.</p><p>However armed forces spokesman Ramon Zagala told the BBC that relief workers were struggling to deliver aid for a number of reasons.</p><p>\"The area is very vast and the number of helicopters – although we have a lot of helicopters at the moment – it's really a challenge for us to bring [aid] to all the places and [bring] the number of goods that are needed.\"</p><p>The BBC quoted a Leyte official as saying that although relief goods like medicine and equipment were arriving into the province \"it's just not reaching the people affected\".</p><p>The UN released $25m (£15.7m) in emergency funds for shelter materials and household items, and for assistance with emergency health services, safe water supplies and sanitation.</p><p>The UN aid chief, Valerie Amos, launched an appeal for $300m as she arrived in Manila. \"We have deployed specialist teams, vital logistics support and dispatched critical supplies but we have to do more and faster,\" she said.</p><p>The US, Britain, Japan, Australia and other nations have pledged tens of millions of dollars in immediate aid, and some businesses have also offered help: banking group HSBC announced a $1m (£630,000) cash donation.</p><p>In Tacloban shops were stripped of food and water by hungry residents. While some tents had arrived, the widespread damage left many people sleeping in the ruins of their homes or under shredded trees.</p><p>Military doctors at a makeshift clinic at the airport said they had treated about 1,000 people for cuts, bruises and deep wounds but did not have enough medical supplies.</p><p>\"It's overwhelming,\" said Antonio Tamayo, an air force captain. \"We need more medicine. We can't give anti-tetanus vaccine shots because we have none.\"</p><p>The typhoon flattened Basey, a seaside town in Samar province about six miles across a bay from Tacloban. About 2,000 people were missing there, its governor said. Rescue and relief workers were yet to reach many of the more remote areas.</p><p>\"There are hundreds of other towns and villages stretched over thousands of kilometres that were in the path of the typhoon and with which all communication has been cut,\" said Natasha Reyes, emergency co-ordinator in the Philippines at Médecins Sans Frontières. \"No one knows what the situation is like in these more rural and remote places, and it's going to be some time before we have a full picture.\"</p><p>Damage to communications left the armed forces struggling to reach local authorities and many officials were dead, missing or trying to protect their own families.</p><p>\"Basically the only branch of government that is working here is the military,\" Ruben Guinolbay, a Philippine army captain, told Reuters in Tacloban. \"That is not good. We are not supposed to take over government.\"</p><p>The interior secretary, Manuel Roxas, said on Tuesday that only 20 of Tacloban's 293 police had arrived for work. But he added: \"Today we have stabilised the situation. There are no longer reports of looting. The food supply is coming in. Up to 50,000 food packs are coming in every day, with each pack able to feed up to a family of five for three days.\"</p><p>A team of British medical experts and the first consignment of aid from the UK was leaving for the Philippines, David Cameron said on Tuesday.</p><p>The UK surgical team, led by Anthony Redmond, Manchester University professor of international emergency medicine, includes three emergency physicians, two orthopaedic surgeons, a plastic surgeon, two accident and emergency nurses, a theatre nurse, two anaesthetists and one specialist physiotherapist.</p><p>The USS George Washington aircraft carrier, transporting about 5,000 sailors and more than 80 aircraft, plus four other US navy ships, should arrive in two to three days, the Pentagon said.</p><p>Britain's HMS Daring, a warship with equipment to make drinking water from seawater, and a military transport aircraft should arrive around the same time.</p><p>Japan is sending a team of 40 from its self-defence force.</p><p>Aquino has declared a state of national calamity, allowing the central government to release emergency funds more quickly and impose price controls.</p><p>Initial estimates of the cost of the damage vary widely, with a report from German-based CEDIM Forensic Disaster Analysis putting the total at anywhere from $8bn to $19bn.</p><!-- Guardian Watermark: internal-code/content/422353950|2013-11-13T15:50:02Z|1b088629789b800f85fe2370f2d4235e37131e6c -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgx",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+        "wordcount":"1488",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/typhoon-haiyan",
+        "type":"keyword",
+        "webTitle":"Typhoon Haiyan",
+        "webUrl":"http://www.theguardian.com/world/typhoon-haiyan",
+        "apiUrl":"http://content.guardianapis.com/world/typhoon-haiyan",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/philippines",
+        "type":"keyword",
+        "webTitle":"Philippines",
+        "webUrl":"http://www.theguardian.com/world/philippines",
+        "apiUrl":"http://content.guardianapis.com/world/philippines",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/natural-disasters",
+        "type":"keyword",
+        "webTitle":"Natural disasters and extreme weather",
+        "webUrl":"http://www.theguardian.com/world/natural-disasters",
+        "apiUrl":"http://content.guardianapis.com/world/natural-disasters",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/asia-pacific",
+        "type":"keyword",
+        "webTitle":"Asia Pacific",
+        "webUrl":"http://www.theguardian.com/world/asia-pacific",
+        "apiUrl":"http://content.guardianapis.com/world/asia-pacific",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/taniabranigan",
+        "type":"contributor",
+        "webTitle":"Tania Branigan",
+        "webUrl":"http://www.theguardian.com/profile/taniabranigan",
+        "apiUrl":"http://content.guardianapis.com/profile/taniabranigan",
+        "bio":"<p>Tania Branigan is <a href=\"http://www.guardian.co.uk/world/china\">China correspondent</a> for the Guardian</p>",
+        "rcsId":"GNL004773",
+        "r2ContributorId":"16507",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/tania_branigan_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/kate-hodal",
+        "type":"contributor",
+        "webTitle":"Kate Hodal",
+        "webUrl":"http://www.theguardian.com/profile/kate-hodal",
+        "apiUrl":"http://content.guardianapis.com/profile/kate-hodal",
+        "r2ContributorId":"47767",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422364488",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Bullit Marquez",
+            "altText":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban",
+            "height":"84",
+            "credit":"Bullit Marquez/AP",
+            "caption":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban. Photograph: Bullit Marquez/AP",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-video-422358527",
+        "relation":"body",
+        "type":"video",
+        "assets":[{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "sectionId":"travel",
+      "sectionName":"Travel",
+      "webPublicationDate":"2013-11-13T14:06:00Z",
+      "webTitle":"Top 10 budget restaurants and cafes in central London",
+      "webUrl":"http://www.theguardian.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "apiUrl":"http://content.guardianapis.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "fields":{
+        "trailText":"<p>Updating his last budget eats guide to central London, Tony Naylor discovers that, particularly in and around Soho, the capital is home to a thriving casual dining scene</p>",
+        "headline":"Top 10 budget restaurants and cafes in central London",
+        "body":"<h2>Koshari Street</h2><p>Koshari is an Egyptian snack food, a warm mix of rice, chickpeas and macaroni, topped with fresh tomato sauce, sold from street stalls and hole-in-the-wall takeaways. Koshari Street – a tiny, slick canteen with limited counter seating – serves Lebanese cook and food writer Anissa Helou's take on this Cairo classic, which she has jazzed-up with toasted vermicelli, crispy, caramelised onions, garlic sauce and an aromatic sprinkling of mixed nuts, herbs and spices. The &quot;hot&quot; tomato sauce is a little meek (there is also a &quot;mad&quot; version to try), but the filling koshari offers layers of bright, interesting flavours. Thanks to that secret doqqa spice mix, you get a heady whiff of something exotic each time you exhale. <br />• <em>Koshari from &pound;4.50, salads, soups and wraps from &pound;2.95. 56 St Martin's Lane WC2, 020-7836 1056, </em><a href=\"http://www.kosharistreet.com/\" title=\"\"><em>kosharistreet.com</em></a></p><h2>Honey &amp; Co.</h2><figure data-media-id=\"gu-image-422397456\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg\" alt=\"Honey &amp; Co Cafe, Soho, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption>Photograph: Heloise Faure</figcaption></figure><p>At lunch and dinner, this small, critically acclaimed cafe-restaurant is a little too expensive for the true budget traveller. Instead, slip in at breakfast to try Sarit Packer and Itamar Srulovich's skilful Levantine cooking at sub-&pound;10 prices. The morning menu runs from baked goods (blueberry and sour cream doughnuts; toasted fig, walnut and orange loaf), to pizza-like lahma breads topped with, for instance, spiced lamb, tahini and pine nuts. There is usually an ijje (herb and feta) frittata on the menu, too. A merguez sausage roll was excellent: the pastry light and buttery, the two spicy lamb sausages nicely moistened by a base slather of vivid tomato sauce. On the side, a dollop of sweetly perfumed harissa added colour and, even at this time of day, you get a little complimentary bowl of chopped tomatoes, tiny hot green guindilla peppers and amazing kalamata olives, as sweet as they are salty and sour.<br />• <em>Breakfast, &pound;3–&pound;6. 25a Warren Street W1, 020-7388 6175,</em><a href=\"http://honeyandco.co.uk/\" title=\"\"><em> honeyandco.co.uk</em></a></p><h2>Attendant</h2><figure data-media-id=\"gu-image-422397457\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg\" alt=\"Attendant cafe-restaurant, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption>Photograph: Ming Tang-Evans</figcaption></figure><p>With its blaring music and old copies of The Face left about as reading material, there will be plenty of people who find Attendant too cool for school. And that is before we get to the quirky fact that this subterranean space was once a public toilet. You eat and drink at tiny counters built into an ornate Victorian urinal. Which would be painfully trendy, were Attendant's food and its artisan coffee (Caravan beans, Jersey cows' milk) not as good as they are. It's all relatively simple stuff: almond milk porridge and croissants at breakfast; soup, hot deli sandwiches, salads and Bittersweet bakery cakes at lunch. However, the ingredients used are first-rate and it's all rendered with a quiet flair. A breakfast muffin of Montgomery cheddar souffl&eacute; (actually, more a flattened omelette) was exemplary in its detail. Dressed with oven-roasted tomatoes, buttery pan-fried mushrooms and fresh baby spinach, every element tasted vibrantly of itself. That shouldn't be a surprise, but it is. <br /><em>• Sandwiches and hot dishes around &pound;3–&pound;5.50. 27a Foley Street W1, 020-7637 3794, </em><a href=\"http://www.the-attendant.com/\" title=\"\"><em>the-attendant.com</em></a></p><h2>Scandinavian Kitchen<br /></h2><figure data-media-id=\"gu-image-422397458\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg\" alt=\"Scandinavian kitchen, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>This specialist Scandi food store and cafe offers what can only be described as a smorgasbord of food to eat-in or takeaway. You can start your morning with toasted sourdough sandwiches, a smoked salmon and egg roll, or a Nordic rye and oat porridge that will put hairs on your chest. Then, for lunch, the kitchen dishes up numerous varieties of mix 'n' match wraps and open sandwiches (tiny, moreish meatballs in a sweet, sharp beetroot cream; smoked mackerel with fennel and crushed peas), accompanied by various salads. These might include new potatoes in a dill vinaigrette, or sharp, spritzy shredded white cabbage and oregano. The portions don't look huge, but, rest assured, those dark, heavy Scandinavian breads will fill you up. Of course, the cardamom-spiked kanelbullar swirls, sticky with cinnamon jam, are excellent; as are the smiley, eager-to-please staff. <br />• <em>Breakfast &pound;2.25–&pound;4.50, lunch &pound;2.95–&pound;9.95. 61 Great Titchfield Street W1, 020-7580 7161,</em><a href=\"http://www.scandikitchen.co.uk/\" title=\"\"><em> scandikitchen.co.uk</em></a></p><h2>Honest Burger</h2><figure data-media-id=\"gu-image-422397459\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg\" alt=\"Honest Burger\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>Made from 35-day aged beef (sourced from ace butcher the Ginger Pig), these thick patties – and Honest Burger's salty, rosemary-flecked, skin-on chips – are legendary across London. Arrive early to grab a seat or, if you're looking to keep the cost down, takeaway and dodge the queues altogether. At &pound;9.50, the eponymous Honest burger may sound expensive, but this is the sort of profoundly beefy burger – charred with a sensational crust on the outside, but still juicy and pink within – that will live long in the memory. It is complemented by a not overly sweet caramelised onion jam; dill-and-mustard-seed pickled cucumber; and superb thick-cut smoked bacon. <br />• <em>Beef burger and chips from &pound;8. 4a Meard Street W1, 020-3609 9524, </em><a href=\"http://honestburgers.co.uk/\" title=\"\"><em>honestburgers.co.uk</em> </a></p><h2>Foxcroft &amp; Ginger<br /></h2><figure data-media-id=\"gu-image-422397460\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg\" alt=\"Foxcroft and Ginger, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>With its utilitarian, white-tiled interior, hip music and good coffee, F&amp;G is quintessential modern Soho. A basement bakery keeps the counter filled with fantastic cakes (rich, ganache-like chocolate brownies are particularly brilliant, &pound;1.70), and breads that are used at lunch for &quot;saucy buns&quot;, filled with, for instance, slow-cooked pork, jalapenos, smoky tomatoes and mozzarella, or buttermilk fried chicken with avocado and garlic mayonnaise. My shredded beef and cheddar bun could have done with more of the advertised beef juices, but it was tasty enough. There are gourmet salads (such new potato with roasted lemon and radicchio), sandwiches and frittatas available and, in the evening, Foxcroft serves sourdough pizzas with innovative toppings.<br />• <em>Breakfast/weekend brunch, &pound;2.80–&pound;9.50, lunch &pound;3.50–&pound;6.50, pizzas from &pound;4.95. 3 Berwick Street W1, 020-3602 3371,</em><a href=\"http://foxcroftandginger.co.uk/\" title=\"\"><em> foxcroftandginger.co.uk</em></a></p><h2>Pizza Pilgrims</h2><figure data-media-id=\"gu-image-422397461\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg\" alt=\"Pizza Pilgrims, Soho, London\" width=\"460\" height=\"277\" class=\"gu-image\" /><figcaption>Photograph: Paul Winch-Furness</figcaption></figure><p>The gilded rise of brothers Thom and James Elliot, from street food sensations to proper restaurateurs (of course, they already have a glossy cookbook out), may rankle with those who, romantically, regard street food as eating's punk rock: a matter of grassroots passion, not a career. However, it is difficult to carp when, thanks to the Elliots, you can now takeaway A1 pizza, in the middle of Soho, from &pound;6. Whichever way you slice it, that has to be a good thing. Pilgrims' bases are somewhat thicker and softer than you might expect, yet blackened with patches of delicious char. Toppings run to the spicy Calabrian 'nduja, fennel sausage, portobello mushrooms and truffle, but the house-blitzed San Marzano plum tomato sauce is so vibrant it will, finally, make you understand why the Neapolitans love a cheese-free marina pizza. On a sunny day, take your pizza around the corner into the Soho Square gardens.<br />Pizza lovers should note that, at the time of writing, the renowned (and, for my money, marginally better)<a href=\"http://francomanca.co.uk\" title=\"\"> Franco Manca</a> were about to open a site on nearby Tottenham Court Road. <br />• <em>From &pound;6 takeaway, &pound;7 eat-in. 11 Dean Street W1, 020-7287 8964, </em><a href=\"http://pizzapilgrims.co.uk/\" title=\"\"><em>pizzapilgrims.co.uk</em></a></p><h2>Chettinad<br /></h2><figure data-media-id=\"gu-image-422397462\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg\" alt=\"Chettinad lunch box, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>When discussing tasty, affordable curry in central London, two venues come up again and again: the canteen at the Indian YMCA (41 Fitzroy Square, W1) and the &pound;6.95 daily buffet at Diwana Bhel Poori, close to Euston station (121-123 Drummond Street, NW1, 020-7387 5556). For the ultimate in budget dining, however, neither can compete with the take-out, lunch-box deal at Tamil restaurant Chettinad. Served in a moulded, airline-style tray, it comprises a nibbly starter, three curries, raita, a roti and rice, for &pound;3.75 (vegetarian) or &pound;3.95 (meat). No, that isn't a typo. That is a full meal for under four quid. Impressively studded with fresh herbs and spices, a couple of tiny, lukewarm bhajis were a bit tough and leathery, but rest of the food was remarkable for the money. The rice had been winningly mined with cashew nuts, lentils and mustard seeds and, like the best south Indian food, the curries were restrained in their heat, allowing well-rounded flavour to shine through. On a cold day, a melting, slow-cooked chickpea curry in a rich tomato sauce was first-rate comfort food. Note: you can eat-in and takeaway for under &pound;10 in the evening, too.<br />• <em>Lunch box from &pound;3.75, takeaway, eat-in lunch &pound;6.95. Evening curries with shared rice,from around &pound;8. 16 Percy Street W1, 020-3556 1229, </em><a href=\"http://chettinadrestaurant.com/\" title=\"\"><em>chettinadrestaurant.com</em></a></p><h2>Bi Bim Bap<br /></h2><figure data-media-id=\"gu-image-422397463\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg\" alt=\"Bi Bim Bap Soho \" width=\"460\" height=\"277\" class=\"gu-image\" /><figcaption></figcaption></figure><p>Served in blisteringly hot stone bowls, which cook the ingredients as you eat, bibimbap is a Korean mixed-rice dish of seemingly endless variations. One of which is catching on in central London, too. Bi Bim Bap has just opened a second site in Fitzrovia, in addition to its Soho original. My traditional dol sot, a mixed vegetable version with mooli, daikon, spinach and more, was surprisingly tasty, a fried egg giving it a lovely creamy texture. You can add sinus-clearing gochujang chilli sauce as you go. The staff will happily explain the intricacies of all this to any bibimbap virgins. <br />• <em>Bi Bim Bap from &pound;6.45–&pound;9.95. Branches at 11 Greek Street and 10 Charlotte Street W1, 020-7287 3434, </em><a href=\"http://www.bibimbaplondon.com/\" title=\"\"><em>bibimbaplondon.com</em></a></p><h2>Banh Mi Bay<br /></h2><p>The Theobalds Road branch has a slightly weird farmhouse kitchen look (as if set-up for a modern British tea room, rather than a busy Vietnamese cafe), but the Bay's food hits the mark. Behind the counter, a huge grill keeps the meats coming for bun salads and banh canh soups, both made using homemade noodles. They also server creditable banh mi, Vietnamese baguette sandwiches, which aren't the best in London – you'll have to go further east for that – but are authentically lighter than their French cousins; the meats deliver good flavours and, crucially, the shavings of pickled carrot and mooli are sharp enough to jangle your taste buds. Elsewhere, the menu runs from a six-hour simmered pho to savoury banh xeo pancakes. <br />• <em>Takeaway banh mi, &pound;4.35, noodle dishes and rice boxes from &pound;5.50. Branches at 4-6 Theobalds Road, Holborn, WC1, 020-7831 4079, and 21 Rathbone Street W1, 020-3609 4830, </em><a href=\"http://banhmibay.co.uk/\" title=\"\"><em>banhmibay.co.uk</em></a></p><p>• <em>Travel between Manchester and London was provided by </em><a href=\"http://virgintrains.co.uk/\" title=\"\"><em>Virgin Trains</em></a></p><!-- Guardian Watermark: internal-code/content/422388356|2013-11-13T15:50:01Z|4631bb312ce31beccd20be6f5f8f1461335ce0e5 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbp6",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+        "wordcount":"1573",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"travel/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/travel/london",
+        "apiUrl":"http://content.guardianapis.com/travel/london",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/travel/restaurants",
+        "apiUrl":"http://content.guardianapis.com/travel/restaurants",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/series/britains-best-budget-eats",
+        "type":"series",
+        "webTitle":"Britain's best budget eats",
+        "webUrl":"http://www.theguardian.com/travel/series/britains-best-budget-eats",
+        "apiUrl":"http://content.guardianapis.com/travel/series/britains-best-budget-eats",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"profile/tonynaylor",
+        "type":"contributor",
+        "webTitle":"Tony Naylor",
+        "webUrl":"http://www.theguardian.com/profile/tonynaylor",
+        "apiUrl":"http://content.guardianapis.com/profile/tonynaylor",
+        "bio":"<p>Tony Naylor lives in the north of England. He likes Greggs pasties, molecular gastronomy and lots of things in between. Outside of filling his face his interests include any licensed establishments, Manchester City, electronic music and some other stuff which could look a bit pretentious in print</p>",
+        "rcsId":"GNL009141",
+        "r2ContributorId":"16542",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/tony_naylor.jpg",
+        "references":[]
+      },{
+        "id":"travel/travel",
+        "type":"keyword",
+        "webTitle":"Travel",
+        "webUrl":"http://www.theguardian.com/travel/travel",
+        "apiUrl":"http://content.guardianapis.com/travel/travel",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/travelfoodanddrink",
+        "type":"keyword",
+        "webTitle":"Food and drink",
+        "webUrl":"http://www.theguardian.com/travel/travelfoodanddrink",
+        "apiUrl":"http://content.guardianapis.com/travel/travelfoodanddrink",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"travel/uk",
+        "type":"keyword",
+        "webTitle":"United Kingdom",
+        "webUrl":"http://www.theguardian.com/travel/uk",
+        "apiUrl":"http://content.guardianapis.com/travel/uk",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/europe",
+        "type":"keyword",
+        "webTitle":"Europe",
+        "webUrl":"http://www.theguardian.com/travel/europe",
+        "apiUrl":"http://content.guardianapis.com/travel/europe",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/england",
+        "type":"keyword",
+        "webTitle":"England",
+        "webUrl":"http://www.theguardian.com/travel/england",
+        "apiUrl":"http://content.guardianapis.com/travel/england",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/budget",
+        "type":"keyword",
+        "webTitle":"Budget travel",
+        "webUrl":"http://www.theguardian.com/travel/budget",
+        "apiUrl":"http://content.guardianapis.com/travel/budget",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397454",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349264516/Koshari-Street-London-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Koshari Street's twist on Egyptian street food",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397455",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Koshari Street, London",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422397456",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg",
+          "typeData":{
+            "source":"Heloise Faure",
+            "photographer":"Heloise Faure",
+            "altText":"Honey & Co Cafe, Soho, London",
+            "height":"276",
+            "credit":"Heloise Faure/Heloise Faure",
+            "caption":"Photograph: Heloise Faure",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397457",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg",
+          "typeData":{
+            "source":"Ming Tang-Evans",
+            "photographer":"Ming Tang-Evans",
+            "altText":"Attendant cafe-restaurant, London",
+            "height":"276",
+            "credit":"Ming Tang-Evans/Ming Tang-Evans",
+            "caption":"Photograph: Ming Tang-Evans",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397458",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Scandinavian kitchen, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397459",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Honest Burger",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397460",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Foxcroft and Ginger, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397461",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg",
+          "typeData":{
+            "source":"Paul Winch-Furness",
+            "photographer":"Paul Winch-Furness",
+            "altText":"Pizza Pilgrims, Soho, London",
+            "height":"277",
+            "credit":"Paul Winch-Furness/Paul Winch-Furness",
+            "caption":"Photograph: Paul Winch-Furness",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397462",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Chettinad lunch box, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397463",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Bi Bim Bap Soho ",
+            "height":"277",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-12T15:43:09Z",
+      "webTitle":"Jennifer Lawrence is striking a blow for healthy, sweaty women | Muireann Carey-Campbell",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "fields":{
+        "trailText":"<p><strong>Muireann Carey-Campbell:</strong> Shock, horror – a female film star says she wants to be 'fit and strong'. But the more women she gets into the gym the better</p>",
+        "headline":"Jennifer Lawrence is striking a blow for healthy, sweaty women",
+        "body":"<p>Glancing at gossip mags while waiting in the queue at the supermarket suggests that women have just two body types: grossly overweight (which is seemingly anything over a size 12) or skinny and boney. So when Jennifer Lawrence, current heroine of Hollywood and legend among outspoken women everywhere, says that she wants to be <a href=\"http://abcnews.go.com/blogs/entertainment/2012/11/jennifer-lawrence-considered-a-fat-actress/\" title=\"\">\"fit and strong\"</a>, it is music to our ears. Finally, recognition of another option.</p><p>On Newsnight, speaking of playing Katniss Everdeen in the Hunger Games, Lawrence said that she refused to lose weight for roles, explaining: \"We have the ability to control this image that young girls are going to be seeing. They see enough of this body that they will never be able to obtain and it's an amazing opportunity to rid ourselves of that in this industry.\"</p><p>Sure, it's silly that a body type should even need celebrity endorsement, but what Lawrence has done here is a pretty rare thing among her peers. Various female celebrities will trot out similar lines in what come across as weak Kumbaya moments, where womankind should all join hands and rejoice. Rarely though, do we ever hear high-profile women say they want to look healthy.</p><p>For those of us who lead active lifestyles, we've been flying this flag for a long time. Historically, it's been deemed rather unladylike to sweat, making exercise somewhat of a problem, lest we get a little red faced or our hair get dishevelled. Women have been ushered towards gentler forms of exercise – a spot of yoga, a cheesy Jane Fonda DVD, or if we want to go a bit crazy, some Zumba.</p><p>But the tide has been slowly turning. More and more women are shirking the idea that you're either sporty or not, and experimenting with different ways to stay active. We're pushing the boundaries of what it means to be feminine and fit. We're running ultra marathons, skateboarding, doing Muay Thai and, sorry to upset the apple cart here guys, but we're sweating profusely while doing it. What's more we're not exercising with vanity in mind. A survey of visitors to my fitness website <a href=\"http://spikesandheels.com/\" title=\"\">Spikes &amp; Heels</a> revealed that barely any of the women working out regularly did so for weight loss reasons. The majority cited overall health, fitness and mental wellbeing as their driving force.</p><p>I particularly appreciate that Lawrence mentioned she wants to be strong. Any woman with an ounce of common sense has figured out that the \"lifting weights makes you bulky\" school of thought is utter nonsense. Women are becoming less fearful of the weights section in the gym and are squatting and deadlifting their way to greatness.</p><p>The <a href=\"http://www.theguardian.com/lifeandstyle/2013/nov/03/thigh-gap-pressure-point-women-self-esteem\" title=\"\">\"thigh gap\" brigade</a> on Tumblr – legions of young women whose mission in life is to be so thin as to see a space between the tops of their legs – have come up against a new breed of fit chicks. The \"Strong is the new Sexy\" crowd post photos of women with defined muscles and six packs, doing pull ups while glistening with sweat (they all still have perfect hair and makeup though – I'm not saying that this movement isn't without its flaws).</p><p>Jennifer Lawrence's comments couldn't have come at a better time. With levels of inactivity at an all-time high in this country, having someone in her position championing being fit and strong may be just the boost a young woman needs to make a change. Make your way to the weights section, ladies.</p><!-- Guardian Watermark: internal-code/content/422307757|2013-11-13T15:50:02Z|1fda122d5aabf079c8aed40993b3679f67d8d1cf -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb44",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+        "wordcount":"572",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"film/jennifer-lawrence",
+        "type":"keyword",
+        "webTitle":"Jennifer Lawrence",
+        "webUrl":"http://www.theguardian.com/film/jennifer-lawrence",
+        "apiUrl":"http://content.guardianapis.com/film/jennifer-lawrence",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/body-image",
+        "type":"keyword",
+        "webTitle":"Body image",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/body-image",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/body-image",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fitness",
+        "type":"keyword",
+        "webTitle":"Fitness",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fitness",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fitness",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"lifeandstyle/health-and-wellbeing",
+        "type":"keyword",
+        "webTitle":"Health & wellbeing",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/health-and-wellbeing",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/health-and-wellbeing",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/health",
+        "type":"keyword",
+        "webTitle":"Health",
+        "webUrl":"http://www.theguardian.com/society/health",
+        "apiUrl":"http://content.guardianapis.com/society/health",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/muireann-carey-campbell",
+        "type":"contributor",
+        "webTitle":"Muireann Carey-Campbell",
+        "webUrl":"http://www.theguardian.com/profile/muireann-carey-campbell",
+        "apiUrl":"http://content.guardianapis.com/profile/muireann-carey-campbell",
+        "bio":"<p>Muireann Carey-Campbell is a fashion, lifestyle and fitness blogger based in London. She is an advocate for empowering women through exercise and edits <a href-\"http://spikesandheels.com\">spikesandheels.com</a> and <a href=\"http://www./pikesandheels.com\">bangsandabun.com</a></p>",
+        "r2ContributorId":"59569",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384260881751/Muireann-Carey-Campbell.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422318972",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269380150/Jennifer-Lawrence-with-Jo-001.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"54",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269383552/Jennifer-Lawrence-with-Jo-002.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"130",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269387034/Jennifer-Lawrence-with-Jo-004.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"132",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269388680/Jennifer-Lawrence-with-Jo-005.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"168",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269390391/Jennifer-Lawrence-with-Jo-006.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"180",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269392235/Jennifer-Lawrence-with-Jo-007.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"228",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/Lionsgate/Sportsphoto Ltd",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422318973",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "sectionId":"technology",
+      "sectionName":"Technology",
+      "webPublicationDate":"2013-11-13T11:29:00Z",
+      "webTitle":"PS4: the 10 key launch titles",
+      "webUrl":"http://www.theguardian.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "apiUrl":"http://content.guardianapis.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "fields":{
+        "trailText":"<p>As the Sony PlayStation 4's US launch looms, here are the best initial titles, from Killzone: Shadow Fall to Call of Duty: Ghosts. By <strong>Keith Stuart</strong></p>",
+        "headline":"PS4: the 10 key launch titles",
+        "body":"<p>A few days ago, Amazon US posted a photo of its warehouse, stacked high with thousands of PlayStation 4 boxes, ready to ship out to American stores on Friday. At last, the arrival of the next console generation is imminent and palpable. It'll all be about the games from now on. Hopefully.</p><p>So to get us started, here are the 10 key PS4 launch titles – they're the ones we think will sell, or will define the launch period. Actually, some of them are just the ones that interest <em>us</em>. Whatever, have a look and see if you agree...  </p><h2><strong>Assassin's Creed IV Black Flag, Ubisoft</strong></h2><p>Set amid the swashbuckling and treasure pilfering of piracy's golden age, the latest yarn in Ubisoft's historical adventure series is a distinct improvement on the last couple of instalments. Loaded with visually astonishing sea battles, it's a lavish way to start your next-gen career. Plus, the good news for PS4 owners is that this version of the game contains an hour of additional content in the form of three extra missions. There's also an Assassin's IV console bundle, replacing the Drive Club one that's now on hold due to the game's development delay. You'll find a nice walkthrough of some of the single-player game <a href=\"http://youtu.be/jHDfm2AYZS4\">on PlayStation Access</a>.</p><h2><strong>Battlefield 4, Electronic Arts</strong></h2><p>Fantastic multiplayer maps, wonderfully apocalyptic destruction and the tight, taut action we've come to expect from the series, Battlefield 4 is in a commanding position as the top military shooters make the generational crossover. Several retailers are offering Battlefield bundles for Sony's machine, but you'll have to wait for the Second Assault DLC pack – it's a timed exclusive on Xbox One. YouTuber Ali A has some <a href=\"http://youtu.be/alB3t7-bZ-c\">rather nice multiplayer PS4 footage</a>.</p><h2><strong>Call of Duty: Ghosts, Activison</strong></h2><p>Infinity Ward has abandoned the Modern Warfare arc, but its futuristic America-in-peril narrative is hauntingly familiar, while the multiplayer dwells on the same old twitchcore tricks and tactics. This is, however, still a thrilling ride, and running at 1080p in 60 frames-a-second, it looks its absolute best on PS4. As with Battlefield, a timed Xbox One exclusivity deal means the first DLC drop will be delayed on Sony's machine – but you can just spend that time enjoying the superior graphical performance.</p><h2><strong>Contrast, Compulsion Games</strong></h2><p>One of the first indie titles to appear on PS4's digital platform, Contrast is a fascinating 20s-based platformer, following the imaginary friend of a young girl investigating the secrets of her troubled family. With vaudevillian settings, a cool jazz soundtrack and a stylised mix of 2D and 3D visuals, this is a stark contrast to the triple A hits. It's coming later to a bunch of other platforms, but it's worth catching on PS4 from launch.</p><h2><strong>Fifa 14/Madden, EA Sports</strong></h2><p>Okay, I'm cheating – this is two games – but of course, in launch terms these EA Sports blockbusters are doing the same thing. As well as appeasing sports mad gamers, they're providing the state-of-the-art football action for young male professionals who can afford to buy a new machine in order to play one or two games a year – and who invariably choose one of these two titles on an annual basis. Both games are <a href=\"http://www.theguardian.com/technology/gamesblog/2013/sep/02/fifa-14-preview-interview\">enhanced from their current-gen offerings</a> with better animations, AI and stadia – although the Xbox One version adds the Ultimate Team Legends content, with around 40 classic players.</p><h2><strong>Killzone: Shadow Fall, Sony</strong></h2><p>Guerrilla's ice-cold sci-fi blaster has been the PlayStation technical showcase of choice since the second console – and Shadow Fall is definitely a major player this time round too. Taking place 30 years after the last title, the action now plays out on a hostile planet where the Vektans and the Helghast are divided by a huge wall – and either metaphorically or physically, it's about to come crashing down. The game is clearly a graphical marvel, but the grit is beginning to wear thin. </p><h2><strong>Knack, Sony</strong></h2><p>Designed by Mark Cerny, the engineering leader on PS4 and veteran of such games as Sonic 2, Crash Bandicoot and Ratchet and Clank, this is Sony's own family pleaser. It's a colourful action adventure following the eponymous robot who can transform himself into a range of useful objects to defeat invading goblins. Early reports from the specialist press aren't exactly amazing, but the game looks to have plenty of charm and there are some arresting vistas to gaze upon.</p><h2><strong>Lego Marvel Super Heroes, Warner Bros</strong></h2><p>The latest title in the long-running Lego series switches from Batman and his DC pals to Marvel heroes like Hulk, Spider-Man and Wolverine. The formula is ridiculously familiar, but with that rich comic book heritage, some great set-pieces and a few fresh features for PS4, this entertaining adventure just pips Skylanders Swap Force (which also gets a visual overhaul for PS4) as the third-party kid-friendly title to opt for.</p><h2><strong>Resogun, Sony</strong></h2><p>Ah, another frenetic, hypnotic shooter from Super Stardust creator Housemarque, this time in a rotating 2D environment buzzing with laser blasts, eye-popping explosions and blazing score multipliers. It's got missiles, it's got nova-bombs and it'll be free for users who subscribe to the PlayStation Plus online gaming service. Until Xbox One gets a new Geometry Wars, this is the place to come for next-gen schmup action.</p><h2><strong>Super Motherload, XGen Studios</strong></h2><p>Another indie download, this time a procedurally generated digging sim with four-player co-op. Set on a colonised future Mars, the aim is to burrow deep under the planet's surface, grabbing minerals and bringing them to the surface for cash and experience points, which can be spent on customising your craft. Developed by Edmonton-based XGen Studios, it's sort of an RPG-infused version of brilliant platformer Spelunky, with some Mr Driller (the classic Namco arcade/Dreamcast puzzler) chucked in. This is a good thing.</p><p>• <a href=\"http://www.theguardian.com/technology/2013/oct/31/ps4-sony-playstation-cant-play-audio-cds-mp3s\">PS4: five new things we've learned</a><br />• <a href=\"http://www.theguardian.com/technology/2013/nov/11/playstation-four-makes-debut\">Sony has high hopes for PlayStation 4's debut this month</a><br />• <a href=\"http://www.theguardian.com/technology/2013/nov/06/ps4-or-xbox-one-parents-guide\">PS4 or Xbox One? A parent's guide</a></p><!-- Guardian Watermark: internal-code/content/422302794|2013-11-13T15:50:02Z|c314fd78fe9b31583a74bca281e885f6e94efa6d -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kb3x",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+        "wordcount":"964",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"technology/playstation-4",
+        "type":"keyword",
+        "webTitle":"PlayStation 4",
+        "webUrl":"http://www.theguardian.com/technology/playstation-4",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation-4",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/playstation",
+        "type":"keyword",
+        "webTitle":"PlayStation",
+        "webUrl":"http://www.theguardian.com/technology/playstation",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/sony",
+        "type":"keyword",
+        "webTitle":"Sony",
+        "webUrl":"http://www.theguardian.com/technology/sony",
+        "apiUrl":"http://content.guardianapis.com/technology/sony",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/games",
+        "type":"keyword",
+        "webTitle":"Games",
+        "webUrl":"http://www.theguardian.com/technology/games",
+        "apiUrl":"http://content.guardianapis.com/technology/games",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/technology",
+        "type":"keyword",
+        "webTitle":"Technology",
+        "webUrl":"http://www.theguardian.com/technology/technology",
+        "apiUrl":"http://content.guardianapis.com/technology/technology",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"profile/keithstuart",
+        "type":"contributor",
+        "webTitle":"Keith Stuart",
+        "webUrl":"http://www.theguardian.com/profile/keithstuart",
+        "apiUrl":"http://content.guardianapis.com/profile/keithstuart",
+        "bio":"<p>Keith Stuart is a veteran video game and technology writer, who is also a regular contributor to Edge magazine</p>",
+        "rcsId":"GNL007878",
+        "r2ContributorId":"15953",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Media/Columnists/Columnists/2013/11/8/1383915413362/Keith-Stuart--003.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388207",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288957309/KZ4_Blast3_main.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Killzone: Shadow Fall – a graphical showcase for Sony's next-gen PS4 console",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422388208",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"84",
+            "credit":"PR",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T13:54:18Z",
+      "webTitle":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "fields":{
+        "trailText":"Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol<br />",
+        "headline":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+        "body":"<p>Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol.</p><p>Meulensteen worked at Manchester United alongside Sir Alex Ferguson from 2007 to the summer when he left the club following David Moyes's appointment.</p><p>He had been linked with the vacant Crystal Palace job after <a href=\"http://www.theguardian.com/football/2013/nov/13/middlesbrough-real-madrid-aitor-karanka\" title=\"\">Aitor Karanka opted to join Middlesbrough</a> ahead of the south London club.</p><p>The Fulham chief executive officer, Alistair Mackintosh, <a href=\"http://www.fulhamfc.com/news/2013/november/13/meulensteen-arrives\" title=\"\">told the club website</a>: \"We're all delighted to welcome René to Fulham. There was always going to be a battle for René's services and, with the assistance of our chairman Shahid Khan, we've been able to bring one of the best coaches in the world to Fulham.\"</p><p>The move to bring in Meulensteen comes with the club inside the relegation places after 11 games.</p><p>Meulensteen, who will take up the post immediately, said: \"I was impressed by the vision of Shahid Khan and Alistair Mackintosh. I've spent many hours talking with Martin Jol and we share a vision of how football should be played and how players should be developed. It's our job to make sure we can bring this vision to life on the pitch for the fans.\"</p><p>Meulensteen's last job was in Russia in July at Anzhi Makhachkala, who he joined as assistant coach to another Dutchman, Guus Hiddink. However, Hiddink left the club two games into the season after which Meulensteen only lasted 16 days as manager.</p><p>Fulham have lost their last three matches and lie 18th in the league.</p><!-- Guardian Watermark: internal-code/content/422391502|2013-11-13T15:50:01Z|23b2cb358f236f651feef84f2f5293d946ee6c76 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbqd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+        "wordcount":"247",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"football/martin-jol",
+        "type":"keyword",
+        "webTitle":"Martin Jol",
+        "webUrl":"http://www.theguardian.com/football/martin-jol",
+        "apiUrl":"http://content.guardianapis.com/football/martin-jol",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/fulham",
+        "type":"keyword",
+        "webTitle":"Fulham",
+        "webUrl":"http://www.theguardian.com/football/fulham",
+        "apiUrl":"http://content.guardianapis.com/football/fulham",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/55"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397529",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350779268/Ren--Meulensteen-001.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"54",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350781955/Ren--Meulensteen-002.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"130",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350783658/Ren--Meulensteen-003.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"84",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350785345/Ren--Meulensteen-004.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"132",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350787149/Ren--Meulensteen-005.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"168",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350788867/Ren--Meulensteen-006.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"180",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350790688/Ren--Meulensteen-007.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"228",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350792437/Ren--Meulensteen-008.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"276",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351652017/Martin-Jol-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"276",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by the newly appointed head coach René Meulensteen (right) at Fulham. Photographs: PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397530",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"84",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by new head coach René Meulensteen (right) at Fulham. Photograph: PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/55"
+      }]
+    }],
+    "storyPackage":[]
+  }
+}

--- a/data/database/7d5c7a5540d70948f9338374d35aa72cd90ba5f7
+++ b/data/database/7d5c7a5540d70948f9338374d35aa72cd90ba5f7
@@ -1,0 +1,6211 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":1,
+    "mostViewed":[{
+      "id":"lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Why you won't catch me queuing for a burger",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "fields":{
+        "trailText":"<p><strong>Jay Rayner:</strong> Waiting two hours in a line for beef in a bun was never going to be a good idea</p>",
+        "headline":"Why you won't catch me queuing for a burger",
+        "body":"<p>I'm all for delayed gratification. I will book theatre tickets six months ahead. I will take a shoulder of lamb, stud it with anchovies and garlic and half-submerge it in a broth of red wine, stock and piggy bits, so that it looks like the ravaged island of Dr Moreau, shove it in the oven and know it will have nothing of any interest to say to me for at least seven hours.</p><p>What I won't do is <a href=\"http://www.theguardian.com/lifeandstyle/2013/nov/03/eat-out-queue-for-table\" title=\"\">queue for a hamburger</a>. In this, it seems, I am peculiar. Recently London's Covent Garden has seen the opening of the US operations Shake Shack and Five Guys. We also have home-grown outfits like Meat Liquor, and Burger and Lobster, which seem to regard reservation policies as bourgeois affectations. In the sense that bookable tables suit people with jobs, interesting lives and places they need to be which don't include standing dead-eyed and wet-lipped on a chilly pavement for the running time of <em>The Godfather Part III</em>, I suppose they are. And yes, it's not entirely new. The Hard Rock Cafe has long been famous for its queue, but that was so odd it was a tourist attraction, something people pointed and laughed at. The new queueing has got completely out of hand. It's taken for granted. I have wandered past these places on numerous occasions and been baffled. What in God's name possesses anyone to stand in an endless line – I've been quoted more than two hours for Burger and Lobster – for a lump of ground beef between two sugary buns?</p><p>Of course it's not just a lump of ground beef, is it? Over at the Shake Shack it's \"our proprietary Shack blend\" which makes it sound less like lunch and more like a haemorrhoid ointment; at Five Guys it's \"hand formed burgers cooked to perfection\". Really? Whose version of perfection, given that Westminster Council is trying to outlaw any burger served less than medium? Or completely buggered, as it's known.</p><p>I'll go that extra 10 miles to eat well. I'll cross London to secure an ingredient, take a flight to eat at the right restaurant. But queue? That's not an expression of greed. It's stamp-collecting. It's trainspotting. It's eating out as spectator sport. Except the only thing the queue has to spectate upon is itself, and there it finds validation: standing in line for a hamburger must be entirely reasonable; just look at all the other people doing it.</p><p>The counter-argument involves the P word: patience, and my total lack of it. Apparently patience is a virtue. Really? If everybody was patient, nothing would ever get done. The world depends on restless, impatient people. I should also point out that patience is one of the seven great Christian virtues. Nobody with an appetite should ever sign up to those. Obviously some are OK. I believe fully in humility. I am brilliant at that, do it better than anybody else. But chastity and temperance? Don't be silly. That's the point. Queuing for a burger is not about eating. It's about self-denial. And doing the restaurant's marketing for them by standing outside.</p><p>Me? I will go somewhere that serves a slightly less impressive burger and in so doing, trade a little of the perceived quality of the Shake Shack object of desire, for living more of my life. I've only got one of those, and I'm not wasting it in a queue.</p><!-- Guardian Watermark: internal-code/content/421828691|2013-11-13T15:50:01Z|4b3ef3429e53b630d10c1f8a057f6a070b28ee4f -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k6zt",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+        "wordcount":"567",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fast-food",
+        "type":"keyword",
+        "webTitle":"Fast food",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fast-food",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fast-food",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Observer Food Monthly recipes & features",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly/features",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly/features",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly",
+        "type":"newspaper-book",
+        "webTitle":"Observer Food Monthly",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"lifeandstyle/series/happy-eater",
+        "type":"series",
+        "webTitle":"Happy eater",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/happy-eater",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/happy-eater",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/jayrayner",
+        "type":"contributor",
+        "webTitle":"Jay Rayner",
+        "webUrl":"http://www.theguardian.com/profile/jayrayner",
+        "apiUrl":"http://content.guardianapis.com/profile/jayrayner",
+        "bio":"<p>Jay Rayner is the Observer's restaurant critic and a novelist. His latest book is the Oyster House Siege</p>",
+        "rcsId":"GNL258574",
+        "r2ContributorId":"15803",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2008/06/02/jay_rayner_140x140.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theobserver",
+        "type":"publication",
+        "webTitle":"The Observer",
+        "webUrl":"http://www.theguardian.com/theobserver/all",
+        "apiUrl":"http://content.guardianapis.com/theobserver/all",
+        "sectionId":"theobserver",
+        "sectionName":"From the Observer",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422287525",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259303137/burger-and-fries-from-sha-007.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"276",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about self-denial\". Photograph: Radharc Images/Alamy",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422287526",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"84",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about \nself-denial\". Photograph: Radharc Images /Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T12:58:39Z",
+      "webTitle":"It was hard to stomach David Cameron preaching austerity from a golden throne | Ruth Hardy",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "fields":{
+        "trailText":"<strong>Ruth Hardy: </strong>As a waitress at the lord mayor's banquet, the contrast between what Cameron was saying and where he was saying it felt particularly chilling",
+        "headline":"It was hard to stomach David Cameron preaching austerity from a golden throne",
+        "body":"<p>At a state banquet for the new Lord Mayor on Monday, David Cameron gave a <a href=\"http://www.theguardian.com/politics/2013/nov/11/david-cameron-policy-shift-leaner-efficient-state\" title=\"\">speech about his commitment to the cause of permanent austerity</a>. He stood up to speak from a golden chair, and read his notes from a golden lectern.</p><p></p><p>As it happens, I was at the banquet too and heard the news about permanent spending cutbacks for myself. Sadly I was not there as a dignitary, a foreign diplomat, a captain of industry or the director of a big City firm. I was there as a waitress. The contrast between what he was saying and where he was saying it seemed initially almost too laughable to get worked up about. But actually, it reflected something chilling in Cameron's attitude towards the people he purports to be working for.</p><p></p><p>I work evenings and weekends at an events company. The company is great and the hours are flexible, which allows me to combine it with my main job of an internship. It's tough, and I've been in a state of semi-tiredness for the last two months. I do get to work at interesting events, though, and the fanciness of the Guildhall banquet was breathtaking. Although, as one of my colleagues said: \"I thought Boris Johnson was the lord mayor, that's the only reason I agreed to work!\"</p><p></p><p>The guests enjoyed a champagne reception, and then were served a starter (\"a celebration of British mushrooms\"), a fish course and main course of fillet of beef, all served with wine of course. In the break before dessert, coffee, dessert wine, port, brandy and whisky were served, Cameron gave his speech. We retreated downstairs to a steam-filled kitchen, where we polished the cutlery. Most of us were exhausted by this point. Dinner service is physically demanding, and I am by no means the only person who combines two or three jobs. The contrast of the two worlds was striking; someone said it was like a scene from Downton Abbey.</p><p></p><p>Maybe Cameron didn't see the irony; perhaps he forgot about the army of waiting staff, cleaners, chefs and porters who were also present at the banquet. Perhaps he thought he was in a room of similarly rich people, who understood the necessity for austerity. Perhaps it didn't occur to him that this message might not be as easily comprehended by those who hadn't just enjoyed a four-course meal. Perhaps he forgot about those of us, disabled or unemployed or on the minimum wage, for whom austerity has had a catastrophic and wounding effect.</p><p></p><p>In his speech, Cameron talked about a \"leaner, more efficient, more affordable state\". He argued that austerity could be a permanent government policy; a way of trimming down the administrative excesses of some public services. He framed it in the context of the current tough living conditions – a minimising of state spending, as it \"comes out of the pockets of the same taxpayers whose living standards we want to see improve\".</p><p></p><p>No word yet, of course, on what changes will be made to the state-funded banquet he was speaking at. Perhaps next year there will only be three courses, or the dessert wine will be ruthlessly culled.</p><p></p><p>I wonder how Cameron and his government can do these things. Aside from the idiocy of calling for cuts while wearing a white tie – has the man never heard of Twitter – does he not see what welfare cuts are doing to the vulnerable in society? He enjoys a banquet, while the number of people using food banks has tripled in the past year. As someone on the shift with me said, \"It gets annoying that we always serve free food to the people who really don't need free food.\"</p><p></p><p>The political content of what Cameron is saying is obviously more important than where he was saying it, but I don't think the latter is irrelevant. I have a fundamental problem with a man who sits on a golden throne and lectures us about spending less, like a modern-day, white-tie clad sheriff of Nottingham. And all around him, the insidious stain of austerity creeps across the country, manifesting in the bedroom tax, rising tuition fees and the closure of public services that vulnerable people depend on.</p><p></p><p>Each of us has just one chance at existence, and so many people's lives are being blighted by these cuts. If this is the cruel and damaging reality of permanent austerity, then we should be telling Mr Cameron we don't want it.</p><!-- Guardian Watermark: internal-code/content/422381235|2013-11-13T15:50:01Z|a39e5393ad4fbfe9cb5ea9291bf9c8c72f35b051 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbyq",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+        "wordcount":"738",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"politics/davidcameron",
+        "type":"keyword",
+        "webTitle":"David Cameron",
+        "webUrl":"http://www.theguardian.com/politics/davidcameron",
+        "apiUrl":"http://content.guardianapis.com/politics/davidcameron",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/conservatives",
+        "type":"keyword",
+        "webTitle":"Conservatives",
+        "webUrl":"http://www.theguardian.com/politics/conservatives",
+        "apiUrl":"http://content.guardianapis.com/politics/conservatives",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"society/public-sector-cuts",
+        "type":"keyword",
+        "webTitle":"Public sector cuts",
+        "webUrl":"http://www.theguardian.com/society/public-sector-cuts",
+        "apiUrl":"http://content.guardianapis.com/society/public-sector-cuts",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/policy",
+        "type":"keyword",
+        "webTitle":"Public services policy",
+        "webUrl":"http://www.theguardian.com/society/policy",
+        "apiUrl":"http://content.guardianapis.com/society/policy",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/public-finance",
+        "type":"keyword",
+        "webTitle":"Public finance",
+        "webUrl":"http://www.theguardian.com/society/public-finance",
+        "apiUrl":"http://content.guardianapis.com/society/public-finance",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"business/austerity",
+        "type":"keyword",
+        "webTitle":"Austerity",
+        "webUrl":"http://www.theguardian.com/business/austerity",
+        "apiUrl":"http://content.guardianapis.com/business/austerity",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/economics",
+        "type":"keyword",
+        "webTitle":"Economics",
+        "webUrl":"http://www.theguardian.com/business/economics",
+        "apiUrl":"http://content.guardianapis.com/business/economics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"profile/ruth-hardy",
+        "type":"contributor",
+        "webTitle":"Ruth Hardy",
+        "webUrl":"http://www.theguardian.com/profile/ruth-hardy",
+        "apiUrl":"http://content.guardianapis.com/profile/ruth-hardy",
+        "bio":"<p>Ruth Hardy is a freelance writer and recent graduate in philosophy at King's College London. You can follow her on Twitter <a href=\"https://twitter.com/ruthhardy22\">here</a></p>",
+        "r2ContributorId":"56147",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Education/Pix/pictures/2013/4/24/1366808642483/Ruth-Hardy-student-blogge-002.jpg",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422382150",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344632805/David-Cameron-at-Lord-May-001.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"54",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344634858/David-Cameron-at-Lord-May-002.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"130",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344637355/David-Cameron-at-Lord-May-004.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"132",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344638596/David-Cameron-at-Lord-May-005.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"168",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344639804/David-Cameron-at-Lord-May-006.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"180",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344641041/David-Cameron-at-Lord-May-007.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"228",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422382151",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T14:44:00Z",
+      "webTitle":"MI6 spy found dead in bag probably locked himself inside, Met says",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "fields":{
+        "trailText":"Three-year investigation by Scotland Yard concludes Gareth Williams probably died as a result of tragic accident",
+        "headline":"MI6 spy found dead in bag probably locked himself inside, Met says",
+        "body":"<p></p><p>The MI6 spy found dead in a bag three years ago probably locked himself in the holdall and died as a result of a tragic accident, Scotland Yard has said.</p><p>Outlining the results of a three-year investigation on Wednesday, the Metropolitan police said that Gareth Williams was most likely to have died alone in his flat.</p><p>However, Detective Assistant Commissioner Martin Hewitt said the police could not \"fundamentally and beyond doubt\" rule out the possibility that a third-party was involved in his  death.</p><p>The naked body of Williams was found in the padlocked bag, with the keys discovered under his body, in the otherwise empty bath in his flat in Pimlico, London, in August 2010.</p><p>Last year, a coroner concluded that Williams was probably unlawfully killed and his death the result of a criminal act. Following an eight-day inquest, the Westminster coroner, Dr Fiona Wilcox, said he was probably either suffocated or poisoned, before a third-party locked and placed the bag in the bath.</p><p></p><p>However, Hewitt said Scotland Yard's three-year inquiry had come to a different conclusion and that Williams was \"most probably\" alone when he died.</p><p>\"Despite all of this considerable effort, it is still the case that there is insufficient evidence to be definitive on the circumstances that led to Gareth's death,\" he said.</p><p></p><p>\"Rather, what we are left with is either individual pieces of evidence, or a lack of such evidence, that can logically support one of a number of hypotheses.\"</p><p></p><p></p><p></p><p>Hewitt added that the investigation had added \"some clarity and detail\" to the case, but that \"no evidence has been identified to establish the full circumstances of Gareth's death beyond all reasonable doubt\".</p><p></p><p>A forensic examination of Williams's flat, a security service safe house, has concluded that there was no sign of forced entry or DNA that pointed to a third-party present at the time of the spy's death.</p><p></p><p>Scotland Yard's inquiry also found no evidence of Williams's fingerprints on the padlock of the bag or the rim of the bath, which the coroner last year said supported her assertion of \"third-party involvement\" in the death.</p><p></p><p>However, Hewitt said it was theoretically possible for Williams to lower himself into the holdall without touching the rim of the bath.</p><p></p><p>Winding down the lengthy investigation, which has drawn interviews and statements from 27 of Williams's colleagues in MI6 and GCHQ, Hewitt said the death remained a tragedy that would be kept under review by detectives.</p><p></p><p>In a statement, Williams's family said they were  disappointed with the police findings and that they agreed with the coroner's conclusions that he was most likely killed unlawfully.</p><p></p><p>\"We are naturally disappointed that it is still not possible to state with certainty how Gareth died and the fact that the circumstances of his death are still unknown adds to our grief,\" the  family said.</p><p></p><p>\"We note that the investigation has been conducted with further interviews upon some of the witnesses who gave evidence at the inquest and that the investigation team were at last able to interview directly members of GCHQ and SIS [MI6].</p><p></p><p>\"We consider that on the basis of the facts at present known the coroner's verdict accurately reflects the circumstances of Gareth's death.\"</p><p></p><p>In a press briefing at Scotland Yard, Hewitt admitted it was \"a cause of some regret\" that the police were not able to definitively explain the circumstances surrounding the 31-year-old's death.</p><p></p><p>He rejected suggestions that the security services had \"pulled the wool\" over his eyes, following concerns over how MI6 and counter-terrorism officers had handled some evidence during the initial investigation. It emerged on Wednesday that police only gained access to Williams's spy agency personnel and vetting files after the coroner's inquest ended last May.</p><p></p><p>Williams, a maths prodigy and fitness enthusiast originally from Anglesey, was a private person with few other close friends aside from his family, police said. In interviews, MI6 and GCHQ colleagues described him as a \"conscientious and decent man\" and detectives were unable to identify anyone with any animosity towards him or a motive for causing him harm.</p><p></p><p>As part of the fresh investigation, a forensic sweep of Williams's flat discovered 10 to 15 unidentified traces of DNA, which are being kept under examination, but none on the North Face holdall or around the bath area of the en-suite bathroom of the flat's main bedroom. There was also no evidence of a \"deep clean\" of the flat to wipe all trace of DNA.</p><p></p><p>Hewitt said: \"There are really three hypotheses that you can use here. One is that Gareth, for whatever reason, got himself into that bag and then was unable to get himself out and died as a result of that.</p><p></p><p>\"One is that Gareth, with someone else, got into the bag consensually then something went wrong and he died as a result of that. The third is that someone murdered Gareth by putting him in that bag. I would argue that any physical absence [of evidence of] a third party being present tends to make the hypotheses that there is a third party present less likely.\"</p><p></p><p>He added: \"The coroner drew an inference. I am now drawing a different inference.\"</p><p></p><p>At the coroner's inquest, two experts tried 400 times to lock themselves into the 32-inch by 19-inch holdall without success, with one remarking that even Harry Houdini \"would have struggled\" to squeeze himself inside. But days after the inquest footage emerged of a retired Army sergeant climbing into the bag and locking it from the inside.</p><p></p><p>Hewitt said it was now established that it was theoretically possible for a person to climb into the bag and that it was \"more probable\" that Williams did this before suffocating as a result of the accident. It emerged during the inquest that Williams had an interest in escapology, but the police said it would be speculation to link his death to a failed attempt to escape from the locked holdall.</p><!-- Guardian Watermark: internal-code/content/422374658|2013-11-13T15:50:01Z|2fd9134acad4628a73f05b72533e71cb4f6ef04d -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjj",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+        "wordcount":"962",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"uk/gareth-williams",
+        "type":"keyword",
+        "webTitle":"Gareth Williams",
+        "webUrl":"http://www.theguardian.com/uk/gareth-williams",
+        "apiUrl":"http://content.guardianapis.com/uk/gareth-williams",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/mi6",
+        "type":"keyword",
+        "webTitle":"MI6",
+        "webUrl":"http://www.theguardian.com/uk/mi6",
+        "apiUrl":"http://content.guardianapis.com/uk/mi6",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uksecurity",
+        "type":"keyword",
+        "webTitle":"UK security and counter-terrorism",
+        "webUrl":"http://www.theguardian.com/uk/uksecurity",
+        "apiUrl":"http://content.guardianapis.com/uk/uksecurity",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/josh-halliday",
+        "type":"contributor",
+        "webTitle":"Josh Halliday",
+        "webUrl":"http://www.theguardian.com/profile/josh-halliday",
+        "apiUrl":"http://content.guardianapis.com/profile/josh-halliday",
+        "bio":"<p><a href=\"http://twitter.com/JoshHalliday\">Josh Halliday</a> is a media and technology reporter. Josh has a keen interest in digital media and privacy. Dislikes insufferable enthusiasm. Bradfordian via Wearside</p>",
+        "r2ContributorId":"38624",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/7/14/1279118930047/Josh-Halliday.jpg",
+        "references":[]
+      },{
+        "id":"uk/metropolitan-police",
+        "type":"keyword",
+        "webTitle":"Metropolitan police",
+        "webUrl":"http://www.theguardian.com/uk/metropolitan-police",
+        "apiUrl":"http://content.guardianapis.com/uk/metropolitan-police",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/uk/london",
+        "apiUrl":"http://content.guardianapis.com/uk/london",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379877",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341447432/Gareth-Williams-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"54",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341448835/Gareth-Williams-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"340",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341450089/Gareth-Williams-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"130",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341452580/Gareth-Williams-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"132",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341453889/Gareth-Williams-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"168",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341455246/Gareth-Williams-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"180",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341456514/Gareth-Williams-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"228",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341459093/Gareth-Williams-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"372",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379878",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-12T15:34:27Z",
+      "webTitle":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "fields":{
+        "trailText":"Rolling Jubilee spent $400,000 to purchase debt cheaply from banks before 'abolishing' it, freeing individuals from their bills",
+        "headline":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+        "body":"<p>A group of Occupy Wall Street activists has bought almost $15m of Americans' personal debt over the last year as part of the Rolling Jubilee project to help people pay off their outstanding credit.</p> <p><a href=\"http://rollingjubilee.org/\">Rolling Jubilee</a>,&nbsp;set up by Occupy's <a href=\"http://www.theguardian.com/world/2012/nov/15/occupy-rolling-jubilee-debt-forgiveness\">Strike Debt group</a>&nbsp;following the street protests that swept the world in 2011, launched on 15 November 2012. The group purchases personal debt cheaply from banks before \"abolishing\" it, freeing individuals from their bills.</p> <p>By purchasing the debt at knockdown prices the group has managed to free $14,734,569.87 of personal debt, mainly medical debt, spending only $400,000.</p> <p>\"We thought that the ratio would be about 20 to 1,\" said Andrew Ross, a member of Strike Debt and professor of social and cultural analysis at New York University. He said the team initially envisaged raising $50,000, which would have enabled it to buy $1m in debt.</p> <p>\"In fact we've been able to buy debt a lot more cheaply than that.\"</p> <p>The group is able to buy debt so cheaply due to the nature of the \"secondary debt market\". If individuals consistently fail to pay bills from credit cards, loans, or medical insurance the bank or lender that issued the funds will eventually cut its losses by selling that debt to a third party. These sales occur for a fraction of the debt&rsquo;s true values &ndash; typically for five cents on the dollar &ndash; and debt-buying companies then attempt to recoup the debt from the individual debtor and thus make a profit.</p> <p>The Rolling Jubilee project was mostly conceived as a \"public education project\", Ross said.</p> <p>\"We're under no illusions that $15m is just a tiny drop in the secondary debt market. It doesn't make a dent in the amount of debt.</p> <p>\"Our purpose in doing this, aside from helping some people along the way &ndash; there's certainly many, many people who are very thankful that their debts are abolished &ndash; our primary purpose was to spread information about the workings of this secondary debt market.\"</p> <p>The group has focussed on buying medical debt, and has acquired the $14.7m in three separate purchases, most recently&nbsp;purchasing the value of&nbsp;$13.5m on medical debt owed by 2,693 people across 45 states and Puerto Rico, Rolling Jubilee said in a press release.</p> <p>&ldquo;No one should have to go into debt or bankruptcy because they get sick,&rdquo; said Laura Hanna, an organiser with the group. Hanna said 62% of all personal bankruptcies have medical debt as a contributing factor.</p> <p>Due to the nature of the debt market, the group is unable to specify whose debt it purchases, taking on the amounts before it discovers individuals&rsquo; identities. When Rolling Jubilee has bought the debt they send notes to their debtors &ldquo;telling them they&rsquo;re off the hook&rdquo;, Ross said.</p> <p>Ross, whose book, <a href=\"http://www.orbooks.com/catalog/creditocracy/\">Creditocracy</a> and the case for debt refusal, outlines the problems of the debt industry and calls for a &ldquo;debtors&rsquo; movement&rdquo; to resist credit, said the group had received letters from people whose debt they had lifted thanking them for the service. But the real victory was in spreading knowledge of the nature of the debt industry, he said.</p> <p>\"Very few people know how cheaply their debts have been bought by collectors. It changes the psychology of the debtor, knowing this.</p> <p>&ldquo;So when you get called up by the debt collector, and you're being asked to pay the full amount of your debt, you now know that the debt collector has bought your debt very, very cheaply. As cheaply as we bought it. And that gives you moral ammunition to have a different conversation with the debt collector.\"</p><!-- Guardian Watermark: internal-code/content/422309147|2013-11-13T15:50:01Z|eb1f79972b6a77bb0687b85ebfb26ad79d81d69a -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb4g",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+        "wordcount":"1",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/occupy-movement",
+        "type":"keyword",
+        "webTitle":"Occupy movement",
+        "webUrl":"http://www.theguardian.com/world/occupy-movement",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-movement",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/occupy-wall-street",
+        "type":"keyword",
+        "webTitle":"Occupy Wall Street",
+        "webUrl":"http://www.theguardian.com/world/occupy-wall-street",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-wall-street",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/debt-relief",
+        "type":"keyword",
+        "webTitle":"Debt relief",
+        "webUrl":"http://www.theguardian.com/world/debt-relief",
+        "apiUrl":"http://content.guardianapis.com/world/debt-relief",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"money/us-personal-finance",
+        "type":"keyword",
+        "webTitle":"US personal finance",
+        "webUrl":"http://www.theguardian.com/money/us-personal-finance",
+        "apiUrl":"http://content.guardianapis.com/money/us-personal-finance",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"money/mortgages-us",
+        "type":"keyword",
+        "webTitle":"US mortgages",
+        "webUrl":"http://www.theguardian.com/money/mortgages-us",
+        "apiUrl":"http://content.guardianapis.com/money/mortgages-us",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"business/useconomy",
+        "type":"keyword",
+        "webTitle":"US economy",
+        "webUrl":"http://www.theguardian.com/business/useconomy",
+        "apiUrl":"http://content.guardianapis.com/business/useconomy",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"money/money",
+        "type":"keyword",
+        "webTitle":"Money",
+        "webUrl":"http://www.theguardian.com/money/money",
+        "apiUrl":"http://content.guardianapis.com/money/money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/adam-gabbatt",
+        "type":"contributor",
+        "webTitle":"Adam Gabbatt",
+        "webUrl":"http://www.theguardian.com/profile/adam-gabbatt",
+        "apiUrl":"http://content.guardianapis.com/profile/adam-gabbatt",
+        "bio":"<p>Adam Gabbatt is a reporter and live blogger for the Guardian, based in New York. He won a journalism bursary from the Scott Trust, the company that owns the Guardian, in 2008, and began writing for the newspaper and website in 2009. He was highly commended in the young journalist of the year category at the British Press Awards in 2011</p>",
+        "r2ContributorId":"33854",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/1/24/1359039911843/AdamGabbatt.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"276",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"'Our primary purpose was to spread information about the workings of this secondary debt market,' said Andrew Ross.&nbsp;Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"84",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"The Occupy movement began in Wall Street in November 2011 when protesters attempted to shut down the New York stock exchange. Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T01:25:32Z",
+      "webTitle":"ITV news presenter hits back after abuse for not wearing poppy",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "fields":{
+        "trailText":"Charlene White faced racist and sexist abuse which, she said, acted against all the goals that the fallen soldiers fought for",
+        "headline":"ITV news presenter hits back after abuse for not wearing poppy",
+        "body":"<p>An ITV news presenter who has been subject to racist and sexist abuse for her decision not to wear a Remembrance Day poppy said she made her decision in order to be \"neutral and impartial on-screen\".</p><p>Charlene White, a presenter on ITV News London, received insults on social media after she appeared on screen without the poppy, with many of the jibes focusing on her race.</p><p><a href=\"http://www.itv.com/news/2013-11-12/itv-news-presenter-defends-decision-to-not-wear-a-poppy-on-air/\" title=\"\">In a statement on the ITV website</a>, the journalist said she had made the decision not to wear a poppy a number of years ago but the backlash this year had been the worst so far.</p><p>She said she supported the armed forces, in which her father and uncle had served, but chose to remain impartial on screen.</p><p>\"I support and am patron of a number of charities and I am uncomfortable with giving one of those charities more on-screen time than others,\" she said. \"I prefer to be neutral and impartial on screen so that one of those charities doesn't feel less favoured than another.  Offscreen in my private life – it's different.</p><p>\"I wear a red ribbon at the start of December for World Aids Day, a pink ribbon in October during breast cancer awareness month, a badge in April during Bowel Cancer Awareness month, and yes – a poppy on Armistice Day.</p><p>\"I respect and hold in high esteem those in the armed forces, both my father and my uncle have served in the RAF and the army.  Every year I donate to the Poppy Appeal because above all else it is a charity that needs donations, so that it can continue to help support serving and ex-service men and women and their families.\"</p><p>The abuse directed at her on Twitter included racist jibes that her family would not have been able to settle in Britain but for the deaths of soldiers.  \"Without all those fallen soldiers, Hitler would've taken over Britain and your family would never have been allowed here...,\" user @alhaurincraig wrote.  Another crudely superimposed a picture of a poppy on to an image of the presenter with a banner saying 'Sack the Slag'.</p><p>White said the racist and sexist abuse acted against all of the goals that the fallen soldiers had fought for. \"The messages of \"go back to where you came from\" have been interesting to read, as have the 'fat s--g' comments, and the repeated use of the phrase 'black c--t',\" she said.  \"Mostly because it flies in the face of everything that millions of British men and women and those in the Commonwealth have fought for for generations, and continue to fight for: the right to choose, and the right of freedom of speech and expression.\"</p><p>Google has also been the subject of criticism because it used only a small Remembrance Day poppy on its website. Labour MP Gerry Sutcliffe said it was \"demeaning not to have something spectacular\".</p><p>The search engine said it tried to be sensitive in not putting sombre occasions into one of their trademark doodles but instead featuring them in some way on their homepage.</p><!-- Guardian Watermark: internal-code/content/422347727|2013-11-13T15:50:01Z|78aaf770fdf9c298733094f851d2fcebe3ae8a57 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbfc",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+        "wordcount":"504",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"uk/remembranceday",
+        "type":"keyword",
+        "webTitle":"Remembrance Day",
+        "webUrl":"http://www.theguardian.com/uk/remembranceday",
+        "apiUrl":"http://content.guardianapis.com/uk/remembranceday",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"media/itv1",
+        "type":"keyword",
+        "webTitle":"ITV channel",
+        "webUrl":"http://www.theguardian.com/media/itv1",
+        "apiUrl":"http://content.guardianapis.com/media/itv1",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/television",
+        "type":"keyword",
+        "webTitle":"Television industry",
+        "webUrl":"http://www.theguardian.com/media/television",
+        "apiUrl":"http://content.guardianapis.com/media/television",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/media",
+        "type":"keyword",
+        "webTitle":"Media",
+        "webUrl":"http://www.theguardian.com/media/media",
+        "apiUrl":"http://content.guardianapis.com/media/media",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"tv-and-radio/tv-news",
+        "type":"keyword",
+        "webTitle":"The news on TV",
+        "webUrl":"http://www.theguardian.com/tv-and-radio/tv-news",
+        "apiUrl":"http://content.guardianapis.com/tv-and-radio/tv-news",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"culture/television",
+        "type":"keyword",
+        "webTitle":"Television",
+        "webUrl":"http://www.theguardian.com/culture/television",
+        "apiUrl":"http://content.guardianapis.com/culture/television",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"profile/shane-hickey",
+        "type":"contributor",
+        "webTitle":"Shane Hickey",
+        "webUrl":"http://www.theguardian.com/profile/shane-hickey",
+        "apiUrl":"http://content.guardianapis.com/profile/shane-hickey",
+        "r2ContributorId":"55396",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422347763",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305766581/Poppies-001.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"54",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305768729/Poppies-002.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"340",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305770017/Poppies-003.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"130",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305772726/Poppies-005.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"132",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305773964/Poppies-006.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"168",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305775328/Poppies-007.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"180",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305776636/Poppies-008.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"228",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305779302/Poppies-010.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"372",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422347764",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "sectionId":"society",
+      "sectionName":"Society",
+      "webPublicationDate":"2013-11-13T12:10:00Z",
+      "webTitle":"Hamzah Khan: minister has 'deep concerns' over review findings",
+      "webUrl":"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "apiUrl":"http://content.guardianapis.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "fields":{
+        "trailText":"Edward Timpson criticises review into death of child who starved to death while DfE source describes report as 'risible'",
+        "headline":"Hamzah Khan: minister has 'deep concerns' over review findings",
+        "body":"<p>The children's minister Edward Timpson has said he has deep concerns over <a href=\"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-social-services-warning-signs\" title=\"\">the serious case review by the Bradford safeguarding children board into the death of four-year-old Hamzah Khan</a>, who was starved to death by his mother in Bradford.</p><p>A source from the Department for Education (DfE) used even stronger language, describing the review as \"risible\", but a source at the council accused the government of \"social worker bashing\".</p><p>Hamzah's partially mummified body was found clothed in a Babygro meant for a child aged six to nine months in September 2011, almost two years after his death in December 2009.</p><p><a href=\"http://www.theguardian.com/society/2013/oct/03/hamzah-khan-starved-to-death-amanda-hutton\" title=\"\">His mother, Amanda Hutton, 44, was last month found guilty of his manslaughter</a> and of neglecting six of her eight children.</p><p><a href=\"http://www.theguardian.com/society/interactive/2013/nov/13/hamzah-khan-serious-case-review\" title=\"\">The serious case review (SCR)</a>, commissioned by Bradford safeguarding children board (BSCB), concluded that while social services missed signs that, had they been put together, could have warned that Hamzah and his seven siblings were at risk, his death was \"not predictable\". That appears to have not gone far enough for the DfE.</p><p>In a letter to Nick Frost, chair of BSCB, Edward Timpson, the minister for children and families, wrote: \"I am concerned that it [the SCR] fails to explain sufficiently clearly the actions taken, or not taken, by children's social care when problems in the Khan family were brought to their attention on a number of occasions.\"</p><p>The letter sets out a number of questions, which Timpson says relate to \"missed opportunities to protect the children in the house\".</p><p>He continues: \"It is tragic beyond words that by the time a health visitor did trigger concerns about the whereabouts of the younger children in the household, who were missing from health and education services altogether, Hamzah Khan was already dead.\"</p><p>Frost said in a statement: \"The SCR is very clear that Hamzah's death could not have been predicted but finds that systems, many of them national systems, let Hamzah down both before and following his death.\"</p><p>The DfE's criticism provoked an angry response at Bradford council, with a source claiming that the education secretary, Michael Gove, had initially been ready to accept the SCR's findings.</p><p>The source said: \"Forty-eight hours ago all the indications were that the DfE were going to accept the report but Gove appears to have had a change of heart.\"</p><p>The council accused the education secretary of changing his mind because there was \"not enough social worker bashing\".  It is understood Gove thinks there has been a failure of all agencies in Bradford to accept any responsibility.</p><p>The authors of the SCR make 50 recommendations for \"learning\", which have been accepted by BSCB without blaming any one agency for failing Hamzah. The panel found that the agencies focused their efforts on Hutton as a victim of domestic violence, rather than her children. The experts report that while much help was offered to Hamzah's mother, who was beaten up by her partner for much of their 22-year relationship, not enough focus was put on whether her children were safe and well.</p><p>Annie Hudson, chief executive of the College of Social Work, said the SCR \"brings into sharp focus why there must be strong, joined-up and effective systems in place to keep in contact with, and track, children at risk.</p><p>\"No child should ever fall off the radar or become invisible to child protection agencies and society as a whole.\"</p><p>The NSPCC said it highlighted the need for a red flag when children miss key appointments so youngsters such as Hamzah do not \"slip off the radar of society\".</p><!-- Guardian Watermark: internal-code/content/422378691|2013-11-13T15:50:01Z|d7c3b400464ae84bc4d38dfc68bb6ce1b96a13d1 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kby3",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+        "wordcount":"579",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"society/childprotection",
+        "type":"keyword",
+        "webTitle":"Child protection",
+        "webUrl":"http://www.theguardian.com/society/childprotection",
+        "apiUrl":"http://content.guardianapis.com/society/childprotection",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/children",
+        "type":"keyword",
+        "webTitle":"Children",
+        "webUrl":"http://www.theguardian.com/society/children",
+        "apiUrl":"http://content.guardianapis.com/society/children",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/social-care",
+        "type":"keyword",
+        "webTitle":"Social care",
+        "webUrl":"http://www.theguardian.com/society/social-care",
+        "apiUrl":"http://content.guardianapis.com/society/social-care",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/localgovernment",
+        "type":"keyword",
+        "webTitle":"Local government",
+        "webUrl":"http://www.theguardian.com/society/localgovernment",
+        "apiUrl":"http://content.guardianapis.com/society/localgovernment",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"uk/bradford",
+        "type":"keyword",
+        "webTitle":"Bradford",
+        "webUrl":"http://www.theguardian.com/uk/bradford",
+        "apiUrl":"http://content.guardianapis.com/uk/bradford",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/helenpidd",
+        "type":"contributor",
+        "webTitle":"Helen Pidd",
+        "webUrl":"http://www.theguardian.com/profile/helenpidd",
+        "apiUrl":"http://content.guardianapis.com/profile/helenpidd",
+        "bio":"<p>Helen Pidd is northern editor of the Guardian, based in Manchester. She joined the paper in 2004 to edit the now defunct Office Hours and was a commissioning editor on G2 before joining the home news team in 2007, going on to spend 2011 in Germany as Berlin correspondent followed by a stint in Delhi. She is the author of <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490530\">Bicycle – The Complete<br />Guide to Everyday Cycling</a>.</p>",
+        "r2ContributorId":"19855",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/6/22/1277217764498/Helen-Pidd-byline.-003.jpg",
+        "references":[]
+      },{
+        "id":"profile/haroonsiddique",
+        "type":"contributor",
+        "webTitle":"Haroon Siddique",
+        "webUrl":"http://www.theguardian.com/profile/haroonsiddique",
+        "apiUrl":"http://content.guardianapis.com/profile/haroonsiddique",
+        "bio":"<p>Haroon Siddique is a news reporter on the Guardian website. He previously worked for North London institution the Ham&amp;High, and before pursuing his passion for journalism he was a commodity trader in the City</p>",
+        "r2ContributorId":"19136",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/haroon_siddique.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379573",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343315052/Hamzah-Khan-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"54",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343317421/Hamzah-Khan-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"340",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343318751/Hamzah-Khan-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"130",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343321335/Hamzah-Khan-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"132",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343322756/Hamzah-Khan-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"168",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343324035/Hamzah-Khan-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"180",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343325436/Hamzah-Khan-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"228",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343328488/Hamzah-Khan-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"372",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379574",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T09:50:29Z",
+      "webTitle":"Lily Allen does not represent all feminism – and nor should she | Ellie Mae O'Hagan",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "fields":{
+        "trailText":"<p><strong>Ellie Mae O'Hagan:</strong> Instead of critiquing whether Allen's new video is feminist or not, we should ask why there is such a weight of expectation on one woman</p>",
+        "headline":"Lily Allen does not represent all feminism – and nor should she",
+        "body":"<p>As soon as <a href=\"http://www.theguardian.com/music/musicblog/2013/nov/12/lily-allen-hard-out-here\" title=\"\">Lily Allen released a music video</a> that was purportedly a new feminist anthem, I anticipated that a slew of blogs and commentary would follow. I was right – I've read four on the subject already. Nevertheless, it is my policy to leave no bandwagon unjumped, and so here's my contribution to the unfolding brouhaha.</p><p>I can't deny I enjoyed watching Lily Allen poke fun at the notoriously sexist music industry, and in many ways I thought she was spot on. The presence of a besuited old white man in her music video who encourages her to fellate a banana was pretty revealing. Behind the dancing girls and schmaltzy lyrics that usually characterise pop songs, these men act as the all-oppressing eye of the industry: telling female singers that weight loss and sexual objectification are the only feasible routes to stardom; stripping down women in music videos to their underwear while leaving their male counterparts untouched. Allen was right to identify these shadowy white men as the source of the problem, for though sexism is a structural thing, it does usually manifest itself in the actual men in charge dictating how women should present themselves and their bodies in order to achieve some kind of validation.</p><p>But the video is problematic too. For one thing, it's unclear whether Allen is reserving scorn solely for the rich white men she satirises, or whether some women (like <a href=\"http://www.theguardian.com/commentisfree/2013/nov/07/pop-stars-sexy-netmums-parents-miley-cyrus\" title=\"\">Miley Cyrus</a> – who presumably has also been taught that sexualisation is the route to success) don't cop some too. To twerk or not to twerk may be the zeitgeist question, but whatever answer you come up with, you're still telling women how they should present their own bodies. Then there's the issue of <a href=\"http://www.theguardian.com/commentisfree/2013/nov/10/black-women-music-industry-sex\" title=\"\">race in the video</a>. On a surface level, Allen attempts to mock the way black women are treated as nothing more than sexual objects in music videos – yet she also posits herself as separate from the black women that feature in hers. At the end of the song, she pointedly sashays off, while they remain behind as simply semi-nude backing dancers. <a href=\"http://www.voice-online.co.uk/article/music-videos-exploiting-black-womens-bodies\" title=\"\">Sarah Greene of the End Violence Against Women Coalition recently told the Voice</a>, \"In a particular Calvin Harris video [Drinking from the Bottle ft Tinie Tempah], there is kind of a sea of black women's bottoms. You never even see their faces … young black women say it makes them feel hated.\" In that respect, it's difficult to see Allen's anthem as little more than same old same old, and it's probably why I ultimately feel she misses the mark. As the <a href=\"https://twitter.com/Okwonga/status/400367983299940352\" title=\"\">journalist Musa Okwonga put it</a>, \"She should've swapped the female dancers for a bunch of twerking middle-aged men.\"</p><p>In my mind though, the wider question is not whether or not Lily Allen's feminist song is a success or not; it's why is it that one single music video containing some fairly cursory observations on sexism is able to stir up such a reaction in the feminist movement. One explanation lies in a comment made by the blogger Glosswitch recently (<a href=\"http://glosswatch.com/\" title=\"\">and I recommend you read her piece in full</a>): \"I'd say one objective of feminism should be to help women's decisions become less loaded. It's oppressive to have to represent a whole sex in everything you do.\" Unfortunately for Allen and everybody else, her music video seems unable to stand in and of itself, representing only her opinions, but is instead being seen as some kind of expression of all feminism – and by extension all women. This is part and parcel of being in an oppressed group: women are routinely dehumanised and homogenised, so that every act we undertake in public tends to reflect on all women, instead of our own individual character. It's a problem men just don't have. And feminism is so marginalised as a strain of political thought, that when one feminist woman makes it into the mainstream, a flurry of panic and excitement will inevitably follow simply because there are so few feminist voices in the public sphere. Feminism is an extremely broad church, but I often think feminists are guilty of expecting every single prominent feminist to reflect their exact politics because there aren't enough opinions in the mainstream to choose from – and all too often the feminists that do make it big are white and middle class.</p><p>Perhaps the most helpful response we feminists can have to Lily Allen's video is not to tear it down because of its flaws (although they should be addressed), but to look at feminism itself and discuss how to realise its potential as a political movement. Instead of admonishing or praising Allen, we should ask why there is such a weight of expectation upon something so small, and what we can do to rectify that. There are already exciting projects attempting to do this, like the <a href=\"http://ukfeminista.org.uk/event-details/summer-school-2013/\" title=\"\">UK Feminista summer school</a>, the <a href=\"http://www.theguardian.com/lifeandstyle/the-womens-blog-with-jane-martinson/2013/apr/16/everyday-sexism-project-shouting-back\" title=\"\">Everyday Sexism Project</a>, <a href=\"http://www.southallblacksisters.org.uk/\" title=\"\">Southall Black Sisters</a>, or the indispensable work of the <a href=\"http://www.fawcettsociety.org.uk/\" title=\"\">Fawcett Society</a>. I don't pretend to have a grand feminist plan, and in any case feminists should probably decide on such a plan together, but I do know that if we focus on organising ourselves into a political force and supporting each other in the struggle against patriarchy, the time will come when we care less about what Lily Allen has to say – because the fate of feminism won't seem to rest upon the strengths and weaknesses of one music video.</p><!-- Guardian Watermark: internal-code/content/422367349|2013-11-13T15:50:01Z|eb480736002bcb62f3ac77dca7fbf93c7da33bfc -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbhf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+        "wordcount":"909",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"world/feminism",
+        "type":"keyword",
+        "webTitle":"Feminism",
+        "webUrl":"http://www.theguardian.com/world/feminism",
+        "apiUrl":"http://content.guardianapis.com/world/feminism",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"music/lilyallen",
+        "type":"keyword",
+        "webTitle":"Lily Allen",
+        "webUrl":"http://www.theguardian.com/music/lilyallen",
+        "apiUrl":"http://content.guardianapis.com/music/lilyallen",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/ellie-mae-o-hagan",
+        "type":"contributor",
+        "webTitle":"Ellie Mae O'Hagan",
+        "webUrl":"http://www.theguardian.com/profile/ellie-mae-o-hagan",
+        "apiUrl":"http://content.guardianapis.com/profile/ellie-mae-o-hagan",
+        "bio":"<p>Ellie Mae O'Hagan is a regular columnist for Comment is free. She has also written for the Times, the New Statesman, Red Pepper, False Economy, New Left Project and Union News. She currently works with the Centre for Labour and Social Studies, a think for left debate and discussion originating in the trade union movement. She is also an active member of UK Uncut. She  tweets as <a href=\"http://twitter.com/#!/MissEllieMae\">@MissEllieMae</a></p>",
+        "r2ContributorId":"43367",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/3/22/1300821538131/EllieMaeOHagan.jpg",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388300",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Lily Allen",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Lily Allen",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T10:06:25Z",
+      "webTitle":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "fields":{
+        "trailText":"Ranjit Sinha, chief of India's Central Bureau of Investigation, apologises for remark that causes outrage across country",
+        "headline":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+        "body":"<p>India's top police official has apologised for saying: \"If you can't prevent rape, you enjoy it,\" – a remark that has outraged the country.</p><p>Ranjit Sinha, chief of India's Central Bureau of Investigation, made the remark on Tuesday during a conference about illegal sports betting and the need to legalise gambling. The CBI, the country's premier investigative agency, is India's equivalent of the FBI.</p><p>Sinha said at the conference that if the state could not stop gambling, it could at least make some revenue by legalising it.</p><p>\"If you cannot enforce the ban on betting, it is like saying: 'If you can't prevent rape, you enjoy it,'\" he said.</p><p>The remarks have caused outrage across India, which in the past year has been hit by widespread protests following the<a href=\"http://www.theguardian.com/world/2013/sep/13/delhi-gang-rape-relief-india-men-sentenced-death\" title=\"\"> fatal gang-rape</a> of a 23-year-old woman on a bus in New Delhi.</p><p>On Wednesday, Sinha said  his comments had been taken out of context and misinterpreted, and that he was sorry if he had caused hurt. Angry activists, however, called for his resignation.</p><p>Brinda Karat, leader of the Communist party of India (Marxist), said Sinha's comments were offensive to women everywhere.</p><p>\"It is sickening that a man who is in charge of several rape investigations should use such an analogy,\" Karat told reporters. \"He should be prosecuted for degrading and insulting women.\"</p><p>The New Delhi attack on the young woman last December caused nationwide outrage and forced the government to change rape laws and create fast-track courts for rape cases.</p><p>Laws introduced after the attack make stalking, voyeurism and sexual harassment a crime. They also provide for the death penalty for repeat offenders or for rape attacks that lead to the victim's death.</p><!-- Guardian Watermark: internal-code/content/422368950|2013-11-13T15:50:01Z|3356dd1aba5de54aede55024098d378c1e663a8e -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbhz",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+        "wordcount":"273",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/india",
+        "type":"keyword",
+        "webTitle":"India",
+        "webUrl":"http://www.theguardian.com/world/india",
+        "apiUrl":"http://content.guardianapis.com/world/india",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"society/rape",
+        "type":"keyword",
+        "webTitle":"Rape",
+        "webUrl":"http://www.theguardian.com/society/rape",
+        "apiUrl":"http://content.guardianapis.com/society/rape",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"law/law",
+        "type":"keyword",
+        "webTitle":"Law",
+        "webUrl":"http://www.theguardian.com/law/law",
+        "apiUrl":"http://content.guardianapis.com/law/law",
+        "sectionId":"law",
+        "sectionName":"Law",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422369576",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337123909/Ranjit-Sinha-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"54",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337125231/Ranjit-Sinha-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"340",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337126586/Ranjit-Sinha-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"130",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337129092/Ranjit-Sinha-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"132",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337130310/Ranjit-Sinha-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"168",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337131559/Ranjit-Sinha-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"180",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337132902/Ranjit-Sinha-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"228",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337135575/Ranjit-Sinha-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"372",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422369577",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T11:18:52Z",
+      "webTitle":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "fields":{
+        "trailText":"Roberto Di Matteo is reportedly still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago",
+        "headline":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+        "body":"<p>Roberto Di Matteo is still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago, according to reports.</p><p>The former manager did not agree a pay-off settlement when he was axed as manager last season, and <a href=\"http://www.dailymail.co.uk/sport/football/article-2503321/Chelsea-paying-Roberto-Di-Matteo-130-000-week.html\" title=\"\">the Daily Mail reports</a> the Italian will continue to be paid in full until June 2014 unless he takes another job before then.</p><p>That, however, seems unlikely given Di Matteo has reportedly turned down several offers both in the Premier League and from abroad since his departure, while there are few clubs who could match the lucrative £6.76m annual salary he was earning at Stamford Bridge.</p><p>Di Matteo was <a href=\"http://www.theguardian.com/football/2013/sep/23/roberto-di-matteo-gus-poyet-sunderland\" title=\"\">linked with the Sunderland job</a> before Gus Poyet's appointment and he is seen as a possible replacement for Martin Jol at Fulham should the Dutch manager leave Craven Cottage.</p><!-- Guardian Watermark: internal-code/content/422374266|2013-11-13T15:50:01Z|c1df33eb8d20d8f3e4b39082656cd5158a54e92f -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjb",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+        "wordcount":"140",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"football/roberto-di-matteo",
+        "type":"keyword",
+        "webTitle":"Roberto Di Matteo",
+        "webUrl":"http://www.theguardian.com/football/roberto-di-matteo",
+        "apiUrl":"http://content.guardianapis.com/football/roberto-di-matteo",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/chelsea",
+        "type":"keyword",
+        "webTitle":"Chelsea",
+        "webUrl":"http://www.theguardian.com/football/chelsea",
+        "apiUrl":"http://content.guardianapis.com/football/chelsea",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/4"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422374804",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341239071/Roberto-Di-Matteo-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"54",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341242197/Roberto-Di-Matteo-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"340",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341243440/Roberto-Di-Matteo-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"130",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341244752/Roberto-Di-Matteo-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"720",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341246531/Roberto-Di-Matteo-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341249682/Roberto-Di-Matteo-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"132",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341250911/Roberto-Di-Matteo-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"168",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341252176/Roberto-Di-Matteo-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"180",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341253497/Roberto-Di-Matteo-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"228",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341256016/Roberto-Di-Matteo-012.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"372",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341257472/Roberto-Di-Matteo-013.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1116",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1860"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341259557/Roberto-Di-Matteo-014.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2560"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422374805",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/4"
+      }]
+    },{
+      "id":"film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "sectionId":"film",
+      "sectionName":"Film",
+      "webPublicationDate":"2013-11-12T10:01:00Z",
+      "webTitle":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+      "webUrl":"http://www.theguardian.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "apiUrl":"http://content.guardianapis.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "fields":{
+        "trailText":"<p>Unable to cut his sexually explicit film down from five hours, Danish director opts to let someone else cut the movie down to two, two-hour chunks – both including explicit footage</p>",
+        "headline":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+        "body":"<p>Lars Von Trier has abandoned plans to release a softcore version of his sex epic Nymphomaniac. The film's two-part four-hour cut, which is due to debut in Copenhagen on Christmas Day, will now contain explicit scenes. </p><p>The release of Nymphomaniac will see the Danish director give up final cut for the first time in his career. The decision was apparently taken after Von Trier said he was unwilling to trim the two-part film's current five and a half hour running time himself. Nymphomaniac's strange fate is detailed in an extended making-of feature in the Danish film magazine Filmmagasinet Ekko which was picked up by <a href=\"http://www.hollywoodreporter.com/news/lars-von-trier-gives-up-655155\">the Hollywood Reporter</a>. </p><p>\"The short version is against Lars' own will, but he accepts it because he understands market mechanisms,\" says Von Trier's long-term producing partner Peter Aalbaek Jensen in the magazine article. \"You cannot make a film for more than 60 million kroners (about $11 million or £6.9 million) that is so lengthy. Five and a half hours is so extreme that it reduces market value so radically that investors would have felt they had bought a pig in a poke.\"</p><p>It is extremely unusual a director of the artistic clout of Von Trier to allow somebody else to complete their vision, particularly on such a singular project as Nymphomaniac. It is not known if the longer five-and-a-half-hour cut will ever be released, and Jensen refused to confirm if Von Trier would take it to next year's Cannes film festival.</p><p>Nymphomaniac, which stars the film-maker's regular muse Charlotte Gainsbourg in the lead, has been billed as an exploration of the erotic life of a woman from infancy to middle age. Digital trickery and body doubles have reportedly been used to portray famous stars such as Uma Thurman, Stellan Skarsgård, Christian Slater, Jamie Bell and Shia LaBeouf having sex.</p><p>A teaser trailer for the much anticipated film was briefly <a href=\"http://www.theguardian.com/film/2013/nov/04/nymphomiac-youtube-shia-labeouf-lars-von-trier-clip-removed\">removed from YouTube earlier this month</a> after apparently falling foul of the site's rules on nudity and sexual content.</p><h2>More on Nymphomaniac</h2><p>• <a href=\"http://www.theguardian.com/film/2013/nov/04/nymphomiac-youtube-shia-labeouf-lars-von-trier-clip-removed\">Nymphomaniac clip removed from Youtube</a><br />• <a href=\"http://www.theguardian.com/film/poll/2013/oct/10/nymphomaniac-orgasm-posters-vote-favourite\">Vote for your favourite Nymphomaniac orgasm poster</a></p><!-- Guardian Watermark: internal-code/content/422267679|2013-11-13T15:50:01Z|36aed8ffd86c1865c8018d220088cf262a55dd38 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kakf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+        "wordcount":"343",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"film/lars-von-trier",
+        "type":"keyword",
+        "webTitle":"Lars von Trier",
+        "webUrl":"http://www.theguardian.com/film/lars-von-trier",
+        "apiUrl":"http://content.guardianapis.com/film/lars-von-trier",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"culture/charlotte-gainsbourg",
+        "type":"keyword",
+        "webTitle":"Charlotte Gainsbourg",
+        "webUrl":"http://www.theguardian.com/culture/charlotte-gainsbourg",
+        "apiUrl":"http://content.guardianapis.com/culture/charlotte-gainsbourg",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"profile/benchild",
+        "type":"contributor",
+        "webTitle":"Ben Child",
+        "webUrl":"http://www.theguardian.com/profile/benchild",
+        "apiUrl":"http://content.guardianapis.com/profile/benchild",
+        "bio":"<p>Ben Child is a journalist, DJ and producer whose main interests lie in the worlds of film and music</p>",
+        "r2ContributorId":"24984",
+        "references":[]
+      },{
+        "id":"film/drama",
+        "type":"keyword",
+        "webTitle":"Drama",
+        "webUrl":"http://www.theguardian.com/film/drama",
+        "apiUrl":"http://content.guardianapis.com/film/drama",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"culture/pornography",
+        "type":"keyword",
+        "webTitle":"Pornography",
+        "webUrl":"http://www.theguardian.com/culture/pornography",
+        "apiUrl":"http://content.guardianapis.com/culture/pornography",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"world/denmark",
+        "type":"keyword",
+        "webTitle":"Denmark",
+        "webUrl":"http://www.theguardian.com/world/denmark",
+        "apiUrl":"http://content.guardianapis.com/world/denmark",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422284236",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244020710/Nymphomaniac-chapter-one--008.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"276",
+            "credit":"Christian Geisnaes",
+            "caption":"One of the few fully-clothed stills from Nymphomaniac. Photograph: Christian Geisnaes",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422284237",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"84",
+            "credit":"Christian Geisnaes",
+            "caption":"Nymphomaniac chapter one still Photograph: Christian Geisnaes",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:04:31Z",
+      "webTitle":"Jack Monroe's frozen yoghurt recipe",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "fields":{
+        "trailText":"<p>This simple dessert is a great way to stretch fresh berries, but it works brilliantly with cheaper frozen fruit, too</p>",
+        "headline":"Jack Monroe's frozen yoghurt recipe",
+        "body":"<p>I first made these berry desserts with foraged blackberries and a few things from the fridge, but any berries will do. You can often get bags of mixed frozen berries far cheaper than their fresh counterparts, which are perfect for this simple dessert.</p><p><strong><em>(Makes 4 ramekins or lolly moulds)</em></strong> <em>34p a portion</em><br /><strong>100g white chocolate, </strong><em>30p</em><br /><strong>100g mixed frozen berries, </strong><em>33p</em><br /><strong>150g soft cream cheese, </strong><em>40p</em><br /><strong>300g low fat natural yoghurt, </strong><em>33p</em></p><p>Break up the chocolate and melt it gently in a mixing bowl over a pan containing a couple of inches of boiling water. Make sure the water doesn't touch the bowl, as too much heat will make the chocolate bitter.</p><p>Remove the bowl from the heat, using a tea towel or oven glove.</p><p>Add the berries, cream cheese and yoghurt and stir well to combine until smooth – the cheese will soften into the chocolate and yoghurt.</p><p>Spoon into ramekin dishes or lolly moulds, and freeze for at least two hours.</p><p>The lollies can be served as they are; ramekin dishes should be removed from the freezer 20 minutes before eating to thaw, or pinged in the microwave for a minute to soften.</p><h2>Jack's tip</h2><p>Replace the white chocolate with lemon curd for a sweet, zesty dessert. Dark chocolate and fresh chopped mint works well too.</p><p><em>• For more recipe ideas, including using up remaining ingredients, see <a href=\"http://agirlcalledjack.com/\">agirlcalledjack.com</a> or follow <a href=\"https://twitter.com/MsJackMonroe\">@MsJackMonroe</a> on Twitter.</em></p><!-- Guardian Watermark: internal-code/content/422376870|2013-11-13T15:50:01Z|97ef9d51bfc30f2ea9fd96125522f0c9a9d2232a -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbka",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+        "wordcount":"222",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "type":"series",
+        "webTitle":"Jack Monroe's low-cost recipes",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/dessert",
+        "type":"keyword",
+        "webTitle":"Dessert",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/dessert",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/dessert",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fruit",
+        "type":"keyword",
+        "webTitle":"Fruit",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fruit",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fruit",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"money/saving-money",
+        "type":"keyword",
+        "webTitle":"Saving money",
+        "webUrl":"http://www.theguardian.com/money/saving-money",
+        "apiUrl":"http://content.guardianapis.com/money/saving-money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"profile/jack-monroe",
+        "type":"contributor",
+        "webTitle":"Jack Monroe",
+        "webUrl":"http://www.theguardian.com/profile/jack-monroe",
+        "apiUrl":"http://content.guardianapis.com/profile/jack-monroe",
+        "bio":"<p>Jack Monroe blogs at <a href=\"http://agirlcalledjack.com/\">A Girl Called Jack</a> and is author of the forthcoming A Girl Called Jack recipe book</p>",
+        "r2ContributorId":"57609",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/10/1378813805813/Jack-Monroe.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381337",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344202019/Jack-Monroes-frozen-yoghu-009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"276",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381338",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"84",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "sectionId":"news",
+      "sectionName":"News",
+      "webPublicationDate":"2013-11-13T07:30:00Z",
+      "webTitle":"The daily quiz, 13 November 2013",
+      "webUrl":"http://www.theguardian.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "apiUrl":"http://content.guardianapis.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "fields":{
+        "trailText":"<p>From murder mysteries to famous lakes and luxury goods purveyors to the rules of boxing, 10 questions to test you</p>",
+        "headline":"The daily quiz, 13 November 2013",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k2vg",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"news/series/the-daily-quiz",
+        "type":"series",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/news/series/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/news/series/the-daily-quiz",
+        "sectionId":"news",
+        "sectionName":"News",
+        "references":[]
+      },{
+        "id":"profile/the-daily-quiz",
+        "type":"contributor",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/profile/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/profile/the-daily-quiz",
+        "bio":"<p>A daily general knowledge quiz from theguardian.com. Email: daily.quiz@theguardian.com</p>",
+        "r2ContributorId":"57817",
+        "references":[]
+      },{
+        "id":"type/quiz",
+        "type":"type",
+        "webTitle":"Quiz",
+        "webUrl":"http://www.theguardian.com/quizzes",
+        "apiUrl":"http://content.guardianapis.com/quizzes",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-421318129",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Sinibomb Images",
+            "altText":"Pac-Man",
+            "height":"84",
+            "credit":"Sinibomb Images/Alamy",
+            "caption":"Despite our video games knowledge being prehistoric, we decided such a huge part of the entertainment world would be ignored at our peril. Photograph: Sinibomb Images/Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:55:00Z",
+      "webTitle":"How to make the perfect onion bhajis",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "fields":{
+        "trailText":"<p>Can another member of the fritter family beat the onion bhaji, do you eat them as a starter or a snack, and what do you serve with them?</p>",
+        "headline":"How to make the perfect onion bhajis",
+        "body":"<p>The onion bhaji was probably my first introduction to the joys of Indian food back in the late 80s, so I feel I owe this simple snack a considerable debt of thanks. The word \"bhajia\" means fritter – in fact, they're just one small part of the wider pakora family, which encompasses all manner of good things (<a href=\"http://adventurefoodie.blogspot.co.uk/2011/06/bheja-fry-goat-brain-fritters.html\" title=\"\">goat brain pakora</a> stands out in my memory) fried in chickpea batter, but in Britain, a land never known for its subtle taste, the pungent onion variety rules supreme.</p><p>Usually served <a href=\"http://www.greatbritishchefs.com/community/origins-onion-bhaji\" title=\"\">as a snack in its homeland</a>, generally with a nice cup of chai, bhajis are the stalwart of the starter selection here: a deep-fried appetite whetter for the myriad joys to come. At their best, they're almost ethereally light and addictively crisp. At their worst, they're stodgy and bland – as chef Cyrus Todiwala observes in his new book, <a href=\"http://nr11blog.wordpress.com/tag/onion-bhaji-recipe/\" title=\"\">Mr Todiwala's Bombay</a>: \"What you see in stores and supermarkets does not always represent the bhajia we Indians know.\" So just how do you guarantee great results?</p><h2>Onion</h2><figure data-media-id='gu-image-422395582'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg' alt='SImon Majumdar's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Simon Majumdar's onion bhajis.</figcaption></figure><p>Often lost in mass-produced versions, the bulk of the bhaji should be onion, rather than dough. Most recipes use yellow onion, sliced very thinly so it cooks through quickly, but <a href=\"http://www.simonmajumdar.com/recipes/onion-bhaji/\" title=\"\">food writer Simon Majumdar</a> specifies white and <a href=\"http://www.greatbritishchefs.com/recipes/onion-bhaji-recipe\" title=\"\">Alfred Prasad, executive chef at the Michelin-starred Tamarind</a>, goes for red. I find white too mild, and although I like the sweetness of the red versions, I miss the yellow onion's pungent flavour, so I'm going to stick with that.</p><h2>Batter</h2><figure data-media-id='gu-image-422395583'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg' alt='Flavours of Gujarat's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Flavours of Gujarat's onion bhajis.</figcaption></figure><p>Onions are onions, but where bhaji recipes diverge is in the batter that binds the slices together. Gram, or chickpea flour, is fairly standard, but Prasad and a brilliant little book called Flavours of Gujarat (which has been sitting on my parents' bookshelf for more than 20 years, waiting for this moment) recommend adding rice flour, presumably to make the batter crisper. For me, the difference between a great bhaji and a merely adequate one is in the crunch – as with all deep-fried foods, it should fight back – and Prasad's are particularly fiesty, so I'm going to adopt his 2:1 ratio of gram to rice flour.</p><p>Perhaps more important is the liquid used, both in type and quantity. Water is obviously the first choice, <a href=\"http://uktv.co.uk/food/recipe/aid/653916\" title=\"\">but Nikita Gulhane</a>, whose bhaji recipe features in Madhur Jaffrey's Curry Nation, also adds plain yoghurt, and Prasad stirs in a little melted butter. I like the rich tanginess of Gulhane's yoghurt, but I find it makes the batter a bit thick and gloopy, so I'm going to use Prasad's butter, plus Todiwala's lemon juice for flavour.</p><figure data-media-id='gu-image-422395584'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg' alt='Nikita Gulhane's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Nikita Gulhane's onion bhajis.</figcaption></figure><p>The batters vary enormously in consistency: Gulhane's is a thick paste, while Majumdar counsels aiming for the texture of double cream. This makes all the difference to the finished result: the two thickest batters, from Gulhane and Flavours of Gujarat, produce rather doughy bhajis that seem to be more about the batter than the onion. They're tasty enough, but I prefer the more delicate coating of Todiwala, Prasad and Majumdar's versions. The guiding principle is that it should be thick enough to cling to the onion, but not firm enough to form clumps of its own.</p><p>Majumdar suggests letting the batter rest for an hour before use, much like a yorkshire pudding, presumably to allow the flours to absorb the moisture in the batter. I don't think this is desirable here, though: his coating is tough, but not particularly crisp, and one taster likens it (approvingly, I must add) to a Woolworths onion ring.</p><h2>Spices</h2><figure data-media-id='gu-image-422395585'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg' alt='Alfred Prasad's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Alfred Prasad's onion bhajis.</figcaption></figure><p>The gram flour gives the batter a subtle nutty flavour, but subtle isn't what we're looking for here. Chillies are a popular addition, with Prasad and Todiwala plumping for fresh green chillies, and Prasad, Todiwala, Majumdar and Flavours of Gujarat sticking in dried chilli powder too. I prefer the cleaner, greener flavour of the fresh variety. Turmeric is also fairly standard, as much for colour as flavour.</p><p>Gulhane and Prasad both add garlic and ginger to the batter, which lend it a pleasing and more interesting sweetness than Majumdar's sugar – as do Prasad's unusual, but very welcome, fennel seeds, which I prefer to Todiwala's sharper ajwain, or lovage seeds. I love the earthiness of his cumin seeds with the onion, though. Sesame seeds, as used in Flavours of Gujarat, seem an unnecessary addition.</p><p>Fresh coriander, used by everyone but Majumdar, adds an attractive colour and a fresh, clean flavour to the batter, while curry leaves, as used by Prasad and Gulhane, contribute a herbal note. They're only worth buying fresh though, so if you can't find them, leave them out.</p><h2>Cooking</h2><figure data-media-id='gu-image-422395586'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg' alt='Cyrus Todiwala's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Cyrus Todiwala's onion bhajis.</figcaption></figure><p>It is very important to get the temperature of the oil right, as Todiwala explains: \"Too hot [and] they will fry too fast and remain raw inside and gooey. Too cold and the results will be oily and soft.\" The fairly standard 180C seems about right – most recipes suggest dropping a piece of batter in there to test the heat, but if you do have a food thermometer, use it – it is far more reliable than the sizzle test if you're after perfect results.</p><h2>The perfect onion bhajis</h2><figure data-media-id='gu-image-422395587'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg' alt='Felicity Cloake's perfect onion bhajis' width='460' height='276' class='gu-image'/><figcaption>Felicity Cloake's perfect onion bhajis.</figcaption></figure><p><strong><em>(Makes 8)</em></strong><br /><strong>60g gram flour</strong><br /><strong>30g rice flour</strong><br /><strong>1 tbsp ghee or butter, melted </strong><br /><strong>Juice of ¼ lemon</strong><br /><strong>½ tsp turmeric</strong><br /><strong>1 tsp cumin seeds, coarsely chopped</strong><br /><strong>¼ tsp fennel seeds</strong><br /><strong>1-2 hot green chillies (to taste), finely minced</strong><br /><strong>2 tsp root ginger, finely grated </strong><br /><strong>2 cloves of garlic, finely chopped</strong><br /><strong>Small bunch of coriander, chopped</strong><br /><strong>2 fresh curry leaves, chopped (optional)</strong><br /><strong>2 onions, halved, core removed and thinly sliced</strong><br /><strong>Vegetable oil, to cook</strong></p><p>Sift the flours into a mixing bowl, then stir in the ghee and lemon juice and just enough cold water to bring it to the consistency of double cream. Stir in the spices, aromatics and herbs and add salt to taste. Stir in the onions so they are well coated.</p><p>Heat the oil in a deep-fat fryer to 180C, or fill a large pan a third full with oil and heat – a drop of batter should sizzle as it hits the oil, then float. Meanwhile, put a bowl of cold water next to the hob, and a plate lined with kitchen paper. Put the oven on a low heat.</p><p>Once the oil is up to temperature, wet your hands and shape tablespoon-sized amounts of the mixture into balls. Drop into the oil, being careful not to overcrowd the pan, then stir carefully to stop them sticking. Cook for about four minutes, turning occasionally, until crisp and golden, then drain on the paper and put in the oven to keep warm while you cook the next batch. Serve with chutney or pickle.</p><p><strong>Bhajis – where do you stand: a great curry house starter, or a fabulous teatime treat? Which other members of the pakora family do you rate – and what do you like to serve with them? (For me, aubergine pickle takes some bettering.)</strong></p><!-- Guardian Watermark: internal-code/content/422384559|2013-11-13T15:50:01Z|f51a9b2b64f187bce77f10fd85178b2aabe50b5a -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbnh",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+        "wordcount":"1130",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/how-to-cook-the-perfect",
+        "type":"series",
+        "webTitle":"How to cook the perfect ...",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/indian",
+        "type":"keyword",
+        "webTitle":"Indian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/indian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/indian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/starter",
+        "type":"keyword",
+        "webTitle":"Starter",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/starter",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/starter",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/snacks",
+        "type":"keyword",
+        "webTitle":"Snacks",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/snacks",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/snacks",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/vegetarian",
+        "type":"keyword",
+        "webTitle":"Vegetarian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/vegetarian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/vegetarian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/wordofmouth",
+        "type":"blog",
+        "webTitle":"Word of Mouth blog",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/felicity-cloake",
+        "type":"contributor",
+        "webTitle":"Felicity Cloake",
+        "webUrl":"http://www.theguardian.com/profile/felicity-cloake",
+        "apiUrl":"http://content.guardianapis.com/profile/felicity-cloake",
+        "bio":"<p>Felicity Cloake is a writer specialising in food and drink and winner of the 2011 Guild of Food Writers awards for Food Journalist of the Year and New Media of the Year. Her first recipe book, <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490837\">Perfect</a>, is published by Fig Tree. She likes to think she'd try any food once – although an eyeball recently caused her to question this gung-ho gastronomic philosophy</p>",
+        "r2ContributorId":"32433",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/5/1370451580801/Felicity-Cloake.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422395580",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346619304/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photographs: Felicity Cloake for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422395581",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"84",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photograph: Felicity Cloake for the Guardian",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422395582",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"SImon Majumdar's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Simon Majumdar's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395583",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Flavours of Gujarat's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Flavours of Gujarat's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395584",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Nikita Gulhane's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Nikita Gulhane's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395585",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Alfred Prasad's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Alfred Prasad's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395586",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Cyrus Todiwala's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Cyrus Todiwala's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395587",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis.",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"books/2013/nov/13/autobiography-by-morrissey-review",
+      "sectionId":"books",
+      "sectionName":"Books",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Autobiography by Morrissey – review",
+      "webUrl":"http://www.theguardian.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "apiUrl":"http://content.guardianapis.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "fields":{
+        "trailText":"<p>This book is superb: Mozzer is so devastatingly articulate he could win the Booker, argues <strong>Terry Eagleton</strong></p>",
+        "headline":"Autobiography by Morrissey – review",
+        "body":"<p>Not content with being voted the greatest northern male ever, the second greatest living British icon (he lost out to David Attenborough) and granted the freedom of the city of Tel Aviv, Morrissey is now out to demonstrate that he can write the kind of burnished prose no other singer on the planet could aspire to. There are, to be sure, a&nbsp;few painfully florid patches in this superb autobiography (\"Headmaster Mr Coleman rumbles with grumpiness in a rambling stew of hate\"), but it would be hard to imagine Ronnie Wood or <a href=\"http://www.theguardian.com/music/ericclapton\" title=\"\">Eric Clapton</a> portraying the \"Duchess of nothing\" Sarah Ferguson as \"a little bundle of orange crawling out of a frothy dress, the drone of Sloane, blessed with two daughters of Queen Victoria pot-dog pudginess\".</p><p><a href=\"http://www.theguardian.com/music/morrissey\" title=\"\">Morrissey</a> despises most of the people he meets, often with excellent reason. He is scurrilous, withdrawn and disdainful, an odd mixture of shyness and vitriol. The dreamy, heart-throbbish photo on the cover of the book, the nose rakishly tilted above the&nbsp;Cupid's-bow lips, belies what a mean old bastard he is. He finds an image of himself in (of all people) the minor Georgian poet <a href=\"http://books.theguardian.com/review/story/0,,1788971,00.html\" title=\"\">AE Housman</a>, who preferred art to humanity and whose ascetic, spiritually tortured life seems to echo Morrissey's own. He admires wayward, bloody-minded types much like himself, and takes a&nbsp;sadistic delight in discomforting interviewers. \"Why did you mention Battersea in that song?\" a journalist asks him. \"Because it rhymes with fatty,\" he replies. Taken by his father at the age of eight to watch <a href=\"http://www.theguardian.com/books/2013/oct/04/immortal-biography-george-best-hamilton-review\" title=\"\">George Best</a> play at Old Trafford, he swoons at the sight of such artistry combined with such rebelliousness. Years later, others will swoon at his own mixing of the two.</p><p>Some of his bloody-mindedness springs from a damaged childhood. Born into a working-class Irish-Mancunian family, Steven Patrick Morrissey sang his way out of what struck him as a soulless environment, as other working-class Irish Mancunians have written or acted their way out. The vitriol started to flow early: his bleak mausoleum of a Catholic primary school was ruled by Mother Peter, \"a&nbsp;bearded nun who beat children from&nbsp;dawn to dusk\", and by the time he was 17 he was already emotionally exhausted. Manchester, still in its pre-cool days, was a \"barbaric place where only savages can survive … There are no sexual guidelines, and I see myself naked only by appointment.\" His eloquent contempt for his fellow citizens is terrifying: \"non-human sewer-rats with missing eyes; the loudly insane with indecipherable speech patterns; the mad poor of Manchester's armpit.\" The final indignity is to be turned down for a job&nbsp;as a postman at the local sorting office. At the hour of the birth of the Smiths, which gave him the exit from Manchester he craved, he felt himself dying of boredom, loneliness and disgust. \"I would talk myself through each day,\" he writes, \"as one would nurse a dying friend.\"</p><p>Not long afterwards, hordes of young people throughout the world are&nbsp;wearing his face on their chests. He returns to the streets where he grew up, now with a police escort, to sing to 17,000 fans from a stage overlooking an odious Inland Revenue office where he once worked. Having failed to find love from one man or woman, he can now find it from thousands. <a href=\"http://www.theguardian.com/music/mick-jagger\" title=\"\">Mick Jagger</a> and <a href=\"http://www.theguardian.com/music/elton-john\" title=\"\">Elton John</a> are eager to shake his hand. He enjoys his celebrity, but the sardonic self-irony of the book seeks to&nbsp;persuade us otherwise. There is a relish and energy about its prose that undercuts his misanthropy. Its lyrical quality suggests that beneath the hard-bitten scoffer there lurks a romantic softie, while beneath that again lies a hard-bitten scoffer. Implausibly, he claims to be \"chilled\" by road signs reading \"Morrissey Concert, Next Left\". It's true, however, that having spent years yearning to be seen, he now spends years longing to be invisible. Living in Hollywood is hardly the best place for that. He deals with his own egocentricity by being wryly amusing about it: his birth almost killed his mother, he comments, because even then his head was too&nbsp;big.</p><p>Even so, he remains for the most part icily unillusioned, like a monk passing through a whorehouse. His contempt for the music industry is visceral, and he prefers to spend his time reading <a href=\"http://www.theguardian.com/books/whauden\" title=\"\">Auden</a> and <a href=\"http://www.theguardian.com/books/jamesbaldwin\" title=\"\">James Baldwin</a>. (Spotting Baldwin in a Barcelona hotel, he decides not to approach him, since even the mildest rejection would apparently mean he would have to go and hang himself.) The solution to all problems, he tells us, \"is the goodness of privacy in a warm room with books\". <a href=\"http://www.theguardian.com/music/davidbowie\" title=\"\">David Bowie</a> tells him that he's had so much sex and drugs that he's surprised he is still alive, to which Morrissey replies that he's had so little of both that he feels much the same. <a href=\"http://www.theguardian.com/film/tomhanks\" title=\"\">Tom Hanks</a> comes backstage to say hello, but Morrissey doesn't know who he is. The press lie that he is a racist, that he opened the door to a journalist wearing a tutu, that he hung around public toilets as a youth and that he would welcome the assassination of Margaret Thatcher. The Guardian runs a disapproving piece on him adorned with a photo of somebody else. When he discovers that a Smiths record released in Japan includes a track by Sandie Shaw, he begs the people around him to kill him. \"Many rush forward,\" he adds.</p><p>\"Although a passable human creature on the outside,\" he comments of himself, \"the swirling&nbsp;soul within seemed to speak up for the most awkward people on the planet\", of whom he himself ranks among the most adept. He is one of the great curmudgeons and contrarians of our time. He&nbsp;even puts in a&nbsp;good word for the Kray brothers.</p><p>Surprisingly, he goes easy on his passion for animal rights, but observes no such restraint when it comes to <a href=\"http://www.theguardian.com/world/george-bush\" title=\"\">George Bush</a> (\"the world's most famous active terrorist\") and <a href=\"http://www.theguardian.com/politics/tonyblair\" title=\"\">Tony Blair</a>, at whose feet he lays the London deaths of 2005. At least the vindictive music industry has taught him how to&nbsp;hate, though one suspects he didn't&nbsp;need much tutoring. The music impresario <a href=\"http://www.theguardian.com/music/tonywilson\" title=\"\">Tony Wilson</a> \"managed a lengthy and slow decline which some thought was actually an ongoing career\". There is a cameo of Julie Burchill of such sublime savagery that&nbsp;one expects the page to ignite. The&nbsp;former Smiths who took him to court are subjected to 50 pages of devastatingly articulate venom.</p><p>Though he is careful to inform us that he drives a sky-blue Jag, fame hasn't changed him much. He is still the same miserable old Mozzer he always was. The death of friends leads him to wonder movingly whether life isn't \"all too burdensome, with so much loss taking its root in the heart, as the body goes spinning on towards a&nbsp;dreadful cessation\". It isn't the kind of sentence Robbie Williams would come up with. His interest in the dead, his father warns him, outstrips his affection for the living. He sees a ghost on Saddleworth Moor, burial ground of&nbsp;the Moors murders, and narrowly avoids being kidnapped in Mexico. Everywhere he looks he sees violence: \"military science whaling, nuclear weapons, armed combat, the abattoir, holy war … riot police assaulting innocent civilians.\" When a small, flightless bird comes to live in his back garden, he fences it in with boxes to ward off predators. He has quite a few such boxes of his own.</p><p>Perhaps the time has come for a new&nbsp;career. If he could get treatment for his addiction to alliteration and stop using phrases like \"for you and I\", this prodigiously talented \"small boy of 52\", as he described himself two years ago, could walk away with the Booker prize.</p><!-- Guardian Watermark: internal-code/content/422279954|2013-11-13T15:50:01Z|42551f72bd3fa99ac491fea86fb610ea14c72160 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kann",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+        "wordcount":"1264",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"books/autobiography-and-memoir",
+        "type":"keyword",
+        "webTitle":"Autobiography and memoir",
+        "webUrl":"http://www.theguardian.com/books/autobiography-and-memoir",
+        "apiUrl":"http://content.guardianapis.com/books/autobiography-and-memoir",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/morrissey",
+        "type":"keyword",
+        "webTitle":"Morrissey",
+        "webUrl":"http://www.theguardian.com/music/morrissey",
+        "apiUrl":"http://content.guardianapis.com/music/morrissey",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"books/books",
+        "type":"keyword",
+        "webTitle":"Books",
+        "webUrl":"http://www.theguardian.com/books/books",
+        "apiUrl":"http://content.guardianapis.com/books/books",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"tone/reviews",
+        "type":"tone",
+        "webTitle":"Reviews",
+        "webUrl":"http://www.theguardian.com/tone/reviews",
+        "apiUrl":"http://content.guardianapis.com/tone/reviews",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview/saturdayreviewsfeatres",
+        "type":"newspaper-book-section",
+        "webTitle":"Features & reviews",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview",
+        "type":"newspaper-book",
+        "webTitle":"Guardian review",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/smiths",
+        "type":"keyword",
+        "webTitle":"The Smiths",
+        "webUrl":"http://www.theguardian.com/music/smiths",
+        "apiUrl":"http://content.guardianapis.com/music/smiths",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/indie",
+        "type":"keyword",
+        "webTitle":"Indie",
+        "webUrl":"http://www.theguardian.com/music/indie",
+        "apiUrl":"http://content.guardianapis.com/music/indie",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"uk/manchester",
+        "type":"keyword",
+        "webTitle":"Manchester",
+        "webUrl":"http://www.theguardian.com/uk/manchester",
+        "apiUrl":"http://content.guardianapis.com/uk/manchester",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/terryeagleton",
+        "type":"contributor",
+        "webTitle":"Terry Eagleton",
+        "webUrl":"http://www.theguardian.com/profile/terryeagleton",
+        "apiUrl":"http://content.guardianapis.com/profile/terryeagleton",
+        "bio":"<p>Terry Eaglton is a literary critic, writer and chair in English literature in Lancaster University's department of English and creative writing. His latest book is The Event of Literature</p>",
+        "r2ContributorId":"22184",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/11/3/1320333646305/Terry-Eagleton.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381626",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256764062/Morrissey-at-book-signing-001.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"54",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256766657/Morrissey-at-book-signing-002.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"340",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256768272/Morrissey-at-book-signing-003.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"130",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256771724/Morrissey-at-book-signing-005.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"132",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256773421/Morrissey-at-book-signing-006.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"168",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256775059/Morrissey-at-book-signing-007.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"180",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256776719/Morrissey-at-book-signing-008.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"228",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256780785/Morrissey-at-book-signing-010.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"372",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel/TT/EPA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381627",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "sectionId":"business",
+      "sectionName":"Business",
+      "webPublicationDate":"2013-11-13T15:14:55Z",
+      "webTitle":"Bank of England: UK recovery has finally taken hold - live",
+      "webUrl":"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "apiUrl":"http://content.guardianapis.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "fields":{
+        "trailText":"UK central bank has upgraded its forecasts for growth and unemployment today, with governor Mark Carney telling reporters that the recovery looks more solid",
+        "headline":"Bank of England: UK recovery has finally taken hold - live",
+        "body":"<div id=\"block-52839521e4b06f50dbc6f580\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T15:09:28.623Z\">3.09pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Euro drops as ECB hints at possible negative rates or QE</h2> <div class=\"block-elements\"> <p><strong>The euro has come under pressure after an ECB board member hinted the central bank could authorise negative interest rates or buying assets from banks to hit its inflation target.</strong> Peter Praet <a href=\"http://online.wsj.com/news/articles/SB10001424052702304243904579195631017906684\">told the Wall Street Journal</a>:</p> <blockquote class=\"quoted\"> <p>If our mandate is at risk we are going to take all the measures that we think we should take to fulfil that mandate. That's a very clear signal.&nbsp;The balance sheet capacity of the central bank can also be used. This includes outright purchases that any central bank can do.</p> </blockquote> <p>The ECB cut interest rates to 0.25% last week and kept the deposit rate at zero. Praet said:</p> <blockquote class=\"quoted\"> <p>On standard measures, interest rates, we still have room and that would also include the deposit facility.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/IGSquawk/statuses/400637632176480256\"> <blockquote class=\"twitter-tweet\"><p><a href=\"https://twitter.com/search?q=%24EURUSD&amp;src=ctag\">$EURUSD</a> has fallen 40pips since 14:30 and dropped below the 1.34 handle. ECB not ruling out QE according to WSJ - <a href=\"http://t.co/gZbr2p290S\">http://t.co/gZbr2p290S</a>. AB</p>— IGSquawk (@IGSquawk) <a href=\"https://twitter.com/IGSquawk/statuses/400637632176480256\">November 13, 2013</a></blockquote> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T15:14:55.959Z\">at 3.14pm GMT</time></p> </div> <div id=\"block-528391f3e4b04416f8fd691f\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T15:01:35.421Z\">3.01pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Over in Ireland, some good employment news.</strong> Henry McDonald, Ireland Correspondent, writes:</p> <blockquote class=\"quoted\"> <p>Belfast's iconic shipbuilding firm that constructed the Titanic has given Northern Ireland's economy a temporary boost with the creation of 600 short term skilled jobs.<br />Harland and Wolff, whose giant yellow cranes dominate the Belfast skyline, announced today that they are recruiting the extra skilled tradesmen to work on one of the largest oil rigs ever built in its shipyard.<br />The 360 ft tall Blackford Dolphin offshore drill platform is currently on its way from Brazil to Belfast where it will undergo maintenance work at the yard where the Titanic was made.</p> </blockquote> <figure class=\"element element-image\" data-media-id=\"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg\" alt=\"Belfast Harbour. Photo: Belfast Harbour/PA\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption>Belfast Harbour. Photo: Belfast Harbour/PA</figcaption> </figure> <blockquote class=\"quoted\"> <p>David McVeigh, head of sales and marketing at Harland and Wolff, said the contract was on such a large scale and completed within such a tight time frame, that the 600 additional workers had to be found in a relatively short period of time.</p> <p>&quot;Harland and Wolff continues to compete successfully in a sector which has seen competition grow,&quot; said McVeigh.</p> <p>&quot;Apart from being able to exceed stringent health and safety element requirements for such contracts, H&amp;W is also capable of great flexibility which means we can put 600 contractors from electrical, welding, engineering and painting disciplines in place in a short time.&quot;</p> <p>The shipyard now concentrates on maintaining and repairing oil rigs rather than ships. Its giant Samson and Goliath cranes will have to be moved out of their current positions along tracks to the end of the building dock for the estimated 50 days of work on the Blackford Dolphin rig.</p> </blockquote> </div> </div> <div id=\"block-52838fc0e4b0839b692756a5\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:49:37.980Z\">2.49pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Our <strong><a href=\"http://www.theguardian.com/data\">Data Blog</a></strong> has pulled together statistics on the unemployment figures:</p> <blockquote class=\"quoted\"> <p>The unemployment rate dropped from 7.8% in the three months to June to 7.6% – its <a href=\"http://www.theguardian.com/business/2013/nov/13/unemployment-rate-falls-bank-of-england-interest-rate-target\">lowest level in four years</a>, but what has happened to the claimant count? Using the October 2013 figures from <a href=\"http://www.nomisweb.co.uk/\">Nomis</a>, the map shows the numbers by each local authority.</p> </blockquote> <p>The data is here:</p> <h2><a href=\"http://www.theguardian.com/news/datablog/interactive/2013/nov/13/uk-unemployment-mapped-adult-youth\">UK unemployment mapped</a></h2> </div> </div> <div id=\"block-528388a6e4b04416f8fd6915\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:22:22.515Z\">2.22pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The FTSE 100 is on course for its worse one day fall in months.</strong> It is 105 points or 1.57% lower which would be its biggest drop since 20 June, if it ends like this. On Wall Street, the Dow Jones Industrial Average is forecast to open around 90 points lower, so there will be no help for the bulls from that direction.</p> <p>The falls are being driven by the feeling that central banks could finally start switching off the money taps, which have been providing support for the markets for what seems like forever. On Tuesday US Federal Reserve member Dennis Lockhart - seen as being in the centre as far as the policy debate goes - suggested there was a possibility the bank could reduce its $85bn a month bond buying programme at its December meeting. Most observers had still been banking on no change to the stimulus programme until next year.</p> <p>Meanwhile, as we have been reporting this morning, the Bank of England may also raise rates sooner than had been anticipated.</p> </div> </div> <div id=\"block-528384a1e4b031056a8eeebe\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:06:24.127Z\">2.06pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Back to the Bank of England....</h2> <div class=\"block-elements\"> <p><strong>On the Bank of England's raised growth forecasts, our economics correspondent Phillip Inman reports:</strong></p> <blockquote class=\"quoted\"> <p>The&nbsp;Bank of England&nbsp;expects to consider raising&nbsp;interest rates&nbsp;in 2015, a year earlier than expected, following a sharp fall in unemployment.</p> <p>But the bank tempered expectations of an early increase with the warning that the recovery remained fragile and rates could still remain low for several years.</p> <p>Governor&nbsp;Mark Carney&nbsp;said he expected growth to remain modest over the next couple of years while the economy continues to be hampered by a weak banking sector and stumbling overseas markets.</p> <p>Speaking after publication of the central bank's quarterly inflation report, Carney played down concerns that the current 0.5% base rate would rise before real incomes begin to rise and the recovery is secured.</p> <p>&quot;The economy is growing robustly as lifting uncertainty and thawing credit conditions start to unlock pent-up demand. But significant headwinds – both at home and abroad – remain, and there is a long way to go before the aftermath of the financial crisis has cleared and economic conditions normalise,&quot; he said in the report.</p> <p>&quot;That underpins the monetary policy committee's (MPC) intention to maintain the exceptionally stimulative stance of monetary policy until there has been a substantial reduction in the degree of economic slack.&quot;</p> <p>In August the BoE said as part of its new policy of forward guidance that it would not consider raising interest rates before unemployment fell to 7%. MPC members agreed that unemployment was a strong indicator of slack in the economy. Figures for August show that rate has fallen to 7.6% following an unexpectedly sharp rise in job recruitment over the previous three months.</p> <p>In response the BoE said there was now a three in five chance that the UK unemployment rate would hit 7% in mid-2015 compared to a previous prediction of late 2016.</p> <p>Deputy governor Charlie Bean said forward guidance was still pointing to a rate rise later rather than sooner. He said: &quot;The key message is that policy is not going to be related to growth rates but the elimination of slack.&quot;</p> </blockquote> <h2>Here's the full story:&nbsp;<a href=\"http://www.theguardian.com/business/2013/nov/13/interest-rates-could-rise-2015\">Interest rates could rise in 2015 – BoE</a></h2> <p>The other big news story of the day is the drop in UK unemployment, to a four-year low of 7.6%.</p> <p><strong>Economics editor Larry Elliott writes:</strong></p> <blockquote class=\"quoted\"> <p>Britain's rising population means that a record number of people – 29.95 million – are in work but the employment rate remains lower than it was before the deep recession of 2008-09. The current rate of 71.8% compares with 73% at the peak in early 2008 but above the trough of 70.8% reached in 2011.</p> <p>The bulk of the jobs created in the latest three months were full time but a record 1.46 million people were working part time because they could not find a full-time job. Unemployment as measured by the number of people out of work and claiming eligible benefits dropped by 41,700 in September to 1.3 million.</p> </blockquote> <h2>More here:&nbsp;<a href=\"http://www.theguardian.com/business/2013/nov/13/unemployment-rate-falls-bank-of-england-interest-rate-target\">Jobless rate moves towards Bank of England target</a></h2> <p><em>And that's a good moment to hand over <strong>Nick Fletcher</strong>, before trading begins on Wall Street. Shares are still lower in London, with the FTSE 100 down 107 points... </em><strong>GW</strong></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T14:07:41.474Z\">at 2.07pm GMT</time></p> </div> <div id=\"block-528380e8e4b01a80f661c25a\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:45:06.789Z\">1.45pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>As well as the departure of Sir Hector Sants, Barclays has also reported that chief operations and technology officer,&nbsp;Shaygan Kheradpir, is leaving the company.</strong></p> <p>Here's the bank's statement:</p> <blockquote class=\"quoted\"> <p>Hector Sants has been on sick leave since the beginning of October, suffering from stress and exhaustion. He has concluded that he will not be able to return to work in the near term. Consequently he has decided to resign from Barclays and not return from sick leave.</p> <p>Shaygan Kheradpir, Chief Operations and Technology Officer, is leaving Barclays to take on a role as CEO for a company based in the United States.</p> <p>An internal and external search will be launched for both posts. In the meantime Allen Meyer, Head of Compliance, Corporate and Investment Banking will act as Interim Head of Compliance and Government and Regulatory Relations. Darryl West, Barclays’ Chief Information Officer, will act as Interim Group Chief Operations and Technology Officer. In these posts both will join the Executive Committee and report to Group Chief Executive, Antony Jenkins.</p> </blockquote> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:46:41.132Z\">at 1.46pm GMT</time></p> </div> <div id=\"block-52837ee7e4b01a80f661c259\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:33:57.694Z\">1.33pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Sants leaves Barclays</h2> <div class=\"block-elements\"> <p><strong>Sir Hector Sants</strong>, the former head of the UK's Financial Services Authority, has stepped down from his role as head of compliance at Barclays, my colleague <strong>Jill Treanor</strong> reports.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/jilltreanor/statuses/400613343108411392\"> <blockquote class=\"twitter-tweet\"><p>Barclays says Sir Hector Sants has quit as head of compliance</p>— Jill Treanor (@jilltreanor) <a href=\"https://twitter.com/jilltreanor/statuses/400613343108411392\">November 13, 2013</a></blockquote> </figure> <p><a href=\"http://www.theguardian.com/business/2013/oct/15/hector-sants-barclays-exhaustion\"><strong>This comes a month after Sants began a &quot;leave of absence&quot; after being diagnosed with exhaustion and stress</strong></a>.&nbsp;</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:34:44.051Z\">at 1.34pm GMT</time></p> </div> <div id=\"block-528376d2e4b01a80f661c258\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:29:57.899Z\">1.29pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">EC begins review of German trade surplus</h2> <div class=\"block-elements\"> <p><strong>Over in Brussels, the European Commission has - as anticipated - launched an inquiry into the German trade surplus.</strong></p> <p><a href=\"http://ec.europa.eu/europe2020/pdf/2014/amr2014_en.pdf\"><strong>In a new report</strong></a>, the EC said it would launch an &quot;in-depth review&quot; of both&nbsp;Germany and Luxembourg.</p> <p>It plans to:</p> <blockquote class=\"quoted\"> <p>better scrutinise&nbsp;their external position and analyse internal developments, and assess whether any of these countries is experiencing imbalances.</p> </blockquote> <p>It explained that the&nbsp;German trade surplus has exceeded the EC's 'threshold' (6% of national GDP)&nbsp;each year since 2007, so it clearly isn't a short-term problem.</p> <p>This means Germany becomes one of 16 Member States who are being probed for imbalances (many others face questions over&nbsp;current account&nbsp;deficits, losses of competitiveness and debt and deficit levels).</p> <p>This chart shows the differences between EU member states:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png\" alt=\"Eurozone current account data\" width=\"460\" height=\"386\" class=\"gu-image\" /> <figcaption>Photograph: EC</figcaption> </figure> <p>Germany's defenders say it should not be blamed for running a successful export sector, and suggest that other countries could learn a few lessons.</p> <p>Commission president&nbsp;Jos&eacute; Manuel Barroso sounded conciliatory at a press briefing in Brussels, saying:</p> <blockquote class=\"quoted\"> <p>Europe needs more Germanys.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/OpenEurope/statuses/400603967698108416\"> <blockquote class=\"twitter-tweet\"><p>Barroso: what we are launching here is an indepth review, which is almost automatic as Germany exceeded the threshold of 4 indicators</p>— Open Europe (@OpenEurope) <a href=\"https://twitter.com/OpenEurope/statuses/400603967698108416\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/OpenEurope/statuses/400604259462295554\"> <blockquote class=\"twitter-tweet\"><p>Barroso: this should not be seen as Europe being perceived at odds with German competitiveness...exercise to judge the consequences</p>— Open Europe (@OpenEurope) <a href=\"https://twitter.com/OpenEurope/statuses/400604259462295554\">November 13, 2013</a></blockquote> </figure> <p>Bundesbank presiden<strong>t Jens Weidmann</strong>&nbsp;has already warned that Germany shouldn't be penalised, according to this Reuters newsflash:</p> <p><strong>• WEIDMANN SAYS ANSWER TO GERMANY'S CURRENT ACCOUNT SURPLUS CANNOT BE TO MAKE GERMAN COMPANIES LESS COMPETITIVE&nbsp;</strong></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:34:27.612Z\">at 1.34pm GMT</time></p> </div> <div id=\"block-528376bae4b01a80f661c257\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:55:35.845Z\">12.55pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg\" alt=\"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.\" width=\"460\" height=\"282\" class=\"gu-image\" /> <figcaption>Photograph: TOBY MELVILLE/AFP/Getty Images</figcaption> </figure> </div> </div> <div id=\"block-52837335e4b0f37bee4ff653\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:53:14.524Z\">12.53pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England's report: What the experts say</h2> <div class=\"block-elements\"> <p>Here's some economist reaction:</p> <p><strong>David Kern, chief economist at the British Chambers of Commerce:</strong></p> <blockquote class=\"quoted\"> <p>We support Governor&nbsp;Carney’s statement that the pressure on living standards can only be addressed when productivity increases. Simply raising wages before this happens would make businesses uncompetitive and threaten the recovery.</p> </blockquote> <p><strong>Howard Archer of IHS Global Insight:</strong></p> <blockquote class=\"quoted\"> <p>The message coming loud and clear from the Bank of England is that it remains in no hurry at all to raise interest rates despite the economy’s improved performance and a likely significantly faster fall in unemployment than the central bank had previously expected.</p> <p>It is clear that&nbsp;the Bank of England wants to give the economy every chance to develop sustainable decent growth and not to risk choking it off by any premature increasing of interest rates.</p> </blockquote> <p><strong>Rob Wood of&nbsp;Berenberg Bank:</strong></p> <blockquote class=\"quoted\"> <p>The BoE signalled its first rate hike might come in 2015, rather than late 2016 as it had previously said, in its quarterly forecast update this morning.....</p> <p>We see a 70% chance that unemployment falls to the 7% threshold by Q3 2015, compared to the BoE’s 50% chance.</p> <p>So while they have moved towards our view and the market, they still have some way to go. The risks are probably that the BoE is underestimating the speed at which the economy can recover. With loose policy, falling uncertainty and booming house prices, the recovery could snowball and more than 3% growth next year is not impossible. There are downside risks too of course, that we should not forget, but they seem to be diminishing.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/FGoria/statuses/400592336935485440\"> <blockquote class=\"twitter-tweet\"><p>Schroders now expects BoE to raise rates at beginning of 2016, previously expected BoE rate increase at end of 2016</p>— Fabrizio Goria (@FGoria) <a href=\"https://twitter.com/FGoria/statuses/400592336935485440\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52836f78e4b0f37bee4ff64c\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:40:13.804Z\">12.40pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Market reaction</h2> <div class=\"block-elements\"> <p>The pound has rallied by around 0.5% today, following the Bank of England's new forecasts and this morning's drop in UK unemployment (<a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283464ce4b0f37bee4ff61c\"><strong>see 9.30am onwards)</strong></a>.</p> <p>It's gained three quarters of a cent, against the US dollar to $1.5977.</p> <p>Shares, though, are down in London as traders anticipate monetary policy being tightened more quickly.</p> <p><strong>The FTSE 100 has dropped by 93 points, or 1.39%, to 6633.</strong></p> <p>Financial stocks are among the fallers -- with RSA Insurance down 3.8%, Standard Chartered down 3.4% and Barclays losing 3.1%.</p> </div> </div> <div id=\"block-528368dde4b0312d704c1180\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:24:19.055Z\">12.24pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England quarterly inflation report, a summary</h2> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg\" alt=\"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.\" width=\"460\" height=\"333\" class=\"gu-image\" /> <figcaption>Photograph: Toby Melville/POOL/EPA</figcaption> </figure> <p>So, to quickly recap.</p> <p>•<strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52835455e4b0b9c05d8a3466\">The Bank of England has raised its economic forecasts</a>, concluding that Britain's output will rise faster than expected this year and in 2014.</strong>&nbsp;This will help to pull down the UK unemployment rate, with a roughly 40% chance that it will be 7% by the end of next year.</p> <p>•&nbsp;<strong>Governor Mark Carney said the UK recovery had <a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-528359cfe4b0312d704c1179\">&quot;finally taken hold&quot;</a>,</strong>&nbsp;but warned that it needs to become &quot;strong and sustained&quot; to get more people into work, and to drive wages higher.</p> <blockquote class=\"quoted\"> <p>For the first time in a long time you don't have to be an optimist to see the glass is half full. The recovery has finally taken hold.</p> </blockquote> <p>This chart shows how the BoE sees more chance of the jobless rate hitting 7% soon:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png\" alt=\"Bank of England unemployment forecasts\" width=\"423\" height=\"401\" class=\"gu-image\" /> <figcaption>Photograph: Bank of England</figcaption> </figure> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-528357c1e4b0312d704c1177\">Carney defended his 'forward guidance' on interest rates</a>, which states that borrowing costs won't rise until the jobless rate has hit 7%.</strong> He said the pledge had helped to sustain the recovery, and did not mean that a rate rise was inevitable once the 7% rate has been hit.</p> <p>He said:</p> <blockquote class=\"quoted\"> <p>There was always going to be movement in the timing of when potentially the unemployment threshold was reached .. but what's important is two things.</p> <p>One is what we learn between now and when that threshold is achieved, what we learn about the economy, what we learn about how much extra slack there is in the economy. And secondly what the conditions are when it's achieved and we're providing the confidence to businesses and households that we will not even begin to think about moving interest rates until that threshold is achieved.</p> </blockquote> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52835d8ee4b07aa4168b4b14\">Carney was also asked about the UK housing market,</a> and concerns of a bubble in London</strong>. He replied that the Bank is setting policy for the whole country, not <strong><a href=\"http://cdn.london-insider.co.uk/wp-content/uploads/2009/11/LondonTubeTrainMap2010.jpg\">&quot;inside the Circle Line&quot;</a>, </strong>adding:</p> <blockquote class=\"quoted\"> <p>In terms of housing valuation there are clearly areas in the country where valuation is very elevated. What we are seeing across the UK is the greatest price momentum is for houses that are towards the upper end of the valuation spectrum.</p> <p>The bank, through the Financial Policy Committee, will be vigilant about potential risks there but we need to put the pickup in housing activity in perspective. Activity levels, while they've picked up, are still running at between two thirds or three quarters of historic averages in terms of whether its transactions or approvals, homebuilding, so there is some room for that to further pickup and that's the initial phase of this recovery.</p> </blockquote> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52836023e4b0b9c05d8a346f\">And the Bank is still cautious about the situation in the eurozone</a>, even though the 'pall' of uncertainty over the future of the euro has mostly lifted.</strong> Carney said the UK central bank isn't expecting a big pick-up in demand from Europe.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T12:54:06.834Z\">at 12.54pm GMT</time></p> </div> <div id=\"block-528365f7e4b0b9c05d8a3477\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:47:39.873Z\">11.47am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>And that's the end of the press conference - cue a brief burst of Beethoven* on the webcast feed.</p> <p>* - <a href=\"https://www.youtube.com/watch?v=iwIvS4yIThU\"><em>9th Symphony,&nbsp;2nd movement, rather awesome</em></a></p> </div> </div> <div id=\"block-528363a6e4b0312d704c117e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:42:25.732Z\">11.42am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Several questions on the government's Help to Buy mortgage subsidy scheme.</p> <p><strong>Observer economics editor Heather Stewart</strong> asks about the Treasury Select Committee's concerns (<a href=\"http://www.theguardian.com/business/2013/nov/09/help-to-buy-scrutiny-bank-of-england-mark-carney\"><em>they want the Bank of England to clarify its role in the scheme</em></a>).</p> <p>Carney says that the issue will be considered at the next meeting of the Financial Policy Committee (responsible for ensuring economic stability). He adds that the Bank has a range of ways to influence the housing market.</p> </div> </div> <div id=\"block-5283625fe4b0b9c05d8a3473\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:33:53.080Z\">11.33am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Kathryn Hopkins of The Times raises the issue of gender targets (<em>the Bank of England's senior ranks are dominated by men</em>).</strong></p> <p>Mark Carney replies that &quot;it is an objective of this institution to increase the diversity of our junior ranks, and senior ranks&quot;.</p> <p>Appointments to the senior ranks are made by others, he points out (<em>the Treasury picks the governor, and the members of the rate-setting Monetary Policy Committee</em>), but the Bank can increase diversity at all levels.</p> <p>A review of the Bank's talent management and recruitment policies is underway, he adds, though he won't prejudge its conclusions</p> </div> </div> <div id=\"block-52836023e4b0b9c05d8a346f\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:28:09.358Z\">11.28am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Asked about the eurozone, Mark Carney says that the Bank of England only expects &quot;quite modest demand growth&quot; in this major export market.</p> <p>We do expect the removal, or reduction, of the pall of uncertainty that hung over businesses over the future of the eurozone, he adds.</p> <p>But Threadneedle Street is not&nbsp;relying on any meaningful recovery in Europe to drive this forwards.</p> <p>And that's why the GDP growth forecasts remain relatively modest compared to previous recoveries, he adds.</p> </div> </div> <div id=\"block-528361c5e4b0b9c05d8a3472\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:26:44.887Z\">11.26am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png\" alt=\"Mark Carney\" width=\"460\" height=\"264\" class=\"gu-image\" /> <figcaption>Mark Carney speaking today. Photograph: Bank of England</figcaption> </figure> </div> </div> <div id=\"block-5283607ae4b0312d704c117c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:25:09.673Z\">11.25am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>How much credit does Mark Carney take for the recent pick-up in the UK economy, asks Channel 4's Faisal Islam.</strong></p> <p>Governor Carney says that &quot;our view is that forward guidance is helpful to sustain the recovery, that's why we did it.&quot;</p> <p>You only see the value of it at events like today, and in meetings with people around the country. People understand that the Bank of England &quot;needs to see sustained momentum and the slack picked up&quot; before we would tighten monetary policy.</p> <p>The government's Funding for Lending scheme is also helping to support the recovery and provide support for bank balance sheets, Carney adds.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T11:26:30.294Z\">at 11.26am GMT</time></p> </div> <div id=\"block-52835d8ee4b07aa4168b4b14\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:18:54.159Z\">11.18am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>Should the Bank's Financial Policy Committee&nbsp;act on the house price levels in London, the main topic of conversation at dinner parties in the capital?</em>&nbsp;</p> <p>Carney says the Bank is looking at the bigger picture:</p> <blockquote class=\"quoted\"> <p>We don't make policy for inside the Circle Line, we make it for the entire United Kingdom.</p> </blockquote> <p>And at this stage, the Bank isn't very worried about the housing market.</p> <p>He argues that expectations of future earnings can drive increased consumption levels, rather than the fact that people's houses are worth more (<em>which doesn't deliver a real 'wealth effect' unless people can unlock the value</em>).&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/EdConwaySky/statuses/400581840303828992\"> <blockquote class=\"twitter-tweet\"><p>Carney says for a 2nd time: &quot;We have a good line of sight to dynamics in the housing market&quot;. No idea what it means, but it sure sounds good</p>— Ed Conway (@EdConwaySky) <a href=\"https://twitter.com/EdConwaySky/statuses/400581840303828992\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835cf9e4b0b9c05d8a346d\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:07:19.425Z\">11.07am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>What would a more normal economy look like?</em>&nbsp;</p> <p>Mark Carney says that as the economy 'heals', the natural rate of unemployment should return to the pre-crisis levels of around 5%.</p> <p>But to be a sustainable, we need to see growth in real wages (ie, pay rises need to beat inflation not lag behind it) to sustain consumption growth.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T11:07:41.682Z\">at 11.07am GMT</time></p> </div> <div id=\"block-52835b50e4b0f37bee4ff635\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:05:13.895Z\">11.05am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Our economics editor Larry Elliott calls the Bank of England's forecasting record to account.</strong></p> <p>&nbsp;<strong>Larry asks:</strong></p> <blockquote class=\"quoted\"> <p>You failed to spot the recession in 2008, you&nbsp;failed to spot the flat-lining economy in 2010, and now you've failed to spot the stronger recovery. How can we have any faith in the forecasts that underpin forward guidance?</p> </blockquote> <p>Carney defends the Bank's record, says that it's confident that it's predictions are on the right path. He adds, though, that he's trying to make the forecasts more transparent to that doubters can better understand the bank's thinking.</p> <p>He then bats the question over to chief economist Spencer Dale -- who says that weaker global demand was one reason the Bank's UK growth forecasts were too optimistic in the past.</p> <p>Dale also argues that the real power of forward guidance is that people understand the Bank's approach to monetary policy, rather than its forecasts.</p> </div> </div> <div id=\"block-52835a24e4b0312d704c117a\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:58:17.730Z\">10.58am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Carney defends forward guidance</h2> <div class=\"block-elements\"> <p><em><strong>What on earth is the point of forward guidance on interest rates, asks Chris Giles of the FT, given the dramatic changes in the Bank of England's predictions.</strong></em>&nbsp;</p> <p>Imagine a world without forward guidance, replies Mark Carney.&nbsp;We've had an unexpectedly strong recovery - stronger than most analysts expected.</p> <p>If forward guidance wasn't introduced in August, the discussion would be 'is the Bank going to raise interest rates today'. No-one is asking that question today...</p> <p><strong>...and rightly so, Carney adds. A rate rise would mean the bank would &quot;take a recovery that has finally taken hold and pull the rug out from under it&quot;.</strong></p> </div> </div> <div id=\"block-528359cfe4b0312d704c1179\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:53:20.798Z\">10.53am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England: the recovery is finally taken hold</h2> <div class=\"block-elements\"> <p><strong>Here's the key quote from the Bank of England's report, declaring that the British recovery is, at last, underway:</strong></p> <blockquote class=\"quoted\"> <p>In the United Kingdom, recovery has finally taken hold. The economy is growing robustly as lifting&nbsp;uncertainty and thawing credit conditions start to unlock pent-up demand.</p> <p>But significant&nbsp;headwinds — both at home and abroad — remain, and there is a long way to go before the&nbsp;aftermath of the financial crisis has cleared and economic conditions normalise. That underpins the&nbsp;MPC’s intention to maintain the exceptionally stimulative stance of monetary policy until there has&nbsp;been a substantial reduction in the degree of economic slack.&nbsp;</p> <p>The pace at which that slack is eroded, and the durability of the recovery, will depend on the extent&nbsp;to which productivity picks up alongside demand. Productivity growth has risen in recent quarters,&nbsp;although unemployment has fallen by slightly more than expected on the back of strong output&nbsp;growth.</p> </blockquote> </div> </div> <div id=\"block-52835981e4b0b9c05d8a346a\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:50:50.503Z\">10.50am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><a href=\"http://www.bankofengland.co.uk/publications/Pages/inflationreport/2013/ir1304.aspx\"><strong>The full quarterly inflation report is online here</strong></a>.</p> </div> </div> <div id=\"block-5283584ee4b0b9c05d8a3469\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:50:07.913Z\">10.50am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>What can the Bank of England do to close the gap between wages and inflation, asks Sky's Ed Conway.</em></p> <p>Carney replies that it is important that the recovery persists, and &quot;we need a pickup in business investment&quot; too.</p> <p>The Bank's pledge to keep interest rates at record lows at least until the jobless rate is 7% will also help, he adds.</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png\" alt=\"Mark Carney\" width=\"460\" height=\"264\" class=\"gu-image\" /> <figcaption>Photograph: Sky News</figcaption> </figure> </div> </div> <div id=\"block-528357c1e4b0312d704c1177\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:45:19.433Z\">10.45am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>As expected, Mark Carney is having to defend his forward guidance policy on interest rates.</strong></p> <p>Asked how people and businesses are supposed to plan for the future if the bank's forecasts change so much, governor Carney explains that his priority is to &quot;provide confidence&quot; that borrowing costs won't rise until the recovery is secured.</p> <p>Interest rates won't immediately rise when the jobless rate hits 7%, he insists.</p> </div> </div> <div id=\"block-52835773e4b07aa4168b4b0c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:43:03.177Z\">10.43am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><a href=\"http://streamstudio.world-television.com/CCUIv3/frameset.aspx?ticket=117-118-13642&amp;target=en-default-&amp;status=live&amp;browser=ns-0-0-0-11-0&amp;stream=flash-video-400\"><strong>The Bank of England's Q&amp;A is being webcast here</strong></a>.</p> </div> </div> <div id=\"block-52835651e4b0312d704c1175\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:41:52.871Z\">10.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Mark Carney is telling reporters in London that:</strong></p> <blockquote class=\"quoted\"> <p><strong>For the first time in a long time, you don't need to be an optimist to see that the glass is half full.&nbsp;</strong><strong>The recovery has taken hold.</strong></p> </blockquote> <p>He's explaining that the Bank of England's job is to help secure the recovery, and make it strong enough to get more people back into work.&nbsp;</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T10:47:49.645Z\">at 10.47am GMT</time></p> </div> <div id=\"block-5283566be4b0b9c05d8a3468\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:39:05.299Z\">10.39am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The Bank of England has also raised its growth forecasts.</strong></p> <p>It expects GDP to rise by 1.6% for 2013 as a whole, up from 1.4%.</p> <p>In 2014, it expects growth of 2.8%, up from 2.5% in the August report.</p> <p>It still expects growth of 2.3% in 2015.</p> </div> </div> <div id=\"block-52835455e4b0b9c05d8a3466\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:36:13.581Z\">10.36am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England releases quarterly inflation report</h2> <div class=\"block-elements\"> <p><strong>The Bank of England has just released its latest quarterly report on the UK economy.</strong></p> <p>And it's raised its economic forecasts, saying that the unemployment rate will fall faster than it expected three months ago. There is a &quot;two in five chance&quot; that it could be 7% at the end of 2014, Mark Carney says.</p> <p>However, that doesn't mean interest rates would immediately rise (<em>7% being the target in the Bank's forward guidance</em>).&nbsp;</p> <p>It also believes that the inflation rate will fall to the 2% target faster than it thought in August.</p> <p>Here's the Reuters newsflashes:&nbsp;</p> <p><strong>• BANK OF ENGLAND NOV INFLATION REPORT - UK RECOVERY HAS FINALLY TAKEN HOLD, ECONOMY GROWING ROBUSTLY BUT SIGNIFICANT HEADWINDS REMAIN&nbsp;</strong></p> <p><strong>• BOE - MPC INTENDS TO KEEP EXCEPTIONALLY STIMULATIVE POLICY STANCE UNTIL SLACK HAS REDUCED SUBSTANTIALLY&nbsp;13-Nov-2013 </strong></p> <p><strong>• BOE - UNEMPLOYMENT LIKELY TO FALL MORE QUICKLY THAN FORECAST IN AUGUST, HITTING 7 PCT THRESHOLD WILL NOT NECESSARILY TRIGGER RATE RISE&nbsp;</strong></p> <p><strong>• BOE INFLATION REPORT SAYS MPC SEES 41 PCT CHANCE OF 7 PCT UNEMPLOYMENT AT END-2014, 57 PCT AT END-2015, 68 PCT AT END-2016 BASED ON MARKET INTEREST RATES&nbsp;</strong></p> </div> </div> <div id=\"block-528354a4e4b0312d704c1174\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:29:58.205Z\">10.29am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/notayesmansecon/statuses/400570702014590976\"> <blockquote class=\"twitter-tweet\"><p>Will somebody please point out the 7.1% September UK unemployment number at the Bank of England press conference?! <a href=\"https://twitter.com/search?q=%23ForwardGuidance&amp;src=hash\">#ForwardGuidance</a> <a href=\"https://twitter.com/search?q=%23BoE&amp;src=hash\">#BoE</a></p>— Shaun Richards (@notayesmansecon) <a href=\"https://twitter.com/notayesmansecon/statuses/400570702014590976\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835369e4b0b9c05d8a3464\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:28:19.259Z\">10.28am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The recovery in the UK unemployment rate comes as the Bank of England prepares to release its latest Quarterly Inflation Report (</strong><em>in just a couple of minute<strong>s).</strong></em></p> <p>Having pinned UK interest rates to the jobless rate, will Mark Carney now say that the recovery is accelerating faster than he expected? <em>We're about to find out....</em></p> </div> </div> <div id=\"block-528352bde4b0f37bee4ff631\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:24:08.394Z\">10.24am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment: what the politicians say</h2> <div class=\"block-elements\"> <p>Here's the political reaction to the news that Britain's unemployment rate has fallen to 7.6%, but that pay remains well below inflation (<strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283464ce4b0f37bee4ff61c\">see 9.31am onwards for all the details</a></strong>).</p> <h2>Minister for Employment Esther McVey</h2> <blockquote class=\"quoted\"> <p>This Government is delivering on its promise to rebalance the economy, promote job creation, and support people to get off benefits and into work.</p> <p>Today's figures show that the number of people in work has risen by more than a million under this Government, with the growth driven by full-time private sector jobs.&nbsp;</p> <p>At the same time, the number of people claiming the main out-of-work benefits has fallen by almost half a million. There's more work to do, and we are not complacent, but these are all very positive signs.</p> </blockquote> <h2><strong>Rachel Reeves MP, Labour’s Shadow Work and Pensions Secretary</strong></h2> <blockquote class=\"quoted\"> <p>Today’s fall in unemployment is welcome, but families facing a cost-of-living crisis need a recovery that benefits them, and these figures show we are still far from achieving that.</p> <p>Prices have now risen much faster than wages for 40 of the 41 months since David Cameron became Prime Minister. On average working people are now over &pound;1,600 a year worse off under this out-of-touch Government.</p> <p>The employment figures give no cause for complacency. The number of people who want to work full-time but are stuck on part-time hours is at a record high. And youth unemployment is still at unacceptable and unaffordable levels with almost a million young people still out of work, while the number of young people unemployed for a year or more has gone up by 7,000 this quarter.</p> <p>The Tory-led Government’s Work Programme and Youth Contract are failing – they should adopt Labour’s compulsory jobs guarantee, funded by repeating the tax on bank bonuses, and limiting pension tax relief for the very highest earners. This would guarantee real paid work for young people unemployed for a year, or adults unemployed for two years – work they would have to take or lose benefits.</p> </blockquote> </div> </div> <div id=\"block-52835239e4b07aa4168b4b07\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:21:02.918Z\">10.21am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Incidentally, we've just learned that September was a less cheery month for the eurozone. Factory output fell by 0.5%, rather worse than expected.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BBCGavinHewitt/statuses/400567118460362752\"> <blockquote class=\"twitter-tweet\"><p>Industrial production in euro-zone fell in Sept more than expected. In Portugal it fell 11.2%. in Germany down 0.8%. V fragile recovery.</p>— Gavin Hewitt (@BBCGavinHewitt) <a href=\"https://twitter.com/BBCGavinHewitt/statuses/400567118460362752\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-528350e4e4b0312d704c1173\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:19:20.525Z\">10.19am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Now this is interesting....</strong> the ONS has also released an unofficial snapshot of the UK labour market just for September.</p> <p>It's more informal than the official data -- &quot;not designated as National Statistics&quot; as the jargon has it.</p> <p>But with that caveat duly noted.... the data shows that the jobless rate was just 7.1% in September itself (compared to 7.6% for the July-September quarter). <a href=\"http://www.ons.gov.uk/ons/dcp171766_334875.pdf\"><strong>It's online here....</strong></a></p> <p>That's much closer to the 7% target which the Bank of England has set as a milestone before interest rates could rise.&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/JonPrynn/statuses/400561002107768833\"> <blockquote class=\"twitter-tweet\"><p>Hold on to your hats. The unofficial &quot;one month&quot; measure shows unemployment at just 7.1%. Rate rise for 2014? <a href=\"http://t.co/61oS2mW10V\">http://t.co/61oS2mW10V</a></p>— Jonathan Prynn (@JonPrynn) <a href=\"https://twitter.com/JonPrynn/statuses/400561002107768833\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835028e4b0f37bee4ff62d\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:13:27.217Z\">10.13am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Rob Wood of Berenberg Bank says unemployment is falling faster than economists, or the Bank of England, expected -- but he is also concerned that wage growth is so weak.</strong></p> <p>Wood comments:</p> <blockquote class=\"quoted\"> <p>There is a lot of good news in this release for the UK economy. Stonking job gains show the UK is recovering rapidly.</p> <p>At the same time those jobs gains are not cutting unemployment as fast as might be expected because the workforce is rising rapidly.</p> <p>Unlike in the US, the UK participation rate is rising. People are competing for jobs rather than giving up and leaving the workforce. That is keeping wage growth very subdued.</p> </blockquote> </div> </div> <div id=\"block-528349ade4b0f37bee4ff622\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:10:39.584Z\">10.10am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">The wage squeeze continues....</h2> <div class=\"block-elements\"> <p>Many analysts concerned by the lack of progress in pay (with total weekly earnings up just 0.7% annually).</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/jamestplunkett/statuses/400563344840470528\"> <blockquote class=\"twitter-tweet\"><p>Wages have now been falling in real terms for four years. Uncharted waters. <a href=\"http://t.co/sIfsQolJe0\">pic.twitter.com/sIfsQolJe0</a></p>— James Plunkett (@jamestplunkett) <a href=\"https://twitter.com/jamestplunkett/statuses/400563344840470528\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/faisalislam/statuses/400562487692500992\"> <blockquote class=\"twitter-tweet\"><p>... and pay is still falling well short of prices, particularly now the 50p bonus-tax shifts have stopped: <a href=\"http://t.co/WpmQHq6V5K\">pic.twitter.com/WpmQHq6V5K</a></p>— Faisal Islam (@faisalislam) <a href=\"https://twitter.com/faisalislam/statuses/400562487692500992\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52834dd5e4b0f37bee4ff62c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:07:10.738Z\">10.07am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>As this graph shows, the UK unemployment rate has now dropped to its lowest in over four years - it hit 7.6% in&nbsp;May 2009, during the recession sparked by the financial crisis:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png\" alt=\"Unemployment: the unemployment rate to September 2013\" width=\"460\" height=\"256\" class=\"gu-image\" /> <figcaption>Photograph: ONS</figcaption> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T10:07:40.171Z\">at 10.07am GMT</time></p> </div> <div id=\"block-52834c71e4b0312d704c1171\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:56:34.562Z\">9.56am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>This chart shows how the rise in the labour force was split between men and women, and between full-timer and part-time staff:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png\" alt=\"Unemployment; The 177,000 rise in the labour force in July-September 2013\" width=\"460\" height=\"281\" class=\"gu-image\" /> <figcaption>Photograph: ONS</figcaption> </figure> </div> </div> <div id=\"block-52834b22e4b0312d704c1170\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:54:01.797Z\">9.54am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>At 29.95 million people, the UK workforce is now at a record high having jumped by 177,000 in the July-September quarter.&nbsp;</p> <p>However, this partly reflects increased population levels.<strong> The&nbsp;</strong><strong>employment rate of 71.8% is not at a record high</strong> -- as this graph shows, it's still below its pre-crisis levels:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png\" alt=\"Unemployment: UK employment rate to September 2013\" width=\"460\" height=\"253\" class=\"gu-image\" /> <figcaption>Unemployment: UK employment rate to September 2013 Photograph: /ONS</figcaption> </figure> <p><em>It's moving the right way, though....</em></p> </div> </div> <div id=\"block-52834a2ee4b07aa4168b4b02\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:49:17.013Z\">9.49am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>While the fall in the headline jobless rate is clearly welcome, the detail of the ONS report paints a more sober picture.</p> <p>For example, the number of people working part-time because they can't get full-time employment is at a record high.</p> <p><strong>According to the ONS&nbsp;there were 1.46 million employees and self-employed people who&nbsp;were working part-time because they could not find a full-time job, the highest figure since records&nbsp;began in 1992.</strong></p> </div> </div> <div id=\"block-5283497fe4b0f37bee4ff621\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:43:02.831Z\">9.43am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>The full report from the Office for National Statistics is online here:</p> <h2><a href=\"http://www.ons.gov.uk/ons/dcp171778_332467.pdf\">Labour Market Statistics, November&nbsp;2013</a></h2> </div> </div> <div id=\"block-52834838e4b07aa4168b4b00\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:41:29.326Z\">9.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>But while unemployment is down, pay packets are not yet feeling the benefits.</strong></p> <p>Total pay, including bonuses, rose by 0.7% annually in September -- down from 0.8% in August. That's dwarfed by the 2.2% rise in inflation over the last year in Britain.</p> <p>Average pay fell year-on-year in the public sector.</p> <p>The ONS reported:</p> <blockquote class=\"quoted\"> <p>Average weekly earnings for the private sector increased&nbsp;by 1.1% but average weekly earnings for the public sector fell by 0.4%.&nbsp;</p> <p>In September 2013 average pay including bonus payments in the private sector was &pound;473 a week,&nbsp;&pound;14 a week lower than the public sector figure of &pound;487 a week. However, excluding publicly owned&nbsp;financial corporations, average weekly pay in the public sector was only &pound;3 a week higher than for&nbsp;the private sector, at &pound;476 a week.</p> </blockquote> </div> </div> <div id=\"block-52834798e4b07aa4168b4aff\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:36:43.015Z\">9.36am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The UK claimant count is also down -- dropping by 41,700 people in October. </strong>That takes the claimant count rate down to 3.9%.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T09:36:51.658Z\">at 9.36am GMT</time></p> </div> <div id=\"block-5283473ee4b0312d704c116e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:33:52.032Z\">9.33am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>The total number of people in work across the UK rose by 177,000 in the three months to September, taking the total to 29.953 million. That's the biggest jump since the June to August quarter.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T09:34:01.700Z\">at 9.34am GMT</time></p> </div> <div id=\"block-5283464ce4b0f37bee4ff61c\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:31:39.669Z\">9.31am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment rate falls</h2> <div class=\"block-elements\"> <p><strong>Breaking: the UK unemployment rate has fallen to 7.6% in the three months to September.</strong></p> <p>The number of people out of work fell by 48,000 to 2.466m in the quarter, which Reuters says is the lowest level in three years.</p> <p><em><strong>More to follow....</strong></em></p> </div> </div> <div id=\"block-52833ed7e4b0312d704c116d\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:17:55.081Z\">9.17am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment data due soon</h2> <div class=\"block-elements\"> <p>We get the latest UK unemployment data in less than 15 minutes time. As mentioned at the start, economists expect:</p> <p><strong>• a drop in the claimant count of around 30,000 people in October (compared with 41k last month)&nbsp;</strong></p> <p><strong>• a rise in the number of people in work in the three months to September, of around&nbsp;113,000 </strong></p> <p><strong>• No change to the unemployment rate, of 7.7% [<em>which is crucial to UK monetary policy given the Bank of England's pledge not to raise rates till it hits 7%</em>]&nbsp;</strong></p> <p><strong>• Another fall in real pay, with average weekly earnings expected to have risen by just 0.7% over the last year.</strong></p> <p>In other words, some signs of recovery in the labour market, but no relief to the squeeze on living standards and wages.</p> <p>The youth unemployment data will also be scrutinised, with <a href=\"http://www.presstv.ir/detail/2013/11/13/334472/uk-youth-unemployment-rises-report/\"><strong>a new report warning that the jobless rate among young people has still risen despite the UK economy returning to growth</strong></a>.</p> </div> </div> <div id=\"block-52834019e4b07aa4168b4afa\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:05:22.339Z\">9.05am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Bad economic data from the Netherlands -- retail sales tumbled by 6.1% year-on-year in September.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/lexvandam/statuses/400544001645752320\"> <blockquote class=\"twitter-tweet\"><p>Shocking: NETHERLANDS SEPT RETAIL SALES Y/Y: -6.1% V -0.7% PRIOR</p>— Lex van Dam (@lexvandam) <a href=\"https://twitter.com/lexvandam/statuses/400544001645752320\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52833b63e4b0b9c05d8a345e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:54:03.704Z\">8.54am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png\" alt=\"European stock markets, early trading, November 13 2013\" width=\"460\" height=\"137\" class=\"gu-image\" /> <figcaption>European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters</figcaption> </figure> <p>European stock markets are in the red this morning, with the FTSE 100 shedding 47 points or 0.7%.</p> <p>Traders are blaming nervousness ahead of <a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283235be4b0312d704c116a\"><strong>the Bank of England's inflation report</strong></a>&nbsp;(<em>what will Mark Carney say about growth prospects and rate rises?</em>), and another bout of jitters over when the US Federal Reserve will start to slow its own stimulus programme.</p> <p>There's also a knock-on effect from Asia. China's stock market shed 2% following the conclusion of the Beijing government's Plenary meeting where <a href=\"http://www.theguardian.com/world/2013/nov/12/china-markets-decisive-role-economy\"><strong>leaders pledged to give the markets a &quot;decisive role&quot; in the country's economic future</strong></a>.</p> <p><a href=\"https://twitter.com/Accendo_Mike\"><strong>Mike van Dulken of Accendo Markets</strong></a> says traders are</p> <blockquote class=\"quoted\"> <p>disappointed&nbsp;by the rather general/vague&nbsp;Chinese statement&nbsp;in terms of its plan for the next decade.</p> </blockquote> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T08:54:21.368Z\">at 8.54am GMT</time></p> </div> <div id=\"block-52833755e4b0b9c05d8a345c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:41:50.014Z\">8.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>In the corporate world, Sainsbury's is getting into the early festive spirit with a 7% jump in profits, the top of analyst forecasts.</strong></p> <p>The supermarket chain also reported that its market share was at its highest for a decade, but remained cautious about UK economic prospects.</p> <p>Phil Dorrell, director of the retail consultants Retail Remedy, reckons &quot;The fairytale continues at Sainsbury's&quot;, and predicts it will do well this Christmas.</p> <h2>More here: <a href=\"http://www.theguardian.com/business/2013/nov/13/sainsburys-rise-7-percent-own-brand-online-sales\">Sainsbury's profit rise 7% as own-brand and online sales thrive</a></h2> </div> </div> <div id=\"block-52833971e4b0f37bee4ff615\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:39:02.545Z\">8.39am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Robin Bew</strong> of the&nbsp;Economist Intelligence Unit tweets that <a href=\"http://www.theguardian.com/business/2013/nov/12/inflation-fall-welcomed-by-government\"><strong>yesterday's drop in UK inflation, to 2.2%</strong></a>, gives Mark Carney and colleagues a little more room to&nbsp;manoeuvre.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/RobinBew/statuses/400513462440566784\"> <blockquote class=\"twitter-tweet\"><p>Lower <a href=\"https://twitter.com/search?q=%23UK&amp;src=hash\">#UK</a> inflation data means <a href=\"https://twitter.com/search?q=%23BoE&amp;src=hash\">#BoE</a> faces better growth/price mix than expected. Gives them a bit more policy flexibility</p>— Robin Bew (@RobinBew) <a href=\"https://twitter.com/RobinBew/statuses/400513462440566784\">November 13, 2013</a></blockquote> </figure> <p>And as our economics editor Larry Elliott wrote yesterday, spending power is on the wane in many countries.</p> <h2><a href=\"http://www.theguardian.com/business/2013/nov/12/inflation-fall-spending-power-squeeze-uk\">Inflation fall shows effects of spending power squeeze</a></h2> </div> </div> <div id=\"block-528330a5e4b0f37bee4ff613\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:21:27.995Z\">8.21am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Speaking of the eurozone, we get also industrial production data for September at 10am -- economists expect a 0.3% drop month-on-month.</strong></p> <p>Germany's top central banker, Jens Weidmann, is giving a speech around noon GMT. Let's hope he comments on last week's ECB interest rate cut, given the Bundesbank chief is understood to have opposed it.</p> <p>Greece's finance minister, Yannis Stournaras, meanwhile is reported to be in Brussels - perhaps preparing for tomorrow's Eurogroup meeting of finance ministers.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BloombergAthens/statuses/400527179475214337\"> <blockquote class=\"twitter-tweet\"><p>Greek Finance Minister Yannis Stournaras in Brussels</p>— Bloomberg Athens (@BloombergAthens) <a href=\"https://twitter.com/BloombergAthens/statuses/400527179475214337\">November 13, 2013</a></blockquote> </figure> <p>Yesterday, Stournaras denied that the Athens government and its troika inspectors were &quot;miles&quot; apart in their assessment of Greece's performance against its bailout programme. <a href=\"http://www.ekathimerini.com/4dcgi/_w_articles_wsite1_1_12/11/2013_527556\"><strong>It's just meters, he insisted</strong></a>.&nbsp;</p> </div> </div> <div id=\"block-52833237e4b0b9c05d8a345b\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:13:11.498Z\">8.13am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Spain reports deflation in October</h2> <div class=\"block-elements\"> <p><strong>Spain's annual inflation rate turned negative last month, according to new data that will heighten concerns that parts of the eurozone are slipping into deflation</strong>.</p> <p>The latest inflation data showed that the Spanish consumer prices index <strong>fell by 0.1% in October</strong>, on an annual basis. On a monthly basis, the CPI rose by 0.4%.&nbsp;</p> <p>On an 'EU harmonised basis', prices were flat year-on-year.&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/minefornothing/statuses/400534375164825600\"> <blockquote class=\"twitter-tweet\"><p>Spanish CPI drops to -0.1% YoY in October <a href=\"https://twitter.com/search?q=%23deflation&amp;src=hash\">#deflation</a></p>— MineForNothing (@minefornothing) <a href=\"https://twitter.com/minefornothing/statuses/400534375164825600\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BBCGavinHewitt/statuses/400535222162579456\"> <blockquote class=\"twitter-tweet\"><p>Further indication of weak demand in euro-zone. Spanish consumer prices fell 0.1% compared to October last year - the first fall in 4 years.</p>— Gavin Hewitt (@BBCGavinHewitt) <a href=\"https://twitter.com/BBCGavinHewitt/statuses/400535222162579456\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/ReutersJamie/statuses/400535572650807296\"> <blockquote class=\"twitter-tweet\"><p>Spain in deflation. Annual CPI -0.1% in Oct. It was +3.5% only a year ago: <a href=\"http://t.co/x5f5Z9iEcr\">pic.twitter.com/x5f5Z9iEcr</a></p>— Jamie McGeever (@ReutersJamie) <a href=\"https://twitter.com/ReutersJamie/statuses/400535572650807296\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/fwred/statuses/400536877502971904\"> <blockquote class=\"twitter-tweet\"><p>Spanish HICP inflation revised down to 0.0% YoY in October (vs. preliminary estimate of +0.1%). <a href=\"https://twitter.com/search?q=%23Dword&amp;src=hash\">#Dword</a></p>— Frederik Ducrozet (@fwred) <a href=\"https://twitter.com/fwred/statuses/400536877502971904\">November 13, 2013</a></blockquote> </figure> <p>We have seen a steady stream of low inflation rates recently (German's CPI fell to 1.2%), while <a href=\"http://www.reuters.com/article/2013/11/08/greece-inflation-idUSEMS1C747020131108\">the cost of living fell by 2.0% in Greece last month</a>. <em>Understandable, given sluggish demand, weak European growth and cash-strapped consumers.</em></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T08:24:37.877Z\">at 8.24am GMT</time></p> </div> <div id=\"block-52833020e4b0312d704c116b\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:56:12.818Z\">7.56am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>City traders are predicting the blue-chip Footsie index will drop by around 0.6%, when trading begins in a few minutes.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/DavidJones_IG/statuses/400529358357798912\"> <blockquote class=\"twitter-tweet\"><p>Quite a weak start forecast for the FTSE this morning- currently expected to open -45 at 6682.</p>— David Jones (@DavidJones_IG) <a href=\"https://twitter.com/DavidJones_IG/statuses/400529358357798912\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52832e69e4b0b9c05d8a3459\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:52:46.164Z\">7.52am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Much was made of Mark Carney's Canadian background when he was named as Sir Mervyn King's successor. The FT has now discovered that he's also the proud holder of Irish citizenship too:</p> <p>Chris Giles reports:</p> <blockquote class=\"quoted\"> <p>Since his arrival as governor of the Bank of England in July Mark Carney has had the luck of the Irish, enjoying rising growth, falling unemployment and rapidly moderating inflation.</p> <p>That cannot have been much of a surprise to the BoE or Treasury as on Tuesday night both confirmed that the Canadian running the old Lady of Threadneedle Street has also held Irish citizenship since 1988 when he started working for Goldman Sachs in London.</p> </blockquote> <h2>More here:&nbsp;<a href=\"http://www.ft.com/cms/s/0/ee169c30-4bc6-11e3-a02f-00144feabdc0.html?siteedition=uk#axzz2kQ6dOH6F\"><strong>Mark Carney brings luck of the Irish to BoE</strong></a></h2> <p>And on the FT's front page:</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/suttonnick/statuses/400384504235184128\"> <blockquote class=\"twitter-tweet\"><p>Wednesday's FT front page - &quot;Forex probe widens to at least 15 big banks&quot; <a href=\"https://twitter.com/search?q=%23tomorrowspaperstoday&amp;src=hash\">#tomorrowspaperstoday</a> <a href=\"https://twitter.com/search?q=%23bbcpapers&amp;src=hash\">#bbcpapers</a> <a href=\"http://t.co/YQkIpAjAkY\">pic.twitter.com/YQkIpAjAkY</a></p>— Nick Sutton (@suttonnick) <a href=\"https://twitter.com/suttonnick/statuses/400384504235184128\">November 12, 2013</a></blockquote> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T07:52:56.198Z\">at 7.52am GMT</time></p> </div> <div id=\"block-5283235be4b0312d704c116a\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:31:30.171Z\">7.31am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England and UK unemployment data</h2> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg\" alt=\"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.\" width=\"460\" height=\"307\" class=\"gu-image\" /> <figcaption>Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS</figcaption> </figure> <p><strong>Good morning, and welcome to our rolling coverage of events across the economy, the financial markets, the eurozone and the business world.</strong></p> <p>UK economics is centre-stage today, with the release of fresh unemployment data (<strong>at 9.30am</strong>) followed by the Bank of England's quarterly inflation report (<strong>from 10.30am</strong>).&nbsp;</p> <p><strong>And what a difference three months makes.</strong> Back on August 7, governor Mark Carney pushed the Bank of England into a bold new era by <a href=\"http://www.theguardian.com/business/2013/aug/07/bank-of-engand-links-interest-rates-jobless-target\"><strong>setting 'forward guidance' on interest rates</strong></a>. Effectively he pledged that borrowing costs won't rise until the UK jobless rate drops to 7% (<em>from 7.7% a month ago</em>), which Carney didn't see happening until 2016.</p> <p>Since then, a rich seam of solid economic data has shown that Britain's economy is performing better than most analysts thought in August. So the Bank is likely to upgrade its growth forecasts, and could also predict that unemployment will fall faster than previously expected.</p> <p><strong>And that could fuel predictions that UK interest rates will finally rise from their record low of 0.5% somewhat earlier than 2016</strong>.</p> <p>The unemployment data, meanwhile, is expected to show another drop in the number of people signing on for the Jobseeker's Allowance in October. The headline jobless rate is expected to stay at 7.7% for the three months to September.</p> <p>Michael Hewson of CMC helpfully rounds up the recent figures:</p> <blockquote class=\"quoted\"> <p>The latest&nbsp;unemployment&nbsp;numbers look set to show the&nbsp;ILO September&nbsp;unemployment&nbsp;rate stuck at 7.7%&nbsp;despite double digit falls in jobless claims numbers for the last four months.</p> <p>Claims numbers for October&nbsp;are expected to show another&nbsp;double digit decline of 33k, following on from declines of 41.7k, 32.6k, 29.2k and 21.2k, in previous months.</p> </blockquote> <p>But with pay still lagging behind inflation (which fell to 2.2% yesterday), it may not feel like a recovery to many.</p> <p><em><strong>We'll be tracking all the events through the day...</strong></em></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T07:42:19.086Z\">at 7.42am GMT</time></p> </div><!-- Guardian Watermark: internal-code/content/422360318|2013-11-13T15:50:01Z|c26f4ab4f6e13790bb78440fbf15a02fc58d90e8 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+        "wordcount":"1",
+        "liveBloggingNow":"true"
+      },
+      "tags":[{
+        "id":"business/series/guardian-business-live",
+        "type":"series",
+        "webTitle":"Guardian business live",
+        "webUrl":"http://www.theguardian.com/business/series/guardian-business-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/guardian-business-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/debt-crisis",
+        "type":"keyword",
+        "webTitle":"Eurozone crisis",
+        "webUrl":"http://www.theguardian.com/business/debt-crisis",
+        "apiUrl":"http://content.guardianapis.com/business/debt-crisis",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/series/eurozone-crisis-live",
+        "type":"series",
+        "webTitle":"Eurozone crisis live",
+        "webUrl":"http://www.theguardian.com/business/series/eurozone-crisis-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/eurozone-crisis-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/euro",
+        "type":"keyword",
+        "webTitle":"Euro",
+        "webUrl":"http://www.theguardian.com/business/euro",
+        "apiUrl":"http://content.guardianapis.com/business/euro",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/bankofenglandgovernor",
+        "type":"keyword",
+        "webTitle":"Bank of England",
+        "webUrl":"http://www.theguardian.com/business/bankofenglandgovernor",
+        "apiUrl":"http://content.guardianapis.com/business/bankofenglandgovernor",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/mark-carney",
+        "type":"keyword",
+        "webTitle":"Mark Carney",
+        "webUrl":"http://www.theguardian.com/business/mark-carney",
+        "apiUrl":"http://content.guardianapis.com/business/mark-carney",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/unemployment-and-employment-statistics",
+        "type":"keyword",
+        "webTitle":"Unemployment and employment statistics",
+        "webUrl":"http://www.theguardian.com/business/unemployment-and-employment-statistics",
+        "apiUrl":"http://content.guardianapis.com/business/unemployment-and-employment-statistics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/minutebyminute",
+        "type":"tone",
+        "webTitle":"Minute by minutes",
+        "webUrl":"http://www.theguardian.com/tone/minutebyminute",
+        "apiUrl":"http://content.guardianapis.com/tone/minutebyminute",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"profile/graemewearden",
+        "type":"contributor",
+        "webTitle":"Graeme Wearden",
+        "webUrl":"http://www.theguardian.com/profile/graemewearden",
+        "apiUrl":"http://content.guardianapis.com/profile/graemewearden",
+        "bio":"<p>Graeme Wearden is a <a href=\"http://www.guardian.co.uk/business\">business</a> reporter on guardian.co.uk and writes breaking City news plus the occasional blog. Previously he worked as a technology journalist at CNET Networks</p>",
+        "r2ContributorId":"19202",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/01/graeme_wearden_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/nickfletcher",
+        "type":"contributor",
+        "webTitle":"Nick Fletcher",
+        "webUrl":"http://www.theguardian.com/profile/nickfletcher",
+        "apiUrl":"http://content.guardianapis.com/profile/nickfletcher",
+        "bio":"<p>Nick Fletcher is a Guardian columnist and writer of the Market Forces column</p>",
+        "rcsId":"GNL023406",
+        "r2ContributorId":"16178",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/03/nick_fletcher_140x140.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"84",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"276",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"132",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"612",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"180",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"324",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"68",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"228",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"372",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"620"
+          }
+        }]
+      },{
+        "id":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"251",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"453",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"386",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"117",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"318",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"184",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"68",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"68"
+          }
+        }]
+      },{
+        "id":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"184",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"233",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"282",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"380",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1261",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"68",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"331",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"625",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"768",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"86",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"135",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"159",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"448",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"101",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1490",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"333",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"275",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"738",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"68",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1536",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"217",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"390",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"768",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"360",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"133",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"284",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"401",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"423"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"209",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"310",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"586",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"356",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"768",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"355",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"309",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"256",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"346",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"167",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"78",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"123",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"212",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"301",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"134",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"86",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"330",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"232",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"379",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"281",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"183",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"121",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"253",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"77",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"340",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"209",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"296",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"165",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"161",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"66",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"185",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"68",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"90",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"114",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"137",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"42",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"211",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"706"
+          }
+        }]
+      },{
+        "id":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"680",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"93",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1374",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"147",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"68",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1536",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"307",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"200",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"253",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"768",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"413",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"360",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"540"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T08:30:00Z",
+      "webTitle":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "fields":{
+        "trailText":"<p>Thousands storm rice warehouse in the devastated central Philippines while Haiyan relief effort flounders</p>",
+        "headline":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+        "body":"<video data-media-id=\"gu-video-422358527\" class=\"gu-video\" controls=\"controls\" poster=\"\">\n        <source src=\"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4\"></source><source src=\"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp\"></source><source src=\"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp\"></source><source src=\"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8\"></source>\n      </video><p>Eight people have been killed in the typhoon-ravaged central Philippines after thousands of Haiyan survivors stormed a government-owned rice warehouse seeking food supplies.</p><p>The Philippines National Food Authority said police and soldiers stood by helpless as people streamed into the warehouse in Alangalang, Leyte province – an area where hunger and desperation are running high after Haiyan made landfall early on Friday morning, ravaging vast swaths of Leyte and Samar islands. The security forces could only watch as more than 100,000 sacks of rice were carried away. </p><p>The eight were crushed to death when a wall in the warehouse collapsed, spokesman Rex Estoperez told the Associated Press. Other rice warehouses were dotted around the region, he said, refusing to give their locations for security reasons.</p><p>The Philippines government has come under fire for failing to deliver aid adequately or quickly enough, with growing frustration in the hardest hit areas, such as Tacloban, the capital of Leyte province where dead bodies have piled up on the streets and residents have resorted to looting to find food.</p><p>A military official told the Guardian on Wednesday that the government was aiming to double its relief efforts within the next two days. Attempts to provide help were buoyed by the expected arrival of two extra US military C-130 planes and one additional Australian air force plane.</p><p>Three relief distribution points were being set up in the Leyte island towns of Tacloban, Guiuan and Ormoc, the official said, with the main aid effort operating out of neighbouring Cebu instead of Manila, the capital, which is 360 miles to the north.</p><p>More than 10,000 people are feared to have been killed in the Philippines due to Haiyan, most of them in Leyte province, with aid workers suggesting that number may rise significantly. As many as 29 municipalities have still not been reached due to impassable roads and downed telecommunications. </p><p>President Benigno Aquino III said on Tuesday that he believed the number killed to be far lower – around 2,500 – and told CNN that the 10,000 figure may have come from an \"emotional\" official, with government figures alleging that the death toll stands at 2,275. The UN has said more than 670,000 people have been displaced and a total of 11.3 million people directly affected by the super storm.</p><p>International relief efforts intensified with the launch of a UN appeal and the dispatch of American, British and Japanese troops to the affected regions. But minimal amounts of aid have reached the worst‑hit areas.</p><p>More than 3,000 people surged on to the tarmac of Tacloban airport on Tuesday morning in the hope of flying out on the two Philippine air force planes that had just arrived.</p><p>Babies and sick or elderly people were given priority but only a few hundred were able to leave. Others were held back by soldiers and police. Many had walked for hours and camped at the base overnight.</p><p>\"I was pleading with the soldiers. I was kneeling and begging because I have diabetes,\" said Helen Cordial as she lay on a stretcher, shaking. \"Do they want me to die in this airport? They are stone-hearted,\" she told the Associated Press.</p><p>Dean Smith, an Australian who has been living with his family near Palo, Leyte province, for the last five years, told the Guardian that he waited eight hours to be able to get one of the first commercial flights out of Tacloban to Cebu. On the way to the airport he said he saw \"horrifying things that I know I have seen but my brain hasn't processed yet\". </p><p>He described scenes of chaos in the city centre, where police were stealing money from the local cashpoints, people in cars were refusing to drive the injured to get help, and the bloated body of a man floating in dirty water was being gnawed at by a dog.</p><p>\"What people have gone through, what they have seen – there is going to be a lot of post-traumatic stress after this event I assure you,\" he said shakily. \"No one has ever seen anything like this.\"</p><p>Having arrived on Tuesday in Cebu, Smith was planning to stock up on food, medicine and water and take it back to his Palo home, where his wife, six children, a 92-year-old grandmother and a pregnant nanny were all desperately awaiting supplies. He departed for Tacloban early on Wednesday morning.</p><p>Domestic and international relief efforts were being hampered by wet weather, poor communications and damaged infrastructure, with aircraft only able to land in Tacloban during daylight hours because the air control tower had been destroyed by Haiyan. Unsubstantiated reports of aid convoys being attacked by hungry victims circulated, with the Telegraph reporting that communist rebels had been killed whilst <a href=\"http://www.telegraph.co.uk/news/worldnews/asia/philippines/10445615/Typhoon-Haiyan-aid-convoys-come-under-fire-as-relief-operation-becomes-logistical-nightmare.html\">trying to intercept a Red Cross convoy</a> destined for the island of Samar.</p><p>Still, Corizon Soliman, secretary of the Philippine department of social welfare and development, said aid had so far reached a third of the city's 45,000 families.</p><p>However armed forces spokesman Ramon Zagala told the BBC that relief workers were struggling to deliver aid for a number of reasons.</p><p>\"The area is very vast and the number of helicopters – although we have a lot of helicopters at the moment – it's really a challenge for us to bring [aid] to all the places and [bring] the number of goods that are needed.\"</p><p>The BBC quoted a Leyte official as saying that although relief goods like medicine and equipment were arriving into the province \"it's just not reaching the people affected\".</p><p>The UN released $25m (£15.7m) in emergency funds for shelter materials and household items, and for assistance with emergency health services, safe water supplies and sanitation.</p><p>The UN aid chief, Valerie Amos, launched an appeal for $300m as she arrived in Manila. \"We have deployed specialist teams, vital logistics support and dispatched critical supplies but we have to do more and faster,\" she said.</p><p>The US, Britain, Japan, Australia and other nations have pledged tens of millions of dollars in immediate aid, and some businesses have also offered help: banking group HSBC announced a $1m (£630,000) cash donation.</p><p>In Tacloban shops were stripped of food and water by hungry residents. While some tents had arrived, the widespread damage left many people sleeping in the ruins of their homes or under shredded trees.</p><p>Military doctors at a makeshift clinic at the airport said they had treated about 1,000 people for cuts, bruises and deep wounds but did not have enough medical supplies.</p><p>\"It's overwhelming,\" said Antonio Tamayo, an air force captain. \"We need more medicine. We can't give anti-tetanus vaccine shots because we have none.\"</p><p>The typhoon flattened Basey, a seaside town in Samar province about six miles across a bay from Tacloban. About 2,000 people were missing there, its governor said. Rescue and relief workers were yet to reach many of the more remote areas.</p><p>\"There are hundreds of other towns and villages stretched over thousands of kilometres that were in the path of the typhoon and with which all communication has been cut,\" said Natasha Reyes, emergency co-ordinator in the Philippines at Médecins Sans Frontières. \"No one knows what the situation is like in these more rural and remote places, and it's going to be some time before we have a full picture.\"</p><p>Damage to communications left the armed forces struggling to reach local authorities and many officials were dead, missing or trying to protect their own families.</p><p>\"Basically the only branch of government that is working here is the military,\" Ruben Guinolbay, a Philippine army captain, told Reuters in Tacloban. \"That is not good. We are not supposed to take over government.\"</p><p>The interior secretary, Manuel Roxas, said on Tuesday that only 20 of Tacloban's 293 police had arrived for work. But he added: \"Today we have stabilised the situation. There are no longer reports of looting. The food supply is coming in. Up to 50,000 food packs are coming in every day, with each pack able to feed up to a family of five for three days.\"</p><p>A team of British medical experts and the first consignment of aid from the UK was leaving for the Philippines, David Cameron said on Tuesday.</p><p>The UK surgical team, led by Anthony Redmond, Manchester University professor of international emergency medicine, includes three emergency physicians, two orthopaedic surgeons, a plastic surgeon, two accident and emergency nurses, a theatre nurse, two anaesthetists and one specialist physiotherapist.</p><p>The USS George Washington aircraft carrier, transporting about 5,000 sailors and more than 80 aircraft, plus four other US navy ships, should arrive in two to three days, the Pentagon said.</p><p>Britain's HMS Daring, a warship with equipment to make drinking water from seawater, and a military transport aircraft should arrive around the same time.</p><p>Japan is sending a team of 40 from its self-defence force.</p><p>Aquino has declared a state of national calamity, allowing the central government to release emergency funds more quickly and impose price controls.</p><p>Initial estimates of the cost of the damage vary widely, with a report from German-based CEDIM Forensic Disaster Analysis putting the total at anywhere from $8bn to $19bn.</p><!-- Guardian Watermark: internal-code/content/422353950|2013-11-13T15:50:01Z|7325428a23f22798381e4da038c16d690f93c266 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgx",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+        "wordcount":"1488",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/typhoon-haiyan",
+        "type":"keyword",
+        "webTitle":"Typhoon Haiyan",
+        "webUrl":"http://www.theguardian.com/world/typhoon-haiyan",
+        "apiUrl":"http://content.guardianapis.com/world/typhoon-haiyan",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/philippines",
+        "type":"keyword",
+        "webTitle":"Philippines",
+        "webUrl":"http://www.theguardian.com/world/philippines",
+        "apiUrl":"http://content.guardianapis.com/world/philippines",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/natural-disasters",
+        "type":"keyword",
+        "webTitle":"Natural disasters and extreme weather",
+        "webUrl":"http://www.theguardian.com/world/natural-disasters",
+        "apiUrl":"http://content.guardianapis.com/world/natural-disasters",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/asia-pacific",
+        "type":"keyword",
+        "webTitle":"Asia Pacific",
+        "webUrl":"http://www.theguardian.com/world/asia-pacific",
+        "apiUrl":"http://content.guardianapis.com/world/asia-pacific",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/taniabranigan",
+        "type":"contributor",
+        "webTitle":"Tania Branigan",
+        "webUrl":"http://www.theguardian.com/profile/taniabranigan",
+        "apiUrl":"http://content.guardianapis.com/profile/taniabranigan",
+        "bio":"<p>Tania Branigan is <a href=\"http://www.guardian.co.uk/world/china\">China correspondent</a> for the Guardian</p>",
+        "rcsId":"GNL004773",
+        "r2ContributorId":"16507",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/tania_branigan_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/kate-hodal",
+        "type":"contributor",
+        "webTitle":"Kate Hodal",
+        "webUrl":"http://www.theguardian.com/profile/kate-hodal",
+        "apiUrl":"http://content.guardianapis.com/profile/kate-hodal",
+        "r2ContributorId":"47767",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422364488",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Bullit Marquez",
+            "altText":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban",
+            "height":"84",
+            "credit":"Bullit Marquez/AP",
+            "caption":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban. Photograph: Bullit Marquez/AP",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-video-422358527",
+        "relation":"body",
+        "type":"video",
+        "assets":[{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "sectionId":"travel",
+      "sectionName":"Travel",
+      "webPublicationDate":"2013-11-13T14:06:00Z",
+      "webTitle":"Top 10 budget restaurants and cafes in central London",
+      "webUrl":"http://www.theguardian.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "apiUrl":"http://content.guardianapis.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "fields":{
+        "trailText":"<p>Updating his last budget eats guide to central London, Tony Naylor discovers that, particularly in and around Soho, the capital is home to a thriving casual dining scene</p>",
+        "headline":"Top 10 budget restaurants and cafes in central London",
+        "body":"<h2>Koshari Street</h2><p>Koshari is an Egyptian snack food, a warm mix of rice, chickpeas and macaroni, topped with fresh tomato sauce, sold from street stalls and hole-in-the-wall takeaways. Koshari Street – a tiny, slick canteen with limited counter seating – serves Lebanese cook and food writer Anissa Helou's take on this Cairo classic, which she has jazzed-up with toasted vermicelli, crispy, caramelised onions, garlic sauce and an aromatic sprinkling of mixed nuts, herbs and spices. The &quot;hot&quot; tomato sauce is a little meek (there is also a &quot;mad&quot; version to try), but the filling koshari offers layers of bright, interesting flavours. Thanks to that secret doqqa spice mix, you get a heady whiff of something exotic each time you exhale. <br />• <em>Koshari from &pound;4.50, salads, soups and wraps from &pound;2.95. 56 St Martin's Lane WC2, 020-7836 1056, </em><a href=\"http://www.kosharistreet.com/\" title=\"\"><em>kosharistreet.com</em></a></p><h2>Honey &amp; Co.</h2><figure data-media-id=\"gu-image-422397456\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg\" alt=\"Honey &amp; Co Cafe, Soho, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption>Photograph: Heloise Faure</figcaption></figure><p>At lunch and dinner, this small, critically acclaimed cafe-restaurant is a little too expensive for the true budget traveller. Instead, slip in at breakfast to try Sarit Packer and Itamar Srulovich's skilful Levantine cooking at sub-&pound;10 prices. The morning menu runs from baked goods (blueberry and sour cream doughnuts; toasted fig, walnut and orange loaf), to pizza-like lahma breads topped with, for instance, spiced lamb, tahini and pine nuts. There is usually an ijje (herb and feta) frittata on the menu, too. A merguez sausage roll was excellent: the pastry light and buttery, the two spicy lamb sausages nicely moistened by a base slather of vivid tomato sauce. On the side, a dollop of sweetly perfumed harissa added colour and, even at this time of day, you get a little complimentary bowl of chopped tomatoes, tiny hot green guindilla peppers and amazing kalamata olives, as sweet as they are salty and sour.<br />• <em>Breakfast, &pound;3–&pound;6. 25a Warren Street W1, 020-7388 6175,</em><a href=\"http://honeyandco.co.uk/\" title=\"\"><em> honeyandco.co.uk</em></a></p><h2>Attendant</h2><figure data-media-id=\"gu-image-422397457\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg\" alt=\"Attendant cafe-restaurant, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption>Photograph: Ming Tang-Evans</figcaption></figure><p>With its blaring music and old copies of The Face left about as reading material, there will be plenty of people who find Attendant too cool for school. And that is before we get to the quirky fact that this subterranean space was once a public toilet. You eat and drink at tiny counters built into an ornate Victorian urinal. Which would be painfully trendy, were Attendant's food and its artisan coffee (Caravan beans, Jersey cows' milk) not as good as they are. It's all relatively simple stuff: almond milk porridge and croissants at breakfast; soup, hot deli sandwiches, salads and Bittersweet bakery cakes at lunch. However, the ingredients used are first-rate and it's all rendered with a quiet flair. A breakfast muffin of Montgomery cheddar souffl&eacute; (actually, more a flattened omelette) was exemplary in its detail. Dressed with oven-roasted tomatoes, buttery pan-fried mushrooms and fresh baby spinach, every element tasted vibrantly of itself. That shouldn't be a surprise, but it is. <br /><em>• Sandwiches and hot dishes around &pound;3–&pound;5.50. 27a Foley Street W1, 020-7637 3794, </em><a href=\"http://www.the-attendant.com/\" title=\"\"><em>the-attendant.com</em></a></p><h2>Scandinavian Kitchen<br /></h2><figure data-media-id=\"gu-image-422397458\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg\" alt=\"Scandinavian kitchen, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>This specialist Scandi food store and cafe offers what can only be described as a smorgasbord of food to eat-in or takeaway. You can start your morning with toasted sourdough sandwiches, a smoked salmon and egg roll, or a Nordic rye and oat porridge that will put hairs on your chest. Then, for lunch, the kitchen dishes up numerous varieties of mix 'n' match wraps and open sandwiches (tiny, moreish meatballs in a sweet, sharp beetroot cream; smoked mackerel with fennel and crushed peas), accompanied by various salads. These might include new potatoes in a dill vinaigrette, or sharp, spritzy shredded white cabbage and oregano. The portions don't look huge, but, rest assured, those dark, heavy Scandinavian breads will fill you up. Of course, the cardamom-spiked kanelbullar swirls, sticky with cinnamon jam, are excellent; as are the smiley, eager-to-please staff. <br />• <em>Breakfast &pound;2.25–&pound;4.50, lunch &pound;2.95–&pound;9.95. 61 Great Titchfield Street W1, 020-7580 7161,</em><a href=\"http://www.scandikitchen.co.uk/\" title=\"\"><em> scandikitchen.co.uk</em></a></p><h2>Honest Burger</h2><figure data-media-id=\"gu-image-422397459\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg\" alt=\"Honest Burger\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>Made from 35-day aged beef (sourced from ace butcher the Ginger Pig), these thick patties – and Honest Burger's salty, rosemary-flecked, skin-on chips – are legendary across London. Arrive early to grab a seat or, if you're looking to keep the cost down, takeaway and dodge the queues altogether. At &pound;9.50, the eponymous Honest burger may sound expensive, but this is the sort of profoundly beefy burger – charred with a sensational crust on the outside, but still juicy and pink within – that will live long in the memory. It is complemented by a not overly sweet caramelised onion jam; dill-and-mustard-seed pickled cucumber; and superb thick-cut smoked bacon. <br />• <em>Beef burger and chips from &pound;8. 4a Meard Street W1, 020-3609 9524, </em><a href=\"http://honestburgers.co.uk/\" title=\"\"><em>honestburgers.co.uk</em> </a></p><h2>Foxcroft &amp; Ginger<br /></h2><figure data-media-id=\"gu-image-422397460\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg\" alt=\"Foxcroft and Ginger, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>With its utilitarian, white-tiled interior, hip music and good coffee, F&amp;G is quintessential modern Soho. A basement bakery keeps the counter filled with fantastic cakes (rich, ganache-like chocolate brownies are particularly brilliant, &pound;1.70), and breads that are used at lunch for &quot;saucy buns&quot;, filled with, for instance, slow-cooked pork, jalapenos, smoky tomatoes and mozzarella, or buttermilk fried chicken with avocado and garlic mayonnaise. My shredded beef and cheddar bun could have done with more of the advertised beef juices, but it was tasty enough. There are gourmet salads (such new potato with roasted lemon and radicchio), sandwiches and frittatas available and, in the evening, Foxcroft serves sourdough pizzas with innovative toppings.<br />• <em>Breakfast/weekend brunch, &pound;2.80–&pound;9.50, lunch &pound;3.50–&pound;6.50, pizzas from &pound;4.95. 3 Berwick Street W1, 020-3602 3371,</em><a href=\"http://foxcroftandginger.co.uk/\" title=\"\"><em> foxcroftandginger.co.uk</em></a></p><h2>Pizza Pilgrims</h2><figure data-media-id=\"gu-image-422397461\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg\" alt=\"Pizza Pilgrims, Soho, London\" width=\"460\" height=\"277\" class=\"gu-image\" /><figcaption>Photograph: Paul Winch-Furness</figcaption></figure><p>The gilded rise of brothers Thom and James Elliot, from street food sensations to proper restaurateurs (of course, they already have a glossy cookbook out), may rankle with those who, romantically, regard street food as eating's punk rock: a matter of grassroots passion, not a career. However, it is difficult to carp when, thanks to the Elliots, you can now takeaway A1 pizza, in the middle of Soho, from &pound;6. Whichever way you slice it, that has to be a good thing. Pilgrims' bases are somewhat thicker and softer than you might expect, yet blackened with patches of delicious char. Toppings run to the spicy Calabrian 'nduja, fennel sausage, portobello mushrooms and truffle, but the house-blitzed San Marzano plum tomato sauce is so vibrant it will, finally, make you understand why the Neapolitans love a cheese-free marina pizza. On a sunny day, take your pizza around the corner into the Soho Square gardens.<br />Pizza lovers should note that, at the time of writing, the renowned (and, for my money, marginally better)<a href=\"http://francomanca.co.uk\" title=\"\"> Franco Manca</a> were about to open a site on nearby Tottenham Court Road. <br />• <em>From &pound;6 takeaway, &pound;7 eat-in. 11 Dean Street W1, 020-7287 8964, </em><a href=\"http://pizzapilgrims.co.uk/\" title=\"\"><em>pizzapilgrims.co.uk</em></a></p><h2>Chettinad<br /></h2><figure data-media-id=\"gu-image-422397462\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg\" alt=\"Chettinad lunch box, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>When discussing tasty, affordable curry in central London, two venues come up again and again: the canteen at the Indian YMCA (41 Fitzroy Square, W1) and the &pound;6.95 daily buffet at Diwana Bhel Poori, close to Euston station (121-123 Drummond Street, NW1, 020-7387 5556). For the ultimate in budget dining, however, neither can compete with the take-out, lunch-box deal at Tamil restaurant Chettinad. Served in a moulded, airline-style tray, it comprises a nibbly starter, three curries, raita, a roti and rice, for &pound;3.75 (vegetarian) or &pound;3.95 (meat). No, that isn't a typo. That is a full meal for under four quid. Impressively studded with fresh herbs and spices, a couple of tiny, lukewarm bhajis were a bit tough and leathery, but rest of the food was remarkable for the money. The rice had been winningly mined with cashew nuts, lentils and mustard seeds and, like the best south Indian food, the curries were restrained in their heat, allowing well-rounded flavour to shine through. On a cold day, a melting, slow-cooked chickpea curry in a rich tomato sauce was first-rate comfort food. Note: you can eat-in and takeaway for under &pound;10 in the evening, too.<br />• <em>Lunch box from &pound;3.75, takeaway, eat-in lunch &pound;6.95. Evening curries with shared rice,from around &pound;8. 16 Percy Street W1, 020-3556 1229, </em><a href=\"http://chettinadrestaurant.com/\" title=\"\"><em>chettinadrestaurant.com</em></a></p><h2>Bi Bim Bap<br /></h2><figure data-media-id=\"gu-image-422397463\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg\" alt=\"Bi Bim Bap Soho \" width=\"460\" height=\"277\" class=\"gu-image\" /><figcaption></figcaption></figure><p>Served in blisteringly hot stone bowls, which cook the ingredients as you eat, bibimbap is a Korean mixed-rice dish of seemingly endless variations. One of which is catching on in central London, too. Bi Bim Bap has just opened a second site in Fitzrovia, in addition to its Soho original. My traditional dol sot, a mixed vegetable version with mooli, daikon, spinach and more, was surprisingly tasty, a fried egg giving it a lovely creamy texture. You can add sinus-clearing gochujang chilli sauce as you go. The staff will happily explain the intricacies of all this to any bibimbap virgins. <br />• <em>Bi Bim Bap from &pound;6.45–&pound;9.95. Branches at 11 Greek Street and 10 Charlotte Street W1, 020-7287 3434, </em><a href=\"http://www.bibimbaplondon.com/\" title=\"\"><em>bibimbaplondon.com</em></a></p><h2>Banh Mi Bay<br /></h2><p>The Theobalds Road branch has a slightly weird farmhouse kitchen look (as if set-up for a modern British tea room, rather than a busy Vietnamese cafe), but the Bay's food hits the mark. Behind the counter, a huge grill keeps the meats coming for bun salads and banh canh soups, both made using homemade noodles. They also server creditable banh mi, Vietnamese baguette sandwiches, which aren't the best in London – you'll have to go further east for that – but are authentically lighter than their French cousins; the meats deliver good flavours and, crucially, the shavings of pickled carrot and mooli are sharp enough to jangle your taste buds. Elsewhere, the menu runs from a six-hour simmered pho to savoury banh xeo pancakes. <br />• <em>Takeaway banh mi, &pound;4.35, noodle dishes and rice boxes from &pound;5.50. Branches at 4-6 Theobalds Road, Holborn, WC1, 020-7831 4079, and 21 Rathbone Street W1, 020-3609 4830, </em><a href=\"http://banhmibay.co.uk/\" title=\"\"><em>banhmibay.co.uk</em></a></p><p>• <em>Travel between Manchester and London was provided by </em><a href=\"http://virgintrains.co.uk/\" title=\"\"><em>Virgin Trains</em></a></p><!-- Guardian Watermark: internal-code/content/422388356|2013-11-13T15:50:01Z|4631bb312ce31beccd20be6f5f8f1461335ce0e5 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbp6",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+        "wordcount":"1573",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"travel/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/travel/london",
+        "apiUrl":"http://content.guardianapis.com/travel/london",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/travel/restaurants",
+        "apiUrl":"http://content.guardianapis.com/travel/restaurants",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/series/britains-best-budget-eats",
+        "type":"series",
+        "webTitle":"Britain's best budget eats",
+        "webUrl":"http://www.theguardian.com/travel/series/britains-best-budget-eats",
+        "apiUrl":"http://content.guardianapis.com/travel/series/britains-best-budget-eats",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"profile/tonynaylor",
+        "type":"contributor",
+        "webTitle":"Tony Naylor",
+        "webUrl":"http://www.theguardian.com/profile/tonynaylor",
+        "apiUrl":"http://content.guardianapis.com/profile/tonynaylor",
+        "bio":"<p>Tony Naylor lives in the north of England. He likes Greggs pasties, molecular gastronomy and lots of things in between. Outside of filling his face his interests include any licensed establishments, Manchester City, electronic music and some other stuff which could look a bit pretentious in print</p>",
+        "rcsId":"GNL009141",
+        "r2ContributorId":"16542",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/tony_naylor.jpg",
+        "references":[]
+      },{
+        "id":"travel/travel",
+        "type":"keyword",
+        "webTitle":"Travel",
+        "webUrl":"http://www.theguardian.com/travel/travel",
+        "apiUrl":"http://content.guardianapis.com/travel/travel",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/travelfoodanddrink",
+        "type":"keyword",
+        "webTitle":"Food and drink",
+        "webUrl":"http://www.theguardian.com/travel/travelfoodanddrink",
+        "apiUrl":"http://content.guardianapis.com/travel/travelfoodanddrink",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"travel/uk",
+        "type":"keyword",
+        "webTitle":"United Kingdom",
+        "webUrl":"http://www.theguardian.com/travel/uk",
+        "apiUrl":"http://content.guardianapis.com/travel/uk",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/europe",
+        "type":"keyword",
+        "webTitle":"Europe",
+        "webUrl":"http://www.theguardian.com/travel/europe",
+        "apiUrl":"http://content.guardianapis.com/travel/europe",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/england",
+        "type":"keyword",
+        "webTitle":"England",
+        "webUrl":"http://www.theguardian.com/travel/england",
+        "apiUrl":"http://content.guardianapis.com/travel/england",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/budget",
+        "type":"keyword",
+        "webTitle":"Budget travel",
+        "webUrl":"http://www.theguardian.com/travel/budget",
+        "apiUrl":"http://content.guardianapis.com/travel/budget",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397454",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349264516/Koshari-Street-London-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Koshari Street's twist on Egyptian street food",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397455",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Koshari Street, London",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422397456",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg",
+          "typeData":{
+            "source":"Heloise Faure",
+            "photographer":"Heloise Faure",
+            "altText":"Honey & Co Cafe, Soho, London",
+            "height":"276",
+            "credit":"Heloise Faure/Heloise Faure",
+            "caption":"Photograph: Heloise Faure",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397457",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg",
+          "typeData":{
+            "source":"Ming Tang-Evans",
+            "photographer":"Ming Tang-Evans",
+            "altText":"Attendant cafe-restaurant, London",
+            "height":"276",
+            "credit":"Ming Tang-Evans/Ming Tang-Evans",
+            "caption":"Photograph: Ming Tang-Evans",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397458",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Scandinavian kitchen, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397459",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Honest Burger",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397460",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Foxcroft and Ginger, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397461",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg",
+          "typeData":{
+            "source":"Paul Winch-Furness",
+            "photographer":"Paul Winch-Furness",
+            "altText":"Pizza Pilgrims, Soho, London",
+            "height":"277",
+            "credit":"Paul Winch-Furness/Paul Winch-Furness",
+            "caption":"Photograph: Paul Winch-Furness",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397462",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Chettinad lunch box, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397463",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Bi Bim Bap Soho ",
+            "height":"277",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-12T15:43:09Z",
+      "webTitle":"Jennifer Lawrence is striking a blow for healthy, sweaty women | Muireann Carey-Campbell",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "fields":{
+        "trailText":"<p><strong>Muireann Carey-Campbell:</strong> Shock, horror – a female film star says she wants to be 'fit and strong'. But the more women she gets into the gym the better</p>",
+        "headline":"Jennifer Lawrence is striking a blow for healthy, sweaty women",
+        "body":"<p>Glancing at gossip mags while waiting in the queue at the supermarket suggests that women have just two body types: grossly overweight (which is seemingly anything over a size 12) or skinny and boney. So when Jennifer Lawrence, current heroine of Hollywood and legend among outspoken women everywhere, says that she wants to be <a href=\"http://abcnews.go.com/blogs/entertainment/2012/11/jennifer-lawrence-considered-a-fat-actress/\" title=\"\">\"fit and strong\"</a>, it is music to our ears. Finally, recognition of another option.</p><p>On Newsnight, speaking of playing Katniss Everdeen in the Hunger Games, Lawrence said that she refused to lose weight for roles, explaining: \"We have the ability to control this image that young girls are going to be seeing. They see enough of this body that they will never be able to obtain and it's an amazing opportunity to rid ourselves of that in this industry.\"</p><p>Sure, it's silly that a body type should even need celebrity endorsement, but what Lawrence has done here is a pretty rare thing among her peers. Various female celebrities will trot out similar lines in what come across as weak Kumbaya moments, where womankind should all join hands and rejoice. Rarely though, do we ever hear high-profile women say they want to look healthy.</p><p>For those of us who lead active lifestyles, we've been flying this flag for a long time. Historically, it's been deemed rather unladylike to sweat, making exercise somewhat of a problem, lest we get a little red faced or our hair get dishevelled. Women have been ushered towards gentler forms of exercise – a spot of yoga, a cheesy Jane Fonda DVD, or if we want to go a bit crazy, some Zumba.</p><p>But the tide has been slowly turning. More and more women are shirking the idea that you're either sporty or not, and experimenting with different ways to stay active. We're pushing the boundaries of what it means to be feminine and fit. We're running ultra marathons, skateboarding, doing Muay Thai and, sorry to upset the apple cart here guys, but we're sweating profusely while doing it. What's more we're not exercising with vanity in mind. A survey of visitors to my fitness website <a href=\"http://spikesandheels.com/\" title=\"\">Spikes &amp; Heels</a> revealed that barely any of the women working out regularly did so for weight loss reasons. The majority cited overall health, fitness and mental wellbeing as their driving force.</p><p>I particularly appreciate that Lawrence mentioned she wants to be strong. Any woman with an ounce of common sense has figured out that the \"lifting weights makes you bulky\" school of thought is utter nonsense. Women are becoming less fearful of the weights section in the gym and are squatting and deadlifting their way to greatness.</p><p>The <a href=\"http://www.theguardian.com/lifeandstyle/2013/nov/03/thigh-gap-pressure-point-women-self-esteem\" title=\"\">\"thigh gap\" brigade</a> on Tumblr – legions of young women whose mission in life is to be so thin as to see a space between the tops of their legs – have come up against a new breed of fit chicks. The \"Strong is the new Sexy\" crowd post photos of women with defined muscles and six packs, doing pull ups while glistening with sweat (they all still have perfect hair and makeup though – I'm not saying that this movement isn't without its flaws).</p><p>Jennifer Lawrence's comments couldn't have come at a better time. With levels of inactivity at an all-time high in this country, having someone in her position championing being fit and strong may be just the boost a young woman needs to make a change. Make your way to the weights section, ladies.</p><!-- Guardian Watermark: internal-code/content/422307757|2013-11-13T15:50:01Z|fdae8da322868f19a7318c2815da07b886ce1198 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb44",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+        "wordcount":"572",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"film/jennifer-lawrence",
+        "type":"keyword",
+        "webTitle":"Jennifer Lawrence",
+        "webUrl":"http://www.theguardian.com/film/jennifer-lawrence",
+        "apiUrl":"http://content.guardianapis.com/film/jennifer-lawrence",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/body-image",
+        "type":"keyword",
+        "webTitle":"Body image",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/body-image",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/body-image",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fitness",
+        "type":"keyword",
+        "webTitle":"Fitness",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fitness",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fitness",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"lifeandstyle/health-and-wellbeing",
+        "type":"keyword",
+        "webTitle":"Health & wellbeing",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/health-and-wellbeing",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/health-and-wellbeing",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/health",
+        "type":"keyword",
+        "webTitle":"Health",
+        "webUrl":"http://www.theguardian.com/society/health",
+        "apiUrl":"http://content.guardianapis.com/society/health",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/muireann-carey-campbell",
+        "type":"contributor",
+        "webTitle":"Muireann Carey-Campbell",
+        "webUrl":"http://www.theguardian.com/profile/muireann-carey-campbell",
+        "apiUrl":"http://content.guardianapis.com/profile/muireann-carey-campbell",
+        "bio":"<p>Muireann Carey-Campbell is a fashion, lifestyle and fitness blogger based in London. She is an advocate for empowering women through exercise and edits <a href-\"http://spikesandheels.com\">spikesandheels.com</a> and <a href=\"http://www./pikesandheels.com\">bangsandabun.com</a></p>",
+        "r2ContributorId":"59569",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384260881751/Muireann-Carey-Campbell.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422318972",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269380150/Jennifer-Lawrence-with-Jo-001.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"54",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269383552/Jennifer-Lawrence-with-Jo-002.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"130",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269387034/Jennifer-Lawrence-with-Jo-004.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"132",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269388680/Jennifer-Lawrence-with-Jo-005.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"168",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269390391/Jennifer-Lawrence-with-Jo-006.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"180",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269392235/Jennifer-Lawrence-with-Jo-007.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"228",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/Lionsgate/Sportsphoto Ltd",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422318973",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "sectionId":"technology",
+      "sectionName":"Technology",
+      "webPublicationDate":"2013-11-13T11:29:00Z",
+      "webTitle":"PS4: the 10 key launch titles",
+      "webUrl":"http://www.theguardian.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "apiUrl":"http://content.guardianapis.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "fields":{
+        "trailText":"<p>As the Sony PlayStation 4's US launch looms, here are the best initial titles, from Killzone: Shadow Fall to Call of Duty: Ghosts. By <strong>Keith Stuart</strong></p>",
+        "headline":"PS4: the 10 key launch titles",
+        "body":"<p>A few days ago, Amazon US posted a photo of its warehouse, stacked high with thousands of PlayStation 4 boxes, ready to ship out to American stores on Friday. At last, the arrival of the next console generation is imminent and palpable. It'll all be about the games from now on. Hopefully.</p><p>So to get us started, here are the 10 key PS4 launch titles – they're the ones we think will sell, or will define the launch period. Actually, some of them are just the ones that interest <em>us</em>. Whatever, have a look and see if you agree...  </p><h2><strong>Assassin's Creed IV Black Flag, Ubisoft</strong></h2><p>Set amid the swashbuckling and treasure pilfering of piracy's golden age, the latest yarn in Ubisoft's historical adventure series is a distinct improvement on the last couple of instalments. Loaded with visually astonishing sea battles, it's a lavish way to start your next-gen career. Plus, the good news for PS4 owners is that this version of the game contains an hour of additional content in the form of three extra missions. There's also an Assassin's IV console bundle, replacing the Drive Club one that's now on hold due to the game's development delay. You'll find a nice walkthrough of some of the single-player game <a href=\"http://youtu.be/jHDfm2AYZS4\">on PlayStation Access</a>.</p><h2><strong>Battlefield 4, Electronic Arts</strong></h2><p>Fantastic multiplayer maps, wonderfully apocalyptic destruction and the tight, taut action we've come to expect from the series, Battlefield 4 is in a commanding position as the top military shooters make the generational crossover. Several retailers are offering Battlefield bundles for Sony's machine, but you'll have to wait for the Second Assault DLC pack – it's a timed exclusive on Xbox One. YouTuber Ali A has some <a href=\"http://youtu.be/alB3t7-bZ-c\">rather nice multiplayer PS4 footage</a>.</p><h2><strong>Call of Duty: Ghosts, Activison</strong></h2><p>Infinity Ward has abandoned the Modern Warfare arc, but its futuristic America-in-peril narrative is hauntingly familiar, while the multiplayer dwells on the same old twitchcore tricks and tactics. This is, however, still a thrilling ride, and running at 1080p in 60 frames-a-second, it looks its absolute best on PS4. As with Battlefield, a timed Xbox One exclusivity deal means the first DLC drop will be delayed on Sony's machine – but you can just spend that time enjoying the superior graphical performance.</p><h2><strong>Contrast, Compulsion Games</strong></h2><p>One of the first indie titles to appear on PS4's digital platform, Contrast is a fascinating 20s-based platformer, following the imaginary friend of a young girl investigating the secrets of her troubled family. With vaudevillian settings, a cool jazz soundtrack and a stylised mix of 2D and 3D visuals, this is a stark contrast to the triple A hits. It's coming later to a bunch of other platforms, but it's worth catching on PS4 from launch.</p><h2><strong>Fifa 14/Madden, EA Sports</strong></h2><p>Okay, I'm cheating – this is two games – but of course, in launch terms these EA Sports blockbusters are doing the same thing. As well as appeasing sports mad gamers, they're providing the state-of-the-art football action for young male professionals who can afford to buy a new machine in order to play one or two games a year – and who invariably choose one of these two titles on an annual basis. Both games are <a href=\"http://www.theguardian.com/technology/gamesblog/2013/sep/02/fifa-14-preview-interview\">enhanced from their current-gen offerings</a> with better animations, AI and stadia – although the Xbox One version adds the Ultimate Team Legends content, with around 40 classic players.</p><h2><strong>Killzone: Shadow Fall, Sony</strong></h2><p>Guerrilla's ice-cold sci-fi blaster has been the PlayStation technical showcase of choice since the second console – and Shadow Fall is definitely a major player this time round too. Taking place 30 years after the last title, the action now plays out on a hostile planet where the Vektans and the Helghast are divided by a huge wall – and either metaphorically or physically, it's about to come crashing down. The game is clearly a graphical marvel, but the grit is beginning to wear thin. </p><h2><strong>Knack, Sony</strong></h2><p>Designed by Mark Cerny, the engineering leader on PS4 and veteran of such games as Sonic 2, Crash Bandicoot and Ratchet and Clank, this is Sony's own family pleaser. It's a colourful action adventure following the eponymous robot who can transform himself into a range of useful objects to defeat invading goblins. Early reports from the specialist press aren't exactly amazing, but the game looks to have plenty of charm and there are some arresting vistas to gaze upon.</p><h2><strong>Lego Marvel Super Heroes, Warner Bros</strong></h2><p>The latest title in the long-running Lego series switches from Batman and his DC pals to Marvel heroes like Hulk, Spider-Man and Wolverine. The formula is ridiculously familiar, but with that rich comic book heritage, some great set-pieces and a few fresh features for PS4, this entertaining adventure just pips Skylanders Swap Force (which also gets a visual overhaul for PS4) as the third-party kid-friendly title to opt for.</p><h2><strong>Resogun, Sony</strong></h2><p>Ah, another frenetic, hypnotic shooter from Super Stardust creator Housemarque, this time in a rotating 2D environment buzzing with laser blasts, eye-popping explosions and blazing score multipliers. It's got missiles, it's got nova-bombs and it'll be free for users who subscribe to the PlayStation Plus online gaming service. Until Xbox One gets a new Geometry Wars, this is the place to come for next-gen schmup action.</p><h2><strong>Super Motherload, XGen Studios</strong></h2><p>Another indie download, this time a procedurally generated digging sim with four-player co-op. Set on a colonised future Mars, the aim is to burrow deep under the planet's surface, grabbing minerals and bringing them to the surface for cash and experience points, which can be spent on customising your craft. Developed by Edmonton-based XGen Studios, it's sort of an RPG-infused version of brilliant platformer Spelunky, with some Mr Driller (the classic Namco arcade/Dreamcast puzzler) chucked in. This is a good thing.</p><p>• <a href=\"http://www.theguardian.com/technology/2013/oct/31/ps4-sony-playstation-cant-play-audio-cds-mp3s\">PS4: five new things we've learned</a><br />• <a href=\"http://www.theguardian.com/technology/2013/nov/11/playstation-four-makes-debut\">Sony has high hopes for PlayStation 4's debut this month</a><br />• <a href=\"http://www.theguardian.com/technology/2013/nov/06/ps4-or-xbox-one-parents-guide\">PS4 or Xbox One? A parent's guide</a></p><!-- Guardian Watermark: internal-code/content/422302794|2013-11-13T15:50:01Z|3f2953ddc61ff43a6885f069a3700a7ba75a7aba -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kb3x",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+        "wordcount":"964",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"technology/playstation-4",
+        "type":"keyword",
+        "webTitle":"PlayStation 4",
+        "webUrl":"http://www.theguardian.com/technology/playstation-4",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation-4",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/playstation",
+        "type":"keyword",
+        "webTitle":"PlayStation",
+        "webUrl":"http://www.theguardian.com/technology/playstation",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/sony",
+        "type":"keyword",
+        "webTitle":"Sony",
+        "webUrl":"http://www.theguardian.com/technology/sony",
+        "apiUrl":"http://content.guardianapis.com/technology/sony",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/games",
+        "type":"keyword",
+        "webTitle":"Games",
+        "webUrl":"http://www.theguardian.com/technology/games",
+        "apiUrl":"http://content.guardianapis.com/technology/games",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/technology",
+        "type":"keyword",
+        "webTitle":"Technology",
+        "webUrl":"http://www.theguardian.com/technology/technology",
+        "apiUrl":"http://content.guardianapis.com/technology/technology",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"profile/keithstuart",
+        "type":"contributor",
+        "webTitle":"Keith Stuart",
+        "webUrl":"http://www.theguardian.com/profile/keithstuart",
+        "apiUrl":"http://content.guardianapis.com/profile/keithstuart",
+        "bio":"<p>Keith Stuart is a veteran video game and technology writer, who is also a regular contributor to Edge magazine</p>",
+        "rcsId":"GNL007878",
+        "r2ContributorId":"15953",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Media/Columnists/Columnists/2013/11/8/1383915413362/Keith-Stuart--003.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388207",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288957309/KZ4_Blast3_main.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Killzone: Shadow Fall – a graphical showcase for Sony's next-gen PS4 console",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422388208",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"84",
+            "credit":"PR",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T13:54:18Z",
+      "webTitle":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "fields":{
+        "trailText":"Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol<br />",
+        "headline":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+        "body":"<p>Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol.</p><p>Meulensteen worked at Manchester United alongside Sir Alex Ferguson from 2007 to the summer when he left the club following David Moyes's appointment.</p><p>He had been linked with the vacant Crystal Palace job after <a href=\"http://www.theguardian.com/football/2013/nov/13/middlesbrough-real-madrid-aitor-karanka\" title=\"\">Aitor Karanka opted to join Middlesbrough</a> ahead of the south London club.</p><p>The Fulham chief executive officer, Alistair Mackintosh, <a href=\"http://www.fulhamfc.com/news/2013/november/13/meulensteen-arrives\" title=\"\">told the club website</a>: \"We're all delighted to welcome René to Fulham. There was always going to be a battle for René's services and, with the assistance of our chairman Shahid Khan, we've been able to bring one of the best coaches in the world to Fulham.\"</p><p>The move to bring in Meulensteen comes with the club inside the relegation places after 11 games.</p><p>Meulensteen, who will take up the post immediately, said: \"I was impressed by the vision of Shahid Khan and Alistair Mackintosh. I've spent many hours talking with Martin Jol and we share a vision of how football should be played and how players should be developed. It's our job to make sure we can bring this vision to life on the pitch for the fans.\"</p><p>Meulensteen's last job was in Russia in July at Anzhi Makhachkala, who he joined as assistant coach to another Dutchman, Guus Hiddink. However, Hiddink left the club two games into the season after which Meulensteen only lasted 16 days as manager.</p><p>Fulham have lost their last three matches and lie 18th in the league.</p><!-- Guardian Watermark: internal-code/content/422391502|2013-11-13T15:50:01Z|23b2cb358f236f651feef84f2f5293d946ee6c76 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbqd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+        "wordcount":"247",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"football/martin-jol",
+        "type":"keyword",
+        "webTitle":"Martin Jol",
+        "webUrl":"http://www.theguardian.com/football/martin-jol",
+        "apiUrl":"http://content.guardianapis.com/football/martin-jol",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/fulham",
+        "type":"keyword",
+        "webTitle":"Fulham",
+        "webUrl":"http://www.theguardian.com/football/fulham",
+        "apiUrl":"http://content.guardianapis.com/football/fulham",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/55"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397529",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350779268/Ren--Meulensteen-001.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"54",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350781955/Ren--Meulensteen-002.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"130",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350783658/Ren--Meulensteen-003.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"84",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350785345/Ren--Meulensteen-004.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"132",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350787149/Ren--Meulensteen-005.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"168",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350788867/Ren--Meulensteen-006.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"180",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350790688/Ren--Meulensteen-007.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"228",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350792437/Ren--Meulensteen-008.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"276",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351652017/Martin-Jol-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"276",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by the newly appointed head coach René Meulensteen (right) at Fulham. Photographs: PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397530",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"84",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by new head coach René Meulensteen (right) at Fulham. Photograph: PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/55"
+      }]
+    }],
+    "storyPackage":[]
+  }
+}

--- a/data/database/df8b74c8d42d907f012ce073a8f1f2dbe9cc65d5
+++ b/data/database/df8b74c8d42d907f012ce073a8f1f2dbe9cc65d5
@@ -1,0 +1,6211 @@
+{
+  "response":{
+    "status":"ok",
+    "userTier":"internal",
+    "total":1,
+    "mostViewed":[{
+      "id":"lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Why you won't catch me queuing for a burger",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jay-rayner-queue-for-hamburger",
+      "fields":{
+        "trailText":"<p><strong>Jay Rayner:</strong> Waiting two hours in a line for beef in a bun was never going to be a good idea</p>",
+        "headline":"Why you won't catch me queuing for a burger",
+        "body":"<p>I'm all for delayed gratification. I will book theatre tickets six months ahead. I will take a shoulder of lamb, stud it with anchovies and garlic and half-submerge it in a broth of red wine, stock and piggy bits, so that it looks like the ravaged island of Dr Moreau, shove it in the oven and know it will have nothing of any interest to say to me for at least seven hours.</p><p>What I won't do is <a href=\"http://www.theguardian.com/lifeandstyle/2013/nov/03/eat-out-queue-for-table\" title=\"\">queue for a hamburger</a>. In this, it seems, I am peculiar. Recently London's Covent Garden has seen the opening of the US operations Shake Shack and Five Guys. We also have home-grown outfits like Meat Liquor, and Burger and Lobster, which seem to regard reservation policies as bourgeois affectations. In the sense that bookable tables suit people with jobs, interesting lives and places they need to be which don't include standing dead-eyed and wet-lipped on a chilly pavement for the running time of <em>The Godfather Part III</em>, I suppose they are. And yes, it's not entirely new. The Hard Rock Cafe has long been famous for its queue, but that was so odd it was a tourist attraction, something people pointed and laughed at. The new queueing has got completely out of hand. It's taken for granted. I have wandered past these places on numerous occasions and been baffled. What in God's name possesses anyone to stand in an endless line – I've been quoted more than two hours for Burger and Lobster – for a lump of ground beef between two sugary buns?</p><p>Of course it's not just a lump of ground beef, is it? Over at the Shake Shack it's \"our proprietary Shack blend\" which makes it sound less like lunch and more like a haemorrhoid ointment; at Five Guys it's \"hand formed burgers cooked to perfection\". Really? Whose version of perfection, given that Westminster Council is trying to outlaw any burger served less than medium? Or completely buggered, as it's known.</p><p>I'll go that extra 10 miles to eat well. I'll cross London to secure an ingredient, take a flight to eat at the right restaurant. But queue? That's not an expression of greed. It's stamp-collecting. It's trainspotting. It's eating out as spectator sport. Except the only thing the queue has to spectate upon is itself, and there it finds validation: standing in line for a hamburger must be entirely reasonable; just look at all the other people doing it.</p><p>The counter-argument involves the P word: patience, and my total lack of it. Apparently patience is a virtue. Really? If everybody was patient, nothing would ever get done. The world depends on restless, impatient people. I should also point out that patience is one of the seven great Christian virtues. Nobody with an appetite should ever sign up to those. Obviously some are OK. I believe fully in humility. I am brilliant at that, do it better than anybody else. But chastity and temperance? Don't be silly. That's the point. Queuing for a burger is not about eating. It's about self-denial. And doing the restaurant's marketing for them by standing outside.</p><p>Me? I will go somewhere that serves a slightly less impressive burger and in so doing, trade a little of the perceived quality of the Shake Shack object of desire, for living more of my life. I've only got one of those, and I'm not wasting it in a queue.</p><!-- Guardian Watermark: internal-code/content/421828691|2013-11-13T15:50:01Z|4b3ef3429e53b630d10c1f8a057f6a070b28ee4f -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k6zt",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+        "wordcount":"567",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fast-food",
+        "type":"keyword",
+        "webTitle":"Fast food",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fast-food",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fast-food",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Observer Food Monthly recipes & features",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly/features",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly/features",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"theobserver/foodmonthly",
+        "type":"newspaper-book",
+        "webTitle":"Observer Food Monthly",
+        "webUrl":"http://www.theguardian.com/theobserver/foodmonthly",
+        "apiUrl":"http://content.guardianapis.com/theobserver/foodmonthly",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"lifeandstyle/series/happy-eater",
+        "type":"series",
+        "webTitle":"Happy eater",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/happy-eater",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/happy-eater",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/jayrayner",
+        "type":"contributor",
+        "webTitle":"Jay Rayner",
+        "webUrl":"http://www.theguardian.com/profile/jayrayner",
+        "apiUrl":"http://content.guardianapis.com/profile/jayrayner",
+        "bio":"<p>Jay Rayner is the Observer's restaurant critic and a novelist. His latest book is the Oyster House Siege</p>",
+        "rcsId":"GNL258574",
+        "r2ContributorId":"15803",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2008/06/02/jay_rayner_140x140.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theobserver",
+        "type":"publication",
+        "webTitle":"The Observer",
+        "webUrl":"http://www.theguardian.com/theobserver/all",
+        "apiUrl":"http://content.guardianapis.com/theobserver/all",
+        "sectionId":"theobserver",
+        "sectionName":"From the Observer",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422287525",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259303137/burger-and-fries-from-sha-007.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"276",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about self-denial\". Photograph: Radharc Images/Alamy",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422287526",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384259295726/burger-and-fries-from-sha-002.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Radharc Images ",
+            "altText":"burger and fries from shake shack burger restaurant newly opened in covent garden london, england uk",
+            "height":"84",
+            "credit":"Radharc Images /Alamy",
+            "caption":"\"Queuing for a burger is not about eating. It is about \nself-denial\". Photograph: Radharc Images /Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T12:58:39Z",
+      "webTitle":"It was hard to stomach David Cameron preaching austerity from a golden throne | Ruth Hardy",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/david-cameron-austerity-public-sector-cuts",
+      "fields":{
+        "trailText":"<strong>Ruth Hardy: </strong>As a waitress at the lord mayor's banquet, the contrast between what Cameron was saying and where he was saying it felt particularly chilling",
+        "headline":"It was hard to stomach David Cameron preaching austerity from a golden throne",
+        "body":"<p>At a state banquet for the new Lord Mayor on Monday, David Cameron gave a <a href=\"http://www.theguardian.com/politics/2013/nov/11/david-cameron-policy-shift-leaner-efficient-state\" title=\"\">speech about his commitment to the cause of permanent austerity</a>. He stood up to speak from a golden chair, and read his notes from a golden lectern.</p><p></p><p>As it happens, I was at the banquet too and heard the news about permanent spending cutbacks for myself. Sadly I was not there as a dignitary, a foreign diplomat, a captain of industry or the director of a big City firm. I was there as a waitress. The contrast between what he was saying and where he was saying it seemed initially almost too laughable to get worked up about. But actually, it reflected something chilling in Cameron's attitude towards the people he purports to be working for.</p><p></p><p>I work evenings and weekends at an events company. The company is great and the hours are flexible, which allows me to combine it with my main job of an internship. It's tough, and I've been in a state of semi-tiredness for the last two months. I do get to work at interesting events, though, and the fanciness of the Guildhall banquet was breathtaking. Although, as one of my colleagues said: \"I thought Boris Johnson was the lord mayor, that's the only reason I agreed to work!\"</p><p></p><p>The guests enjoyed a champagne reception, and then were served a starter (\"a celebration of British mushrooms\"), a fish course and main course of fillet of beef, all served with wine of course. In the break before dessert, coffee, dessert wine, port, brandy and whisky were served, Cameron gave his speech. We retreated downstairs to a steam-filled kitchen, where we polished the cutlery. Most of us were exhausted by this point. Dinner service is physically demanding, and I am by no means the only person who combines two or three jobs. The contrast of the two worlds was striking; someone said it was like a scene from Downton Abbey.</p><p></p><p>Maybe Cameron didn't see the irony; perhaps he forgot about the army of waiting staff, cleaners, chefs and porters who were also present at the banquet. Perhaps he thought he was in a room of similarly rich people, who understood the necessity for austerity. Perhaps it didn't occur to him that this message might not be as easily comprehended by those who hadn't just enjoyed a four-course meal. Perhaps he forgot about those of us, disabled or unemployed or on the minimum wage, for whom austerity has had a catastrophic and wounding effect.</p><p></p><p>In his speech, Cameron talked about a \"leaner, more efficient, more affordable state\". He argued that austerity could be a permanent government policy; a way of trimming down the administrative excesses of some public services. He framed it in the context of the current tough living conditions – a minimising of state spending, as it \"comes out of the pockets of the same taxpayers whose living standards we want to see improve\".</p><p></p><p>No word yet, of course, on what changes will be made to the state-funded banquet he was speaking at. Perhaps next year there will only be three courses, or the dessert wine will be ruthlessly culled.</p><p></p><p>I wonder how Cameron and his government can do these things. Aside from the idiocy of calling for cuts while wearing a white tie – has the man never heard of Twitter – does he not see what welfare cuts are doing to the vulnerable in society? He enjoys a banquet, while the number of people using food banks has tripled in the past year. As someone on the shift with me said, \"It gets annoying that we always serve free food to the people who really don't need free food.\"</p><p></p><p>The political content of what Cameron is saying is obviously more important than where he was saying it, but I don't think the latter is irrelevant. I have a fundamental problem with a man who sits on a golden throne and lectures us about spending less, like a modern-day, white-tie clad sheriff of Nottingham. And all around him, the insidious stain of austerity creeps across the country, manifesting in the bedroom tax, rising tuition fees and the closure of public services that vulnerable people depend on.</p><p></p><p>Each of us has just one chance at existence, and so many people's lives are being blighted by these cuts. If this is the cruel and damaging reality of permanent austerity, then we should be telling Mr Cameron we don't want it.</p><!-- Guardian Watermark: internal-code/content/422381235|2013-11-13T15:50:01Z|a39e5393ad4fbfe9cb5ea9291bf9c8c72f35b051 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbyq",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+        "wordcount":"738",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"politics/davidcameron",
+        "type":"keyword",
+        "webTitle":"David Cameron",
+        "webUrl":"http://www.theguardian.com/politics/davidcameron",
+        "apiUrl":"http://content.guardianapis.com/politics/davidcameron",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/conservatives",
+        "type":"keyword",
+        "webTitle":"Conservatives",
+        "webUrl":"http://www.theguardian.com/politics/conservatives",
+        "apiUrl":"http://content.guardianapis.com/politics/conservatives",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"society/public-sector-cuts",
+        "type":"keyword",
+        "webTitle":"Public sector cuts",
+        "webUrl":"http://www.theguardian.com/society/public-sector-cuts",
+        "apiUrl":"http://content.guardianapis.com/society/public-sector-cuts",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/policy",
+        "type":"keyword",
+        "webTitle":"Public services policy",
+        "webUrl":"http://www.theguardian.com/society/policy",
+        "apiUrl":"http://content.guardianapis.com/society/policy",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/public-finance",
+        "type":"keyword",
+        "webTitle":"Public finance",
+        "webUrl":"http://www.theguardian.com/society/public-finance",
+        "apiUrl":"http://content.guardianapis.com/society/public-finance",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"business/austerity",
+        "type":"keyword",
+        "webTitle":"Austerity",
+        "webUrl":"http://www.theguardian.com/business/austerity",
+        "apiUrl":"http://content.guardianapis.com/business/austerity",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/economics",
+        "type":"keyword",
+        "webTitle":"Economics",
+        "webUrl":"http://www.theguardian.com/business/economics",
+        "apiUrl":"http://content.guardianapis.com/business/economics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"profile/ruth-hardy",
+        "type":"contributor",
+        "webTitle":"Ruth Hardy",
+        "webUrl":"http://www.theguardian.com/profile/ruth-hardy",
+        "apiUrl":"http://content.guardianapis.com/profile/ruth-hardy",
+        "bio":"<p>Ruth Hardy is a freelance writer and recent graduate in philosophy at King's College London. You can follow her on Twitter <a href=\"https://twitter.com/ruthhardy22\">here</a></p>",
+        "r2ContributorId":"56147",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Education/Pix/pictures/2013/4/24/1366808642483/Ruth-Hardy-student-blogge-002.jpg",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422382150",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344632805/David-Cameron-at-Lord-May-001.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"54",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344634858/David-Cameron-at-Lord-May-002.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"130",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344637355/David-Cameron-at-Lord-May-004.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"132",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344638596/David-Cameron-at-Lord-May-005.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"168",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344639804/David-Cameron-at-Lord-May-006.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"180",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344641041/David-Cameron-at-Lord-May-007.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"228",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344642510/David-Cameron-at-Lord-May-008.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"276",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422382151",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344636166/David-Cameron-at-Lord-May-003.jpg",
+          "typeData":{
+            "source":"Rex Features",
+            "photographer":"Ray Tang",
+            "altText":"David Cameron at Lord Mayor's Banquet",
+            "height":"84",
+            "credit":"Ray Tang/Rex Features",
+            "caption":"David Cameron prepares to speak on the need for 'permanent austerity' at the Lord Mayor's banquet. Photograph: Ray Tang/Rex Features",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T14:44:00Z",
+      "webTitle":"MI6 spy found dead in bag probably locked himself inside, Met says",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/mi6-spy-dead-bag-locked-himself-gareth-williams",
+      "fields":{
+        "trailText":"Three-year investigation by Scotland Yard concludes Gareth Williams probably died as a result of tragic accident",
+        "headline":"MI6 spy found dead in bag probably locked himself inside, Met says",
+        "body":"<p></p><p>The MI6 spy found dead in a bag three years ago probably locked himself in the holdall and died as a result of a tragic accident, Scotland Yard has said.</p><p>Outlining the results of a three-year investigation on Wednesday, the Metropolitan police said that Gareth Williams was most likely to have died alone in his flat.</p><p>However, Detective Assistant Commissioner Martin Hewitt said the police could not \"fundamentally and beyond doubt\" rule out the possibility that a third-party was involved in his  death.</p><p>The naked body of Williams was found in the padlocked bag, with the keys discovered under his body, in the otherwise empty bath in his flat in Pimlico, London, in August 2010.</p><p>Last year, a coroner concluded that Williams was probably unlawfully killed and his death the result of a criminal act. Following an eight-day inquest, the Westminster coroner, Dr Fiona Wilcox, said he was probably either suffocated or poisoned, before a third-party locked and placed the bag in the bath.</p><p></p><p>However, Hewitt said Scotland Yard's three-year inquiry had come to a different conclusion and that Williams was \"most probably\" alone when he died.</p><p>\"Despite all of this considerable effort, it is still the case that there is insufficient evidence to be definitive on the circumstances that led to Gareth's death,\" he said.</p><p></p><p>\"Rather, what we are left with is either individual pieces of evidence, or a lack of such evidence, that can logically support one of a number of hypotheses.\"</p><p></p><p></p><p></p><p>Hewitt added that the investigation had added \"some clarity and detail\" to the case, but that \"no evidence has been identified to establish the full circumstances of Gareth's death beyond all reasonable doubt\".</p><p></p><p>A forensic examination of Williams's flat, a security service safe house, has concluded that there was no sign of forced entry or DNA that pointed to a third-party present at the time of the spy's death.</p><p></p><p>Scotland Yard's inquiry also found no evidence of Williams's fingerprints on the padlock of the bag or the rim of the bath, which the coroner last year said supported her assertion of \"third-party involvement\" in the death.</p><p></p><p>However, Hewitt said it was theoretically possible for Williams to lower himself into the holdall without touching the rim of the bath.</p><p></p><p>Winding down the lengthy investigation, which has drawn interviews and statements from 27 of Williams's colleagues in MI6 and GCHQ, Hewitt said the death remained a tragedy that would be kept under review by detectives.</p><p></p><p>In a statement, Williams's family said they were  disappointed with the police findings and that they agreed with the coroner's conclusions that he was most likely killed unlawfully.</p><p></p><p>\"We are naturally disappointed that it is still not possible to state with certainty how Gareth died and the fact that the circumstances of his death are still unknown adds to our grief,\" the  family said.</p><p></p><p>\"We note that the investigation has been conducted with further interviews upon some of the witnesses who gave evidence at the inquest and that the investigation team were at last able to interview directly members of GCHQ and SIS [MI6].</p><p></p><p>\"We consider that on the basis of the facts at present known the coroner's verdict accurately reflects the circumstances of Gareth's death.\"</p><p></p><p>In a press briefing at Scotland Yard, Hewitt admitted it was \"a cause of some regret\" that the police were not able to definitively explain the circumstances surrounding the 31-year-old's death.</p><p></p><p>He rejected suggestions that the security services had \"pulled the wool\" over his eyes, following concerns over how MI6 and counter-terrorism officers had handled some evidence during the initial investigation. It emerged on Wednesday that police only gained access to Williams's spy agency personnel and vetting files after the coroner's inquest ended last May.</p><p></p><p>Williams, a maths prodigy and fitness enthusiast originally from Anglesey, was a private person with few other close friends aside from his family, police said. In interviews, MI6 and GCHQ colleagues described him as a \"conscientious and decent man\" and detectives were unable to identify anyone with any animosity towards him or a motive for causing him harm.</p><p></p><p>As part of the fresh investigation, a forensic sweep of Williams's flat discovered 10 to 15 unidentified traces of DNA, which are being kept under examination, but none on the North Face holdall or around the bath area of the en-suite bathroom of the flat's main bedroom. There was also no evidence of a \"deep clean\" of the flat to wipe all trace of DNA.</p><p></p><p>Hewitt said: \"There are really three hypotheses that you can use here. One is that Gareth, for whatever reason, got himself into that bag and then was unable to get himself out and died as a result of that.</p><p></p><p>\"One is that Gareth, with someone else, got into the bag consensually then something went wrong and he died as a result of that. The third is that someone murdered Gareth by putting him in that bag. I would argue that any physical absence [of evidence of] a third party being present tends to make the hypotheses that there is a third party present less likely.\"</p><p></p><p>He added: \"The coroner drew an inference. I am now drawing a different inference.\"</p><p></p><p>At the coroner's inquest, two experts tried 400 times to lock themselves into the 32-inch by 19-inch holdall without success, with one remarking that even Harry Houdini \"would have struggled\" to squeeze himself inside. But days after the inquest footage emerged of a retired Army sergeant climbing into the bag and locking it from the inside.</p><p></p><p>Hewitt said it was now established that it was theoretically possible for a person to climb into the bag and that it was \"more probable\" that Williams did this before suffocating as a result of the accident. It emerged during the inquest that Williams had an interest in escapology, but the police said it would be speculation to link his death to a failed attempt to escape from the locked holdall.</p><!-- Guardian Watermark: internal-code/content/422374658|2013-11-13T15:50:01Z|2fd9134acad4628a73f05b72533e71cb4f6ef04d -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjj",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+        "wordcount":"962",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"uk/gareth-williams",
+        "type":"keyword",
+        "webTitle":"Gareth Williams",
+        "webUrl":"http://www.theguardian.com/uk/gareth-williams",
+        "apiUrl":"http://content.guardianapis.com/uk/gareth-williams",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/mi6",
+        "type":"keyword",
+        "webTitle":"MI6",
+        "webUrl":"http://www.theguardian.com/uk/mi6",
+        "apiUrl":"http://content.guardianapis.com/uk/mi6",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uksecurity",
+        "type":"keyword",
+        "webTitle":"UK security and counter-terrorism",
+        "webUrl":"http://www.theguardian.com/uk/uksecurity",
+        "apiUrl":"http://content.guardianapis.com/uk/uksecurity",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/josh-halliday",
+        "type":"contributor",
+        "webTitle":"Josh Halliday",
+        "webUrl":"http://www.theguardian.com/profile/josh-halliday",
+        "apiUrl":"http://content.guardianapis.com/profile/josh-halliday",
+        "bio":"<p><a href=\"http://twitter.com/JoshHalliday\">Josh Halliday</a> is a media and technology reporter. Josh has a keen interest in digital media and privacy. Dislikes insufferable enthusiasm. Bradfordian via Wearside</p>",
+        "r2ContributorId":"38624",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/7/14/1279118930047/Josh-Halliday.jpg",
+        "references":[]
+      },{
+        "id":"uk/metropolitan-police",
+        "type":"keyword",
+        "webTitle":"Metropolitan police",
+        "webUrl":"http://www.theguardian.com/uk/metropolitan-police",
+        "apiUrl":"http://content.guardianapis.com/uk/metropolitan-police",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/uk/london",
+        "apiUrl":"http://content.guardianapis.com/uk/london",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379877",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341447432/Gareth-Williams-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"54",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341448835/Gareth-Williams-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"340",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341450089/Gareth-Williams-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"130",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341452580/Gareth-Williams-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"132",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341453889/Gareth-Williams-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"168",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341455246/Gareth-Williams-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"180",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341456514/Gareth-Williams-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"228",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341459093/Gareth-Williams-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"372",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341457790/Gareth-Williams-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"276",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379878",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384341451308/Gareth-Williams-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Anonymous",
+            "altText":"Gareth Williams",
+            "height":"84",
+            "credit":"Anonymous/AP",
+            "caption":"Gareth Williams: last year a coroner concluded that the spy was probably unlawfully killed and his death the result of a criminal act. Photograph: Anonymous/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-12T15:34:27Z",
+      "webTitle":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/12/occupy-wall-street-activists-15m-personal-debt",
+      "fields":{
+        "trailText":"Rolling Jubilee spent $400,000 to purchase debt cheaply from banks before 'abolishing' it, freeing individuals from their bills",
+        "headline":"Occupy Wall Street activists buy $15m of Americans' personal debt",
+        "body":"<p>A group of Occupy Wall Street activists has bought almost $15m of Americans' personal debt over the last year as part of the Rolling Jubilee project to help people pay off their outstanding credit.</p> <p><a href=\"http://rollingjubilee.org/\">Rolling Jubilee</a>,&nbsp;set up by Occupy's <a href=\"http://www.theguardian.com/world/2012/nov/15/occupy-rolling-jubilee-debt-forgiveness\">Strike Debt group</a>&nbsp;following the street protests that swept the world in 2011, launched on 15 November 2012. The group purchases personal debt cheaply from banks before \"abolishing\" it, freeing individuals from their bills.</p> <p>By purchasing the debt at knockdown prices the group has managed to free $14,734,569.87 of personal debt, mainly medical debt, spending only $400,000.</p> <p>\"We thought that the ratio would be about 20 to 1,\" said Andrew Ross, a member of Strike Debt and professor of social and cultural analysis at New York University. He said the team initially envisaged raising $50,000, which would have enabled it to buy $1m in debt.</p> <p>\"In fact we've been able to buy debt a lot more cheaply than that.\"</p> <p>The group is able to buy debt so cheaply due to the nature of the \"secondary debt market\". If individuals consistently fail to pay bills from credit cards, loans, or medical insurance the bank or lender that issued the funds will eventually cut its losses by selling that debt to a third party. These sales occur for a fraction of the debt&rsquo;s true values &ndash; typically for five cents on the dollar &ndash; and debt-buying companies then attempt to recoup the debt from the individual debtor and thus make a profit.</p> <p>The Rolling Jubilee project was mostly conceived as a \"public education project\", Ross said.</p> <p>\"We're under no illusions that $15m is just a tiny drop in the secondary debt market. It doesn't make a dent in the amount of debt.</p> <p>\"Our purpose in doing this, aside from helping some people along the way &ndash; there's certainly many, many people who are very thankful that their debts are abolished &ndash; our primary purpose was to spread information about the workings of this secondary debt market.\"</p> <p>The group has focussed on buying medical debt, and has acquired the $14.7m in three separate purchases, most recently&nbsp;purchasing the value of&nbsp;$13.5m on medical debt owed by 2,693 people across 45 states and Puerto Rico, Rolling Jubilee said in a press release.</p> <p>&ldquo;No one should have to go into debt or bankruptcy because they get sick,&rdquo; said Laura Hanna, an organiser with the group. Hanna said 62% of all personal bankruptcies have medical debt as a contributing factor.</p> <p>Due to the nature of the debt market, the group is unable to specify whose debt it purchases, taking on the amounts before it discovers individuals&rsquo; identities. When Rolling Jubilee has bought the debt they send notes to their debtors &ldquo;telling them they&rsquo;re off the hook&rdquo;, Ross said.</p> <p>Ross, whose book, <a href=\"http://www.orbooks.com/catalog/creditocracy/\">Creditocracy</a> and the case for debt refusal, outlines the problems of the debt industry and calls for a &ldquo;debtors&rsquo; movement&rdquo; to resist credit, said the group had received letters from people whose debt they had lifted thanking them for the service. But the real victory was in spreading knowledge of the nature of the debt industry, he said.</p> <p>\"Very few people know how cheaply their debts have been bought by collectors. It changes the psychology of the debtor, knowing this.</p> <p>&ldquo;So when you get called up by the debt collector, and you're being asked to pay the full amount of your debt, you now know that the debt collector has bought your debt very, very cheaply. As cheaply as we bought it. And that gives you moral ammunition to have a different conversation with the debt collector.\"</p><!-- Guardian Watermark: internal-code/content/422309147|2013-11-13T15:50:01Z|eb1f79972b6a77bb0687b85ebfb26ad79d81d69a -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb4g",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+        "wordcount":"1",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/occupy-movement",
+        "type":"keyword",
+        "webTitle":"Occupy movement",
+        "webUrl":"http://www.theguardian.com/world/occupy-movement",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-movement",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/occupy-wall-street",
+        "type":"keyword",
+        "webTitle":"Occupy Wall Street",
+        "webUrl":"http://www.theguardian.com/world/occupy-wall-street",
+        "apiUrl":"http://content.guardianapis.com/world/occupy-wall-street",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/debt-relief",
+        "type":"keyword",
+        "webTitle":"Debt relief",
+        "webUrl":"http://www.theguardian.com/world/debt-relief",
+        "apiUrl":"http://content.guardianapis.com/world/debt-relief",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"money/us-personal-finance",
+        "type":"keyword",
+        "webTitle":"US personal finance",
+        "webUrl":"http://www.theguardian.com/money/us-personal-finance",
+        "apiUrl":"http://content.guardianapis.com/money/us-personal-finance",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"money/mortgages-us",
+        "type":"keyword",
+        "webTitle":"US mortgages",
+        "webUrl":"http://www.theguardian.com/money/mortgages-us",
+        "apiUrl":"http://content.guardianapis.com/money/mortgages-us",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"business/useconomy",
+        "type":"keyword",
+        "webTitle":"US economy",
+        "webUrl":"http://www.theguardian.com/business/useconomy",
+        "apiUrl":"http://content.guardianapis.com/business/useconomy",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/business",
+        "type":"keyword",
+        "webTitle":"Business",
+        "webUrl":"http://www.theguardian.com/business/business",
+        "apiUrl":"http://content.guardianapis.com/business/business",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"money/money",
+        "type":"keyword",
+        "webTitle":"Money",
+        "webUrl":"http://www.theguardian.com/money/money",
+        "apiUrl":"http://content.guardianapis.com/money/money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/adam-gabbatt",
+        "type":"contributor",
+        "webTitle":"Adam Gabbatt",
+        "webUrl":"http://www.theguardian.com/profile/adam-gabbatt",
+        "apiUrl":"http://content.guardianapis.com/profile/adam-gabbatt",
+        "bio":"<p>Adam Gabbatt is a reporter and live blogger for the Guardian, based in New York. He won a journalism bursary from the Scott Trust, the company that owns the Guardian, in 2008, and began writing for the newspaper and website in 2009. He was highly commended in the young journalist of the year category at the British Press Awards in 2011</p>",
+        "r2ContributorId":"33854",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/1/24/1359039911843/AdamGabbatt.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001361114/Occupy-Wall-Street-010.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"276",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"'Our primary purpose was to spread information about the workings of this secondary debt market,' said Andrew Ross.&nbsp;Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-7946e698-9a7d-4cbb-a1c3-4d52c604ae77",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/23/1372001353031/Occupy-Wall-Street-005.jpg",
+            "source":"Getty Images",
+            "photographer":"Spencer Platt",
+            "altText":"Occupy Wall Street",
+            "height":"84",
+            "credit":"Spencer Platt/Getty Images",
+            "caption":"The Occupy movement began in Wall Street in November 2011 when protesters attempted to shut down the New York stock exchange. Photograph: Spencer Platt/Getty Images",
+            "mediaId":"gu-fc-c19a2f43-d48d-4c14-b85b-69523dc1a6cd",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "sectionId":"uk-news",
+      "sectionName":"UK news",
+      "webPublicationDate":"2013-11-13T01:25:32Z",
+      "webTitle":"ITV news presenter hits back after abuse for not wearing poppy",
+      "webUrl":"http://www.theguardian.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "apiUrl":"http://content.guardianapis.com/uk-news/2013/nov/13/charlene-white-itv-news-presenter-remembrance-day-poppy",
+      "fields":{
+        "trailText":"Charlene White faced racist and sexist abuse which, she said, acted against all the goals that the fallen soldiers fought for",
+        "headline":"ITV news presenter hits back after abuse for not wearing poppy",
+        "body":"<p>An ITV news presenter who has been subject to racist and sexist abuse for her decision not to wear a Remembrance Day poppy said she made her decision in order to be \"neutral and impartial on-screen\".</p><p>Charlene White, a presenter on ITV News London, received insults on social media after she appeared on screen without the poppy, with many of the jibes focusing on her race.</p><p><a href=\"http://www.itv.com/news/2013-11-12/itv-news-presenter-defends-decision-to-not-wear-a-poppy-on-air/\" title=\"\">In a statement on the ITV website</a>, the journalist said she had made the decision not to wear a poppy a number of years ago but the backlash this year had been the worst so far.</p><p>She said she supported the armed forces, in which her father and uncle had served, but chose to remain impartial on screen.</p><p>\"I support and am patron of a number of charities and I am uncomfortable with giving one of those charities more on-screen time than others,\" she said. \"I prefer to be neutral and impartial on screen so that one of those charities doesn't feel less favoured than another.  Offscreen in my private life – it's different.</p><p>\"I wear a red ribbon at the start of December for World Aids Day, a pink ribbon in October during breast cancer awareness month, a badge in April during Bowel Cancer Awareness month, and yes – a poppy on Armistice Day.</p><p>\"I respect and hold in high esteem those in the armed forces, both my father and my uncle have served in the RAF and the army.  Every year I donate to the Poppy Appeal because above all else it is a charity that needs donations, so that it can continue to help support serving and ex-service men and women and their families.\"</p><p>The abuse directed at her on Twitter included racist jibes that her family would not have been able to settle in Britain but for the deaths of soldiers.  \"Without all those fallen soldiers, Hitler would've taken over Britain and your family would never have been allowed here...,\" user @alhaurincraig wrote.  Another crudely superimposed a picture of a poppy on to an image of the presenter with a banner saying 'Sack the Slag'.</p><p>White said the racist and sexist abuse acted against all of the goals that the fallen soldiers had fought for. \"The messages of \"go back to where you came from\" have been interesting to read, as have the 'fat s--g' comments, and the repeated use of the phrase 'black c--t',\" she said.  \"Mostly because it flies in the face of everything that millions of British men and women and those in the Commonwealth have fought for for generations, and continue to fight for: the right to choose, and the right of freedom of speech and expression.\"</p><p>Google has also been the subject of criticism because it used only a small Remembrance Day poppy on its website. Labour MP Gerry Sutcliffe said it was \"demeaning not to have something spectacular\".</p><p>The search engine said it tried to be sensitive in not putting sombre occasions into one of their trademark doodles but instead featuring them in some way on their homepage.</p><!-- Guardian Watermark: internal-code/content/422347727|2013-11-13T15:50:01Z|78aaf770fdf9c298733094f851d2fcebe3ae8a57 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbfc",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+        "wordcount":"504",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"uk/remembranceday",
+        "type":"keyword",
+        "webTitle":"Remembrance Day",
+        "webUrl":"http://www.theguardian.com/uk/remembranceday",
+        "apiUrl":"http://content.guardianapis.com/uk/remembranceday",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"media/itv1",
+        "type":"keyword",
+        "webTitle":"ITV channel",
+        "webUrl":"http://www.theguardian.com/media/itv1",
+        "apiUrl":"http://content.guardianapis.com/media/itv1",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/television",
+        "type":"keyword",
+        "webTitle":"Television industry",
+        "webUrl":"http://www.theguardian.com/media/television",
+        "apiUrl":"http://content.guardianapis.com/media/television",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"media/media",
+        "type":"keyword",
+        "webTitle":"Media",
+        "webUrl":"http://www.theguardian.com/media/media",
+        "apiUrl":"http://content.guardianapis.com/media/media",
+        "sectionId":"media",
+        "sectionName":"Media",
+        "references":[]
+      },{
+        "id":"tv-and-radio/tv-news",
+        "type":"keyword",
+        "webTitle":"The news on TV",
+        "webUrl":"http://www.theguardian.com/tv-and-radio/tv-news",
+        "apiUrl":"http://content.guardianapis.com/tv-and-radio/tv-news",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"culture/television",
+        "type":"keyword",
+        "webTitle":"Television",
+        "webUrl":"http://www.theguardian.com/culture/television",
+        "apiUrl":"http://content.guardianapis.com/culture/television",
+        "sectionId":"tv-and-radio",
+        "sectionName":"Television &amp; radio",
+        "references":[]
+      },{
+        "id":"profile/shane-hickey",
+        "type":"contributor",
+        "webTitle":"Shane Hickey",
+        "webUrl":"http://www.theguardian.com/profile/shane-hickey",
+        "apiUrl":"http://content.guardianapis.com/profile/shane-hickey",
+        "r2ContributorId":"55396",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422347763",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305766581/Poppies-001.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"54",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305768729/Poppies-002.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"340",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305770017/Poppies-003.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"130",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305772726/Poppies-005.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"132",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305773964/Poppies-006.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"168",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305775328/Poppies-007.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"180",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305776636/Poppies-008.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"228",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305779302/Poppies-010.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"372",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305777973/Poppies-009.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"276",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422347764",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384305771405/Poppies-004.jpg",
+          "typeData":{
+            "source":"Athena Pictures",
+            "photographer":"Dimitris Legakis",
+            "altText":"Poppies",
+            "height":"84",
+            "credit":"Dimitris Legakis/Athena Pictures",
+            "caption":"Charlene White received abuse for not wearing a poppy on ITV News London. Photograph: Dimitris Legakis/Athena Pictures",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "sectionId":"society",
+      "sectionName":"Society",
+      "webPublicationDate":"2013-11-13T12:10:00Z",
+      "webTitle":"Hamzah Khan: minister has 'deep concerns' over review findings",
+      "webUrl":"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "apiUrl":"http://content.guardianapis.com/society/2013/nov/13/hamzah-khan-minister-deep-concerns-review",
+      "fields":{
+        "trailText":"Edward Timpson criticises review into death of child who starved to death while DfE source describes report as 'risible'",
+        "headline":"Hamzah Khan: minister has 'deep concerns' over review findings",
+        "body":"<p>The children's minister Edward Timpson has said he has deep concerns over <a href=\"http://www.theguardian.com/society/2013/nov/13/hamzah-khan-social-services-warning-signs\" title=\"\">the serious case review by the Bradford safeguarding children board into the death of four-year-old Hamzah Khan</a>, who was starved to death by his mother in Bradford.</p><p>A source from the Department for Education (DfE) used even stronger language, describing the review as \"risible\", but a source at the council accused the government of \"social worker bashing\".</p><p>Hamzah's partially mummified body was found clothed in a Babygro meant for a child aged six to nine months in September 2011, almost two years after his death in December 2009.</p><p><a href=\"http://www.theguardian.com/society/2013/oct/03/hamzah-khan-starved-to-death-amanda-hutton\" title=\"\">His mother, Amanda Hutton, 44, was last month found guilty of his manslaughter</a> and of neglecting six of her eight children.</p><p><a href=\"http://www.theguardian.com/society/interactive/2013/nov/13/hamzah-khan-serious-case-review\" title=\"\">The serious case review (SCR)</a>, commissioned by Bradford safeguarding children board (BSCB), concluded that while social services missed signs that, had they been put together, could have warned that Hamzah and his seven siblings were at risk, his death was \"not predictable\". That appears to have not gone far enough for the DfE.</p><p>In a letter to Nick Frost, chair of BSCB, Edward Timpson, the minister for children and families, wrote: \"I am concerned that it [the SCR] fails to explain sufficiently clearly the actions taken, or not taken, by children's social care when problems in the Khan family were brought to their attention on a number of occasions.\"</p><p>The letter sets out a number of questions, which Timpson says relate to \"missed opportunities to protect the children in the house\".</p><p>He continues: \"It is tragic beyond words that by the time a health visitor did trigger concerns about the whereabouts of the younger children in the household, who were missing from health and education services altogether, Hamzah Khan was already dead.\"</p><p>Frost said in a statement: \"The SCR is very clear that Hamzah's death could not have been predicted but finds that systems, many of them national systems, let Hamzah down both before and following his death.\"</p><p>The DfE's criticism provoked an angry response at Bradford council, with a source claiming that the education secretary, Michael Gove, had initially been ready to accept the SCR's findings.</p><p>The source said: \"Forty-eight hours ago all the indications were that the DfE were going to accept the report but Gove appears to have had a change of heart.\"</p><p>The council accused the education secretary of changing his mind because there was \"not enough social worker bashing\".  It is understood Gove thinks there has been a failure of all agencies in Bradford to accept any responsibility.</p><p>The authors of the SCR make 50 recommendations for \"learning\", which have been accepted by BSCB without blaming any one agency for failing Hamzah. The panel found that the agencies focused their efforts on Hutton as a victim of domestic violence, rather than her children. The experts report that while much help was offered to Hamzah's mother, who was beaten up by her partner for much of their 22-year relationship, not enough focus was put on whether her children were safe and well.</p><p>Annie Hudson, chief executive of the College of Social Work, said the SCR \"brings into sharp focus why there must be strong, joined-up and effective systems in place to keep in contact with, and track, children at risk.</p><p>\"No child should ever fall off the radar or become invisible to child protection agencies and society as a whole.\"</p><p>The NSPCC said it highlighted the need for a red flag when children miss key appointments so youngsters such as Hamzah do not \"slip off the radar of society\".</p><!-- Guardian Watermark: internal-code/content/422378691|2013-11-13T15:50:01Z|d7c3b400464ae84bc4d38dfc68bb6ce1b96a13d1 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kby3",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+        "wordcount":"579",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"society/childprotection",
+        "type":"keyword",
+        "webTitle":"Child protection",
+        "webUrl":"http://www.theguardian.com/society/childprotection",
+        "apiUrl":"http://content.guardianapis.com/society/childprotection",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/children",
+        "type":"keyword",
+        "webTitle":"Children",
+        "webUrl":"http://www.theguardian.com/society/children",
+        "apiUrl":"http://content.guardianapis.com/society/children",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/social-care",
+        "type":"keyword",
+        "webTitle":"Social care",
+        "webUrl":"http://www.theguardian.com/society/social-care",
+        "apiUrl":"http://content.guardianapis.com/society/social-care",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"society/localgovernment",
+        "type":"keyword",
+        "webTitle":"Local government",
+        "webUrl":"http://www.theguardian.com/society/localgovernment",
+        "apiUrl":"http://content.guardianapis.com/society/localgovernment",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"uk/bradford",
+        "type":"keyword",
+        "webTitle":"Bradford",
+        "webUrl":"http://www.theguardian.com/uk/bradford",
+        "apiUrl":"http://content.guardianapis.com/uk/bradford",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"politics/politics",
+        "type":"keyword",
+        "webTitle":"Politics",
+        "webUrl":"http://www.theguardian.com/politics/politics",
+        "apiUrl":"http://content.guardianapis.com/politics/politics",
+        "sectionId":"politics",
+        "sectionName":"Politics",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/helenpidd",
+        "type":"contributor",
+        "webTitle":"Helen Pidd",
+        "webUrl":"http://www.theguardian.com/profile/helenpidd",
+        "apiUrl":"http://content.guardianapis.com/profile/helenpidd",
+        "bio":"<p>Helen Pidd is northern editor of the Guardian, based in Manchester. She joined the paper in 2004 to edit the now defunct Office Hours and was a commissioning editor on G2 before joining the home news team in 2007, going on to spend 2011 in Germany as Berlin correspondent followed by a stint in Delhi. She is the author of <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490530\">Bicycle – The Complete<br />Guide to Everyday Cycling</a>.</p>",
+        "r2ContributorId":"19855",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/6/22/1277217764498/Helen-Pidd-byline.-003.jpg",
+        "references":[]
+      },{
+        "id":"profile/haroonsiddique",
+        "type":"contributor",
+        "webTitle":"Haroon Siddique",
+        "webUrl":"http://www.theguardian.com/profile/haroonsiddique",
+        "apiUrl":"http://content.guardianapis.com/profile/haroonsiddique",
+        "bio":"<p>Haroon Siddique is a news reporter on the Guardian website. He previously worked for North London institution the Ham&amp;High, and before pursuing his passion for journalism he was a commodity trader in the City</p>",
+        "r2ContributorId":"19136",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/haroon_siddique.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422379573",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343315052/Hamzah-Khan-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"54",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343317421/Hamzah-Khan-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"340",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343318751/Hamzah-Khan-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"130",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343321335/Hamzah-Khan-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"132",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343322756/Hamzah-Khan-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"168",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343324035/Hamzah-Khan-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"180",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343325436/Hamzah-Khan-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"228",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343328488/Hamzah-Khan-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"372",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343327081/Hamzah-Khan-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"276",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422379574",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384343320054/Hamzah-Khan-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"West Yorkshire police",
+            "altText":"Hamzah Khan",
+            "height":"84",
+            "credit":"West Yorkshire police/PA",
+            "caption":"The minister attacked the serious case review into the death of four-year-old Hamzah Khan (pictured), who was starved to death by his mother in Bradford. \r Photograph: West Yorkshire police/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-13T09:50:29Z",
+      "webTitle":"Lily Allen does not represent all feminism – and nor should she | Ellie Mae O'Hagan",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/13/lily-allen-video-represent-feminism-feminist-woman",
+      "fields":{
+        "trailText":"<p><strong>Ellie Mae O'Hagan:</strong> Instead of critiquing whether Allen's new video is feminist or not, we should ask why there is such a weight of expectation on one woman</p>",
+        "headline":"Lily Allen does not represent all feminism – and nor should she",
+        "body":"<p>As soon as <a href=\"http://www.theguardian.com/music/musicblog/2013/nov/12/lily-allen-hard-out-here\" title=\"\">Lily Allen released a music video</a> that was purportedly a new feminist anthem, I anticipated that a slew of blogs and commentary would follow. I was right – I've read four on the subject already. Nevertheless, it is my policy to leave no bandwagon unjumped, and so here's my contribution to the unfolding brouhaha.</p><p>I can't deny I enjoyed watching Lily Allen poke fun at the notoriously sexist music industry, and in many ways I thought she was spot on. The presence of a besuited old white man in her music video who encourages her to fellate a banana was pretty revealing. Behind the dancing girls and schmaltzy lyrics that usually characterise pop songs, these men act as the all-oppressing eye of the industry: telling female singers that weight loss and sexual objectification are the only feasible routes to stardom; stripping down women in music videos to their underwear while leaving their male counterparts untouched. Allen was right to identify these shadowy white men as the source of the problem, for though sexism is a structural thing, it does usually manifest itself in the actual men in charge dictating how women should present themselves and their bodies in order to achieve some kind of validation.</p><p>But the video is problematic too. For one thing, it's unclear whether Allen is reserving scorn solely for the rich white men she satirises, or whether some women (like <a href=\"http://www.theguardian.com/commentisfree/2013/nov/07/pop-stars-sexy-netmums-parents-miley-cyrus\" title=\"\">Miley Cyrus</a> – who presumably has also been taught that sexualisation is the route to success) don't cop some too. To twerk or not to twerk may be the zeitgeist question, but whatever answer you come up with, you're still telling women how they should present their own bodies. Then there's the issue of <a href=\"http://www.theguardian.com/commentisfree/2013/nov/10/black-women-music-industry-sex\" title=\"\">race in the video</a>. On a surface level, Allen attempts to mock the way black women are treated as nothing more than sexual objects in music videos – yet she also posits herself as separate from the black women that feature in hers. At the end of the song, she pointedly sashays off, while they remain behind as simply semi-nude backing dancers. <a href=\"http://www.voice-online.co.uk/article/music-videos-exploiting-black-womens-bodies\" title=\"\">Sarah Greene of the End Violence Against Women Coalition recently told the Voice</a>, \"In a particular Calvin Harris video [Drinking from the Bottle ft Tinie Tempah], there is kind of a sea of black women's bottoms. You never even see their faces … young black women say it makes them feel hated.\" In that respect, it's difficult to see Allen's anthem as little more than same old same old, and it's probably why I ultimately feel she misses the mark. As the <a href=\"https://twitter.com/Okwonga/status/400367983299940352\" title=\"\">journalist Musa Okwonga put it</a>, \"She should've swapped the female dancers for a bunch of twerking middle-aged men.\"</p><p>In my mind though, the wider question is not whether or not Lily Allen's feminist song is a success or not; it's why is it that one single music video containing some fairly cursory observations on sexism is able to stir up such a reaction in the feminist movement. One explanation lies in a comment made by the blogger Glosswitch recently (<a href=\"http://glosswatch.com/\" title=\"\">and I recommend you read her piece in full</a>): \"I'd say one objective of feminism should be to help women's decisions become less loaded. It's oppressive to have to represent a whole sex in everything you do.\" Unfortunately for Allen and everybody else, her music video seems unable to stand in and of itself, representing only her opinions, but is instead being seen as some kind of expression of all feminism – and by extension all women. This is part and parcel of being in an oppressed group: women are routinely dehumanised and homogenised, so that every act we undertake in public tends to reflect on all women, instead of our own individual character. It's a problem men just don't have. And feminism is so marginalised as a strain of political thought, that when one feminist woman makes it into the mainstream, a flurry of panic and excitement will inevitably follow simply because there are so few feminist voices in the public sphere. Feminism is an extremely broad church, but I often think feminists are guilty of expecting every single prominent feminist to reflect their exact politics because there aren't enough opinions in the mainstream to choose from – and all too often the feminists that do make it big are white and middle class.</p><p>Perhaps the most helpful response we feminists can have to Lily Allen's video is not to tear it down because of its flaws (although they should be addressed), but to look at feminism itself and discuss how to realise its potential as a political movement. Instead of admonishing or praising Allen, we should ask why there is such a weight of expectation upon something so small, and what we can do to rectify that. There are already exciting projects attempting to do this, like the <a href=\"http://ukfeminista.org.uk/event-details/summer-school-2013/\" title=\"\">UK Feminista summer school</a>, the <a href=\"http://www.theguardian.com/lifeandstyle/the-womens-blog-with-jane-martinson/2013/apr/16/everyday-sexism-project-shouting-back\" title=\"\">Everyday Sexism Project</a>, <a href=\"http://www.southallblacksisters.org.uk/\" title=\"\">Southall Black Sisters</a>, or the indispensable work of the <a href=\"http://www.fawcettsociety.org.uk/\" title=\"\">Fawcett Society</a>. I don't pretend to have a grand feminist plan, and in any case feminists should probably decide on such a plan together, but I do know that if we focus on organising ourselves into a political force and supporting each other in the struggle against patriarchy, the time will come when we care less about what Lily Allen has to say – because the fate of feminism won't seem to rest upon the strengths and weaknesses of one music video.</p><!-- Guardian Watermark: internal-code/content/422367349|2013-11-13T15:50:01Z|eb480736002bcb62f3ac77dca7fbf93c7da33bfc -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbhf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+        "wordcount":"909",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"world/feminism",
+        "type":"keyword",
+        "webTitle":"Feminism",
+        "webUrl":"http://www.theguardian.com/world/feminism",
+        "apiUrl":"http://content.guardianapis.com/world/feminism",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"music/lilyallen",
+        "type":"keyword",
+        "webTitle":"Lily Allen",
+        "webUrl":"http://www.theguardian.com/music/lilyallen",
+        "apiUrl":"http://content.guardianapis.com/music/lilyallen",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/ellie-mae-o-hagan",
+        "type":"contributor",
+        "webTitle":"Ellie Mae O'Hagan",
+        "webUrl":"http://www.theguardian.com/profile/ellie-mae-o-hagan",
+        "apiUrl":"http://content.guardianapis.com/profile/ellie-mae-o-hagan",
+        "bio":"<p>Ellie Mae O'Hagan is a regular columnist for Comment is free. She has also written for the Times, the New Statesman, Red Pepper, False Economy, New Left Project and Union News. She currently works with the Centre for Labour and Social Studies, a think for left debate and discussion originating in the trade union movement. She is also an active member of UK Uncut. She  tweets as <a href=\"http://twitter.com/#!/MissEllieMae\">@MissEllieMae</a></p>",
+        "r2ContributorId":"43367",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/3/22/1300821538131/EllieMaeOHagan.jpg",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388300",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348250282/Lily-Allen-001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Lily Allen",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Lily Allen",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T10:06:25Z",
+      "webTitle":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/prevent-rape-enjoy-it-india-police-chief",
+      "fields":{
+        "trailText":"Ranjit Sinha, chief of India's Central Bureau of Investigation, apologises for remark that causes outrage across country",
+        "headline":"'If you can't prevent rape, you enjoy it,' says India's top police official",
+        "body":"<p>India's top police official has apologised for saying: \"If you can't prevent rape, you enjoy it,\" – a remark that has outraged the country.</p><p>Ranjit Sinha, chief of India's Central Bureau of Investigation, made the remark on Tuesday during a conference about illegal sports betting and the need to legalise gambling. The CBI, the country's premier investigative agency, is India's equivalent of the FBI.</p><p>Sinha said at the conference that if the state could not stop gambling, it could at least make some revenue by legalising it.</p><p>\"If you cannot enforce the ban on betting, it is like saying: 'If you can't prevent rape, you enjoy it,'\" he said.</p><p>The remarks have caused outrage across India, which in the past year has been hit by widespread protests following the<a href=\"http://www.theguardian.com/world/2013/sep/13/delhi-gang-rape-relief-india-men-sentenced-death\" title=\"\"> fatal gang-rape</a> of a 23-year-old woman on a bus in New Delhi.</p><p>On Wednesday, Sinha said  his comments had been taken out of context and misinterpreted, and that he was sorry if he had caused hurt. Angry activists, however, called for his resignation.</p><p>Brinda Karat, leader of the Communist party of India (Marxist), said Sinha's comments were offensive to women everywhere.</p><p>\"It is sickening that a man who is in charge of several rape investigations should use such an analogy,\" Karat told reporters. \"He should be prosecuted for degrading and insulting women.\"</p><p>The New Delhi attack on the young woman last December caused nationwide outrage and forced the government to change rape laws and create fast-track courts for rape cases.</p><p>Laws introduced after the attack make stalking, voyeurism and sexual harassment a crime. They also provide for the death penalty for repeat offenders or for rape attacks that lead to the victim's death.</p><!-- Guardian Watermark: internal-code/content/422368950|2013-11-13T15:50:01Z|3356dd1aba5de54aede55024098d378c1e663a8e -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbhz",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+        "wordcount":"273",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/india",
+        "type":"keyword",
+        "webTitle":"India",
+        "webUrl":"http://www.theguardian.com/world/india",
+        "apiUrl":"http://content.guardianapis.com/world/india",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"society/rape",
+        "type":"keyword",
+        "webTitle":"Rape",
+        "webUrl":"http://www.theguardian.com/society/rape",
+        "apiUrl":"http://content.guardianapis.com/society/rape",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"law/law",
+        "type":"keyword",
+        "webTitle":"Law",
+        "webUrl":"http://www.theguardian.com/law/law",
+        "apiUrl":"http://content.guardianapis.com/law/law",
+        "sectionId":"law",
+        "sectionName":"Law",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422369576",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337123909/Ranjit-Sinha-001.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"54",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337125231/Ranjit-Sinha-002.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"340",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337126586/Ranjit-Sinha-003.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"130",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337129092/Ranjit-Sinha-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"132",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337130310/Ranjit-Sinha-006.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"168",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337131559/Ranjit-Sinha-007.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"180",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337132902/Ranjit-Sinha-008.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"228",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337135575/Ranjit-Sinha-010.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"372",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337134239/Ranjit-Sinha-009.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"276",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422369577",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/About/General/2013/11/13/1384337127850/Ranjit-Sinha-004.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Mustafa Quraishi",
+            "altText":"Ranjit Sinha",
+            "height":"84",
+            "credit":"Mustafa Quraishi/AP",
+            "caption":"Ranjit Sinha addresses a press conference at the CBI headquarters in New Delhi, India.  Photograph: Mustafa Quraishi/AP",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T11:18:52Z",
+      "webTitle":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/chelsea-still-paying-roberto-di-matteo-130000-week",
+      "fields":{
+        "trailText":"Roberto Di Matteo is reportedly still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago",
+        "headline":"Chelsea 'still paying ex-manager Roberto Di Matteo £130,000-a-week'",
+        "body":"<p>Roberto Di Matteo is still being paid £130,000-a-week by Chelsea as the club continues to foot the bill for his sacking 12 months ago, according to reports.</p><p>The former manager did not agree a pay-off settlement when he was axed as manager last season, and <a href=\"http://www.dailymail.co.uk/sport/football/article-2503321/Chelsea-paying-Roberto-Di-Matteo-130-000-week.html\" title=\"\">the Daily Mail reports</a> the Italian will continue to be paid in full until June 2014 unless he takes another job before then.</p><p>That, however, seems unlikely given Di Matteo has reportedly turned down several offers both in the Premier League and from abroad since his departure, while there are few clubs who could match the lucrative £6.76m annual salary he was earning at Stamford Bridge.</p><p>Di Matteo was <a href=\"http://www.theguardian.com/football/2013/sep/23/roberto-di-matteo-gus-poyet-sunderland\" title=\"\">linked with the Sunderland job</a> before Gus Poyet's appointment and he is seen as a possible replacement for Martin Jol at Fulham should the Dutch manager leave Craven Cottage.</p><!-- Guardian Watermark: internal-code/content/422374266|2013-11-13T15:50:01Z|c1df33eb8d20d8f3e4b39082656cd5158a54e92f -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbjb",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+        "wordcount":"140",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"football/roberto-di-matteo",
+        "type":"keyword",
+        "webTitle":"Roberto Di Matteo",
+        "webUrl":"http://www.theguardian.com/football/roberto-di-matteo",
+        "apiUrl":"http://content.guardianapis.com/football/roberto-di-matteo",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/chelsea",
+        "type":"keyword",
+        "webTitle":"Chelsea",
+        "webUrl":"http://www.theguardian.com/football/chelsea",
+        "apiUrl":"http://content.guardianapis.com/football/chelsea",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/4"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422374804",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341239071/Roberto-Di-Matteo-001.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"54",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341242197/Roberto-Di-Matteo-002.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"340",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341243440/Roberto-Di-Matteo-003.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"130",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341244752/Roberto-Di-Matteo-004.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"720",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341246531/Roberto-Di-Matteo-005.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341249682/Roberto-Di-Matteo-007.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"132",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341250911/Roberto-Di-Matteo-008.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"168",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341252176/Roberto-Di-Matteo-009.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"180",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341253497/Roberto-Di-Matteo-010.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"228",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341256016/Roberto-Di-Matteo-012.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"372",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341257472/Roberto-Di-Matteo-013.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1116",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"1860"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341259557/Roberto-Di-Matteo-014.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"1536",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"2560"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341254769/Roberto-Di-Matteo-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"276",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422374805",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384341248432/Roberto-Di-Matteo-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "photographer":"Ian Nicholson",
+            "altText":"Roberto Di Matteo",
+            "height":"84",
+            "credit":"Ian Nicholson/PA",
+            "caption":"Roberto Di Matteo is still being paid in full by Chelsea despite his sacking 12 months ago. Photograph: Ian Nicholson/PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/4"
+      }]
+    },{
+      "id":"film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "sectionId":"film",
+      "sectionName":"Film",
+      "webPublicationDate":"2013-11-12T10:01:00Z",
+      "webTitle":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+      "webUrl":"http://www.theguardian.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "apiUrl":"http://content.guardianapis.com/film/2013/nov/12/nymphomaniac-lars-von-trier-hardcore",
+      "fields":{
+        "trailText":"<p>Unable to cut his sexually explicit film down from five hours, Danish director opts to let someone else cut the movie down to two, two-hour chunks – both including explicit footage</p>",
+        "headline":"Nymphomaniac to be hardcore only as Lars von Trier gives up final cut",
+        "body":"<p>Lars Von Trier has abandoned plans to release a softcore version of his sex epic Nymphomaniac. The film's two-part four-hour cut, which is due to debut in Copenhagen on Christmas Day, will now contain explicit scenes. </p><p>The release of Nymphomaniac will see the Danish director give up final cut for the first time in his career. The decision was apparently taken after Von Trier said he was unwilling to trim the two-part film's current five and a half hour running time himself. Nymphomaniac's strange fate is detailed in an extended making-of feature in the Danish film magazine Filmmagasinet Ekko which was picked up by <a href=\"http://www.hollywoodreporter.com/news/lars-von-trier-gives-up-655155\">the Hollywood Reporter</a>. </p><p>\"The short version is against Lars' own will, but he accepts it because he understands market mechanisms,\" says Von Trier's long-term producing partner Peter Aalbaek Jensen in the magazine article. \"You cannot make a film for more than 60 million kroners (about $11 million or £6.9 million) that is so lengthy. Five and a half hours is so extreme that it reduces market value so radically that investors would have felt they had bought a pig in a poke.\"</p><p>It is extremely unusual a director of the artistic clout of Von Trier to allow somebody else to complete their vision, particularly on such a singular project as Nymphomaniac. It is not known if the longer five-and-a-half-hour cut will ever be released, and Jensen refused to confirm if Von Trier would take it to next year's Cannes film festival.</p><p>Nymphomaniac, which stars the film-maker's regular muse Charlotte Gainsbourg in the lead, has been billed as an exploration of the erotic life of a woman from infancy to middle age. Digital trickery and body doubles have reportedly been used to portray famous stars such as Uma Thurman, Stellan Skarsgård, Christian Slater, Jamie Bell and Shia LaBeouf having sex.</p><p>A teaser trailer for the much anticipated film was briefly <a href=\"http://www.theguardian.com/film/2013/nov/04/nymphomiac-youtube-shia-labeouf-lars-von-trier-clip-removed\">removed from YouTube earlier this month</a> after apparently falling foul of the site's rules on nudity and sexual content.</p><h2>More on Nymphomaniac</h2><p>• <a href=\"http://www.theguardian.com/film/2013/nov/04/nymphomiac-youtube-shia-labeouf-lars-von-trier-clip-removed\">Nymphomaniac clip removed from Youtube</a><br />• <a href=\"http://www.theguardian.com/film/poll/2013/oct/10/nymphomaniac-orgasm-posters-vote-favourite\">Vote for your favourite Nymphomaniac orgasm poster</a></p><!-- Guardian Watermark: internal-code/content/422267679|2013-11-13T15:50:01Z|36aed8ffd86c1865c8018d220088cf262a55dd38 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kakf",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+        "wordcount":"343",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"film/lars-von-trier",
+        "type":"keyword",
+        "webTitle":"Lars von Trier",
+        "webUrl":"http://www.theguardian.com/film/lars-von-trier",
+        "apiUrl":"http://content.guardianapis.com/film/lars-von-trier",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"culture/charlotte-gainsbourg",
+        "type":"keyword",
+        "webTitle":"Charlotte Gainsbourg",
+        "webUrl":"http://www.theguardian.com/culture/charlotte-gainsbourg",
+        "apiUrl":"http://content.guardianapis.com/culture/charlotte-gainsbourg",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"profile/benchild",
+        "type":"contributor",
+        "webTitle":"Ben Child",
+        "webUrl":"http://www.theguardian.com/profile/benchild",
+        "apiUrl":"http://content.guardianapis.com/profile/benchild",
+        "bio":"<p>Ben Child is a journalist, DJ and producer whose main interests lie in the worlds of film and music</p>",
+        "r2ContributorId":"24984",
+        "references":[]
+      },{
+        "id":"film/drama",
+        "type":"keyword",
+        "webTitle":"Drama",
+        "webUrl":"http://www.theguardian.com/film/drama",
+        "apiUrl":"http://content.guardianapis.com/film/drama",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"culture/pornography",
+        "type":"keyword",
+        "webTitle":"Pornography",
+        "webUrl":"http://www.theguardian.com/culture/pornography",
+        "apiUrl":"http://content.guardianapis.com/culture/pornography",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"world/denmark",
+        "type":"keyword",
+        "webTitle":"Denmark",
+        "webUrl":"http://www.theguardian.com/world/denmark",
+        "apiUrl":"http://content.guardianapis.com/world/denmark",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422284236",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244020710/Nymphomaniac-chapter-one--008.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"276",
+            "credit":"Christian Geisnaes",
+            "caption":"One of the few fully-clothed stills from Nymphomaniac. Photograph: Christian Geisnaes",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422284237",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Film/Pix/pictures/2013/6/26/1372244013236/Nymphomaniac-chapter-one--003.jpg",
+          "typeData":{
+            "source":"Christian Geisnaes",
+            "altText":"Nymphomaniac chapter one still",
+            "height":"84",
+            "credit":"Christian Geisnaes",
+            "caption":"Nymphomaniac chapter one still Photograph: Christian Geisnaes",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:04:31Z",
+      "webTitle":"Jack Monroe's frozen yoghurt recipe",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/2013/nov/13/jack-monroe-frozen-yoghurt-recipe",
+      "fields":{
+        "trailText":"<p>This simple dessert is a great way to stretch fresh berries, but it works brilliantly with cheaper frozen fruit, too</p>",
+        "headline":"Jack Monroe's frozen yoghurt recipe",
+        "body":"<p>I first made these berry desserts with foraged blackberries and a few things from the fridge, but any berries will do. You can often get bags of mixed frozen berries far cheaper than their fresh counterparts, which are perfect for this simple dessert.</p><p><strong><em>(Makes 4 ramekins or lolly moulds)</em></strong> <em>34p a portion</em><br /><strong>100g white chocolate, </strong><em>30p</em><br /><strong>100g mixed frozen berries, </strong><em>33p</em><br /><strong>150g soft cream cheese, </strong><em>40p</em><br /><strong>300g low fat natural yoghurt, </strong><em>33p</em></p><p>Break up the chocolate and melt it gently in a mixing bowl over a pan containing a couple of inches of boiling water. Make sure the water doesn't touch the bowl, as too much heat will make the chocolate bitter.</p><p>Remove the bowl from the heat, using a tea towel or oven glove.</p><p>Add the berries, cream cheese and yoghurt and stir well to combine until smooth – the cheese will soften into the chocolate and yoghurt.</p><p>Spoon into ramekin dishes or lolly moulds, and freeze for at least two hours.</p><p>The lollies can be served as they are; ramekin dishes should be removed from the freezer 20 minutes before eating to thaw, or pinged in the microwave for a minute to soften.</p><h2>Jack's tip</h2><p>Replace the white chocolate with lemon curd for a sweet, zesty dessert. Dark chocolate and fresh chopped mint works well too.</p><p><em>• For more recipe ideas, including using up remaining ingredients, see <a href=\"http://agirlcalledjack.com/\">agirlcalledjack.com</a> or follow <a href=\"https://twitter.com/MsJackMonroe\">@MsJackMonroe</a> on Twitter.</em></p><!-- Guardian Watermark: internal-code/content/422376870|2013-11-13T15:50:01Z|97ef9d51bfc30f2ea9fd96125522f0c9a9d2232a -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbka",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+        "wordcount":"222",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "type":"series",
+        "webTitle":"Jack Monroe's low-cost recipes",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/jack-monroe-low-cost-recipes",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/dessert",
+        "type":"keyword",
+        "webTitle":"Dessert",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/dessert",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/dessert",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fruit",
+        "type":"keyword",
+        "webTitle":"Fruit",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fruit",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fruit",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"money/saving-money",
+        "type":"keyword",
+        "webTitle":"Saving money",
+        "webUrl":"http://www.theguardian.com/money/saving-money",
+        "apiUrl":"http://content.guardianapis.com/money/saving-money",
+        "sectionId":"money",
+        "sectionName":"Money",
+        "references":[]
+      },{
+        "id":"profile/jack-monroe",
+        "type":"contributor",
+        "webTitle":"Jack Monroe",
+        "webUrl":"http://www.theguardian.com/profile/jack-monroe",
+        "apiUrl":"http://content.guardianapis.com/profile/jack-monroe",
+        "bio":"<p>Jack Monroe blogs at <a href=\"http://agirlcalledjack.com/\">A Girl Called Jack</a> and is author of the forthcoming A Girl Called Jack recipe book</p>",
+        "r2ContributorId":"57609",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/9/10/1378813805813/Jack-Monroe.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381337",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344202019/Jack-Monroes-frozen-yoghu-009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"276",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381338",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384344193427/Jack-Monroes-frozen-yoghu-004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Graham Turner",
+            "altText":"Jack Monroe's frozen yoghurt",
+            "height":"84",
+            "credit":"Graham Turner/Guardian",
+            "caption":"Jack Monroe's frozen yoghurt. Photograph: Graham Turner for the Guardian",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "sectionId":"news",
+      "sectionName":"News",
+      "webPublicationDate":"2013-11-13T07:30:00Z",
+      "webTitle":"The daily quiz, 13 November 2013",
+      "webUrl":"http://www.theguardian.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "apiUrl":"http://content.guardianapis.com/news/quiz/2013/nov/13/daily-quiz-13-november-2013",
+      "fields":{
+        "trailText":"<p>From murder mysteries to famous lakes and luxury goods purveyors to the rules of boxing, 10 questions to test you</p>",
+        "headline":"The daily quiz, 13 November 2013",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3k2vg",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"news/series/the-daily-quiz",
+        "type":"series",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/news/series/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/news/series/the-daily-quiz",
+        "sectionId":"news",
+        "sectionName":"News",
+        "references":[]
+      },{
+        "id":"profile/the-daily-quiz",
+        "type":"contributor",
+        "webTitle":"The daily quiz",
+        "webUrl":"http://www.theguardian.com/profile/the-daily-quiz",
+        "apiUrl":"http://content.guardianapis.com/profile/the-daily-quiz",
+        "bio":"<p>A daily general knowledge quiz from theguardian.com. Email: daily.quiz@theguardian.com</p>",
+        "r2ContributorId":"57817",
+        "references":[]
+      },{
+        "id":"type/quiz",
+        "type":"type",
+        "webTitle":"Quiz",
+        "webUrl":"http://www.theguardian.com/quizzes",
+        "apiUrl":"http://content.guardianapis.com/quizzes",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-421318129",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/1/13/1294934370078/Pac-Man-003.jpg",
+          "typeData":{
+            "source":"Alamy",
+            "photographer":"Sinibomb Images",
+            "altText":"Pac-Man",
+            "height":"84",
+            "credit":"Sinibomb Images/Alamy",
+            "caption":"Despite our video games knowledge being prehistoric, we decided such a huge part of the entertainment world would be ignored at our peril. Photograph: Sinibomb Images/Alamy",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "sectionId":"lifeandstyle",
+      "sectionName":"Life and style",
+      "webPublicationDate":"2013-11-13T12:55:00Z",
+      "webTitle":"How to make the perfect onion bhajis",
+      "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth/2013/nov/13/how-to-make-perfect-onion-bhajis",
+      "fields":{
+        "trailText":"<p>Can another member of the fritter family beat the onion bhaji, do you eat them as a starter or a snack, and what do you serve with them?</p>",
+        "headline":"How to make the perfect onion bhajis",
+        "body":"<p>The onion bhaji was probably my first introduction to the joys of Indian food back in the late 80s, so I feel I owe this simple snack a considerable debt of thanks. The word \"bhajia\" means fritter – in fact, they're just one small part of the wider pakora family, which encompasses all manner of good things (<a href=\"http://adventurefoodie.blogspot.co.uk/2011/06/bheja-fry-goat-brain-fritters.html\" title=\"\">goat brain pakora</a> stands out in my memory) fried in chickpea batter, but in Britain, a land never known for its subtle taste, the pungent onion variety rules supreme.</p><p>Usually served <a href=\"http://www.greatbritishchefs.com/community/origins-onion-bhaji\" title=\"\">as a snack in its homeland</a>, generally with a nice cup of chai, bhajis are the stalwart of the starter selection here: a deep-fried appetite whetter for the myriad joys to come. At their best, they're almost ethereally light and addictively crisp. At their worst, they're stodgy and bland – as chef Cyrus Todiwala observes in his new book, <a href=\"http://nr11blog.wordpress.com/tag/onion-bhaji-recipe/\" title=\"\">Mr Todiwala's Bombay</a>: \"What you see in stores and supermarkets does not always represent the bhajia we Indians know.\" So just how do you guarantee great results?</p><h2>Onion</h2><figure data-media-id='gu-image-422395582'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg' alt='SImon Majumdar's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Simon Majumdar's onion bhajis.</figcaption></figure><p>Often lost in mass-produced versions, the bulk of the bhaji should be onion, rather than dough. Most recipes use yellow onion, sliced very thinly so it cooks through quickly, but <a href=\"http://www.simonmajumdar.com/recipes/onion-bhaji/\" title=\"\">food writer Simon Majumdar</a> specifies white and <a href=\"http://www.greatbritishchefs.com/recipes/onion-bhaji-recipe\" title=\"\">Alfred Prasad, executive chef at the Michelin-starred Tamarind</a>, goes for red. I find white too mild, and although I like the sweetness of the red versions, I miss the yellow onion's pungent flavour, so I'm going to stick with that.</p><h2>Batter</h2><figure data-media-id='gu-image-422395583'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg' alt='Flavours of Gujarat's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Flavours of Gujarat's onion bhajis.</figcaption></figure><p>Onions are onions, but where bhaji recipes diverge is in the batter that binds the slices together. Gram, or chickpea flour, is fairly standard, but Prasad and a brilliant little book called Flavours of Gujarat (which has been sitting on my parents' bookshelf for more than 20 years, waiting for this moment) recommend adding rice flour, presumably to make the batter crisper. For me, the difference between a great bhaji and a merely adequate one is in the crunch – as with all deep-fried foods, it should fight back – and Prasad's are particularly fiesty, so I'm going to adopt his 2:1 ratio of gram to rice flour.</p><p>Perhaps more important is the liquid used, both in type and quantity. Water is obviously the first choice, <a href=\"http://uktv.co.uk/food/recipe/aid/653916\" title=\"\">but Nikita Gulhane</a>, whose bhaji recipe features in Madhur Jaffrey's Curry Nation, also adds plain yoghurt, and Prasad stirs in a little melted butter. I like the rich tanginess of Gulhane's yoghurt, but I find it makes the batter a bit thick and gloopy, so I'm going to use Prasad's butter, plus Todiwala's lemon juice for flavour.</p><figure data-media-id='gu-image-422395584'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg' alt='Nikita Gulhane's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Nikita Gulhane's onion bhajis.</figcaption></figure><p>The batters vary enormously in consistency: Gulhane's is a thick paste, while Majumdar counsels aiming for the texture of double cream. This makes all the difference to the finished result: the two thickest batters, from Gulhane and Flavours of Gujarat, produce rather doughy bhajis that seem to be more about the batter than the onion. They're tasty enough, but I prefer the more delicate coating of Todiwala, Prasad and Majumdar's versions. The guiding principle is that it should be thick enough to cling to the onion, but not firm enough to form clumps of its own.</p><p>Majumdar suggests letting the batter rest for an hour before use, much like a yorkshire pudding, presumably to allow the flours to absorb the moisture in the batter. I don't think this is desirable here, though: his coating is tough, but not particularly crisp, and one taster likens it (approvingly, I must add) to a Woolworths onion ring.</p><h2>Spices</h2><figure data-media-id='gu-image-422395585'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg' alt='Alfred Prasad's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Alfred Prasad's onion bhajis.</figcaption></figure><p>The gram flour gives the batter a subtle nutty flavour, but subtle isn't what we're looking for here. Chillies are a popular addition, with Prasad and Todiwala plumping for fresh green chillies, and Prasad, Todiwala, Majumdar and Flavours of Gujarat sticking in dried chilli powder too. I prefer the cleaner, greener flavour of the fresh variety. Turmeric is also fairly standard, as much for colour as flavour.</p><p>Gulhane and Prasad both add garlic and ginger to the batter, which lend it a pleasing and more interesting sweetness than Majumdar's sugar – as do Prasad's unusual, but very welcome, fennel seeds, which I prefer to Todiwala's sharper ajwain, or lovage seeds. I love the earthiness of his cumin seeds with the onion, though. Sesame seeds, as used in Flavours of Gujarat, seem an unnecessary addition.</p><p>Fresh coriander, used by everyone but Majumdar, adds an attractive colour and a fresh, clean flavour to the batter, while curry leaves, as used by Prasad and Gulhane, contribute a herbal note. They're only worth buying fresh though, so if you can't find them, leave them out.</p><h2>Cooking</h2><figure data-media-id='gu-image-422395586'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg' alt='Cyrus Todiwala's onion bhajis' width='220' height='132' class='gu-image'/><figcaption>Cyrus Todiwala's onion bhajis.</figcaption></figure><p>It is very important to get the temperature of the oil right, as Todiwala explains: \"Too hot [and] they will fry too fast and remain raw inside and gooey. Too cold and the results will be oily and soft.\" The fairly standard 180C seems about right – most recipes suggest dropping a piece of batter in there to test the heat, but if you do have a food thermometer, use it – it is far more reliable than the sizzle test if you're after perfect results.</p><h2>The perfect onion bhajis</h2><figure data-media-id='gu-image-422395587'><img src='http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg' alt='Felicity Cloake's perfect onion bhajis' width='460' height='276' class='gu-image'/><figcaption>Felicity Cloake's perfect onion bhajis.</figcaption></figure><p><strong><em>(Makes 8)</em></strong><br /><strong>60g gram flour</strong><br /><strong>30g rice flour</strong><br /><strong>1 tbsp ghee or butter, melted </strong><br /><strong>Juice of ¼ lemon</strong><br /><strong>½ tsp turmeric</strong><br /><strong>1 tsp cumin seeds, coarsely chopped</strong><br /><strong>¼ tsp fennel seeds</strong><br /><strong>1-2 hot green chillies (to taste), finely minced</strong><br /><strong>2 tsp root ginger, finely grated </strong><br /><strong>2 cloves of garlic, finely chopped</strong><br /><strong>Small bunch of coriander, chopped</strong><br /><strong>2 fresh curry leaves, chopped (optional)</strong><br /><strong>2 onions, halved, core removed and thinly sliced</strong><br /><strong>Vegetable oil, to cook</strong></p><p>Sift the flours into a mixing bowl, then stir in the ghee and lemon juice and just enough cold water to bring it to the consistency of double cream. Stir in the spices, aromatics and herbs and add salt to taste. Stir in the onions so they are well coated.</p><p>Heat the oil in a deep-fat fryer to 180C, or fill a large pan a third full with oil and heat – a drop of batter should sizzle as it hits the oil, then float. Meanwhile, put a bowl of cold water next to the hob, and a plate lined with kitchen paper. Put the oven on a low heat.</p><p>Once the oil is up to temperature, wet your hands and shape tablespoon-sized amounts of the mixture into balls. Drop into the oil, being careful not to overcrowd the pan, then stir carefully to stop them sticking. Cook for about four minutes, turning occasionally, until crisp and golden, then drain on the paper and put in the oven to keep warm while you cook the next batch. Serve with chutney or pickle.</p><p><strong>Bhajis – where do you stand: a great curry house starter, or a fabulous teatime treat? Which other members of the pakora family do you rate – and what do you like to serve with them? (For me, aubergine pickle takes some bettering.)</strong></p><!-- Guardian Watermark: internal-code/content/422384559|2013-11-13T15:50:01Z|f51a9b2b64f187bce77f10fd85178b2aabe50b5a -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbnh",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+        "wordcount":"1130",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"lifeandstyle/series/how-to-cook-the-perfect",
+        "type":"series",
+        "webTitle":"How to cook the perfect ...",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/series/how-to-cook-the-perfect",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/indian",
+        "type":"keyword",
+        "webTitle":"Indian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/indian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/indian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/starter",
+        "type":"keyword",
+        "webTitle":"Starter",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/starter",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/starter",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/snacks",
+        "type":"keyword",
+        "webTitle":"Snacks",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/snacks",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/snacks",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/vegetarian",
+        "type":"keyword",
+        "webTitle":"Vegetarian food and drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/vegetarian",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/vegetarian",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/wordofmouth",
+        "type":"blog",
+        "webTitle":"Word of Mouth blog",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/wordofmouth",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/wordofmouth",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"profile/felicity-cloake",
+        "type":"contributor",
+        "webTitle":"Felicity Cloake",
+        "webUrl":"http://www.theguardian.com/profile/felicity-cloake",
+        "apiUrl":"http://content.guardianapis.com/profile/felicity-cloake",
+        "bio":"<p>Felicity Cloake is a writer specialising in food and drink and winner of the 2011 Guild of Food Writers awards for Food Journalist of the Year and New Media of the Year. Her first recipe book, <a href=\"http://www.guardianbookshop.co.uk/BerteShopWeb/viewProduct.do?ISBN=9781905490837\">Perfect</a>, is published by Fig Tree. She likes to think she'd try any food once – although an eyeball recently caused her to question this gung-ho gastronomic philosophy</p>",
+        "r2ContributorId":"32433",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/6/5/1370451580801/Felicity-Cloake.jpg",
+        "references":[]
+      },{
+        "id":"tone/recipes",
+        "type":"tone",
+        "webTitle":"Recipes",
+        "webUrl":"http://www.theguardian.com/tone/recipes",
+        "apiUrl":"http://content.guardianapis.com/tone/recipes",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"tone/features",
+        "type":"tone",
+        "webTitle":"Features",
+        "webUrl":"http://www.theguardian.com/tone/features",
+        "apiUrl":"http://content.guardianapis.com/tone/features",
+        "references":[]
+      },{
+        "id":"theguardian/g2/features",
+        "type":"newspaper-book-section",
+        "webTitle":"Comment & features",
+        "webUrl":"http://www.theguardian.com/theguardian/g2/features",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2/features",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"theguardian/g2",
+        "type":"newspaper-book",
+        "webTitle":"G2",
+        "webUrl":"http://www.theguardian.com/theguardian/g2",
+        "apiUrl":"http://content.guardianapis.com/theguardian/g2",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422395580",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346619304/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photographs: Felicity Cloake for the Guardian",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422395581",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346436156/Felicity-Cloakes-perfect--004.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"84",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis. Photograph: Felicity Cloake for the Guardian",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422395582",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346350260/SImon-Majumdars-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"SImon Majumdar's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Simon Majumdar's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395583",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346305213/Flavours-of-Gujarats-onio-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Flavours of Gujarat's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Flavours of Gujarat's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395584",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346235959/Nikita-Gulhanes-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Nikita Gulhane's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Nikita Gulhane's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395585",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346198283/Alfred-Prasads-onion-bhaj-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Alfred Prasad's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Alfred Prasad's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395586",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346279529/Cyrus-Todiwalas-onion-bha-002.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Cyrus Todiwala's onion bhajis",
+            "height":"132",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Cyrus Todiwala's onion bhajis.",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-image-422395587",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Lifeandhealth/Pix/pictures/2013/11/13/1384346444696/Felicity-Cloakes-perfect--009.jpg",
+          "typeData":{
+            "source":"Guardian",
+            "photographer":"Felicity Cloake",
+            "altText":"Felicity Cloake's perfect onion bhajis",
+            "height":"276",
+            "credit":"Felicity Cloake/Guardian",
+            "caption":"Felicity Cloake's perfect onion bhajis.",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"books/2013/nov/13/autobiography-by-morrissey-review",
+      "sectionId":"books",
+      "sectionName":"Books",
+      "webPublicationDate":"2013-11-13T12:00:00Z",
+      "webTitle":"Autobiography by Morrissey – review",
+      "webUrl":"http://www.theguardian.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "apiUrl":"http://content.guardianapis.com/books/2013/nov/13/autobiography-by-morrissey-review",
+      "fields":{
+        "trailText":"<p>This book is superb: Mozzer is so devastatingly articulate he could win the Booker, argues <strong>Terry Eagleton</strong></p>",
+        "headline":"Autobiography by Morrissey – review",
+        "body":"<p>Not content with being voted the greatest northern male ever, the second greatest living British icon (he lost out to David Attenborough) and granted the freedom of the city of Tel Aviv, Morrissey is now out to demonstrate that he can write the kind of burnished prose no other singer on the planet could aspire to. There are, to be sure, a&nbsp;few painfully florid patches in this superb autobiography (\"Headmaster Mr Coleman rumbles with grumpiness in a rambling stew of hate\"), but it would be hard to imagine Ronnie Wood or <a href=\"http://www.theguardian.com/music/ericclapton\" title=\"\">Eric Clapton</a> portraying the \"Duchess of nothing\" Sarah Ferguson as \"a little bundle of orange crawling out of a frothy dress, the drone of Sloane, blessed with two daughters of Queen Victoria pot-dog pudginess\".</p><p><a href=\"http://www.theguardian.com/music/morrissey\" title=\"\">Morrissey</a> despises most of the people he meets, often with excellent reason. He is scurrilous, withdrawn and disdainful, an odd mixture of shyness and vitriol. The dreamy, heart-throbbish photo on the cover of the book, the nose rakishly tilted above the&nbsp;Cupid's-bow lips, belies what a mean old bastard he is. He finds an image of himself in (of all people) the minor Georgian poet <a href=\"http://books.theguardian.com/review/story/0,,1788971,00.html\" title=\"\">AE Housman</a>, who preferred art to humanity and whose ascetic, spiritually tortured life seems to echo Morrissey's own. He admires wayward, bloody-minded types much like himself, and takes a&nbsp;sadistic delight in discomforting interviewers. \"Why did you mention Battersea in that song?\" a journalist asks him. \"Because it rhymes with fatty,\" he replies. Taken by his father at the age of eight to watch <a href=\"http://www.theguardian.com/books/2013/oct/04/immortal-biography-george-best-hamilton-review\" title=\"\">George Best</a> play at Old Trafford, he swoons at the sight of such artistry combined with such rebelliousness. Years later, others will swoon at his own mixing of the two.</p><p>Some of his bloody-mindedness springs from a damaged childhood. Born into a working-class Irish-Mancunian family, Steven Patrick Morrissey sang his way out of what struck him as a soulless environment, as other working-class Irish Mancunians have written or acted their way out. The vitriol started to flow early: his bleak mausoleum of a Catholic primary school was ruled by Mother Peter, \"a&nbsp;bearded nun who beat children from&nbsp;dawn to dusk\", and by the time he was 17 he was already emotionally exhausted. Manchester, still in its pre-cool days, was a \"barbaric place where only savages can survive … There are no sexual guidelines, and I see myself naked only by appointment.\" His eloquent contempt for his fellow citizens is terrifying: \"non-human sewer-rats with missing eyes; the loudly insane with indecipherable speech patterns; the mad poor of Manchester's armpit.\" The final indignity is to be turned down for a job&nbsp;as a postman at the local sorting office. At the hour of the birth of the Smiths, which gave him the exit from Manchester he craved, he felt himself dying of boredom, loneliness and disgust. \"I would talk myself through each day,\" he writes, \"as one would nurse a dying friend.\"</p><p>Not long afterwards, hordes of young people throughout the world are&nbsp;wearing his face on their chests. He returns to the streets where he grew up, now with a police escort, to sing to 17,000 fans from a stage overlooking an odious Inland Revenue office where he once worked. Having failed to find love from one man or woman, he can now find it from thousands. <a href=\"http://www.theguardian.com/music/mick-jagger\" title=\"\">Mick Jagger</a> and <a href=\"http://www.theguardian.com/music/elton-john\" title=\"\">Elton John</a> are eager to shake his hand. He enjoys his celebrity, but the sardonic self-irony of the book seeks to&nbsp;persuade us otherwise. There is a relish and energy about its prose that undercuts his misanthropy. Its lyrical quality suggests that beneath the hard-bitten scoffer there lurks a romantic softie, while beneath that again lies a hard-bitten scoffer. Implausibly, he claims to be \"chilled\" by road signs reading \"Morrissey Concert, Next Left\". It's true, however, that having spent years yearning to be seen, he now spends years longing to be invisible. Living in Hollywood is hardly the best place for that. He deals with his own egocentricity by being wryly amusing about it: his birth almost killed his mother, he comments, because even then his head was too&nbsp;big.</p><p>Even so, he remains for the most part icily unillusioned, like a monk passing through a whorehouse. His contempt for the music industry is visceral, and he prefers to spend his time reading <a href=\"http://www.theguardian.com/books/whauden\" title=\"\">Auden</a> and <a href=\"http://www.theguardian.com/books/jamesbaldwin\" title=\"\">James Baldwin</a>. (Spotting Baldwin in a Barcelona hotel, he decides not to approach him, since even the mildest rejection would apparently mean he would have to go and hang himself.) The solution to all problems, he tells us, \"is the goodness of privacy in a warm room with books\". <a href=\"http://www.theguardian.com/music/davidbowie\" title=\"\">David Bowie</a> tells him that he's had so much sex and drugs that he's surprised he is still alive, to which Morrissey replies that he's had so little of both that he feels much the same. <a href=\"http://www.theguardian.com/film/tomhanks\" title=\"\">Tom Hanks</a> comes backstage to say hello, but Morrissey doesn't know who he is. The press lie that he is a racist, that he opened the door to a journalist wearing a tutu, that he hung around public toilets as a youth and that he would welcome the assassination of Margaret Thatcher. The Guardian runs a disapproving piece on him adorned with a photo of somebody else. When he discovers that a Smiths record released in Japan includes a track by Sandie Shaw, he begs the people around him to kill him. \"Many rush forward,\" he adds.</p><p>\"Although a passable human creature on the outside,\" he comments of himself, \"the swirling&nbsp;soul within seemed to speak up for the most awkward people on the planet\", of whom he himself ranks among the most adept. He is one of the great curmudgeons and contrarians of our time. He&nbsp;even puts in a&nbsp;good word for the Kray brothers.</p><p>Surprisingly, he goes easy on his passion for animal rights, but observes no such restraint when it comes to <a href=\"http://www.theguardian.com/world/george-bush\" title=\"\">George Bush</a> (\"the world's most famous active terrorist\") and <a href=\"http://www.theguardian.com/politics/tonyblair\" title=\"\">Tony Blair</a>, at whose feet he lays the London deaths of 2005. At least the vindictive music industry has taught him how to&nbsp;hate, though one suspects he didn't&nbsp;need much tutoring. The music impresario <a href=\"http://www.theguardian.com/music/tonywilson\" title=\"\">Tony Wilson</a> \"managed a lengthy and slow decline which some thought was actually an ongoing career\". There is a cameo of Julie Burchill of such sublime savagery that&nbsp;one expects the page to ignite. The&nbsp;former Smiths who took him to court are subjected to 50 pages of devastatingly articulate venom.</p><p>Though he is careful to inform us that he drives a sky-blue Jag, fame hasn't changed him much. He is still the same miserable old Mozzer he always was. The death of friends leads him to wonder movingly whether life isn't \"all too burdensome, with so much loss taking its root in the heart, as the body goes spinning on towards a&nbsp;dreadful cessation\". It isn't the kind of sentence Robbie Williams would come up with. His interest in the dead, his father warns him, outstrips his affection for the living. He sees a ghost on Saddleworth Moor, burial ground of&nbsp;the Moors murders, and narrowly avoids being kidnapped in Mexico. Everywhere he looks he sees violence: \"military science whaling, nuclear weapons, armed combat, the abattoir, holy war … riot police assaulting innocent civilians.\" When a small, flightless bird comes to live in his back garden, he fences it in with boxes to ward off predators. He has quite a few such boxes of his own.</p><p>Perhaps the time has come for a new&nbsp;career. If he could get treatment for his addiction to alliteration and stop using phrases like \"for you and I\", this prodigiously talented \"small boy of 52\", as he described himself two years ago, could walk away with the Booker prize.</p><!-- Guardian Watermark: internal-code/content/422279954|2013-11-13T15:50:01Z|42551f72bd3fa99ac491fea86fb610ea14c72160 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kann",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+        "wordcount":"1264",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"books/autobiography-and-memoir",
+        "type":"keyword",
+        "webTitle":"Autobiography and memoir",
+        "webUrl":"http://www.theguardian.com/books/autobiography-and-memoir",
+        "apiUrl":"http://content.guardianapis.com/books/autobiography-and-memoir",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/morrissey",
+        "type":"keyword",
+        "webTitle":"Morrissey",
+        "webUrl":"http://www.theguardian.com/music/morrissey",
+        "apiUrl":"http://content.guardianapis.com/music/morrissey",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"books/books",
+        "type":"keyword",
+        "webTitle":"Books",
+        "webUrl":"http://www.theguardian.com/books/books",
+        "apiUrl":"http://content.guardianapis.com/books/books",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"culture/culture",
+        "type":"keyword",
+        "webTitle":"Culture",
+        "webUrl":"http://www.theguardian.com/culture/culture",
+        "apiUrl":"http://content.guardianapis.com/culture/culture",
+        "sectionId":"culture",
+        "sectionName":"Culture",
+        "references":[]
+      },{
+        "id":"tone/reviews",
+        "type":"tone",
+        "webTitle":"Reviews",
+        "webUrl":"http://www.theguardian.com/tone/reviews",
+        "apiUrl":"http://content.guardianapis.com/tone/reviews",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview/saturdayreviewsfeatres",
+        "type":"newspaper-book-section",
+        "webTitle":"Features & reviews",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview/saturdayreviewsfeatres",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"theguardian/guardianreview",
+        "type":"newspaper-book",
+        "webTitle":"Guardian review",
+        "webUrl":"http://www.theguardian.com/theguardian/guardianreview",
+        "apiUrl":"http://content.guardianapis.com/theguardian/guardianreview",
+        "sectionId":"books",
+        "sectionName":"Books",
+        "references":[]
+      },{
+        "id":"music/music",
+        "type":"keyword",
+        "webTitle":"Music",
+        "webUrl":"http://www.theguardian.com/music/music",
+        "apiUrl":"http://content.guardianapis.com/music/music",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/smiths",
+        "type":"keyword",
+        "webTitle":"The Smiths",
+        "webUrl":"http://www.theguardian.com/music/smiths",
+        "apiUrl":"http://content.guardianapis.com/music/smiths",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"music/indie",
+        "type":"keyword",
+        "webTitle":"Indie",
+        "webUrl":"http://www.theguardian.com/music/indie",
+        "apiUrl":"http://content.guardianapis.com/music/indie",
+        "sectionId":"music",
+        "sectionName":"Music",
+        "references":[]
+      },{
+        "id":"uk/manchester",
+        "type":"keyword",
+        "webTitle":"Manchester",
+        "webUrl":"http://www.theguardian.com/uk/manchester",
+        "apiUrl":"http://content.guardianapis.com/uk/manchester",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"profile/terryeagleton",
+        "type":"contributor",
+        "webTitle":"Terry Eagleton",
+        "webUrl":"http://www.theguardian.com/profile/terryeagleton",
+        "apiUrl":"http://content.guardianapis.com/profile/terryeagleton",
+        "bio":"<p>Terry Eaglton is a literary critic, writer and chair in English literature in Lancaster University's department of English and creative writing. His latest book is The Event of Literature</p>",
+        "r2ContributorId":"22184",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/11/3/1320333646305/Terry-Eagleton.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"publication/theguardian",
+        "type":"publication",
+        "webTitle":"The Guardian",
+        "webUrl":"http://www.theguardian.com/theguardian/all",
+        "apiUrl":"http://content.guardianapis.com/theguardian/all",
+        "sectionId":"theguardian",
+        "sectionName":"From the Guardian",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422381626",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256764062/Morrissey-at-book-signing-001.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"54",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256766657/Morrissey-at-book-signing-002.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"340",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"480"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256768272/Morrissey-at-book-signing-003.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"130",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256771724/Morrissey-at-book-signing-005.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"132",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256773421/Morrissey-at-book-signing-006.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"168",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256775059/Morrissey-at-book-signing-007.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"180",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256776719/Morrissey-at-book-signing-008.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"228",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256780785/Morrissey-at-book-signing-010.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"372",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256779097/Morrissey-at-book-signing-009.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"276",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel/TT/EPA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422381627",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384256769996/Morrissey-at-book-signing-004.jpg",
+          "typeData":{
+            "source":"EPA",
+            "photographer":"Adam Ihsel / TT",
+            "altText":"Morrissey at book signing",
+            "height":"84",
+            "credit":"Adam Ihsel / TT/EPA",
+            "caption":"'A new career beckons' … Morrissey at a book signing in Sweden. Photograph: Adam Ihsel / TT/EPA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "sectionId":"business",
+      "sectionName":"Business",
+      "webPublicationDate":"2013-11-13T15:14:55Z",
+      "webTitle":"Bank of England: UK recovery has finally taken hold - live",
+      "webUrl":"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "apiUrl":"http://content.guardianapis.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live",
+      "fields":{
+        "trailText":"UK central bank has upgraded its forecasts for growth and unemployment today, with governor Mark Carney telling reporters that the recovery looks more solid",
+        "headline":"Bank of England: UK recovery has finally taken hold - live",
+        "body":"<div id=\"block-52839521e4b06f50dbc6f580\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T15:09:28.623Z\">3.09pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Euro drops as ECB hints at possible negative rates or QE</h2> <div class=\"block-elements\"> <p><strong>The euro has come under pressure after an ECB board member hinted the central bank could authorise negative interest rates or buying assets from banks to hit its inflation target.</strong> Peter Praet <a href=\"http://online.wsj.com/news/articles/SB10001424052702304243904579195631017906684\">told the Wall Street Journal</a>:</p> <blockquote class=\"quoted\"> <p>If our mandate is at risk we are going to take all the measures that we think we should take to fulfil that mandate. That's a very clear signal.&nbsp;The balance sheet capacity of the central bank can also be used. This includes outright purchases that any central bank can do.</p> </blockquote> <p>The ECB cut interest rates to 0.25% last week and kept the deposit rate at zero. Praet said:</p> <blockquote class=\"quoted\"> <p>On standard measures, interest rates, we still have room and that would also include the deposit facility.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/IGSquawk/statuses/400637632176480256\"> <blockquote class=\"twitter-tweet\"><p><a href=\"https://twitter.com/search?q=%24EURUSD&amp;src=ctag\">$EURUSD</a> has fallen 40pips since 14:30 and dropped below the 1.34 handle. ECB not ruling out QE according to WSJ - <a href=\"http://t.co/gZbr2p290S\">http://t.co/gZbr2p290S</a>. AB</p>— IGSquawk (@IGSquawk) <a href=\"https://twitter.com/IGSquawk/statuses/400637632176480256\">November 13, 2013</a></blockquote> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T15:14:55.959Z\">at 3.14pm GMT</time></p> </div> <div id=\"block-528391f3e4b04416f8fd691f\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T15:01:35.421Z\">3.01pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Over in Ireland, some good employment news.</strong> Henry McDonald, Ireland Correspondent, writes:</p> <blockquote class=\"quoted\"> <p>Belfast's iconic shipbuilding firm that constructed the Titanic has given Northern Ireland's economy a temporary boost with the creation of 600 short term skilled jobs.<br />Harland and Wolff, whose giant yellow cranes dominate the Belfast skyline, announced today that they are recruiting the extra skilled tradesmen to work on one of the largest oil rigs ever built in its shipyard.<br />The 360 ft tall Blackford Dolphin offshore drill platform is currently on its way from Brazil to Belfast where it will undergo maintenance work at the yard where the Titanic was made.</p> </blockquote> <figure class=\"element element-image\" data-media-id=\"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg\" alt=\"Belfast Harbour. Photo: Belfast Harbour/PA\" width=\"460\" height=\"276\" class=\"gu-image\" /> <figcaption>Belfast Harbour. Photo: Belfast Harbour/PA</figcaption> </figure> <blockquote class=\"quoted\"> <p>David McVeigh, head of sales and marketing at Harland and Wolff, said the contract was on such a large scale and completed within such a tight time frame, that the 600 additional workers had to be found in a relatively short period of time.</p> <p>&quot;Harland and Wolff continues to compete successfully in a sector which has seen competition grow,&quot; said McVeigh.</p> <p>&quot;Apart from being able to exceed stringent health and safety element requirements for such contracts, H&amp;W is also capable of great flexibility which means we can put 600 contractors from electrical, welding, engineering and painting disciplines in place in a short time.&quot;</p> <p>The shipyard now concentrates on maintaining and repairing oil rigs rather than ships. Its giant Samson and Goliath cranes will have to be moved out of their current positions along tracks to the end of the building dock for the estimated 50 days of work on the Blackford Dolphin rig.</p> </blockquote> </div> </div> <div id=\"block-52838fc0e4b0839b692756a5\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:49:37.980Z\">2.49pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Our <strong><a href=\"http://www.theguardian.com/data\">Data Blog</a></strong> has pulled together statistics on the unemployment figures:</p> <blockquote class=\"quoted\"> <p>The unemployment rate dropped from 7.8% in the three months to June to 7.6% – its <a href=\"http://www.theguardian.com/business/2013/nov/13/unemployment-rate-falls-bank-of-england-interest-rate-target\">lowest level in four years</a>, but what has happened to the claimant count? Using the October 2013 figures from <a href=\"http://www.nomisweb.co.uk/\">Nomis</a>, the map shows the numbers by each local authority.</p> </blockquote> <p>The data is here:</p> <h2><a href=\"http://www.theguardian.com/news/datablog/interactive/2013/nov/13/uk-unemployment-mapped-adult-youth\">UK unemployment mapped</a></h2> </div> </div> <div id=\"block-528388a6e4b04416f8fd6915\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:22:22.515Z\">2.22pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The FTSE 100 is on course for its worse one day fall in months.</strong> It is 105 points or 1.57% lower which would be its biggest drop since 20 June, if it ends like this. On Wall Street, the Dow Jones Industrial Average is forecast to open around 90 points lower, so there will be no help for the bulls from that direction.</p> <p>The falls are being driven by the feeling that central banks could finally start switching off the money taps, which have been providing support for the markets for what seems like forever. On Tuesday US Federal Reserve member Dennis Lockhart - seen as being in the centre as far as the policy debate goes - suggested there was a possibility the bank could reduce its $85bn a month bond buying programme at its December meeting. Most observers had still been banking on no change to the stimulus programme until next year.</p> <p>Meanwhile, as we have been reporting this morning, the Bank of England may also raise rates sooner than had been anticipated.</p> </div> </div> <div id=\"block-528384a1e4b031056a8eeebe\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T14:06:24.127Z\">2.06pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Back to the Bank of England....</h2> <div class=\"block-elements\"> <p><strong>On the Bank of England's raised growth forecasts, our economics correspondent Phillip Inman reports:</strong></p> <blockquote class=\"quoted\"> <p>The&nbsp;Bank of England&nbsp;expects to consider raising&nbsp;interest rates&nbsp;in 2015, a year earlier than expected, following a sharp fall in unemployment.</p> <p>But the bank tempered expectations of an early increase with the warning that the recovery remained fragile and rates could still remain low for several years.</p> <p>Governor&nbsp;Mark Carney&nbsp;said he expected growth to remain modest over the next couple of years while the economy continues to be hampered by a weak banking sector and stumbling overseas markets.</p> <p>Speaking after publication of the central bank's quarterly inflation report, Carney played down concerns that the current 0.5% base rate would rise before real incomes begin to rise and the recovery is secured.</p> <p>&quot;The economy is growing robustly as lifting uncertainty and thawing credit conditions start to unlock pent-up demand. But significant headwinds – both at home and abroad – remain, and there is a long way to go before the aftermath of the financial crisis has cleared and economic conditions normalise,&quot; he said in the report.</p> <p>&quot;That underpins the monetary policy committee's (MPC) intention to maintain the exceptionally stimulative stance of monetary policy until there has been a substantial reduction in the degree of economic slack.&quot;</p> <p>In August the BoE said as part of its new policy of forward guidance that it would not consider raising interest rates before unemployment fell to 7%. MPC members agreed that unemployment was a strong indicator of slack in the economy. Figures for August show that rate has fallen to 7.6% following an unexpectedly sharp rise in job recruitment over the previous three months.</p> <p>In response the BoE said there was now a three in five chance that the UK unemployment rate would hit 7% in mid-2015 compared to a previous prediction of late 2016.</p> <p>Deputy governor Charlie Bean said forward guidance was still pointing to a rate rise later rather than sooner. He said: &quot;The key message is that policy is not going to be related to growth rates but the elimination of slack.&quot;</p> </blockquote> <h2>Here's the full story:&nbsp;<a href=\"http://www.theguardian.com/business/2013/nov/13/interest-rates-could-rise-2015\">Interest rates could rise in 2015 – BoE</a></h2> <p>The other big news story of the day is the drop in UK unemployment, to a four-year low of 7.6%.</p> <p><strong>Economics editor Larry Elliott writes:</strong></p> <blockquote class=\"quoted\"> <p>Britain's rising population means that a record number of people – 29.95 million – are in work but the employment rate remains lower than it was before the deep recession of 2008-09. The current rate of 71.8% compares with 73% at the peak in early 2008 but above the trough of 70.8% reached in 2011.</p> <p>The bulk of the jobs created in the latest three months were full time but a record 1.46 million people were working part time because they could not find a full-time job. Unemployment as measured by the number of people out of work and claiming eligible benefits dropped by 41,700 in September to 1.3 million.</p> </blockquote> <h2>More here:&nbsp;<a href=\"http://www.theguardian.com/business/2013/nov/13/unemployment-rate-falls-bank-of-england-interest-rate-target\">Jobless rate moves towards Bank of England target</a></h2> <p><em>And that's a good moment to hand over <strong>Nick Fletcher</strong>, before trading begins on Wall Street. Shares are still lower in London, with the FTSE 100 down 107 points... </em><strong>GW</strong></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T14:07:41.474Z\">at 2.07pm GMT</time></p> </div> <div id=\"block-528380e8e4b01a80f661c25a\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:45:06.789Z\">1.45pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>As well as the departure of Sir Hector Sants, Barclays has also reported that chief operations and technology officer,&nbsp;Shaygan Kheradpir, is leaving the company.</strong></p> <p>Here's the bank's statement:</p> <blockquote class=\"quoted\"> <p>Hector Sants has been on sick leave since the beginning of October, suffering from stress and exhaustion. He has concluded that he will not be able to return to work in the near term. Consequently he has decided to resign from Barclays and not return from sick leave.</p> <p>Shaygan Kheradpir, Chief Operations and Technology Officer, is leaving Barclays to take on a role as CEO for a company based in the United States.</p> <p>An internal and external search will be launched for both posts. In the meantime Allen Meyer, Head of Compliance, Corporate and Investment Banking will act as Interim Head of Compliance and Government and Regulatory Relations. Darryl West, Barclays’ Chief Information Officer, will act as Interim Group Chief Operations and Technology Officer. In these posts both will join the Executive Committee and report to Group Chief Executive, Antony Jenkins.</p> </blockquote> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:46:41.132Z\">at 1.46pm GMT</time></p> </div> <div id=\"block-52837ee7e4b01a80f661c259\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:33:57.694Z\">1.33pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Sants leaves Barclays</h2> <div class=\"block-elements\"> <p><strong>Sir Hector Sants</strong>, the former head of the UK's Financial Services Authority, has stepped down from his role as head of compliance at Barclays, my colleague <strong>Jill Treanor</strong> reports.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/jilltreanor/statuses/400613343108411392\"> <blockquote class=\"twitter-tweet\"><p>Barclays says Sir Hector Sants has quit as head of compliance</p>— Jill Treanor (@jilltreanor) <a href=\"https://twitter.com/jilltreanor/statuses/400613343108411392\">November 13, 2013</a></blockquote> </figure> <p><a href=\"http://www.theguardian.com/business/2013/oct/15/hector-sants-barclays-exhaustion\"><strong>This comes a month after Sants began a &quot;leave of absence&quot; after being diagnosed with exhaustion and stress</strong></a>.&nbsp;</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:34:44.051Z\">at 1.34pm GMT</time></p> </div> <div id=\"block-528376d2e4b01a80f661c258\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T13:29:57.899Z\">1.29pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">EC begins review of German trade surplus</h2> <div class=\"block-elements\"> <p><strong>Over in Brussels, the European Commission has - as anticipated - launched an inquiry into the German trade surplus.</strong></p> <p><a href=\"http://ec.europa.eu/europe2020/pdf/2014/amr2014_en.pdf\"><strong>In a new report</strong></a>, the EC said it would launch an &quot;in-depth review&quot; of both&nbsp;Germany and Luxembourg.</p> <p>It plans to:</p> <blockquote class=\"quoted\"> <p>better scrutinise&nbsp;their external position and analyse internal developments, and assess whether any of these countries is experiencing imbalances.</p> </blockquote> <p>It explained that the&nbsp;German trade surplus has exceeded the EC's 'threshold' (6% of national GDP)&nbsp;each year since 2007, so it clearly isn't a short-term problem.</p> <p>This means Germany becomes one of 16 Member States who are being probed for imbalances (many others face questions over&nbsp;current account&nbsp;deficits, losses of competitiveness and debt and deficit levels).</p> <p>This chart shows the differences between EU member states:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png\" alt=\"Eurozone current account data\" width=\"460\" height=\"386\" class=\"gu-image\" /> <figcaption>Photograph: EC</figcaption> </figure> <p>Germany's defenders say it should not be blamed for running a successful export sector, and suggest that other countries could learn a few lessons.</p> <p>Commission president&nbsp;Jos&eacute; Manuel Barroso sounded conciliatory at a press briefing in Brussels, saying:</p> <blockquote class=\"quoted\"> <p>Europe needs more Germanys.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/OpenEurope/statuses/400603967698108416\"> <blockquote class=\"twitter-tweet\"><p>Barroso: what we are launching here is an indepth review, which is almost automatic as Germany exceeded the threshold of 4 indicators</p>— Open Europe (@OpenEurope) <a href=\"https://twitter.com/OpenEurope/statuses/400603967698108416\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/OpenEurope/statuses/400604259462295554\"> <blockquote class=\"twitter-tweet\"><p>Barroso: this should not be seen as Europe being perceived at odds with German competitiveness...exercise to judge the consequences</p>— Open Europe (@OpenEurope) <a href=\"https://twitter.com/OpenEurope/statuses/400604259462295554\">November 13, 2013</a></blockquote> </figure> <p>Bundesbank presiden<strong>t Jens Weidmann</strong>&nbsp;has already warned that Germany shouldn't be penalised, according to this Reuters newsflash:</p> <p><strong>• WEIDMANN SAYS ANSWER TO GERMANY'S CURRENT ACCOUNT SURPLUS CANNOT BE TO MAKE GERMAN COMPANIES LESS COMPETITIVE&nbsp;</strong></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T13:34:27.612Z\">at 1.34pm GMT</time></p> </div> <div id=\"block-528376bae4b01a80f661c257\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:55:35.845Z\">12.55pm <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg\" alt=\"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.\" width=\"460\" height=\"282\" class=\"gu-image\" /> <figcaption>Photograph: TOBY MELVILLE/AFP/Getty Images</figcaption> </figure> </div> </div> <div id=\"block-52837335e4b0f37bee4ff653\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:53:14.524Z\">12.53pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England's report: What the experts say</h2> <div class=\"block-elements\"> <p>Here's some economist reaction:</p> <p><strong>David Kern, chief economist at the British Chambers of Commerce:</strong></p> <blockquote class=\"quoted\"> <p>We support Governor&nbsp;Carney’s statement that the pressure on living standards can only be addressed when productivity increases. Simply raising wages before this happens would make businesses uncompetitive and threaten the recovery.</p> </blockquote> <p><strong>Howard Archer of IHS Global Insight:</strong></p> <blockquote class=\"quoted\"> <p>The message coming loud and clear from the Bank of England is that it remains in no hurry at all to raise interest rates despite the economy’s improved performance and a likely significantly faster fall in unemployment than the central bank had previously expected.</p> <p>It is clear that&nbsp;the Bank of England wants to give the economy every chance to develop sustainable decent growth and not to risk choking it off by any premature increasing of interest rates.</p> </blockquote> <p><strong>Rob Wood of&nbsp;Berenberg Bank:</strong></p> <blockquote class=\"quoted\"> <p>The BoE signalled its first rate hike might come in 2015, rather than late 2016 as it had previously said, in its quarterly forecast update this morning.....</p> <p>We see a 70% chance that unemployment falls to the 7% threshold by Q3 2015, compared to the BoE’s 50% chance.</p> <p>So while they have moved towards our view and the market, they still have some way to go. The risks are probably that the BoE is underestimating the speed at which the economy can recover. With loose policy, falling uncertainty and booming house prices, the recovery could snowball and more than 3% growth next year is not impossible. There are downside risks too of course, that we should not forget, but they seem to be diminishing.</p> </blockquote> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/FGoria/statuses/400592336935485440\"> <blockquote class=\"twitter-tweet\"><p>Schroders now expects BoE to raise rates at beginning of 2016, previously expected BoE rate increase at end of 2016</p>— Fabrizio Goria (@FGoria) <a href=\"https://twitter.com/FGoria/statuses/400592336935485440\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52836f78e4b0f37bee4ff64c\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:40:13.804Z\">12.40pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Market reaction</h2> <div class=\"block-elements\"> <p>The pound has rallied by around 0.5% today, following the Bank of England's new forecasts and this morning's drop in UK unemployment (<a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283464ce4b0f37bee4ff61c\"><strong>see 9.30am onwards)</strong></a>.</p> <p>It's gained three quarters of a cent, against the US dollar to $1.5977.</p> <p>Shares, though, are down in London as traders anticipate monetary policy being tightened more quickly.</p> <p><strong>The FTSE 100 has dropped by 93 points, or 1.39%, to 6633.</strong></p> <p>Financial stocks are among the fallers -- with RSA Insurance down 3.8%, Standard Chartered down 3.4% and Barclays losing 3.1%.</p> </div> </div> <div id=\"block-528368dde4b0312d704c1180\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T12:24:19.055Z\">12.24pm <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England quarterly inflation report, a summary</h2> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg\" alt=\"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.\" width=\"460\" height=\"333\" class=\"gu-image\" /> <figcaption>Photograph: Toby Melville/POOL/EPA</figcaption> </figure> <p>So, to quickly recap.</p> <p>•<strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52835455e4b0b9c05d8a3466\">The Bank of England has raised its economic forecasts</a>, concluding that Britain's output will rise faster than expected this year and in 2014.</strong>&nbsp;This will help to pull down the UK unemployment rate, with a roughly 40% chance that it will be 7% by the end of next year.</p> <p>•&nbsp;<strong>Governor Mark Carney said the UK recovery had <a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-528359cfe4b0312d704c1179\">&quot;finally taken hold&quot;</a>,</strong>&nbsp;but warned that it needs to become &quot;strong and sustained&quot; to get more people into work, and to drive wages higher.</p> <blockquote class=\"quoted\"> <p>For the first time in a long time you don't have to be an optimist to see the glass is half full. The recovery has finally taken hold.</p> </blockquote> <p>This chart shows how the BoE sees more chance of the jobless rate hitting 7% soon:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png\" alt=\"Bank of England unemployment forecasts\" width=\"423\" height=\"401\" class=\"gu-image\" /> <figcaption>Photograph: Bank of England</figcaption> </figure> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-528357c1e4b0312d704c1177\">Carney defended his 'forward guidance' on interest rates</a>, which states that borrowing costs won't rise until the jobless rate has hit 7%.</strong> He said the pledge had helped to sustain the recovery, and did not mean that a rate rise was inevitable once the 7% rate has been hit.</p> <p>He said:</p> <blockquote class=\"quoted\"> <p>There was always going to be movement in the timing of when potentially the unemployment threshold was reached .. but what's important is two things.</p> <p>One is what we learn between now and when that threshold is achieved, what we learn about the economy, what we learn about how much extra slack there is in the economy. And secondly what the conditions are when it's achieved and we're providing the confidence to businesses and households that we will not even begin to think about moving interest rates until that threshold is achieved.</p> </blockquote> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52835d8ee4b07aa4168b4b14\">Carney was also asked about the UK housing market,</a> and concerns of a bubble in London</strong>. He replied that the Bank is setting policy for the whole country, not <strong><a href=\"http://cdn.london-insider.co.uk/wp-content/uploads/2009/11/LondonTubeTrainMap2010.jpg\">&quot;inside the Circle Line&quot;</a>, </strong>adding:</p> <blockquote class=\"quoted\"> <p>In terms of housing valuation there are clearly areas in the country where valuation is very elevated. What we are seeing across the UK is the greatest price momentum is for houses that are towards the upper end of the valuation spectrum.</p> <p>The bank, through the Financial Policy Committee, will be vigilant about potential risks there but we need to put the pickup in housing activity in perspective. Activity levels, while they've picked up, are still running at between two thirds or three quarters of historic averages in terms of whether its transactions or approvals, homebuilding, so there is some room for that to further pickup and that's the initial phase of this recovery.</p> </blockquote> <p>• <strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-52836023e4b0b9c05d8a346f\">And the Bank is still cautious about the situation in the eurozone</a>, even though the 'pall' of uncertainty over the future of the euro has mostly lifted.</strong> Carney said the UK central bank isn't expecting a big pick-up in demand from Europe.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T12:54:06.834Z\">at 12.54pm GMT</time></p> </div> <div id=\"block-528365f7e4b0b9c05d8a3477\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:47:39.873Z\">11.47am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>And that's the end of the press conference - cue a brief burst of Beethoven* on the webcast feed.</p> <p>* - <a href=\"https://www.youtube.com/watch?v=iwIvS4yIThU\"><em>9th Symphony,&nbsp;2nd movement, rather awesome</em></a></p> </div> </div> <div id=\"block-528363a6e4b0312d704c117e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:42:25.732Z\">11.42am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Several questions on the government's Help to Buy mortgage subsidy scheme.</p> <p><strong>Observer economics editor Heather Stewart</strong> asks about the Treasury Select Committee's concerns (<a href=\"http://www.theguardian.com/business/2013/nov/09/help-to-buy-scrutiny-bank-of-england-mark-carney\"><em>they want the Bank of England to clarify its role in the scheme</em></a>).</p> <p>Carney says that the issue will be considered at the next meeting of the Financial Policy Committee (responsible for ensuring economic stability). He adds that the Bank has a range of ways to influence the housing market.</p> </div> </div> <div id=\"block-5283625fe4b0b9c05d8a3473\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:33:53.080Z\">11.33am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Kathryn Hopkins of The Times raises the issue of gender targets (<em>the Bank of England's senior ranks are dominated by men</em>).</strong></p> <p>Mark Carney replies that &quot;it is an objective of this institution to increase the diversity of our junior ranks, and senior ranks&quot;.</p> <p>Appointments to the senior ranks are made by others, he points out (<em>the Treasury picks the governor, and the members of the rate-setting Monetary Policy Committee</em>), but the Bank can increase diversity at all levels.</p> <p>A review of the Bank's talent management and recruitment policies is underway, he adds, though he won't prejudge its conclusions</p> </div> </div> <div id=\"block-52836023e4b0b9c05d8a346f\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:28:09.358Z\">11.28am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Asked about the eurozone, Mark Carney says that the Bank of England only expects &quot;quite modest demand growth&quot; in this major export market.</p> <p>We do expect the removal, or reduction, of the pall of uncertainty that hung over businesses over the future of the eurozone, he adds.</p> <p>But Threadneedle Street is not&nbsp;relying on any meaningful recovery in Europe to drive this forwards.</p> <p>And that's why the GDP growth forecasts remain relatively modest compared to previous recoveries, he adds.</p> </div> </div> <div id=\"block-528361c5e4b0b9c05d8a3472\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:26:44.887Z\">11.26am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png\" alt=\"Mark Carney\" width=\"460\" height=\"264\" class=\"gu-image\" /> <figcaption>Mark Carney speaking today. Photograph: Bank of England</figcaption> </figure> </div> </div> <div id=\"block-5283607ae4b0312d704c117c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:25:09.673Z\">11.25am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>How much credit does Mark Carney take for the recent pick-up in the UK economy, asks Channel 4's Faisal Islam.</strong></p> <p>Governor Carney says that &quot;our view is that forward guidance is helpful to sustain the recovery, that's why we did it.&quot;</p> <p>You only see the value of it at events like today, and in meetings with people around the country. People understand that the Bank of England &quot;needs to see sustained momentum and the slack picked up&quot; before we would tighten monetary policy.</p> <p>The government's Funding for Lending scheme is also helping to support the recovery and provide support for bank balance sheets, Carney adds.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T11:26:30.294Z\">at 11.26am GMT</time></p> </div> <div id=\"block-52835d8ee4b07aa4168b4b14\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:18:54.159Z\">11.18am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>Should the Bank's Financial Policy Committee&nbsp;act on the house price levels in London, the main topic of conversation at dinner parties in the capital?</em>&nbsp;</p> <p>Carney says the Bank is looking at the bigger picture:</p> <blockquote class=\"quoted\"> <p>We don't make policy for inside the Circle Line, we make it for the entire United Kingdom.</p> </blockquote> <p>And at this stage, the Bank isn't very worried about the housing market.</p> <p>He argues that expectations of future earnings can drive increased consumption levels, rather than the fact that people's houses are worth more (<em>which doesn't deliver a real 'wealth effect' unless people can unlock the value</em>).&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/EdConwaySky/statuses/400581840303828992\"> <blockquote class=\"twitter-tweet\"><p>Carney says for a 2nd time: &quot;We have a good line of sight to dynamics in the housing market&quot;. No idea what it means, but it sure sounds good</p>— Ed Conway (@EdConwaySky) <a href=\"https://twitter.com/EdConwaySky/statuses/400581840303828992\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835cf9e4b0b9c05d8a346d\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:07:19.425Z\">11.07am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>What would a more normal economy look like?</em>&nbsp;</p> <p>Mark Carney says that as the economy 'heals', the natural rate of unemployment should return to the pre-crisis levels of around 5%.</p> <p>But to be a sustainable, we need to see growth in real wages (ie, pay rises need to beat inflation not lag behind it) to sustain consumption growth.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T11:07:41.682Z\">at 11.07am GMT</time></p> </div> <div id=\"block-52835b50e4b0f37bee4ff635\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T11:05:13.895Z\">11.05am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Our economics editor Larry Elliott calls the Bank of England's forecasting record to account.</strong></p> <p>&nbsp;<strong>Larry asks:</strong></p> <blockquote class=\"quoted\"> <p>You failed to spot the recession in 2008, you&nbsp;failed to spot the flat-lining economy in 2010, and now you've failed to spot the stronger recovery. How can we have any faith in the forecasts that underpin forward guidance?</p> </blockquote> <p>Carney defends the Bank's record, says that it's confident that it's predictions are on the right path. He adds, though, that he's trying to make the forecasts more transparent to that doubters can better understand the bank's thinking.</p> <p>He then bats the question over to chief economist Spencer Dale -- who says that weaker global demand was one reason the Bank's UK growth forecasts were too optimistic in the past.</p> <p>Dale also argues that the real power of forward guidance is that people understand the Bank's approach to monetary policy, rather than its forecasts.</p> </div> </div> <div id=\"block-52835a24e4b0312d704c117a\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:58:17.730Z\">10.58am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Carney defends forward guidance</h2> <div class=\"block-elements\"> <p><em><strong>What on earth is the point of forward guidance on interest rates, asks Chris Giles of the FT, given the dramatic changes in the Bank of England's predictions.</strong></em>&nbsp;</p> <p>Imagine a world without forward guidance, replies Mark Carney.&nbsp;We've had an unexpectedly strong recovery - stronger than most analysts expected.</p> <p>If forward guidance wasn't introduced in August, the discussion would be 'is the Bank going to raise interest rates today'. No-one is asking that question today...</p> <p><strong>...and rightly so, Carney adds. A rate rise would mean the bank would &quot;take a recovery that has finally taken hold and pull the rug out from under it&quot;.</strong></p> </div> </div> <div id=\"block-528359cfe4b0312d704c1179\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:53:20.798Z\">10.53am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England: the recovery is finally taken hold</h2> <div class=\"block-elements\"> <p><strong>Here's the key quote from the Bank of England's report, declaring that the British recovery is, at last, underway:</strong></p> <blockquote class=\"quoted\"> <p>In the United Kingdom, recovery has finally taken hold. The economy is growing robustly as lifting&nbsp;uncertainty and thawing credit conditions start to unlock pent-up demand.</p> <p>But significant&nbsp;headwinds — both at home and abroad — remain, and there is a long way to go before the&nbsp;aftermath of the financial crisis has cleared and economic conditions normalise. That underpins the&nbsp;MPC’s intention to maintain the exceptionally stimulative stance of monetary policy until there has&nbsp;been a substantial reduction in the degree of economic slack.&nbsp;</p> <p>The pace at which that slack is eroded, and the durability of the recovery, will depend on the extent&nbsp;to which productivity picks up alongside demand. Productivity growth has risen in recent quarters,&nbsp;although unemployment has fallen by slightly more than expected on the back of strong output&nbsp;growth.</p> </blockquote> </div> </div> <div id=\"block-52835981e4b0b9c05d8a346a\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:50:50.503Z\">10.50am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><a href=\"http://www.bankofengland.co.uk/publications/Pages/inflationreport/2013/ir1304.aspx\"><strong>The full quarterly inflation report is online here</strong></a>.</p> </div> </div> <div id=\"block-5283584ee4b0b9c05d8a3469\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:50:07.913Z\">10.50am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><em>What can the Bank of England do to close the gap between wages and inflation, asks Sky's Ed Conway.</em></p> <p>Carney replies that it is important that the recovery persists, and &quot;we need a pickup in business investment&quot; too.</p> <p>The Bank's pledge to keep interest rates at record lows at least until the jobless rate is 7% will also help, he adds.</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png\" alt=\"Mark Carney\" width=\"460\" height=\"264\" class=\"gu-image\" /> <figcaption>Photograph: Sky News</figcaption> </figure> </div> </div> <div id=\"block-528357c1e4b0312d704c1177\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:45:19.433Z\">10.45am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>As expected, Mark Carney is having to defend his forward guidance policy on interest rates.</strong></p> <p>Asked how people and businesses are supposed to plan for the future if the bank's forecasts change so much, governor Carney explains that his priority is to &quot;provide confidence&quot; that borrowing costs won't rise until the recovery is secured.</p> <p>Interest rates won't immediately rise when the jobless rate hits 7%, he insists.</p> </div> </div> <div id=\"block-52835773e4b07aa4168b4b0c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:43:03.177Z\">10.43am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><a href=\"http://streamstudio.world-television.com/CCUIv3/frameset.aspx?ticket=117-118-13642&amp;target=en-default-&amp;status=live&amp;browser=ns-0-0-0-11-0&amp;stream=flash-video-400\"><strong>The Bank of England's Q&amp;A is being webcast here</strong></a>.</p> </div> </div> <div id=\"block-52835651e4b0312d704c1175\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:41:52.871Z\">10.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Mark Carney is telling reporters in London that:</strong></p> <blockquote class=\"quoted\"> <p><strong>For the first time in a long time, you don't need to be an optimist to see that the glass is half full.&nbsp;</strong><strong>The recovery has taken hold.</strong></p> </blockquote> <p>He's explaining that the Bank of England's job is to help secure the recovery, and make it strong enough to get more people back into work.&nbsp;</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T10:47:49.645Z\">at 10.47am GMT</time></p> </div> <div id=\"block-5283566be4b0b9c05d8a3468\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:39:05.299Z\">10.39am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The Bank of England has also raised its growth forecasts.</strong></p> <p>It expects GDP to rise by 1.6% for 2013 as a whole, up from 1.4%.</p> <p>In 2014, it expects growth of 2.8%, up from 2.5% in the August report.</p> <p>It still expects growth of 2.3% in 2015.</p> </div> </div> <div id=\"block-52835455e4b0b9c05d8a3466\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:36:13.581Z\">10.36am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England releases quarterly inflation report</h2> <div class=\"block-elements\"> <p><strong>The Bank of England has just released its latest quarterly report on the UK economy.</strong></p> <p>And it's raised its economic forecasts, saying that the unemployment rate will fall faster than it expected three months ago. There is a &quot;two in five chance&quot; that it could be 7% at the end of 2014, Mark Carney says.</p> <p>However, that doesn't mean interest rates would immediately rise (<em>7% being the target in the Bank's forward guidance</em>).&nbsp;</p> <p>It also believes that the inflation rate will fall to the 2% target faster than it thought in August.</p> <p>Here's the Reuters newsflashes:&nbsp;</p> <p><strong>• BANK OF ENGLAND NOV INFLATION REPORT - UK RECOVERY HAS FINALLY TAKEN HOLD, ECONOMY GROWING ROBUSTLY BUT SIGNIFICANT HEADWINDS REMAIN&nbsp;</strong></p> <p><strong>• BOE - MPC INTENDS TO KEEP EXCEPTIONALLY STIMULATIVE POLICY STANCE UNTIL SLACK HAS REDUCED SUBSTANTIALLY&nbsp;13-Nov-2013 </strong></p> <p><strong>• BOE - UNEMPLOYMENT LIKELY TO FALL MORE QUICKLY THAN FORECAST IN AUGUST, HITTING 7 PCT THRESHOLD WILL NOT NECESSARILY TRIGGER RATE RISE&nbsp;</strong></p> <p><strong>• BOE INFLATION REPORT SAYS MPC SEES 41 PCT CHANCE OF 7 PCT UNEMPLOYMENT AT END-2014, 57 PCT AT END-2015, 68 PCT AT END-2016 BASED ON MARKET INTEREST RATES&nbsp;</strong></p> </div> </div> <div id=\"block-528354a4e4b0312d704c1174\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:29:58.205Z\">10.29am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/notayesmansecon/statuses/400570702014590976\"> <blockquote class=\"twitter-tweet\"><p>Will somebody please point out the 7.1% September UK unemployment number at the Bank of England press conference?! <a href=\"https://twitter.com/search?q=%23ForwardGuidance&amp;src=hash\">#ForwardGuidance</a> <a href=\"https://twitter.com/search?q=%23BoE&amp;src=hash\">#BoE</a></p>— Shaun Richards (@notayesmansecon) <a href=\"https://twitter.com/notayesmansecon/statuses/400570702014590976\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835369e4b0b9c05d8a3464\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:28:19.259Z\">10.28am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The recovery in the UK unemployment rate comes as the Bank of England prepares to release its latest Quarterly Inflation Report (</strong><em>in just a couple of minute<strong>s).</strong></em></p> <p>Having pinned UK interest rates to the jobless rate, will Mark Carney now say that the recovery is accelerating faster than he expected? <em>We're about to find out....</em></p> </div> </div> <div id=\"block-528352bde4b0f37bee4ff631\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:24:08.394Z\">10.24am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment: what the politicians say</h2> <div class=\"block-elements\"> <p>Here's the political reaction to the news that Britain's unemployment rate has fallen to 7.6%, but that pay remains well below inflation (<strong><a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283464ce4b0f37bee4ff61c\">see 9.31am onwards for all the details</a></strong>).</p> <h2>Minister for Employment Esther McVey</h2> <blockquote class=\"quoted\"> <p>This Government is delivering on its promise to rebalance the economy, promote job creation, and support people to get off benefits and into work.</p> <p>Today's figures show that the number of people in work has risen by more than a million under this Government, with the growth driven by full-time private sector jobs.&nbsp;</p> <p>At the same time, the number of people claiming the main out-of-work benefits has fallen by almost half a million. There's more work to do, and we are not complacent, but these are all very positive signs.</p> </blockquote> <h2><strong>Rachel Reeves MP, Labour’s Shadow Work and Pensions Secretary</strong></h2> <blockquote class=\"quoted\"> <p>Today’s fall in unemployment is welcome, but families facing a cost-of-living crisis need a recovery that benefits them, and these figures show we are still far from achieving that.</p> <p>Prices have now risen much faster than wages for 40 of the 41 months since David Cameron became Prime Minister. On average working people are now over &pound;1,600 a year worse off under this out-of-touch Government.</p> <p>The employment figures give no cause for complacency. The number of people who want to work full-time but are stuck on part-time hours is at a record high. And youth unemployment is still at unacceptable and unaffordable levels with almost a million young people still out of work, while the number of young people unemployed for a year or more has gone up by 7,000 this quarter.</p> <p>The Tory-led Government’s Work Programme and Youth Contract are failing – they should adopt Labour’s compulsory jobs guarantee, funded by repeating the tax on bank bonuses, and limiting pension tax relief for the very highest earners. This would guarantee real paid work for young people unemployed for a year, or adults unemployed for two years – work they would have to take or lose benefits.</p> </blockquote> </div> </div> <div id=\"block-52835239e4b07aa4168b4b07\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:21:02.918Z\">10.21am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Incidentally, we've just learned that September was a less cheery month for the eurozone. Factory output fell by 0.5%, rather worse than expected.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BBCGavinHewitt/statuses/400567118460362752\"> <blockquote class=\"twitter-tweet\"><p>Industrial production in euro-zone fell in Sept more than expected. In Portugal it fell 11.2%. in Germany down 0.8%. V fragile recovery.</p>— Gavin Hewitt (@BBCGavinHewitt) <a href=\"https://twitter.com/BBCGavinHewitt/statuses/400567118460362752\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-528350e4e4b0312d704c1173\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:19:20.525Z\">10.19am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Now this is interesting....</strong> the ONS has also released an unofficial snapshot of the UK labour market just for September.</p> <p>It's more informal than the official data -- &quot;not designated as National Statistics&quot; as the jargon has it.</p> <p>But with that caveat duly noted.... the data shows that the jobless rate was just 7.1% in September itself (compared to 7.6% for the July-September quarter). <a href=\"http://www.ons.gov.uk/ons/dcp171766_334875.pdf\"><strong>It's online here....</strong></a></p> <p>That's much closer to the 7% target which the Bank of England has set as a milestone before interest rates could rise.&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/JonPrynn/statuses/400561002107768833\"> <blockquote class=\"twitter-tweet\"><p>Hold on to your hats. The unofficial &quot;one month&quot; measure shows unemployment at just 7.1%. Rate rise for 2014? <a href=\"http://t.co/61oS2mW10V\">http://t.co/61oS2mW10V</a></p>— Jonathan Prynn (@JonPrynn) <a href=\"https://twitter.com/JonPrynn/statuses/400561002107768833\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52835028e4b0f37bee4ff62d\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:13:27.217Z\">10.13am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Rob Wood of Berenberg Bank says unemployment is falling faster than economists, or the Bank of England, expected -- but he is also concerned that wage growth is so weak.</strong></p> <p>Wood comments:</p> <blockquote class=\"quoted\"> <p>There is a lot of good news in this release for the UK economy. Stonking job gains show the UK is recovering rapidly.</p> <p>At the same time those jobs gains are not cutting unemployment as fast as might be expected because the workforce is rising rapidly.</p> <p>Unlike in the US, the UK participation rate is rising. People are competing for jobs rather than giving up and leaving the workforce. That is keeping wage growth very subdued.</p> </blockquote> </div> </div> <div id=\"block-528349ade4b0f37bee4ff622\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:10:39.584Z\">10.10am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">The wage squeeze continues....</h2> <div class=\"block-elements\"> <p>Many analysts concerned by the lack of progress in pay (with total weekly earnings up just 0.7% annually).</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/jamestplunkett/statuses/400563344840470528\"> <blockquote class=\"twitter-tweet\"><p>Wages have now been falling in real terms for four years. Uncharted waters. <a href=\"http://t.co/sIfsQolJe0\">pic.twitter.com/sIfsQolJe0</a></p>— James Plunkett (@jamestplunkett) <a href=\"https://twitter.com/jamestplunkett/statuses/400563344840470528\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/faisalislam/statuses/400562487692500992\"> <blockquote class=\"twitter-tweet\"><p>... and pay is still falling well short of prices, particularly now the 50p bonus-tax shifts have stopped: <a href=\"http://t.co/WpmQHq6V5K\">pic.twitter.com/WpmQHq6V5K</a></p>— Faisal Islam (@faisalislam) <a href=\"https://twitter.com/faisalislam/statuses/400562487692500992\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52834dd5e4b0f37bee4ff62c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T10:07:10.738Z\">10.07am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>As this graph shows, the UK unemployment rate has now dropped to its lowest in over four years - it hit 7.6% in&nbsp;May 2009, during the recession sparked by the financial crisis:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png\" alt=\"Unemployment: the unemployment rate to September 2013\" width=\"460\" height=\"256\" class=\"gu-image\" /> <figcaption>Photograph: ONS</figcaption> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T10:07:40.171Z\">at 10.07am GMT</time></p> </div> <div id=\"block-52834c71e4b0312d704c1171\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:56:34.562Z\">9.56am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>This chart shows how the rise in the labour force was split between men and women, and between full-timer and part-time staff:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png\" alt=\"Unemployment; The 177,000 rise in the labour force in July-September 2013\" width=\"460\" height=\"281\" class=\"gu-image\" /> <figcaption>Photograph: ONS</figcaption> </figure> </div> </div> <div id=\"block-52834b22e4b0312d704c1170\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:54:01.797Z\">9.54am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>At 29.95 million people, the UK workforce is now at a record high having jumped by 177,000 in the July-September quarter.&nbsp;</p> <p>However, this partly reflects increased population levels.<strong> The&nbsp;</strong><strong>employment rate of 71.8% is not at a record high</strong> -- as this graph shows, it's still below its pre-crisis levels:</p> <figure class=\"element element-image\" data-media-id=\"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png\" alt=\"Unemployment: UK employment rate to September 2013\" width=\"460\" height=\"253\" class=\"gu-image\" /> <figcaption>Unemployment: UK employment rate to September 2013 Photograph: /ONS</figcaption> </figure> <p><em>It's moving the right way, though....</em></p> </div> </div> <div id=\"block-52834a2ee4b07aa4168b4b02\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:49:17.013Z\">9.49am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>While the fall in the headline jobless rate is clearly welcome, the detail of the ONS report paints a more sober picture.</p> <p>For example, the number of people working part-time because they can't get full-time employment is at a record high.</p> <p><strong>According to the ONS&nbsp;there were 1.46 million employees and self-employed people who&nbsp;were working part-time because they could not find a full-time job, the highest figure since records&nbsp;began in 1992.</strong></p> </div> </div> <div id=\"block-5283497fe4b0f37bee4ff621\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:43:02.831Z\">9.43am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>The full report from the Office for National Statistics is online here:</p> <h2><a href=\"http://www.ons.gov.uk/ons/dcp171778_332467.pdf\">Labour Market Statistics, November&nbsp;2013</a></h2> </div> </div> <div id=\"block-52834838e4b07aa4168b4b00\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:41:29.326Z\">9.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>But while unemployment is down, pay packets are not yet feeling the benefits.</strong></p> <p>Total pay, including bonuses, rose by 0.7% annually in September -- down from 0.8% in August. That's dwarfed by the 2.2% rise in inflation over the last year in Britain.</p> <p>Average pay fell year-on-year in the public sector.</p> <p>The ONS reported:</p> <blockquote class=\"quoted\"> <p>Average weekly earnings for the private sector increased&nbsp;by 1.1% but average weekly earnings for the public sector fell by 0.4%.&nbsp;</p> <p>In September 2013 average pay including bonus payments in the private sector was &pound;473 a week,&nbsp;&pound;14 a week lower than the public sector figure of &pound;487 a week. However, excluding publicly owned&nbsp;financial corporations, average weekly pay in the public sector was only &pound;3 a week higher than for&nbsp;the private sector, at &pound;476 a week.</p> </blockquote> </div> </div> <div id=\"block-52834798e4b07aa4168b4aff\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:36:43.015Z\">9.36am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>The UK claimant count is also down -- dropping by 41,700 people in October. </strong>That takes the claimant count rate down to 3.9%.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T09:36:51.658Z\">at 9.36am GMT</time></p> </div> <div id=\"block-5283473ee4b0312d704c116e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:33:52.032Z\">9.33am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>The total number of people in work across the UK rose by 177,000 in the three months to September, taking the total to 29.953 million. That's the biggest jump since the June to August quarter.</p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T09:34:01.700Z\">at 9.34am GMT</time></p> </div> <div id=\"block-5283464ce4b0f37bee4ff61c\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:31:39.669Z\">9.31am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment rate falls</h2> <div class=\"block-elements\"> <p><strong>Breaking: the UK unemployment rate has fallen to 7.6% in the three months to September.</strong></p> <p>The number of people out of work fell by 48,000 to 2.466m in the quarter, which Reuters says is the lowest level in three years.</p> <p><em><strong>More to follow....</strong></em></p> </div> </div> <div id=\"block-52833ed7e4b0312d704c116d\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:17:55.081Z\">9.17am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">UK unemployment data due soon</h2> <div class=\"block-elements\"> <p>We get the latest UK unemployment data in less than 15 minutes time. As mentioned at the start, economists expect:</p> <p><strong>• a drop in the claimant count of around 30,000 people in October (compared with 41k last month)&nbsp;</strong></p> <p><strong>• a rise in the number of people in work in the three months to September, of around&nbsp;113,000 </strong></p> <p><strong>• No change to the unemployment rate, of 7.7% [<em>which is crucial to UK monetary policy given the Bank of England's pledge not to raise rates till it hits 7%</em>]&nbsp;</strong></p> <p><strong>• Another fall in real pay, with average weekly earnings expected to have risen by just 0.7% over the last year.</strong></p> <p>In other words, some signs of recovery in the labour market, but no relief to the squeeze on living standards and wages.</p> <p>The youth unemployment data will also be scrutinised, with <a href=\"http://www.presstv.ir/detail/2013/11/13/334472/uk-youth-unemployment-rises-report/\"><strong>a new report warning that the jobless rate among young people has still risen despite the UK economy returning to growth</strong></a>.</p> </div> </div> <div id=\"block-52834019e4b07aa4168b4afa\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T09:05:22.339Z\">9.05am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Bad economic data from the Netherlands -- retail sales tumbled by 6.1% year-on-year in September.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/lexvandam/statuses/400544001645752320\"> <blockquote class=\"twitter-tweet\"><p>Shocking: NETHERLANDS SEPT RETAIL SALES Y/Y: -6.1% V -0.7% PRIOR</p>— Lex van Dam (@lexvandam) <a href=\"https://twitter.com/lexvandam/statuses/400544001645752320\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52833b63e4b0b9c05d8a345e\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:54:03.704Z\">8.54am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png\" alt=\"European stock markets, early trading, November 13 2013\" width=\"460\" height=\"137\" class=\"gu-image\" /> <figcaption>European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters</figcaption> </figure> <p>European stock markets are in the red this morning, with the FTSE 100 shedding 47 points or 0.7%.</p> <p>Traders are blaming nervousness ahead of <a href=\"http://www.theguardian.com/business/2013/nov/13/bank-of-england-inflation-report-and-uk-unemployment-data-live#block-5283235be4b0312d704c116a\"><strong>the Bank of England's inflation report</strong></a>&nbsp;(<em>what will Mark Carney say about growth prospects and rate rises?</em>), and another bout of jitters over when the US Federal Reserve will start to slow its own stimulus programme.</p> <p>There's also a knock-on effect from Asia. China's stock market shed 2% following the conclusion of the Beijing government's Plenary meeting where <a href=\"http://www.theguardian.com/world/2013/nov/12/china-markets-decisive-role-economy\"><strong>leaders pledged to give the markets a &quot;decisive role&quot; in the country's economic future</strong></a>.</p> <p><a href=\"https://twitter.com/Accendo_Mike\"><strong>Mike van Dulken of Accendo Markets</strong></a> says traders are</p> <blockquote class=\"quoted\"> <p>disappointed&nbsp;by the rather general/vague&nbsp;Chinese statement&nbsp;in terms of its plan for the next decade.</p> </blockquote> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T08:54:21.368Z\">at 8.54am GMT</time></p> </div> <div id=\"block-52833755e4b0b9c05d8a345c\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:41:50.014Z\">8.41am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>In the corporate world, Sainsbury's is getting into the early festive spirit with a 7% jump in profits, the top of analyst forecasts.</strong></p> <p>The supermarket chain also reported that its market share was at its highest for a decade, but remained cautious about UK economic prospects.</p> <p>Phil Dorrell, director of the retail consultants Retail Remedy, reckons &quot;The fairytale continues at Sainsbury's&quot;, and predicts it will do well this Christmas.</p> <h2>More here: <a href=\"http://www.theguardian.com/business/2013/nov/13/sainsburys-rise-7-percent-own-brand-online-sales\">Sainsbury's profit rise 7% as own-brand and online sales thrive</a></h2> </div> </div> <div id=\"block-52833971e4b0f37bee4ff615\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:39:02.545Z\">8.39am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Robin Bew</strong> of the&nbsp;Economist Intelligence Unit tweets that <a href=\"http://www.theguardian.com/business/2013/nov/12/inflation-fall-welcomed-by-government\"><strong>yesterday's drop in UK inflation, to 2.2%</strong></a>, gives Mark Carney and colleagues a little more room to&nbsp;manoeuvre.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/RobinBew/statuses/400513462440566784\"> <blockquote class=\"twitter-tweet\"><p>Lower <a href=\"https://twitter.com/search?q=%23UK&amp;src=hash\">#UK</a> inflation data means <a href=\"https://twitter.com/search?q=%23BoE&amp;src=hash\">#BoE</a> faces better growth/price mix than expected. Gives them a bit more policy flexibility</p>— Robin Bew (@RobinBew) <a href=\"https://twitter.com/RobinBew/statuses/400513462440566784\">November 13, 2013</a></blockquote> </figure> <p>And as our economics editor Larry Elliott wrote yesterday, spending power is on the wane in many countries.</p> <h2><a href=\"http://www.theguardian.com/business/2013/nov/12/inflation-fall-spending-power-squeeze-uk\">Inflation fall shows effects of spending power squeeze</a></h2> </div> </div> <div id=\"block-528330a5e4b0f37bee4ff613\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:21:27.995Z\">8.21am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p><strong>Speaking of the eurozone, we get also industrial production data for September at 10am -- economists expect a 0.3% drop month-on-month.</strong></p> <p>Germany's top central banker, Jens Weidmann, is giving a speech around noon GMT. Let's hope he comments on last week's ECB interest rate cut, given the Bundesbank chief is understood to have opposed it.</p> <p>Greece's finance minister, Yannis Stournaras, meanwhile is reported to be in Brussels - perhaps preparing for tomorrow's Eurogroup meeting of finance ministers.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BloombergAthens/statuses/400527179475214337\"> <blockquote class=\"twitter-tweet\"><p>Greek Finance Minister Yannis Stournaras in Brussels</p>— Bloomberg Athens (@BloombergAthens) <a href=\"https://twitter.com/BloombergAthens/statuses/400527179475214337\">November 13, 2013</a></blockquote> </figure> <p>Yesterday, Stournaras denied that the Athens government and its troika inspectors were &quot;miles&quot; apart in their assessment of Greece's performance against its bailout programme. <a href=\"http://www.ekathimerini.com/4dcgi/_w_articles_wsite1_1_12/11/2013_527556\"><strong>It's just meters, he insisted</strong></a>.&nbsp;</p> </div> </div> <div id=\"block-52833237e4b0b9c05d8a345b\" class=\"block is-key-event\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T08:13:11.498Z\">8.13am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Spain reports deflation in October</h2> <div class=\"block-elements\"> <p><strong>Spain's annual inflation rate turned negative last month, according to new data that will heighten concerns that parts of the eurozone are slipping into deflation</strong>.</p> <p>The latest inflation data showed that the Spanish consumer prices index <strong>fell by 0.1% in October</strong>, on an annual basis. On a monthly basis, the CPI rose by 0.4%.&nbsp;</p> <p>On an 'EU harmonised basis', prices were flat year-on-year.&nbsp;</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/minefornothing/statuses/400534375164825600\"> <blockquote class=\"twitter-tweet\"><p>Spanish CPI drops to -0.1% YoY in October <a href=\"https://twitter.com/search?q=%23deflation&amp;src=hash\">#deflation</a></p>— MineForNothing (@minefornothing) <a href=\"https://twitter.com/minefornothing/statuses/400534375164825600\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/BBCGavinHewitt/statuses/400535222162579456\"> <blockquote class=\"twitter-tweet\"><p>Further indication of weak demand in euro-zone. Spanish consumer prices fell 0.1% compared to October last year - the first fall in 4 years.</p>— Gavin Hewitt (@BBCGavinHewitt) <a href=\"https://twitter.com/BBCGavinHewitt/statuses/400535222162579456\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/ReutersJamie/statuses/400535572650807296\"> <blockquote class=\"twitter-tweet\"><p>Spain in deflation. Annual CPI -0.1% in Oct. It was +3.5% only a year ago: <a href=\"http://t.co/x5f5Z9iEcr\">pic.twitter.com/x5f5Z9iEcr</a></p>— Jamie McGeever (@ReutersJamie) <a href=\"https://twitter.com/ReutersJamie/statuses/400535572650807296\">November 13, 2013</a></blockquote> </figure> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/fwred/statuses/400536877502971904\"> <blockquote class=\"twitter-tweet\"><p>Spanish HICP inflation revised down to 0.0% YoY in October (vs. preliminary estimate of +0.1%). <a href=\"https://twitter.com/search?q=%23Dword&amp;src=hash\">#Dword</a></p>— Frederik Ducrozet (@fwred) <a href=\"https://twitter.com/fwred/statuses/400536877502971904\">November 13, 2013</a></blockquote> </figure> <p>We have seen a steady stream of low inflation rates recently (German's CPI fell to 1.2%), while <a href=\"http://www.reuters.com/article/2013/11/08/greece-inflation-idUSEMS1C747020131108\">the cost of living fell by 2.0% in Greece last month</a>. <em>Understandable, given sluggish demand, weak European growth and cash-strapped consumers.</em></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T08:24:37.877Z\">at 8.24am GMT</time></p> </div> <div id=\"block-52833020e4b0312d704c116b\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:56:12.818Z\">7.56am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>City traders are predicting the blue-chip Footsie index will drop by around 0.6%, when trading begins in a few minutes.</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/DavidJones_IG/statuses/400529358357798912\"> <blockquote class=\"twitter-tweet\"><p>Quite a weak start forecast for the FTSE this morning- currently expected to open -45 at 6682.</p>— David Jones (@DavidJones_IG) <a href=\"https://twitter.com/DavidJones_IG/statuses/400529358357798912\">November 13, 2013</a></blockquote> </figure> </div> </div> <div id=\"block-52832e69e4b0b9c05d8a3459\" class=\"block\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:52:46.164Z\">7.52am <span class=\"timezone\">GMT</span></time> </p> <div class=\"block-elements\"> <p>Much was made of Mark Carney's Canadian background when he was named as Sir Mervyn King's successor. The FT has now discovered that he's also the proud holder of Irish citizenship too:</p> <p>Chris Giles reports:</p> <blockquote class=\"quoted\"> <p>Since his arrival as governor of the Bank of England in July Mark Carney has had the luck of the Irish, enjoying rising growth, falling unemployment and rapidly moderating inflation.</p> <p>That cannot have been much of a surprise to the BoE or Treasury as on Tuesday night both confirmed that the Canadian running the old Lady of Threadneedle Street has also held Irish citizenship since 1988 when he started working for Goldman Sachs in London.</p> </blockquote> <h2>More here:&nbsp;<a href=\"http://www.ft.com/cms/s/0/ee169c30-4bc6-11e3-a02f-00144feabdc0.html?siteedition=uk#axzz2kQ6dOH6F\"><strong>Mark Carney brings luck of the Irish to BoE</strong></a></h2> <p>And on the FT's front page:</p> <figure class=\"element element-tweet\" data-canonical-url=\"https://twitter.com/suttonnick/statuses/400384504235184128\"> <blockquote class=\"twitter-tweet\"><p>Wednesday's FT front page - &quot;Forex probe widens to at least 15 big banks&quot; <a href=\"https://twitter.com/search?q=%23tomorrowspaperstoday&amp;src=hash\">#tomorrowspaperstoday</a> <a href=\"https://twitter.com/search?q=%23bbcpapers&amp;src=hash\">#bbcpapers</a> <a href=\"http://t.co/YQkIpAjAkY\">pic.twitter.com/YQkIpAjAkY</a></p>— Nick Sutton (@suttonnick) <a href=\"https://twitter.com/suttonnick/statuses/400384504235184128\">November 12, 2013</a></blockquote> </figure> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T07:52:56.198Z\">at 7.52am GMT</time></p> </div> <div id=\"block-5283235be4b0312d704c116a\" class=\"block is-summary\"> <p class=\"block-time published-time\"> <time datetime=\"2013-11-13T07:31:30.171Z\">7.31am <span class=\"timezone\">GMT</span></time> </p> <h2 class=\"block-title\">Bank of England and UK unemployment data</h2> <div class=\"block-elements\"> <figure class=\"element element-image\" data-media-id=\"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67\"> <img src=\"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg\" alt=\"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.\" width=\"460\" height=\"307\" class=\"gu-image\" /> <figcaption>Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS</figcaption> </figure> <p><strong>Good morning, and welcome to our rolling coverage of events across the economy, the financial markets, the eurozone and the business world.</strong></p> <p>UK economics is centre-stage today, with the release of fresh unemployment data (<strong>at 9.30am</strong>) followed by the Bank of England's quarterly inflation report (<strong>from 10.30am</strong>).&nbsp;</p> <p><strong>And what a difference three months makes.</strong> Back on August 7, governor Mark Carney pushed the Bank of England into a bold new era by <a href=\"http://www.theguardian.com/business/2013/aug/07/bank-of-engand-links-interest-rates-jobless-target\"><strong>setting 'forward guidance' on interest rates</strong></a>. Effectively he pledged that borrowing costs won't rise until the UK jobless rate drops to 7% (<em>from 7.7% a month ago</em>), which Carney didn't see happening until 2016.</p> <p>Since then, a rich seam of solid economic data has shown that Britain's economy is performing better than most analysts thought in August. So the Bank is likely to upgrade its growth forecasts, and could also predict that unemployment will fall faster than previously expected.</p> <p><strong>And that could fuel predictions that UK interest rates will finally rise from their record low of 0.5% somewhat earlier than 2016</strong>.</p> <p>The unemployment data, meanwhile, is expected to show another drop in the number of people signing on for the Jobseeker's Allowance in October. The headline jobless rate is expected to stay at 7.7% for the three months to September.</p> <p>Michael Hewson of CMC helpfully rounds up the recent figures:</p> <blockquote class=\"quoted\"> <p>The latest&nbsp;unemployment&nbsp;numbers look set to show the&nbsp;ILO September&nbsp;unemployment&nbsp;rate stuck at 7.7%&nbsp;despite double digit falls in jobless claims numbers for the last four months.</p> <p>Claims numbers for October&nbsp;are expected to show another&nbsp;double digit decline of 33k, following on from declines of 41.7k, 32.6k, 29.2k and 21.2k, in previous months.</p> </blockquote> <p>But with pay still lagging behind inflation (which fell to 2.2% yesterday), it may not feel like a recovery to many.</p> <p><em><strong>We'll be tracking all the events through the day...</strong></em></p> </div> <p class=\"block-time updated-time\">Updated <time datetime=\"2013-11-13T07:42:19.086Z\">at 7.42am GMT</time></p> </div><!-- Guardian Watermark: internal-code/content/422360318|2013-11-13T15:50:01Z|c26f4ab4f6e13790bb78440fbf15a02fc58d90e8 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+        "wordcount":"1",
+        "liveBloggingNow":"true"
+      },
+      "tags":[{
+        "id":"business/series/guardian-business-live",
+        "type":"series",
+        "webTitle":"Guardian business live",
+        "webUrl":"http://www.theguardian.com/business/series/guardian-business-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/guardian-business-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/debt-crisis",
+        "type":"keyword",
+        "webTitle":"Eurozone crisis",
+        "webUrl":"http://www.theguardian.com/business/debt-crisis",
+        "apiUrl":"http://content.guardianapis.com/business/debt-crisis",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/series/eurozone-crisis-live",
+        "type":"series",
+        "webTitle":"Eurozone crisis live",
+        "webUrl":"http://www.theguardian.com/business/series/eurozone-crisis-live",
+        "apiUrl":"http://content.guardianapis.com/business/series/eurozone-crisis-live",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/euro",
+        "type":"keyword",
+        "webTitle":"Euro",
+        "webUrl":"http://www.theguardian.com/business/euro",
+        "apiUrl":"http://content.guardianapis.com/business/euro",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/bankofenglandgovernor",
+        "type":"keyword",
+        "webTitle":"Bank of England",
+        "webUrl":"http://www.theguardian.com/business/bankofenglandgovernor",
+        "apiUrl":"http://content.guardianapis.com/business/bankofenglandgovernor",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/mark-carney",
+        "type":"keyword",
+        "webTitle":"Mark Carney",
+        "webUrl":"http://www.theguardian.com/business/mark-carney",
+        "apiUrl":"http://content.guardianapis.com/business/mark-carney",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"business/unemployment-and-employment-statistics",
+        "type":"keyword",
+        "webTitle":"Unemployment and employment statistics",
+        "webUrl":"http://www.theguardian.com/business/unemployment-and-employment-statistics",
+        "apiUrl":"http://content.guardianapis.com/business/unemployment-and-employment-statistics",
+        "sectionId":"business",
+        "sectionName":"Business",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      },{
+        "id":"tone/minutebyminute",
+        "type":"tone",
+        "webTitle":"Minute by minutes",
+        "webUrl":"http://www.theguardian.com/tone/minutebyminute",
+        "apiUrl":"http://content.guardianapis.com/tone/minutebyminute",
+        "references":[]
+      },{
+        "id":"tone/blog",
+        "type":"tone",
+        "webTitle":"Blogposts",
+        "webUrl":"http://www.theguardian.com/tone/blog",
+        "apiUrl":"http://content.guardianapis.com/tone/blog",
+        "references":[]
+      },{
+        "id":"profile/graemewearden",
+        "type":"contributor",
+        "webTitle":"Graeme Wearden",
+        "webUrl":"http://www.theguardian.com/profile/graemewearden",
+        "apiUrl":"http://content.guardianapis.com/profile/graemewearden",
+        "bio":"<p>Graeme Wearden is a <a href=\"http://www.guardian.co.uk/business\">business</a> reporter on guardian.co.uk and writes breaking City news plus the occasional blog. Previously he worked as a technology journalist at CNET Networks</p>",
+        "r2ContributorId":"19202",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/01/graeme_wearden_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/nickfletcher",
+        "type":"contributor",
+        "webTitle":"Nick Fletcher",
+        "webUrl":"http://www.theguardian.com/profile/nickfletcher",
+        "apiUrl":"http://content.guardianapis.com/profile/nickfletcher",
+        "bio":"<p>Nick Fletcher is a Guardian columnist and writer of the Market Forces column</p>",
+        "rcsId":"GNL023406",
+        "r2ContributorId":"16178",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/10/03/nick_fletcher_140x140.jpg",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821421/244fb4b5-1417-4452-affe-565d25e877fb-140x84.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"84",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821532/244fb4b5-1417-4452-affe-565d25e877fb-460x276.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"276",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341821759/244fb4b5-1417-4452-affe-565d25e877fb-220x132.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"132",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341822392/244fb4b5-1417-4452-affe-565d25e877fb-2060x1236.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1236",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823359/244fb4b5-1417-4452-affe-565d25e877fb-1020x612.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"612",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823662/244fb4b5-1417-4452-affe-565d25e877fb-300x180.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"180",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823837/244fb4b5-1417-4452-affe-565d25e877fb-540x324.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"324",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341823968/244fb4b5-1417-4452-affe-565d25e877fb-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"68",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824114/244fb4b5-1417-4452-affe-565d25e877fb-380x228.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"228",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341824749/244fb4b5-1417-4452-affe-565d25e877fb-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825642/244fb4b5-1417-4452-affe-565d25e877fb-620x372.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"372",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341825995/244fb4b5-1417-4452-affe-565d25e877fb-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference, November 13",
+            "height":"768",
+            "credit":"TOBY MELVILLE/REUTERS",
+            "caption":"Bank of England Governor Mark Carney speaks during the bank's quarterly inflation report news conference. Photograph: TOBY MELVILLE/REUTERS",
+            "mediaId":"gu-fc-cb120448-6a72-4be7-9150-e035b2147d38",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354839918/6e988acc-b496-4800-88bb-d01ca3ec38bb-140x84.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"84",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840168/6e988acc-b496-4800-88bb-d01ca3ec38bb-460x276.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"276",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840321/6e988acc-b496-4800-88bb-d01ca3ec38bb-220x132.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"132",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354840625/6e988acc-b496-4800-88bb-d01ca3ec38bb-1020x612.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"612",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841006/6e988acc-b496-4800-88bb-d01ca3ec38bb-300x180.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"180",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841239/6e988acc-b496-4800-88bb-d01ca3ec38bb-540x324.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"324",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841371/6e988acc-b496-4800-88bb-d01ca3ec38bb-68x68.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"68",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841552/6e988acc-b496-4800-88bb-d01ca3ec38bb-380x228.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"228",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384354841679/6e988acc-b496-4800-88bb-d01ca3ec38bb-620x372.jpeg",
+            "source":"PA",
+            "photographer":"Belfast Harbour",
+            "altText":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "height":"372",
+            "credit":"Belfast Harbour/PA",
+            "caption":"Belfast Harbour. Photo: Belfast Harbour/PA",
+            "mediaId":"gu-fc-872df7e7-7d90-4ae7-918b-5e50d2933a8a",
+            "width":"620"
+          }
+        }]
+      },{
+        "id":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929539/9945903c-e084-42c4-9703-6b70c320ae29-300x251.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"251",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348929785/e74ab6ba-53d6-427b-8a09-779bb7edd128-540x453.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"453",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930105/2675e076-5390-44fc-9278-9a4a63a0e148-460x386.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"386",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930272/53158166-aaf0-411d-a983-b6e444b44fcc-140x117.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"117",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930446/099c9ca2-528d-4768-a2b4-542c4c3b1035-380x318.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"318",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930617/f3673e90-d8f8-497d-98cd-932c14557f5a-220x184.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"184",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384348930725/991b561f-deff-4173-b955-f3869a8b8f2e-68x68.png",
+            "source":"EC",
+            "altText":"Eurozone current account data",
+            "height":"68",
+            "credit":"EC",
+            "caption":"Photograph: EC",
+            "mediaId":"gu-fc-c0e9b794-31d0-4974-a716-3d7dc3938dfd",
+            "width":"68"
+          }
+        }]
+      },{
+        "id":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318258/f719ef2a-fc97-4432-aea0-ebcfd86341f1-300x184.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"184",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318447/f719ef2a-fc97-4432-aea0-ebcfd86341f1-380x233.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"233",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318625/f719ef2a-fc97-4432-aea0-ebcfd86341f1-460x282.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"282",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347318820/f719ef2a-fc97-4432-aea0-ebcfd86341f1-620x380.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"380",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347319421/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2060x1261.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1261",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320202/f719ef2a-fc97-4432-aea0-ebcfd86341f1-68x68.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"68",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320319/f719ef2a-fc97-4432-aea0-ebcfd86341f1-540x331.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"331",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347320920/f719ef2a-fc97-4432-aea0-ebcfd86341f1-2048x1536.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"1536",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347321893/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1020x625.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"625",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322342/f719ef2a-fc97-4432-aea0-ebcfd86341f1-1024x768.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"768",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322608/f719ef2a-fc97-4432-aea0-ebcfd86341f1-140x86.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"86",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384347322730/f719ef2a-fc97-4432-aea0-ebcfd86341f1-220x135.jpeg",
+            "source":"AFP/Getty Images",
+            "photographer":"TOBY MELVILLE",
+            "altText":"Bank of England Governor Mark Carney (C) leads the bank's quarterly inflation report news conference at the Bank of England in London November 13, 2013.",
+            "height":"135",
+            "credit":"TOBY MELVILLE/AFP/Getty Images",
+            "caption":"Photograph: TOBY MELVILLE/AFP/Getty Images",
+            "mediaId":"gu-fc-c30ba81d-775a-4312-b9e8-fe6a01e80d72",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416345/82ca57b7-eae8-4938-9666-aa050cb6b3d8-220x159.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"159",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416512/82ca57b7-eae8-4938-9666-aa050cb6b3d8-620x448.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"448",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345416666/82ca57b7-eae8-4938-9666-aa050cb6b3d8-140x101.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"101",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345417335/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2060x1490.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1490",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418199/82ca57b7-eae8-4938-9666-aa050cb6b3d8-460x333.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"333",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418344/82ca57b7-eae8-4938-9666-aa050cb6b3d8-380x275.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"275",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418629/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1020x738.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"738",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345418870/82ca57b7-eae8-4938-9666-aa050cb6b3d8-68x68.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"68",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345419524/82ca57b7-eae8-4938-9666-aa050cb6b3d8-2048x1536.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"1536",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420358/82ca57b7-eae8-4938-9666-aa050cb6b3d8-300x217.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"217",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420507/82ca57b7-eae8-4938-9666-aa050cb6b3d8-540x390.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"390",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384345420797/82ca57b7-eae8-4938-9666-aa050cb6b3d8-1024x768.jpeg",
+            "source":"EPA",
+            "photographer":"Toby Melville / POOL",
+            "altText":"Bank of England Governor Mark Carney during the bank's quarterly inflation report news conference at the Bank of England in London, Britain, 13 November 2013.",
+            "height":"768",
+            "credit":"Toby Melville / POOL/EPA",
+            "caption":"Photograph: Toby Melville/POOL/EPA",
+            "mediaId":"gu-fc-36458cce-d1fe-42e9-96c3-39acc4d7724d",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914561/d2e6d348-9f48-4a99-b81a-ab53300fa038-380x360.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"360",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914706/fd37d228-d2f7-405f-ba4c-4452d8a1d7f1-140x133.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"133",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914873/bce69404-54bc-4b67-b73c-635635a1532c-300x284.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"284",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344914994/0581ea0f-1525-4856-bbce-7167baffb58f-68x68.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915312/018c9a28-da19-424e-84eb-b8be65c206fe-bestSizeAvailable.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"401",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"423"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384344915467/4c6928a7-2c5e-4c8d-99fa-a5ccdb8d0c7e-220x209.png",
+            "source":"Bank of England",
+            "altText":"Bank of England unemployment forecasts",
+            "height":"209",
+            "credit":"Bank of England",
+            "caption":"Photograph: Bank of England",
+            "mediaId":"gu-fc-859a381e-ac3a-440e-ad56-a93f0d586d12",
+            "width":"220"
+          }
+        }]
+      },{
+        "id":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341953412/d698e12f-ec93-4484-9cdc-9f12ce8df1b0-540x310.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"310",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954186/8839c234-fa85-48ce-b497-243fb80eec8a-1020x586.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"586",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954603/2619ab73-d410-43fb-aa89-7f57ae55944a-460x264.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954783/2b7b4b4c-ff25-41d9-8f5d-82be002b435b-300x172.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341954975/c09fe527-9a21-4c53-bf13-d4efef8cab3a-380x218.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955232/c4a2329b-8e69-4e9c-92a0-03be52386ca5-220x126.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955492/3d5a0f55-1919-4322-a4f1-ecf56628c146-68x68.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955650/3209701a-e93c-4f2c-abca-ac5bc27479c4-140x80.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341955935/b877cc9a-f074-443e-bf95-d02321355a83-620x356.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"356",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384341956577/fd0fd941-4ed9-470a-8175-418a0ab25ff7-1024x768.png",
+            "source":"Bank of England",
+            "altText":"Mark Carney",
+            "height":"768",
+            "credit":"Bank of England",
+            "caption":"Mark Carney speaking today. Photograph: Bank of England",
+            "mediaId":"gu-fc-87f05afc-d4a4-4de9-be38-9e434d9d8678",
+            "width":"1024"
+          }
+        }]
+      },{
+        "id":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727456/b8f61397-cba0-4ef2-982e-6dc721b66d62-220x126.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"126",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727595/09ecef93-6189-4131-81a2-cd94688ea9b5-140x80.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"80",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339727748/80d012ad-69cf-401d-beba-b9e1968f0be8-300x172.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"172",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728039/11cd298b-4e93-4220-a793-72bcf35d0133-620x355.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"355",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728321/1301bba3-a146-4044-add0-fc193b3948e6-460x264.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"264",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728470/9276c603-0c0c-4e40-8289-560e22edcf2d-68x68.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"68",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728601/872355c1-f76d-434e-a254-f8c53b64ec51-380x218.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"218",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384339728808/30a48779-ff1f-4e6a-98e5-8e59f77f3815-540x309.png",
+            "source":"Sky News",
+            "altText":"Mark Carney",
+            "height":"309",
+            "credit":"Sky News",
+            "caption":"Photograph: Sky News",
+            "mediaId":"gu-fc-3a01d422-ac14-435b-9312-9354ed3391a3",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337218895/98f3cb5f-5349-4cf1-9b19-f096ade2f077-460x256.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"256",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219131/ddd9ed70-16dd-467a-9574-d661a0400f1a-620x346.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"346",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219506/622903b9-0243-45bf-8510-9dac20818bb4-300x167.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"167",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219682/cff6a31c-2998-494e-8ccf-09da55642aef-140x78.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"78",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219813/84692c0d-3f79-462e-a265-be07abac19d1-220x123.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"123",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337219928/d670fd25-1999-42bc-8c50-f4afde5b6db2-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220165/4bffb2b1-e048-41d2-9fc6-3953648d57ef-380x212.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"212",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384337220415/03633c62-8585-496e-9968-d96e1e438be3-540x301.png",
+            "source":"ONS",
+            "altText":"Unemployment: the unemployment rate to September 2013",
+            "height":"301",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-539caeeb-2828-46d6-8065-259aef6737ae",
+            "width":"540"
+          }
+        }]
+      },{
+        "id":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558247/e51d34ca-63dc-4b01-af61-c08f7cc6fae8-220x134.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"134",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558370/4e7cc5b3-a57c-4405-824a-f181495992fb-140x86.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"86",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558533/f155a144-2954-44c6-b7dd-c5f1a4457daa-540x330.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"330",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558712/1eb5e2ca-fdd9-4e60-b81e-7f4f9730f442-380x232.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"232",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336558941/48da9e96-9f8b-47f5-86b9-b3339a5641ff-620x379.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"379",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559078/23e9a139-a38e-4f5f-be19-5331fb708393-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559212/2c44e80f-e83e-444b-873a-e29254208f6c-460x281.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"281",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336559359/d0c4b4e6-216a-4cac-9ad7-f979773f50eb-300x183.png",
+            "source":"ONS",
+            "altText":"Unemployment; The 177,000 rise in the labour force in July-September 2013",
+            "height":"183",
+            "credit":"ONS",
+            "caption":"Photograph: ONS",
+            "mediaId":"gu-fc-0ebfdfe6-4d2f-436b-9ce9-12aef4d3fa27",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336396931/bdb46369-0fbf-4a53-97eb-20bd37bef070-220x121.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"121",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397085/22e03843-99e6-4ff7-bf06-45041006b3ff-460x253.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"253",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397223/92014a9d-3e93-4c8d-ba0d-ed87c6558558-140x77.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"77",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397455/34010289-d130-4b2f-abf0-20d708d63de7-620x340.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"340",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397691/c252b870-1264-4e7a-8513-6f1c7258128f-380x209.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"209",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397803/e64d239f-a5cf-4f64-a180-6297b5d9425a-68x68.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"68",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336397946/f44aadd1-0617-48c6-96c0-781d38d7b3c2-540x296.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"296",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384336398143/6924acee-af81-4b42-8e03-f8697a1ca76f-300x165.png",
+            "source":"ONS",
+            "altText":"Unemployment: UK employment rate to September 2013",
+            "height":"165",
+            "credit":"ONS",
+            "caption":"Unemployment: UK employment rate to September 2013 Photograph: /ONS",
+            "mediaId":"gu-fc-50e2f003-8ecb-4901-be45-b66d3b29a68c",
+            "width":"300"
+          }
+        }]
+      },{
+        "id":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332807882/846efde8-092f-4dca-a9ff-9171ecc15fa8-540x161.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"161",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"540"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808019/caf22301-be04-4313-983a-cbba958e1840-220x66.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"66",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808220/2d9f6377-076d-44d2-8c34-129f9dc5a937-620x185.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"185",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808328/fa5e94e5-1e0a-497b-a021-680d188b9809-68x68.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"68",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808428/8d699472-b6e6-4370-9a93-079f2925c6f1-300x90.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"90",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808591/a9f8e132-df29-40b0-898f-4e03450a89a9-380x114.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"114",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808782/42816891-1877-4dde-a592-10edfc483a51-460x137.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"137",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332808918/2c83c3f9-1b6f-4c67-b627-afa8bed7ffc9-140x42.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"42",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384332809145/5a0633da-5650-4a74-950f-43c6e5f528c3-bestSizeAvailable.png",
+            "source":"Thomson Reuters",
+            "altText":"European stock markets, early trading, November 13 2013",
+            "height":"211",
+            "credit":"Thomson Reuters",
+            "caption":"European stock markets, early trading, November 13 2013 Photograph: /Thomson Reuters",
+            "mediaId":"gu-fc-b72c4642-a5e4-4f26-af7b-107da3aff428",
+            "width":"706"
+          }
+        }]
+      },{
+        "id":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075179/2604c91d-f345-4324-ba6e-531b13826877-1020x680.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"680",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1020"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327075582/2604c91d-f345-4324-ba6e-531b13826877-140x93.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"93",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076073/2604c91d-f345-4324-ba6e-531b13826877-2060x1374.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1374",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2060"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076789/2604c91d-f345-4324-ba6e-531b13826877-220x147.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"147",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327076892/2604c91d-f345-4324-ba6e-531b13826877-68x68.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"68",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"68"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327077415/2604c91d-f345-4324-ba6e-531b13826877-2048x1536.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"1536",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"2048"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078209/2604c91d-f345-4324-ba6e-531b13826877-460x307.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"307",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078358/2604c91d-f345-4324-ba6e-531b13826877-300x200.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"200",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078584/2604c91d-f345-4324-ba6e-531b13826877-380x253.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"253",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327078826/2604c91d-f345-4324-ba6e-531b13826877-1024x768.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"768",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"1024"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079157/2604c91d-f345-4324-ba6e-531b13826877-620x413.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"413",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"620"
+          }
+        },{
+          "type":"image",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+          "typeData":{
+            "secureFile":"https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384327079327/2604c91d-f345-4324-ba6e-531b13826877-540x360.jpeg",
+            "source":"REUTERS",
+            "photographer":"POOL",
+            "altText":"Britain's Queen Elizabeth greets the Governor of the Bank of England, Mark Carney, during an audience at Buckingham Palace in central London November 6, 2013.",
+            "height":"360",
+            "credit":"POOL/REUTERS",
+            "caption":"Britain's Queen Elizabeth greeting the Governor of the Bank of England, Mark Carney, last week. Today he has the pleasure of an audience with the UK economics press pack. Photograph: POOL/REUTERS",
+            "mediaId":"gu-fc-bb9d1c66-dd72-475e-a7ea-134b1ae06a67",
+            "width":"540"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "sectionId":"world",
+      "sectionName":"World news",
+      "webPublicationDate":"2013-11-13T08:30:00Z",
+      "webTitle":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+      "webUrl":"http://www.theguardian.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "apiUrl":"http://content.guardianapis.com/world/2013/nov/13/philippines-typhoon-food-stampede-aid",
+      "fields":{
+        "trailText":"<p>Thousands storm rice warehouse in the devastated central Philippines while Haiyan relief effort flounders</p>",
+        "headline":"Typhoon Haiyan: eight die in food stampede amid desperate wait for aid",
+        "body":"<video data-media-id=\"gu-video-422358527\" class=\"gu-video\" controls=\"controls\" poster=\"\">\n        <source src=\"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4\"></source><source src=\"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp\"></source><source src=\"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp\"></source><source src=\"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8\"></source>\n      </video><p>Eight people have been killed in the typhoon-ravaged central Philippines after thousands of Haiyan survivors stormed a government-owned rice warehouse seeking food supplies.</p><p>The Philippines National Food Authority said police and soldiers stood by helpless as people streamed into the warehouse in Alangalang, Leyte province – an area where hunger and desperation are running high after Haiyan made landfall early on Friday morning, ravaging vast swaths of Leyte and Samar islands. The security forces could only watch as more than 100,000 sacks of rice were carried away. </p><p>The eight were crushed to death when a wall in the warehouse collapsed, spokesman Rex Estoperez told the Associated Press. Other rice warehouses were dotted around the region, he said, refusing to give their locations for security reasons.</p><p>The Philippines government has come under fire for failing to deliver aid adequately or quickly enough, with growing frustration in the hardest hit areas, such as Tacloban, the capital of Leyte province where dead bodies have piled up on the streets and residents have resorted to looting to find food.</p><p>A military official told the Guardian on Wednesday that the government was aiming to double its relief efforts within the next two days. Attempts to provide help were buoyed by the expected arrival of two extra US military C-130 planes and one additional Australian air force plane.</p><p>Three relief distribution points were being set up in the Leyte island towns of Tacloban, Guiuan and Ormoc, the official said, with the main aid effort operating out of neighbouring Cebu instead of Manila, the capital, which is 360 miles to the north.</p><p>More than 10,000 people are feared to have been killed in the Philippines due to Haiyan, most of them in Leyte province, with aid workers suggesting that number may rise significantly. As many as 29 municipalities have still not been reached due to impassable roads and downed telecommunications. </p><p>President Benigno Aquino III said on Tuesday that he believed the number killed to be far lower – around 2,500 – and told CNN that the 10,000 figure may have come from an \"emotional\" official, with government figures alleging that the death toll stands at 2,275. The UN has said more than 670,000 people have been displaced and a total of 11.3 million people directly affected by the super storm.</p><p>International relief efforts intensified with the launch of a UN appeal and the dispatch of American, British and Japanese troops to the affected regions. But minimal amounts of aid have reached the worst‑hit areas.</p><p>More than 3,000 people surged on to the tarmac of Tacloban airport on Tuesday morning in the hope of flying out on the two Philippine air force planes that had just arrived.</p><p>Babies and sick or elderly people were given priority but only a few hundred were able to leave. Others were held back by soldiers and police. Many had walked for hours and camped at the base overnight.</p><p>\"I was pleading with the soldiers. I was kneeling and begging because I have diabetes,\" said Helen Cordial as she lay on a stretcher, shaking. \"Do they want me to die in this airport? They are stone-hearted,\" she told the Associated Press.</p><p>Dean Smith, an Australian who has been living with his family near Palo, Leyte province, for the last five years, told the Guardian that he waited eight hours to be able to get one of the first commercial flights out of Tacloban to Cebu. On the way to the airport he said he saw \"horrifying things that I know I have seen but my brain hasn't processed yet\". </p><p>He described scenes of chaos in the city centre, where police were stealing money from the local cashpoints, people in cars were refusing to drive the injured to get help, and the bloated body of a man floating in dirty water was being gnawed at by a dog.</p><p>\"What people have gone through, what they have seen – there is going to be a lot of post-traumatic stress after this event I assure you,\" he said shakily. \"No one has ever seen anything like this.\"</p><p>Having arrived on Tuesday in Cebu, Smith was planning to stock up on food, medicine and water and take it back to his Palo home, where his wife, six children, a 92-year-old grandmother and a pregnant nanny were all desperately awaiting supplies. He departed for Tacloban early on Wednesday morning.</p><p>Domestic and international relief efforts were being hampered by wet weather, poor communications and damaged infrastructure, with aircraft only able to land in Tacloban during daylight hours because the air control tower had been destroyed by Haiyan. Unsubstantiated reports of aid convoys being attacked by hungry victims circulated, with the Telegraph reporting that communist rebels had been killed whilst <a href=\"http://www.telegraph.co.uk/news/worldnews/asia/philippines/10445615/Typhoon-Haiyan-aid-convoys-come-under-fire-as-relief-operation-becomes-logistical-nightmare.html\">trying to intercept a Red Cross convoy</a> destined for the island of Samar.</p><p>Still, Corizon Soliman, secretary of the Philippine department of social welfare and development, said aid had so far reached a third of the city's 45,000 families.</p><p>However armed forces spokesman Ramon Zagala told the BBC that relief workers were struggling to deliver aid for a number of reasons.</p><p>\"The area is very vast and the number of helicopters – although we have a lot of helicopters at the moment – it's really a challenge for us to bring [aid] to all the places and [bring] the number of goods that are needed.\"</p><p>The BBC quoted a Leyte official as saying that although relief goods like medicine and equipment were arriving into the province \"it's just not reaching the people affected\".</p><p>The UN released $25m (£15.7m) in emergency funds for shelter materials and household items, and for assistance with emergency health services, safe water supplies and sanitation.</p><p>The UN aid chief, Valerie Amos, launched an appeal for $300m as she arrived in Manila. \"We have deployed specialist teams, vital logistics support and dispatched critical supplies but we have to do more and faster,\" she said.</p><p>The US, Britain, Japan, Australia and other nations have pledged tens of millions of dollars in immediate aid, and some businesses have also offered help: banking group HSBC announced a $1m (£630,000) cash donation.</p><p>In Tacloban shops were stripped of food and water by hungry residents. While some tents had arrived, the widespread damage left many people sleeping in the ruins of their homes or under shredded trees.</p><p>Military doctors at a makeshift clinic at the airport said they had treated about 1,000 people for cuts, bruises and deep wounds but did not have enough medical supplies.</p><p>\"It's overwhelming,\" said Antonio Tamayo, an air force captain. \"We need more medicine. We can't give anti-tetanus vaccine shots because we have none.\"</p><p>The typhoon flattened Basey, a seaside town in Samar province about six miles across a bay from Tacloban. About 2,000 people were missing there, its governor said. Rescue and relief workers were yet to reach many of the more remote areas.</p><p>\"There are hundreds of other towns and villages stretched over thousands of kilometres that were in the path of the typhoon and with which all communication has been cut,\" said Natasha Reyes, emergency co-ordinator in the Philippines at Médecins Sans Frontières. \"No one knows what the situation is like in these more rural and remote places, and it's going to be some time before we have a full picture.\"</p><p>Damage to communications left the armed forces struggling to reach local authorities and many officials were dead, missing or trying to protect their own families.</p><p>\"Basically the only branch of government that is working here is the military,\" Ruben Guinolbay, a Philippine army captain, told Reuters in Tacloban. \"That is not good. We are not supposed to take over government.\"</p><p>The interior secretary, Manuel Roxas, said on Tuesday that only 20 of Tacloban's 293 police had arrived for work. But he added: \"Today we have stabilised the situation. There are no longer reports of looting. The food supply is coming in. Up to 50,000 food packs are coming in every day, with each pack able to feed up to a family of five for three days.\"</p><p>A team of British medical experts and the first consignment of aid from the UK was leaving for the Philippines, David Cameron said on Tuesday.</p><p>The UK surgical team, led by Anthony Redmond, Manchester University professor of international emergency medicine, includes three emergency physicians, two orthopaedic surgeons, a plastic surgeon, two accident and emergency nurses, a theatre nurse, two anaesthetists and one specialist physiotherapist.</p><p>The USS George Washington aircraft carrier, transporting about 5,000 sailors and more than 80 aircraft, plus four other US navy ships, should arrive in two to three days, the Pentagon said.</p><p>Britain's HMS Daring, a warship with equipment to make drinking water from seawater, and a military transport aircraft should arrive around the same time.</p><p>Japan is sending a team of 40 from its self-defence force.</p><p>Aquino has declared a state of national calamity, allowing the central government to release emergency funds more quickly and impose price controls.</p><p>Initial estimates of the cost of the damage vary widely, with a report from German-based CEDIM Forensic Disaster Analysis putting the total at anywhere from $8bn to $19bn.</p><!-- Guardian Watermark: internal-code/content/422353950|2013-11-13T15:50:01Z|7325428a23f22798381e4da038c16d690f93c266 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbgx",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+        "wordcount":"1488",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"world/typhoon-haiyan",
+        "type":"keyword",
+        "webTitle":"Typhoon Haiyan",
+        "webUrl":"http://www.theguardian.com/world/typhoon-haiyan",
+        "apiUrl":"http://content.guardianapis.com/world/typhoon-haiyan",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/philippines",
+        "type":"keyword",
+        "webTitle":"Philippines",
+        "webUrl":"http://www.theguardian.com/world/philippines",
+        "apiUrl":"http://content.guardianapis.com/world/philippines",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/natural-disasters",
+        "type":"keyword",
+        "webTitle":"Natural disasters and extreme weather",
+        "webUrl":"http://www.theguardian.com/world/natural-disasters",
+        "apiUrl":"http://content.guardianapis.com/world/natural-disasters",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/asia-pacific",
+        "type":"keyword",
+        "webTitle":"Asia Pacific",
+        "webUrl":"http://www.theguardian.com/world/asia-pacific",
+        "apiUrl":"http://content.guardianapis.com/world/asia-pacific",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"world/world",
+        "type":"keyword",
+        "webTitle":"World news",
+        "webUrl":"http://www.theguardian.com/world/world",
+        "apiUrl":"http://content.guardianapis.com/world/world",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"profile/taniabranigan",
+        "type":"contributor",
+        "webTitle":"Tania Branigan",
+        "webUrl":"http://www.theguardian.com/profile/taniabranigan",
+        "apiUrl":"http://content.guardianapis.com/profile/taniabranigan",
+        "bio":"<p>Tania Branigan is <a href=\"http://www.guardian.co.uk/world/china\">China correspondent</a> for the Guardian</p>",
+        "rcsId":"GNL004773",
+        "r2ContributorId":"16507",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2007/09/28/tania_branigan_140x140.jpg",
+        "references":[]
+      },{
+        "id":"profile/kate-hodal",
+        "type":"contributor",
+        "webTitle":"Kate Hodal",
+        "webUrl":"http://www.theguardian.com/profile/kate-hodal",
+        "apiUrl":"http://content.guardianapis.com/profile/kate-hodal",
+        "r2ContributorId":"47767",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422364488",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384316630825/Soldiers-help-a-woman-who-005.jpg",
+          "typeData":{
+            "source":"AP",
+            "photographer":"Bullit Marquez",
+            "altText":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban",
+            "height":"84",
+            "credit":"Bullit Marquez/AP",
+            "caption":"Soldiers help a woman who collapsed while trying to board an evacuation plane out of Tacloban. Photograph: Bullit Marquez/AP",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-video-422358527",
+        "relation":"body",
+        "type":"video",
+        "assets":[{
+          "type":"video",
+          "mimeType":"video/m3u8",
+          "file":"http://cdn.theguardian.tv/ad/2013/11/13/131113airport_FromGAus/131113airport_FromGAus.m3u8",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/mp4",
+          "file":"http://cdn.theguardian.tv/mainwebsite/2013/11/13/131113airport_FromGAus-16x9.mp4",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:large",
+          "file":"http://cdn.theguardian.tv/3gp/large/2013/11/13/131113airport_FromGAus_3gpLg16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        },{
+          "type":"video",
+          "mimeType":"video/3gpp:small",
+          "file":"http://cdn.theguardian.tv/3gp/small/2013/11/13/131113airport_FromGAus_3gpSml16x9.3gp",
+          "typeData":{
+            "source":"Reuters",
+            "embeddable":"false",
+            "blockAds":"false",
+            "thumbnailImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321669186/Typhoon-survivors-prepare-002.jpg",
+            "height":"360",
+            "durationMinutes":"1",
+            "stillImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/13/1384321673788/Typhoon-survivors-prepare-004.jpg",
+            "width":"480",
+            "durationSeconds":"41"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "sectionId":"travel",
+      "sectionName":"Travel",
+      "webPublicationDate":"2013-11-13T14:06:00Z",
+      "webTitle":"Top 10 budget restaurants and cafes in central London",
+      "webUrl":"http://www.theguardian.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "apiUrl":"http://content.guardianapis.com/travel/2013/nov/13/top-10-budget-restaurants-central-london-soho",
+      "fields":{
+        "trailText":"<p>Updating his last budget eats guide to central London, Tony Naylor discovers that, particularly in and around Soho, the capital is home to a thriving casual dining scene</p>",
+        "headline":"Top 10 budget restaurants and cafes in central London",
+        "body":"<h2>Koshari Street</h2><p>Koshari is an Egyptian snack food, a warm mix of rice, chickpeas and macaroni, topped with fresh tomato sauce, sold from street stalls and hole-in-the-wall takeaways. Koshari Street – a tiny, slick canteen with limited counter seating – serves Lebanese cook and food writer Anissa Helou's take on this Cairo classic, which she has jazzed-up with toasted vermicelli, crispy, caramelised onions, garlic sauce and an aromatic sprinkling of mixed nuts, herbs and spices. The &quot;hot&quot; tomato sauce is a little meek (there is also a &quot;mad&quot; version to try), but the filling koshari offers layers of bright, interesting flavours. Thanks to that secret doqqa spice mix, you get a heady whiff of something exotic each time you exhale. <br />• <em>Koshari from &pound;4.50, salads, soups and wraps from &pound;2.95. 56 St Martin's Lane WC2, 020-7836 1056, </em><a href=\"http://www.kosharistreet.com/\" title=\"\"><em>kosharistreet.com</em></a></p><h2>Honey &amp; Co.</h2><figure data-media-id=\"gu-image-422397456\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg\" alt=\"Honey &amp; Co Cafe, Soho, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption>Photograph: Heloise Faure</figcaption></figure><p>At lunch and dinner, this small, critically acclaimed cafe-restaurant is a little too expensive for the true budget traveller. Instead, slip in at breakfast to try Sarit Packer and Itamar Srulovich's skilful Levantine cooking at sub-&pound;10 prices. The morning menu runs from baked goods (blueberry and sour cream doughnuts; toasted fig, walnut and orange loaf), to pizza-like lahma breads topped with, for instance, spiced lamb, tahini and pine nuts. There is usually an ijje (herb and feta) frittata on the menu, too. A merguez sausage roll was excellent: the pastry light and buttery, the two spicy lamb sausages nicely moistened by a base slather of vivid tomato sauce. On the side, a dollop of sweetly perfumed harissa added colour and, even at this time of day, you get a little complimentary bowl of chopped tomatoes, tiny hot green guindilla peppers and amazing kalamata olives, as sweet as they are salty and sour.<br />• <em>Breakfast, &pound;3–&pound;6. 25a Warren Street W1, 020-7388 6175,</em><a href=\"http://honeyandco.co.uk/\" title=\"\"><em> honeyandco.co.uk</em></a></p><h2>Attendant</h2><figure data-media-id=\"gu-image-422397457\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg\" alt=\"Attendant cafe-restaurant, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption>Photograph: Ming Tang-Evans</figcaption></figure><p>With its blaring music and old copies of The Face left about as reading material, there will be plenty of people who find Attendant too cool for school. And that is before we get to the quirky fact that this subterranean space was once a public toilet. You eat and drink at tiny counters built into an ornate Victorian urinal. Which would be painfully trendy, were Attendant's food and its artisan coffee (Caravan beans, Jersey cows' milk) not as good as they are. It's all relatively simple stuff: almond milk porridge and croissants at breakfast; soup, hot deli sandwiches, salads and Bittersweet bakery cakes at lunch. However, the ingredients used are first-rate and it's all rendered with a quiet flair. A breakfast muffin of Montgomery cheddar souffl&eacute; (actually, more a flattened omelette) was exemplary in its detail. Dressed with oven-roasted tomatoes, buttery pan-fried mushrooms and fresh baby spinach, every element tasted vibrantly of itself. That shouldn't be a surprise, but it is. <br /><em>• Sandwiches and hot dishes around &pound;3–&pound;5.50. 27a Foley Street W1, 020-7637 3794, </em><a href=\"http://www.the-attendant.com/\" title=\"\"><em>the-attendant.com</em></a></p><h2>Scandinavian Kitchen<br /></h2><figure data-media-id=\"gu-image-422397458\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg\" alt=\"Scandinavian kitchen, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>This specialist Scandi food store and cafe offers what can only be described as a smorgasbord of food to eat-in or takeaway. You can start your morning with toasted sourdough sandwiches, a smoked salmon and egg roll, or a Nordic rye and oat porridge that will put hairs on your chest. Then, for lunch, the kitchen dishes up numerous varieties of mix 'n' match wraps and open sandwiches (tiny, moreish meatballs in a sweet, sharp beetroot cream; smoked mackerel with fennel and crushed peas), accompanied by various salads. These might include new potatoes in a dill vinaigrette, or sharp, spritzy shredded white cabbage and oregano. The portions don't look huge, but, rest assured, those dark, heavy Scandinavian breads will fill you up. Of course, the cardamom-spiked kanelbullar swirls, sticky with cinnamon jam, are excellent; as are the smiley, eager-to-please staff. <br />• <em>Breakfast &pound;2.25–&pound;4.50, lunch &pound;2.95–&pound;9.95. 61 Great Titchfield Street W1, 020-7580 7161,</em><a href=\"http://www.scandikitchen.co.uk/\" title=\"\"><em> scandikitchen.co.uk</em></a></p><h2>Honest Burger</h2><figure data-media-id=\"gu-image-422397459\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg\" alt=\"Honest Burger\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>Made from 35-day aged beef (sourced from ace butcher the Ginger Pig), these thick patties – and Honest Burger's salty, rosemary-flecked, skin-on chips – are legendary across London. Arrive early to grab a seat or, if you're looking to keep the cost down, takeaway and dodge the queues altogether. At &pound;9.50, the eponymous Honest burger may sound expensive, but this is the sort of profoundly beefy burger – charred with a sensational crust on the outside, but still juicy and pink within – that will live long in the memory. It is complemented by a not overly sweet caramelised onion jam; dill-and-mustard-seed pickled cucumber; and superb thick-cut smoked bacon. <br />• <em>Beef burger and chips from &pound;8. 4a Meard Street W1, 020-3609 9524, </em><a href=\"http://honestburgers.co.uk/\" title=\"\"><em>honestburgers.co.uk</em> </a></p><h2>Foxcroft &amp; Ginger<br /></h2><figure data-media-id=\"gu-image-422397460\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg\" alt=\"Foxcroft and Ginger, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>With its utilitarian, white-tiled interior, hip music and good coffee, F&amp;G is quintessential modern Soho. A basement bakery keeps the counter filled with fantastic cakes (rich, ganache-like chocolate brownies are particularly brilliant, &pound;1.70), and breads that are used at lunch for &quot;saucy buns&quot;, filled with, for instance, slow-cooked pork, jalapenos, smoky tomatoes and mozzarella, or buttermilk fried chicken with avocado and garlic mayonnaise. My shredded beef and cheddar bun could have done with more of the advertised beef juices, but it was tasty enough. There are gourmet salads (such new potato with roasted lemon and radicchio), sandwiches and frittatas available and, in the evening, Foxcroft serves sourdough pizzas with innovative toppings.<br />• <em>Breakfast/weekend brunch, &pound;2.80–&pound;9.50, lunch &pound;3.50–&pound;6.50, pizzas from &pound;4.95. 3 Berwick Street W1, 020-3602 3371,</em><a href=\"http://foxcroftandginger.co.uk/\" title=\"\"><em> foxcroftandginger.co.uk</em></a></p><h2>Pizza Pilgrims</h2><figure data-media-id=\"gu-image-422397461\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg\" alt=\"Pizza Pilgrims, Soho, London\" width=\"460\" height=\"277\" class=\"gu-image\" /><figcaption>Photograph: Paul Winch-Furness</figcaption></figure><p>The gilded rise of brothers Thom and James Elliot, from street food sensations to proper restaurateurs (of course, they already have a glossy cookbook out), may rankle with those who, romantically, regard street food as eating's punk rock: a matter of grassroots passion, not a career. However, it is difficult to carp when, thanks to the Elliots, you can now takeaway A1 pizza, in the middle of Soho, from &pound;6. Whichever way you slice it, that has to be a good thing. Pilgrims' bases are somewhat thicker and softer than you might expect, yet blackened with patches of delicious char. Toppings run to the spicy Calabrian 'nduja, fennel sausage, portobello mushrooms and truffle, but the house-blitzed San Marzano plum tomato sauce is so vibrant it will, finally, make you understand why the Neapolitans love a cheese-free marina pizza. On a sunny day, take your pizza around the corner into the Soho Square gardens.<br />Pizza lovers should note that, at the time of writing, the renowned (and, for my money, marginally better)<a href=\"http://francomanca.co.uk\" title=\"\"> Franco Manca</a> were about to open a site on nearby Tottenham Court Road. <br />• <em>From &pound;6 takeaway, &pound;7 eat-in. 11 Dean Street W1, 020-7287 8964, </em><a href=\"http://pizzapilgrims.co.uk/\" title=\"\"><em>pizzapilgrims.co.uk</em></a></p><h2>Chettinad<br /></h2><figure data-media-id=\"gu-image-422397462\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg\" alt=\"Chettinad lunch box, London\" width=\"460\" height=\"276\" class=\"gu-image\" /><figcaption></figcaption></figure><p>When discussing tasty, affordable curry in central London, two venues come up again and again: the canteen at the Indian YMCA (41 Fitzroy Square, W1) and the &pound;6.95 daily buffet at Diwana Bhel Poori, close to Euston station (121-123 Drummond Street, NW1, 020-7387 5556). For the ultimate in budget dining, however, neither can compete with the take-out, lunch-box deal at Tamil restaurant Chettinad. Served in a moulded, airline-style tray, it comprises a nibbly starter, three curries, raita, a roti and rice, for &pound;3.75 (vegetarian) or &pound;3.95 (meat). No, that isn't a typo. That is a full meal for under four quid. Impressively studded with fresh herbs and spices, a couple of tiny, lukewarm bhajis were a bit tough and leathery, but rest of the food was remarkable for the money. The rice had been winningly mined with cashew nuts, lentils and mustard seeds and, like the best south Indian food, the curries were restrained in their heat, allowing well-rounded flavour to shine through. On a cold day, a melting, slow-cooked chickpea curry in a rich tomato sauce was first-rate comfort food. Note: you can eat-in and takeaway for under &pound;10 in the evening, too.<br />• <em>Lunch box from &pound;3.75, takeaway, eat-in lunch &pound;6.95. Evening curries with shared rice,from around &pound;8. 16 Percy Street W1, 020-3556 1229, </em><a href=\"http://chettinadrestaurant.com/\" title=\"\"><em>chettinadrestaurant.com</em></a></p><h2>Bi Bim Bap<br /></h2><figure data-media-id=\"gu-image-422397463\"><img src=\"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg\" alt=\"Bi Bim Bap Soho \" width=\"460\" height=\"277\" class=\"gu-image\" /><figcaption></figcaption></figure><p>Served in blisteringly hot stone bowls, which cook the ingredients as you eat, bibimbap is a Korean mixed-rice dish of seemingly endless variations. One of which is catching on in central London, too. Bi Bim Bap has just opened a second site in Fitzrovia, in addition to its Soho original. My traditional dol sot, a mixed vegetable version with mooli, daikon, spinach and more, was surprisingly tasty, a fried egg giving it a lovely creamy texture. You can add sinus-clearing gochujang chilli sauce as you go. The staff will happily explain the intricacies of all this to any bibimbap virgins. <br />• <em>Bi Bim Bap from &pound;6.45–&pound;9.95. Branches at 11 Greek Street and 10 Charlotte Street W1, 020-7287 3434, </em><a href=\"http://www.bibimbaplondon.com/\" title=\"\"><em>bibimbaplondon.com</em></a></p><h2>Banh Mi Bay<br /></h2><p>The Theobalds Road branch has a slightly weird farmhouse kitchen look (as if set-up for a modern British tea room, rather than a busy Vietnamese cafe), but the Bay's food hits the mark. Behind the counter, a huge grill keeps the meats coming for bun salads and banh canh soups, both made using homemade noodles. They also server creditable banh mi, Vietnamese baguette sandwiches, which aren't the best in London – you'll have to go further east for that – but are authentically lighter than their French cousins; the meats deliver good flavours and, crucially, the shavings of pickled carrot and mooli are sharp enough to jangle your taste buds. Elsewhere, the menu runs from a six-hour simmered pho to savoury banh xeo pancakes. <br />• <em>Takeaway banh mi, &pound;4.35, noodle dishes and rice boxes from &pound;5.50. Branches at 4-6 Theobalds Road, Holborn, WC1, 020-7831 4079, and 21 Rathbone Street W1, 020-3609 4830, </em><a href=\"http://banhmibay.co.uk/\" title=\"\"><em>banhmibay.co.uk</em></a></p><p>• <em>Travel between Manchester and London was provided by </em><a href=\"http://virgintrains.co.uk/\" title=\"\"><em>Virgin Trains</em></a></p><!-- Guardian Watermark: internal-code/content/422388356|2013-11-13T15:50:01Z|4631bb312ce31beccd20be6f5f8f1461335ce0e5 -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kbp6",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+        "wordcount":"1573",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"travel/london",
+        "type":"keyword",
+        "webTitle":"London",
+        "webUrl":"http://www.theguardian.com/travel/london",
+        "apiUrl":"http://content.guardianapis.com/travel/london",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/travel/restaurants",
+        "apiUrl":"http://content.guardianapis.com/travel/restaurants",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/series/britains-best-budget-eats",
+        "type":"series",
+        "webTitle":"Britain's best budget eats",
+        "webUrl":"http://www.theguardian.com/travel/series/britains-best-budget-eats",
+        "apiUrl":"http://content.guardianapis.com/travel/series/britains-best-budget-eats",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"profile/tonynaylor",
+        "type":"contributor",
+        "webTitle":"Tony Naylor",
+        "webUrl":"http://www.theguardian.com/profile/tonynaylor",
+        "apiUrl":"http://content.guardianapis.com/profile/tonynaylor",
+        "bio":"<p>Tony Naylor lives in the north of England. He likes Greggs pasties, molecular gastronomy and lots of things in between. Outside of filling his face his interests include any licensed establishments, Manchester City, electronic music and some other stuff which could look a bit pretentious in print</p>",
+        "rcsId":"GNL009141",
+        "r2ContributorId":"16542",
+        "bylineImageUrl":"http://static.guim.co.uk/artsblog/authorpics/tony_naylor.jpg",
+        "references":[]
+      },{
+        "id":"travel/travel",
+        "type":"keyword",
+        "webTitle":"Travel",
+        "webUrl":"http://www.theguardian.com/travel/travel",
+        "apiUrl":"http://content.guardianapis.com/travel/travel",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/travelfoodanddrink",
+        "type":"keyword",
+        "webTitle":"Food and drink",
+        "webUrl":"http://www.theguardian.com/travel/travelfoodanddrink",
+        "apiUrl":"http://content.guardianapis.com/travel/travelfoodanddrink",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/food-and-drink",
+        "type":"keyword",
+        "webTitle":"Food & drink",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/food-and-drink",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/food-and-drink",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"travel/uk",
+        "type":"keyword",
+        "webTitle":"United Kingdom",
+        "webUrl":"http://www.theguardian.com/travel/uk",
+        "apiUrl":"http://content.guardianapis.com/travel/uk",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/europe",
+        "type":"keyword",
+        "webTitle":"Europe",
+        "webUrl":"http://www.theguardian.com/travel/europe",
+        "apiUrl":"http://content.guardianapis.com/travel/europe",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/england",
+        "type":"keyword",
+        "webTitle":"England",
+        "webUrl":"http://www.theguardian.com/travel/england",
+        "apiUrl":"http://content.guardianapis.com/travel/england",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"travel/budget",
+        "type":"keyword",
+        "webTitle":"Budget travel",
+        "webUrl":"http://www.theguardian.com/travel/budget",
+        "apiUrl":"http://content.guardianapis.com/travel/budget",
+        "sectionId":"travel",
+        "sectionName":"Travel",
+        "references":[]
+      },{
+        "id":"lifeandstyle/restaurants",
+        "type":"keyword",
+        "webTitle":"Restaurants",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/restaurants",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/restaurants",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397454",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349264516/Koshari-Street-London-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Koshari Street's twist on Egyptian street food",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397455",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349258129/Koshari-Street-London-003.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Koshari Street, London",
+            "height":"84",
+            "credit":"PR",
+            "caption":"Koshari Street, London",
+            "width":"140"
+          }
+        }]
+      },{
+        "id":"gu-image-422397456",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342200655/Honey--Co-Cafe-Soho-Londo-008.jpg",
+          "typeData":{
+            "source":"Heloise Faure",
+            "photographer":"Heloise Faure",
+            "altText":"Honey & Co Cafe, Soho, London",
+            "height":"276",
+            "credit":"Heloise Faure/Heloise Faure",
+            "caption":"Photograph: Heloise Faure",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397457",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342333173/Attendant-cafe-restaurant-008.jpg",
+          "typeData":{
+            "source":"Ming Tang-Evans",
+            "photographer":"Ming Tang-Evans",
+            "altText":"Attendant cafe-restaurant, London",
+            "height":"276",
+            "credit":"Ming Tang-Evans/Ming Tang-Evans",
+            "caption":"Photograph: Ming Tang-Evans",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397458",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342518921/Scandinavian-kitchen-Lond-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Scandinavian kitchen, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397459",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349089666/Honest-Burger-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Honest Burger",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397460",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384349181239/Foxcroft-and-Ginger-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Foxcroft and Ginger, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397461",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342133649/Pizza-Pilgrims-Soho-Londo-001.jpg",
+          "typeData":{
+            "source":"Paul Winch-Furness",
+            "photographer":"Paul Winch-Furness",
+            "altText":"Pizza Pilgrims, Soho, London",
+            "height":"277",
+            "credit":"Paul Winch-Furness/Paul Winch-Furness",
+            "caption":"Photograph: Paul Winch-Furness",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397462",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384342684114/Chettinad-lunch-box-Londo-008.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Chettinad lunch box, London",
+            "height":"276",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397463",
+        "relation":"body",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Travel/Pix/pictures/2013/11/13/1384347265434/Bi-Bim-Bap-Soho--001.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Bi Bim Bap Soho ",
+            "height":"277",
+            "credit":"PR",
+            "width":"460"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "sectionId":"commentisfree",
+      "sectionName":"Comment is free",
+      "webPublicationDate":"2013-11-12T15:43:09Z",
+      "webTitle":"Jennifer Lawrence is striking a blow for healthy, sweaty women | Muireann Carey-Campbell",
+      "webUrl":"http://www.theguardian.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "apiUrl":"http://content.guardianapis.com/commentisfree/2013/nov/12/jennifer-lawrence-strong-healthy-sweaty-women",
+      "fields":{
+        "trailText":"<p><strong>Muireann Carey-Campbell:</strong> Shock, horror – a female film star says she wants to be 'fit and strong'. But the more women she gets into the gym the better</p>",
+        "headline":"Jennifer Lawrence is striking a blow for healthy, sweaty women",
+        "body":"<p>Glancing at gossip mags while waiting in the queue at the supermarket suggests that women have just two body types: grossly overweight (which is seemingly anything over a size 12) or skinny and boney. So when Jennifer Lawrence, current heroine of Hollywood and legend among outspoken women everywhere, says that she wants to be <a href=\"http://abcnews.go.com/blogs/entertainment/2012/11/jennifer-lawrence-considered-a-fat-actress/\" title=\"\">\"fit and strong\"</a>, it is music to our ears. Finally, recognition of another option.</p><p>On Newsnight, speaking of playing Katniss Everdeen in the Hunger Games, Lawrence said that she refused to lose weight for roles, explaining: \"We have the ability to control this image that young girls are going to be seeing. They see enough of this body that they will never be able to obtain and it's an amazing opportunity to rid ourselves of that in this industry.\"</p><p>Sure, it's silly that a body type should even need celebrity endorsement, but what Lawrence has done here is a pretty rare thing among her peers. Various female celebrities will trot out similar lines in what come across as weak Kumbaya moments, where womankind should all join hands and rejoice. Rarely though, do we ever hear high-profile women say they want to look healthy.</p><p>For those of us who lead active lifestyles, we've been flying this flag for a long time. Historically, it's been deemed rather unladylike to sweat, making exercise somewhat of a problem, lest we get a little red faced or our hair get dishevelled. Women have been ushered towards gentler forms of exercise – a spot of yoga, a cheesy Jane Fonda DVD, or if we want to go a bit crazy, some Zumba.</p><p>But the tide has been slowly turning. More and more women are shirking the idea that you're either sporty or not, and experimenting with different ways to stay active. We're pushing the boundaries of what it means to be feminine and fit. We're running ultra marathons, skateboarding, doing Muay Thai and, sorry to upset the apple cart here guys, but we're sweating profusely while doing it. What's more we're not exercising with vanity in mind. A survey of visitors to my fitness website <a href=\"http://spikesandheels.com/\" title=\"\">Spikes &amp; Heels</a> revealed that barely any of the women working out regularly did so for weight loss reasons. The majority cited overall health, fitness and mental wellbeing as their driving force.</p><p>I particularly appreciate that Lawrence mentioned she wants to be strong. Any woman with an ounce of common sense has figured out that the \"lifting weights makes you bulky\" school of thought is utter nonsense. Women are becoming less fearful of the weights section in the gym and are squatting and deadlifting their way to greatness.</p><p>The <a href=\"http://www.theguardian.com/lifeandstyle/2013/nov/03/thigh-gap-pressure-point-women-self-esteem\" title=\"\">\"thigh gap\" brigade</a> on Tumblr – legions of young women whose mission in life is to be so thin as to see a space between the tops of their legs – have come up against a new breed of fit chicks. The \"Strong is the new Sexy\" crowd post photos of women with defined muscles and six packs, doing pull ups while glistening with sweat (they all still have perfect hair and makeup though – I'm not saying that this movement isn't without its flaws).</p><p>Jennifer Lawrence's comments couldn't have come at a better time. With levels of inactivity at an all-time high in this country, having someone in her position championing being fit and strong may be just the boost a young woman needs to make a change. Make your way to the weights section, ladies.</p><!-- Guardian Watermark: internal-code/content/422307757|2013-11-13T15:50:01Z|fdae8da322868f19a7318c2815da07b886ce1198 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kb44",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+        "wordcount":"572",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"commentisfree/commentisfree",
+        "type":"blog",
+        "webTitle":"Comment is free",
+        "webUrl":"http://www.theguardian.com/commentisfree/commentisfree",
+        "apiUrl":"http://content.guardianapis.com/commentisfree/commentisfree",
+        "sectionId":"commentisfree",
+        "sectionName":"Comment is free",
+        "references":[]
+      },{
+        "id":"film/jennifer-lawrence",
+        "type":"keyword",
+        "webTitle":"Jennifer Lawrence",
+        "webUrl":"http://www.theguardian.com/film/jennifer-lawrence",
+        "apiUrl":"http://content.guardianapis.com/film/jennifer-lawrence",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"film/film",
+        "type":"keyword",
+        "webTitle":"Film",
+        "webUrl":"http://www.theguardian.com/film/film",
+        "apiUrl":"http://content.guardianapis.com/film/film",
+        "sectionId":"film",
+        "sectionName":"Film",
+        "references":[]
+      },{
+        "id":"lifeandstyle/women",
+        "type":"keyword",
+        "webTitle":"Women",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/women",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/women",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/lifeandstyle",
+        "type":"keyword",
+        "webTitle":"Life and style",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/lifeandstyle",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/lifeandstyle",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/body-image",
+        "type":"keyword",
+        "webTitle":"Body image",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/body-image",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/body-image",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"lifeandstyle/fitness",
+        "type":"keyword",
+        "webTitle":"Fitness",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/fitness",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/fitness",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/society",
+        "type":"keyword",
+        "webTitle":"Society",
+        "webUrl":"http://www.theguardian.com/society/society",
+        "apiUrl":"http://content.guardianapis.com/society/society",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"lifeandstyle/health-and-wellbeing",
+        "type":"keyword",
+        "webTitle":"Health & wellbeing",
+        "webUrl":"http://www.theguardian.com/lifeandstyle/health-and-wellbeing",
+        "apiUrl":"http://content.guardianapis.com/lifeandstyle/health-and-wellbeing",
+        "sectionId":"lifeandstyle",
+        "sectionName":"Life and style",
+        "references":[]
+      },{
+        "id":"society/health",
+        "type":"keyword",
+        "webTitle":"Health",
+        "webUrl":"http://www.theguardian.com/society/health",
+        "apiUrl":"http://content.guardianapis.com/society/health",
+        "sectionId":"society",
+        "sectionName":"Society",
+        "references":[]
+      },{
+        "id":"tone/comment",
+        "type":"tone",
+        "webTitle":"Comment",
+        "webUrl":"http://www.theguardian.com/tone/comment",
+        "apiUrl":"http://content.guardianapis.com/tone/comment",
+        "references":[]
+      },{
+        "id":"profile/muireann-carey-campbell",
+        "type":"contributor",
+        "webTitle":"Muireann Carey-Campbell",
+        "webUrl":"http://www.theguardian.com/profile/muireann-carey-campbell",
+        "apiUrl":"http://content.guardianapis.com/profile/muireann-carey-campbell",
+        "bio":"<p>Muireann Carey-Campbell is a fashion, lifestyle and fitness blogger based in London. She is an advocate for empowering women through exercise and edits <a href-\"http://spikesandheels.com\">spikesandheels.com</a> and <a href=\"http://www./pikesandheels.com\">bangsandabun.com</a></p>",
+        "r2ContributorId":"59569",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384260881751/Muireann-Carey-Campbell.jpg",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422318972",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269380150/Jennifer-Lawrence-with-Jo-001.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"54",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269383552/Jennifer-Lawrence-with-Jo-002.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"130",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269387034/Jennifer-Lawrence-with-Jo-004.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"132",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269388680/Jennifer-Lawrence-with-Jo-005.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"168",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269390391/Jennifer-Lawrence-with-Jo-006.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"180",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269392235/Jennifer-Lawrence-with-Jo-007.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"228",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269394005/Jennifer-Lawrence-with-Jo-008.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"276",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/Lionsgate/Sportsphoto Ltd",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422318973",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384269385251/Jennifer-Lawrence-with-Jo-003.jpg",
+          "typeData":{
+            "source":"Sportsphoto Ltd./Allstar",
+            "photographer":"Allstar/LIONSGATE",
+            "altText":"Jennifer Lawrence with Josh Hutcheson in The Hunger Games",
+            "height":"84",
+            "credit":"Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "caption":"Jennifer Lawrence, pictured with Josh Hutcheson in The Hunger Games, said she refused to lose weight for her film roles. Photograph: Allstar/LIONSGATE/Sportsphoto Ltd./Allstar",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "sectionId":"technology",
+      "sectionName":"Technology",
+      "webPublicationDate":"2013-11-13T11:29:00Z",
+      "webTitle":"PS4: the 10 key launch titles",
+      "webUrl":"http://www.theguardian.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "apiUrl":"http://content.guardianapis.com/technology/2013/nov/13/ps4-10-key-launch-titles-sony-playstation-4",
+      "fields":{
+        "trailText":"<p>As the Sony PlayStation 4's US launch looms, here are the best initial titles, from Killzone: Shadow Fall to Call of Duty: Ghosts. By <strong>Keith Stuart</strong></p>",
+        "headline":"PS4: the 10 key launch titles",
+        "body":"<p>A few days ago, Amazon US posted a photo of its warehouse, stacked high with thousands of PlayStation 4 boxes, ready to ship out to American stores on Friday. At last, the arrival of the next console generation is imminent and palpable. It'll all be about the games from now on. Hopefully.</p><p>So to get us started, here are the 10 key PS4 launch titles – they're the ones we think will sell, or will define the launch period. Actually, some of them are just the ones that interest <em>us</em>. Whatever, have a look and see if you agree...  </p><h2><strong>Assassin's Creed IV Black Flag, Ubisoft</strong></h2><p>Set amid the swashbuckling and treasure pilfering of piracy's golden age, the latest yarn in Ubisoft's historical adventure series is a distinct improvement on the last couple of instalments. Loaded with visually astonishing sea battles, it's a lavish way to start your next-gen career. Plus, the good news for PS4 owners is that this version of the game contains an hour of additional content in the form of three extra missions. There's also an Assassin's IV console bundle, replacing the Drive Club one that's now on hold due to the game's development delay. You'll find a nice walkthrough of some of the single-player game <a href=\"http://youtu.be/jHDfm2AYZS4\">on PlayStation Access</a>.</p><h2><strong>Battlefield 4, Electronic Arts</strong></h2><p>Fantastic multiplayer maps, wonderfully apocalyptic destruction and the tight, taut action we've come to expect from the series, Battlefield 4 is in a commanding position as the top military shooters make the generational crossover. Several retailers are offering Battlefield bundles for Sony's machine, but you'll have to wait for the Second Assault DLC pack – it's a timed exclusive on Xbox One. YouTuber Ali A has some <a href=\"http://youtu.be/alB3t7-bZ-c\">rather nice multiplayer PS4 footage</a>.</p><h2><strong>Call of Duty: Ghosts, Activison</strong></h2><p>Infinity Ward has abandoned the Modern Warfare arc, but its futuristic America-in-peril narrative is hauntingly familiar, while the multiplayer dwells on the same old twitchcore tricks and tactics. This is, however, still a thrilling ride, and running at 1080p in 60 frames-a-second, it looks its absolute best on PS4. As with Battlefield, a timed Xbox One exclusivity deal means the first DLC drop will be delayed on Sony's machine – but you can just spend that time enjoying the superior graphical performance.</p><h2><strong>Contrast, Compulsion Games</strong></h2><p>One of the first indie titles to appear on PS4's digital platform, Contrast is a fascinating 20s-based platformer, following the imaginary friend of a young girl investigating the secrets of her troubled family. With vaudevillian settings, a cool jazz soundtrack and a stylised mix of 2D and 3D visuals, this is a stark contrast to the triple A hits. It's coming later to a bunch of other platforms, but it's worth catching on PS4 from launch.</p><h2><strong>Fifa 14/Madden, EA Sports</strong></h2><p>Okay, I'm cheating – this is two games – but of course, in launch terms these EA Sports blockbusters are doing the same thing. As well as appeasing sports mad gamers, they're providing the state-of-the-art football action for young male professionals who can afford to buy a new machine in order to play one or two games a year – and who invariably choose one of these two titles on an annual basis. Both games are <a href=\"http://www.theguardian.com/technology/gamesblog/2013/sep/02/fifa-14-preview-interview\">enhanced from their current-gen offerings</a> with better animations, AI and stadia – although the Xbox One version adds the Ultimate Team Legends content, with around 40 classic players.</p><h2><strong>Killzone: Shadow Fall, Sony</strong></h2><p>Guerrilla's ice-cold sci-fi blaster has been the PlayStation technical showcase of choice since the second console – and Shadow Fall is definitely a major player this time round too. Taking place 30 years after the last title, the action now plays out on a hostile planet where the Vektans and the Helghast are divided by a huge wall – and either metaphorically or physically, it's about to come crashing down. The game is clearly a graphical marvel, but the grit is beginning to wear thin. </p><h2><strong>Knack, Sony</strong></h2><p>Designed by Mark Cerny, the engineering leader on PS4 and veteran of such games as Sonic 2, Crash Bandicoot and Ratchet and Clank, this is Sony's own family pleaser. It's a colourful action adventure following the eponymous robot who can transform himself into a range of useful objects to defeat invading goblins. Early reports from the specialist press aren't exactly amazing, but the game looks to have plenty of charm and there are some arresting vistas to gaze upon.</p><h2><strong>Lego Marvel Super Heroes, Warner Bros</strong></h2><p>The latest title in the long-running Lego series switches from Batman and his DC pals to Marvel heroes like Hulk, Spider-Man and Wolverine. The formula is ridiculously familiar, but with that rich comic book heritage, some great set-pieces and a few fresh features for PS4, this entertaining adventure just pips Skylanders Swap Force (which also gets a visual overhaul for PS4) as the third-party kid-friendly title to opt for.</p><h2><strong>Resogun, Sony</strong></h2><p>Ah, another frenetic, hypnotic shooter from Super Stardust creator Housemarque, this time in a rotating 2D environment buzzing with laser blasts, eye-popping explosions and blazing score multipliers. It's got missiles, it's got nova-bombs and it'll be free for users who subscribe to the PlayStation Plus online gaming service. Until Xbox One gets a new Geometry Wars, this is the place to come for next-gen schmup action.</p><h2><strong>Super Motherload, XGen Studios</strong></h2><p>Another indie download, this time a procedurally generated digging sim with four-player co-op. Set on a colonised future Mars, the aim is to burrow deep under the planet's surface, grabbing minerals and bringing them to the surface for cash and experience points, which can be spent on customising your craft. Developed by Edmonton-based XGen Studios, it's sort of an RPG-infused version of brilliant platformer Spelunky, with some Mr Driller (the classic Namco arcade/Dreamcast puzzler) chucked in. This is a good thing.</p><p>• <a href=\"http://www.theguardian.com/technology/2013/oct/31/ps4-sony-playstation-cant-play-audio-cds-mp3s\">PS4: five new things we've learned</a><br />• <a href=\"http://www.theguardian.com/technology/2013/nov/11/playstation-four-makes-debut\">Sony has high hopes for PlayStation 4's debut this month</a><br />• <a href=\"http://www.theguardian.com/technology/2013/nov/06/ps4-or-xbox-one-parents-guide\">PS4 or Xbox One? A parent's guide</a></p><!-- Guardian Watermark: internal-code/content/422302794|2013-11-13T15:50:01Z|3f2953ddc61ff43a6885f069a3700a7ba75a7aba -->",
+        "hasStoryPackage":"false",
+        "shortUrl":"http://gu.com/p/3kb3x",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+        "wordcount":"964",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"technology/playstation-4",
+        "type":"keyword",
+        "webTitle":"PlayStation 4",
+        "webUrl":"http://www.theguardian.com/technology/playstation-4",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation-4",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/playstation",
+        "type":"keyword",
+        "webTitle":"PlayStation",
+        "webUrl":"http://www.theguardian.com/technology/playstation",
+        "apiUrl":"http://content.guardianapis.com/technology/playstation",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/sony",
+        "type":"keyword",
+        "webTitle":"Sony",
+        "webUrl":"http://www.theguardian.com/technology/sony",
+        "apiUrl":"http://content.guardianapis.com/technology/sony",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/games",
+        "type":"keyword",
+        "webTitle":"Games",
+        "webUrl":"http://www.theguardian.com/technology/games",
+        "apiUrl":"http://content.guardianapis.com/technology/games",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"technology/technology",
+        "type":"keyword",
+        "webTitle":"Technology",
+        "webUrl":"http://www.theguardian.com/technology/technology",
+        "apiUrl":"http://content.guardianapis.com/technology/technology",
+        "sectionId":"technology",
+        "sectionName":"Technology",
+        "references":[]
+      },{
+        "id":"profile/keithstuart",
+        "type":"contributor",
+        "webTitle":"Keith Stuart",
+        "webUrl":"http://www.theguardian.com/profile/keithstuart",
+        "apiUrl":"http://content.guardianapis.com/profile/keithstuart",
+        "bio":"<p>Keith Stuart is a veteran video game and technology writer, who is also a regular contributor to Edge magazine</p>",
+        "rcsId":"GNL007878",
+        "r2ContributorId":"15953",
+        "bylineImageUrl":"http://static.guim.co.uk/sys-images/Media/Columnists/Columnists/2013/11/8/1383915413362/Keith-Stuart--003.jpg",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"uk/uk",
+        "type":"keyword",
+        "webTitle":"UK news",
+        "webUrl":"http://www.theguardian.com/uk/uk",
+        "apiUrl":"http://content.guardianapis.com/uk/uk",
+        "sectionId":"uk-news",
+        "sectionName":"UK news",
+        "references":[]
+      },{
+        "id":"world/usa",
+        "type":"keyword",
+        "webTitle":"United States",
+        "webUrl":"http://www.theguardian.com/world/usa",
+        "apiUrl":"http://content.guardianapis.com/world/usa",
+        "sectionId":"world",
+        "sectionName":"World news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422388207",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288957309/KZ4_Blast3_main.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"276",
+            "credit":"PR",
+            "caption":"Killzone: Shadow Fall – a graphical showcase for Sony's next-gen PS4 console",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422388208",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/12/1384288970276/KZ4_Blast3_small.jpg",
+          "typeData":{
+            "source":"PR",
+            "altText":"Killzone: Shadow Fall",
+            "height":"84",
+            "credit":"PR",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[]
+    },{
+      "id":"football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "sectionId":"football",
+      "sectionName":"Football",
+      "webPublicationDate":"2013-11-13T13:54:18Z",
+      "webTitle":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+      "webUrl":"http://www.theguardian.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "apiUrl":"http://content.guardianapis.com/football/2013/nov/13/rene-meulensteen-coach-fulham-martin-jol",
+      "fields":{
+        "trailText":"Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol<br />",
+        "headline":"René Meulensteen joins Fulham as head coach to work with Martin Jol",
+        "body":"<p>Fulham have appointed René Meulensteen as head coach to work alongside his fellow Dutchman, the manager Martin Jol.</p><p>Meulensteen worked at Manchester United alongside Sir Alex Ferguson from 2007 to the summer when he left the club following David Moyes's appointment.</p><p>He had been linked with the vacant Crystal Palace job after <a href=\"http://www.theguardian.com/football/2013/nov/13/middlesbrough-real-madrid-aitor-karanka\" title=\"\">Aitor Karanka opted to join Middlesbrough</a> ahead of the south London club.</p><p>The Fulham chief executive officer, Alistair Mackintosh, <a href=\"http://www.fulhamfc.com/news/2013/november/13/meulensteen-arrives\" title=\"\">told the club website</a>: \"We're all delighted to welcome René to Fulham. There was always going to be a battle for René's services and, with the assistance of our chairman Shahid Khan, we've been able to bring one of the best coaches in the world to Fulham.\"</p><p>The move to bring in Meulensteen comes with the club inside the relegation places after 11 games.</p><p>Meulensteen, who will take up the post immediately, said: \"I was impressed by the vision of Shahid Khan and Alistair Mackintosh. I've spent many hours talking with Martin Jol and we share a vision of how football should be played and how players should be developed. It's our job to make sure we can bring this vision to life on the pitch for the fans.\"</p><p>Meulensteen's last job was in Russia in July at Anzhi Makhachkala, who he joined as assistant coach to another Dutchman, Guus Hiddink. However, Hiddink left the club two games into the season after which Meulensteen only lasted 16 days as manager.</p><p>Fulham have lost their last three matches and lie 18th in the league.</p><!-- Guardian Watermark: internal-code/content/422391502|2013-11-13T15:50:01Z|23b2cb358f236f651feef84f2f5293d946ee6c76 -->",
+        "hasStoryPackage":"true",
+        "shortUrl":"http://gu.com/p/3kbqd",
+        "thumbnail":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+        "wordcount":"247",
+        "liveBloggingNow":"false"
+      },
+      "tags":[{
+        "id":"football/martin-jol",
+        "type":"keyword",
+        "webTitle":"Martin Jol",
+        "webUrl":"http://www.theguardian.com/football/martin-jol",
+        "apiUrl":"http://content.guardianapis.com/football/martin-jol",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"football/fulham",
+        "type":"keyword",
+        "webTitle":"Fulham",
+        "webUrl":"http://www.theguardian.com/football/fulham",
+        "apiUrl":"http://content.guardianapis.com/football/fulham",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[{
+          "type":"pa-football-team",
+          "id":"pa-football-team/55"
+        }]
+      },{
+        "id":"football/football",
+        "type":"keyword",
+        "webTitle":"Football",
+        "webUrl":"http://www.theguardian.com/football/football",
+        "apiUrl":"http://content.guardianapis.com/football/football",
+        "sectionId":"football",
+        "sectionName":"Football",
+        "references":[]
+      },{
+        "id":"sport/sport",
+        "type":"keyword",
+        "webTitle":"Sport",
+        "webUrl":"http://www.theguardian.com/sport/sport",
+        "apiUrl":"http://content.guardianapis.com/sport/sport",
+        "sectionId":"sport",
+        "sectionName":"Sport",
+        "references":[]
+      },{
+        "id":"tone/news",
+        "type":"tone",
+        "webTitle":"News",
+        "webUrl":"http://www.theguardian.com/tone/news",
+        "apiUrl":"http://content.guardianapis.com/tone/news",
+        "references":[]
+      },{
+        "id":"type/article",
+        "type":"type",
+        "webTitle":"Article",
+        "webUrl":"http://www.theguardian.com/articles",
+        "apiUrl":"http://content.guardianapis.com/articles",
+        "references":[]
+      }],
+      "elements":[{
+        "id":"gu-image-422397529",
+        "relation":"main",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350779268/Ren--Meulensteen-001.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"54",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"54"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350781955/Ren--Meulensteen-002.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"130",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350783658/Ren--Meulensteen-003.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"84",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"140"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350785345/Ren--Meulensteen-004.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"132",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"220"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350787149/Ren--Meulensteen-005.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"168",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"280"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350788867/Ren--Meulensteen-006.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"180",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"300"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350790688/Ren--Meulensteen-007.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"228",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"380"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/pictures/2013/11/13/1384350792437/Ren--Meulensteen-008.jpg",
+          "typeData":{
+            "source":"Action Images",
+            "photographer":"Henry Browne",
+            "altText":"René Meulensteen",
+            "height":"276",
+            "credit":"Henry Browne/Action Images",
+            "caption":"René Meulensteen enjoyed considerable success with Sir Alex Ferguson at Manchester United. Photograph: Henry Browne/Action Images",
+            "width":"460"
+          }
+        },{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351652017/Martin-Jol-011.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"276",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by the newly appointed head coach René Meulensteen (right) at Fulham. Photographs: PA",
+            "width":"460"
+          }
+        }]
+      },{
+        "id":"gu-image-422397530",
+        "relation":"thumbnail",
+        "type":"image",
+        "assets":[{
+          "type":"image",
+          "mimeType":"image/jpeg",
+          "file":"http://static.guim.co.uk/sys-images/Sport/Pix/columnists/2013/11/13/1384351642890/Martin-Jol-006.jpg",
+          "typeData":{
+            "source":"PA",
+            "altText":"Martin Jol",
+            "height":"84",
+            "credit":"PA",
+            "caption":"Martin Jol will be assisted by new head coach René Meulensteen (right) at Fulham. Photograph: PA",
+            "width":"140"
+          }
+        }]
+      }],
+      "references":[{
+        "type":"pa-football-team",
+        "id":"pa-football-team/55"
+      }]
+    }],
+    "storyPackage":[]
+  }
+}


### PR DESCRIPTION
Many aeons ago we decided that curated story packages (trailblocks) should be sorted by publication date and not the source order that comes out of the content api. 

Our current thinking is that this decision was wrong and we should in fact adhere to the authors intended ordering.

This PR removes the ordering for story packages but maintains it for related content queries.

/cc @gklopper @ironsidevsquincy @rich-nguyen 
