### PR TITLE
Fetch default sequence from most-popular if none available

### DIFF
--- a/common/app/assets/javascripts/modules/onward/sequence.js
+++ b/common/app/assets/javascripts/modules/onward/sequence.js
@@ -1,16 +1,21 @@
 define([
     'bean',
+
     'utils/ajax',
     'utils/mediator',
-    'lodash/collections/filter',
     'utils/storage',
+    'utils/config',
+
+    'lodash/collections/filter',
+
     'modules/onward/history'
 ], function(
     bean,
     ajax,
     mediator,
-    _filter,
     storage,
+    config,
+    _filter,
     History
     ){
 
@@ -59,6 +64,13 @@ define([
         });
     }
 
+    function getDefaultSequence() {
+        var section = ('page' in config && config.page.section !== '') ? '/' + config.page.section : '';
+        return {
+            path: 'most-read' + section
+        };
+    }
+
     function loadSequence(context) {
         ajax({
             url: '/' + context.path + '.json',
@@ -92,9 +104,12 @@ define([
 
         if(context.path !== null) {
             loadSequence(context);
+        } else if(getSequence() === null) {
+            loadSequence(getDefaultSequence());
         } else {
             mediator.emit('modules:sequence:loaded', getSequence());
         }
+
         bindListeners();
     }
 

--- a/common/test/assets/javascripts/spec/Sequence.spec.js
+++ b/common/test/assets/javascripts/spec/Sequence.spec.js
@@ -41,10 +41,31 @@ define(['utils/mediator', 'utils/ajax', 'modules/onward/sequence'], function(med
             server.restore();
             window.sessionStorage.removeItem('gu.context.path');
             window.sessionStorage.removeItem('gu.context.name');
-            window.localStorage.removeItem('gu.sequence');
+            window.sessionStorage.removeItem('gu.sequence');
         });
 
         it("should load a sequence from the server if none available", function(){
+
+            runs(function() {
+                sequence.init();
+            });
+
+            waitsFor(function () {
+                return sequenceLoadedCallback.calledOnce === true;
+            }, 'sequence callback never called', 500);
+
+        });
+
+        it("should load a default sequence from the server if no context is available", function(){
+
+            guardian.config.page.section = 'sport';
+
+            window.sessionStorage.removeItem('gu.context.path');
+
+            server = sinon.fakeServer.create();
+            server.autoRespond = true;
+            server.autoRespondAfter = 20;
+            server.respondWith('/most-read/sport.json?_edition=UK', [200, {}, response]);
 
             runs(function() {
                 sequence.init();


### PR DESCRIPTION
If no sequence or context is available in the sessionStorage we were not returning a sequence. This introduces a default sequence from the most popular endpoint if one is not available.

/cc @rich-nguyen 
