### PR TITLE
Commercial: Fix data fetch timeout in code env

### DIFF
--- a/commercial/conf/application.conf
+++ b/commercial/conf/application.conf
@@ -56,3 +56,26 @@ logger.play=INFO
 
 # Logger provided to your application:
 logger.application=DEBUG
+
+
+############################################################
+#
+# Threadpool config
+# see http://www.playframework.com/documentation/2.2.x/ThreadPools
+#
+############################################################
+
+play {
+  akka {
+    akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
One fetch is consistently timing out in the code env and this seems to be because it's running in a small (single-processor) instance and a fast feed is following a slow feed.  
It's difficult to reproduce this in dev but reordering the fetches so that the fast ones run first should do it.
