### PR TITLE
Prevent betrad pixel trackers from messing with the layout

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -129,3 +129,12 @@
     height: 250px;
     overflow: hidden;
 }
+
+// Some scripts insert an image that 404s and may create a gap below
+// the footer or on top of gallery overlays
+// List the domains here to prevent pixel trackers from messing with the layout
+img[src*=betrad\.com] {
+    height: 0;
+    position: absolute;
+    width: 0;
+}


### PR DESCRIPTION
Sometimes this pixel tracker is inserted and it 204s:

``` html
<img src="//l.betrad.com/ct/0_0_0_11429/gb/0/1/0/0/0/0/728/90/242/1685/0/pixel.gif?v=1159&amp;ttid=2&amp;d=www.theguardian.com&amp;r=0.34547341195866466">
```

It messes with the layout (see screenshots below).

![screen shot 2013-11-19 at 14 08 27](https://f.cloud.github.com/assets/85783/1572761/1b6f8388-5124-11e3-8ccc-7b38f4476918.PNG)

![screen shot 2013-11-19 at 13 45 54](https://f.cloud.github.com/assets/85783/1572752/fadfa65c-5123-11e3-9364-c28e66cffe05.PNG)

![ ](http://i.imgur.com/MdvIXKa.gif)
