### PR TITLE
Expose the number of in body links to Omniture.

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -196,6 +196,11 @@ define([
                 s.prop30 = 'non-content';
             }
 
+            // the number of Guardian links inside the body
+            if (config.page.inBodyLinkCount) {
+                s.prop58 = config.page.inBodyLinkCount;
+            }
+
             /* Retrieve navigation interaction data, incl. swipe */
             var ni = storage.session.get('gu.analytics.referrerVars');
             if (ni) {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -10,6 +10,7 @@ import views.support.{Naked, ImgSrc}
 import views.support.StripHtmlTagsAndUnescapeEntities
 import com.gu.openplatform.contentapi.model.{Content => ApiContent,Element =>ApiElement}
 import play.api.libs.json.JsValue
+import views.support.countGuardianLinks
 
 class Content protected (val delegate: ApiContent) extends Trail with Tags with MetaData {
 
@@ -156,7 +157,8 @@ class Article(content: ApiContent) extends Content(content) {
 
   override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
     ("content-type", contentType),
-    ("isLiveBlog", isLiveBlog)
+    ("isLiveBlog", isLiveBlog),
+    ("inBodyLinkCount", countGuardianLinks(body))
   )
 
   override def openGraph: List[(String, Any)] = super.openGraph ++ List(

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -428,6 +428,10 @@ object `package` extends Formats {
 
   private object inflector extends Inflector
 
+  def countGuardianLinks(s: String) = Jsoup.parseBodyFragment(s).getElementsByTag("a")
+    .flatMap(link => Option(link.attr("href")))
+    .count(link => link.startsWith(conf.Configuration.site.host))
+
   def withJsoup(html: Html)(cleaners: HtmlCleaner*): Html = withJsoup(html.body) { cleaners: _* }
 
   def withJsoup(html: String)(cleaners: HtmlCleaner*): Html = {

--- a/common/test/assets/javascripts/spec/Omniture.spec.js
+++ b/common/test/assets/javascripts/spec/Omniture.spec.js
@@ -59,7 +59,8 @@ define(['fixtures/config', 'analytics/omniture', 'common'], function(testConfigD
                     buildNumber: "build-73",
                     edition: "US",
                     webPublicationDate: "2012-02-22T16:58:00.000Z",
-                    analyticsName: "GFE:theworld:a-really-long-title-a-really-long-title-a-really-long-title-a-really-long"
+                    analyticsName: "GFE:theworld:a-really-long-title-a-really-long-title-a-really-long-title-a-really-long",
+                    inBodyLinkCount: "7"
             };
 
             var o = new Omniture(s, w);
@@ -77,6 +78,7 @@ define(['fixtures/config', 'analytics/omniture', 'common'], function(testConfigD
             expect(s.prop25).toBe("Middle East Live");
             expect(s.prop14).toBe("build-73");
             expect(s.prop47).toBe("US");
+            expect(s.prop58).toBe("7");
             expect(s.prop68).toBe("low");
             expect(s.prop56).toBe("Javascript");
             expect(s.prop30).toBe("content");


### PR DESCRIPTION
The idea is we will know how effective they are by (for example) comparing bounce rates of articles with lots of links against those with no links.
