### PR TITLE
Discussion nginx

### DIFF
--- a/discussion/README.md
+++ b/discussion/README.md
@@ -4,10 +4,17 @@ Discussion is currently running under the generic [dev-build project](https://gi
 
 To have the have it up and running however, you will need a few things setup for ease of use.
 
+## Play
+    ./sbt
+    project discussion
+    disrun
+
 ## Nginx
 You will need to be running your stack on [Nginx](http://wiki.nginx.org/Main). [See our documentation for more information](https://github.com/guardian/frontend/blob/master/nginx/README.md).
 
-If you are unsure if you are or aren't, just make sure you are viewing the site from `http://m.thegulocal.com`.
+If you are unsure if you are or aren't, just make sure you are viewing the site from `http://m.thegulocal.com`. See above README for more info.
+
+You will need to add `comments.thegulocal.com` to you hosts file too. See [README](https://github.com/guardian/frontend/blob/master/nginx/README.md) above for more info.
 
 ## API locations
 As we have dependancies on both the Content API and Identity API, this can be a little precarious. Never fear, once you're up and running, it's pretty smooth sailing.
@@ -22,7 +29,7 @@ In your local settings file, you should have the following:
 
     # Discussion
     discussion.apiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
-    
+
     # Generic
     guardian.page.host=http://m.thegulocal.com
 

--- a/discussion/build.sbt
+++ b/discussion/build.sbt
@@ -1,0 +1,3 @@
+addCommandAlias("disrun", ";run 1337")
+
+testOptions in Test += Tests.Argument("-oF")

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -12,8 +12,9 @@ Install nginx:
 
 Add the following to your ```/etc/hosts```:
 
-    127.0.0.1   profile.thegulocal.com
     127.0.0.1   m.thegulocal.com
+    127.0.0.1   profile.thegulocal.com
+    127.0.0.1   comments.thegulocal.com
 
 ## Setup Linux
 
@@ -24,8 +25,9 @@ Install nginx:
 
 Add the following to your ```/etc/hosts```:
 
-    127.0.1.1   profile.thegulocal.com
     127.0.1.1   m.thegulocal.com
+    127.0.1.1   profile.thegulocal.com
+    127.0.1.1   comments.thegulocal.com
 
 ## Now run the setup script:
 

--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -7,6 +7,14 @@ server {
 }
 
 server {
+    server_name comments.thegulocal.com;
+
+    location / {
+        proxy_pass http://localhost:1337/;
+    }
+}
+
+server {
     listen 443;
     server_name profile.thegulocal.com;
 


### PR DESCRIPTION
The beginning of moving discussion over to our own stack so we can eat some cookies.
[See here for example](http://comments.theguardian.com/discussion/p/3tycg).

This is an attempt to move rendering to the right place i.e. The Play app.

This does mean that people are going to have to start running their stack through nginx if they want to see comments whilst developing, or using the direct URL.
