### PR TITLE
Better Sass Documentation 

### DIFF
--- a/common/app/assets/stylesheets/_extends-only.scss
+++ b/common/app/assets/stylesheets/_extends-only.scss
@@ -1,24 +1,33 @@
-//Base font-sizes
-//Mixin uses arguments: (family, weight, size, line-height);
+// Base font-sizes
+// Mixin uses arguments: font(family, weight, size, line-height);
 
+// Type extends
+// =============================================================================
 
-//SerifHeadline
+// DEPRECATED:
+// Use font-scale mixins instead
+
+// Serif Headline
 %type-1 { @include font($serifheadline, normal, 20, 28); }
 %type-2 { @include font($serifheadline, normal, 18, 28); }
 
-//SerifText
+// Serif Text
 %type-3 { @include font($serifheadline, normal, 26, 30); }
 %type-4 { @include font($serif, 700, 18, 24); }
 %type-5 { @include font($serifheadline, normal, 18, 24); }
 %type-6 { @include font($serif, normal, 16, 24); }
 %type-7 { @include font($serif, normal, 14, 20); }
 
-//Sans-serif's
+// Sans-serif
 %type-8  { @include font($sans-serif, normal, 14, 20); }
 %type-9  { @include font($sans-serif, bold, 13, 20); }
 %type-10 { @include font($sans-serif, normal, 13, 20); }
 %type-11 { @include font($sans-serif, normal, 13, 16); }
 %type-12 { @include font($sans-serif, normal, 11, 16); }
+
+
+// Misc
+// =============================================================================
 
 %d-badge-icon {
     display: inline-block;

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -31,6 +31,10 @@
     }
 }
 
+
+// Font Helpers
+// =============================================================================
+
 @mixin font-size($size, $line-height: $size) {
     @include rem((
         font-size: $size,
@@ -45,8 +49,9 @@
     @include font-size($size, $line-height);
 }
 
-// -----------------------------------------------------------------------------
+
 // Font Scale
+// =============================================================================
 
 // Prefixes:
 // f- stands for Font: use to set a font-family only

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -38,11 +38,19 @@
     ));
 }
 
+// Use only if necessary, prefer usage of the font-scale
 @mixin font($family, $weight, $size, $line-height: $size) {
     font-family: $family;
     font-weight: $weight;
     @include font-size($size, $line-height);
 }
+
+// -----------------------------------------------------------------------------
+// Font Scale
+
+// Prefixes:
+// f- stands for Font: use to set a font-family only
+// fs- for Font Scale: see documentation in docs/design/font-scale.jpg
 
 @mixin f-header {
     font-family: $serifheadline;
@@ -122,6 +130,9 @@
     }
 }
 
+// CSS3 helpers
+// =============================================================================
+
 @mixin sticky {
     position: -webkit-sticky;
     position: -moz-sticky;
@@ -200,6 +211,9 @@
     user-select: none;
 }
 
+// Misc
+// =============================================================================
+
 @mixin fix-aspect-ratio($width, $height, $startingWidth: 100%) {
     // To get this working, position the child element
     // to 'absolute' in the top left corner
@@ -211,8 +225,7 @@
 }
 
 @mixin old-ie {
-    // Only use this content if we're dealing with old IE
-    @if $old-ie {
+    @if $old-ie { // Only use this content if we're dealing with old IE
         @content;
     }
 }

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -1,22 +1,21 @@
-/* ==========================================================================
-   Global variables
-   ========================================================================== */
+// =============================================================================
+// Global variables
+// =============================================================================
 
-/**
- * Be careful of Sass variable scope:
- * http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#variables_
- */
+// Be careful of Sass variable scope
+// Note: Sass 3.3.0 adds Local and local vars
+// http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#variables
 
 
-/* Support
-   ========================================================================== */
+// Support
+// =============================================================================
 
 $old-ie:      false !default;
 $svg-support: true !default;
 
 
-/* Layout dimensions
-   ========================================================================== */
+// Layout dimensions
+// =============================================================================
 
 $baseline: 4px;
 $gutter: 16px;
@@ -27,8 +26,8 @@ $trailblockImgWidthLarge: 140px;
 $headerHeight: 58px;
 
 
-/* Breakpoints
-   ========================================================================== */
+// Breakpoints
+// =============================================================================
 
 // Name your breakpoints in a way that creates a ubiquitous language
 // across team members. It will improve communication between
@@ -60,8 +59,8 @@ $mq-breakpoints: (
 );
 
 
-/* Fonts
-   ========================================================================== */
+// Fonts
+// =============================================================================
 
 $sans-serif: "AgateSans", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 $serif: "EgyptianText", georgia, serif;
@@ -114,12 +113,11 @@ $fs-data: (
     18 22  // 6
 );
 
-/* Colours
-   ========================================================================== */
+// Colours
+// =============================================================================
 
-/**
- * @todo: Blues need comments to associate with brand/logo colours
- */
+// @todo: Blues need comments to associate with brand/logo colours
+
 $c-brandBlue: #214583;
 
 $c-neutral1: #333333;
@@ -131,8 +129,8 @@ $c-neutral6: #edede7;
 $c-neutral7: #f4f4ee;
 
 
-/* Tones
-   ========================================================================== */
+// Tones
+// =============================================================================
 
 $c-newsDefault: #005689;
 $c-newsAccent: #4BC6DF;
@@ -144,12 +142,11 @@ $c-commentDefault: #E6711B;
 $c-commentAccent: #FFBB00;
 
 
-/* Zones
-   ========================================================================== */
+// Zones
+// =============================================================================
 
-/**
- * note: try to at least alphabetise these within sections
- */
+// Note: try to at least alphabetise these within sections
+
 $articleOrange: #e47a39; //Used for live-blogging
 $businessBlue: #004179;
 $commentBlue: #004179;
@@ -162,8 +159,8 @@ $newsRed: #D61D00;
 $travelBlue: #066EC9;
 
 
-/* Football
-   ========================================================================== */
+// Football
+// =============================================================================
 
 $c-sportBright: #70d2e6;
 $c-sportMid: #005689;

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -1,15 +1,14 @@
-//Set's baseline font size to 10px
-//This is used for all em's
+// Set baseline font size to 10px
+// This is used as a baseline for rem (root ems) values
 html {
     font-size: 62.5%;
     font-size: (10/16)*1em;
     font-family: $serif;
 }
 
-//Bump font-size back upto 16px
+// Bump font-size back up to 16px
 body {
     color: #545454;
-    font-size: 100%;
     font-size: 1.6em;
     line-height: 1.4;
 }
@@ -24,12 +23,12 @@ h1, h2, h3, h4, h5, h6 {
 
 .type-2 { @extend %type-2; }
 
-//SerifText
+// SerifText
 .type-5 { @extend %type-5; }
 .type-6 { @extend %type-6; }
 .type-7 { @extend %type-7; }
 
-//Sans-serif's
+// Sans-serif
 .type-8  { @extend %type-8; }
 .type-10 { @extend %type-10; }
 .type-11 { @extend %type-11; }
@@ -39,7 +38,7 @@ blockquote {
     margin: 0;
 }
 
-//Default type elements
+// Default type elements
 p {
     margin-top: 0;
     margin-bottom: $baseline*2;

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -1,25 +1,40 @@
-// Set baseline font size to 10px
-// This is used as a baseline for rem (root ems) values
-html {
-    font-size: 62.5%;
-    font-size: (10/16)*1em;
-    font-family: $serif;
-}
+/* ==========================================================================
+   Global typography settings
+   ========================================================================== */
 
-// Bump font-size back up to 16px
+/* Root base
+   ========================================================================== */
+
+html {
+    font-family: $serif;
+    font-size: 62.5%; // Set baseline font size to 10px
+                      // This is used as a baseline for rem (root ems) values
+}
 body {
     color: #545454;
-    font-size: 1.6em;
+    font-size: 1.6em; // Bump font-size back up to 16px
     line-height: 1.4;
 }
 
-// Base headings
+
+/* Base headings
+   ========================================================================== */
+
 h1, h2, h3, h4, h5, h6 {
     color: #333333;
     font-family: $serif;
     margin: 0;
     text-rendering: optimizeLegibility;
 }
+
+
+/* Type helpers
+   ========================================================================== */
+
+/**
+ * DEPRECATED:
+ * Use font-scale mixins instead
+ */
 
 .type-2 { @extend %type-2; }
 
@@ -34,25 +49,24 @@ h1, h2, h3, h4, h5, h6 {
 .type-11 { @extend %type-11; }
 .type-12 { @extend %type-12; }
 
+
+/* Default type elements
+   ========================================================================== */
+
 blockquote {
     margin: 0;
 }
-
-// Default type elements
 p {
     margin-top: 0;
     margin-bottom: $baseline*2;
 }
-
 h1 {
     @extend %type-1;
 }
-
 h3 {
     margin-bottom: 7px;
     @extend %type-6;
 }
-
 th,
 td {
     @extend %type-10;

--- a/common/app/assets/stylesheets/layout/_grid-system.scss
+++ b/common/app/assets/stylesheets/layout/_grid-system.scss
@@ -1,10 +1,18 @@
-// Helpers
+// =============================================================================
+// Grid system
+// =============================================================================
+// gs- prefixes stand for Grid System
+
+// Configuration
 $gs-gutter: 20px;
 $gs-baseline: 12px;
 $gs-column-width: 60px;
 $gs-column-height: 36px;
 $gs-max-columns: 16;
 
+
+// Helpers
+// =============================================================================
 
 @function gs-span($n-columns) {
     @return $n-columns * $gs-column-width + $gs-gutter * ($n-columns - 1);
@@ -22,7 +30,10 @@ $gs-max-columns: 16;
     }
 }
 
-// Output grid system
+
+// Output grid system helper classes
+// =============================================================================
+
 @mixin grid-system {
     .gs-container {
         @include gs-container;


### PR DESCRIPTION
- Stop outputting comments when there is no code output (vars… mixins…)
- Font-scale documentation is better
- Grid system documentation is better too
- Remove unnecessary 100% font size on the body (which gets overridden by the 1.6em value

If anything needs disambiguation in the Sass codebase, please ask and I'll document it in this PR.

Thanks to @jamesgorrie for pointing that some stuff was not self-explanatory!

![ ](http://s1.developerslife.ru/public/images/gifs/e24278a6-4242-4d02-b8fb-071f64b66e6a.gif)
