### PR TITLE
Add UserZoom

### DIFF
--- a/common/app/assets/javascripts/bootstraps/facia.js
+++ b/common/app/assets/javascripts/bootstraps/facia.js
@@ -6,6 +6,7 @@ define([
     'qwery',
     // Modules
     'utils/detect',
+    'utils/storage',
     'modules/facia/popular',
     'modules/facia/collection-show-more',
     'modules/facia/container-toggle',
@@ -17,6 +18,7 @@ define([
     bonzo,
     qwery,
     detect,
+    storage,
     popular,
     CollectionShowMore,
     ContainerToggle,
@@ -95,8 +97,32 @@ define([
             mediator.on('page:front:ready', function(config, context) {
                 cricket.cricketTrail(config, context);
             });
-        }
+        },
 
+        showUserzoom: function(config) {
+            var path,
+                load;
+
+            if (config.switches.userzoom) {
+                path = window.location.pathname.substring(1);
+                load = {
+                    'uk': {vistsRequired: 2, script: 'userzoom-uk'},
+                    'uk-alpha': {vistsRequired: 0, script: 'userzoom-uk-alpha'},
+                }[path];
+
+                if(!load) { return; }
+
+                mediator.on('page:front:ready', function(config, context) {
+                    var visits = parseInt(storage.local.get('gu.userzoom.visits.' + path) || 0, 10);
+
+                    if(visits >= load.vistsRequired) {
+                        require(['js!' + load.script]);
+                    } else {
+                        storage.local.set('gu.userzoom.visits.' + path, visits + 1);
+                    }
+                });
+            }
+        }
     };
 
     var ready = function (config, context) {
@@ -106,6 +132,7 @@ define([
             modules.showContainerToggle();
             modules.showFootballFixtures();
             modules.showPopular();
+            modules.showUserzoom(config);
         }
         mediator.emit("page:front:ready", config, context);
     };

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -97,6 +97,10 @@ object Switches extends Collections {
     "Turns on our real-time KPIs",
     safeState = On)
 
+  val UserzoomSwitch = Switch("Analytics", "userzoom",
+    "Turns on userzoom survey popups",
+    safeState = Off)
+
   // Discussion Switches
 
   val DiscussionSwitch = Switch("Discussion", "discussion",
@@ -325,6 +329,7 @@ object Switches extends Collections {
     LiveSummarySwitch,
     LiveCricketSwitch,
     LiveStatsSwitch,
+    UserzoomSwitch,
     FaciaSwitch,
     AdSlotImpressionStatsSwitch,
     ABLiveBlogShowMore,

--- a/common/app/public/javascripts/vendor/userzoom-uk-alpha.js
+++ b/common/app/public/javascripts/vendor/userzoom-uk-alpha.js
@@ -1,0 +1,9 @@
+var _uzactions= _uzactions|| [];
+_uzactions.push(['_setID', '20771CAA655BE31190590022196C4538']);
+_uzactions.push(['_setSID', '1F771CAA655BE31190590022196C4538']);
+_uzactions.push(['_start']);
+(function() {
+  var uz = document.createElement('script'); uz.type = 'text/javascript'; uz.async = true; uz.charset = 'utf-8';
+  uz.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'cdn4.userzoom.com/trueintent/js/uz_til.js?cuid=D32DB4D34334418399C4C7B3626B05B1';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(uz, s);
+})();

--- a/common/app/public/javascripts/vendor/userzoom-uk-alpha.js
+++ b/common/app/public/javascripts/vendor/userzoom-uk-alpha.js
@@ -1,6 +1,6 @@
 var _uzactions= _uzactions|| [];
-_uzactions.push(['_setID', '20771CAA655BE31190590022196C4538']);
-_uzactions.push(['_setSID', '1F771CAA655BE31190590022196C4538']);
+_uzactions.push(['_setID', 'A5D60F93BF5CE31190590022196C4538']);
+_uzactions.push(['_setSID', 'A4D60F93BF5CE31190590022196C4538']);
 _uzactions.push(['_start']);
 (function() {
   var uz = document.createElement('script'); uz.type = 'text/javascript'; uz.async = true; uz.charset = 'utf-8';

--- a/common/app/public/javascripts/vendor/userzoom-uk.js
+++ b/common/app/public/javascripts/vendor/userzoom-uk.js
@@ -1,0 +1,9 @@
+var _uzactions= _uzactions|| [];
+_uzactions.push(['_setID', '20771CAA655BE31190590022196C4538']);
+_uzactions.push(['_setSID', '1F771CAA655BE31190590022196C4538']);
+_uzactions.push(['_start']);
+(function() {
+  var uz = document.createElement('script'); uz.type = 'text/javascript'; uz.async = true; uz.charset = 'utf-8';
+  uz.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'cdn4.userzoom.com/trueintent/js/uz_til.js?cuid=D32DB4D34334418399C4C7B3626B05B1';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(uz, s);
+})();

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -32,7 +32,9 @@
         paths: {
             facebook: '//connect.facebook.net/en_US/all.js',
             swipe: '@Static("javascripts/vendor/swipe.js")',
-            zxcvbn: '@Static("javascripts/vendor/zxcvbn.js")'
+            zxcvbn: '@Static("javascripts/vendor/zxcvbn.js")',
+            'userzoom-uk': '@Static("javascripts/vendor/userzoom-uk.js")',
+            'userzoom-uk-alpha': '@Static("javascripts/vendor/userzoom-uk-alpha.js")'
         }
     };
 


### PR DESCRIPTION
- Behind switch, with example scripts for /uk and /uk-alpha.
- This is the place to set criteria such as number of previous visits required, platform, etc. 
- Userzoom itself can set percentages and return period. 
