### PR TITLE
Use a new AWS client on each request

### DIFF
--- a/admin/app/tools/MemoryMetrics.scala
+++ b/admin/app/tools/MemoryMetrics.scala
@@ -9,7 +9,7 @@ object MemoryMetrics {
   def memory = loadBalancers.map{ loadBalancer =>
     new LineChart(s"${loadBalancer.name} JVM memory", Seq("Memory", "used (mb)", "max (mb)"),
 
-      cloudClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+      euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
         .withStartTime(new DateTime().minusHours(3).toDate)
         .withEndTime(new DateTime().toDate)
         .withPeriod(60)
@@ -19,7 +19,7 @@ object MemoryMetrics {
         .withDimensions(stage),
         asyncHandler),
 
-    cloudClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+    euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
       .withStartTime(new DateTime().minusHours(3).toDate)
       .withEndTime(new DateTime().toDate)
       .withPeriod(60)

--- a/admin/app/tools/errors.scala
+++ b/admin/app/tools/errors.scala
@@ -7,24 +7,24 @@ import org.joda.time.DateTime
 
 object HttpErrors {
 
-  def global4XX = new LineChart("Global 4XX", Seq("Time", "4xx/min"), cloudClient.getMetricStatisticsAsync(
+  def global4XX = new LineChart("Global 4XX", Seq("Time", "4xx/min"), euWestClient.getMetricStatisticsAsync(
     metric("HTTPCode_Backend_4XX")
     ,asyncHandler)
   )
 
-  def global5XX = new LineChart("Global 5XX", Seq("Time", "5XX/ min"), cloudClient.getMetricStatisticsAsync(
+  def global5XX = new LineChart("Global 5XX", Seq("Time", "5XX/ min"), euWestClient.getMetricStatisticsAsync(
     metric("HTTPCode_Backend_5XX")
     ,asyncHandler)
   )
 
   def notFound = (primaryLoadBalancers ++ secondaryLoadBalancers).map{ loadBalancer =>
-    new LineChart(loadBalancer.name, Seq("Time", "4XX/ min"), cloudClient.getMetricStatisticsAsync(
+    new LineChart(loadBalancer.name, Seq("Time", "4XX/ min"), euWestClient.getMetricStatisticsAsync(
       metric("HTTPCode_Backend_4XX", Some(loadBalancer.id))
     ))
   }
 
   def errors = (primaryLoadBalancers ++ secondaryLoadBalancers).map{ loadBalancer =>
-    new LineChart(loadBalancer.name, Seq("Time", "5XX/ min"), cloudClient.getMetricStatisticsAsync(
+    new LineChart(loadBalancer.name, Seq("Time", "5XX/ min"), euWestClient.getMetricStatisticsAsync(
       metric("HTTPCode_Backend_5XX", Some(loadBalancer.id))
     ))
   }


### PR DESCRIPTION
This was the cause of the radiator going offline.

This should stop us from hitting a limit imposed by the JDK due to a possibility of an Entity Expansion Attack...

http://blog.bdoughan.com/2011/03/preventing-entity-expansion-attacks-in.html

@janua take a look and see if this makes sense for the front tool too (and implement there if it does).
