### PR TITLE
Amend aa test to include 4 variants

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/aa.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/aa.js
@@ -1,16 +1,12 @@
-define([
-    'common'
-], function (
-    common
-) {
+define([], function () {
 
     // An AA test is like an AB test but with no difference between the A & B variants. It is useful to prove
     // that the bucketing of users is fair.
     var Aa = function () {
 
-        this.id = 'Aa';
-        this.expiry = '2013-07-19';
-        this.audience = 0.1;
+        this.id = 'abcd';
+        this.expiry = '2013-12-31';
+        this.audience = 0.25;
         this.description = 'A/A test to prove we bucket users evenly';
         this.canRun = function(config) {
             return true;
@@ -23,7 +19,25 @@ define([
                 }
             },
             {
-                id: 'bucketa',
+                id: 'bucketA',
+                test: function () {
+                    return true;
+                }
+            },
+            {
+                id: 'bucketB',
+                test: function () {
+                    return true;
+                }
+            },
+            {
+                id: 'bucketC',
+                test: function () {
+                    return true;
+                }
+            },
+            {
+                id: 'bucketD',
                 test: function () {
                     return true;
                 }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -218,7 +218,7 @@ object Switches extends Collections {
     "If this is switched on an AB test runs to measure the impact of cardifying inline links on number of linked stories read.",
     safeState = Off)
 
-  val ABAa = Switch("A/B Tests", "ab-aa",
+  val ABAa = Switch("A/B Tests", "ab-abcd",
     "If this is switched on an AA test runs to prove the assignment of users in to segments is working reliably.",
     safeState = Off)
 


### PR DESCRIPTION
We want to validate whether there is something fishy up with the ab frameworks or Omniture's MVT bucketing of tests with more than 3 variants. 

This add's a simple aa test with 4 variants and a control group.

/cc @rich-nguyen @commuterjoy 
