### PR TITLE
Remove ShowMore pagination button

### DIFF
--- a/discussion/app/views/fragments/topCommentsBody.scala.html
+++ b/discussion/app/views/fragments/topCommentsBody.scala.html
@@ -7,7 +7,4 @@
             @fragments.topComment(comment, page.isClosedForRecommendation)
         }
     </ul>
-    @if(page.currentPage + 1 <= page.pages){
-        <a class="js-show-more-comments cta" data-link-name="Show more comments" href="@LinkTo{/@page.id?page=@(page.currentPage + 1)}">Show more comments</a>
-    }
 </div>


### PR DESCRIPTION
This button was erroneously left in as part of the topComments template and should be removed.
