### PR TITLE
Refactor static asset data model and style dashboard

### DIFF
--- a/admin/app/controllers/metrics/DashboardController.scala
+++ b/admin/app/controllers/metrics/DashboardController.scala
@@ -6,6 +6,7 @@ import play.api.mvc.Controller
 import tools._
 import model.NoCache
 import conf.Configuration
+import tools.CloudWatch._
 
 object DashboardController extends Controller with Logging with AuthLogging {
   // We only do PROD metrics
@@ -36,7 +37,8 @@ object DashboardController extends Controller with Logging with AuthLogging {
   }
 
   def renderAssets() = Authenticated{ request =>
-    val metrics = AssetMetrics.asset.map(_.withFormat(ChartFormat.DoubleLineBlueRed))
-    NoCache(Ok(views.html.lineCharts(stage, metrics, Some("Size of static assets"))))
+
+    val metrics = AssetMetrics.assets
+    NoCache(Ok(views.html.staticAssets(stage, metrics)))
   }
 }

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -1,38 +1,43 @@
 package tools
 
 import CloudWatch._
-import com.amazonaws.services.cloudwatch.model.{Dimension, GetMetricStatisticsRequest}
+import com.amazonaws.services.cloudwatch.model.{GetMetricStatisticsResult, Dimension, GetMetricStatisticsRequest}
 import org.joda.time.DateTime
+import scala.collection.JavaConversions._
+
+case class AssetData(name: String, raw: AssetChart, zipped: AssetChart) {
+  def combined: AssetChart = new AssetChart(name, Seq("Size", "GZip (kb)", "None (kb)"), raw.charts.head, zipped.charts.head).withFormat(ChartFormat.DoubleLineBlueRed)
+
+  lazy val rawChange = raw.dataset.last.values.headOption.getOrElse(0.0) - raw.dataset.head.values.headOption.getOrElse(0.0)
+}
 
 object AssetMetrics {
 
-  def asset = assetsFiles.map{ file =>
-    new LineChart(s"${file} size in Kb", Seq("Size", "GZip (kb)", "None (kb)"),
+  def zipped(file: String) = new AssetChart(file, Seq("Size", "Kb"), euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+    .withStartTime(new DateTime().minusDays(14).toDate)
+    .withEndTime(new DateTime().toDate)
+    .withPeriod(86400) //One day
+    .withStatistics("Average")
+    .withNamespace("Assets")
+    .withMetricName(file)
+    .withDimensions(
+      new Dimension().withName("Compression").withValue("GZip")
+    ),
+    asyncHandler)).withFormat(ChartFormat.SingleLineRed)
 
-      euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
-        .withStartTime(new DateTime().minusDays(14).toDate)
-        .withEndTime(new DateTime().toDate)
-        .withPeriod(3600) //One hour
-        .withStatistics("Average")
-        .withNamespace("Assets")
-        .withMetricName(file)
-        .withDimensions(
-          new Dimension().withName("Compression").withValue("GZip")
-        ),
-        asyncHandler),
+  def raw(file: String) = new AssetChart(file, Seq("Size", "Kb"), euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+    .withStartTime(new DateTime().minusDays(14).toDate)
+    .withEndTime(new DateTime().toDate)
+    .withPeriod(86400) //One day
+    .withStatistics("Average")
+    .withNamespace("Assets")
+    .withMetricName(file)
+    .withDimensions(
+      new Dimension().withName("Compression").withValue("None")
+    ),
+    asyncHandler)).withFormat(ChartFormat.SingleLineRed)
 
-      euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
-        .withStartTime(new DateTime().minusDays(14).toDate)
-        .withEndTime(new DateTime().toDate)
-        .withPeriod(3600) //One hour
-        .withStatistics("Average")
-        .withNamespace("Assets")
-        .withMetricName(file)
-        .withDimensions(
-          new Dimension().withName("Compression").withValue("None")
-        ),
-        asyncHandler)
-    )
+  def assets = assetsFiles.map{ file =>
+    new AssetData(file, raw(file), zipped(file))
   }
-
 }

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -5,10 +5,18 @@ import com.amazonaws.services.cloudwatch.model.{GetMetricStatisticsResult, Dimen
 import org.joda.time.DateTime
 import scala.collection.JavaConversions._
 
-case class AssetData(name: String, raw: AssetChart, zipped: AssetChart) {
+case class AssetData(
+  name: String,
+  raw: AssetChart,
+  zipped: AssetChart,
+  rules: AssetChart,
+  selectors: AssetChart
+) {
   def combined: AssetChart = new AssetChart(name, Seq("Size", "GZip (kb)", "None (kb)"), raw.charts.head, zipped.charts.head).withFormat(ChartFormat.DoubleLineBlueRed)
-
-  lazy val rawChange = raw.dataset.last.values.headOption.getOrElse(0.0) - raw.dataset.head.values.headOption.getOrElse(0.0)
+  lazy val isCSS = name.endsWith(".css")
+  lazy val isJS = name.endsWith(".js")
+  lazy val rawChange = (raw.dataset.last.values.headOption.getOrElse(0.0) - raw.dataset.head.values.headOption.getOrElse(0.0)).toFloat
+  lazy val isPositiveChange = rawChange <= -0.00
 }
 
 object AssetMetrics {
@@ -23,7 +31,7 @@ object AssetMetrics {
     .withDimensions(
       new Dimension().withName("Compression").withValue("GZip")
     ),
-    asyncHandler)).withFormat(ChartFormat.SingleLineRed)
+    asyncHandler)).withFormat(ChartFormat.SingleLineBlack)
 
   def raw(file: String) = new AssetChart(file, Seq("Size", "Kb"), euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
     .withStartTime(new DateTime().minusDays(14).toDate)
@@ -35,9 +43,33 @@ object AssetMetrics {
     .withDimensions(
       new Dimension().withName("Compression").withValue("None")
     ),
-    asyncHandler)).withFormat(ChartFormat.SingleLineRed)
+    asyncHandler)).withFormat(ChartFormat.SingleLineBlack)
+
+  def rules(file: String) = new AssetChart(file, Seq("Rules", "Count"), euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+    .withStartTime(new DateTime().minusDays(14).toDate)
+    .withEndTime(new DateTime().toDate)
+    .withPeriod(86400) //One day
+    .withStatistics("Average")
+    .withNamespace("Assets")
+    .withMetricName(file)
+    .withDimensions(
+      new Dimension().withName("Metric").withValue("Rules")
+    ),
+    asyncHandler)).withFormat(ChartFormat.SingleLineBlack)
+
+  def selectors(file: String) = new AssetChart(file, Seq("Total selectors", "Count"), euWestClient.getMetricStatisticsAsync(new GetMetricStatisticsRequest()
+    .withStartTime(new DateTime().minusDays(14).toDate)
+    .withEndTime(new DateTime().toDate)
+    .withPeriod(86400) //One day
+    .withStatistics("Average")
+    .withNamespace("Assets")
+    .withMetricName(file)
+    .withDimensions(
+      new Dimension().withName("Metric").withValue("Total Selectors")
+    ),
+    asyncHandler)).withFormat(ChartFormat.SingleLineBlack)
 
   def assets = assetsFiles.map{ file =>
-    new AssetData(file, raw(file), zipped(file))
+    new AssetData(file, raw(file), zipped(file), rules(file), selectors(file))
   }
 }

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -216,7 +216,7 @@ object ChartFormat {
   val MultiLine = ChartFormat(colours = Seq("#FF6600", "#99CC33", "#CC0066", "#660099", "#0099FF"), cssClass =  "charts charts-full")
 }
 
-class LineChart(val name: String, val labels: Seq[String], charts: Future[GetMetricStatisticsResult]*) extends Chart {
+class LineChart(val name: String, val labels: Seq[String], val charts: Future[GetMetricStatisticsResult]*) extends Chart {
 
   override lazy val dataset = {
     val allPoints: List[List[(String, Double)]] = charts.toList.map(_.get())
@@ -243,6 +243,13 @@ class LineChart(val name: String, val labels: Seq[String], charts: Future[GetMet
   lazy val format = ChartFormat.SingleLineBlue
 
   def withFormat(f: ChartFormat) = new LineChart(name, labels, charts:_*) {
+    override lazy val format = f
+  }
+}
+
+class AssetChart(name: String, labels: Seq[String], charts: Future[GetMetricStatisticsResult]*) extends LineChart(name, labels, charts:_*) {
+  override def toLabel(dataPoint: Datapoint): String = new DateTime(dataPoint.getTimestamp.getTime).toString("dd/MM")
+  override def withFormat(f: ChartFormat) = new AssetChart(name, labels, charts:_*) {
     override lazy val format = f
   }
 }

--- a/admin/app/views/staticAssets.scala.html
+++ b/admin/app/views/staticAssets.scala.html
@@ -1,0 +1,41 @@
+@(env: String, assets: Seq[tools.AssetData])
+
+@admin_main("Dashboard", env, isAuthed = true, hasCharts = true) {
+
+    <h1 class="page-header">Static assets</h1>
+
+    @assets.filter(_.combined.hasData).map{ asset =>
+        <h3>@asset.name</h3>
+
+        <table class="table table-bordered table-striped">
+            <thead>
+                <tr>
+                    <th colspan="3">Size in Kb (last 14 days)</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan="3">@fragments.lineChart(asset.raw)</td>
+                </tr>
+            </tbody>
+            <thead>
+                <tr>
+                    <th>Current size (Raw)</th>
+                    <th>Current size (GZip)</th>
+                    <th>Week-on-week Change</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>@asset.raw.latest.floor Kb</td>
+                    <td>@asset.zipped.latest.floor Kb</td>
+                    <td>
+                        <span class="label @if(asset.rawChange.isNegInfinity || asset.rawChange == 0.0) { label-success } else { label-important }">
+                            @{"%.2f".format(asset.rawChange) } Kb
+                        </span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    }
+}

--- a/admin/app/views/staticAssets.scala.html
+++ b/admin/app/views/staticAssets.scala.html
@@ -1,41 +1,124 @@
 @(env: String, assets: Seq[tools.AssetData])
 
+@chart(chart: tools.AssetChart) = {
+    <div id="@chart.id" class="chart @chart.format.cssClass"></div>
+
+    <script type="text/javascript">
+    new google.visualization.LineChart(document.getElementById('@chart.id'))
+    .draw(google.visualization.arrayToDataTable(@Html(chart.asDataset)), {
+        curveType: 'function',
+        colors: [@Html(chart.format.colours.map(c => s"'$c'").mkString(","))],
+        chartArea: {
+            width: "98%"
+        },
+        vAxis: {
+            title: 'Kb',
+            textPosition: 'in',
+        },
+        fontName : 'Helvetica'
+    });
+    </script>
+}
+
+@data(asset: tools.AssetData, index: Int) = {
+    <h4><i class="icon icon-file"></i> @asset.name</h4>
+    <hr />
+    <div class="row-fluid" id="asset-@index">
+        <div class="span8">
+            <table class="table table-bordered table--asset">
+                <thead>
+                    <tr>
+                        <th class="table__head" colspan="4">Size in Kb (last 14 days)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td colspan="4">@chart(asset.raw)</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="span4">
+            <table class="table table-bordered table--asset">
+                <tbody>
+                    <tr>
+                        <th class="table__head" colspan="3">Size</th>
+                    </tr>
+                    <tr>
+                        <th>Current size (Raw)</th>
+                        <th>Current size (GZip)</th>
+                        <th>Week-on-week Change</th>
+                    </tr>
+                    <tr>
+                        <td>@asset.raw.latest.floor Kb</td>
+                        <td>@asset.zipped.latest.floor Kb</td>
+                        <td>
+                        @change(asset)
+                        </td>
+                    </tr>
+                    @if(asset.isCSS) {
+                        <tr>
+                            <th class="table__head" colspan="3">Metrics</th>
+                        </tr>
+                        <tr>
+                            <th>Rules</th>
+                            <th>Total Selectors</th>
+                            <th>Average Selectors</th>
+                        </tr>
+                        <tr>
+                            <td>@asset.rules.latest</td>
+                            <td>@asset.selectors.latest</td>
+                            <td></td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@change(asset: tools.AssetData) = {
+    @defining(asset.isPositiveChange) { change =>
+        <span class="label @if(change) { label-success } else { label-important }">
+            <i class="icon-arrow-@if(change) {down} else {up} icon-white"></i>
+            @{"%.2f".format(asset.rawChange) } Kb
+        </span>
+    }
+}
+
 @admin_main("Dashboard", env, isAuthed = true, hasCharts = true) {
 
     <h1 class="page-header">Static assets</h1>
 
-    @assets.filter(_.combined.hasData).map{ asset =>
-        <h3>@asset.name</h3>
+    <h3>Summary</h3>
 
-        <table class="table table-bordered table-striped">
-            <thead>
+    <table class="table table-bordered table-striped table--asset">
+        <thead>
+            <tr>
+                <th class="table__head">Asset filename</th>
+                <th class="table__head">Current size (Raw)</th>
+                <th class="table__head">Current size (GZip)</th>
+                <th class="table__head">Week-on-week Change</th>
+            </tr>
+        </thead>
+        <tbody>
+            @assets.filter(_.combined.hasData).zipWithIndex.map{ case (asset, index) =>
                 <tr>
-                    <th colspan="3">Size in Kb (last 14 days)</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td colspan="3">@fragments.lineChart(asset.raw)</td>
-                </tr>
-            </tbody>
-            <thead>
-                <tr>
-                    <th>Current size (Raw)</th>
-                    <th>Current size (GZip)</th>
-                    <th>Week-on-week Change</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
+                    <td>
+                        <a href="#asset-@index">
+                            <strong>@asset.name</strong></td>
+                        </a>
                     <td>@asset.raw.latest.floor Kb</td>
                     <td>@asset.zipped.latest.floor Kb</td>
                     <td>
-                        <span class="label @if(asset.rawChange.isNegInfinity || asset.rawChange == 0.0) { label-success } else { label-important }">
-                            @{"%.2f".format(asset.rawChange) } Kb
-                        </span>
+                        @change(asset)
                     </td>
                 </tr>
-            </tbody>
-        </table>
+            }
+        </tbody>
+    </table>
+
+    @assets.filter(_.combined.hasData).zipWithIndex.map{ case (asset, index) =>
+        @data(asset, index)
     }
 }

--- a/admin/public/css/admin.css
+++ b/admin/public/css/admin.css
@@ -19,3 +19,15 @@
 .chart {
     margin-bottom: 20px;
 }
+
+.table--asset .table__head {
+    background-color: #F5F5F5;
+    font-size: 14px;
+    color: black;
+}
+
+.table--asset th {
+    font-size: 12px;
+    font-weight: bold;
+    color: #9da0a4;
+}


### PR DESCRIPTION
This refactors the data model behind the static asset admin dashboard, introducing `AssetChart` and `AssetData` classes.

Also adds some Bootstrap loving to the view and re-style the charts.
#### Screenshot

![google chrome](https://f.cloud.github.com/assets/80089/1844504/03e55cf6-7532-11e3-9745-52f98fb225d3.png)

/cc @gklopper can you please give my Scala foo a once over.
