### PR TITLE
Comment body is more legible on tablet and up

### DIFF
--- a/common/app/assets/stylesheets/module/_discussion-mixins.scss
+++ b/common/app/assets/stylesheets/module/_discussion-mixins.scss
@@ -2,10 +2,11 @@
     word-wrap: break-word;
 
     @include mq(768px) {
-        line-height: 22px;
+        @include rem((line-height: 24px));
 
         p {
             @include fs-data(5);
+            @include rem((line-height: 24px));
         }
     }
 


### PR DESCRIPTION
Sets the line-height a bit higher to make comments more legible.

Line-height was set to 20px on paragraphs and 22px on the rest.

Change proposed by Chris P, you can discuss with him.
## Before

![screen shot 2013-12-02 at 10 52 14](https://f.cloud.github.com/assets/85783/1653938/d97c3b8a-5b3f-11e3-8f69-04147c6bd9ee.png)
## After

![screen shot 2013-12-02 at 10 51 55](https://f.cloud.github.com/assets/85783/1653940/dcb28124-5b3f-11e3-9ff6-a2186a3c2184.png)

![ ](http://4.bp.blogspot.com/-pJrU_3aH2zY/UpY2Uw3NsvI/AAAAAAABDys/2opGDJKWgI0/s1600/1.gif)
