### PR TITLE
Upgrade node modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-/* global module: false */
+/* global module: false, process: false */
 module.exports = function (grunt) {
     var isDev = grunt.option('dev') || process.env.GRUNT_ISDEV === '1',
         singleRun = grunt.option('single-run') !== false,

--- a/common/app/assets/javascripts/modules/ui/overlay.js
+++ b/common/app/assets/javascripts/modules/ui/overlay.js
@@ -24,8 +24,8 @@ define([
                        '</div>';
 
         bonzo(document.body).append(template);
-    
-        this._savedPos   = 0,
+
+        this._savedPos   = 0;
         this.node        = document.body.querySelector('.overlay');
         this.headerNode  = this.node.querySelector('.overlay__header');
         this.toolbarNode = this.node.querySelector('.overlay__toolbar');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,1893 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "dependencies": {
+    "casperjs": {
+      "version": "1.1.0-DEV",
+      "from": "casperjs@git://github.com/smlgbl/casperjs.git#feature/makeUsableByNPM",
+      "resolved": "git://github.com/smlgbl/casperjs.git#71fb75889ba940eadfbb6a4e4dc921ecf4605d4e"
+    },
+    "grunt-contrib-copy": {
+      "version": "0.4.1",
+      "from": "grunt-contrib-copy@~0.4.1"
+    },
+    "grunt-hash": {
+      "version": "0.4.0",
+      "from": "grunt-hash@git://github.com/guardian/grunt-hash.git#master",
+      "resolved": "git://github.com/guardian/grunt-hash.git#71e2e6acabd2a6df601afcdc0daccf0d2d671b3d"
+    },
+    "grunt-mkdir": {
+      "version": "0.1.1",
+      "from": "grunt-mkdir@~0.1.1"
+    },
+    "karma-chrome-launcher": {
+      "version": "0.1.1",
+      "from": "karma-chrome-launcher@~0.1.0"
+    },
+    "karma-firefox-launcher": {
+      "version": "0.1.2",
+      "from": "karma-firefox-launcher@~0.1.0"
+    },
+    "karma-html2js-preprocessor": {
+      "version": "0.1.0",
+      "from": "karma-html2js-preprocessor@~0.1.0"
+    },
+    "karma-jasmine": {
+      "version": "0.1.3",
+      "from": "karma-jasmine@~0.1.3"
+    },
+    "karma-phantomjs-launcher": {
+      "version": "0.1.1",
+      "from": "karma-phantomjs-launcher@~0.1.0"
+    },
+    "karma-requirejs": {
+      "version": "0.2.0",
+      "from": "karma-requirejs@~0.2"
+    },
+    "karma-script-launcher": {
+      "version": "0.1.0",
+      "from": "karma-script-launcher@~0.1.0"
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "from": "mkdirp@~0.3.5"
+    },
+    "moment": {
+      "version": "2.4.0",
+      "from": "moment@~2.4"
+    },
+    "requirejs": {
+      "version": "2.1.9",
+      "from": "requirejs@~2.1.0"
+    },
+    "grunt-contrib-requirejs": {
+      "version": "0.4.1",
+      "from": "grunt-contrib-requirejs@~0.4",
+      "dependencies": {
+        "requirejs": {
+          "version": "2.1.9",
+          "from": "requirejs@~2.1.0"
+        }
+      }
+    },
+    "grunt-contrib-sass": {
+      "version": "0.5.1",
+      "from": "grunt-contrib-sass@~0.5",
+      "dependencies": {
+        "dargs": {
+          "version": "0.1.0",
+          "from": "dargs@~0.1.0"
+        },
+        "async": {
+          "version": "0.2.9",
+          "from": "async@~0.2.9"
+        }
+      }
+    },
+    "grunt-env": {
+      "version": "0.4.0",
+      "from": "grunt-env@git://github.com/smlgbl/grunt-env.git",
+      "resolved": "git://github.com/smlgbl/grunt-env.git#7973f7e35f88f71b26a48c4ca73cb09585ed815a",
+      "dependencies": {
+        "ini": {
+          "version": "1.1.0",
+          "from": "ini@~1.1.0"
+        }
+      }
+    },
+    "karma-coffee-preprocessor": {
+      "version": "0.1.1",
+      "from": "karma-coffee-preprocessor@~0.1.0",
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.3",
+          "from": "coffee-script@1.6.3"
+        }
+      }
+    },
+    "grunt-casperjs": {
+      "version": "1.0.9",
+      "from": "grunt-casperjs@git://github.com/guardian/grunt-casperjs.git#upgrade",
+      "resolved": "git://github.com/guardian/grunt-casperjs.git#9eb27bf2be8a254a41e50d1ea652af26df334936",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.1.4",
+          "from": "rimraf@~2.1.4",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1"
+            }
+          }
+        },
+        "adm-zip": {
+          "version": "0.4.3",
+          "from": "adm-zip@~0.4.3"
+        }
+      }
+    },
+    "grunt-contrib-clean": {
+      "version": "0.5.0",
+      "from": "grunt-contrib-clean@~0.5",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.2",
+          "from": "rimraf@~2.2.1",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.1",
+              "from": "graceful-fs@~2"
+            }
+          }
+        }
+      }
+    },
+    "grunt-karma": {
+      "version": "0.6.2",
+      "from": "grunt-karma@~0.6.2",
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.0",
+          "from": "optimist@~0.6.0",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2"
+            },
+            "minimist": {
+              "version": "0.0.5",
+              "from": "minimist@~0.0.1"
+            }
+          }
+        }
+      }
+    },
+    "grunt-shell": {
+      "version": "0.6.1",
+      "from": "grunt-shell@~0.6",
+      "dependencies": {
+        "chalk": {
+          "version": "0.3.0",
+          "from": "chalk@~0.3.0",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.1",
+              "from": "has-color@~0.1.0"
+            },
+            "ansi-styles": {
+              "version": "0.2.0",
+              "from": "ansi-styles@~0.2.0"
+            }
+          }
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.2",
+      "from": "grunt@~0.4.0",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "async@~0.1.22"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "coffee-script@~1.3.3"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@~0.6.2"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "dateformat@1.0.2-1.2.3"
+        },
+        "eventemitter2": {
+          "version": "0.4.13",
+          "from": "eventemitter2@~0.4.13"
+        },
+        "findup-sync": {
+          "version": "0.1.2",
+          "from": "findup-sync@~0.1.2",
+          "dependencies": {
+            "lodash": {
+              "version": "1.0.1",
+              "from": "lodash@~1.0.1"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@~3.1.21",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1.2.0"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@1"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@~0.2.3"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@~0.2.11"
+        },
+        "minimatch": {
+          "version": "0.2.12",
+          "from": "minimatch@~0.2.12",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@~1.0.10",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.4",
+              "from": "abbrev@1"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.0.3",
+          "from": "rimraf@~2.0.3",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.1.14",
+              "from": "graceful-fs@~1.1"
+            }
+          }
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@~0.9.2"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "underscore.string@~2.2.1"
+        },
+        "which": {
+          "version": "1.0.5",
+          "from": "which@~1.0.5"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@~2.0.5",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.15",
+              "from": "argparse@~ 0.1.11",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@~1.4.3"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@~2.3.1"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~ 1.0.2"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@~0.1.1"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@~0.1.0"
+        }
+      }
+    },
+    "grunt-contrib-uglify": {
+      "version": "0.2.7",
+      "from": "grunt-contrib-uglify@~0.2.5",
+      "dependencies": {
+        "uglify-js": {
+          "version": "2.4.6",
+          "from": "uglify-js@~2.4.0",
+          "dependencies": {
+            "async": {
+              "version": "0.2.9",
+              "from": "async@~0.2.6"
+            },
+            "source-map": {
+              "version": "0.1.31",
+              "from": "source-map@~0.1.7",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@~0.3",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.1",
+              "from": "uglify-to-browserify@~1.0.0"
+            }
+          }
+        },
+        "grunt-lib-contrib": {
+          "version": "0.6.1",
+          "from": "grunt-lib-contrib@~0.6.1",
+          "dependencies": {
+            "zlib-browserify": {
+              "version": "0.0.1",
+              "from": "zlib-browserify@0.0.1"
+            }
+          }
+        }
+      }
+    },
+    "grunt-css-metrics": {
+      "version": "0.1.2",
+      "from": "grunt-css-metrics@~0.1.1",
+      "dependencies": {
+        "glob": {
+          "version": "3.2.1",
+          "from": "glob@3.2.1",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.12",
+              "from": "minimatch@~0.2.11",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1.2.0"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@1"
+            }
+          }
+        },
+        "css-parse": {
+          "version": "1.4.0",
+          "from": "css-parse@~1.4.0"
+        },
+        "humanize": {
+          "version": "0.0.9",
+          "from": "humanize@~0.0.7"
+        }
+      }
+    },
+    "grunt-s3": {
+      "version": "0.2.0-alpha.3",
+      "from": "grunt-s3@~0.2.0-alpha.3",
+      "dependencies": {
+        "underscore.deferred": {
+          "version": "0.1.5",
+          "from": "underscore.deferred@~0.1.4"
+        },
+        "knox": {
+          "version": "0.8.8",
+          "from": "knox@0.8.x",
+          "dependencies": {
+            "xml2js": {
+              "version": "0.2.8",
+              "from": "xml2js@0.2.x",
+              "dependencies": {
+                "sax": {
+                  "version": "0.5.5",
+                  "from": "sax@0.5.x"
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@~0.7.0"
+            },
+            "stream-counter": {
+              "version": "0.1.0",
+              "from": "stream-counter@~0.1.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.17",
+                  "from": "readable-stream@~1.0.2"
+                }
+              }
+            }
+          }
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@~1.2.5"
+        },
+        "temporary": {
+          "version": "0.0.5",
+          "from": "temporary@0.0.5",
+          "dependencies": {
+            "package": {
+              "version": "1.0.1",
+              "from": "package@>= 1.0.0 < 1.2.0"
+            }
+          }
+        }
+      }
+    },
+    "grunt-webfontjson": {
+      "version": "0.0.3",
+      "from": "grunt-webfontjson@~0.0.3",
+      "dependencies": {
+        "webfontjson": {
+          "version": "0.0.3",
+          "from": "webfontjson@0.0.3",
+          "dependencies": {
+            "commander": {
+              "version": "1.1.1",
+              "from": "commander@~1.1.1",
+              "dependencies": {
+                "keypress": {
+                  "version": "0.1.0",
+                  "from": "keypress@0.1.x"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "phantomjs": {
+      "version": "1.9.2-4",
+      "from": "phantomjs@~1.9.1",
+      "dependencies": {
+        "adm-zip": {
+          "version": "0.2.1",
+          "from": "adm-zip@0.2.1"
+        },
+        "kew": {
+          "version": "0.1.7",
+          "from": "kew@~0.1.7"
+        },
+        "ncp": {
+          "version": "0.4.2",
+          "from": "ncp@0.4.2"
+        },
+        "npmconf": {
+          "version": "0.0.24",
+          "from": "npmconf@0.0.24",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.8",
+              "from": "config-chain@~1.1.1",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.2",
+                  "from": "proto-list@~1.2.1"
+                }
+              }
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@~1.0.0"
+            },
+            "once": {
+              "version": "1.1.1",
+              "from": "once@~1.1.1"
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3"
+            },
+            "nopt": {
+              "version": "2.1.2",
+              "from": "nopt@2",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.4",
+                  "from": "abbrev@1"
+                }
+              }
+            },
+            "semver": {
+              "version": "1.1.4",
+              "from": "semver@~1.1.0"
+            },
+            "ini": {
+              "version": "1.1.0",
+              "from": "ini@~1.1.0"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.2",
+          "from": "rimraf@~2.2.1",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.1",
+              "from": "graceful-fs@~2"
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.5",
+          "from": "which@~1.0.5"
+        }
+      }
+    },
+    "svgo": {
+      "version": "0.2.4",
+      "from": "svgo@~0.2",
+      "dependencies": {
+        "sax": {
+          "version": "0.5.5",
+          "from": "sax@~0.5.0"
+        },
+        "q": {
+          "version": "0.8.12",
+          "from": "q@~0.8.10"
+        },
+        "q-fs": {
+          "version": "0.1.36",
+          "from": "q-fs@~0.1.0",
+          "dependencies": {
+            "q-io": {
+              "version": "0.0.18",
+              "from": "q-io@0.0.x"
+            },
+            "fs-boot": {
+              "version": "0.0.9",
+              "from": "fs-boot@0.0.x"
+            }
+          }
+        },
+        "coa": {
+          "version": "0.3.9",
+          "from": "coa@~0.3.7"
+        },
+        "inherit": {
+          "version": "2.1.0",
+          "from": "inherit@"
+        },
+        "node.extend": {
+          "version": "1.0.8",
+          "from": "node.extend@",
+          "dependencies": {
+            "is": {
+              "version": "0.2.6",
+              "from": "is@~0.2.6"
+            },
+            "object-keys": {
+              "version": "0.4.0",
+              "from": "object-keys@~0.4.0"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "2.1.3",
+          "from": "js-yaml@",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.15",
+              "from": "argparse@~ 0.1.11",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@~1.4.3"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@~2.3.1"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~ 1.0.2"
+            }
+          }
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@~0.6.0"
+        }
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.7.2",
+      "from": "grunt-contrib-jshint@~0.7",
+      "dependencies": {
+        "jshint": {
+          "version": "2.3.0",
+          "from": "jshint@~2.3.0",
+          "dependencies": {
+            "shelljs": {
+              "version": "0.1.4",
+              "from": "shelljs@0.1.x"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@~1.4.3"
+            },
+            "cli": {
+              "version": "0.4.5",
+              "from": "cli@0.4.x",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.7",
+                  "from": "glob@>= 3.1.4",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.12",
+              "from": "minimatch@0.x.x",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "0.1.6",
+              "from": "console-browserify@0.1.x"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "0.5.3",
+      "from": "grunt-contrib-watch@~0.5.3",
+      "dependencies": {
+        "gaze": {
+          "version": "0.4.3",
+          "from": "gaze@~0.4.0",
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "from": "globule@~0.1.0",
+              "dependencies": {
+                "lodash": {
+                  "version": "1.0.1",
+                  "from": "lodash@~1.0.1"
+                },
+                "glob": {
+                  "version": "3.1.21",
+                  "from": "glob@~3.1.21",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@~1.2.0"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@1"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.12",
+                  "from": "minimatch@~0.2.11",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tiny-lr": {
+          "version": "0.0.4",
+          "from": "tiny-lr@0.0.4",
+          "dependencies": {
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@~0.5.2"
+            },
+            "faye-websocket": {
+              "version": "0.4.4",
+              "from": "faye-websocket@~0.4.3"
+            },
+            "noptify": {
+              "version": "0.0.3",
+              "from": "noptify@latest",
+              "dependencies": {
+                "nopt": {
+                  "version": "2.0.0",
+                  "from": "nopt@~2.0.0",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.4",
+                      "from": "abbrev@1"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@~0.7.0"
+            }
+          }
+        }
+      }
+    },
+    "karma": {
+      "version": "0.10.6",
+      "from": "karma@~0.10.4",
+      "dependencies": {
+        "di": {
+          "version": "0.0.1",
+          "from": "di@~0.0.1"
+        },
+        "socket.io": {
+          "version": "0.9.16",
+          "from": "socket.io@~0.9.13",
+          "dependencies": {
+            "socket.io-client": {
+              "version": "0.9.16",
+              "from": "socket.io-client@0.9.16",
+              "dependencies": {
+                "uglify-js": {
+                  "version": "1.2.5",
+                  "from": "uglify-js@1.2.5"
+                },
+                "ws": {
+                  "version": "0.4.31",
+                  "from": "ws@0.4.x",
+                  "dependencies": {
+                    "commander": {
+                      "version": "0.6.1",
+                      "from": "commander@~0.6.1"
+                    },
+                    "nan": {
+                      "version": "0.3.2",
+                      "from": "nan@~0.3.0"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "from": "tinycolor@0.x"
+                    },
+                    "options": {
+                      "version": "0.0.5",
+                      "from": "options@>=0.0.5"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.4.2",
+                  "from": "xmlhttprequest@1.4.2"
+                },
+                "active-x-obfuscator": {
+                  "version": "0.0.1",
+                  "from": "active-x-obfuscator@0.0.1",
+                  "dependencies": {
+                    "zeparser": {
+                      "version": "0.0.5",
+                      "from": "zeparser@0.0.5"
+                    }
+                  }
+                }
+              }
+            },
+            "policyfile": {
+              "version": "0.0.4",
+              "from": "policyfile@0.0.4"
+            },
+            "base64id": {
+              "version": "0.1.0",
+              "from": "base64id@0.1.0"
+            },
+            "redis": {
+              "version": "0.7.3",
+              "from": "redis@0.7.3"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "0.7.1",
+          "from": "chokidar@~0.7.0"
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@~3.1.21",
+          "dependencies": {
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@1"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.2.12",
+          "from": "minimatch@0.x.x",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0"
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "0.10.3",
+          "from": "http-proxy@~0.10",
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.2.3",
+              "from": "pkginfo@0.2.x"
+            },
+            "utile": {
+              "version": "0.1.7",
+              "from": "utile@~0.1.7",
+              "dependencies": {
+                "async": {
+                  "version": "0.1.22",
+                  "from": "async@0.1.x"
+                },
+                "deep-equal": {
+                  "version": "0.1.0",
+                  "from": "deep-equal@*"
+                },
+                "i": {
+                  "version": "0.3.2",
+                  "from": "i@0.3.x"
+                },
+                "ncp": {
+                  "version": "0.2.7",
+                  "from": "ncp@0.2.x"
+                },
+                "rimraf": {
+                  "version": "1.0.9",
+                  "from": "rimraf@1.x.x"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.3.7",
+          "from": "optimist@~0.3",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2"
+            }
+          }
+        },
+        "coffee-script": {
+          "version": "1.6.3",
+          "from": "coffee-script@~1.6"
+        },
+        "rimraf": {
+          "version": "2.1.4",
+          "from": "rimraf@~2.1"
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@~0.9"
+        },
+        "colors": {
+          "version": "0.6.0-1",
+          "from": "colors@0.6.0-1"
+        },
+        "lodash": {
+          "version": "1.1.1",
+          "from": "lodash@~1.1"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@~1.2"
+        },
+        "log4js": {
+          "version": "0.6.9",
+          "from": "log4js@~0.6.3",
+          "dependencies": {
+            "async": {
+              "version": "0.1.15",
+              "from": "async@0.1.15"
+            },
+            "semver": {
+              "version": "1.1.4",
+              "from": "semver@~1.1.4"
+            },
+            "readable-stream": {
+              "version": "1.0.17",
+              "from": "readable-stream@~1.0.2"
+            }
+          }
+        },
+        "useragent": {
+          "version": "2.0.7",
+          "from": "useragent@~2.0.4",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.2.4",
+              "from": "lru-cache@2.2.x"
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "from": "graceful-fs@~1.2.0"
+        },
+        "connect": {
+          "version": "2.8.8",
+          "from": "connect@~2.8.4",
+          "dependencies": {
+            "qs": {
+              "version": "0.6.5",
+              "from": "qs@0.6.5"
+            },
+            "formidable": {
+              "version": "1.0.14",
+              "from": "formidable@1.0.14"
+            },
+            "cookie-signature": {
+              "version": "1.0.1",
+              "from": "cookie-signature@1.0.1"
+            },
+            "buffer-crc32": {
+              "version": "0.2.1",
+              "from": "buffer-crc32@0.2.1"
+            },
+            "cookie": {
+              "version": "0.1.0",
+              "from": "cookie@0.1.0"
+            },
+            "send": {
+              "version": "0.1.4",
+              "from": "send@0.1.4",
+              "dependencies": {
+                "range-parser": {
+                  "version": "0.0.4",
+                  "from": "range-parser@0.0.4"
+                }
+              }
+            },
+            "bytes": {
+              "version": "0.2.0",
+              "from": "bytes@0.2.0"
+            },
+            "fresh": {
+              "version": "0.2.0",
+              "from": "fresh@0.2.0"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "pause@0.0.1"
+            },
+            "uid2": {
+              "version": "0.0.2",
+              "from": "uid2@0.0.2"
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@*"
+            },
+            "methods": {
+              "version": "0.0.1",
+              "from": "methods@0.0.1"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-imagemin": {
+      "version": "0.3.0",
+      "from": "grunt-contrib-imagemin@git://github.com/guardian/grunt-contrib-imagemin#master",
+      "resolved": "git://github.com/guardian/grunt-contrib-imagemin#867a4fd8c6214e3ce0bc76309384b719828158c4",
+      "dependencies": {
+        "filesize": {
+          "version": "1.10.0",
+          "from": "filesize@~1.10.0"
+        },
+        "jpegtran-bin": {
+          "version": "0.2.0",
+          "from": "jpegtran-bin@0.2.0",
+          "dependencies": {
+            "which": {
+              "version": "1.0.5",
+              "from": "which@~1.0.5"
+            },
+            "mocha": {
+              "version": "1.12.1",
+              "from": "mocha@~1.12.0",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1"
+                },
+                "growl": {
+                  "version": "1.7.0",
+                  "from": "growl@1.7.x"
+                },
+                "jade": {
+                  "version": "0.26.3",
+                  "from": "jade@0.26.3",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0"
+                    }
+                  }
+                },
+                "diff": {
+                  "version": "1.0.2",
+                  "from": "diff@1.0.2"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@*"
+                },
+                "glob": {
+                  "version": "3.2.1",
+                  "from": "glob@3.2.1",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.12",
+                      "from": "minimatch@~0.2.11",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@~1.2.0"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@1"
+                    }
+                  }
+                }
+              }
+            },
+            "tar": {
+              "version": "0.1.18",
+              "from": "tar@~0.1.17",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "block-stream": {
+                  "version": "0.0.7",
+                  "from": "block-stream@*"
+                },
+                "fstream": {
+                  "version": "0.1.25",
+                  "from": "fstream@~0.1.8",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.2",
+                      "from": "rimraf@2"
+                    },
+                    "graceful-fs": {
+                      "version": "2.0.1",
+                      "from": "graceful-fs@~2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "request": {
+              "version": "2.26.0",
+              "from": "request@~2.26.0",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.5",
+                  "from": "qs@~0.6.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.0",
+                  "from": "forever-agent@~0.5.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "from": "tunnel-agent@~0.3.0"
+                },
+                "http-signature": {
+                  "version": "0.10.0",
+                  "from": "http-signature@~0.10.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "from": "assert-plus@0.1.2"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "from": "ctype@0.5.2"
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "hawk@~1.0.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x"
+                    }
+                  }
+                },
+                "aws-sign": {
+                  "version": "0.3.0",
+                  "from": "aws-sign@~0.3.0"
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@~0.3.0"
+                },
+                "cookie-jar": {
+                  "version": "0.3.0",
+                  "from": "cookie-jar@~0.3.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "from": "node-uuid@~1.4.0"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2.9"
+                },
+                "form-data": {
+                  "version": "0.1.2",
+                  "from": "form-data@~0.1.0",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.4",
+                      "from": "combined-stream@~0.0.4",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.2.9",
+                      "from": "async@~0.2.9"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optipng-bin": {
+          "version": "0.3.0",
+          "from": "optipng-bin@0.3.0",
+          "dependencies": {
+            "which": {
+              "version": "1.0.5",
+              "from": "which@~1.0.5"
+            },
+            "mocha": {
+              "version": "1.12.1",
+              "from": "mocha@~1.12.0",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1"
+                },
+                "growl": {
+                  "version": "1.7.0",
+                  "from": "growl@1.7.x"
+                },
+                "jade": {
+                  "version": "0.26.3",
+                  "from": "jade@0.26.3",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0"
+                    }
+                  }
+                },
+                "diff": {
+                  "version": "1.0.2",
+                  "from": "diff@1.0.2"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@*"
+                },
+                "glob": {
+                  "version": "3.2.1",
+                  "from": "glob@3.2.1",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.12",
+                      "from": "minimatch@~0.2.11",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@~1.2.0"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@1"
+                    }
+                  }
+                }
+              }
+            },
+            "tar": {
+              "version": "0.1.18",
+              "from": "tar@~0.1.17",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "block-stream": {
+                  "version": "0.0.7",
+                  "from": "block-stream@*"
+                },
+                "fstream": {
+                  "version": "0.1.25",
+                  "from": "fstream@~0.1.8",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.2",
+                      "from": "rimraf@2"
+                    },
+                    "graceful-fs": {
+                      "version": "2.0.1",
+                      "from": "graceful-fs@~2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "request": {
+              "version": "2.26.0",
+              "from": "request@~2.26.0",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.5",
+                  "from": "qs@~0.6.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.0",
+                  "from": "forever-agent@~0.5.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "from": "tunnel-agent@~0.3.0"
+                },
+                "http-signature": {
+                  "version": "0.10.0",
+                  "from": "http-signature@~0.10.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "from": "assert-plus@0.1.2"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "from": "ctype@0.5.2"
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "hawk@~1.0.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x"
+                    }
+                  }
+                },
+                "aws-sign": {
+                  "version": "0.3.0",
+                  "from": "aws-sign@~0.3.0"
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@~0.3.0"
+                },
+                "cookie-jar": {
+                  "version": "0.3.0",
+                  "from": "cookie-jar@~0.3.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "from": "node-uuid@~1.4.0"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2"
+                },
+                "form-data": {
+                  "version": "0.1.2",
+                  "from": "form-data@~0.1.0",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.4",
+                      "from": "combined-stream@~0.0.4",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.2.9",
+                      "from": "async@~0.2.9"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "gifsicle": {
+          "version": "0.1.3",
+          "from": "gifsicle@0.1.3",
+          "dependencies": {
+            "which": {
+              "version": "1.0.5",
+              "from": "which@~1.0.5"
+            },
+            "mocha": {
+              "version": "1.12.1",
+              "from": "mocha@~1.12.0",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1"
+                },
+                "growl": {
+                  "version": "1.7.0",
+                  "from": "growl@1.7.x"
+                },
+                "jade": {
+                  "version": "0.26.3",
+                  "from": "jade@0.26.3",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0"
+                    }
+                  }
+                },
+                "diff": {
+                  "version": "1.0.2",
+                  "from": "diff@1.0.2"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@*"
+                },
+                "glob": {
+                  "version": "3.2.1",
+                  "from": "glob@3.2.1",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.12",
+                      "from": "minimatch@~0.2.11",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@~1.2.0"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@1"
+                    }
+                  }
+                }
+              }
+            },
+            "tar": {
+              "version": "0.1.18",
+              "from": "tar@~0.1.17",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "block-stream": {
+                  "version": "0.0.7",
+                  "from": "block-stream@*"
+                },
+                "fstream": {
+                  "version": "0.1.25",
+                  "from": "fstream@~0.1.8",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.2",
+                      "from": "rimraf@2"
+                    },
+                    "graceful-fs": {
+                      "version": "2.0.1",
+                      "from": "graceful-fs@~2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "request": {
+              "version": "2.25.0",
+              "from": "request@~2.25.0",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.5",
+                  "from": "qs@~0.6.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.0",
+                  "from": "forever-agent@~0.5.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "from": "tunnel-agent@~0.3.0"
+                },
+                "http-signature": {
+                  "version": "0.10.0",
+                  "from": "http-signature@~0.10.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "from": "assert-plus@0.1.2"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "from": "ctype@0.5.2"
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "hawk@~1.0.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x"
+                    }
+                  }
+                },
+                "aws-sign": {
+                  "version": "0.3.0",
+                  "from": "aws-sign@~0.3.0"
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@~0.3.0"
+                },
+                "cookie-jar": {
+                  "version": "0.3.0",
+                  "from": "cookie-jar@~0.3.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "from": "node-uuid@~1.4.0"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2"
+                },
+                "form-data": {
+                  "version": "0.1.2",
+                  "from": "form-data@~0.1.0",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.4",
+                      "from": "combined-stream@~0.0.4",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.2.9",
+                      "from": "async@~0.2.9"
+                    }
+                  }
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.2.3",
+              "from": "request-progress@~0.2.1",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@~0.0.2"
+                }
+              }
+            }
+          }
+        },
+        "pngquant-bin": {
+          "version": "0.1.4",
+          "from": "pngquant-bin@0.1.4",
+          "dependencies": {
+            "which": {
+              "version": "1.0.5",
+              "from": "which@~1.0.5"
+            },
+            "mocha": {
+              "version": "1.12.1",
+              "from": "mocha@~1.12.0",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1"
+                },
+                "growl": {
+                  "version": "1.7.0",
+                  "from": "growl@1.7.x"
+                },
+                "jade": {
+                  "version": "0.26.3",
+                  "from": "jade@0.26.3",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0"
+                    }
+                  }
+                },
+                "diff": {
+                  "version": "1.0.2",
+                  "from": "diff@1.0.2"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@*"
+                },
+                "glob": {
+                  "version": "3.2.1",
+                  "from": "glob@3.2.1",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.12",
+                      "from": "minimatch@~0.2.11",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@~1.2.0"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@1"
+                    }
+                  }
+                }
+              }
+            },
+            "tar": {
+              "version": "0.1.18",
+              "from": "tar@~0.1.17",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "block-stream": {
+                  "version": "0.0.7",
+                  "from": "block-stream@*"
+                },
+                "fstream": {
+                  "version": "0.1.25",
+                  "from": "fstream@~0.1.8",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.2",
+                      "from": "rimraf@2"
+                    },
+                    "graceful-fs": {
+                      "version": "2.0.1",
+                      "from": "graceful-fs@~2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "request": {
+              "version": "2.25.0",
+              "from": "request@~2.25.0",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.5",
+                  "from": "qs@~0.6.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.0",
+                  "from": "forever-agent@~0.5.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "from": "tunnel-agent@~0.3.0"
+                },
+                "http-signature": {
+                  "version": "0.10.0",
+                  "from": "http-signature@~0.10.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "from": "assert-plus@0.1.2"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "from": "ctype@0.5.2"
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "hawk@~1.0.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x"
+                    }
+                  }
+                },
+                "aws-sign": {
+                  "version": "0.3.0",
+                  "from": "aws-sign@~0.3.0"
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@~0.3.0"
+                },
+                "cookie-jar": {
+                  "version": "0.3.0",
+                  "from": "cookie-jar@~0.3.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "from": "node-uuid@~1.4.0"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2.9"
+                },
+                "form-data": {
+                  "version": "0.1.2",
+                  "from": "form-data@~0.1.0",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.4",
+                      "from": "combined-stream@~0.0.4",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.2.9",
+                      "from": "async@~0.2.9"
+                    }
+                  }
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.2.3",
+              "from": "request-progress@~0.2.1",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@~0.0.2"
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.2.1",
+          "from": "chalk@~0.2.0",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.1",
+              "from": "has-color@~0.1.0"
+            },
+            "ansi-styles": {
+              "version": "0.2.0",
+              "from": "ansi-styles@~0.2.0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "~0.4.0",
-    "grunt-shell": "~0.2.1",
+    "grunt-shell": "~0.6",
     "grunt-css-metrics": "~0.1.1",
     "grunt-env": "git://github.com/smlgbl/grunt-env.git",
     "grunt-casperjs": "git://github.com/guardian/grunt-casperjs.git#upgrade",
@@ -16,10 +16,10 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-uglify": "~0.2.5",
-    "grunt-contrib-jshint": "~0.1.0",
-    "grunt-contrib-requirejs": "~0.3.4",
-    "grunt-contrib-sass": "~0.4.0",
-    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-jshint": "~0.7",
+    "grunt-contrib-requirejs": "~0.4",
+    "grunt-contrib-sass": "~0.5",
+    "grunt-contrib-clean": "~0.5",
 
     "karma-script-launcher": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
@@ -27,14 +27,14 @@
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma": "~0.10.4",
 
     "phantomjs": "~1.9.1",
-    "svgo": "~0.2.3",
+    "svgo": "~0.2",
     "casperjs": "git://github.com/smlgbl/casperjs.git#feature/makeUsableByNPM",
-    "moment": "~2.1.0",
+    "moment": "~2.4",
     "mkdirp": "~0.3.5"
   },
   "scripts": {

--- a/resources/jshint_conf.json
+++ b/resources/jshint_conf.json
@@ -24,7 +24,6 @@
     "debug"         : false,
     "devel"         : false,
 
-    "es5"           : true,
     "strict"        : false,
     "globalstrict"  : false,
 


### PR DESCRIPTION
Committing `node_modules` is a no-go if there's binaries inside.

However, shrinkwrapping npm (https://npmjs.org/doc/cli/npm-shrinkwrap.html) allows us to lock down dependency versions of libraries, at least solving part of the problem

Also updated some of our node modules to the latest versions
