### PR TITLE
Adding Bonzo's static methods to $

### DIFF
--- a/common/app/assets/javascripts/$.js
+++ b/common/app/assets/javascripts/$.js
@@ -6,8 +6,14 @@ define([
     qwery
 ) {
 
+var staticMethod;
 function $(selector, context) {
     return bonzo(qwery(selector, context));
+}
+for (staticMethod in bonzo) {
+    if(bonzo.hasOwnProperty(staticMethod)) {
+        $[staticMethod] = bonzo[staticMethod];
+    }
 }
 return $;
 


### PR DESCRIPTION
Bonzo has some pretty nifty static methods.
Unfortunately our $ utility doesn't give us these.

So, we could have:

``` javascript
define(['$'], function($) {
  $('.select-me').height($.viewport().height)
});
```

But instead we need to have:

``` javascript
define(['$', 'bonzo'], function($, bonzo) {
  $('.select-me').height(bonzo.viewport().height)
});
```

Which, I would argue, is a little annoying.

Yay or nay?
![Not sure about this!](http://www.gifbin.com/bin/1234872079_bacon_in_a_sink.gif)
