### PR TITLE
Stop pick buttons appearing twice on replies

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -189,7 +189,7 @@ Comments.prototype.renderPickButtons = function(comments) {
                                 .text(e.getAttribute('data-comment-highlighted') !== 'true' ? 'Pick' : 'Un-Pick');
                 button.data('thisComment', e);
                 var sep = bonzo.create(sepText);
-                $(self.getClass('commentActions'), e).append([sep[0],button[0]]);
+                $(self.getClass('commentActions'), e).first().append([sep[0],button[0]]);
                 self.on('click', button, self.handlePickClick.bind(self));
             }
         });


### PR DESCRIPTION
![screen shot 2013-12-04 at 15 45 37](https://f.cloud.github.com/assets/1170410/1674575/2532df4a-5cfb-11e3-859d-7a0ddd784276.png)

Pick buttons were appearing twice on comment replies. This change fixes that.

![code-09](https://f.cloud.github.com/assets/1170410/1674603/888cfa62-5cfb-11e3-9b4b-64083544f712.gif)
