### PR TITLE
Discussion switches

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -116,7 +116,9 @@ Comments.prototype.ready = function() {
         }
 
         this.hideExcessReplies();
-        this.bindCommentEvents();
+        if (!this.isReadOnly()) {
+            this.bindCommentEvents();
+        }
         this.on('click', this.getClass('showReplies'), this.showMoreReplies);
     }
     this.emit('ready');
@@ -215,6 +217,13 @@ Comments.prototype.hideExcessReplies = function(comments) {
 };
 
 /**
+ * @return {Boolean}
+ */
+Comments.prototype.isReadOnly = function() {
+    return this.elem.getAttribute('data-read-only') === 'true';
+};
+
+/**
  * @param {Object} resp
  */
 Comments.prototype.commentsLoaded = function(resp) {
@@ -234,7 +243,10 @@ Comments.prototype.commentsLoaded = function(resp) {
 
     this.hideExcessReplies(comments);
 
-    RecommendComments.init(this.context);
+    if (!this.isReadOnly()) {
+        RecommendComments.init(this.context);
+
+    }
     this.emit('loaded');
 };
 

--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -235,7 +235,9 @@ Comments.prototype.commentsLoaded = function(resp) {
         this.removeShowMoreButton();
     }
 
-    this.renderReplyButtons(qwery(this.getClass('comment'), bonzo(comments).parent()));
+    if (!this.isReadOnly()) {
+        this.renderReplyButtons(qwery(this.getClass('comment'), bonzo(comments).parent()));
+    }
     bonzo(this.getElem('comments')).append(comments);
 
     showMoreButton.innerHTML = 'Show more';

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -113,10 +113,9 @@ Loader.prototype.ready = function() {
         // !Top comments ========================================== //
 
     });
+
     this.getUser();
-
     this.renderCommentCount();
-
     DiscussionAnalytics.init();
 };
 
@@ -190,6 +189,14 @@ Loader.prototype.loadingError = function() {
     bonzo(this.getElem('commentsContainer')).remove();
 };
 
+Loader.prototype.renderReadOnly = function() {
+    this.getElem('commentBox').innerHTML =
+        '<div class="d-bar d-bar--closed">'+
+            'We\'re doing some maintenance right now.'+
+            ' You can still read comments, but please come back later to add your own.'+
+        '</div>';
+};
+
 /** TODO: This logic will be moved to the Play app renderer */
 Loader.prototype.renderDiscussionClosedMessage = function() {
     this.getElem('commentBox').innerHTML = '<div class="d-bar d-bar--closed">This discussion is closed for comments.</div>';
@@ -212,7 +219,9 @@ Loader.prototype.renderSignin = function() {
  * Else render comment box
  */
 Loader.prototype.renderCommentBar = function() {
-    if (this.getDiscussionClosed()) {
+    if (this.comments.isReadOnly()) {
+        this.renderReadOnly();
+    } else if (this.getDiscussionClosed()) {
         this.renderDiscussionClosedMessage();
     } else if (!Id.getUserFromCookie()) {
         this.renderSignin();

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -192,7 +192,7 @@ Loader.prototype.loadingError = function() {
 Loader.prototype.renderReadOnly = function() {
     this.getElem('commentBox').innerHTML =
         '<div class="d-bar d-bar--closed">'+
-            'We\'re doing some maintenance right now.'+
+            '<b>We\'re doing some maintenance right now.</b>'+
             ' You can still read comments, but please come back later to add your own.'+
         '</div>';
 };

--- a/discussion/app/discussion/CommentPage.scala
+++ b/discussion/app/discussion/CommentPage.scala
@@ -1,7 +1,8 @@
 package discussion
 
 import _root_.model.Page
-import model.Comment
+import model.{Comment, Switch}
+import play.api.libs.json.JsObject
 
 case class CommentPage(
                         override val id: String,
@@ -13,7 +14,8 @@ case class CommentPage(
                         contentUrl: String,
                         currentPage: Int,
                         pages: Int,
-                        isClosedForRecommendation: Boolean
+                        isClosedForRecommendation: Boolean,
+                        switches: Seq[Switch]
                         ) extends Page(id = id, section = "Global", webTitle = title, analyticsName = s"GFE:Article:Comment discussion page $currentPage") {
 
   lazy val hasMore: Boolean = currentPage < pages

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.JsArray
 import play.api.libs.ws.Response
 import play.api.libs.json.JsObject
 import play.api.libs.json.JsNumber
-import discussion.model.{Profile, Comment, CommentCount}
+import discussion.model.{Profile, Comment, CommentCount, Switch}
 import play.api.mvc.Headers
 
 trait DiscussionApi extends ExecutionContexts with Logging {
@@ -61,7 +61,8 @@ trait DiscussionApi extends ExecutionContexts with Logging {
           commenterCount =  (json \ "discussion" \ "commenterCount").as[Option[Int]].getOrElse(0),
           currentPage = (json \ "currentPage").as[Int],
           pages = (json \ "pages").as[Int],
-          isClosedForRecommendation = (json \ "discussion" \ "isClosedForRecommendation").as[Boolean]
+          isClosedForRecommendation = (json \ "discussion" \ "isClosedForRecommendation").as[Boolean],
+          switches = (json \ "switches").as[Seq[JsObject]] map { json => Switch(json) }
         )
     }
   }

--- a/discussion/app/discussion/model/Switch.scala
+++ b/discussion/app/discussion/model/Switch.scala
@@ -1,0 +1,21 @@
+package discussion
+package model
+
+import play.api.libs.json.{JsObject, JsValue}
+
+case class Switch(
+  name: String,
+  description: String,
+  state: Boolean
+)
+
+object Switch {
+
+  def apply(json: JsValue): Switch = {
+    Switch(
+      name = (json \ "name").as[String].toLowerCase,
+      description = (json \ "description").as[String],
+      state = if((json \ "state").as[String] == "On") true else false
+    )
+  }
+}

--- a/discussion/app/views/fragments/commentsBody.scala.html
+++ b/discussion/app/views/fragments/commentsBody.scala.html
@@ -1,8 +1,12 @@
 @(page: CommentPage, blankComment: Comment = null)(implicit request: RequestHeader)
 
-<div class="d-discussion"
-     data-page-count="@page.pages"
-     data-comment-count="@page.commentCount">
+<div
+    class="d-discussion"
+    data-page-count="@page.pages"
+    data-comment-count="@page.commentCount"
+    @page.switches.map{ switch =>
+        data-@switch.name="@switch.state"
+    }>
     <div class="d-discussion__header">
         @if(page.commentCount > 0){
         <div class="d-discussion__meta d-meta-item">


### PR DESCRIPTION
# Open - Discussion: Read only mode

Pending our DB update tomorrow (26/11/2013), we realised we don't have any way of telling users that we are in read only mode.

This is a quick solution to that.
# Looky

![discussion-read-only](https://f.cloud.github.com/assets/31692/1613967/5f35b08e-55e2-11e3-9313-2141c9a0333e.png)
# Notes
- This has highlighted a design challenge of how we deal with states (read-only, signed-in). I have a few solutions but might want to run them through someone else's brain first
