### PR TITLE
Append uk-alpha to omniture tag

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -149,6 +149,13 @@ define([
                     s.eVar51  = alphaTag + s.eVar51;
                 }
 
+                // is user is viewing uk-alpha front
+                if (config.page.pageId === 'uk-alpha') {
+                    var ukAlphaTag = 'uk-alpha,';
+                    s.prop51  = ukAlphaTag + s.prop51;
+                    s.eVar51  = ukAlphaTag + s.eVar51;
+                }
+
                 s.events = s.apl(s.events,'event58',',');
             }
 


### PR DESCRIPTION
á la how `r2alpha` tracking works -  https://github.com/guardian/frontend/blob/7a29829bcbaf37a83cfe102ab645197a06e47d41/common/app/assets/javascripts/modules/analytics/omniture.js#L146

@kungpochicken 
