### PR TITLE
Try to infer the edition from the path

### DIFF
--- a/facia/app/controllers/front/Front.scala
+++ b/facia/app/controllers/front/Front.scala
@@ -12,7 +12,9 @@ class Front extends Logging {
     if (editions.contains(sectionId)) "" else sectionId
   }
 
-  def configList: List[(Edition, String)] = Edition.all.map(e => (e, e.id)).toList ++ ConfigAgent().map(c => (Edition.defaultEdition, c))
+  def configList: List[(Edition, String)] =
+    Edition.all.map(e => (e, e.id)).toList ++
+    ConfigAgent().map(c => (Edition.byId(c.take(2)).getOrElse(Edition.defaultEdition), c))
 
   def faciaFronts: Map[String, PageFront] = configList.map {case (e, id) =>
     id.toLowerCase -> new PageFront(id.toLowerCase, e)


### PR DESCRIPTION
For a `contentApiQuery` defined for a specific path, we always use `Edition.defaultEdition`. We should be at least trying to infer what the edition might be.

So we try, and if we don't know, we use the default.

@stephanfowler @ironsidevsquincy 
~~This means before this PR, requests out to anything other than `/uk`, `/us` and `/au` had the `defaultEdition` in its query. The `defaultEdition` being `Edition.UK`.~~

Although the above is true, as the `ContentApiClient` needs an edition, there is another step. We override the edition with what is in the `contentApiQuery` string, after setting it to `defaultEdition`. That means this PR will change nothing. But it is still better behaviour. Thanks @ironsidevsquincy !
