### PR TITLE
Ad-Data Feed Clients More Consistent

### DIFF
--- a/commercial/app/model/commercial/AdsApi.scala
+++ b/commercial/app/model/commercial/AdsApi.scala
@@ -1,0 +1,76 @@
+package model.commercial
+
+import scala.concurrent.Future
+import play.api.libs.json.JsValue
+import play.api.libs.ws.WS
+import common.{ExecutionContexts, Logging}
+import scala.xml.{XML, Elem}
+
+trait AdsApi {
+
+  protected val adTypeName: String
+
+  protected val loadTimeout: Int = 2000
+}
+
+trait JsonAdsApi[T <: Ad] extends AdsApi with ExecutionContexts with Logging {
+
+  def parse(json: JsValue): Seq[T]
+
+  def loadAds(url: => Option[String]): Future[Seq[T]] = {
+    url map {
+      u =>
+        val fads = WS.url(u) withRequestTimeout loadTimeout get() map {
+          response => {
+            val json = response.json
+            parse(json)
+          }
+        }
+
+        fads onSuccess {
+          case ads => log.info(s"Loaded ${ads.size} $adTypeName from $u")
+        }
+        fads onFailure {
+          case e: Exception => log.error(s"Loading $adTypeName ads from $u failed: ${e.getMessage}")
+        }
+
+        fads
+
+    } getOrElse {
+      log.warn(s"Missing $adTypeName URL")
+      Future(Nil)
+    }
+  }
+}
+
+trait XmlAdsApi[T <: Ad] extends AdsApi with ExecutionContexts with Logging {
+
+  def cleanResponseBody(body: String): String = body
+
+  def parse(xml: Elem): Seq[T]
+
+  def loadAds(url: => Option[String]): Future[Seq[T]] = {
+    url map {
+      u =>
+        val fads = WS.url(u) withRequestTimeout loadTimeout get() map {
+          response => {
+            val xml = XML.loadString(cleanResponseBody(response.body))
+            parse(xml)
+          }
+        }
+
+        fads onSuccess {
+          case ads => log.info(s"Loaded ${ads.size} $adTypeName from $u")
+        }
+        fads onFailure {
+          case e: Exception => log.error(s"Loading $adTypeName ads from $u failed: ${e.getMessage}")
+        }
+
+        fads
+
+    } getOrElse {
+      log.warn(s"Missing $adTypeName URL")
+      Future(Nil)
+    }
+  }
+}

--- a/commercial/app/model/commercial/jobs/JobsAgent.scala
+++ b/commercial/app/model/commercial/jobs/JobsAgent.scala
@@ -16,11 +16,13 @@ object JobsAgent extends AdAgent[Job] with ExecutionContexts with Logging {
     val currentJobs =
       if (Play.isDev) {
         val jobAdData = Try(S3.get("DEV/commercial/job-ads.xml")) getOrElse None
-        jobAdData.map {
-          content =>
-            val xml = Future(XML.loadString(content))
-            JobsApi.getCurrentJobs(xml)
-        }.getOrElse(Future(Nil))
+        Future {
+          jobAdData.map {
+            content =>
+              val xml = XML.loadString(content)
+              JobsApi.parse(xml)
+          }.getOrElse(Nil)
+        }
       }
       else JobsApi.getCurrentJobs()
 

--- a/commercial/app/model/commercial/jobs/JobsApi.scala
+++ b/commercial/app/model/commercial/jobs/JobsApi.scala
@@ -1,80 +1,54 @@
 package model.commercial.jobs
 
 import scala.concurrent.Future
-import common.{Logging, ExecutionContexts}
 import org.joda.time.format.DateTimeFormat
-import scala.xml.{XML, Elem}
-import play.api.libs.ws.WS
+import scala.xml.Elem
 import conf.CommercialConfiguration
 import model.commercial.Utils.OptString
+import model.commercial.XmlAdsApi
 
-object JobsApi extends ExecutionContexts with Logging {
+object JobsApi extends XmlAdsApi[Job] {
+
+  protected val adTypeName = "Jobs"
+
+  override protected val loadTimeout = 60000
 
   private val dateFormat = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm:ss")
 
-  private def loadXml: Future[Elem] = {
+  override def cleanResponseBody(body: String) = body.replace(0x001b.toChar, ' ')
 
-    def buildUrl: Option[String] = {
-      for {
-        url <- CommercialConfiguration.jobsApi.url
-        key <- CommercialConfiguration.jobsApi.key
-      } yield s"$url?login=$key"
-    }
+  private def loadJobs: Future[Seq[Job]] = loadAds {
+    for {
+      url <- CommercialConfiguration.jobsApi.url
+      key <- CommercialConfiguration.jobsApi.key
+    } yield s"$url?login=$key"
+  }
 
-    buildUrl map {
-      url =>
-        val xml = WS.url(url) withRequestTimeout 60000 get() map {
-          response =>
-            val body = response.body.replace(0x001b.toChar, ' ')
-            XML.loadString(body)
-        }
-
-        xml onFailure {
-          case e: Exception => log.error(s"Loading job ads failed: ${e.getMessage}")
-        }
-
-        xml
-    } getOrElse {
-      log.warn("No Jobs API config properties set")
-      Future(<jobs/>)
+  def parse(xml: Elem): Seq[Job] = {
+    (xml \ "Job") map {
+      job =>
+        Job(
+          (job \ "JobID").text.toInt,
+          (job \ "AdType").text,
+          dateFormat.parseDateTime((job \ "StartDateTime").text),
+          dateFormat.parseDateTime((job \ "EndDateTime").text),
+          (job \ "IsPremium").text.toBoolean,
+          (job \ "PositionType").text,
+          (job \ "JobTitle").text,
+          (job \ "ShortJobDescription").text,
+          (job \ "SalaryDescription").text,
+          OptString((job \ "LocationDescription").text),
+          OptString((job \ "RecruiterLogoURL").text),
+          OptString((job \ "EmployerLogoURL").text),
+          (job \ "JobListingURL").text,
+          (job \ "ApplyURL").text,
+          ((job \ "Sector" \ "Description") map (_.text)).distinct,
+          (job \ "Location" \ "Description") map (_.text)
+        )
     }
   }
 
-  private def getAllJobs(xml: => Future[Elem] = loadXml): Future[Seq[Job]] = {
-
-    log.info("Loading job ads...")
-
-    val jobs = xml map {
-      jobs => (jobs \ "Job") map {
-        job =>
-          Job(
-            (job \ "JobID").text.toInt,
-            (job \ "AdType").text,
-            dateFormat.parseDateTime((job \ "StartDateTime").text),
-            dateFormat.parseDateTime((job \ "EndDateTime").text),
-            (job \ "IsPremium").text.toBoolean,
-            (job \ "PositionType").text,
-            (job \ "JobTitle").text,
-            (job \ "ShortJobDescription").text,
-            (job \ "SalaryDescription").text,
-            OptString((job \ "LocationDescription").text),
-            OptString((job \ "RecruiterLogoURL").text),
-            OptString((job \ "EmployerLogoURL").text),
-            (job \ "JobListingURL").text,
-            (job \ "ApplyURL").text,
-            ((job \ "Sector" \ "Description") map (_.text)).distinct,
-            (job \ "Location" \ "Description") map (_.text)
-          )
-      }
-    }
-
-    for (loadedJobs <- jobs) log.info(s"Loaded ${loadedJobs.size} job ads")
-
-    jobs
+  def getCurrentJobs(allJobs: Future[Seq[Job]] = loadJobs): Future[Seq[Job]] = {
+    allJobs map (_ filter (_.isCurrent))
   }
-
-  def getCurrentJobs(xml: => Future[Elem] = loadXml): Future[Seq[Job]] = {
-    getAllJobs(xml) map (_ filter (_.isCurrent))
-  }
-
 }

--- a/commercial/app/model/commercial/jobs/LightJobsAgent.scala
+++ b/commercial/app/model/commercial/jobs/LightJobsAgent.scala
@@ -7,7 +7,7 @@ object LightJobsAgent extends AdAgent[LightJob] with ExecutionContexts with Logg
 
   def refresh() {
     for {
-      jobs <- LightJobsApi.getCurrentJobs()
+      jobs <- LightJobsApi.getCurrentJobs
     } updateCurrentAds(jobs)
   }
 

--- a/commercial/app/model/commercial/jobs/LightJobsApi.scala
+++ b/commercial/app/model/commercial/jobs/LightJobsApi.scala
@@ -1,66 +1,34 @@
 package model.commercial.jobs
 
 import scala.concurrent.Future
-import common.{Logging, ExecutionContexts}
-import scala.xml.{XML, Elem}
-import play.api.libs.ws.WS
+import scala.xml.Elem
 import conf.CommercialConfiguration
 import model.commercial.Utils.OptString
+import model.commercial.XmlAdsApi
 
-object LightJobsApi extends ExecutionContexts with Logging {
+object LightJobsApi extends XmlAdsApi[LightJob] {
 
-  private def loadXml: Future[Elem] = {
+  val adTypeName = "Jobs"
 
-    def buildUrl: Option[String] = {
-      for {
-        url <- CommercialConfiguration.jobsApi.lightFeedUrl
-      } yield {
-        val feedUrl = s"$url"
-        log.info(s"Using job ads feed URL: $feedUrl")
-        feedUrl
-      }
-    }
+  override protected val loadTimeout = 10000
 
-    buildUrl map {
-      url =>
-        val xml = WS.url(url) withRequestTimeout 10000 get() map {
-          response =>
-            val body = response.body dropWhile (_ != '<')
-            XML.loadString(body)
-        }
+  override def cleanResponseBody(body: String) = body.dropWhile(_ != '<')
 
-        xml onFailure {
-          case e: Exception => log.error(s"Loading job ads failed: ${e.getMessage}")
-        }
-
-        xml
-    } getOrElse {
-      log.error("No Jobs API config properties set")
-      Future(<jobs/>)
+  def parse(xml: Elem): Seq[LightJob] = {
+    (xml \ "Job") map {
+      job =>
+        LightJob(
+          (job \ "JobID").text.toInt,
+          (job \ "JobTitle").text,
+          (job \ "ShortJobDescription").text,
+          (job \ "RecruiterName").text,
+          OptString((job \ "RecruiterLogoURL").text),
+          ((job \ "Sectors" \ "Sector") map (_.text.toInt)).toSet
+        )
     }
   }
 
-  def getCurrentJobs(xml: => Future[Elem] = loadXml): Future[Seq[LightJob]] = {
-
-    log.info("Loading job ads...")
-
-    val jobs = xml map {
-      jobs => (jobs \ "Job") map {
-        job =>
-          LightJob(
-            (job \ "JobID").text.toInt,
-            (job \ "JobTitle").text,
-            (job \ "ShortJobDescription").text,
-            (job \ "RecruiterName").text,
-            OptString((job \ "RecruiterLogoURL").text),
-            ((job \ "Sectors" \ "Sector") map (_.text.toInt)).toSet
-          )
-      }
-    }
-
-    for (loadedJobs <- jobs) log.info(s"Loaded ${loadedJobs.size} job ads")
-
-    jobs
+  def getCurrentJobs: Future[Seq[LightJob]] = loadAds {
+    for {url <- CommercialConfiguration.jobsApi.lightFeedUrl} yield s"$url"
   }
-
 }

--- a/commercial/app/model/commercial/masterclasses/MasterClass.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClass.scala
@@ -5,6 +5,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.JsValue
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Element, Document}
+import model.commercial.{Segment, Ad}
 
 object MasterClass {
   private val datePattern: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")
@@ -37,7 +38,7 @@ object MasterClass {
       new MasterClass(id.toString, title, startDate, url, description, status, tickets.toList, capacity, element.attr("href"), paragraphs.head.text)
     }
 
-    return result.headOption
+    result.headOption
   }
 }
 
@@ -50,7 +51,7 @@ case class MasterClass(id: String,
                        tickets: List[Ticket],
                        capacity: Int,
                        guardianUrl: String,
-                       firstParagraph: String = "") {
+                       firstParagraph: String = "") extends Ad {
   def isOpen = {status == "Live"}
 
   lazy val displayPrice = {
@@ -60,6 +61,8 @@ case class MasterClass(id: String,
       "%1.2f to %1.2f".format(low, high)
     } else "%1.2f".format(priceList.head)
   }
+
+  def matches(segment: Segment) = true
 }
 
 case class Ticket(price: Double)

--- a/commercial/app/model/commercial/masterclasses/MasterClassesApi.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClassesApi.scala
@@ -1,35 +1,27 @@
 package model.commercial.masterclasses
 
-import common.ExecutionContexts
-import play.api.libs.ws.WS
-import play.api.libs.json.{JsNull, JsValue}
+import play.api.libs.json.JsValue
 import scala.concurrent.Future
 import conf.CommercialConfiguration
+import model.commercial.JsonAdsApi
 
-object MasterClassesApi extends ExecutionContexts {
+object MasterClassesApi extends JsonAdsApi[MasterClass] {
+
   lazy val apiId = "3497465071"
   lazy val apiKeyOption = CommercialConfiguration.masterclasses.apiKey
 
+  val adTypeName = "Masterclasses"
+
+  override protected val loadTimeout = 20000
+
   def extractEventsFromFeed(jsValue: JsValue) = jsValue \\ "event"
 
-  def getAll: Future[Seq[MasterClass]] = {
-    getMasterClassJson map {
-      eventBriteJson =>
-        val maybes: Seq[Option[MasterClass]] = extractEventsFromFeed(eventBriteJson) map (MasterClass(_))
-        maybes.flatten
-    }
+  def parse(json: JsValue) = {
+    val maybes = extractEventsFromFeed(json) map (MasterClass(_))
+    maybes.flatten
   }
 
-  def getMasterClassJson: Future[JsValue] = {
-    apiKeyOption match {
-      case Some(apiKey) =>
-        WS.url(s"https://www.eventbrite.com/json/organizer_list_events?app_key=$apiKey&id=$apiId")
-          .withHeaders(("Cache-Control", "public, max-age=1"))
-          .withRequestTimeout(20000)
-          .get()
-          .map(_.json)
-      case None =>
-        Future(JsNull)
-    }
+  def getAll: Future[Seq[MasterClass]] = loadAds {
+    apiKeyOption map (apiKey => s"https://www.eventbrite.com/json/organizer_list_events?app_key=$apiKey&id=$apiId")
   }
 }

--- a/commercial/app/model/commercial/soulmates/SoulmatesApi.scala
+++ b/commercial/app/model/commercial/soulmates/SoulmatesApi.scala
@@ -1,56 +1,37 @@
 package model.commercial.soulmates
 
 import scala.concurrent.Future
-import common.{Logging, ExecutionContexts}
-import play.api.libs.ws.WS
 import conf.CommercialConfiguration
-import play.api.libs.json.{JsNull, JsArray, JsValue}
+import play.api.libs.json.{JsArray, JsValue}
+import model.commercial.JsonAdsApi
 
-object SoulmatesApi extends ExecutionContexts with Logging {
+object SoulmatesApi extends JsonAdsApi[Member] {
 
-  private def loadMembers(url: => Option[String]): Future[JsValue] = {
-    url map {
-      u =>
-        val json = WS.url(u) withRequestTimeout 10000 get() map {
-          response => response.json
-        }
+  val adTypeName = "Soulmates"
 
-        json onSuccess {
-          case JsArray(ads) => log.info(s"Loaded ${ads.size} soulmates ads from $u")
-        }
-        json onFailure {
-          case e: Exception => log.error(s"Loading soulmates ads from $u failed: ${e.getMessage}")
-        }
+  override protected val loadTimeout = 10000
 
-        json
-    } getOrElse {
-      log.warn("No Soulmates API config properties set")
-      Future(JsNull)
-    }
-  }
-
-  def parse(json: => Future[JsValue]): Future[Seq[Member]] = {
-    json map {
-      case JsArray(members) =>
-        members map {
-          member =>
-            Member(
-              (member \ "username").as[String],
-              Gender((member \ "gender").as[String]),
-              (member \ "age").as[Int],
-              (member \ "profile_photo").as[String]
-            )
-        }
+  def parse(json: JsValue): Seq[Member] = {
+    json match {
+      case JsArray(members) => members map {
+        member =>
+          Member(
+            (member \ "username").as[String],
+            Gender((member \ "gender").as[String]),
+            (member \ "age").as[Int],
+            (member \ "profile_photo").as[String]
+          )
+      }
       case other => Nil
     }
   }
 
-  def getMenMembers: Future[Seq[Member]] = parse(loadMembers {
+  def getMenMembers: Future[Seq[Member]] = loadAds {
     CommercialConfiguration.soulmatesApi.menUrl
-  })
+  }
 
-  def getWomenMembers: Future[Seq[Member]] = parse(loadMembers {
+  def getWomenMembers: Future[Seq[Member]] = loadAds {
     CommercialConfiguration.soulmatesApi.womenUrl
-  })
+  }
 
 }

--- a/commercial/app/model/commercial/travel/OffersAgent.scala
+++ b/commercial/app/model/commercial/travel/OffersAgent.scala
@@ -53,9 +53,8 @@ object OffersAgent extends AdAgent[Offer] with Logging with ExecutionContexts {
       }
     }
 
-    OffersApi.getAllOffers() onSuccess {
+    OffersApi.getAllOffers onSuccess {
       case untaggedOffers =>
-        log info s"Loaded ${untaggedOffers.size} travel offers"
         tagAssociatedCountries(untaggedOffers) onSuccess {
           case countryTags =>
             val offers = tagOffers(untaggedOffers, countryTags)

--- a/commercial/app/model/commercial/travel/OffersApi.scala
+++ b/commercial/app/model/commercial/travel/OffersApi.scala
@@ -1,13 +1,12 @@
 package model.commercial.travel
 
 import scala.concurrent.Future
-import common.Logging
 import org.joda.time.format.DateTimeFormat
 import scala.xml.{Elem, Node}
 import conf.CommercialConfiguration
 import model.commercial.XmlAdsApi
 
-object OffersApi extends XmlAdsApi[Offer] with Logging {
+object OffersApi extends XmlAdsApi[Offer] {
 
   val adTypeName = "Travel Offers"
 

--- a/commercial/test/model/commercial/jobs/JobsApiTest.scala
+++ b/commercial/test/model/commercial/jobs/JobsApiTest.scala
@@ -10,9 +10,9 @@ import scala.xml.XML
 class JobsApiTest extends FlatSpec with Matchers with ExecutionContexts {
 
   "getCurrentJobs" should "load all unexpired jobs from XML feed" in {
-    val jobs = JobsApi.getCurrentJobs(Future {
-      XML.loadString(Fixtures.xml)
-    })
+    val jobs = JobsApi.getCurrentJobs {
+      Future(JobsApi.parse(XML.loadString(Fixtures.xml)))
+    }
 
     Await.result(jobs, atMost = 1.seconds) should be(Fixtures.jobs)
   }

--- a/commercial/test/model/commercial/jobs/LightJobsApiTest.scala
+++ b/commercial/test/model/commercial/jobs/LightJobsApiTest.scala
@@ -1,20 +1,16 @@
 package model.commercial.jobs
 
-import scala.concurrent.{Await, Future}
 import common.ExecutionContexts
-import scala.concurrent.duration._
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import scala.xml.XML
 
 class LightJobsApiTest extends FlatSpec with Matchers with ExecutionContexts {
 
-  "getCurrentJobs" should "load all unexpired jobs from XML feed" in {
-    val jobs = LightJobsApi.getCurrentJobs(Future {
-      XML.loadString(LightFixtures.xml)
-    })
+  "parse" should "parse all jobs in XML feed" in {
+    val jobs = LightJobsApi.parse(XML.loadString(LightFixtures.xml))
 
-    Await.result(jobs, atMost = 1.seconds) should be(LightFixtures.jobs)
+    jobs should be(LightFixtures.jobs)
   }
 
 }

--- a/commercial/test/model/commercial/soulmates/SoulmatesApiTest.scala
+++ b/commercial/test/model/commercial/soulmates/SoulmatesApiTest.scala
@@ -1,8 +1,6 @@
 package model.commercial.soulmates
 
-import scala.concurrent.{Await, Future}
 import common.ExecutionContexts
-import scala.concurrent.duration._
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import play.api.libs.json.Json
@@ -10,11 +8,9 @@ import play.api.libs.json.Json
 class SoulmatesApiTest extends FlatSpec with Matchers with ExecutionContexts {
 
   "parse" should "parse members from json feed" in {
-    val members = SoulmatesApi.parse(Future {
-      Json.parse(Fixtures.Popular.json)
-    })
+    val members = SoulmatesApi.parse(Json.parse(Fixtures.Popular.json))
 
-    Await.result(members, atMost = 1.seconds) should be(Fixtures.Popular.members)
+    members should be(Fixtures.Popular.members)
   }
 
 }

--- a/commercial/test/model/commercial/travel/OffersApiTest.scala
+++ b/commercial/test/model/commercial/travel/OffersApiTest.scala
@@ -1,15 +1,13 @@
 package model.commercial.travel
 
 import org.scalatest.Matchers
-import scala.concurrent.{Await, Future}
 import common.ExecutionContexts
-import scala.concurrent.duration._
 import org.scalatest.FlatSpec
 import scala.xml.XML
 
 class OffersApiTest extends FlatSpec with Matchers with ExecutionContexts {
 
-  val xml = Future(XML.loadString {
+  val xml = XML.loadString {
     """
       |<guardianholidayoffers>
       |<offers count="273" generated="15-Oct-2013 13:59:37">
@@ -184,10 +182,10 @@ class OffersApiTest extends FlatSpec with Matchers with ExecutionContexts {
       |</offers>
       |</guardianholidayoffers>
     """.stripMargin
-  })
+  }
 
   "OffersApi" should "build Offers from XML" in {
-    val offers = Await.result(OffersApi.getAllOffers(xml), atMost = 1.seconds)
+    val offers = OffersApi.parse(xml)
     offers should be(Fixtures.untaggedOffers)
   }
 


### PR DESCRIPTION
Put feed-loading clients into consistent framework so that they work in the same way and get consistent logging.
