### PR TITLE
Add asset graphs to admin dashboard

### DIFF
--- a/admin/app/controllers/metrics/DashboardController.scala
+++ b/admin/app/controllers/metrics/DashboardController.scala
@@ -34,4 +34,9 @@ object DashboardController extends Controller with Logging with AuthLogging {
     val metrics = MemoryMetrics.memory.map(_.withFormat(ChartFormat.DoubleLineBlueRed))
     NoCache(Ok(views.html.lineCharts(stage, metrics)))
   }
+
+  def renderAssets() = Authenticated{ request =>
+    val metrics = AssetMetrics.asset.map(_.withFormat(ChartFormat.DoubleLineBlueRed))
+    NoCache(Ok(views.html.lineCharts(stage, metrics, Some("Size of static assets"))))
+  }
 }

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -1,8 +1,8 @@
 package tools
 
 import CloudWatch._
-import com.amazonaws.services.cloudwatch.model.{Dimension, StandardUnit, GetMetricStatisticsRequest}
-import org.joda.time.{DateTime, Duration}
+import com.amazonaws.services.cloudwatch.model.{Dimension, GetMetricStatisticsRequest}
+import org.joda.time.DateTime
 
 object AssetMetrics {
 
@@ -12,21 +12,21 @@ object AssetMetrics {
       euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
         .withStartTime(new DateTime().minusDays(7).toDate)
         .withEndTime(new DateTime().toDate)
-        .withPeriod(3600)
+        .withPeriod(3600) //One hour
         .withStatistics("Average")
         .withNamespace("Assets")
         .withMetricName(file)
-        .withDimensions(stage, new Dimension().withName("Compression").withValue("GZip")),
+        .withDimensions(new Dimension().withName("Stage").withValue("PROD"), new Dimension().withName("Compression").withValue("GZip")),
         asyncHandler),
 
       euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
         .withStartTime(new DateTime().minusDays(7).toDate)
         .withEndTime(new DateTime().toDate)
-        .withPeriod(3600)
+        .withPeriod(3600) //One hour
         .withStatistics("Average")
         .withNamespace("Assets")
         .withMetricName(file)
-        .withDimensions(stage, new Dimension().withName("Compression").withValue("None")),
+        .withDimensions(new Dimension().withName("Stage").withValue("PROD"), new Dimension().withName("Compression").withValue("None")),
         asyncHandler)
     )
   }

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -1,0 +1,34 @@
+package tools
+
+import CloudWatch._
+import com.amazonaws.services.cloudwatch.model.{Dimension, StandardUnit, GetMetricStatisticsRequest}
+import org.joda.time.{DateTime, Duration}
+
+object AssetMetrics {
+
+  def asset = assetsFiles.map{ file =>
+    new LineChart(s"${file} size in Kb", Seq("Size", "GZip (kb)", "None (kb)"),
+
+      euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+        .withStartTime(new DateTime().minusDays(7).toDate)
+        .withEndTime(new DateTime().toDate)
+        .withPeriod(3600)
+        .withStatistics("Average")
+        .withNamespace("Assets")
+        .withMetricName(file)
+        .withDimensions(stage, new Dimension().withName("Compression").withValue("GZip")),
+        asyncHandler),
+
+      euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+        .withStartTime(new DateTime().minusDays(7).toDate)
+        .withEndTime(new DateTime().toDate)
+        .withPeriod(3600)
+        .withStatistics("Average")
+        .withNamespace("Assets")
+        .withMetricName(file)
+        .withDimensions(stage, new Dimension().withName("Compression").withValue("None")),
+        asyncHandler)
+    )
+  }
+
+}

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -10,7 +10,7 @@ object AssetMetrics {
     new LineChart(s"${file} size in Kb", Seq("Size", "GZip (kb)", "None (kb)"),
 
       euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
-        .withStartTime(new DateTime().minusDays(7).toDate)
+        .withStartTime(new DateTime().minusDays(14).toDate)
         .withEndTime(new DateTime().toDate)
         .withPeriod(3600) //One hour
         .withStatistics("Average")
@@ -22,7 +22,7 @@ object AssetMetrics {
         asyncHandler),
 
       euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
-        .withStartTime(new DateTime().minusDays(7).toDate)
+        .withStartTime(new DateTime().minusDays(14).toDate)
         .withEndTime(new DateTime().toDate)
         .withPeriod(3600) //One hour
         .withStatistics("Average")

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -17,7 +17,6 @@ object AssetMetrics {
         .withNamespace("Assets")
         .withMetricName(file)
         .withDimensions(
-          new Dimension().withName("Stage").withValue("PROD"),
           new Dimension().withName("Compression").withValue("GZip")
         ),
         asyncHandler),
@@ -30,7 +29,6 @@ object AssetMetrics {
         .withNamespace("Assets")
         .withMetricName(file)
         .withDimensions(
-          new Dimension().withName("Stage").withValue("PROD"),
           new Dimension().withName("Compression").withValue("None")
         ),
         asyncHandler)

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -16,7 +16,10 @@ object AssetMetrics {
         .withStatistics("Average")
         .withNamespace("Assets")
         .withMetricName(file)
-        .withDimensions(new Dimension().withName("Stage").withValue("PROD"), new Dimension().withName("Compression").withValue("GZip")),
+        .withDimensions(
+          new Dimension().withName("Stage").withValue("PROD"),
+          new Dimension().withName("Compression").withValue("GZip")
+        ),
         asyncHandler),
 
       euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
@@ -26,7 +29,10 @@ object AssetMetrics {
         .withStatistics("Average")
         .withNamespace("Assets")
         .withMetricName(file)
-        .withDimensions(new Dimension().withName("Stage").withValue("PROD"), new Dimension().withName("Compression").withValue("None")),
+        .withDimensions(
+          new Dimension().withName("Stage").withValue("PROD"),
+          new Dimension().withName("Compression").withValue("None")
+        ),
         asyncHandler)
     )
   }

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -19,7 +19,7 @@ object CloudWatch {
     executor.shutdownNow()
   }
 
-  val stage = new Dimension().withName("Stage").withValue(environment.stage)
+  val stage = new Dimension().withName("Stage").withValue("PROD")
 
   // we create a new client on each request, otherwise we run into this problem
   // http://blog.bdoughan.com/2011/03/preventing-entity-expansion-attacks-in.html
@@ -68,6 +68,13 @@ object CloudWatch {
     ("JavaScript errors from iOS", "js.android"),
     ("JavaScript errors from iOS", "js.unknown"),
     ("JavaScript errors from iOS", "js.windows")
+  )
+
+  val assetsFiles = Seq(
+    "app.js",
+    "global.css",
+    "head.default.css",
+    "head.facia.css"
   )
 
   def shortStackLatency = latency(primaryLoadBalancers)

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -19,7 +19,7 @@ object CloudWatch {
     executor.shutdownNow()
   }
 
-  val stage = new Dimension().withName("Stage").withValue("PROD")
+  val stage = new Dimension().withName("Stage").withValue(environment.stage)
 
   // we create a new client on each request, otherwise we run into this problem
   // http://blog.bdoughan.com/2011/03/preventing-entity-expansion-attacks-in.html

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -33,6 +33,7 @@
                 </ul>
             </li>
             <li><a href="@controllers.admin.routes.DashboardController.renderMemory()">JVM Memory</a></li>
+            <li><a href="@controllers.admin.routes.DashboardController.renderAssets()">Static assets</a></li>
         </ul>
     </div>
     <div class="row">

--- a/admin/app/views/lineCharts.scala.html
+++ b/admin/app/views/lineCharts.scala.html
@@ -1,6 +1,10 @@
-@(env: String, charts: Seq[tools.LineChart])
+@(env: String, charts: Seq[tools.LineChart], title: Option[String] = None)
 
 @admin_main("Dashboard", env, isAuthed = true, hasCharts = true) {
+
+    @title.map{ title =>
+        <h3>@title</h3>
+    }
 
     @* some servers have no data *@
     @defining(charts.filterNot(_.hasData).map(_.name).mkString(", ")){ noData =>

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -48,6 +48,7 @@ GET         /metrics/errors               controllers.admin.DashboardController.
 GET         /metrics/errors/4xx           controllers.admin.DashboardController.render4XX()
 GET         /metrics/errors/5xx           controllers.admin.DashboardController.render5XX()
 GET         /metrics/memory               controllers.admin.DashboardController.renderMemory()
+GET         /metrics/assets               controllers.admin.DashboardController.renderAssets()
 
 # Radiator
 GET         /radiator                     controllers.admin.RadiatorController.renderRadiator()

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -541,8 +541,8 @@
             }
         },
         "grunt-asset-monitor": {
-            "version": "0.1.2",
-            "from": "grunt-asset-monitor@~0.1.2",
+            "version": "0.1.3",
+            "from": "grunt-asset-monitor@~0.1.3",
             "dependencies": {
                 "prettysize": {
                     "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "grunt": "~0.4.0",
     "grunt-shell": "~0.6",
     "grunt-css-metrics": "~0.1.1",
-    "grunt-asset-monitor": "~0.1.2",
+    "grunt-asset-monitor": "~0.1.3",
     "grunt-env": "smlgbl/grunt-env",
     "grunt-casperjs": "guardian/grunt-casperjs#upgrade",
     "grunt-s3": "~0.2.0-alpha.3",


### PR DESCRIPTION
This PR adds a new page which graphs the size of our static assets to the admin metrics dashboards.

![screenshot from 2014-01-02 16 51 47](https://f.cloud.github.com/assets/80089/1833732/3f70901a-73cf-11e3-93b4-ecb2496b6b1d.png)
#### Todo
- Use [grunt-css-metrics task](https://github.com/phamann/grunt-css-metrics) to gather additional CSS metrics
- Use [Esprima](https://github.com/ariya/esprima) to gather additional JS metrics
- Make it look pretty like GitHubs one: https://speakerdeck.com/bleikamp/sass-at-github?slide=26

/cc @rich-nguyen 
