### PR TITLE
Add PreProd module to Identity for CODE

### DIFF
--- a/identity/app/Global.scala
+++ b/identity/app/Global.scala
@@ -8,6 +8,7 @@ import play.api.mvc._
 import play.api.mvc.Results._
 import scala.concurrent.Future
 import utils.SafeLogging
+import conf.Configuration
 
 object Global extends WithFilters(HeaderLoggingFilter :: RequestMeasurementMetrics.asFilters: _*) with SafeLogging
                                                                                     with CloudWatchApplicationMetrics {
@@ -17,8 +18,11 @@ object Global extends WithFilters(HeaderLoggingFilter :: RequestMeasurementMetri
   private lazy val injector = {
     val module =
       Play.mode match {
+        case Mode.Prod => {
+          if (Configuration.environment.isNonProd) new PreProdModule
+          else new ProdModule
+        }
         case Mode.Dev => new DevModule
-        case Mode.Prod => new ProdModule
         case Mode.Test => new TestModule
       }
 

--- a/identity/app/conf/Modules.scala
+++ b/identity/app/conf/Modules.scala
@@ -13,6 +13,14 @@ class ProdModule extends ScalaModule {
   def getKeys():IdentityKeys = new ProductionKeys
 }
 
+class PreProdModule extends ScalaModule {
+  def configure() {
+  }
+
+  @Provides()
+  def getKeys():IdentityKeys = new PreProductionKeys
+}
+
 class DevModule extends ScalaModule {
   def configure() {
   }


### PR DESCRIPTION
When the application is running in "prod-mode" but isn't actually in
production (e.g. CODE) we still need to create a PreProd injector.
