### PR TITLE
Throwaway endpoint to count adverts in view

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/livestats-ads.js
+++ b/common/app/assets/javascripts/modules/analytics/livestats-ads.js
@@ -1,0 +1,36 @@
+/*global Event:true */
+define(function () {
+
+    var LiveStatsAds = function (config) {
+
+        var c = config || {},
+            url = config.beaconUrl,
+            path = config.beaconName || '/ad.gif',
+            body = document.body,
+            createImage = function(url) {
+                var image = new Image();
+                image.id = 'js-livestats-ads';
+                image.className = 'u-h';
+                image.src = url;
+                body.appendChild(image);
+            },
+            makeUrl = function(properties) {
+                var query = [];
+                for (var name in properties) {
+                    query.push(name + '=' + encodeURIComponent(properties[name]));
+                }
+                return path + '?' + query.join('&');
+            },
+            log = function(params) {
+                url += makeUrl(params);
+                createImage(url);
+            };
+
+        return {
+            log: log
+        };
+
+    };
+
+    return LiveStatsAds;
+});

--- a/common/app/assets/javascripts/modules/analytics/livestats.js
+++ b/common/app/assets/javascripts/modules/analytics/livestats.js
@@ -45,19 +45,14 @@ define([
                 }
                 return path + '?' + query.join('&');
             },
-            log = function(params) {
-                params = params || {};
+            log = function() {
                 if (!inAlphaTest) {
                     return false;
                 }
                 if (new Session().isNewSession()) {
-                    params.type = 'session';
-                    params.platform = platform;
-                    url += makeUrl(params);
+                    url += makeUrl({ type: 'session', platform: platform });
                 } else {
-                    params.type = 'view';
-                    params.platform = platform;
-                    url += makeUrl(params);
+                    url += makeUrl({ type: 'view', platform: platform });
                 }
                 createImage(url);
             };

--- a/common/app/assets/javascripts/modules/analytics/livestats.js
+++ b/common/app/assets/javascripts/modules/analytics/livestats.js
@@ -45,14 +45,19 @@ define([
                 }
                 return path + '?' + query.join('&');
             },
-            log = function() {
+            log = function(params) {
+                params = params || {};
                 if (!inAlphaTest) {
                     return false;
                 }
                 if (new Session().isNewSession()) {
-                    url += makeUrl({ type: 'session', platform: platform });
+                    params.type = 'session';
+                    params.platform = platform;
+                    url += makeUrl(params);
                 } else {
-                    url += makeUrl({ type: 'view', platform: platform });
+                    params.type = 'view';
+                    params.platform = platform;
+                    url += makeUrl(params);
                 }
                 createImage(url);
             };

--- a/common/app/assets/javascripts/modules/analytics/livestats.js
+++ b/common/app/assets/javascripts/modules/analytics/livestats.js
@@ -26,7 +26,7 @@ define([
 
         var c = config || {},
             url = config.beaconUrl,
-            path = '/px.gif',
+            path = config.beaconName || '/px.gif',
             inAlphaTest = !!Cookies.get('GU_ALPHA'),
             body = document.body,
             platform = 'responsive',

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -85,14 +85,6 @@ define([
             s.tl(true, 'o', tagStr);
         };
 
-        this.trackAdImpression = function(tagStr) {
-            s.linkTrackVars = 'eVar53,events';
-            s.linkTrackEvents = 'event29';
-            s.events = 'event29';
-            s.eVar53 = (config.page.contentType) ? config.page.contentType + ':' + tagStr : tagStr;
-            s.tl(true, 'o', tagStr);
-        };
-
         this.populatePageProperties = function() {
 
             // http://www.scribd.com/doc/42029685/15/cookieDomainPeriods
@@ -248,8 +240,6 @@ define([
                 clearInterval(checkForPageViewInterval);
             }, 10000);
         };
-
-        common.mediator.on('module:analytics:adimpression', that.trackAdImpression );
 
         common.mediator.on('module:clickstream:interaction', that.trackNonLinkEvent );
 

--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
@@ -57,7 +57,7 @@ define([
             var beaconInterval = setInterval(function() {
                 new LiveStats({
                     beaconUrl: config.page.beaconUrl,
-                    beaconName: 'ads.px'
+                    beaconName: '/ad.gif'
                 }).log(adDwellTimes);
 
                 adDwellTimes = {}; // reset

--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
@@ -6,7 +6,7 @@ define([
     'bean',
     'utils/detect',
     'modules/analytics/adverts',
-    'modules/analytics/livestats',
+    'modules/analytics/livestats-ads',
     'modules/adverts/sticky',
     'lodash/objects/transform',
     'lodash/arrays/findLastIndex',
@@ -18,7 +18,7 @@ define([
     bean,
     detect,
     inview,
-    LiveStats,
+    LiveStatsAds,
     Sticky,
     transform,
     findLastIndex,
@@ -55,9 +55,8 @@ define([
         // a timer to submit the data to diagnostics every nth second
         if (config.switches.liveStats) {
             var beaconInterval = setInterval(function() {
-                new LiveStats({
-                    beaconUrl: config.page.beaconUrl,
-                    beaconName: '/ad.gif'
+                new LiveStatsAds({
+                    beaconUrl: config.page.beaconUrl
                 }).log(adDwellTimes);
 
                 adDwellTimes = {}; // reset

--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
@@ -108,7 +108,7 @@ define([
 
         this.id = 'AlphaAdverts';
         this.expiry = '2013-11-30';
-        this.audience = 1;
+        this.audience = 0.1;
         this.description = 'Test new advert formats for alpha release';
         this.canRun = function(config) {
             _config = config;

--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
@@ -55,6 +55,11 @@ define([
         // a timer to submit the data to diagnostics every nth second
         if (config.switches.liveStats) {
             var beaconInterval = setInterval(function() {
+                // if there's nothing to report, don't generate the request
+                if (Object.keys(adDwellTimes).length === 0) {
+                    return false;
+                }
+
                 new LiveStatsAds({
                     beaconUrl: config.page.beaconUrl
                 }).log(adDwellTimes);

--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-adverts.js
@@ -6,6 +6,7 @@ define([
     'bean',
     'utils/detect',
     'modules/analytics/adverts',
+    'modules/analytics/livestats',
     'modules/adverts/sticky',
     'lodash/objects/transform',
     'lodash/arrays/findLastIndex',
@@ -17,63 +18,58 @@ define([
     bean,
     detect,
     inview,
+    LiveStats,
     Sticky,
     transform,
     findLastIndex,
     map) {
 
     var variantName,
-        adViewTimings = [1, 2, 4, 6, 8, 10, 15, 20, 25, 30, 40, 50, 60],
-        adDwellTimes = {};
+        adDwellTimes = {},
+        flushInterval = 5000, // every 5 seconds
+        trackInterval = 1000;
 
+    /*
+        This idea here is that we have two timers. One to monitor whether an advert is in the viewport
+        every 1 second, and a second to flush the data to the server every 5 seconds.
 
-    function initAdDwellTracking() {
-        startAdViewTimer();
+        As the user scrolls down the page and views adverts they increment the collective counter on
+        the server by one each time they view an advert.
 
-        // Listen for unload event
-        bean.on(window, 'beforeunload', function() {
-            common.mediator.emit('module:analytics:adimpression', getAdTimesReport());
-        });
-    }
+        For example, a user that sticks at the top of the page for 20 seconds will increment the 'Top' slot
+        counter by '20' and the server count by '4'.
 
+        We say can the Top slot has been viewed for 20 seconds by 4 instances, or an average of 5 seconds per
+        instance.
+        
+        The highest counter indicates the more viewed the advert.
+    */
 
-    function startAdViewTimer() {
+    function initAdDwellTracking(config) {
+
         var $trackedAdSlots = common.$g('.ad-slot');
+       
+        // a timer to submit the data to diagnostics every nth second
+        if (config.switches.liveStats) {
+            setInterval(function() {
+                new LiveStats({ beaconUrl: config.page.beaconUrl, beaconName: 'ads.px' }).log();
+                
+                // TODO - need to rewrite LiveStats to take params - ?sticky=2&top=5...
 
+                adDwellTimes = {}; // reset
+            }, flushInterval);
+        }
+
+        // a timer to monitor the pages for ad-slots inside the viewport
         setInterval(function() {
             var viewport = detect.getLayoutMode();
-
             $trackedAdSlots.each(function(adEl) {
                 var adId = adEl.getAttribute('data-inview-name') || adEl.getAttribute('data-' + viewport) || '';
                 if (adId && isVisible(adEl)) {
-                    adDwellTimes[adId] = (adDwellTimes[adId]) ? adDwellTimes[adId] += 1 : 1;
+                    adDwellTimes[adId] = (adDwellTimes[adId]) ? adDwellTimes[adId] += 1 : 1; // has been seen inside this 1 second window
                 }
             });
-        }, 1000);
-    }
-
-    function getAdTimesReport() {
-        // This mental piece of code maps the actual advert dwell times to the
-        // predefined dwell times in adViewTimings. Pretty sure there's a better
-        // way, but it's late, and everyone is gone
-        // ex: {MPU: 17, Top: 29}  becomes {MPU: 15, Top: 25}
-        var mappedDwellTimes = transform(adDwellTimes, function(result, time, adId) {
-            var slottedTimeIndex = findLastIndex(adViewTimings, function(timeSlot) {
-                return timeSlot < time;
-            });
-            result[adId] = adViewTimings[slottedTimeIndex];
-        });
-
-        // Convert to string friendly format
-        var reportArray = map(mappedDwellTimes, function(val, key) {
-            return key+':'+val;
-        });
-
-        // Stick the variant name in front
-        reportArray.unshift(variantName);
-
-        // Dinner is served with a sprinkling of commas
-        return reportArray.join(',');
+        }, trackInterval);
     }
 
     function isVisible(el) {
@@ -86,7 +82,6 @@ define([
         );
     }
 
-
     var AlphaAdverts = function () {
 
         var self = this,
@@ -98,7 +93,7 @@ define([
 
         this.id = 'AlphaAdverts';
         this.expiry = '2013-11-30';
-        this.audience = 0.1;
+        this.audience = 1;
         this.description = 'Test new advert formats for alpha release';
         this.canRun = function(config) {
             if(config.page.contentType === 'Article') {

--- a/common/test/assets/javascripts/spec/LiveStats.spec.js
+++ b/common/test/assets/javascripts/spec/LiveStats.spec.js
@@ -26,5 +26,14 @@ define(['common', 'modules/analytics/livestats', 'utils/cookies'], function(comm
             );
         });
 
+        it("should accept parameters and serialize them in the request", function(){
+            ls.log({ foo:'bar', lorem:'ipsum' });
+            expect(document.getElementById('js-livestats').getAttribute('src')).toContain(
+                'beacon.gu.com/px.gif?foo=bar&lorem=ipsum&type=session&platform=responsive'
+            );
+        });
+
+
+
     });
 })

--- a/common/test/assets/javascripts/spec/LiveStats.spec.js
+++ b/common/test/assets/javascripts/spec/LiveStats.spec.js
@@ -26,14 +26,5 @@ define(['common', 'modules/analytics/livestats', 'utils/cookies'], function(comm
             );
         });
 
-        it("should accept parameters and serialize them in the request", function(){
-            ls.log({ foo:'bar', lorem:'ipsum' });
-            expect(document.getElementById('js-livestats').getAttribute('src')).toContain(
-                'beacon.gu.com/px.gif?foo=bar&lorem=ipsum&type=session&platform=responsive'
-            );
-        });
-
-
-
     });
 })

--- a/common/test/assets/javascripts/spec/LiveStatsAds.spec.js
+++ b/common/test/assets/javascripts/spec/LiveStatsAds.spec.js
@@ -1,0 +1,30 @@
+define(['common', 'modules/analytics/livestats-ads', 'utils/cookies'], function(common, LiveStatsAds) {
+
+    describe("LiveStatsAds", function() {
+       
+        var ls;
+       
+        beforeEach(function() {
+            common.$g('#js-livestats-ads').remove();
+            ls = new LiveStatsAds({ beaconUrl: 'beacon.gu.com' });
+        });
+
+        it("should accept a parameter and serialize it in the request", function(){
+            ls.log({ foo:'bar' });
+            expect(document.getElementById('js-livestats-ads').getAttribute('src')).toContain(
+                'beacon.gu.com/ad.gif?foo=bar'
+            );
+        });
+
+
+        it("should accept multiple parameters and serialize them in the request", function(){
+            ls.log({ foo:'bar', lorem:'ipsum' });
+            expect(document.getElementById('js-livestats-ads').getAttribute('src')).toContain(
+                'beacon.gu.com/ad.gif?foo=bar&lorem=ipsum'
+            );
+        });
+
+
+
+    });
+})

--- a/common/test/assets/javascripts/spec/Omniture.spec.js
+++ b/common/test/assets/javascripts/spec/Omniture.spec.js
@@ -112,20 +112,7 @@ define(['analytics/omniture', 'common'], function(Omniture, common) {
                 expect(s.t).toHaveBeenCalledOnce();
             });
         });
-
-        it("should log an ad impression event", function() {
-            var o = new Omniture(s).go(config);
-            waits(100);
-            runs(function() {
-                common.mediator.emit('module:analytics:adimpression', 'top banner');
-                expect(s.linkTrackVars).toBe('eVar53,events');
-                expect(s.linkTrackEvents).toBe('event29');
-                expect(s.events).toBe('event29');
-                expect(s.eVar53).toBe('top banner');
-            });
-        });
-
-
+        
         it("should send event46 when a page has comments", function(){
             config.page.contentType = 'Article';
             config.page.commentable = true;

--- a/diagnostics/app/controllers/ErrorController.scala
+++ b/diagnostics/app/controllers/ErrorController.scala
@@ -22,5 +22,10 @@ object ErrorController extends Controller with Logging {
     Error.report(request.queryString, request.headers.get("user-agent").getOrElse("UNKNOWN USER AGENT"))
     NoCache(Ok(gif).as("image/gif"))
   } 
+  
+  def ads = Action { implicit request =>
+    Ads.report(request.queryString)
+    NoCache(Ok(gif).as("image/gif"))
+  } 
 
 }

--- a/diagnostics/app/model/diagnostics/Ads.scala
+++ b/diagnostics/app/model/diagnostics/Ads.scala
@@ -1,0 +1,22 @@
+package model.diagnostics 
+
+import common._
+import conf._
+import model.diagnostics._
+import play.api.mvc.{ Content => _, _ }
+
+object Ads extends Logging {
+  
+  //  ads.gif?slot=seconds-in-view - Eg. sticky=23&top=12
+
+  def report(queryString: Map[String, Seq[String]]) {
+      
+    val params = queryString.map { case (k,v) => k -> v.mkString }
+    
+    params.get("top").getOrElse(0) match {
+      case Some(x:Int) =>
+        Top.increment(x)
+      case _ => {}
+    }
+  }
+}

--- a/diagnostics/app/model/diagnostics/Ads.scala
+++ b/diagnostics/app/model/diagnostics/Ads.scala
@@ -6,20 +6,23 @@ import model.diagnostics._
 import play.api.mvc.{ Content => _, _ }
 
 object Ads extends Logging {
-  
-  //  ads.gif?slot=seconds-in-view - Eg. sticky=23&top=12
+
+  def safeStringToInt(str: Option[String]): Option[Int] = {
+      import scala.util.control.Exception._
+          catching(classOf[NumberFormatException]) opt str.getOrElse("0").toInt
+  }
 
   def report(queryString: Map[String, Seq[String]]) {
       
     val params = queryString.map { case (k,v) => k -> v.mkString }
     
-    params.get("Top").getOrElse(0) match {
+    safeStringToInt(params.get("Top")) match {
       case Some(x:Int) =>
         Top.increment(x)
       case _ => {}
     }
 
-    params.get("Bottom").getOrElse(0) match {
+    safeStringToInt(params.get("Bottom")) match {
       case Some(x:Int) =>
         Bottom.increment(x)
       case _ => {}

--- a/diagnostics/app/model/diagnostics/Ads.scala
+++ b/diagnostics/app/model/diagnostics/Ads.scala
@@ -13,10 +13,17 @@ object Ads extends Logging {
       
     val params = queryString.map { case (k,v) => k -> v.mkString }
     
-    params.get("top").getOrElse(0) match {
+    params.get("Top").getOrElse(0) match {
       case Some(x:Int) =>
         Top.increment(x)
       case _ => {}
     }
+
+    params.get("Bottom").getOrElse(0) match {
+      case Some(x:Int) =>
+        Bottom.increment(x)
+      case _ => {}
+    }
+
   }
 }

--- a/diagnostics/app/model/diagnostics/Adverts.scala
+++ b/diagnostics/app/model/diagnostics/Adverts.scala
@@ -1,0 +1,37 @@
+package model.diagnostics
+
+import common.Logging
+import com.google.common.util.concurrent.AtomicDouble
+
+abstract class Advert extends Logging {
+
+  private lazy val seconds = new AtomicDouble()  
+  private lazy val counter = new AtomicDouble()  
+
+  def increment(amount: Double) = {
+    seconds.addAndGet(amount)
+    counter.addAndGet(1.0)
+  }
+
+  def count = {
+    counter.doubleValue match {
+       case 0.0 => 0.01
+       case _ => counter.doubleValue
+    }
+  }
+  
+  def secondsInView = {
+    seconds.doubleValue match {
+       case 0.0 => 0.01
+       case _ => seconds.doubleValue
+    }
+  }
+
+  def reset() = {
+    seconds.set(0.0)
+    counter.set(0.0)
+  }
+}
+
+object Top extends Advert
+object Bottom extends Advert

--- a/diagnostics/app/model/diagnostics/DiagnosticsLoadJob.scala
+++ b/diagnostics/app/model/diagnostics/DiagnosticsLoadJob.scala
@@ -4,7 +4,9 @@ import common._
 
 object DiagnosticsLoadJob extends Logging {
   def run() {
+
     log.info("Loading diagnostics data in to CloudWatch")
+    
     CloudWatch.put( "Diagnostics", Metric.averages ++ Map(
                     ("views.desktop", DesktopView.count),
                     ("viewsOverSessions.desktop", DesktopView.count / DesktopSession.count),
@@ -22,6 +24,8 @@ object DiagnosticsLoadJob extends Logging {
     ResponsiveSession.reset()
     DesktopView.reset()
     DesktopSession.reset()
+    Top.reset()
+    Bottom.reset()
   }
 
 }

--- a/diagnostics/app/model/diagnostics/DiagnosticsLoadJob.scala
+++ b/diagnostics/app/model/diagnostics/DiagnosticsLoadJob.scala
@@ -6,10 +6,17 @@ object DiagnosticsLoadJob extends Logging {
   def run() {
     log.info("Loading diagnostics data in to CloudWatch")
     CloudWatch.put( "Diagnostics", Metric.averages ++ Map(
-                    "views.desktop" -> DesktopView.count,
-                    "viewsOverSessions.desktop" -> DesktopView.count / DesktopSession.count,
-                    "views.responsive" -> ResponsiveView.count,
-                    "viewsOverSessions.responsive" -> ResponsiveView.count / ResponsiveSession.count))
+                    ("views.desktop", DesktopView.count),
+                    ("viewsOverSessions.desktop", DesktopView.count / DesktopSession.count),
+                    ("views.responsive", ResponsiveView.count),
+                    ("viewsOverSessions.responsive", ResponsiveView.count / ResponsiveSession.count),
+                    ("ads.top.count", Top.count),
+                    ("ads.top.secondsInView", Top.secondsInView),
+                    ("ads.bottom.count", Bottom.count),
+                    ("ads.bottom.secondsInView", Bottom.secondsInView)
+                  ))
+
+
     Metric.reset()
     ResponsiveView.reset()
     ResponsiveSession.reset()

--- a/diagnostics/conf/routes
+++ b/diagnostics/conf/routes
@@ -6,3 +6,5 @@
 GET     /   controllers.Application.front
 
 GET     /px.gif         controllers.ErrorController.px
+GET     /ad.gif         controllers.ErrorController.ads
+


### PR DESCRIPTION
[http://localhost:9000/ad.gif?sticky=10&top=4&bottom=4&...]()

I.e, user has viewed the sticky slot for 10 seconds, top slot for 4 seconds.

Will let us throw the in-view advert measures at it in next-gen, so we can make a simple dashboard.
