### PR TITLE
In body links AB test.

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -13,6 +13,7 @@ object BodyCleaner {
     InBodyElementCleaner,
     UnindentBulletParents,
     PictureCleaner(article.bodyImages),
+    new InBodyLinksABTestCleaner(article),
     InBodyLinkCleaner("in body link")(Edition(request)),
     BlockNumberCleaner,
     TweetCleaner,

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -11,7 +11,8 @@ define([
     'common/modules/experiments/tests/alpha-comm',
     'common/modules/experiments/tests/right-most-popular',
     'common/modules/experiments/tests/right-most-popular-control',
-    'common/modules/experiments/tests/tag-links'
+    'common/modules/experiments/tests/tag-links',
+    'common/modules/experiments/tests/in-body-links'
 ], function (
     common,
     store,
@@ -24,7 +25,8 @@ define([
     AlphaComm,
     RightPopular,
     RightPopularControl,
-    TagLinks
+    TagLinks,
+    InBodyLinks
     ) {
 
     var TESTS = [
@@ -35,7 +37,8 @@ define([
             new AlphaComm(),
             new RightPopular(),
             new RightPopularControl(),
-            new TagLinks()
+            new TagLinks(),
+            new InBodyLinks()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/in-body-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/in-body-links.js
@@ -1,0 +1,35 @@
+define(['common/$'], function ($) {
+
+    var ExperimentArticleLinking = function () {
+
+        this.id = 'InBodyLinking';
+        this.expiry = "2014-01-20";
+        this.audience = 0.2;
+        this.audienceOffset = 0.5;
+        this.description = 'Removes In body links to see change to bounce rate';
+        this.canRun = function(config) {
+            return (
+                //only the pages we are interested in will have these items on them
+                $('.ab-in-body-link').length > 0
+            );
+        };
+        this.variants = [
+            {
+                id: 'control',
+                test: function (context) {
+                    return true;
+                }
+            },
+            {
+                id: 'remove-links',
+                test: function (context) {
+                    $('.ab-in-body-link').hide();
+                    $('.ab-in-body-text').removeClass('is-hidden');
+                }
+            }
+        ];
+    };
+
+    return ExperimentArticleLinking;
+
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/in-body-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/in-body-links.js
@@ -4,7 +4,7 @@ define(['common/$'], function ($) {
 
         this.id = 'InBodyLinking';
         this.expiry = "2014-01-20";
-        this.audience = 0.2;
+        this.audience = 0.1;
         this.audienceOffset = 0.3;
         this.description = 'Removes In body links to see change to bounce rate';
         this.canRun = function(config) {

--- a/common/app/assets/javascripts/modules/experiments/tests/in-body-links.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/in-body-links.js
@@ -5,7 +5,7 @@ define(['common/$'], function ($) {
         this.id = 'InBodyLinking';
         this.expiry = "2014-01-20";
         this.audience = 0.2;
-        this.audienceOffset = 0.5;
+        this.audienceOffset = 0.3;
         this.description = 'Removes In body links to see change to bounce rate';
         this.canRun = function(config) {
             return (

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -240,6 +240,9 @@ object Switches extends Collections {
     "If this is switched on an AB test runs whereby articles that have no in body links auto link to their tags",
     safeState = Off)
 
+  val ABInBodyLinking = Switch("A/B Tests", "ab-in-body-linking",
+    "If this is switched on an AB test runs whereby articles have in body links hidden",
+    safeState = Off)
 
   // Sport Switch
 
@@ -319,7 +322,8 @@ object Switches extends Collections {
     ABRightPopular,
     AdDwellTimeLoggerSwitch,
     UkAlphaSwitch,
-    ABTagLinking
+    ABTagLinking,
+    ABInBodyLinking
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -4,6 +4,7 @@
 <div class="article__standfirst" itemprop="description" data-link-name="standfirst">
     @content.standfirst.map { s =>
         @withJsoup(BulletCleaner(s))(
+            new InBodyLinksABTestCleaner(content)(Edition(request)),
             InBodyLinkCleaner("in standfirst link")(Edition(request))
         )
         @content.starRating.map { s =>


### PR DESCRIPTION
Stats show that articles with in body editorial links have a 10% better bounce rate that those without links.

To see how much of this is purely down to the links themselves I am running a test that removes the links form a small proportion of articles.
