### PR TITLE
Clickstream.js type error

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -55,7 +55,7 @@ define([
             }
 
             if (elName === 'body') {
-                if (spec.validTarget && spec.tag.length) {
+                if (spec.validTarget && spec.tag && spec.tag.length) {
                     spec.tag = [].concat(spec.tag).reverse().join(' | ');
                     if(el.getAttribute('data-link-test')) {
                         spec.tag = el.getAttribute('data-link-test') + ' | ' + spec.tag;


### PR DESCRIPTION
Clickstream.js gives a type error if, on recursion through the DOM, it doesn't find a 'data-link-name' attribute and doesn't create the `tag` property on the `spec` object at line 53.

This adds an extra check to make sure that a type error is not generated further down the line.

This bug was picked up from seeing the error generated when the comment form is submitted on NextGen.

I'm not involved with clickstream.js and found the source of the error through debugging so if someone knows how it works please check this to make sure it doesn't break anything.

Thanks!
