### PR TITLE
Allow all origins for cors

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -28,7 +28,7 @@ trait Requests {
     lazy val hasParameters = !r.queryString.isEmpty
 
     lazy val accessControlAllowOrigin = r.headers.get("Origin").map{ requestOrigin =>
-      "Access-Control-Allow-Origin" -> corsOrigins.find(_ == requestOrigin).getOrElse("*")
+      "Access-Control-Allow-Origin" -> "*"
     }
   }
 }


### PR DESCRIPTION
Will allow devs to hit code/prod endpoints from localhost, e.g. can hit discussion on prod for the comment counts, so wont need to run the discussion app locally

Can't see a downside to this - doesn't impact security or potential DOS attacks
