### PR TITLE
Commercial: Add pages to healthcheck

### DIFF
--- a/commercial/app/conf/AnyOfTheGivenUrlsHealthCheckManagementPage.scala
+++ b/commercial/app/conf/AnyOfTheGivenUrlsHealthCheckManagementPage.scala
@@ -1,0 +1,38 @@
+package conf
+
+import com.gu.management.{ManagementPage, ErrorResponse, PlainTextResponse, HttpRequest}
+import play.api.libs.ws.WS
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+/*
+ * App is considered healthy if any of the given URLs is OK.
+ */
+class AnyOfTheGivenUrlsHealthCheckManagementPage(urls: String*) extends ManagementPage {
+
+  import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+  override val path = "/management/healthcheck"
+
+  val base = "http://localhost:9000"
+
+  override def get(req: HttpRequest) = {
+    val checks = urls map (base + _) map {
+      url => WS.url(url).get().map {
+        response => url -> response.status
+      }
+    }
+    val sequenced = Future.sequence(checks)
+
+    Await.result(sequenced, atMost = 10.seconds) match {
+
+      case results if results.exists(_._2 == 200) => PlainTextResponse("OK")
+
+      case results =>
+        val message = results map {
+          case (u, status) => s"FAIL: $u ($status)"
+        }
+        ErrorResponse(503, message mkString "\n")
+    }
+  }
+}

--- a/commercial/app/conf/context.scala
+++ b/commercial/app/conf/context.scala
@@ -14,8 +14,11 @@ object Management extends GuManagement {
 
   lazy val pages = List(
     new ManifestPage,
-    new UrlPagesHealthcheckManagementPage(
-      "/commercial/travel/offers.json?k=france"
+    new AnyOfTheGivenUrlsHealthCheckManagementPage(
+      "/commercial/soulmates/mixed.json",
+      "/commercial/masterclasses.json",
+      "/commercial/travel/offers.json?k=france",
+      "/commercial/jobs.json?s=law"
     ),
     StatusPage(applicationName, metrics),
     new PropertiesPage(Configuration.toString()),


### PR DESCRIPTION
All the endpoints in the commercial app are dependent on data feeds, any one of which may fail.

This change modifies the commercial healthcheck so that it checks multiple endpoints and considers the app to be healthy if any of them are OK.
