### PR TITLE
Remove text-rendering properties - Fixes webfont in Android 4.2+

### DIFF
--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -47,7 +47,6 @@
 @mixin f-header {
     font-family: $serifheadline;
     font-weight: 900;
-    text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
 }
 @mixin fs-header($level, $size-only: false) {
@@ -63,7 +62,6 @@
 @mixin f-headline {
     font-family: $serifheadline;
     font-weight: normal;
-    text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
 }
 @mixin fs-headline($level, $size-only: false) {
@@ -79,7 +77,6 @@
 @mixin f-bodyHeading {
     font-family: $serif;
     font-weight: bold;
-    text-rendering: optimizeLegibility;
     -webkit-font-smoothing: subpixel-antialiased;
 }
 @mixin fs-bodyHeading($level, $size-only: false) {
@@ -95,7 +92,6 @@
 @mixin f-bodyCopy {
     font-family: $serif;
     -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeSpeed;
 }
 @mixin fs-bodyCopy($level, $size-only: false) {
     $bodycopy: nth($fs-bodyCopy, $level);
@@ -110,7 +106,6 @@
 @mixin f-data {
     font-family: $sans-serif;
     -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeSpeed;
 }
 @mixin fs-data($level, $size-only: false) {
     $data: nth($fs-data, $level);

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -19,7 +19,6 @@ h1, h2, h3, h4, h5, h6 {
     color: #333333;
     font-family: $serif;
     margin: 0;
-    text-rendering: optimizeLegibility;
 }
 
 .type-2 { @extend %type-2; }

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -189,7 +189,6 @@
 
 .article__standfirst {
     @include fs-headline(1, true);
-    text-rendering: optimizeLegibility;
     margin-bottom: $baseline*3;
     color: $c-neutral2;
 

--- a/common/app/assets/stylesheets/module/external/_witness.scss
+++ b/common/app/assets/stylesheets/module/external/_witness.scss
@@ -137,7 +137,6 @@
     @include font($serif, 700, 16, 16);
     letter-spacing: -.04em;
     text-transform: lowercase;
-    text-rendering: optimizeLegibility;
 }
 .witness-logo__witness {
     color: $c-neutral2;

--- a/common/app/assets/stylesheets/module/trails/_trail.scss
+++ b/common/app/assets/stylesheets/module/trails/_trail.scss
@@ -61,7 +61,6 @@
 }
 .trail__text {
     @include fs-bodyCopy(1);
-    text-rendering: optimizeLegibility;
 
     @include mq(tablet) {
         @include fs-bodyCopy(3, true);


### PR DESCRIPTION
Android 4.2+ stock browser & webview has trouble rendering webfonts when text-rendering is set on an element…

PS: If we really care about kerning in headlines we can try to use opentype font settings but this is a very code heavy method.

![ ](http://s1.developerslife.ru/public/images/gifs/4d77bd92-f824-479a-8a8b-af4c25830bee.gif)
