### PR TITLE
Add for attribute to checkbox and radio labels

### DIFF
--- a/identity/app/views/fragments/form/checkboxField.scala.html
+++ b/identity/app/views/fragments/form/checkboxField.scala.html
@@ -4,7 +4,7 @@
 @import play.api.templates.PlayMagic.toHtmlArgs
 
 @input(idInput.field, idInput.args:_*) { (id, name, value, htmlArgs) =>
-    <label class="check-label">
+    <label class="check-label" for="@idInput.field.id">
         @fragments.form.checkbox(idInput.field, idInput.args:_*)
         @idInput.args.toMap.get('_label).map { label =>
             @label

--- a/identity/app/views/fragments/form/radioField.scala.html
+++ b/identity/app/views/fragments/form/radioField.scala.html
@@ -9,7 +9,7 @@
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
   @for((inputValue, inputLabel) <- valueAndLabel) {
-      <label class="radio-label">
+      <label class="radio-label" for="@{s"${field.id}_$inputValue"}">
           <input type="radio" name="@field.name" id="@{s"${field.id}_$inputValue"}" value="@inputValue"
           @if(value.map(_ == inputValue).getOrElse(false)){ checked } @toHtmlArgs(args.toMap) />
           @inputLabel

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -29,11 +29,11 @@
                 @inputField(Password(registrationForm("user.password"), '_label -> "Password", '_help -> "Between 6 and 20 characters", 'class -> "js-register-password js-password-strength"))
 
                 <li>
-                    <label class="check-label">
+                    <label class="check-label" for="@registrationForm("receive_gnm_marketing").id">
                         @checkbox(registrationForm("receive_gnm_marketing"))
                         Keep me up to date with offers and developments from the Guardian
                     </label>
-                    <label class="check-label">
+                    <label class="check-label" for="@registrationForm("receive_third_party_marketing").id">
                         @checkbox(registrationForm("receive_third_party_marketing"))
                         Send me messages from 3rd party organisations screened by the Guardian
                     </label>

--- a/identity/app/views/signin.scala.html
+++ b/identity/app/views/signin.scala.html
@@ -33,7 +33,7 @@
                     </div>
                     <button type="submit" class="submit-input" data-link-name="Sign in">Sign in</button>
 
-                    <label class="check-label check-label--helper">
+                    <label class="check-label check-label--helper" for="@signinForm("keepMeSignedIn").id">
                         @checkbox(signinForm("keepMeSignedIn"))
                         Remember me
                     </label>


### PR DESCRIPTION
Even when input is wrapped in label, since some browsers need it to make the text of the label clickable, cc @kaelig #2265.
