### PR TITLE
Added AB test for autolinking tags

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -17,6 +17,7 @@ object BodyCleaner {
     BlockNumberCleaner,
     TweetCleaner,
     WitnessCleaner,
-    VideoEmbedCleaner(article.bodyVideos)
+    VideoEmbedCleaner(article.bodyVideos),
+    new TagLinker(article)
   )
 }

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -10,7 +10,8 @@ define([
     'common/modules/experiments/tests/onward-highlights-panel',
     'common/modules/experiments/tests/alpha-comm',
     'common/modules/experiments/tests/right-most-popular',
-    'common/modules/experiments/tests/right-most-popular-control'
+    'common/modules/experiments/tests/right-most-popular-control',
+    'common/modules/experiments/tests/tag-links'
 ], function (
     common,
     store,
@@ -22,7 +23,8 @@ define([
     OnwardHighlightsPanel,
     AlphaComm,
     RightPopular,
-    RightPopularControl
+    RightPopularControl,
+    TagLinks
     ) {
 
     var TESTS = [
@@ -32,7 +34,8 @@ define([
             new OnwardHighlightsPanel(),
             new AlphaComm(),
             new RightPopular(),
-            new RightPopularControl()
+            new RightPopularControl(),
+            new TagLinks()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/tag-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/tag-links.js
@@ -1,0 +1,35 @@
+define(['common/$'], function ($) {
+
+    var ExperimentTagLinking = function () {
+
+        this.id = 'TagLinking';
+        this.expiry = "2014-01-20";
+        this.audience = 0.3;
+        this.audienceOffset = 0.7;
+        this.description = 'Auto links to tags if the article has no other links in the body';
+        this.canRun = function(config) {
+            return (
+                //only the pages we are interested in will have these items on them
+                $('.unlinked-tag-name').length > 0
+            );
+        };
+        this.variants = [
+            {
+                id: 'control',
+                test: function (context) {
+                    return true;
+                }
+            },
+            {
+                id: 'link-tags',
+                test: function (context) {
+                    $('.unlinked-tag-name').hide();
+                    $('.linked-tag-name').removeClass('is-hidden');
+                }
+            }
+        ];
+    };
+
+    return ExperimentTagLinking;
+
+});

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -42,6 +42,7 @@ trait LinkTo extends Logging {
 
 case class LinkCounts(internal: Int, external: Int) {
   def + (that: LinkCounts): LinkCounts = LinkCounts(this.internal + that.internal, this.external + that.external)
+  lazy val noLinks = internal == 0 && external == 0
 }
 
 object LinkCounts {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -192,7 +192,7 @@ object Switches extends Collections {
 
   val ArticleKeywordsSwitch = Switch("Feature Switches", "article-keywords",
     "If this is switched on then keywords will be shown at the end of articles.",
-    safeState = Off)
+    safeState = On)
 
   val ClientSideErrorSwitch = Switch("Feature Switches", "client-side-errors",
     "If this is switch on the the browser will log JavaScript errors to the server (via a beacon)",
@@ -235,6 +235,11 @@ object Switches extends Collections {
   val ABRightPopularControl = Switch("A/B Tests", "ab-right-popular-control",
     "If this is switched on an AB test runs as a control variant for right most popular",
     safeState = Off)
+
+  val ABTagLinking = Switch("A/B Tests", "ab-tag-linking",
+    "If this is switched on an AB test runs whereby articles that have no in body links auto link to their tags",
+    safeState = Off)
+
 
   // Sport Switch
 
@@ -313,7 +318,8 @@ object Switches extends Collections {
     ABMobileFacebookAutosignin,
     ABRightPopular,
     AdDwellTimeLoggerSwitch,
-    UkAlphaSwitch
+    UkAlphaSwitch,
+    ABTagLinking
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -155,7 +155,7 @@ class Article(content: ApiContent) extends Content(content) {
       .orElse(mainPicture).orElse(videos.headOption)
 
 
-  private lazy val linkCounts = LinkTo.countLinks(body) + standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
+  lazy val linkCounts = LinkTo.countLinks(body) + standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
   override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
     ("content-type", contentType),
     ("isLiveBlog", isLiveBlog),


### PR DESCRIPTION
We know that articles with links in the body have a 10% better bounce rate than those without links.

This test will see if we can claw some of that back from articles that have **_no**_ links in the body by auto linking to tags.

I'm pretty sure we will not get the same uptake as carefully considered linking to content, but the potential pay-off is big enough to warrant a test.

Note, this is **_only**_ for articles that have **_no**_ other links in the body.
