### PR TITLE
Modified DEV java settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ SBT for the Play Framework backend. Neither of these tools are much use for
 building the other half of the project and coupling them together with an
 integration is one of those bad ideas that is even worse than it sounds.
 
+You ***must*** start SBT with the supplied script called `sbt` if you start
+SBT any other way the project will not run.
+
 Start the Grunt build and watch for development changes:
 
 ```

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -16,8 +16,6 @@ trait Prototypes {
     maxErrors := 20,
     javacOptions := Seq(
       "-g",
-      "-source", "1.6",
-      "-target", "1.6",
       "-encoding", "utf8"
     ),
     scalacOptions := Seq("-unchecked", "-optimise", "-deprecation",

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -119,7 +119,7 @@ trait Prototypes {
 
   def root() = Project("root", base = file("."))
     .settings(
-      scalaVersion := "2.10.2"
+      scalaVersion := "2.10.3"
     )
 
   def application(name: String) = play.Project(name, version, path = file(name))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.1

--- a/sbt
+++ b/sbt
@@ -67,9 +67,11 @@ echo "**************************************************************************
 echo ''
 
 
-# NOTE APP_SECRET below is not a REAL secret, it is just for DEV environments
+# NOTE this is not a REAL APP_SECRET it is just for DEV environments
+fake_secret="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS"
+
 java $FRONTEND_JVM_ARGS  \
   -Dsbt.boot.directory=$SBT_BOOT_DIR \
   $DEBUG_PARAMS \
-  -DAPP_SECRET="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS" \
+  -DAPP_SECRET=$fake_secret \
   -jar `dirname $0`/dev/sbt-launch-0.13.0.jar "$@"

--- a/sbt
+++ b/sbt
@@ -42,7 +42,18 @@ do
 done
 
 # gives physical memory in KB
-physical_mem=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+
+os=$(uname)
+
+if [ "$os" == "Darwin" ]; then
+    physical_mem="8388608"
+else
+    physical_mem=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+fi
+
+echo $physical_mem
+
+exit # DELETEME
 
 #http://stackoverflow.com/questions/5374455/what-does-java-option-xmx-stand-for
 jvm_mem="-Xmx$((physical_mem / 2 / 1024))m"

--- a/sbt-tc
+++ b/sbt-tc
@@ -41,6 +41,8 @@ java -version
 echo "*****************************************************************************************"
 echo ''
 
+# NOTE this is not a REAL APP_SECRET it is just for DEV environments
+fake_secret="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS"
 
 #MaxPermSize specifies the the maximum size for the permanent generation heap,
 # a heap that holds objects such as classes and methods. Xmx is the heap size.
@@ -50,7 +52,7 @@ cat /dev/null | java -Xmx4096M -XX:MaxPermSize=2048m \
   -Dsbt.log.noformat=true \
   -XX:+UseConcMarkSweepGC \
   -XX:+CMSIncrementalMode \
-  -DAPP_SECRET="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS" \
+  -DAPP_SECRET=$fake_secret \
   $BUILD_PARAMS \
   $IVY_PARAMS \
   -jar `dirname $0`/dev/sbt-launch-0.13.0.jar "$@"

--- a/sbt-tc
+++ b/sbt-tc
@@ -35,8 +35,16 @@ echo $IVY_PARAMS
 
 DOMAIN=`hostname -d`
 
+echo ''
+echo "******************************* JAVA VERION *********************************************"
+java -version
+echo "*****************************************************************************************"
+echo ''
+
+
 #MaxPermSize specifies the the maximum size for the permanent generation heap,
 # a heap that holds objects such as classes and methods. Xmx is the heap size.
+# TODO ensure we are building against OpenJDK 7 in TC
 cat /dev/null | java -Xmx4096M -XX:MaxPermSize=2048m \
   -XX:ReservedCodeCacheSize=128m \
   -Dsbt.boot.directory=$SBT_BOOT_DIR \

--- a/sbt-tc
+++ b/sbt-tc
@@ -44,7 +44,6 @@ echo ''
 
 #MaxPermSize specifies the the maximum size for the permanent generation heap,
 # a heap that holds objects such as classes and methods. Xmx is the heap size.
-# TODO ensure we are building against OpenJDK 7 in TC
 cat /dev/null | java -Xmx4096M -XX:MaxPermSize=2048m \
   -XX:ReservedCodeCacheSize=128m \
   -Dsbt.boot.directory=$SBT_BOOT_DIR \


### PR DESCRIPTION
We have a number of different developer machines with varying amounts of memory and such (not to metion different operating systems).

The JVM will now use a percentage of physical memory by default, but it is easy to override options by doing `export FRONTEND_JVM_ARGS='XXXXX'` in for example you `~/.bashrc` file.

JVM options and Java version are now also displayed when starting SBT.
