### PR TITLE
WIP Sponsored content

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -2,6 +2,11 @@
 @import conf.Switches._
 
 @defining((model.article, model.storyPackage)) { case (article, storyPackage) =>
+    
+    @if(article.isSponsored) {
+        @fragments.sponsored()
+    }
+
     <h2 class="article-zone left-col-deport tone-@VisualTone(article) tone-accent-border">
         <span class="left-col-deport__body">
             <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>

--- a/common/app/common/Sponsors.scala
+++ b/common/app/common/Sponsors.scala
@@ -1,0 +1,19 @@
+package common
+
+case class Sponsor(
+  campaign: String,
+  tag: String
+)
+
+object Sponsors {
+
+  lazy val campaigns: Map[String, Sponsor] = Map(
+    "sponsored/discover-america" -> Sponsor("Discover America", "discover-america"),
+    "sponsored/rent-a-car" -> Sponsor("Enterprise: rent-a-car", "rent-a-car")
+  )
+
+  def find(tag:String) = {
+    campaigns.get(tag) 
+  }
+
+}

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -3,7 +3,7 @@ package model
 import com.gu.openplatform.contentapi.model.{Content => ApiContent}
 import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
-import common.Reference
+import common.{Reference, Sponsor, Sponsors}
 import org.jsoup.Jsoup
 import collection.JavaConversions._
 import views.support.{Naked, ImgSrc}
@@ -27,6 +27,14 @@ class Content protected (val delegate: ApiContent) extends Trail with Tags with 
   lazy val blockAds: Boolean = videoAssets.exists(_.blockAds)
   lazy val isLiveBlog: Boolean = delegate.isLiveBlog
   lazy val openGraphImage: String = mainPicture.flatMap(_.largestImage.flatMap(_.url)).getOrElse(conf.Configuration.facebook.imageFallback)
+  lazy val isSponsored: Boolean = tags.exists(_.id == "sponsored/sponsored")
+  lazy val sponsor: Option[Sponsor] = {
+    if (isSponsored) {
+      Sponsors.find(tags.filter(_.tagType == "keyword").head.id) 
+    } else {
+      None
+    }
+  } 
 
   lazy val witnessAssignment = delegate.references.find(_.`type` == "witness-assignment")
     .map(_.id).map(Reference(_)).map(_._2)
@@ -57,6 +65,7 @@ class Content protected (val delegate: ApiContent) extends Trail with Tags with 
 
     souped getOrElse Nil
   }
+  
   override lazy val byline: Option[String] = fields.get("byline")
   override lazy val trailType: Option[String] = {
     if (tags.exists(_.id == "tone/comment")) {

--- a/common/app/views/fragments/sponsored.scala.html
+++ b/common/app/views/fragments/sponsored.scala.html
@@ -1,0 +1,5 @@
+@()(implicit request: RequestHeader)
+
+<div class="sponsored-message">
+    This content is sponsored.
+</div>


### PR DESCRIPTION
@kenlim @kelvin-chappell Hi, here's my simple starter for 10 ...
- Someone tags a bit of content with _sponsored/sponsored_ tag to represent advertorial stuff and also adds a tag(s) for the individual _sponsor_. 
- We map that to some meta-data in our Content model.
- We render that in to our view templates.

http://content.guardianapis.com/action-for-children/csa-ask-action-for-children?format=json&show-tags=type,keyword

TODO
- Do the tagging properly - Ie. a tag type called 'sponsor' 
- We need a list of sponsors.
- Think about the section fronts.
- Find a place in our repository for sponsor logos etc.
