### PR TITLE
Expose the number of in body links to Omniture.

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -196,7 +196,7 @@ define([
                 s.prop30 = 'non-content';
             }
 
-            // the number of Guardian links inside the body
+            // the number of links inside the body
             if (config.page.inBodyLinkCount) {
                 s.prop58 = config.page.inBodyLinkCount;
             }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -10,7 +10,7 @@ import views.support.{Naked, ImgSrc}
 import views.support.StripHtmlTagsAndUnescapeEntities
 import com.gu.openplatform.contentapi.model.{Content => ApiContent,Element =>ApiElement}
 import play.api.libs.json.JsValue
-import views.support.countGuardianLinks
+import views.support.countLinks
 
 class Content protected (val delegate: ApiContent) extends Trail with Tags with MetaData {
 
@@ -158,7 +158,7 @@ class Article(content: ApiContent) extends Content(content) {
   override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
     ("content-type", contentType),
     ("isLiveBlog", isLiveBlog),
-    ("inBodyLinkCount", countGuardianLinks(body))
+    ("inBodyLinkCount", countLinks(body))
   )
 
   override def openGraph: List[(String, Any)] = super.openGraph ++ List(

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -428,9 +428,7 @@ object `package` extends Formats {
 
   private object inflector extends Inflector
 
-  def countGuardianLinks(s: String) = Jsoup.parseBodyFragment(s).getElementsByTag("a")
-    .flatMap(link => Option(link.attr("href")))
-    .count(link => link.startsWith(conf.Configuration.site.host))
+  def countLinks(s: String): Int = Jsoup.parseBodyFragment(s).getElementsByTag("a").length
 
   def withJsoup(html: Html)(cleaners: HtmlCleaner*): Html = withJsoup(html.body) { cleaners: _* }
 


### PR DESCRIPTION
The idea is we will know how effective they are by (for example) comparing bounce rates of articles with lots of links against those with no links.
