### PR TITLE
Update sequence items during right ear traversal

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/onward-intrusive.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/onward-intrusive.js
@@ -1,10 +1,14 @@
 define([
     "modules/onward/sequence",
-    "modules/onward/right-ear"
+    "modules/onward/right-ear",
+    'utils/mediator'
 ], function(
     sequence,
-    RightEar
+    RightEar,
+    mediator
     ) {
+
+    var rendered = false;
 
     return function() {
 
@@ -20,12 +24,16 @@ define([
             {
                 id: 'RightEar',
                 test: function (context) {
+
+                    mediator.on('modules:sequence:loaded', function(currentSequence) {
+                        if (currentSequence && currentSequence.items.length > 0 && !rendered) {
+                            var rightEar = new RightEar(currentSequence.items, {});
+                            rightEar.render();
+                            rendered = true;
+                        }
+                    });
+
                     sequence.init();
-                    var currentSequence = sequence.getSequence();
-                    if (currentSequence && currentSequence.items.length > 0) {
-                        var rightEar = new RightEar(currentSequence.items, {});
-                        rightEar.render();
-                    }
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/onward/sequence.js
+++ b/common/app/assets/javascripts/modules/onward/sequence.js
@@ -16,7 +16,6 @@ define([
 
     var context,
         store = storage.session,
-        sequence = [],
         prefixes = {
             contextName: 'gu.context.name',
             contextPath: 'gu.context.path',
@@ -32,9 +31,19 @@ define([
         return store.get(prefixes[type]);
     }
 
-    function getSequence() { return get('sequence'); }
+    function getSequence() {
+        var currentSequence = get('sequence');
+        return {
+            name: currentSequence.name,
+            items: dedupeSequence(currentSequence.items)
+        };
+    }
+
     function getContext() { return { name: get('contextName'), path: get('contextPath') }; }
-    function removeContext() { return store.remove(prefixes.contextPath); }
+    function removeContext() {
+        store.remove(prefixes.contextName);
+        store.remove(prefixes.contextPath);
+    }
 
     function dedupeSequence(sequence) {
         var history = new History({}).get().map(function(i){

--- a/common/app/assets/javascripts/modules/onward/sequence.js
+++ b/common/app/assets/javascripts/modules/onward/sequence.js
@@ -33,10 +33,14 @@ define([
 
     function getSequence() {
         var currentSequence = get('sequence');
-        return {
-            name: currentSequence.name,
-            items: dedupeSequence(currentSequence.items)
-        };
+        if (currentSequence) {
+            return {
+                name: currentSequence.name,
+                items: dedupeSequence(currentSequence.items)
+            };
+        } else {
+            return null;
+        }
     }
 
     function getContext() { return { name: get('contextName'), path: get('contextPath') }; }


### PR DESCRIPTION
Moved Right Ear init to after sequence load, and ensure sequences are always deduped.
