### PR TITLE
Make sure temp file prefix is at least 3 characters.

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -6,7 +6,6 @@ import implicits.Collections
 import play.api.Plugin
 import play.api.libs.ws.WS
 
-
 sealed trait SwitchState
 case object On extends SwitchState
 case object Off extends SwitchState
@@ -277,11 +276,7 @@ object Switches extends Collections {
 
   val ServeWebPImagesSwitch = Switch("Image Server", "serve-webp-images",
     "If this is switched on the Image server will use the webp format when requested.",
-    safeState = Off)
-
-  val AddVaryAcceptHeader = Switch("Image Server", "add-vary-accept-header",
-    "If this is switched on the Image server will add vary-accept to responses.",
-    safeState = Off)
+    safeState = On)
 
   val ImageServerSwitch = Switch("Image Server", "image-server",
     "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
@@ -332,7 +327,6 @@ object Switches extends Collections {
     ElasticSearchSwitch,
     ShowUnsupportedEmbedsSwitch,
     ServeWebPImagesSwitch,
-    AddVaryAcceptHeader,
     ArticleKeywordsSwitch,
     ABAlphaAdverts,
     ABCommercialComponents,

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -1,6 +1,7 @@
 package implicits
 
 import play.api.mvc.RequestHeader
+import play.api.http.MediaRange
 
 trait Requests {
   implicit class Request2rich(r: RequestHeader) {
@@ -16,6 +17,12 @@ trait Requests {
       header.contains("text/javascript") ||
       header.contains("application/javascript")
     } || r.path.endsWith(".json")
+
+    lazy val isWebp = {
+      val requestedContentType = r.acceptedTypes.sorted(MediaRange.ordering)
+      val imageMimeType = requestedContentType.find(media => media.accepts("image/jpeg")|| media.accepts("image/webp"))
+      imageMimeType.exists(_.mediaSubType == "webp")
+    }
 
     lazy val hasParameters = !r.queryString.isEmpty
   }

--- a/image/app/services/ImageResizer.scala
+++ b/image/app/services/ImageResizer.scala
@@ -17,9 +17,11 @@ object ImageResizer extends Logging with Results with controllers.Implicits{
     response.status match {
       case 200 =>
 
-        // Write the original file to temp
-        val inputFile = File.createTempFile(FilenameUtils.getName(path),"")
-        val outputFile = File.createTempFile(FilenameUtils.getBaseName(path),".webp")
+        // Write the original file to temp.
+        // NOTE prefix must be at least 3 characters long.
+        // http://docs.oracle.com/javase/6/docs/api/java/io/File.html#createTempFile(java.lang.String, java.lang.String, java.io.File)
+        val inputFile = File.createTempFile(s"webp-${FilenameUtils.getName(path)}", "")
+        val outputFile = File.createTempFile(s"webp-${FilenameUtils.getBaseName(path)}", ".webp")
 
         try {
           val image = response.getAHCResponse.getResponseBodyAsStream.toBufferedImage
@@ -86,7 +88,7 @@ object ImageResizer extends Logging with Results with controllers.Implicits{
   }
 
   private def addResponseHeaders(result: SimpleResult): SimpleResult = {
-    if (AddVaryAcceptHeader.isSwitchedOn || ServeWebPImagesSwitch.isSwitchedOn) {
+    if (ServeWebPImagesSwitch.isSwitchedOn) {
       result.withHeaders("Vary" -> "Accept")
     } else {
       result


### PR DESCRIPTION
Started out figuring out why PNG did not worked, turned out it was an arbitrary requirement of the Java language...

http://docs.oracle.com/javase/6/docs/api/java/io/File.html#createTempFile(java.lang.String, java.lang.String, java.io.File)

While I was in there I also did some cleaniing up and turned on some switches by default.

This is why this image currently is broken http://www.theguardian.com/info/developer-blog/2012/sep/21/funtional-programming-principles-scala-setting-up-intellij
