### PR TITLE
Require Sign in class

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -134,17 +134,17 @@ Comments.prototype.bindCommentEvents = function() {
 };
 
 Comments.prototype.renderReplyButtons = function(comments) {
-    var actions,
-        self = this;
+    // var actions,
+    //     self = this;
 
-    comments = comments || this.comments;
+    // comments = comments || this.comments;
 
-    comments.forEach(function(elem, i) {
-        actions = qwery(self.getClass('commentActions'), elem)[0];
-        bonzo(actions).prepend(
-            '<div class="u-fauxlink d-comment__action '+ self.getClass('commentReply', true) +'" '+
-            'role="button" data-link-name="reply to comment" data-comment-id="'+ elem.getAttribute('data-comment-id') +'">Reply</div>');
-    });
+    // comments.forEach(function(elem, i) {
+    //     actions = qwery(self.getClass('commentActions'), elem)[0];
+    //     bonzo(actions).prepend(
+    //         '<div class="u-fauxlink d-comment__action '+ self.getClass('commentReply', true) +'" '+
+    //         'role="button" data-link-name="reply to comment" data-comment-id="'+ elem.getAttribute('data-comment-id') +'">Reply</div>');
+    // });
 };
 
 /**

--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -128,23 +128,8 @@ Comments.prototype.bindCommentEvents = function() {
     RecommendComments.init(this.context);
 
     if (this.user && this.user.privateFields.canPostComment) {
-        this.renderReplyButtons();
         this.on('click', this.getClass('commentReply'), this.replyToComment);
     }
-};
-
-Comments.prototype.renderReplyButtons = function(comments) {
-    // var actions,
-    //     self = this;
-
-    // comments = comments || this.comments;
-
-    // comments.forEach(function(elem, i) {
-    //     actions = qwery(self.getClass('commentActions'), elem)[0];
-    //     bonzo(actions).prepend(
-    //         '<div class="u-fauxlink d-comment__action '+ self.getClass('commentReply', true) +'" '+
-    //         'role="button" data-link-name="reply to comment" data-comment-id="'+ elem.getAttribute('data-comment-id') +'">Reply</div>');
-    // });
 };
 
 /**
@@ -235,9 +220,6 @@ Comments.prototype.commentsLoaded = function(resp) {
         this.removeShowMoreButton();
     }
 
-    if (!this.isReadOnly()) {
-        this.renderReplyButtons(qwery(this.getClass('comment'), bonzo(comments).parent()));
-    }
     bonzo(this.getElem('comments')).append(comments);
 
     showMoreButton.innerHTML = 'Show more';

--- a/common/app/assets/javascripts/modules/discussion/top-comments.js
+++ b/common/app/assets/javascripts/modules/discussion/top-comments.js
@@ -185,20 +185,6 @@ TopComments.prototype.bindCommentEvents = function() {
     }
 };
 
-TopComments.prototype.renderReplyButtons = function(comments) {
-    var actions,
-        self = this;
-
-    comments = comments || this.comments;
-
-    comments.forEach(function(elem, i) {
-        actions = qwery(self.getClass('commentActions'), elem)[0];
-        bonzo(actions).prepend(
-            '<div class="u-fauxlink d-comment__action '+ self.getClass('commentReply', true) +'" '+
-            'role="button" data-link-name="reply to comment" data-comment-id="'+ elem.getAttribute('data-comment-id') +'">Reply</div>');
-    });
-};
-
 /**
  * @param {Event} e
  */

--- a/common/app/assets/javascripts/modules/discussion/top-comments.js
+++ b/common/app/assets/javascripts/modules/discussion/top-comments.js
@@ -180,7 +180,6 @@ TopComments.prototype.bindCommentEvents = function() {
     RecommendComments.init(this.context);
 
     if (this.user && this.user.privateFields.canPostComment) {
-        this.renderReplyButtons();
         this.on('click', this.getClass('commentReply'), this.replyToComment);
     }
 };
@@ -227,7 +226,6 @@ TopComments.prototype.showHiddenComments = function() {
 //         this.removeShowMoreButton();
 //     }
 
-//     this.renderReplyButtons(qwery(this.getClass('comment'), bonzo(comments).parent()));
 //     bonzo(this.getElem('comments')).append(comments);
 
 //     showMoreButton.innerHTML = 'Show more';

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -93,6 +93,9 @@
     @include d-comment__body;
 }
 
+.d-discussion[data-read-only="true"] .sign-in-required {
+    display: none; /* Not the most performant, but it happens so rarely */
+}
 
 /* New Comment
    ===========================================================================*/

--- a/common/app/assets/stylesheets/state/_state.scss
+++ b/common/app/assets/stylesheets/state/_state.scss
@@ -95,3 +95,7 @@
     background-color: #ec1c1c;
     display: inline-block;
 }
+
+.id--signed-out .sign-in-required {
+    display: none;
+}

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -56,6 +56,7 @@
             @if(!comment.isBlocked){
                 <div class="d-comment__actions">
                     <div class="d-comment__actions__main u-cf">
+                        <div class="u-fauxlink d-comment__action d-comment__action--reply" role="button" data-link-name="reply to comment" data-comment-id="@comment.id">Reply</div>'
                         <a href="http://discussion.theguardian.com/components/report-abuse/@comment.id" class="d-comment__action d-comment__action--report" target="_blank">Report</a>
                     </div>
                 </div>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -56,7 +56,7 @@
             @if(!comment.isBlocked){
                 <div class="d-comment__actions">
                     <div class="d-comment__actions__main u-cf">
-                        <div class="u-fauxlink d-comment__action d-comment__action--reply" role="button" data-link-name="reply to comment" data-comment-id="@comment.id">Reply</div>'
+                        <div class="u-fauxlink d-comment__action d-comment__action--reply sign-in-required" role="button" data-link-name="reply to comment" data-comment-id="@comment.id">Reply</div>
                         <a href="http://discussion.theguardian.com/components/report-abuse/@comment.id" class="d-comment__action d-comment__action--report" target="_blank">Report</a>
                     </div>
                 </div>

--- a/discussion/app/views/fragments/commentsBody.scala.html
+++ b/discussion/app/views/fragments/commentsBody.scala.html
@@ -4,7 +4,9 @@
     class="d-discussion"
     data-page-count="@page.pages"
     data-comment-count="@page.commentCount"
-    data-read-only="true">
+    @page.switches.map{ switch =>
+        data-@switch.name="@switch.state"
+    }>
     <div class="d-discussion__header">
         @if(page.commentCount > 0){
         <div class="d-discussion__meta d-meta-item">

--- a/discussion/app/views/fragments/commentsBody.scala.html
+++ b/discussion/app/views/fragments/commentsBody.scala.html
@@ -4,9 +4,7 @@
     class="d-discussion"
     data-page-count="@page.pages"
     data-comment-count="@page.commentCount"
-    @page.switches.map{ switch =>
-        data-@switch.name="@switch.state"
-    }>
+    data-read-only="true">
     <div class="d-discussion__header">
         @if(page.commentCount > 0){
         <div class="d-discussion__meta d-meta-item">


### PR DESCRIPTION
# Why

Trying to make our discussion pages as cachable and performant as possible. User data and state makes this a little tricky. We're shifting a bit of the responsibility to the CSS, which might seem a bit odd, but is by far the tidiest. [See here for more explanation](https://github.com/guardian/frontend/pull/2384).

This is our first attempt of not cluttering up the JS with the reply button.

There is another small edge case which has been made easier with this is read only mode.

![Faster!](http://gifs.gifbin.com/102011/reverse-1319482109_fast_shirt_removal.gif)
