### PR TITLE
Commercial: Shouldn't show a sector for general jobs

### DIFF
--- a/commercial/app/model/commercial/jobs/Job.scala
+++ b/commercial/app/model/commercial/jobs/Job.scala
@@ -24,10 +24,7 @@ case class Job(id: Int,
 
   val industries = sectorIds.flatMap(sectorId => Industries.sectorIdIndustryMap.get(sectorId))
 
-  val mainIndustry: Option[String] = industries.headOption.flatMap {
-    case "General" => None
-    case industry => Some(industry)
-  }
+  val mainIndustry: Option[String] = industries.headOption.filterNot(_ == "General")
 }
 
 object Industries extends ExecutionContexts {

--- a/commercial/app/model/commercial/jobs/Job.scala
+++ b/commercial/app/model/commercial/jobs/Job.scala
@@ -24,7 +24,10 @@ case class Job(id: Int,
 
   val industries = sectorIds.flatMap(sectorId => Industries.sectorIdIndustryMap.get(sectorId))
 
-  val mainIndustry: Option[String] = industries.headOption
+  val mainIndustry: Option[String] = industries.headOption.flatMap {
+    case "General" => None
+    case industry => Some(industry)
+  }
 }
 
 object Industries extends ExecutionContexts {

--- a/commercial/test/model/commercial/jobs/JobTest.scala
+++ b/commercial/test/model/commercial/jobs/JobTest.scala
@@ -1,0 +1,24 @@
+package model.commercial.jobs
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class JobTest extends FlatSpec with Matchers {
+
+  "mainIndustry" should "give a value for non-general jobs" in {
+    val job = Job(1, "title", "desc", "recruiter", None, Seq(218))
+
+    job.mainIndustry should be(Some("Legal"))
+  }
+
+  "mainIndustry" should "not give a value for jobs without an industry sector" in {
+    val job = Job(1, "title", "desc", "recruiter", None, Nil)
+
+    job.mainIndustry should be(None)
+  }
+
+  "mainIndustry" should "not give a value for general jobs" in {
+    val job = Job(1, "title", "desc", "recruiter", None, Seq(158))
+
+    job.mainIndustry should be(None)
+  }
+}


### PR DESCRIPTION
Commercial component for general jobs currently shows
_Find your next **General** job on Guardian Jobs_

which looks a bit odd. 
So this change will mean that the job sector is only shown for non-general jobs, eg _Media_.
