### PR TITLE
Make facia more accepting of routes

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -146,8 +146,9 @@ GET         /                                                                   
 GET         /$path<(culture|sport|australia|commentisfree|business|money)>                                   controllers.FaciaController.editionRedirect(path)
 GET         /$path<(us|uk|au)?>                                                                              controllers.FaciaController.renderEditionFront(path)
 GET         /$path<(us|uk|au)?>.json                                                                         controllers.FaciaController.renderEditionFrontJson(path)
-GET         /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>                           controllers.FaciaController.renderEditionSectionFront(path)
-GET         /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json                      controllers.FaciaController.renderEditionSectionFrontJson(path)
+GET         /$path<((uk|us|au)/)?(film|travel|football|culture|sport|australia|commentisfree|business|money)>                           controllers.FaciaController.renderEditionSectionFront(path)
+GET         /$path<((uk|us|au)/)?(culture|sport|australia|commentisfree|business|money)>.json controllers.FaciaController.renderEditionSectionFrontJson(path)
+GET         /$path<(football/arsenal|world/nsa|world/edward-snowden)>    controllers.FaciaController.renderArbitraryFront(path)
 
 GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                controllers.FaciaController.renderEditionCollection(id)
 GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                           controllers.FaciaController.renderEditionCollectionJson(id)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -160,6 +160,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
   def renderEditionFront(path: String) = renderFront(path)
   def renderEditionSectionFrontJson(path: String) = renderFront(path)
   def renderEditionSectionFront(path: String) = renderFront(path)
+  def renderArbitraryFront(path: String) = renderFront(path)
   def renderFrontJson(path: String) = renderFront(path)
 
   def renderEditionCollection(id: String) = renderCollection(id)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -12,10 +12,10 @@ GET        /$path<(culture|sport|australia|commentisfree|business|money)>       
 
 
 # Editionalised pages
-GET        /$path<(us|uk|au)?>                                                                controllers.FaciaController.renderEditionFront(path)
-GET        /$path<(us|uk|au)?>.json                                                           controllers.FaciaController.renderEditionFrontJson(path)
-GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>             controllers.FaciaController.renderEditionSectionFront(path)
-GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json        controllers.FaciaController.renderEditionSectionFrontJson(path)
+GET        /$path<(us|uk|au)?>                   controllers.FaciaController.renderEditionFront(path)
+GET        /$path<(us|uk|au)?>.json              controllers.FaciaController.renderEditionFrontJson(path)
+GET        /$path<(\w+/)?([\d\w-]*)>             controllers.FaciaController.renderEditionSectionFront(path)
+GET        /$path<(\w+/)?([\d\w-]*)>.json        controllers.FaciaController.renderEditionSectionFrontJson(path)
 
 GET        /responsive-viewer                                                                 controllers.FaciaController.renderResponsiveViewer()
 


### PR DESCRIPTION
Facia now accepts any url of the form `foo/bar` making it suitable for tags, sections etc.
