### PR TITLE
Summaries are expandable in Chrome

### DIFF
--- a/common/app/views/fragments/liveSummary.scala.html
+++ b/common/app/views/fragments/liveSummary.scala.html
@@ -17,14 +17,14 @@
                    for="live-summary__expander-trigger-@summaryId"
                    data-link-name="live summary expander"
                    aria-hidden="true">
-                <button class="u-button-reset live-summary__expander-cta__button live-summary__expander-show tone-colour"
+                <span class="u-button-reset live-summary__expander-cta__button live-summary__expander-show tone-colour"
                         data-link-name="live summary close">
                     Hide summary
-                </button>
-                <button class="u-button-reset live-summary__expander-cta__button live-summary__expander-hide tone-colour"
+                </span>
+                <span class="u-button-reset live-summary__expander-cta__button live-summary__expander-hide tone-colour"
                         data-link-name="live summary expand">
                     Show full summary
-                </button>
+                </span>
             </label>
         </div>
     </div>


### PR DESCRIPTION
- [fix] Summaries are expandable in Chrome on Tablet/Desktop in live blogs

To reproduce the bug, try to show the full summary in the sidebar in this live blog: http://www.theguardian.com/business/2013/dec/04/banks-braced-for-new-rate-rigging-fines-tesco-sales-slide-business-live

For some reason Chrome does not register the click on a label if performed on a button or an anchor: http://codepen.io/kaelig/pen/ksxlb

Incidentally, the click may not be registered by our tracking script. Any suggestion?

![ ](http://i.imgur.com/zCtMzFa.gif)
