### PR TITLE
Remove old feature-trailblock route from dev-build routes file

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -106,8 +106,6 @@ POST        /login                                                              
 GET         /openIDCallback                                                                                  controllers.admin.Login.openIDCallback
 GET         /logout                                                                                          controllers.admin.Login.logout
 GET         /admin                                                                                           controllers.admin.IndexController.admin()
-GET         /admin/feature-trailblock                                                                        controllers.admin.FeatureTrailblockController.edit()
-POST        /admin/feature-trailblock                                                                        controllers.admin.FeatureTrailblockController.save()
 GET         /api/proxy/*path                                                                                 controllers.admin.Api.proxy(path, callback)
 GET         /api/tag                                                                                         controllers.admin.Api.tag(q, callback)
 GET         /api/item/*path                                                                                  controllers.admin.Api.item(path, callback)


### PR DESCRIPTION
CC @gklopper

I think that this feature was removed in [4be38b4e2e2943eb39b0a3989a29cc87459e331e](https://github.com/guardian/frontend/commit/4be38b4e2e2943eb39b0a3989a29cc87459e331e) but the route for it still remains in the `dev-build` `dev-build/conf/routes` file.

This causes a compilation error on `dev-build` in SBT; removing it fixes the error.

Edit:
Credit for solving this goes to @rtyley
