### PR TITLE
Use play framework content types that apply character encoding

### DIFF
--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -18,7 +18,7 @@ class GalleryControllerTest extends FlatSpec with Matchers {
   it should "return JSONP when callback is supplied" in Fake {
     val result = controllers.GalleryController.render(galleryUrl)(TestRequest(s"/${galleryUrl}?callback=$callbackName"))
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -28,7 +28,7 @@ class GalleryControllerTest extends FlatSpec with Matchers {
 
     val result = controllers.GalleryController.render(galleryUrl)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
 
@@ -50,7 +50,7 @@ class GalleryControllerTest extends FlatSpec with Matchers {
 
     val result = controllers.GalleryController.renderLightbox(galleryUrl)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
     contentAsString(result) should include("gallery--lightbox")
   }

--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -22,7 +22,7 @@ class IndexControllerTest extends FlatSpec with Matchers with UsesElasticSearch 
 
     val result = controllers.IndexController.render(section)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"html\"""")
   }
 
@@ -33,7 +33,7 @@ class IndexControllerTest extends FlatSpec with Matchers with UsesElasticSearch 
 
     val result = controllers.IndexController.render(section)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"html\"")
   }
 
@@ -71,7 +71,7 @@ class IndexControllerTest extends FlatSpec with Matchers with UsesElasticSearch 
 
     val result = controllers.IndexController.renderTrails(section)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"html\"""")
   }
 
@@ -82,7 +82,7 @@ class IndexControllerTest extends FlatSpec with Matchers with UsesElasticSearch 
 
     val result = controllers.IndexController.renderTrails(section)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"html\"")
   }
 

--- a/applications/test/SectionsControllerTest.scala
+++ b/applications/test/SectionsControllerTest.scala
@@ -1,6 +1,5 @@
 package test
 
-import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
@@ -20,7 +19,7 @@ class SectionsControllerTest extends FlatSpec with Matchers {
 
     val result = controllers.SectionsController.renderSections()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -31,7 +30,7 @@ class SectionsControllerTest extends FlatSpec with Matchers {
 
     val result = controllers.SectionsController.renderSectionsJson()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
 }

--- a/applications/test/VideoControllerTest.scala
+++ b/applications/test/VideoControllerTest.scala
@@ -1,6 +1,5 @@
 package test
 
-import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
@@ -21,7 +20,7 @@ class VideoControllerTest extends FlatSpec with Matchers {
 
     val result = controllers.VideoController.render(videoUrl)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -32,7 +31,7 @@ class VideoControllerTest extends FlatSpec with Matchers {
 
     val result = controllers.VideoController.render(videoUrl)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
 

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -94,7 +94,7 @@ class ArticleControllerTest extends FlatSpec with Matchers  with UsesElasticSear
 
     val result = controllers.ArticleController.renderArticle(expiredArticle)(fakeRequest)
     status(result) should be(200)
-    contentType(result).get should be("application/javascript")
+    contentType(result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""") // the callback
   }
 

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -99,7 +99,7 @@ object JsonNotFound {
   private val ValidCallback = """([a-zA-Z0-9_]+)""".r
 
   def apply()(implicit request: RequestHeader) = request.getQueryString("callback").map {
-    case ValidCallback(callback) => Ok("""%s({"status":404});""" format (callback)).as(JAVASCRIPT)
+    case ValidCallback(callback) => Ok("""%s({"status":404});""" format (callback)).as(withCharset("application/javascript"))
     case badCallback => Forbidden("bad callback name")
   }.getOrElse(NotFound)
 }

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -66,7 +66,7 @@ object JsonComponent extends Results {
   private def resultFor(request: RequestHeader, json: String): SimpleResult = {
     // JSONP if it has a callback
     request.getQueryString("callback").map {
-      case ValidCallback(callback) => Ok(s"$callback($json);").as(JAVASCRIPT)
+      case ValidCallback(callback) => Ok(s"$callback($json);").as(withCharset("application/javascript"))
       case badCallback => Forbidden("bad callback name")
 
     // Crossdomain if it has an origin header

--- a/sport/test/controllers/CompetitionFixturesControllerTest.scala
+++ b/sport/test/controllers/CompetitionFixturesControllerTest.scala
@@ -21,7 +21,7 @@ class CompetitionFixturesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.CompetitionFixturesController.renderFor("2012", "oct", "20", "premierleague")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -32,7 +32,7 @@ class CompetitionFixturesControllerTest extends FlatSpec with Matchers {
         
     val result = football.controllers.CompetitionFixturesController.renderFor("2012", "oct", "20", "premierleague")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   

--- a/sport/test/controllers/CompetitionListControllerTest.scala
+++ b/sport/test/controllers/CompetitionListControllerTest.scala
@@ -22,7 +22,7 @@ class CompetitionListControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.CompetitionListController.renderCompetitionList()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -33,7 +33,7 @@ class CompetitionListControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.CompetitionListController.renderCompetitionListJson()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   

--- a/sport/test/controllers/CompetitionResultsControllerTest.scala
+++ b/sport/test/controllers/CompetitionResultsControllerTest.scala
@@ -21,7 +21,7 @@ class CompetitionResultsControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.CompetitionResultsController.renderFor("2012", "oct", "20", "premierleague")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -32,7 +32,7 @@ class CompetitionResultsControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.CompetitionResultsController.renderFor("2012", "oct", "20", "premierleague")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -23,7 +23,7 @@ class FixturesControllerTest extends FlatSpec with Matchers {
     
     val result = football.controllers.FixturesController.render()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -34,7 +34,7 @@ class FixturesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.FixturesController.render()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   
@@ -49,7 +49,7 @@ class FixturesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.FixturesController.renderTag(tag)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -60,7 +60,7 @@ class FixturesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.FixturesController.renderTag(tag)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   
@@ -75,7 +75,7 @@ class FixturesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.FixturesController.renderFor("2012", "oct", "20")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
     contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
@@ -86,7 +86,7 @@ class FixturesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.FixturesController.renderFor("2012", "oct", "20")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -18,7 +18,7 @@ class LeagueTableControllerTest extends FlatSpec with Matchers {
       .withHeaders("Accept" -> "application/javascript")
     val result = football.controllers.LeagueTableController.renderLeagueTable()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to table" in Fake {
@@ -28,7 +28,7 @@ class LeagueTableControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.LeagueTableController.renderLeagueTableJson()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   
@@ -43,7 +43,7 @@ class LeagueTableControllerTest extends FlatSpec with Matchers {
       .withHeaders("Accept" -> "application/javascript")
     val result = football.controllers.LeagueTableController.renderTeamlist()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to teams" in Fake {
@@ -53,7 +53,7 @@ class LeagueTableControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.LeagueTableController.renderTeamlist()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   
@@ -70,7 +70,7 @@ class LeagueTableControllerTest extends FlatSpec with Matchers {
       .withHeaders("Accept" -> "application/javascript")
     val result = football.controllers.LeagueTableController.renderCompetition(competitionId)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to competition table" in Fake {
@@ -80,7 +80,7 @@ class LeagueTableControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.LeagueTableController.renderCompetition(competitionId)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   

--- a/sport/test/controllers/LiveMatchesControllerTest.scala
+++ b/sport/test/controllers/LiveMatchesControllerTest.scala
@@ -18,7 +18,7 @@ class LiveMatchesControllerTest extends FlatSpec with Matchers {
       .withHeaders("Accept" -> "application/javascript")
     val result = football.controllers.LiveMatchesController.renderLiveMatches()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to live match" in Fake {
@@ -28,7 +28,7 @@ class LiveMatchesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.LiveMatchesController.renderLiveMatchesJson()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   
@@ -45,7 +45,7 @@ class LiveMatchesControllerTest extends FlatSpec with Matchers {
       .withHeaders("Accept" -> "application/javascript")
     val result = football.controllers.LiveMatchesController.renderLiveMatchesFor(competitionId)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON .json format is supplied to competition live match" in Fake {
@@ -55,7 +55,7 @@ class LiveMatchesControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.LiveMatchesController.renderLiveMatchesJsonFor(competitionId)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -16,7 +16,7 @@ class ResultsControllerTest extends FlatSpec with Matchers {
     val fakeRequest = FakeRequest(GET, "/football/results?callback=foo").withHeaders("host" -> "localhost:9000")
     val result = football.controllers.ResultsController.render()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to results" in Fake {
@@ -26,7 +26,7 @@ class ResultsControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.ResultsController.render()(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   
@@ -41,7 +41,7 @@ class ResultsControllerTest extends FlatSpec with Matchers {
     val fakeRequest = FakeRequest(GET, "/football/" + tag + "/results?callback=foo").withHeaders("host" -> "localhost:9000")
     val result = football.controllers.ResultsController.renderTag(tag)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to tag results" in Fake {
@@ -51,7 +51,7 @@ class ResultsControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.ResultsController.renderTag(tag)(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   
@@ -64,7 +64,7 @@ class ResultsControllerTest extends FlatSpec with Matchers {
     val fakeRequest = FakeRequest(GET, "/football/results/2012/oct/20?callback=foo").withHeaders("host" -> "localhost:9000")
     val result = football.controllers.ResultsController.renderFor("2012", "oct", "20")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript")
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to for results" in Fake {
@@ -74,7 +74,7 @@ class ResultsControllerTest extends FlatSpec with Matchers {
       
     val result = football.controllers.ResultsController.renderFor("2012", "oct", "20")(fakeRequest)
     status(result) should be(200)
-    header("Content-Type", result).get should be("application/json")
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
   


### PR DESCRIPTION
Explicitly specify character encoding in content type header of json components.
