### PR TITLE
Remove get config by ID endpoint

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -40,14 +40,6 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     } getOrElse NotFound
   }
 
-  def getConfig(id: String) = AjaxExpiringAuthentication { request =>
-    FaciaToolMetrics.ApiUsageCount.increment()
-    S3FrontsApi.getConfig(id) map {json =>
-      Ok(json).as("application/json")
-    } getOrElse NotFound
-  }
-
-
   def updateBlock(id: String): Action[AnyContent] = AjaxExpiringAuthentication { request =>
     FaciaToolMetrics.ApiUsageCount.increment()
     request.body.asJson flatMap JsonExtract.build map {

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -26,7 +26,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     Ok(Json.toJson(S3FrontsApi.listCollectionIds))
   }
 
-  def listConfigs = AjaxExpiringAuthentication { request =>
+  def getConfig = AjaxExpiringAuthentication { request =>
     FaciaToolMetrics.ApiUsageCount.increment()
     S3FrontsApi.getMasterConfig map { json =>
       Ok(json).as("application/json")

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -22,7 +22,7 @@ GET           /collection/*id            controllers.FaciaToolController.readBlo
 POST          /collection/*id            controllers.FaciaToolController.updateBlock(id)
 DELETE        /collection/*id            controllers.FaciaToolController.deleteTrail(id)
 GET           /collection                controllers.FaciaToolController.listCollections
-GET           /config                    controllers.FaciaToolController.listConfigs
+GET           /config                    controllers.FaciaToolController.getConfig
 
 # endpoints for proxying https
 GET           /api/proxy/*path           controllers.FaciaContentApiProxy.proxy(path)

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -17,7 +17,6 @@ GET           /assets/*file              controllers.Assets.at(path="/public", f
 
 # Fronts
 GET           /                          controllers.FaciaToolController.index()
-GET           /config/*id                controllers.FaciaToolController.getConfig(id)
 
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
 POST          /collection/*id            controllers.FaciaToolController.updateBlock(id)


### PR DESCRIPTION
This removes the ability to get a config file by ID. We no longer need to get a `config.json` file by ID since the JSON restructuring; we now have one `config.json`.
