### PR TITLE
Uk Alpha

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -276,6 +276,11 @@ object Switches extends Collections {
     "Switch to redirect to facia if request has X-Gu-Facia=true",
     safeState = Off  )
 
+  val UkAlphaSwitch = Switch("Facia", "facia-uk-alpha",
+    "Switch to turn on UK-Alpha for requests with the cookie GU_UK_ALPHA",
+    safeState = Off
+  )
+
   // Image Switch
 
   val ServeWebPImagesSwitch = Switch("Image Server", "serve-webp-images",
@@ -342,7 +347,8 @@ object Switches extends Collections {
     ABInitialShowMore,
     AdDwellTimeLoggerSwitch,
     ABShowMoreLayout,
-    ABMobileFacebookAutosignin
+    ABMobileFacebookAutosignin,
+    UkAlphaSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -277,7 +277,7 @@ object Switches extends Collections {
     safeState = Off  )
 
   val UkAlphaSwitch = Switch("Facia", "facia-uk-alpha",
-    "Switch to turn on UK-Alpha for requests with the cookie GU_UK_ALPHA",
+    "If this is switched on then UK-Alpha will be served for requests with the cookie GU_UK_ALPHA",
     safeState = Off
   )
 

--- a/core-navigation/app/controllers/ChangeAlphaController.scala
+++ b/core-navigation/app/controllers/ChangeAlphaController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.mvc._
 
-object ChangeBucketController extends Controller with PreferenceController {
+object ChangeAlphaController extends Controller with PreferenceController {
 
   val abCookieName: String = "GU_UK_ALPHA"
 

--- a/core-navigation/app/controllers/ChangeBucketController.scala
+++ b/core-navigation/app/controllers/ChangeBucketController.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import play.api.mvc._
+
+object ChangeBucketController extends Controller with PreferenceController {
+
+  val abCookieName: String = "GU_ALPHA"
+
+  def render(optaction: String, redirectUrl: String) = Action { implicit request =>
+    optaction match {
+      case "optin"  => switchTo(abCookieName -> "True", redirectUrl)
+      case "optout" => switchTo(abCookieName -> "False", redirectUrl)
+      case _ => NotFound("unknown action")
+    }
+  }
+}

--- a/core-navigation/app/controllers/ChangeBucketController.scala
+++ b/core-navigation/app/controllers/ChangeBucketController.scala
@@ -4,12 +4,12 @@ import play.api.mvc._
 
 object ChangeBucketController extends Controller with PreferenceController {
 
-  val abCookieName: String = "GU_ALPHA"
+  val abCookieName: String = "GU_ALPHA_TEST"
 
   def render(optaction: String, redirectUrl: String) = Action { implicit request =>
     optaction match {
-      case "optin"  => switchTo(abCookieName -> "True", redirectUrl)
-      case "optout" => switchTo(abCookieName -> "False", redirectUrl)
+      case "optin"  => switchTo(abCookieName -> "true", redirectUrl)
+      case "optout" => switchTo(abCookieName -> "false", redirectUrl)
       case _ => NotFound("unknown action")
     }
   }

--- a/core-navigation/app/controllers/ChangeBucketController.scala
+++ b/core-navigation/app/controllers/ChangeBucketController.scala
@@ -4,7 +4,7 @@ import play.api.mvc._
 
 object ChangeBucketController extends Controller with PreferenceController {
 
-  val abCookieName: String = "GU_ALPHA_TEST"
+  val abCookieName: String = "GU_UK_ALPHA"
 
   def render(optaction: String, redirectUrl: String) = Action { implicit request =>
     optaction match {

--- a/core-navigation/conf/routes
+++ b/core-navigation/conf/routes
@@ -21,7 +21,7 @@ GET        /recent/card.json                     controllers.RecentController.re
 
 GET        /preference/platform/:platform        controllers.ChangeViewController.render(platform, page)
 GET        /preference/edition/:edition          controllers.ChangeEditionController.render(edition)
-GET        /preference/alphatest/:optaction      controllers.ChangeBucketController.render(optaction, page)
+GET        /preference/ukalpha/:optaction        controllers.ChangeBucketController.render(optaction, page)
 
 # Experimental
 GET        /cards/opengraph/*path.json           controllers.CardController.opengraph(path)

--- a/core-navigation/conf/routes
+++ b/core-navigation/conf/routes
@@ -21,6 +21,7 @@ GET        /recent/card.json                     controllers.RecentController.re
 
 GET        /preference/platform/:platform        controllers.ChangeViewController.render(platform, page)
 GET        /preference/edition/:edition          controllers.ChangeEditionController.render(edition)
+GET        /preference/alphatest/:optaction      controllers.ChangeBucketController.render(optaction, page)
 
 # Experimental
 GET        /cards/opengraph/*path.json           controllers.CardController.opengraph(path)

--- a/core-navigation/conf/routes
+++ b/core-navigation/conf/routes
@@ -21,7 +21,7 @@ GET        /recent/card.json                     controllers.RecentController.re
 
 GET        /preference/platform/:platform        controllers.ChangeViewController.render(platform, page)
 GET        /preference/edition/:edition          controllers.ChangeEditionController.render(edition)
-GET        /preference/ukalpha/:optaction        controllers.ChangeBucketController.render(optaction, page)
+GET        /preference/ukalpha/:optaction        controllers.ChangeAlphaController.render(optaction, page)
 
 # Experimental
 GET        /cards/opengraph/*path.json           controllers.CardController.opengraph(path)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -263,7 +263,7 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
     if (path == "uk" &&
       Switches.UkAlphaSwitch.isSwitchedOn &&
       Edition(request) == Uk &&
-      request.headers.get("X-Gu-Uk-Alpha").filter(_.toLowerCase == "true").isDefined
+      request.headers.get("X-Gu-Uk-Alpha").exists(_.toLowerCase == "true")
     ) {
       "uk-alpha"
     }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -260,7 +260,8 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
   }
 
   def getPathForUkAlpha(path: String, request: RequestHeader): String =
-    if (Switches.UkAlphaSwitch.isSwitchedOn &&
+    if (path == "uk" &&
+      Switches.UkAlphaSwitch.isSwitchedOn &&
       Edition(request) == Uk &&
       request.headers.get("X-Gu-Uk-Alpha").filter(_.toLowerCase == "true").isDefined
     ) {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -8,6 +8,7 @@ import play.api.mvc._
 import play.api.libs.json.{JsArray, Json}
 import Switches.EditionRedirectLoggingSwitch
 import views.support.NewsContainer
+import common.editions.Uk
 
 abstract class FrontPage(val isNetworkFront: Boolean) extends MetaData
 
@@ -257,6 +258,16 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
 
     NoCache(Redirect(redirectPath))
   }
+
+  def getPathForUkAlpha(path: String, request: RequestHeader): String =
+    if (Switches.UkAlphaSwitch.isSwitchedOn &&
+      Edition(request) == Uk &&
+      request.headers.get("X-Gu-Uk-Alpha").filter(_.toLowerCase == "true").isDefined
+    ) {
+      "uk-alpha"
+    }
+    else
+      path
   
   // Needed as aliases for reverse routing
   def renderEditionFrontJson(path: String) = renderFront(path)
@@ -270,7 +281,10 @@ class FaciaController extends Controller with Logging with JsonTrails with Execu
   def renderEditionCollectionJson(id: String) = renderCollection(id)
 
   def renderFront(path: String) = Action { implicit request =>
-      val editionalisedPath = editionPath(path, Edition(request))
+      //For UK alpha only
+      val newPath = getPathForUkAlpha(path, request)
+
+      val editionalisedPath = editionPath(newPath, Edition(request))
 
       FrontPage(editionalisedPath).flatMap { frontPage =>
 


### PR DESCRIPTION
This adds:
- A path for dropping the opting in and opting out of UK Alpha via the cookie `GU_UK_ALPHA`.
- A switch `UkAlphaSwitch` for switching the UK Alpha on and off.

I have also added a path lookup for the `renderFront` method in `FaciaController`. This will serve `uk-alpha` under three conditions:
- The path is `uk`
- The UkAlphaSwitch switch is on
- We think the requests `Edition` is `Uk`
- They have the correct header `X-Gu-Uk-Alpha=true`
