### PR TITLE
Change MVT max integer to a lower more manageable number of 1 million

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/mvt-cookie.js
+++ b/common/app/assets/javascripts/modules/analytics/mvt-cookie.js
@@ -7,11 +7,11 @@ define([
         VISITOR_ID_COOKIE ="s_vi",
         BROWSER_ID_COOKIE = "bwid";
 
-    // Max integer in IEEE-754 is 2^53 (52-bit mantissa plus implicit integer bit 1).
-    var MAX_INT = 9007199254740992;
+    // Nice manageable range :)
+    var MAX_INT = 1000000;
 
     function generateMvtCookie() {
-        if (!getMvtValue()) {
+        if (!getMvtValue() || getMvtValue() >  MAX_INT) {
             var mvtId = generateRandomInteger(MAX_INT, 1);
             cookies.add(MULTIVARIATE_ID_COOKIE, mvtId, 365);
         }

--- a/common/app/assets/javascripts/modules/analytics/mvt-cookie.js
+++ b/common/app/assets/javascripts/modules/analytics/mvt-cookie.js
@@ -11,7 +11,7 @@ define([
     var MAX_INT = 1000000;
 
     function generateMvtCookie() {
-        if (!getMvtValue() || getMvtValue() >  MAX_INT) {
+        if (!getMvtValue() || getMvtValue() > MAX_INT) {
             var mvtId = generateRandomInteger(MAX_INT, 1);
             cookies.add(MULTIVARIATE_ID_COOKIE, mvtId, 365);
         }


### PR DESCRIPTION
The maximum integer we were previously using as the upper boundary for our MVT cookie value seems to be _too high_ for some JavaScript engines to compute and play nicely with. 

Our hypothesis is that using a smaller range of 0-1000000 should prevent incorrect calculations.

/cc @rich-nguyen @stephanfowler @wenjiaz @selwyn-mccracken 
