### PR TITLE
Add JSON endpoint for facia collection ID's

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -150,6 +150,9 @@ GET         /$path<(us|uk|au)?>.json                                            
 GET         /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>                           controllers.FaciaController.renderEditionSectionFront(path)
 GET         /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json                      controllers.FaciaController.renderEditionSectionFrontJson(path)
 
+GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                controllers.FaciaController.renderEditionCollection(id)
+GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                           controllers.FaciaController.renderEditionCollectionJson(id)
+
 # Applications
 GET         /sections                                                                                        controllers.SectionsController.renderSections()
 GET         /sections.json                                                                                   controllers.SectionsController.renderSectionsJson()

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -203,7 +203,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
         faciaPageOption map { faciaPage =>
           Cached(frontPage) {
             if (request.isJson) {
-              val collection = faciaPage.copy(collections = faciaPage.collections.filter(t => t._1.id == id.dropRight(5)))
+              val collection = faciaPage.copy(collections = faciaPage.collections.filter(t => t._1.id == id))
               val html = views.html.fragments.frontBody(frontPage, collection)
               JsonComponent(
                 "html" -> html,

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -162,6 +162,9 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
   def renderEditionSectionFront(path: String) = renderFront(path)
   def renderFrontJson(path: String) = renderFront(path)
 
+  def renderEditionCollection(id: String) = renderCollection(id)
+  def renderEditionCollectionJson(id: String) = renderCollection(id)
+
   def renderFront(path: String) = Action { implicit request =>
       val editionalisedPath = editionPath(path, Edition(request))
 
@@ -184,6 +187,36 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
           }
         }
       }.getOrElse(NotFound) //TODO is 404 the right thing here
+  }
+
+  def renderCollection(id: String) = Action { implicit request =>
+    val pathOption = request.queryString("path").headOption
+
+    pathOption.map { path =>
+
+      val editionalisedPath = editionPath(path, Edition(request))
+
+      FrontPage(editionalisedPath).flatMap { frontPage =>
+
+      // get the trailblocks
+        val faciaPageOption: Option[FaciaPage] = front(editionalisedPath)
+        faciaPageOption map { faciaPage =>
+          Cached(frontPage) {
+            if (request.isJson) {
+              val collection = faciaPage.copy(collections = faciaPage.collections.filter(t => t._1.id == id.dropRight(5)))
+              val html = views.html.fragments.frontBody(frontPage, collection)
+              JsonComponent(
+                "html" -> html,
+                "trails" -> JsArray(collection.collections.flatMap(_._2.items.map(TrailToJson(_))))
+              )
+            }
+            else
+              Ok(views.html.front(frontPage, faciaPage))
+          }
+        }
+      }.getOrElse(NotFound) //TODO is 404 the right thing here
+
+    }.getOrElse(NotFound)
   }
 
   def renderResponsiveViewer() = Action {

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -4,17 +4,20 @@
 
 
 # For dev machines
-GET        /assets/*path                                                                             dev.DevAssetsController.at(path)
+GET        /assets/*path                                                                      dev.DevAssetsController.at(path)
 
 # Editionalised redirects
-GET        /                                                                                         controllers.FaciaController.editionRedirect(path = "")
-GET        /$path<(culture|sport|australia|commentisfree|business|money)>                            controllers.FaciaController.editionRedirect(path)
+GET        /                                                                                  controllers.FaciaController.editionRedirect(path = "")
+GET        /$path<(culture|sport|australia|commentisfree|business|money)>                     controllers.FaciaController.editionRedirect(path)
 
 
 # Editionalised pages
-GET        /$path<(us|uk|au)?>                                                                       controllers.FaciaController.renderEditionFront(path)
-GET        /$path<(us|uk|au)?>.json                                                                  controllers.FaciaController.renderEditionFrontJson(path)
-GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>                    controllers.FaciaController.renderEditionSectionFront(path)
-GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json               controllers.FaciaController.renderEditionSectionFrontJson(path)
+GET        /$path<(us|uk|au)?>                                                                controllers.FaciaController.renderEditionFront(path)
+GET        /$path<(us|uk|au)?>.json                                                           controllers.FaciaController.renderEditionFrontJson(path)
+GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>             controllers.FaciaController.renderEditionSectionFront(path)
+GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json        controllers.FaciaController.renderEditionSectionFrontJson(path)
 
-GET        /responsive-viewer                                                                        controllers.FaciaController.renderResponsiveViewer()
+GET        /responsive-viewer                                                                 controllers.FaciaController.renderResponsiveViewer()
+
+GET        /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                  controllers.FaciaController.renderEditionCollection(id)
+GET        /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                             controllers.FaciaController.renderEditionCollectionJson(id)


### PR DESCRIPTION
This add's and API endpoint for to request container HTML markup and array of trail data for a specific collection ID. This then allows us to use this as a data source to drive onward journey components.
#### Note

This currently uses a query-string to supply the path of the front it came from to circumnavigate a complex lookup for the collection. This will all go away with the work @janua is doing to refactor Facia. In the future we should just eb able to do: `CollectionCache.get(id)`

@janua @gklopper As discussed can you please sanity check my Scala foo.

/cc @stephanfowler @commuterjoy this allows you to add your RSS endpoint.
