### PR TITLE
AB test to see if underlined links are clicked more frequently than not underlined ones.

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -11,7 +11,8 @@ define([
     'common/modules/experiments/tests/alpha-comm',
     'common/modules/experiments/tests/right-most-popular',
     'common/modules/experiments/tests/right-most-popular-control',
-    'common/modules/experiments/tests/tag-links'
+    'common/modules/experiments/tests/tag-links',
+    'common/modules/experiments/tests/underline-links'
 ], function (
     common,
     store,
@@ -24,7 +25,8 @@ define([
     AlphaComm,
     RightPopular,
     RightPopularControl,
-    TagLinks
+    TagLinks,
+    UnderlineLinks
     ) {
 
     var TESTS = [
@@ -35,7 +37,8 @@ define([
             new AlphaComm(),
             new RightPopular(),
             new RightPopularControl(),
-            new TagLinks()
+            new TagLinks(),
+            new UnderlineLinks()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
@@ -1,0 +1,33 @@
+define(['common/$'], function ($) {
+
+    var ExperimentUnderlineLinks = function () {
+
+        this.id = 'UnderlineLinks';
+        this.expiry = "2014-01-17";
+        this.audience = 0.1;
+        this.audienceOffset = 0.6;
+        this.description = 'Underlines links to make them more obvious, and clickable';
+        this.canRun = function(config) {
+            return (
+               config.page.contentType === 'Article' 
+            );
+        };
+        this.variants = [
+            {
+                id: 'control',
+                test: function (context) {
+                    return true;
+                }
+            },
+            {
+                id: 'underlined',
+                test: function (context) {
+                    $('.article__main-column p a').addClass('u-underline');
+                }
+            }
+        ];
+    };
+
+    return ExperimentTagLinking;
+
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
@@ -24,6 +24,18 @@ define(['common/$'], function ($) {
                 test: function (context) {
                     $('.article__main-column p a').addClass('u-underline');
                 }
+            },
+            {
+                id: 'highlight',
+                test: function (context) {
+                    $('.article__main-column p a').addClass('u-underline-hiviz');
+                }
+            },
+            {
+                id: 'novisual',
+                test: function (context) {
+                    $('.article__main-column p a').addClass('u-underline-masklink');
+                }
             }
         ];
     };

--- a/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
@@ -22,19 +22,19 @@ define(['common/$'], function ($) {
             {
                 id: 'underlined',
                 test: function (context) {
-                    $('.article__main-column p a').addClass('u-underline');
+                    $('.article-body p a').addClass('u-underline');
                 }
             },
             {
                 id: 'highlight',
                 test: function (context) {
-                    $('.article__main-column p a').addClass('u-underline-hiviz');
+                    $('.article-body p a').addClass('u-underline-hiviz');
                 }
             },
             {
                 id: 'novisual',
                 test: function (context) {
-                    $('.article__main-column p a').addClass('u-underline-masklink');
+                    $('.article-body p a').addClass('u-underline-masklink');
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/underline-links.js
@@ -28,6 +28,6 @@ define(['common/$'], function ($) {
         ];
     };
 
-    return ExperimentTagLinking;
+    return ExperimentUnderlineLinks; 
 
 });

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -121,3 +121,8 @@
         outline: 0;
     }
 }
+
+.u-underline {
+    text-decoration: underline;
+}
+

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -121,8 +121,3 @@
         outline: 0;
     }
 }
-
-.u-underline {
-    text-decoration: underline;
-}
-

--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -75,7 +75,7 @@
 @import "module/experiments/_ab-inline-link-card";
 @import "module/experiments/_highlight-panel";
 @import "module/experiments/_right-hand-most-popular";
-
+@import "module/experiments/_underline-links";
 
 /* ==========================================================================
    Icons

--- a/common/app/assets/stylesheets/module/experiments/_underline-links.scss
+++ b/common/app/assets/stylesheets/module/experiments/_underline-links.scss
@@ -1,0 +1,15 @@
+/**
+ * style for `javascripts/modules/experiments/tests/underline-links.js`
+ */
+
+.u-underline {
+    text-decoration: underline;
+}
+
+.u-underline-hiviz {
+    background-color: #FFFFBB;
+}
+
+.u-underline-masklink {
+    color: $c-neutral1; 
+}

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -242,7 +242,7 @@ object Switches extends Collections {
 
   val ABUnderlineLinks = Switch("A/B Tests", "ab-underline-links",
     "If this is switched on an AB test runs whereby links in articles are underline (with CSS)",
-    safeState = On)
+    safeState = Off)
 
   // Sport Switch
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -240,6 +240,9 @@ object Switches extends Collections {
     "If this is switched on an AB test runs whereby articles that have no in body links auto link to their tags",
     safeState = Off)
 
+  val ABUnderlineLinks = Switch("A/B Tests", "ab-underline-links",
+    "If this is switched on an AB test runs whereby links in articles are underline (with CSS)",
+    safeState = On)
 
   // Sport Switch
 
@@ -319,7 +322,8 @@ object Switches extends Collections {
     ABRightPopular,
     AdDwellTimeLoggerSwitch,
     UkAlphaSwitch,
-    ABTagLinking
+    ABTagLinking,
+    ABUnderlineLinks
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }


### PR DESCRIPTION
Bounce rate on articles should be slightly lower for the users who have underlined links.

> WCAG 2.0 has 2 additional requirements for body text links that are not underlined by default
> - The link text must have a 3:1 contrast ratio from the surrounding non-link text.
> - The link must present a "non-color designator" (typically the introduction of the underline) on both mouse hover and keyboard focus.

ref: http://webaim.org/techniques/hypertext/link_text#appearance

We are currently in breach of that first point as our text only has a [contrast ratio](http://webaim.org/resources/contrastchecker/) of 2.7:1 - #005689 vs #000000

**underlined**

![inline](https://f.cloud.github.com/assets/84996/1833720/e9f63162-73ce-11e3-99eb-730c026dcc13.png)

**highlight**

![highlight](https://f.cloud.github.com/assets/84996/1841280/9cc85702-74a1-11e3-8758-811416953e12.png)

**novisual**

![noviz](https://f.cloud.github.com/assets/84996/1835598/6f1bf8fe-73f2-11e3-962c-1d40850ce15f.png)

![hercules-nutty-professor-o](https://f.cloud.github.com/assets/84996/1833712/c82b2272-73ce-11e3-82d2-22c692f3fac1.gif)
