### PR TITLE
Better top comments error handling

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -85,11 +85,12 @@ Loader.prototype.canComment = false;
  * 3. render comment bar
  */
 Loader.prototype.ready = function() {
-    var topLoadingElem = bonzo.create('<div class="preload-msg">Loading comments…<div class="is-updating"></div></div>')[0],
-        topCommentsElem = this.getElem('topComments'),
+    var topCommentsElem = this.getElem('topComments'),
         self = this;
 
-    bonzo(topLoadingElem).insertAfter(topCommentsElem);
+    self.topLoadingElem = bonzo.create('<div class="preload-msg">Loading comments…<div class="is-updating"></div></div>')[0];
+
+    bonzo(self.topLoadingElem).insertAfter(topCommentsElem);
 
     this.on('user:loaded', function(user) {
 
@@ -103,7 +104,7 @@ Loader.prototype.ready = function() {
         self.topComments
             .fetch(topCommentsElem)
             .then(function appendTopComments() {
-                bonzo(topLoadingElem).addClass('u-h');
+                bonzo(self.topLoadingElem).addClass('u-h');
                 self.on('click', $(self.topComments.showMoreButton), self.topComments.showMore.bind(self.topComments)); // Module-hopping calls - refactor needed
             });
 
@@ -131,7 +132,8 @@ Loader.prototype.loadComments = function (args) {
         // Comments are being loaded in the no-top-comments-available context
         bonzo(commentsContainer).removeClass('u-h');
     }
-   
+
+    bonzo(self.topLoadingElem).addClass('u-h');
     bonzo(loadingElem).insertAfter(commentsElem);
 
     this.comments = new Comments(this.context, this.mediator, {

--- a/common/app/assets/javascripts/modules/discussion/topComments.js
+++ b/common/app/assets/javascripts/modules/discussion/topComments.js
@@ -98,7 +98,7 @@ TopComments.prototype.fetch = function(parent) {
         crossOrigin: true
     }).then(
         function render(resp) {
-
+            // Success: Render Top or Regular comments
             if (resp.commentCount > 0 && self.topCommentsSwitch) {
                 
                 // Render Top Comments
@@ -120,6 +120,11 @@ TopComments.prototype.fetch = function(parent) {
                 // Render Regular Comments
                 self.mediator.emit("module:topcomments:loadcomments", { amount: 2, showLoader: true });
             }
+        },
+        function () {
+            // Error: Render Regular Comments
+            $('.discussion__comments--top-comments').remove();
+            self.mediator.emit("module:topcomments:loadcomments", { amount: 2, showLoader: true });
         }
     );
 };


### PR DESCRIPTION
If the topComments endpoint happens to break then the default comments should be loaded - this code now uses the ajax module error handler to do that.

No image as only small code change.
