### PR TITLE
Deprecate old CSS classes

### DIFF
--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -56,8 +56,7 @@
     }
 }
 
-.u-cf,
-.cf {
+.u-cf {
     @include clearfix;
 }
 

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -1,8 +1,7 @@
 /* Accessible hidden content.
    ========================================================================== */
 
-.u-h,
-.h {
+.u-h {
     border: 0 !important;
     clip: rect(0 0 0 0) !important;
     height: 1px !important;

--- a/common/app/assets/stylesheets/base/_links.scss
+++ b/common/app/assets/stylesheets/base/_links.scss
@@ -12,8 +12,3 @@ a,
         color: $c-newsAccent;
     }
 }
-
-a.u-underline,
-.u-fauxlink.u-underline {
-    text-decoration: underline;
-}

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -54,14 +54,6 @@ h3 {
     @extend %type-6;
 }
 
-h4 {
-    @extend %type-6;
-    margin: 0;
-    padding: 8px 10px 7px;
-    background-color: #ededed;
-    border-top: 1px solid #cccccc;
-}
-
 th,
 td {
     @extend %type-10;

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -22,19 +22,15 @@ h1, h2, h3, h4, h5, h6 {
     text-rendering: optimizeLegibility;
 }
 
-.type-1 { @extend %type-1; }
 .type-2 { @extend %type-2; }
 
 //SerifText
-.type-3 { @extend %type-3; }
-.type-4 { @extend %type-4; }
 .type-5 { @extend %type-5; }
 .type-6 { @extend %type-6; }
 .type-7 { @extend %type-7; }
 
 //Sans-serif's
 .type-8  { @extend %type-8; }
-.type-9  { @extend %type-9; }
 .type-10 { @extend %type-10; }
 .type-11 { @extend %type-11; }
 .type-12 { @extend %type-12; }

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -95,9 +95,6 @@ input.commercial__submit {
 
 .lineitem__title {
     @include fs-bodyHeading(1);
-    padding: 0;
-    background-color: transparent;
-    border-top: 0;
 
     a {
         color: #FFFFFF;


### PR DESCRIPTION
ALL DEVS REVIEW PLEASE
(I don't want to break anything, so have a look just in case)
All these elements and classes are not used and/or should be deprecated:

`.u-underline`
`.cf`
`.h`
`h4`
`.type-1`
`.type-3`
`.type-4`
`.type-9`

![squirell!](http://i.imgur.com/7L6nPA4.gif)
