### PR TITLE
Facia tool: drag meta

### DIFF
--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -206,7 +206,7 @@
                             template: {name: 'template_article', foreach: items}"></div>
 
                     </div>
-                    <div class="supporting-message">Supporting links &raquo;</div>
+                    <div class="supporting-message">Supporting content &raquo;</div>
                     <div class="tools">
                         <a class="tool" data-bind="click: stopMetaEdit">Close</a>
                     </div>

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -214,11 +214,11 @@ input[type=text] {
 }
 
 .trail.underDrag {
-    border-top-color: #f89406 !important; 
+    border-top-color: #f89406; 
 }
 
 .editingMeta .trail.underDrag {
-    border-top-color: #999999 !important; 
+    border-top-color: #999999; 
 }
 
 .trail:last-child {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -125,11 +125,15 @@ input[type=text] {
 }
 
 .supporting .droppable {
-    padding: 0 0 26px 0;
+    padding: 0 0 25px 0;
 }
 
 .droppable.underDrag {
     background-color: #f89406;
+}
+
+.editingMeta .droppable.underDrag {
+    background-color: #999999;
 }
 
 .pending {
@@ -201,16 +205,20 @@ input[type=text] {
 }
 
 .supporting .trail {
-    border-color: #DDDDDD;
-    background: #DDDDDD;
+    border-color: #CCCCCC;
+    background: #CCCCCC;
 }
 
 .trail.editingMeta {
-    background: #DDDDDD;
+    background: #CCCCCC;
 }
 
 .trail.underDrag {
     border-top-color: #f89406 !important; 
+}
+
+.editingMeta .trail.underDrag {
+    border-top-color: #999999 !important; 
 }
 
 .trail:last-child {
@@ -576,11 +584,11 @@ button {
 
 .supporting-message {
     position: absolute;
-    bottom: 3px;
+    bottom: 2px;
     z-index: 2;
     left: 4px;
     font-size: 11px;
-    color: #666666;
+    color: #FFFFFF;
 }
 
 .supporting-count {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -124,8 +124,8 @@ input[type=text] {
     transition: background-color 50ms;
 }
 
-.supporting  .droppable {
-    padding: 0 0 27px 0;
+.supporting .droppable {
+    padding: 0 0 26px 0;
 }
 
 .droppable.underDrag {
@@ -145,8 +145,8 @@ input[type=text] {
 }
 
 .list-header__saving  {
+    color: #999999;
     float: right;
-    color: #d61d00;
     font-size: 12px;
 }
 
@@ -257,7 +257,8 @@ input[type=text] {
 }
 
 .headline:hover {
-    color: #438835;
+    color: #f89406;
+    text-decoration: none;
 }
 
 .trail .trail__meta {

--- a/facia-tool/public/javascripts/app.js
+++ b/facia-tool/public/javascripts/app.js
@@ -4,5 +4,9 @@ curl([
 ]).then(function(
     ListManager
 ){
-    new ListManager().init();
+    if ('localStorage' in window) {
+        new ListManager().init();
+    } else {
+        window.alert('Sorry, this browser is not supported');
+    }
 });

--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -23,7 +23,8 @@ define([
     ophanApi
 ) {
     var sourceList,
-        storage = window.localStorage;
+        storage = window.localStorage,
+        storageKey ='gu.fronts-tool.drag-source';
 
     function init() {
 
@@ -42,7 +43,7 @@ define([
                     var sourceItem = ko.dataFor(event.target);
 
                     if (sourceItem.constructor === Article) {
-                        storage.setItem('gu.fronts-tool.drag-source', JSON.stringify(sourceItem.get()));
+                        storage.setItem(storageKey, JSON.stringify(sourceItem.get()));
                     }
                     sourceList = ko.dataFor(element);
                 }, false);
@@ -132,10 +133,10 @@ define([
                     }
 
                     try {
-                        sourceItem = JSON.parse(storage.getItem('gu.fronts-tool.drag-source'));
+                        sourceItem = JSON.parse(storage.getItem(storageKey));
                     } catch(e) {}
 
-                    storage.removeItem('gu.fronts-tool.drag-source');
+                    storage.removeItem(storageKey);
 
                     if (!sourceItem || sourceItem.id !== id) {
                         sourceItem = undefined;

--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -4,6 +4,7 @@ define([
     'modules/vars',
     'utils/parse-query-params',
     'utils/url-abs-path',
+    'utils/clean-clone',
     'modules/authed-ajax',
     'models/group',
     'models/article',
@@ -14,6 +15,7 @@ define([
     vars,
     parseQueryParams,
     urlAbsPath,
+    cleanClone,
     authedAjax,
     Group,
     Article,
@@ -21,7 +23,7 @@ define([
     ophanApi
 ) {
     var sourceList,
-        sourceItem;
+        storage = window.localStorage;
 
     function init() {
 
@@ -37,8 +39,12 @@ define([
             init: function(element) {
 
                 element.addEventListener('dragstart', function(event) {
+                    var sourceItem = ko.dataFor(event.target);
+
+                    if (sourceItem.constructor === Article) {
+                        storage.setItem('gu.fronts-tool.drag-source', JSON.stringify(sourceItem.get()));
+                    }
                     sourceList = ko.dataFor(element);
-                    sourceItem = ko.dataFor(event.target);
                 }, false);
 
                 element.addEventListener('dragover', function(event) {
@@ -75,6 +81,7 @@ define([
                     var targetList = ko.dataFor(element),
                         targetItem = ko.dataFor(event.target),
                         id = event.testData ? event.testData : event.dataTransfer.getData('Text'),
+                        sourceItem,
                         position,
                         article,
                         groups,
@@ -84,7 +91,7 @@ define([
                     event.preventDefault();
                     event.stopPropagation();
 
-                    if (!targetList.items || !targetList.underDrag) { return; }
+                    if (!targetList) { return; }
 
                     targetList.underDrag(false);
                     _.each(targetList.items(), function(item) {
@@ -124,9 +131,13 @@ define([
                         return;
                     }
 
-                    // sourceItem var doesn't get repopulated when the drag was from an arbitrary link elsewhere
-                    // so garbage collect it - if it's a leftover from a previous drag.
-                    if(sourceItem && sourceItem.props.id() !== id) {
+                    try {
+                        sourceItem = JSON.parse(storage.getItem('gu.fronts-tool.drag-source'));
+                    } catch(e) {}
+
+                    storage.removeItem('gu.fronts-tool.drag-source');
+
+                    if (!sourceItem || sourceItem.id !== id) {
                         sourceItem = undefined;
                         sourceList = undefined;
                     }
@@ -138,7 +149,7 @@ define([
  
                     article = new Article({
                         id: id,
-                        meta: sourceItem ? sourceItem.getMeta() : undefined,
+                        meta: sourceItem ? cleanClone(sourceItem.meta) : undefined,
                         parent: targetList.parent,
                         parentType: targetList.parentType
                     });
@@ -172,8 +183,7 @@ define([
                             return;
                         }
 
-                        itemMeta = sourceItem && _.isFunction(sourceItem.getMeta) ? sourceItem.getMeta() : undefined;
-                        itemMeta = itemMeta || {};
+                        itemMeta = sourceItem && sourceItem.meta ? sourceItem.meta : {};
                         itemMeta.group = targetList.group + '';
 
                         authedAjax.updateCollection(
@@ -197,7 +207,7 @@ define([
                             return;
                         }
 
-                        sourceList.omitItem(sourceItem);
+                        removeMatchingItems(sourceList, id);
 
                         authedAjax.updateCollection(
                             'delete',

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -136,6 +136,13 @@ define([
             this.saveMetaEdit();
         };
 
+        Article.prototype.get = function() {
+            return {
+                id:   this.props.id(),
+                meta: this.getMeta()
+            };
+        };
+
         Article.prototype.getMeta = function() {
             var self = this;
 
@@ -154,10 +161,7 @@ define([
                     if (p[0] === 'supporting') {
                         // but only on first level Articles, i.e. those whose parent isn't an Article
                         return [p[0], self.parentType === 'Article' ? [] : _.map(p[1].items(), function(item) {
-                            return {
-                                id:   item.props.id(),
-                                meta: item.getMeta()
-                            };
+                            return item.get();
                         })];
                     }
                     return [p[0], p[1]];

--- a/facia-tool/public/javascripts/utils/clean-clone.js
+++ b/facia-tool/public/javascripts/utils/clean-clone.js
@@ -1,5 +1,5 @@
 define(function() {
     return function(obj){
-        return JSON.parse(JSON.stringify(obj));
+        return obj === undefined ? undefined : JSON.parse(JSON.stringify(obj));
     };
 });

--- a/facia-tool/public/javascripts/utils/clean-clone.js
+++ b/facia-tool/public/javascripts/utils/clean-clone.js
@@ -1,0 +1,5 @@
+define(function() {
+    return function(obj){
+        return JSON.parse(JSON.stringify(obj));
+    };
+});


### PR DESCRIPTION
Make article meta (supported links, etc) survive dragging between windows. Uses localStorage between drag start and drop.
