### PR TITLE
Fix the interface to each AB test in alpha-comm

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/alpha-comm.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/alpha-comm.js
@@ -53,11 +53,12 @@ define([
         var startTime = new Date().getTime(),
             $trackedAdSlots = common.$g('.ad-slot'),
             firstRun = true;
-       
 
         // a timer to submit the data to diagnostics every nth second
         if (config.switches.liveStats) {
+        
             var beaconInterval = setInterval(function() {
+
                 // if there's nothing to report, don't generate the request
                 if (Object.keys(adDwellTimes).length === 0) {
                     return false;
@@ -126,7 +127,6 @@ define([
         this.audienceOffset = 0;
         this.description = 'Test new advert formats for alpha release';
         this.canRun = function(config) {
-            _config = config;
             if(config.page.contentType === 'Article') {
                 return true;
             } else {
@@ -136,7 +136,7 @@ define([
         this.variants = [
             {
                 id: 'Inline', //Article A
-                test: function(context, isBoth) {
+                test: function(context, config, isBoth) {
                     variantName = 'Inline';
                     guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha1.com';
                     var article = document.getElementsByClassName('js-article__container')[0];
@@ -157,7 +157,7 @@ define([
 
                     // The timer for the 'Both' variant is setup only once in the variant itself
                     if (!isBoth) {
-                        initAdDwellTracking(_config, this.id);
+                        initAdDwellTracking(config, this.id);
                     }
 
                     return true;
@@ -165,7 +165,7 @@ define([
             },
             {
                 id: 'Adhesive', //Article B
-                test: function(context, isBoth) {
+                test: function(context, config, isBoth) {
                     variantName = 'Adhesive';
                     guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha2.com';
                     var viewport = detect.getBreakpoint(),
@@ -203,7 +203,7 @@ define([
 
                     // The timer for the 'Both' variant is setup only once in the variant itself
                     if (!isBoth) {
-                        initAdDwellTracking(_config, this.id);
+                        initAdDwellTracking(config, this.id);
                     }
 
                     return true;
@@ -211,7 +211,7 @@ define([
             },
             {
                 id: 'Both',  //Article C
-                test: function() {
+                test: function(context, config) {
                     guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha3.com';
                     document.body.className += ' test-inline-adverts--on';
                     self.variants.forEach(function(variant){
@@ -224,14 +224,14 @@ define([
                     guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha3.com';
                     variantName = 'Both';
 
-                    initAdDwellTracking(_config, this.id);
+                    initAdDwellTracking(config, this.id);
 
                     return true;
                 }
             },
             {
                 id: 'Static',
-                test: function() {
+                test: function(context, config) {
                     variantName = 'Static';
                     guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha4.com';
                     
@@ -250,19 +250,19 @@ define([
                         bonzo(qwery('.ad-slot--top-banner-ad')).attr('data-inview-name', 'Top');
                     }
                     // This needs to be last as the previous calls set their own variant hosts
-                    initAdDwellTracking(_config, this.id);
+                    initAdDwellTracking(config, this.id);
                     return true;
                 }
             },
             {
                 id: 'control', //Article D
-                test: function() {
+                test: function(context, config) {
                     variantName = 'Control';
                     guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha.com';
                     bonzo(qwery('.ad-slot--bottom-banner-ad')).attr('data-inview-name', 'Bottom');
                     bonzo(qwery('.ad-slot--top-banner-ad')).attr('data-inview-name', 'Top');
 
-                    initAdDwellTracking(_config, this.id);
+                    initAdDwellTracking(config, this.id);
 
                     return true;
                 }


### PR DESCRIPTION
The AB test run(context, config) interface changed yesterday (b4520afd0182d434e8ae49705b3a664875191569), which half broke our alpha-comm test when it was merged in to master as it was already using the second parameter internally for something else.

The alpha-comm code shouldn't have been doing that really.

/cc @rich-nguyen Oops.

```
$ git diff b09c774..HEAD app/assets/javascripts/modules/experiments/ab.js

@@ -127,7 +115,7 @@ define([
             variantId = participations[test.id].variant;
             test.variants.some(function(variant) {
                 if (variant.id === variantId) {
-                    variant.test(context);
+                    variant.test(context, config);
                     return true;
                 }
```
