### PR TITLE
Adding new 'fronts'

### DIFF
--- a/applications/app/views/indexFacia.scala.html
+++ b/applications/app/views/indexFacia.scala.html
@@ -11,7 +11,7 @@
                 }"
          data-link-name="Front" role="main">
 
-        @fragments.containers.sport(index.page, Config("uk/" + index.page.id + "/regular-stories", None, Some(index.page.webTitle), collectionType = None), Collection(index.trails, None), SportContainer(showMore = false), containerIndex = 0)
+        @fragments.containers.sport(index.page, Config("uk/" + index.page.id + "/regular-stories", None, Some(index.page.webTitle), collectionTone = None), Collection(index.trails, None), SportContainer(showMore = false), containerIndex = 0)
 
         <section class="article-zone-no-indent">
             @fragments.footballNav(index.page)

--- a/applications/app/views/indexFacia.scala.html
+++ b/applications/app/views/indexFacia.scala.html
@@ -11,7 +11,7 @@
                 }"
          data-link-name="Front" role="main">
 
-        @fragments.containers.sport(index.page, Config("uk/" + index.page.id + "/regular-stories", None, Some(index.page.webTitle)), Collection(index.trails, None), SportContainer(showMore = false), containerIndex = 0)
+        @fragments.containers.sport(index.page, Config("uk/" + index.page.id + "/regular-stories", None, Some(index.page.webTitle), collectionType = None), Collection(index.trails, None), SportContainer(showMore = false), containerIndex = 0)
 
         <section class="article-zone-no-indent">
             @fragments.footballNav(index.page)

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -3,7 +3,8 @@ package model
 case class Config(
                    id: String,
                    contentApiQuery: Option[String],
-                   displayName: Option[String]) {
+                   displayName: Option[String],
+                   collectionType: Option[String]) {
   // 'middle' part of the id is the section
   val section: String = id.split("/").tail.dropRight(1).mkString("/")
 }

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -4,7 +4,7 @@ case class Config(
                    id: String,
                    contentApiQuery: Option[String],
                    displayName: Option[String],
-                   collectionType: Option[String]) {
+                   collectionTone: Option[String]) {
   // 'middle' part of the id is the section
   val section: String = id.split("/").tail.dropRight(1).mkString("/")
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -148,8 +148,9 @@ GET         /                                                                   
 GET         /$path<(culture|sport|australia|commentisfree|business|money)>                                   controllers.FaciaController.editionRedirect(path)
 GET         /$path<(us|uk|au|uk-alpha)?>                                                                     controllers.FaciaController.renderEditionFront(path)
 GET         /$path<(us|uk|au|uk-alpha)?>.json                                                                controllers.FaciaController.renderEditionFrontJson(path)
-GET         /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>                           controllers.FaciaController.renderEditionSectionFront(path)
-GET         /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json                      controllers.FaciaController.renderEditionSectionFrontJson(path)
+GET         /$path<((uk|us|au)/)?(film|travel|football|culture|sport|australia|commentisfree|business|money)>   controllers.FaciaController.renderEditionSectionFront(path)
+GET         /$path<((uk|us|au)/)?(culture|sport|australia|commentisfree|business|money)>.json                controllers.FaciaController.renderEditionSectionFrontJson(path)
+GET         /$path<(football/arsenal|world/nsa|world/edward-snowden)>                                        controllers.FaciaController.renderArbitraryFront(path)
 
 GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                controllers.FaciaController.renderEditionCollection(id)
 GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                           controllers.FaciaController.renderEditionCollectionJson(id)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -150,7 +150,7 @@ GET         /$path<(us|uk|au|uk-alpha)?>                                        
 GET         /$path<(us|uk|au|uk-alpha)?>.json                                                                controllers.FaciaController.renderEditionFrontJson(path)
 GET         /$path<((uk|us|au)/)?(film|travel|football|culture|sport|australia|commentisfree|business|money)>   controllers.FaciaController.renderEditionSectionFront(path)
 GET         /$path<((uk|us|au)/)?(culture|sport|australia|commentisfree|business|money)>.json                controllers.FaciaController.renderEditionSectionFrontJson(path)
-GET         /$path<(football/arsenal|world/nsa|world/edward-snowden)>                                        controllers.FaciaController.renderArbitraryFront(path)
+GET         /$path<(football/arsenal|world/nsa|world/edward-snowden|artanddesign/photography)>               controllers.FaciaController.renderArbitraryFront(path)
 
 GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                controllers.FaciaController.renderEditionCollection(id)
 GET         /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                           controllers.FaciaController.renderEditionCollectionJson(id)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -284,7 +284,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
 
   def renderCollection(id: String) = Action { implicit request =>
     CollectionAgent.getCollection(id) map { collection =>
-      val html = views.html.fragments.collections.standard(Config(id, None, None), collection, NewsContainer(true, true), 1)
+      val html = views.html.fragments.collections.standard(Config(id, None, None, None), collection, NewsContainer(true, true), 1)
       Cached(60) {
         if (request.isJson) {
             JsonComponent(

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -106,6 +106,97 @@ object FrontPage {
       )
     },
 
+    new FrontPage(isNetworkFront = false) {
+      override val id = "football"
+      override val section = "football"
+      override val webTitle = "Football"
+      override lazy val analyticsName = "GFE:football"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Football",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "technology"
+      override val section = "technology"
+      override val webTitle = "Technology"
+      override lazy val analyticsName = "GFE:technology"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Technology",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "travel"
+      override val section = "travel"
+      override val webTitle = "Travel"
+      override lazy val analyticsName = "GFE:travel"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Travel",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "world/nsa"
+      override val section = "world"
+      override val webTitle = "NSA"
+      override lazy val analyticsName = "GFE:world/nsa"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "NSA",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "world/edward-snowden"
+      override val section = "world"
+      override val webTitle = "Edward Snowden"
+      override lazy val analyticsName = "GFE:world/edward-snowden"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Edward Snowden",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "football/arsenal"
+      override val section = "football"
+      override val webTitle = "Arsenal"
+      override lazy val analyticsName = "GFE:football/arsenal"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Arsenal",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "artanddesign/photography"
+      override val section = "artanddesign"
+      override val webTitle = "Photography"
+      override lazy val analyticsName = "GFE:artanddesign/photography"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Photography",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
     //TODO important this one is last for matching purposes
     new FrontPage(isNetworkFront = true) {
       override val id = ""
@@ -140,7 +231,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
 
     val edition = Edition(request)
     val editionBase = s"/${edition.id.toLowerCase}"
-    
+
     val redirectPath = path match {
       case "" => editionBase
       case sectionFront => s"$editionBase/$sectionFront"
@@ -152,7 +243,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
 
       log.info(s"Edition redirect: geolocation: $country | edition: ${edition.id} | edition cookie set: $editionCookie"  )
     }
-  
+
     NoCache(Redirect(redirectPath))
   }
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -161,6 +161,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
   def renderEditionFront(path: String) = renderFront(path)
   def renderEditionSectionFrontJson(path: String) = renderFront(path)
   def renderEditionSectionFront(path: String) = renderFront(path)
+  def renderArbitraryFront(path: String) = renderFront(path)
   def renderFrontJson(path: String) = renderFront(path)
 
   def renderEditionCollection(id: String) = renderCollection(id)

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -53,7 +53,7 @@ trait ParseConfig extends ExecutionContexts with Logging {
       (json \ "id").as[String],
       (json \ "contentApiQuery").asOpt[String].filter(_.nonEmpty),
       (json \ "displayName").asOpt[String],
-      (json \ "type").asOpt[String]
+      (json \ "tone").asOpt[String]
     )
 
 }
@@ -225,7 +225,7 @@ trait ConfigAgent extends ExecutionContexts {
         id,
         (collectionJson \ "apiQuery").asOpt[String],
         (collectionJson \ "displayName").asOpt[String],
-        (collectionJson \ "type").asOpt[String]
+        (collectionJson \ "tone").asOpt[String]
       )
     }
   }

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -223,7 +223,8 @@ trait ConfigAgent extends ExecutionContexts {
       Config(
         id,
         (collectionJson \ "apiQuery").asOpt[String],
-        (collectionJson \ "displayName").asOpt[String]
+        (collectionJson \ "displayName").asOpt[String],
+        (collectionJson \ "type").asOpt[String]
       )
     }
   }

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -52,7 +52,8 @@ trait ParseConfig extends ExecutionContexts with Logging {
     Config(
       (json \ "id").as[String],
       (json \ "contentApiQuery").asOpt[String].filter(_.nonEmpty),
-      (json \ "displayName").asOpt[String]
+      (json \ "displayName").asOpt[String],
+      (json \ "type").asOpt[String]
     )
 
 }
@@ -181,7 +182,7 @@ object CollectionAgent extends ParseCollection {
   def updateCollection(id: String, collection: Collection): Unit = collectionAgent.send { _.updated(id, collection) }
 
   def updateCollectionById(id: String): Unit = {
-    val config: Config = ConfigAgent.getConfig(id).getOrElse(Config(id, None, None))
+    val config: Config = ConfigAgent.getConfig(id).getOrElse(Config(id, None, None, None))
     val edition = Edition.byId(id.take(2)).getOrElse(Edition.defaultEdition)
     //TODO: Refactor isWarmedUp into method by ID
     updateCollection(id, config, edition, isWarmedUp=true)

--- a/facia/app/controllers/front/FaciaDefaults.scala
+++ b/facia/app/controllers/front/FaciaDefaults.scala
@@ -17,7 +17,8 @@ trait FaciaDefaults {
   def createConfig(id: String): Config = Config(
     id              = "%s/%s".format(id, defaultStyle),
     contentApiQuery = Option(ContentApi.FaciaDefaults.generateContentApiQuery(id)),
-    displayName     = None
+    displayName     = None,
+    collectionType  = None
   )
 
   def getEdition(id: String): Edition = Edition.all.find(edition => id.toLowerCase.startsWith(edition.id.toLowerCase)).getOrElse(Edition.defaultEdition)

--- a/facia/app/controllers/front/FaciaDefaults.scala
+++ b/facia/app/controllers/front/FaciaDefaults.scala
@@ -18,7 +18,7 @@ trait FaciaDefaults {
     id              = "%s/%s".format(id, defaultStyle),
     contentApiQuery = Option(ContentApi.FaciaDefaults.generateContentApiQuery(id)),
     displayName     = None,
-    collectionType  = None
+    collectionTone  = None
   )
 
   def getEdition(id: String): Edition = Edition.all.find(edition => id.toLowerCase.startsWith(edition.id.toLowerCase)).getOrElse(Edition.defaultEdition)

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -7,7 +7,7 @@
 
         @defining {TemplateDeduping()} { dedupe: TemplateDeduping =>
             @faciaTrailblock.collections.filter(_._2.items.nonEmpty).zipWithIndex.map{ case(block, index) =>
-                @FindStyle(faciaTrailblock.id, block._1) match {
+                @GetContainer(faciaTrailblock.id, block._1) match {
                     case style: NewsContainer     => { @containers.news(block._1,  dedupe(5, block._2), style, index) }
                     case style: SportContainer    => { @containers.sport(front, block._1, dedupe(5, block._2), style, index) }
                     case style: CommentContainer  => { @containers.comment(block._1,  dedupe(5, block._2), style, index) }

--- a/facia/app/views/support/package.scala
+++ b/facia/app/views/support/package.scala
@@ -46,6 +46,15 @@ object GetContainer {
       ("uk/culture/regular-stories", FeaturesContainer()),
       ("uk/contributors/feature-stories", CommentContainer())
     )),
+    ("uk-alpha", Map(
+      ("uk-alpha/top-story/special-story", NewsContainer()),
+      ("uk-alpha/news/regular-stories", SportContainer()),
+      ("uk-alpha/features/feature-stories", FeaturesContainer()),
+      ("uk-alpha/special/special-story", SportContainer()),
+      ("uk-alpha/contributors/feature-stories", CommentContainer()),
+      ("uk-alpha/people-in-the-news/feature-stories", NewsContainer()),
+      ("uk-alpha/readers-contributions/feature-stories", FeaturesContainer())
+    )),
     ("uk/business", Map(
       ("uk/business/regular-stories", SportContainer(showMore = false))
     )),

--- a/facia/app/views/support/package.scala
+++ b/facia/app/views/support/package.scala
@@ -5,29 +5,46 @@ import model.Config
 object GetContainer {
 
   /**
-   * Mapping of collection 'type' to Container - in general, this should suffice
+   * Mapping of collection 'tone' to Container
    */
-  val collectionTypeMapping: Map[String, Container] = Map(
-    "news"            -> NewsContainer(),
-    "sport"           -> SportContainer(),
-    "feature"         -> FeaturesContainer(),
-    "comment"         -> CommentContainer(),
-    "section"         -> SectionContainer(),
-    "section-feature" -> SectionContainer(tone = "feature")
+  val collectionToneMapping: Map[String, Container] = Map(
+    "news"    -> SectionContainer(),
+    "feature" -> SectionContainer(tone = "feature"),
+    "comment" -> SectionContainer()
   )
 
   /**
-   * Allows use of different containers on specific fronts for specific collection
+   * Allows use of different containers on specific fronts for specific collections
    */
   val specificContainers: Map[String, Map[String, Container]] = Map(
+    ("au", Map(
+      ("au/news/regular-stories", NewsContainer()),
+      ("au/sport/regular-stories", SportContainer()),
+      ("au/commentisfree/regular-stories", CommentContainer()),
+      ("au/culture/regular-stories", FeaturesContainer()),
+      ("au/contributors/feature-stories", CommentContainer())
+    )),
     ("au/business", Map(
       ("au/business/regular-stories", SportContainer(showMore = false))
     )),
     ("au/commentisfree", Map(
       ("au/commentisfree/regular-stories", CommentContainer(showMore = false))
     )),
+    ("au/culture", Map(
+      ("au/culture/regular-stories", FeaturesContainer())
+    )),
     ("au/money", Map(
       ("au/money/regular-stories", SportContainer(showMore = false))
+    )),
+    ("au/sport", Map(
+      ("au/sport/regular-stories", SportContainer())
+    )),
+    ("uk", Map(
+      ("uk/news/regular-stories", NewsContainer()),
+      ("uk/sport/regular-stories", SportContainer()),
+      ("uk/commentisfree/regular-stories", CommentContainer()),
+      ("uk/culture/regular-stories", FeaturesContainer()),
+      ("uk/contributors/feature-stories", CommentContainer())
     )),
     ("uk/business", Map(
       ("uk/business/regular-stories", SportContainer(showMore = false))
@@ -35,8 +52,21 @@ object GetContainer {
     ("uk/commentisfree", Map(
       ("uk/commentisfree/regular-stories", CommentContainer(showMore = false))
     )),
+    ("uk/culture", Map(
+      ("uk/culture/regular-stories", FeaturesContainer())
+    )),
     ("uk/money", Map(
       ("uk/money/regular-stories", SportContainer(showMore = false))
+    )),
+    ("uk/sport", Map(
+      ("uk/sport/regular-stories", SportContainer())
+    )),
+    ("us", Map(
+      ("us/news/regular-stories", NewsContainer()),
+      ("us/sport/regular-stories", SportContainer()),
+      ("us/commentisfree/regular-stories", CommentContainer()),
+      ("us/culture/regular-stories", FeaturesContainer()),
+      ("us/contributors/feature-stories", CommentContainer())
     )),
     ("us/business", Map(
       ("us/business/regular-stories", SportContainer(showMore = false))
@@ -44,8 +74,14 @@ object GetContainer {
     ("us/commentisfree", Map(
       ("us/commentisfree/regular-stories", CommentContainer(showMore = false))
     )),
+    ("us/culture", Map(
+      ("us/culture/regular-stories", FeaturesContainer())
+    )),
     ("us/money", Map(
       ("us/money/regular-stories", SportContainer(showMore = false))
+    )),
+    ("us/sport", Map(
+      ("us/sport/regular-stories", SportContainer())
     )),
 
     ("football", Map(
@@ -80,8 +116,8 @@ object GetContainer {
       frontContainers.get(config.id)
     }.getOrElse {
       // else use general, defaulting to Highlights
-      config.collectionType.flatMap { collectionType =>
-        collectionTypeMapping.get(collectionType)
+      config.collectionTone.flatMap { collectionTone =>
+        collectionToneMapping.get(collectionTone)
       }.getOrElse(SectionContainer())
     }
   }

--- a/facia/app/views/support/package.scala
+++ b/facia/app/views/support/package.scala
@@ -2,54 +2,32 @@ package views.support
 
 import model.Config
 
-object FindStyle {
+object GetContainer {
 
   /**
-   * Mapping of collection 'type' to Style - in general, this should suffice
+   * Mapping of collection 'type' to Container - in general, this should suffice
    */
-  val generalStyles: Map[String, Container] = Map(
-    "regular-stories" -> SectionContainer(),
-    "feature-stories" -> FeaturesContainer(headerLink = false),
-    "special-story" -> NewsContainer()
+  val collectionTypeMapping: Map[String, Container] = Map(
+    "news"            -> NewsContainer(),
+    "sport"           -> SportContainer(),
+    "feature"         -> FeaturesContainer(),
+    "comment"         -> CommentContainer(),
+    "section"         -> SectionContainer(),
+    "section-feature" -> SectionContainer(tone = "feature")
   )
 
   /**
-   * Allows use of different styles on specific fronts for specific collection
+   * Allows use of different containers on specific fronts for specific collection
    */
-  val specificStyles: Map[String, Map[String, Container]] = Map(
-    ("au", Map(
-      ("au/news/regular-stories", NewsContainer()),
-      ("au/sport/regular-stories", SportContainer()),
-      ("au/commentisfree/regular-stories", CommentContainer()),
-      ("au/culture/regular-stories", FeaturesContainer()),
-      ("au/contributors/feature-stories", CommentContainer())
-    )),
+  val specificContainers: Map[String, Map[String, Container]] = Map(
     ("au/business", Map(
       ("au/business/regular-stories", SportContainer(showMore = false))
     )),
     ("au/commentisfree", Map(
       ("au/commentisfree/regular-stories", CommentContainer(showMore = false))
     )),
-    ("au/culture", Map(
-      ("au/culture/regular-stories", FeaturesContainer()),
-      ("au/film/regular-stories", SectionContainer(tone = "feature")),
-      ("au/music/regular-stories", SectionContainer(tone = "feature")),
-      ("au/books/regular-stories", SectionContainer(tone = "feature"))
-    )),
     ("au/money", Map(
       ("au/money/regular-stories", SportContainer(showMore = false))
-    )),
-    ("au/sport", Map(
-      ("au/sport/regular-stories", SportContainer())
-    )),
-    ("uk", Map(
-      ("uk/news/regular-stories", NewsContainer()),
-      ("uk/sport/regular-stories", SportContainer()),
-      ("uk/commentisfree/regular-stories", CommentContainer()),
-      ("uk/culture/regular-stories", FeaturesContainer()),
-      ("uk/lifeandstyle/regular-stories", SectionContainer(tone = "feature")),
-      ("uk/travel/regular-stories", SectionContainer(tone = "feature")),
-      ("uk/contributors/feature-stories", CommentContainer())
     )),
     ("uk/business", Map(
       ("uk/business/regular-stories", SportContainer(showMore = false))
@@ -57,27 +35,8 @@ object FindStyle {
     ("uk/commentisfree", Map(
       ("uk/commentisfree/regular-stories", CommentContainer(showMore = false))
     )),
-    ("uk/culture", Map(
-      ("uk/culture/regular-stories", FeaturesContainer()),
-      ("uk/tv-and-radio/regular-stories", SectionContainer(tone = "feature")),
-      ("uk/film/regular-stories", SectionContainer(tone = "feature")),
-      ("uk/music/regular-stories", SectionContainer(tone = "feature")),
-      ("uk/stage/regular-stories", SectionContainer(tone = "feature")),
-      ("uk/books/regular-stories", SectionContainer(tone = "feature")),
-      ("uk/artanddesign/regular-stories", SectionContainer(tone = "feature"))
-    )),
     ("uk/money", Map(
       ("uk/money/regular-stories", SportContainer(showMore = false))
-    )),
-    ("uk/sport", Map(
-      ("uk/sport/regular-stories", SportContainer())
-    )),
-    ("us", Map(
-      ("us/news/regular-stories", NewsContainer()),
-      ("us/sport/regular-stories", SportContainer()),
-      ("us/commentisfree/regular-stories", CommentContainer()),
-      ("us/culture/regular-stories", FeaturesContainer()),
-      ("us/contributors/feature-stories", CommentContainer())
     )),
     ("us/business", Map(
       ("us/business/regular-stories", SportContainer(showMore = false))
@@ -85,30 +44,45 @@ object FindStyle {
     ("us/commentisfree", Map(
       ("us/commentisfree/regular-stories", CommentContainer(showMore = false))
     )),
-    ("us/culture", Map(
-      ("us/culture/regular-stories", FeaturesContainer()),
-      ("us/film/regular-stories", SectionContainer(tone = "feature")),
-      ("us/music/regular-stories", SectionContainer(tone = "feature")),
-      ("us/stage/regular-stories", SectionContainer(tone = "feature")),
-      ("us/books/regular-stories", SectionContainer(tone = "feature")),
-      ("us/artanddesign/regular-stories", SectionContainer(tone = "feature")),
-      ("us/tv-and-radio/regular-stories", SectionContainer(tone = "feature"))
-    )),
     ("us/money", Map(
       ("us/money/regular-stories", SportContainer(showMore = false))
     )),
-    ("us/sport", Map(
-      ("us/sport/regular-stories", SportContainer())
+
+    ("football", Map(
+      ("football/latest-news/regular-stories", SportContainer(showMore = false))
+    )),
+    ("technology", Map(
+      ("technology/latest-news/regular-stories", NewsContainer(showMore = false))
+    )),
+    ("travel", Map(
+      ("travel/latest-news/regular-stories", FeaturesContainer(showMore = false))
+    )),
+    ("film", Map(
+      ("film/latest-news/regular-stories", FeaturesContainer(showMore = false))
+    )),
+    ("world/nsa", Map(
+      ("world/nsa/latest-news/regular-stories", NewsContainer(showMore = false))
+    )),
+    ("world/edward-snowden", Map(
+      ("world/edward-snowden/latest-news/regular-stories", NewsContainer(showMore = false))
+    )),
+    ("football/arsenal", Map(
+      ("football/arsenal/latest-news/regular-stories", SportContainer(showMore = false))
+    )),
+    ("artanddesign/photography", Map(
+      ("artanddesign/photography/latest-news/regular-stories", FeaturesContainer(showMore = false))
     ))
   )
 
   def apply(path: String, config: Config): Container = {
     // first check if we have a specific style
-    specificStyles.get(path).flatMap { frontStyles =>
-      frontStyles.get(config.id)
+    specificContainers.get(path).flatMap { frontContainers =>
+      frontContainers.get(config.id)
     }.getOrElse {
       // else use general, defaulting to Highlights
-      generalStyles.get(config.id.split("/").last).getOrElse(SectionContainer())
+      config.collectionType.flatMap { collectionType =>
+        collectionTypeMapping.get(collectionType)
+      }.getOrElse(SectionContainer())
     }
   }
 

--- a/facia/app/views/support/package.scala
+++ b/facia/app/views/support/package.scala
@@ -52,7 +52,7 @@ object GetContainer {
       ("football/latest-news/regular-stories", SportContainer(showMore = false))
     )),
     ("technology", Map(
-      ("technology/latest-news/regular-stories", NewsContainer(showMore = false))
+      ("technology/latest-news/regular-stories", SportContainer(showMore = false))
     )),
     ("travel", Map(
       ("travel/latest-news/regular-stories", FeaturesContainer(showMore = false))
@@ -61,10 +61,10 @@ object GetContainer {
       ("film/latest-news/regular-stories", FeaturesContainer(showMore = false))
     )),
     ("world/nsa", Map(
-      ("world/nsa/latest-news/regular-stories", NewsContainer(showMore = false))
+      ("world/nsa/latest-news/regular-stories", SportContainer(showMore = false))
     )),
     ("world/edward-snowden", Map(
-      ("world/edward-snowden/latest-news/regular-stories", NewsContainer(showMore = false))
+      ("world/edward-snowden/latest-news/regular-stories", SportContainer(showMore = false))
     )),
     ("football/arsenal", Map(
       ("football/arsenal/latest-news/regular-stories", SportContainer(showMore = false))

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -4,18 +4,18 @@
 
 
 # For dev machines
-GET        /assets/*path                                                                      dev.DevAssetsController.at(path)
+GET        /assets/*path                                                    dev.DevAssetsController.at(path)
 
 # Editionalised redirects
-GET        /                                                                                  controllers.FaciaController.editionRedirect(path = "")
-GET        /$path<(culture|sport|australia|commentisfree|business|money)>                     controllers.FaciaController.editionRedirect(path)
+GET        /                                                                controllers.FaciaController.editionRedirect(path = "")
+GET        /$path<(culture|sport|australia|commentisfree|business|money)>   controllers.FaciaController.editionRedirect(path)
 
 
 # Editionalised pages
-GET        /$path<(us|uk|au|uk-alpha)?>                                                       controllers.FaciaController.renderEditionFront(path)
-GET        /$path<(us|uk|au|uk-alpha)?>.json                                                  controllers.FaciaController.renderEditionFrontJson(path)
-GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>             controllers.FaciaController.renderEditionSectionFront(path)
-GET        /$path<(\w\w/)?(culture|sport|australia|commentisfree|business|money)>.json        controllers.FaciaController.renderEditionSectionFrontJson(path)
+GET        /$path<(us|uk|au|uk-alpha)?>                                     controllers.FaciaController.renderEditionFront(path)
+GET        /$path<(us|uk|au|uk-alpha)?>.json                                controllers.FaciaController.renderEditionFrontJson(path)
+GET        /$path<(\w+/)?([\d\w-]*)>                                        controllers.FaciaController.renderEditionSectionFront(path)
+GET        /$path<(\w+/)?([\d\w-]*)>.json                                   controllers.FaciaController.renderEditionSectionFrontJson(path)
 
-GET        /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                  controllers.FaciaController.renderEditionCollection(id)
-GET        /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                             controllers.FaciaController.renderEditionCollectionJson(id)
+GET        /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                controllers.FaciaController.renderEditionCollection(id)
+GET        /collection/$id<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json           controllers.FaciaController.renderEditionCollectionJson(id)


### PR DESCRIPTION
Also, facia config now has added `type` hinting (https://github.com/guardian/skeleton/pull/25/files), so can simplify how we choose which template to use
