### PR TITLE
Make sure that the comments error handler gets called and works

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -124,14 +124,13 @@ Loader.prototype.loadComments = function (args) {
 
     var self = this;
 
-    var commentsElem        = this.getElem('comments'),
+    var commentsContainer   = this.getElem('commentsContainer'),
+        commentsElem        = this.getElem('comments'),
         loadingElem         = bonzo.create('<div class="preload-msg">Loading comments…<div class="is-updating"></div></div>')[0];
-
-    self.commentsContainer   = this.getElem('commentsContainer'); // Set on the context to allow AJAX error hadnling
 
     if (args.showLoader) {
         // Comments are being loaded in the no-top-comments-available context
-        bonzo(self.commentsContainer).removeClass('u-h');
+        bonzo(commentsContainer).removeClass('u-h');
     }
 
     bonzo(self.topLoadingElem).addClass('u-h');
@@ -162,7 +161,7 @@ Loader.prototype.loadComments = function (args) {
                 self.comments.showMore(event);
                 self.cleanUpOnShowComments();
             });
-            bonzo(self.commentsContainer).removeClass('u-h');
+            bonzo(commentsContainer).removeClass('u-h');
         }).fail(self.loadingError.bind(self));
 };
 
@@ -188,7 +187,7 @@ Loader.prototype.getUser = function() {
  * often is on code due to syncing problems
  */
 Loader.prototype.loadingError = function() {
-    bonzo(this.commentsContainer).remove();
+    bonzo(this.getElem('commentsContainer')).remove();
 };
 
 /** TODO: This logic will be moved to the Play app renderer */

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -124,13 +124,14 @@ Loader.prototype.loadComments = function (args) {
 
     var self = this;
 
-    var commentsContainer   = this.getElem('commentsContainer'),
-        commentsElem        = this.getElem('comments'),
+    var commentsElem        = this.getElem('comments'),
         loadingElem         = bonzo.create('<div class="preload-msg">Loading comments…<div class="is-updating"></div></div>')[0];
+
+    self.commentsContainer   = this.getElem('commentsContainer'); // Set on the context to allow AJAX error hadnling
 
     if (args.showLoader) {
         // Comments are being loaded in the no-top-comments-available context
-        bonzo(commentsContainer).removeClass('u-h');
+        bonzo(self.commentsContainer).removeClass('u-h');
     }
 
     bonzo(self.topLoadingElem).addClass('u-h');
@@ -161,8 +162,8 @@ Loader.prototype.loadComments = function (args) {
                 self.comments.showMore(event);
                 self.cleanUpOnShowComments();
             });
-            bonzo(commentsContainer).removeClass('u-h');
-        });
+            bonzo(self.commentsContainer).removeClass('u-h');
+        }).fail(self.loadingError.bind(self));
 };
 
 /** @return {Reqwest|null} */
@@ -187,7 +188,7 @@ Loader.prototype.getUser = function() {
  * often is on code due to syncing problems
  */
 Loader.prototype.loadingError = function() {
-    bonzo(this.elem).remove();
+    bonzo(this.commentsContainer).remove();
 };
 
 /** TODO: This logic will be moved to the Play app renderer */

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -117,7 +117,7 @@ object Switches extends Collections {
 
   val DiscussionTopCommentsSwitch = Switch("Discussion", "discussion-top-comments",
     "If this switch is on, users will see top comments if there are any",
-    safeState = Off)
+    safeState = On)
 
   // Swipe Switches
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -117,7 +117,7 @@ object Switches extends Collections {
 
   val DiscussionTopCommentsSwitch = Switch("Discussion", "discussion-top-comments",
     "If this switch is on, users will see top comments if there are any",
-    safeState = On)
+    safeState = Off)
 
   // Swipe Switches
 


### PR DESCRIPTION
Using ajax promises, ensure that the comments error handler gets called and removes the broken element.
