### PR TITLE
Add nginx heading to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ STAGE=DEV
 The second file is called `[YOUR_HOME_DIR]/.gu/frontend.properties` and you can get its contents from a shared
 document. Ask your team mates to share it with you. If it has already been shared with you just search for "frontend.properties" in your documents.
 
+Nginx
+-----
+
+Nginx must be installed and configured to correctly serve the application, please refer to `/nginx/README.md` in this project.
+
 Vagrant
 -------
 You can run the project with the supplied Vagrantfile - make sure you understand what vagrant is http://www.vagrantup.com/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ document. Ask your team mates to share it with you. If it has already been share
 Nginx
 -----
 
-Nginx must be installed and configured to correctly serve the application, please refer to `/nginx/README.md` in this project.
+Nginx must be installed and configured to correctly serve the application, please refer to [`/nginx/README.md`](./nginx/README.md) in this project.
 
 Vagrant
 -------


### PR DESCRIPTION
Whilst installing frontend on a new machine I neglected to check the nginx readme for a while which left me stumped as the why my local hosts urls were not working.

This addition to the main readme should ensure that it doesn't happen to anyone else.
