### PR TITLE
Fake bullet points all look the same - Fixes #2407

### DIFF
--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -232,18 +232,16 @@
 
 @mixin faux-bullet-point {
     position: relative;
-    text-indent: 20px;
-    text-indent: 2.2rem;
+    @include rem((text-indent: 20px));
 
     &:before {
-        font-size: 48px;
-        font-size: 4.8rem;
-        content: "\2022";
-        color: $c-neutral3;
         position: absolute;
-        left: -22px;
-        left: -2.2rem;
-        top: 2px;
-        top: .2rem;
+        content: "\2022";
+        @include rem((
+            left: -22px,
+            top: 2px,
+            font-size: 48px
+        ));
+        color: $c-neutral3;
     }
 }

--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -153,18 +153,20 @@
 /* Bullet points
    ========================================================================== */
 
-.no-indent {
+.bullet-container {
     text-indent: 0 !important;
+    margin-bottom: .8em !important;
 }
 .bullet {
-    font-size: 13px;
     display: inline-block;
     color: $c-neutral3;
-    margin: $baseline/2 4px $baseline/-2 0;
+    vertical-align: bottom;
 
-    &:first-of-type {
-        margin-top: $baseline;
-    }
+    @include rem((
+        font-size: 48px,
+        margin-top: 15px,
+        margin-bottom: -2px
+    ));
 }
 
 
@@ -234,7 +236,6 @@ p + figure,
 p + video {
     margin-top: $baseline;
 }
-
 
 
 /* Video embeds
@@ -342,6 +343,9 @@ p + video {
                     text-indent: 2.8rem;
                 }
             }
+        }
+        > p.bullet-container + p {
+            text-indent: 0;
         }
     }
     .from-content-api blockquote.quoted {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -279,7 +279,7 @@ object BulletCleaner {
 object UnindentBulletParents extends HtmlCleaner with implicits.JSoup {
   def clean(body: Document): Document = {
     val bullets = body.getElementsByClass("bullet")
-    bullets flatMap { _.parentTag("p") } foreach { _.addClass("no-indent") }
+    bullets flatMap { _.parentTag("p") } foreach { _.addClass("bullet-container") }
     body
   }
 }


### PR DESCRIPTION
- paragraphs containing bullet point chars mimic rendering of real unordered lists (there is a 1-2 px difference in vertical margins that unfortunately can't be compensated but I can't see it being a problem).
- Paragraphs following a fake unordered list are not indented
## Before

![screen shot 2013-11-27 at 17 11 05](https://f.cloud.github.com/assets/85783/1633411/1a24b8e4-5788-11e3-88d4-f58cb9889c02.png)
## After

![screen shot 2013-11-27 at 17 11 14](https://f.cloud.github.com/assets/85783/1633409/141ca614-5788-11e3-92a0-f596b334eb9f.png)
## What it would look like with a real `ul`

![screen shot 2013-11-27 at 17 22 31](https://f.cloud.github.com/assets/85783/1633432/92c1e54c-5788-11e3-8474-6e316dceec06.png)

![ ](http://media3.giphy.com/media/uAxBm0H1QaJ32/200.gif)
