### PR TITLE
Remove facia switch

### DIFF
--- a/common/app/common/Site.scala
+++ b/common/app/common/Site.scala
@@ -7,10 +7,3 @@ import conf.Switches
 object Host {
   def apply(request: RequestHeader) = request.host
 }
-
-object IsFacia {
-
-  def apply(request: RequestHeader): Boolean =
-    request.headers.get("X-Gu-Facia").filter(_=="true").isDefined &&
-    Switches.FaciaSwitch.isSwitchedOn
-}

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -244,10 +244,6 @@ object Switches extends Collections {
     "Switch that is only used while running tests. You never need to change this switch.",
     safeState = Off)
 
-  val FaciaSwitch = Switch("Facia", "facia",
-    "Switch to redirect to facia if request has X-Gu-Facia=true",
-    safeState = Off  )
-
   val UkAlphaSwitch = Switch("Facia", "facia-uk-alpha",
     "If this is switched on then UK-Alpha will be served for requests with the cookie GU_UK_ALPHA",
     safeState = Off
@@ -297,7 +293,6 @@ object Switches extends Collections {
     LiveCricketSwitch,
     LiveStatsSwitch,
     UserzoomSwitch,
-    FaciaSwitch,
     AdSlotImpressionStatsSwitch,
     CssFromStorageSwitch,
     ElasticSearchSwitch,


### PR DESCRIPTION
This was once used in `applications` to either render a `Facia` style or the old style.

This is the only reference to `X-Gu-Facia` in the whole project.
