### PR TITLE
Introducing rem mixin and function

### DIFF
--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -7,23 +7,16 @@
 
 // Transform a value into rem
 // Assuming baseline is set to 10px on :root/html
-@function rem($value, $baseline: 10) {
-    @return strip-unit($value) / $baseline + rem;
-}
-
-// Converts a list of values into rem
-@function remCalc($values) {
-    $max: length($values);
-    $remValues: '';
-
-    @for $i from 1 through $max {
-        $value: nth($values, $i);
-        $remValues: #{$remValues + rem($value)};
-        @if $i < $max {
-            $remValues: #{$remValues + " "};
+@function rem($value, $baseline: 10px) {
+    @if type-of($value) == list {
+        $result: ();
+        @each $e in $value {
+            $result: append($result, rem($e));
         }
+        @return $result;
+    } @else {
+        @return if(unit($value) == px, $value / $baseline * 1rem, $value);
     }
-    @return $remValues;
 }
 
 // Output rem units with px fallback

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -1,10 +1,5 @@
 @import "_mq";
 
-// Remove the unit from a number
-@function strip-unit($num){
-    @return $num / ($num * 0 + 1);
-}
-
 // Transform a value into rem
 // Assuming baseline is set to 10px on :root/html
 @function rem($value, $baseline: 10px) {

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -25,6 +25,8 @@
 // or http://sassmeister.com/gist/7451284
 @mixin rem($properties) {
     @each $property, $value in $properties {
+        $value: if(unitless($value), $value * 1px, $value);
+
         #{$property}: $value;
         #{$property}: rem($value);
     }

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -11,6 +11,21 @@
     @return strip-unit($value) / $baseline + rem;
 }
 
+// Converts a list of values into rem
+@function remCalc($values) {
+    $max: length($values);
+    $remValues: '';
+
+    @for $i from 1 through $max {
+        $value: nth($values, $i);
+        $remValues: #{$remValues + rem($value)};
+        @if $i < $max {
+            $remValues: #{$remValues + " "};
+        }
+    }
+    @return $remValues;
+}
+
 // Output rem units with px fallback
 // Expects $properties to be a Sass map
 // Usage: see font-size mixin below
@@ -18,7 +33,7 @@
 @mixin rem($properties) {
     @each $property, $value in $properties {
         #{$property}: $value;
-        #{$property}: rem($value);
+        #{$property}: remCalc($value);
     }
 }
 

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -15,7 +15,7 @@
         }
         @return $result;
     } @else {
-        @if $value == 0 { @return 0; }
+        @if $value == 0 { @return 0; } // 0px => 0
         @return if(unit($value) == px, $value / $baseline * 1rem, $value);
     }
 }
@@ -27,6 +27,7 @@
 @mixin rem($properties) {
     @each $property, $value in $properties {
         @if (type-of($value) == number and $value != 0) {
+            // Turn any value into pixels
             $value: if(unitless($value), $value * 1px, $value);
         }
 

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -15,6 +15,7 @@
         }
         @return $result;
     } @else {
+        @if $value == 0 { @return 0; }
         @return if(unit($value) == px, $value / $baseline * 1rem, $value);
     }
 }
@@ -25,7 +26,9 @@
 // or http://sassmeister.com/gist/7451284
 @mixin rem($properties) {
     @each $property, $value in $properties {
-        $value: if(unitless($value), $value * 1px, $value);
+        @if (type-of($value) == number and $value != 0) {
+            $value: if(unitless($value), $value * 1px, $value);
+        }
 
         #{$property}: $value;
         #{$property}: rem($value);

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -1,11 +1,32 @@
 @import "_mq";
 
-//Output based on body font-size being 10px
+// Remove the unit from a number
+@function strip-unit($num){
+    @return $num / ($num * 0 + 1);
+}
+
+// Transform a value into rem
+// Assuming baseline is set to 10px on :root/html
+@function rem($value, $baseline: 10) {
+    @return strip-unit($value) / $baseline + rem;
+}
+
+// Output rem units with px fallback
+// Expects $properties to be a Sass map
+// Usage: see font-size mixin below
+// or http://sassmeister.com/gist/7451284
+@mixin rem($properties) {
+    @each $property, $value in $properties {
+        #{$property}: $value;
+        #{$property}: rem($value);
+    }
+}
+
 @mixin font-size($size, $line-height: $size) {
-    font-size: $size*1px;
-    font-size: ($size / 10)*1rem;
-    line-height: $line-height*1px;
-    line-height: ($line-height / 10)*1rem;
+    @include rem((
+        font-size: $size,
+        line-height: $line-height
+    ));
 }
 
 @mixin font($family, $weight, $size, $line-height: $size) {

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -26,7 +26,7 @@
 @mixin rem($properties) {
     @each $property, $value in $properties {
         #{$property}: $value;
-        #{$property}: remCalc($value);
+        #{$property}: rem($value);
     }
 }
 


### PR DESCRIPTION
This mixin come in handy for the news container to make it scalable depending on the users choice of text size in their browsers.

Usage:

``` scss
.selector {
    @include rem((
        padding: 20px,
        width: 300px,
        height: 350px,
        line-height: 20px
    ));
}
```

![ ](http://i.imgur.com/pCYonBW.gif)
