### PR TITLE
Agent status page

### DIFF
--- a/facia/app/conf/context.scala
+++ b/facia/app/conf/context.scala
@@ -27,10 +27,12 @@ object Management extends GuManagement {
 
 class ConfigAgentStatus extends ManagementPage {
   val path: String = "/management/configagentstatus"
+  override lazy val linktext = "/management/configagentstatus - ONLY use for debugging"
   def get(request: HttpRequest) = PlainTextResponse(ConfigAgent.contentsAsJsonString)
 }
 
 class CollectionAgentStatus extends ManagementPage {
   val path: String = "/management/collectionagentstatus"
+  override lazy val linktext = "/management/collectionagentstatus - ONLY use for debugging"
   def get(request: HttpRequest) = PlainTextResponse(CollectionAgent.contentsAsJsonString)
 }

--- a/facia/app/conf/context.scala
+++ b/facia/app/conf/context.scala
@@ -20,17 +20,17 @@ object Management extends GuManagement {
     StatusPage(applicationName, metrics),
     new PropertiesPage(Configuration.toString),
     new LogbackLevelPage(applicationName),
-    ConfigAgentStatus,
-    CollectionAgentStatus
+    new ConfigAgentStatus,
+    new CollectionAgentStatus
   )
 }
 
-object ConfigAgentStatus extends ManagementPage {
+class ConfigAgentStatus extends ManagementPage {
   val path: String = "/management/configagentstatus"
   def get(request: HttpRequest) = PlainTextResponse(ConfigAgent.contentsAsJsonString)
 }
 
-object CollectionAgentStatus extends ManagementPage {
+class CollectionAgentStatus extends ManagementPage {
   val path: String = "/management/collectionagentstatus"
   def get(request: HttpRequest) = PlainTextResponse(CollectionAgent.contentsAsJsonString)
 }

--- a/facia/app/conf/context.scala
+++ b/facia/app/conf/context.scala
@@ -1,10 +1,12 @@
 package conf
 
 import common.Metrics
-import com.gu.management.{ PropertiesPage, StatusPage, ManifestPage }
+import com.gu.management.{ PropertiesPage, StatusPage, ManifestPage, ManagementPage, PlainTextResponse }
 import com.gu.management.play.{ Management => GuManagement }
 import com.gu.management.logback.LogbackLevelPage
-import play.api.{ Application => PlayApp }
+import _root_.play.api.{ Application => PlayApp }
+import com.gu.management.HttpRequest
+import controllers.front.{CollectionAgent, ConfigAgent}
 
 class SwitchBoardPlugin(app: PlayApp) extends SwitchBoardAgent(Configuration)
 
@@ -17,6 +19,18 @@ object Management extends GuManagement {
     new UrlPagesHealthcheckManagementPage("/"),
     StatusPage(applicationName, metrics),
     new PropertiesPage(Configuration.toString),
-    new LogbackLevelPage(applicationName)
+    new LogbackLevelPage(applicationName),
+    ConfigAgentStatus,
+    CollectionAgentStatus
   )
+}
+
+object ConfigAgentStatus extends ManagementPage {
+  val path: String = "/management/configagentstatus"
+  def get(request: HttpRequest) = PlainTextResponse(ConfigAgent.contentsAsJsonString)
+}
+
+object CollectionAgentStatus extends ManagementPage {
+  val path: String = "/management/collectionagentstatus"
+  def get(request: HttpRequest) = PlainTextResponse(CollectionAgent.contentsAsJsonString)
 }

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -9,6 +9,7 @@ import play.api.libs.ws.{ WS, Response }
 import play.api.libs.json.JsObject
 import services.S3FrontsApi
 import scala.concurrent.Future
+import scala.collection.immutable.SortedMap
 
 object Path {
   def unapply[T](uri: String) = Some(uri.split('?')(0))
@@ -215,6 +216,11 @@ object CollectionAgent extends ParseCollection {
   }
 
   def close(): Unit = collectionAgent.close()
+
+  def contentsAsJsonString: String = {
+    val contents: SortedMap[String, Seq[String]] = SortedMap(collectionAgent.get().mapValues{v => v.items.map(_.url)}.toSeq:_*)
+    Json.prettyPrint(Json.toJson(contents))
+  }
 }
 
 object QueryAgents {
@@ -264,6 +270,8 @@ trait ConfigAgent extends ExecutionContexts {
   }
 
   def close() = configAgent.close()
+
+  def contentsAsJsonString: String = Json.prettyPrint(configAgent.get)
 }
 
 object ConfigAgent extends ConfigAgent


### PR DESCRIPTION
This adds a status page for both agents, if the event of one needing to know what exists inside the agent of an instance at any given time.

Since I see this as properties of the instance, I have added them to the management pages. This could be moved to `FaciaController` in the future if someone would like to make use of the contents; for either JS or healthchecks.

For the `CollectionAgent`, it just outputs each collection as a key in a map, and a corresponding list of `Item IDs` that exist for this ID.

For the `ConfigAgent`, we just dump out the JSON.
