### PR TITLE
Hide ads on rotate

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -261,13 +261,23 @@ define([
 
         loadAdverts: function () {
             if (!userPrefs.isOff('adverts')){
+                
                 mediator.on('page:common:deferred:loaded', function(config, context) {
                     if (config.switches && config.switches.adverts && !config.page.blockAds) {
                         Adverts.init(config, context);
                     }
                 });
+                
                 mediator.on('modules:adverts:docwrite:loaded', function(){
                     Adverts.loadAds();
+                });
+
+                mediator.on('window:resize', function () {
+                    Adverts.hideAds();
+                });
+                
+                mediator.on('window:orientationchange', function () {
+                    Adverts.hideAds();
                 });
             }
         },

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -260,7 +260,7 @@ define([
         },
 
         loadAdverts: function () {
-            if (!userPrefs.isOff('adverts')){
+            if (!userPrefs.isOff('adverts')) {
                 
                 mediator.on('page:common:deferred:loaded', function(config, context) {
                     if (config.switches && config.switches.adverts && !config.page.blockAds) {
@@ -272,9 +272,10 @@ define([
                     Adverts.loadAds();
                 });
 
-                mediator.on('window:resize', function () {
+                mediator.on('window:resize', debounce(function() {
                     Adverts.hideAds();
-                });
+                    }, 300)
+                );
                 
                 mediator.on('window:orientationchange', function () {
                     Adverts.hideAds();

--- a/common/app/assets/javascripts/modules/adverts/adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/adverts.js
@@ -112,6 +112,10 @@ function (
         );
     }
 
+    function hideAds() {
+        common.$g('.ad-slot').addClass('u-h');
+    }
+
     //Temporary middle slot needs better implementation in the future
     function generateMiddleSlot() {
         var slot,
@@ -132,6 +136,7 @@ function (
     }
 
     return {
+        hideAds: hideAds,
         init: init,
         loadAds: loadAds,
         isOnScreen: isOnScreen

--- a/common/app/assets/javascripts/modules/adverts/adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/adverts.js
@@ -1,5 +1,5 @@
 define([
-    'common',
+    '$',
     'qwery',
     'bonzo',
     'ajax',
@@ -15,7 +15,7 @@ define([
 
 ],
 function (
-    common,
+    $,
     qwery,
     bonzo,
     ajax,
@@ -113,7 +113,7 @@ function (
     }
 
     function hideAds() {
-        common.$g('.ad-slot').addClass('u-h');
+        $('.ad-slot').addClass('u-h');
     }
 
     //Temporary middle slot needs better implementation in the future


### PR DESCRIPTION
After a bit of a play I don't really think it's very nice to reload all the adverts on resize.

For example, when a taller advert comes along the viewport is jolted down. If you accidentally rotate your device and back again then you trigger a double load, which makes everything a bit sluggish.

So I'm just hiding them for now.

Depends on #2278, so diff against that for my local changes.

/cc @phamann @ironsidevsquincy 
