### PR TITLE
Tidy up social sign in for non-JS

### DIFF
--- a/common/app/assets/stylesheets/base/_forms.scss
+++ b/common/app/assets/stylesheets/base/_forms.scss
@@ -122,6 +122,7 @@
     font-size: 1.4rem;
     margin: 0 $gs-gutter 0 0;
     min-width: gs-span(2);
+    outline: none;
     padding: 11px 0;
 
     &:hover,

--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -48,6 +48,7 @@
 }
 
 .social-signin {
+    @include clearfix;
     margin: $baseline*6 0 $baseline*4;
     text-align: center;
 
@@ -55,6 +56,10 @@
         @include box-sizing(border-box);
         display: inline-block;
         margin-bottom: $baseline*2;
+
+        @include mq(tablet) {
+            float: left;
+        }
     }
 
     .social-signin__action {
@@ -75,7 +80,7 @@
 
         @include mq(tablet) {
             margin-right: $gs-gutter/2;
-            width: 218px;
+            width: gs-span(3);
         }
     }
 
@@ -84,7 +89,7 @@
 
         @include mq(tablet) {
             margin-left: $gs-gutter/2;
-            width: 218px;
+            width: gs-span(3);
         }
     }
 


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/481903/1542031/17243e40-4d41-11e3-81fd-0ef1a0725502.png)

After:
![after](https://f.cloud.github.com/assets/481903/1542034/1ec298e0-4d41-11e3-9577-0b2c73c733ea.png)

Also cleans up button outline and removes two magic numbers.
