### PR TITLE
Display staff badges on appended comments

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -287,7 +287,7 @@ Comments.prototype.addComment = function(comment, focus, parent) {
     }
     commentElem.id = 'comment-'+ comment.id;
 
-    var is_staff = this.user.badge.some(function (e, i, a) { // Returns true if any element in array satisfies function
+    var is_staff = this.user.badge.some(function (e) { // Returns true if any element in array satisfies function
         return e.name === "Staff";
     });
 

--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -5,7 +5,8 @@ define([
     'modules/component',
     'modules/identity/api',
     'modules/discussion/comment-box',
-    'modules/discussion/recommend-comments'
+    'modules/discussion/recommend-comments',
+    '$'
 ], function(
     ajax,
     bonzo,
@@ -13,7 +14,8 @@ define([
     Component,
     Id,
     CommentBox,
-    RecommendComments
+    RecommendComments,
+    $
 ) {
 
 /**
@@ -284,6 +286,16 @@ Comments.prototype.addComment = function(comment, focus, parent) {
         }
     }
     commentElem.id = 'comment-'+ comment.id;
+
+    var is_staff = this.user.badge.some(function (e, i, a) { // Returns true if any element in array satisfies function
+        return e.name === "Staff";
+    });
+
+    if (is_staff) {
+        // Hack to allow staff badge to appear
+        var staffBadge = bonzo.create(document.getElementById('tmpl-staff-badge').innerHTML);
+        $('.d-comment__meta div', commentElem).first().append(staffBadge);
+    }
 
     // Stupid hack. Will rearchitect.
     if (!parent) {

--- a/discussion/app/views/fragments/commentsBody.scala.html
+++ b/discussion/app/views/fragments/commentsBody.scala.html
@@ -25,4 +25,7 @@
     <script type="text/template" id="tmpl-comment-box">@fragments.commentBox()</script>
     <script type="text/template" id="tmpl-banned-user">@fragments.cannotComment()</script>
     @if(blankComment != null){<script type="text/template" id="tmpl-comment">@fragments.comment(blankComment)</script>}
+    <script type="text/template" id="tmpl-staff-badge">
+        <i class="d-badge d-badge--guardian-staff d-comment__author-status" title="Guardian staff"><span class="d-badge__label">Guardian Staff</span></i>
+    </script>
 </div>


### PR DESCRIPTION
![screen shot 2013-11-22 at 14 57 12](https://f.cloud.github.com/assets/1170410/1601470/a918a10e-5388-11e3-81b6-49d4de72caae.png)

Previously staff badges on comments on Next Gen were only appearing on Server-side generated comments. This fix ensures that any JS appended comments (such as a comment you just posted) have guardian staff badges if applicable.

![code-03](https://f.cloud.github.com/assets/1170410/1601411/a0e65d60-5387-11e3-82aa-d561ce19e685.gif)
