### PR TITLE
Resolve multiple carriage returns to single <p>

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -258,7 +258,7 @@ Comments.prototype.addComment = function(comment, focus, parent) {
         values = {
             username: this.user.displayName,
             timestamp: 'Just now',
-            body: '<p>'+ comment.body.replace('\n', '</p><p>') +'</p>',
+            body: '<p>'+ comment.body.replace(/\n+/g, '</p><p>') +'</p>',
             report: {
                 href: 'http://discussion.theguardian.com/components/report-abuse/'+ comment.id
             },


### PR DESCRIPTION
![screen shot 2013-11-22 at 15 53 31](https://f.cloud.github.com/assets/1170410/1601871/b56985a2-538f-11e3-89da-20bc0b357445.png)

Currently, when a user enters more than one carriage return in to their comment, on post the inserted comment does not render <p>'s for >1 '\n'.

This results in comments in the page that do not reflect the entered comment until the page is refreshed from the server.

This small fix ensures that, no matter how many carriage returns are entered a single <p> will be inserted.

I would consider this a stopgap solution pending a more accurate way to reflect the entered comment.

![code-23](https://f.cloud.github.com/assets/1170410/1601891/fe2a911e-538f-11e3-9a78-cb99cd8b451d.gif)
