### PR TITLE
Fix recommend sprites

### DIFF
--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -500,15 +500,22 @@ $topCommentsHeight: 600px;
                     display: inline-block;
                     padding: 0 8px 0 0;
                     position: relative;
-                    top: -5px;                                    
+                    top: -5px;
                     font-size: 0.9em;
                 }
 
-                .i-recommend {
-                    background-color: #4490ce;
-                    padding: 4px;
+                .i-reccomend-container {
+                    display: inline-block;
+                    width: 12px;
+                    height: 14px;
+                    padding: 2px 4px 4px 4px;
                     @include rounded-corners(50px);
-                    background-position: 4px 4px;
+                    background-color: #4490ce;
+                    position: relative;
+                    top: -4px;
+                    .i-recommend {
+                        background-color: #4490ce;
+                    }
                 }
 
                 .d-comment__recommend-count {

--- a/discussion/app/views/fragments/topComment.scala.html
+++ b/discussion/app/views/fragments/topComment.scala.html
@@ -18,7 +18,8 @@
                     data-recommend-count="@comment.numRecommends"
                     title="@comment.numRecommends recommendations">
                     <span class="d-comment__recommend-caption">Recommend</span>
-                    <i class="i i-recommend"></i><span class="d-comment__recommend-count js-recommend-count">@comment.numRecommends</span><span class="u-h"> recommendations</span>
+                    <div class="i-reccomend-container"><i class="i i-recommend"></i></div>
+                    <span class="d-comment__recommend-count js-recommend-count">@comment.numRecommends</span>
                 </div>
             }
         </div>


### PR DESCRIPTION
This change fixes the use of the arrow sprite for the top comments recommend button.

![screen shot 2013-11-22 at 09 55 00](https://f.cloud.github.com/assets/1170410/1599653/566e40de-535c-11e3-9a4f-f69dafa2804f.png)
