### PR TITLE
Added the idea of single run to grunt for Karma

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 /* global module: false */
 module.exports = function (grunt) {
     var isDev = grunt.option('dev') || process.env.GRUNT_ISDEV === '1',
+        singleRun = grunt.option('single-run') !== false || process.env.GRUNT_SINGLERUN === '1',
         env = grunt.option('env') || 'code',
         screenshotsDir = './screenshots',
         staticTargetDir = 'static/target/',
@@ -323,7 +324,7 @@ module.exports = function (grunt) {
         karma: {
             options: {
                 configFile: testConfDir + 'common.js',
-                singleRun: isDev ? false : true,
+                singleRun: singleRun ? false : true,
                 reporters: isDev ? ['dots'] : ['progress']
             },
             common: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,7 @@
 /* global module: false */
 module.exports = function (grunt) {
     var isDev = grunt.option('dev') || process.env.GRUNT_ISDEV === '1',
-        singleRun = grunt.option('single-run') !== false || process.env.GRUNT_SINGLERUN === '1',
+        singleRun = grunt.option('single-run') !== false,
         env = grunt.option('env') || 'code',
         screenshotsDir = './screenshots',
         staticTargetDir = 'static/target/',
@@ -324,8 +324,8 @@ module.exports = function (grunt) {
         karma: {
             options: {
                 configFile: testConfDir + 'common.js',
-                singleRun: singleRun ? false : true,
-                reporters: isDev ? ['dots'] : ['progress']
+                reporters: isDev ? ['dots'] : ['progress'],
+                singleRun: singleRun
             },
             common: {
                 configFile: testConfDir + 'common.js'
@@ -550,6 +550,7 @@ module.exports = function (grunt) {
     });
     grunt.registerTask('test', ['jshint:common', 'test:unit', 'test:integration']);
     grunt.registerTask('test:unit', function(app) {
+        grunt.config.set('karma.options.singleRun', (singleRun === false) && app ? false : true);
         grunt.task.run('karma' + (app ? ':' + app : ''));
     });
 


### PR DESCRIPTION
Thought that tying `single-run` to `isDev` was a bit opinionated and also got Grunt stuck in a few bits. This is after a chat with @ironsidevsquincy.

You can now use the `--single-run` option, default set to `true`.

If you'd like to run Karma in `no-single-run`, run `test:unit:subtask --single-run=false`.

One other thing to note is that you cannot run in `no-single-run` mode if you want to run the whole `test:unit` task.
You need to specify a subtask for the same reason above of getting stuck.

i.e. you have to run `test:unit:subtask` or an equivalent.

If all is good, I'll email the change around.
![Karma will come back](http://cdn.gifstache.com/2012/10/12/gifstache.com_2286_1350172800.gif)
