### PR TITLE
Correct content type styling

### DIFF
--- a/applications/app/views/indexFacia.scala.html
+++ b/applications/app/views/indexFacia.scala.html
@@ -1,14 +1,8 @@
 @(index: services.IndexPage)(implicit request: RequestHeader)
 @import conf.Switches._
 @main(index.page, projectName = Option("facia")){ }{
-    <div class="facia-container
-                monocolumn-wrapper
-                monocolumn-wrapper--no-limit
-                @if(NewsContainerSwitch.isSwitchedOn) {
-                    news-container--v2
-                } else {
-                    news-container--v1
-                }"
+    <div class="facia-container monocolumn-wrapper monocolumn-wrapper--no-limit
+                @if(NewsContainerSwitch.isSwitchedOn){ news-container--v2 }else{ news-container--v1}"
          data-link-name="Front" role="main">
 
         @fragments.containers.sport(index.page, Config("uk/" + index.page.id + "/regular-stories", None, Some(index.page.webTitle), collectionTone = None), Collection(index.trails, None), SportContainer(showMore = false), containerIndex = 0)

--- a/common/app/assets/javascripts/modules/facia/collection-show-more.js
+++ b/common/app/assets/javascripts/modules/facia/collection-show-more.js
@@ -86,6 +86,8 @@ define([
         );
 
         this._renderButton = function() {
+            // add tone to button
+            this._$button.addClass('tone-' + (this._$collection.attr('data-tone') || 'news'));
             this._$collection.after(this._$button);
             var that = this;
             bean.on(this._$button[0], 'click', function() {

--- a/common/app/views/fragments/collections/standard.scala.html
+++ b/common/app/views/fragments/collections/standard.scala.html
@@ -3,7 +3,7 @@
 <ul class="unstyled collection collection--without-sport-stats collection--show-more-standard @if(style.showMore){js-collection--show-more}"
      data-link-context-path="collection/@config.id"
      data-link-context-name="@config.displayName"
->
+     data-tone="@style.tone">
     @if(style.showMore) {
         @collection.items.take(5).zipWithIndex.map{ case (trail, index) =>
             @fragments.items.standard(trail, index, containerIndex)

--- a/common/app/views/fragments/containers/comment.scala.html
+++ b/common/app/views/fragments/containers/comment.scala.html
@@ -3,13 +3,13 @@
 @defining(config.displayName.orElse(collection.displayName).getOrElse("")) { title =>
 
     @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle} tone-@style.tone"
+        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
                  data-link-name="block | @config.id"
                  data-id="@config.id"
                  data-type="@style.containerType">
 
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-background tone-accent-border">
+                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                     @if(style.headerLink) {
                         <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                     } else {

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -3,13 +3,13 @@
 @defining(config.displayName.orElse(collection.displayName).getOrElse("")) { title =>
 
     @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle} tone-@style.tone"
+        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
                  data-link-name="block | @config.id"
                  data-id="@config.id"
                  data-type="@style.containerType">
 
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-background tone-accent-border">
+                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                     @if(style.headerLink) {
                         <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                     } else {

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -3,13 +3,13 @@
 @defining(config.displayName.orElse(collection.displayName).getOrElse("")) { title =>
 
     @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle} tone-@style.tone"
+        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
                  data-link-name="block | @config.id"
                  data-id="@config.id"
                  data-type="@style.containerType">
 
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-background tone-accent-border">
+                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                     @if(style.headerLink) {
                         <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                     } else {

--- a/common/app/views/fragments/containers/section.scala.html
+++ b/common/app/views/fragments/containers/section.scala.html
@@ -3,13 +3,13 @@
 @defining(config.displayName.orElse(collection.displayName).getOrElse("")) { title =>
 
     @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle} tone-@style.tone"
+        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
                  data-link-name="block | @config.id"
                  data-id="@config.id"
                  data-type="@style.containerType">
 
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-background tone-accent-border">
+                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                     @if(style.headerLink) {
                         <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                     } else {

--- a/common/app/views/fragments/containers/sport.scala.html
+++ b/common/app/views/fragments/containers/sport.scala.html
@@ -3,13 +3,13 @@
 @defining(config.displayName.orElse(collection.displayName).getOrElse("")) { title =>
 
     @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle} tone-@style.tone"
+        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
                  data-link-name="block | @config.id"
                  data-id="@config.id"
                  data-type="@style.containerType">
 
             @if(title.nonEmpty) {
-                <h2 class="container__title tone-background tone-accent-border">
+                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                     @if(style.headerLink) {
                         <a data-link-name="section heading" href="@LinkTo{/@config.section}">@Html(title)</a>
                     } else {

--- a/common/test/assets/javascripts/spec/facia/collection-show-more.spec.js
+++ b/common/test/assets/javascripts/spec/facia/collection-show-more.spec.js
@@ -124,6 +124,23 @@ define(['modules/facia/collection-show-more', 'bonzo', '$', 'utils/mediator', 'b
             expect($('.item:nth-child(3)', collection)[0]).toBe(extraItem);
         });
 
+        describe('button tone', function() {
+
+            it('should add default "news" tone', function() {
+                collectionShowMore.addShowMore();
+                expect($('button', container).hasClass('tone-news')).toBeTruthy();
+            });
+
+            it('should add tone in collection\'s "data-tone" attribute', function() {
+                var tone = 'feature',
+                    $collection = $('ul', container).attr('data-tone', tone),
+                    collectionShowMore = new CollectionShowMore($collection[0]);
+                collectionShowMore.addShowMore();
+                expect($('button', container).hasClass('tone-' + tone)).toBeTruthy();
+            });
+
+        });
+
     });
 
 });


### PR DESCRIPTION
Styling was getting confused when there was more than one `tone-x` class on an ancestor of an element

This removes the `tone-x` from the `section` element (container)
