### PR TITLE
Commercial: Make keyword lookup consistent

### DIFF
--- a/commercial/app/model/commercial/Keyword.scala
+++ b/commercial/app/model/commercial/Keyword.scala
@@ -1,7 +1,7 @@
 package model.commercial
 
 import scala.concurrent.Future
-import conf.SwitchingContentApi
+import conf.ContentApi
 import common.{Logging, ExecutionContexts}
 
 case class Keyword(id: String, webTitle: String) {
@@ -17,7 +17,11 @@ case class Keyword(id: String, webTitle: String) {
 object Keyword extends ExecutionContexts with Logging {
 
   def lookup(term: String, section: Option[String] = None): Future[Seq[Keyword]] = {
-    val baseQuery = SwitchingContentApi().tags.q(term).tagType("keyword").pageSize(50)
+    /*
+     * Known bug in elastic search implementation means that section will be ignored,
+     * so using Solr implementation until there's a fix.
+     */
+    val baseQuery = ContentApi.tags.q(term).tagType("keyword").pageSize(50)
     val query = section.foldLeft(baseQuery)((acc, sectionName) => acc section sectionName)
 
     val result = query.response.map {

--- a/commercial/app/model/commercial/Keyword.scala
+++ b/commercial/app/model/commercial/Keyword.scala
@@ -17,18 +17,19 @@ case class Keyword(id: String, webTitle: String) {
 object Keyword extends ExecutionContexts with Logging {
 
   def lookup(term: String, section: Option[String] = None): Future[Seq[Keyword]] = {
-    val baseQuery = SwitchingContentApi().tags.stringParam("type", "keyword").stringParam("q", term).pageSize(50)
-    val query = section.foldLeft(baseQuery)((acc, s) => acc.stringParam("section", s))
+    val baseQuery = SwitchingContentApi().tags.q(term).tagType("keyword").pageSize(50)
+    val query = section.foldLeft(baseQuery)((acc, sectionName) => acc section sectionName)
+
     val result = query.response.map {
       _.results.map(tag => Keyword(tag.id, tag.webTitle))
     } recover {
       case e =>
-        log.warn(s"Failed to look up $term: ${e.getMessage}")
+        log.warn(s"Failed to look up [$term]: ${e.getMessage}")
         Nil
     }
 
     result onSuccess {
-      case keywords => log.info(s"Looking up $term gave ${keywords.map(_.id)}")
+      case keywords => log.info(s"Looking up [$term] gave ${keywords.map(_.id)}")
     }
 
     result

--- a/commercial/app/model/commercial/jobs/Job.scala
+++ b/commercial/app/model/commercial/jobs/Job.scala
@@ -3,7 +3,6 @@ package model.commercial.jobs
 import model.commercial.{Keyword, Ad, Segment}
 import model.commercial.Utils._
 import common.{AkkaAgent, ExecutionContexts}
-import conf.ContentApi
 import scala.concurrent.duration._
 import scala.concurrent.Future
 
@@ -56,12 +55,14 @@ object Industries extends ExecutionContexts {
     (350, "Social Enterprise")
   )
 
-  def refresh() = Future.sequence(sectorIdIndustryMap.map{ case (id, name) =>
-    ContentApi.tags.stringParam("type", "keyword").stringParam("q", name).pageSize(50).response.flatMap{ response =>
-      val keywords = response.results.map(tag => Keyword(tag.id, tag.webTitle))
-      industryKeywords.alter(_.updated(id, keywords))(5.seconds)
+  def refresh() = Future.sequence {
+    sectorIdIndustryMap map {
+      case (id, name) =>
+        Keyword.lookup(name) flatMap {
+          keywords => industryKeywords.alter(_.updated(id, keywords))(5.seconds)
+        }
     }
-  })
+  }
 
   def stop() {
     industryKeywords.close()

--- a/commercial/app/model/commercial/jobs/Job.scala
+++ b/commercial/app/model/commercial/jobs/Job.scala
@@ -36,7 +36,6 @@ object Industries extends ExecutionContexts {
     (141, "Environment"),
     (142, "Design"),
     (149, "Finance & Accounting"),
-    (158, "General"),
     (166, "Government & Politics"),
     (184, "Health"),
     (196, "Housing"),


### PR DESCRIPTION
Use Keyword.lookup for job industries as well as travel countries.
