### PR TITLE
Remove host from API call.

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -83,10 +83,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val connection = configuration.getMandatoryStringProperty("mongo.connection.readonly.password")
   }
 
-  object hostMachine {
-    lazy val name = InetAddress.getLocalHost.getHostName
-  }
-
   object site {
     lazy val host = configuration.getStringProperty("guardian.page.host").getOrElse("")
   }

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -12,17 +12,14 @@ class WsHttp(val httpTimingMetric: TimingMetric, val httpTimeoutMetric: CountMet
                                                                                               with ExecutionContexts {
 
   import System.currentTimeMillis
-  import Configuration.hostMachine
-  import java.net.URLEncoder.encode
 
   override def GET(url: String, headers: Iterable[(String, String)]) = {
-    val urlWithHost = url + s"&host-name=${encode(hostMachine.name, "UTF-8")}"
 
     val contentApiTimeout = Configuration.contentApi.timeout
 
     val start = currentTimeMillis
 
-    val response = WS.url(urlWithHost).withHeaders(headers.toSeq: _*).withRequestTimeout(contentApiTimeout).get()
+    val response = WS.url(url).withHeaders(headers.toSeq: _*).withRequestTimeout(contentApiTimeout).get()
 
     // record metrics
     response.onSuccess {


### PR DESCRIPTION
If content API is going to start caching, then they will not thank us for including the host in every call.
