### PR TITLE
Use self-closing line break elements on Identity pages

### DIFF
--- a/identity/app/views/password/email_sent.scala.html
+++ b/identity/app/views/password/email_sent.scala.html
@@ -9,7 +9,7 @@
     <p>We've sent an email to @emailAddress.</p>
 
     <p>Follow the link in the email to reset your password.
-    <br>Reset password links are valid for 30 minutes.</p>
+    <br />Reset password links are valid for 30 minutes.</p>
 
     @registrationFooter(page, idRequest, idUrlBuilder)
 </div>


### PR DESCRIPTION
Mentioned by @kaelig in #2265, turns out there's only one.
