### PR TITLE
Remove debug form Identity main template

### DIFF
--- a/identity/app/views/identityMain.scala.html
+++ b/identity/app/views/identityMain.scala.html
@@ -21,6 +21,5 @@
     @fragments.loadCss()
 
     @fragments.analytics(metaData)
-    @fragments.debug()
 </body>
 </html>


### PR DESCRIPTION
This fixes Rendered At appearing in the bottom of the identity templates -as shown here
(this gets rid of it) 
![renderedat](https://f.cloud.github.com/assets/986155/1583444/25745442-51fd-11e3-9824-4b2f82659a43.png)
