### PR TITLE
We have been incorrectly linking to Protocol relative urls.

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -21,6 +21,7 @@ trait LinkTo extends Logging {
   def apply(url: String, edition: Edition): String = (url match {
     case "http://www.theguardian.com" => urlFor("", edition)
     case "/" => urlFor("", edition)
+    case protocolRelative if protocolRelative.startsWith("//") => protocolRelative
     case AbsoluteGuardianUrl(path) =>  urlFor(path, edition)
     case AbsolutePath(path) => urlFor(path, edition)
     case otherUrl => otherUrl

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -32,6 +32,10 @@ class LinkToTest extends FlatSpec with Matchers {
     TestLinkTo("/", edition) should be ("http://www.foo.com/uk")
   }
 
+  it should "not modify protocol relative paths" in {
+    TestLinkTo("//www.youtube.com/embed/jLoG-fNir0c?enablejsapi=1&version=3", edition) should be ("//www.youtube.com/embed/jLoG-fNir0c?enablejsapi=1&version=3")
+  }
+
   it should "strip leading and trailing whitespace" in {
     TestLinkTo("  http://www.foo.com/uk   ", edition) should be ("http://www.foo.com/uk")
   }


### PR DESCRIPTION
e.g. `//www.youtube.com/embed/jLoG-fNir0c?enablejsapi=1&version=3`

This is now fixed..
