### PR TITLE
Facia tool: trailtext and image controls

### DIFF
--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -143,7 +143,7 @@ trait UpdateActions {
   }
 
   def updateItemMetaList(id: String, trailList: List[Trail], metaData: Map[String, JsValue]): List[Trail] = {
-    lazy val fields: Seq[String] = Seq("headline", "trailText", "group", "supporting")
+    lazy val fields: Seq[String] = Seq("headline", "trailText", "group", "supporting", "imageTone")
     lazy val newMetaMap = metaData.filter{case (k, v) => fields.contains(k)}
 
     for {

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -143,7 +143,7 @@ trait UpdateActions {
   }
 
   def updateItemMetaList(id: String, trailList: List[Trail], metaData: Map[String, JsValue]): List[Trail] = {
-    lazy val fields: Seq[String] = Seq("headline", "group", "supporting")
+    lazy val fields: Seq[String] = Seq("headline", "trailText", "group", "supporting")
     lazy val newMetaMap = metaData.filter{case (k, v) => fields.contains(k)}
 
     for {

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -171,25 +171,30 @@
         <div class="trail u-cf" data-bind="
             css: {
                 editingMeta: state.editingMeta,
-                underDrag: state.underDrag,
-                redundant: $parent.collectionMeta && $parent.collectionMeta.max ? (0 + $index()) >= (0 + $parent.collectionMeta.max()) : false
+                underDrag: state.underDrag
             }">
 
             <a target="article" data-bind="attr: {href: 'http://www.theguardian.com/' + props.id()}">
                 <img draggable="false" data-bind="
                     attr: {src: fields.thumbnail, title: props.id}" />
             </a>
-            <div class="trail__meta">
-                <span data-bind="text: humanDate"></span>
-            </div>
+            <div class="trail__meta" data-bind="text: humanDate"></div>
             <div class="trail__remove" data-bind="click: $parent.omitItem">
                 <i class="icon-trash icon-white"></i>
             </div>
 
             <div data-bind="if: state.editingMeta">
-                <div class="image_tweaks"><a class="selected">show</a> <a class="">hide</a> <a class="">boost</a></div>
+                <div class="image_tweaks">
+                    <a data-bind="
+                        click: toggleImageToneHide,
+                        css: {selected: meta.imageTone() === 'hide'}">Hide</a>
+                    |
+                    <a data-bind="
+                        click: toggleImageToneHighlight,
+                        css: {selected: meta.imageTone() === 'highlight'}">Highlight</a>
+                </div>
                 <div class="trail_tweaks u-cf">
-                    <input type="text" data-bind="
+                    <input class="headline-input" type="text" data-bind="
                         value: headlineInput,
                         event: {blur: saveMetaEdit},
                         attr: {placeholder: fields.headline}"/>
@@ -198,7 +203,7 @@
                         attr: {title: fields.headline},
                         visible: meta.headline">Revert</a>
 
-                    <textarea type="text" data-bind="
+                    <textarea class="trailtext" type="text" data-bind="
                         value: trailTextInput,
                         event: {blur: saveMetaEdit},
                         attr: {placeholder: fields.trailText}"/></textarea>
@@ -232,10 +237,7 @@
                 <div class="content" data-bind="click: startMetaEdit,">
                     <a class="headline" target="article" data-bind="
                         text: meta.headline() || fields.headline(),
-                        attr: {
-                            href: props.id(),
-                            title: meta.trailText() || fields.trailText()
-                        }"></a>
+                        attr: {href: props.id()}"></a>
 
                     <!-- ko if: meta.supporting && meta.supporting.items().length -->
                         <span class="supporting-count">(<span data-bind="text: meta.supporting.items().length"></span>)</span>
@@ -245,7 +247,7 @@
                         <i class="icon-pencil"></i>
                     <!-- /ko -->
 
-                    <div class="trailText" data-bind="
+                    <div class="trailtext" data-bind="
                         attr: {href: props.id()},
                         html: meta.trailText() || fields.trailText()"></div>
 

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -106,8 +106,7 @@
                     <span class="count" data-bind="if: !isPending()">
                         (<span data-bind="
                             text: state.count() ? state.count() : 'empty',
-                            css: {'non-zero':  state.count}
-                            "></span>)
+                            css: {'non-zero':  state.count}"></span>)
                     </span>
 
                     <span class="count" data-bind="if: isPending()">
@@ -128,19 +127,20 @@
                     <button class="btn" value="Cancel" data-bind="click: cancelEditingConfig">Cancel</button>
                 </div>
 
-                <div class="tools" data-bind="visible: state.hasDraft">
-                    <a class="draft-warning" data-bind="
-                        click: $root.setModeDraft,
-                        visible: $root.liveMode">
-                        <span class="tool draft-publish draft-warning">!</span>Unpublished edits exist</a>
+            </div>
 
-                    <div data-bind="visible: !$root.liveMode()">
-                        <a class="tool draft-publish" data-bind="
-                            click: publishDraft">Publish this container's edits</a>
-                            
-                        <a class="tool draft-discard" data-bind="
-                            click: discardDraft">Discard edits</a>
-                    </div>
+            <div class="tools" data-bind="visible: state.hasDraft">
+                <a class="draft-warning" data-bind="
+                    click: $root.setModeDraft,
+                    visible: $root.liveMode">
+                    <span class="tool draft-publish draft-warning">!</span>Unpublished edits exist</a>
+
+                <div data-bind="visible: !$root.liveMode()">
+                    <a class="tool draft-publish" data-bind="
+                        click: publishDraft">Publish this container's edits</a>
+                        
+                    <a class="tool draft-discard" data-bind="
+                        click: discardDraft">Discard edits</a>
                 </div>
             </div>
 

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -94,8 +94,6 @@
         <div class="collection">
             <div class="list-header">
                 <div class="title" data-bind="visible: !state.editingConfig()">
-                    <span class="list-header__saving" data-bind="visible: state.loadIsPending">SAVING</span>
-
                     <a class="list-header__display" data-bind="
                         visible: typeof configMeta.displayName() === 'undefined',
                         text: collectionMeta.displayName() || 'Set title for ' + (configMeta.roleName() || id),
@@ -103,19 +101,23 @@
 
                     <span class="list-header__display" data-bind="
                         visible: typeof configMeta.displayName() !== 'undefined',
-                        text: configMeta.displayName"></span>
+                        text: configMeta.displayName() || configMeta.roleName()"></span>
 
-                    <span class="list-header__display" data-bind="
-                        visible: configMeta.displayName() === '',
-                        text: configMeta.roleName"></span>
+                    <span class="count" data-bind="if: !state.loadIsPending()">
+                        (<span data-bind="
+                            text: state.count() ? state.count() : 'empty',
+                            css: {'non-zero':  state.count}
+                            "></span>)
+                    </span>
+
+                    <span class="count" data-bind="if: state.loadIsPending">
+                        (<span class="non-zero">updating...</span>)
+                    </span>
 
                     <span class="list-header__timings">
                         <!-- ko if: state.timeAgo -->
                             <span class="list-header__timings__last-updated" data-bind="text: state.timeAgo"></span>
                             by <span class="list-header__timings__user" data-bind="text: collectionMeta.updatedBy"></span>
-                        <!-- /ko -->
-                        <!-- ko ifnot: state.timeAgo -->
-                            empty
                         <!-- /ko -->
                     </span>
                 </div>
@@ -240,7 +242,7 @@
                         attr: {href: props.id()}"></a>
 
                     <!-- ko if: meta.supporting && meta.supporting.items().length -->
-                        <span class="supporting-count">(<span data-bind="text: meta.supporting.items().length"></span>)</span>
+                        <span class="count">(<span class="non-zero" data-bind="text: meta.supporting.items().length"></span>)</span>
                     <!-- /ko -->
 
                     <!-- ko if: meta.headline -->

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -97,7 +97,6 @@
 
                 <div data-bind="visible: !state.editingConfig()">
                     <span class="title" data-bind="
-                        click: toggleCollapsed,
                         text: configMeta.displayName() || collectionMeta.displayName() || configMeta.roleName() || id"></span>
 
                     <a class="list-header__edit" data-bind="
@@ -114,7 +113,13 @@
                         (<span class="non-zero">updating...</span>)
                     </span>
 
-                    <span class="list-header__timings" data-bind="click: toggleCollapsed">
+                    <i class="list-header__collapser" data-bind="
+                        click: toggleCollapsed,
+                        css: {
+                            'icon-chevron-down': !state.collapsed(),
+                            'icon-chevron-up'  :  state.collapsed }"></i>
+
+                    <span class="list-header__timings">
                         <!-- ko if: state.timeAgo -->
                             <span class="list-header__timings__last-updated" data-bind="text: state.timeAgo"></span>
                             by <span class="list-header__timings__user" data-bind="text: collectionMeta.updatedBy"></span>

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -103,14 +103,14 @@
                         visible: typeof configMeta.displayName() !== 'undefined',
                         text: configMeta.displayName() || configMeta.roleName()"></span>
 
-                    <span class="count" data-bind="if: !state.loadIsPending()">
+                    <span class="count" data-bind="if: !isPending()">
                         (<span data-bind="
                             text: state.count() ? state.count() : 'empty',
                             css: {'non-zero':  state.count}
                             "></span>)
                     </span>
 
-                    <span class="count" data-bind="if: state.loadIsPending">
+                    <span class="count" data-bind="if: isPending()">
                         (<span class="non-zero">updating...</span>)
                     </span>
 
@@ -145,7 +145,7 @@
             </div>
 
             <div data-bind="
-                css: {'pending': state.loadIsPending},
+                css: {'pending': isPending()},
                 template: {name: 'template_groups', foreach: groups}"></div>
         </div>
     </script>

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -92,16 +92,17 @@
 
     <script type="text/html" id="template_collection">
         <div class="collection">
-            <div class="list-header">
-                <div class="title" data-bind="visible: !state.editingConfig()">
-                    <a class="list-header__display" data-bind="
-                        visible: typeof configMeta.displayName() === 'undefined',
-                        text: collectionMeta.displayName() || 'Set title for ' + (configMeta.roleName() || id),
-                        click: toggleEditingConfig"></a>
+            <div class="list-header" data-bind="
+                css: {collapsed: state.collapsed}">
 
-                    <span class="list-header__display" data-bind="
-                        visible: typeof configMeta.displayName() !== 'undefined',
-                        text: configMeta.displayName() || configMeta.roleName()"></span>
+                <div data-bind="visible: !state.editingConfig()">
+                    <span class="title" data-bind="
+                        click: toggleCollapsed,
+                        text: configMeta.displayName() || collectionMeta.displayName() || configMeta.roleName() || id"></span>
+
+                    <a class="list-header__edit" data-bind="
+                        click: toggleEditingConfig,
+                        visible: typeof configMeta.displayName() === 'undefined' && !state.collapsed()">&laquo; edit title</a>
 
                     <span class="count" data-bind="if: !isPending()">
                         (<span data-bind="
@@ -113,7 +114,7 @@
                         (<span class="non-zero">updating...</span>)
                     </span>
 
-                    <span class="list-header__timings">
+                    <span class="list-header__timings" data-bind="click: toggleCollapsed">
                         <!-- ko if: state.timeAgo -->
                             <span class="list-header__timings__last-updated" data-bind="text: state.timeAgo"></span>
                             by <span class="list-header__timings__user" data-bind="text: collectionMeta.updatedBy"></span>
@@ -122,31 +123,36 @@
                 </div>
 
                 <div class="collection-config" data-bind="visible: state.editingConfig">
-                    <input type="text" data-bind="value: collectionMeta.displayName" placeholder="Title"/>
-                    <input type="submit" class="btn" value="Save" data-bind="click: saveConfig"/>
-                    <button class="btn" value="Cancel" data-bind="click: cancelEditingConfig">Cancel</button>
+                    <input type="text" data-bind="
+                        value: collectionMeta.displayName, hasFocus: true" placeholder="Title"/>
+                    <span>
+                        <a class="tool" data-bind="click: saveConfig">Save</a>
+                        <a class="tool" data-bind="click: cancelEditingConfig">Cancel</a>
+                    </span>
                 </div>
 
             </div>
 
-            <div class="tools" data-bind="visible: state.hasDraft">
-                <a class="draft-warning" data-bind="
-                    click: $root.setModeDraft,
-                    visible: $root.liveMode">
-                    <span class="tool draft-publish draft-warning">!</span>Unpublished edits exist</a>
+            <div data-bind="if: !state.collapsed()">
+                <div class="tools" data-bind="visible: state.hasDraft">
+                    <a class="draft-warning" data-bind="
+                        click: $root.setModeDraft,
+                        visible: $root.liveMode">
+                        <span class="tool draft-publish draft-warning">!</span>Unpublished edits exist</a>
 
-                <div data-bind="visible: !$root.liveMode()">
-                    <a class="tool draft-publish" data-bind="
-                        click: publishDraft">Publish this container's edits</a>
-                        
-                    <a class="tool draft-discard" data-bind="
-                        click: discardDraft">Discard edits</a>
+                    <div data-bind="visible: !$root.liveMode()">
+                        <a class="tool draft-publish" data-bind="
+                            click: publishDraft">Publish this container's edits</a>
+                            
+                        <a class="tool draft-discard" data-bind="
+                            click: discardDraft">Discard edits</a>
+                    </div>
                 </div>
-            </div>
 
-            <div data-bind="
-                css: {'pending': isPending()},
-                template: {name: 'template_groups', foreach: groups}"></div>
+                <div data-bind="
+                    css: {'pending': isPending()},
+                    template: {name: 'template_groups', foreach: groups}"></div>
+            </div>
         </div>
     </script>
 

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -187,15 +187,25 @@
             </div>
 
             <div data-bind="if: state.editingMeta">
+                <div class="image_tweaks"><a class="selected">show</a> <a class="">hide</a> <a class="">boost</a></div>
                 <div class="trail_tweaks u-cf">
                     <input type="text" data-bind="
                         value: headlineInput,
                         event: {blur: saveMetaEdit},
                         attr: {placeholder: fields.headline}"/>
-                    <a data-bind="
-                        click: revertHeadline,
+                    <a class="revert revert--headline" data-bind="
+                        click: headlineRevert,
                         attr: {title: fields.headline},
-                        visible: meta.headline">Revert headline</a>
+                        visible: meta.headline">Revert</a>
+
+                    <textarea type="text" data-bind="
+                        value: trailTextInput,
+                        event: {blur: saveMetaEdit},
+                        attr: {placeholder: fields.trailText}"/></textarea>
+                    <a class="revert revert--trailtext" data-bind="
+                        click: trailTextRevert,
+                        attr: {title: 'Revert to: ' + fields.trailText},
+                        visible: meta.trailText">Revert</a>
                 </div>
 
                 <div data-bind="if: parentType === 'Collection' || parentType === 'Clipboard'">
@@ -221,19 +231,23 @@
 
                 <div class="content" data-bind="click: startMetaEdit,">
                     <a class="headline" target="article" data-bind="
-                        attr: {href: props.id()},
-                        text: meta.headline() || fields.headline()"></a>
+                        text: meta.headline() || fields.headline(),
+                        attr: {
+                            href: props.id(),
+                            title: meta.trailText() || fields.trailText()
+                        }"></a>
+
+                    <!-- ko if: meta.supporting && meta.supporting.items().length -->
+                        <span class="supporting-count">(<span data-bind="text: meta.supporting.items().length"></span>)</span>
+                    <!-- /ko -->
 
                     <!-- ko if: meta.headline -->
                         <i class="icon-pencil"></i>
                     <!-- /ko -->
 
-                    <!-- ko if: meta.supporting && meta.supporting.items().length -->
-                        <div class="supporting-count">
-                            <strong data-bind="text: meta.supporting.items().length"></strong>
-                            supporting link<span data-bind="if: meta.supporting.items().length > 1">s</span>
-                        </div>
-                    <!-- /ko -->
+                    <div class="trailText" data-bind="
+                        attr: {href: props.id()},
+                        html: meta.trailText() || fields.trailText()"></div>
 
                 </div>                   
             </div>

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -179,7 +179,7 @@
     <script type="text/html" id="template_article">
         <div class="article u-cf" data-bind="
             css: {
-                editingMeta: state.editingMeta,
+                open: state.open,
                 underDrag: state.underDrag
             }">
 
@@ -192,7 +192,7 @@
                 <i class="icon-trash icon-white"></i>
             </div>
 
-            <div data-bind="if: state.editingMeta">
+            <div data-bind="if: state.open">
                 <div class="image__overrides">
                     <a data-bind="
                         click: toggleImageToneHide,
@@ -205,7 +205,7 @@
                 <div class="article__overrides u-cf">
                     <input class="headline-input" type="text" data-bind="
                         value: headlineInput,
-                        event: {blur: saveMetaEdit},
+                        event: {blur: save},
                         attr: {placeholder: fields.headline}"/>
                     <a class="revert revert--headline" data-bind="
                         click: headlineRevert,
@@ -214,7 +214,7 @@
 
                     <textarea class="trailtext" type="text" data-bind="
                         value: trailTextInput,
-                        event: {blur: saveMetaEdit},
+                        event: {blur: save},
                         attr: {placeholder: fields.trailText}"/></textarea>
                     <a class="revert revert--trailtext" data-bind="
                         click: trailTextRevert,
@@ -232,18 +232,18 @@
                     </div>
                     <div class="supporting-message">Supporting links &raquo;</div>
                     <div class="tools">
-                        <a class="tool" data-bind="click: stopMetaEdit">Close</a>
+                        <a class="tool" data-bind="click: close">Close</a>
                     </div>
                 </div>
             </div>
 
-            <div data-bind="if: !state.editingMeta()">
+            <div data-bind="if: !state.open()">
                 <a class="article_stats u-cf" target="ophan" data-bind="attr: {href: 'http://dashboard.ophan.co.uk/graph/breakdown?path=/' + props.id()}">
                     <div class="pageviews" data-bind="if: totalHitsFormatted()"><span data-bind="text: totalHitsFormatted"></span></div>
                     <div class="pageviews-graph" data-bind="if: state.pageViewsSeries(), sparkline: state.pageViewsSeries"></div>
                 </a>
 
-                <div class="article_content" data-bind="click: startMetaEdit,">
+                <div class="article_content" data-bind="click: open,">
                     <a class="headline" target="article" data-bind="
                         text: meta.headline() || fields.headline(),
                         attr: {href: props.id()}"></a>

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -142,10 +142,10 @@
 
                     <div data-bind="visible: !$root.liveMode()">
                         <a class="tool draft-publish" data-bind="
-                            click: publishDraft">Publish this container's edits</a>
+                            click: publishDraft">Publish container</a>
                             
                         <a class="tool draft-discard" data-bind="
-                            click: discardDraft">Discard edits</a>
+                            click: discardDraft">Discard changes</a>
                     </div>
                 </div>
 

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -122,9 +122,10 @@
                     </span>
                 </div>
 
-                <div class="collection-config" data-bind="visible: state.editingConfig">
+                <div class="collection-overrides" data-bind="visible: state.editingConfig">
                     <input type="text" data-bind="
-                        value: collectionMeta.displayName, hasFocus: true" placeholder="Title"/>
+                        value: collectionMeta.displayName,
+                        hasFocus: true" placeholder="Title"/>
                     <span>
                         <a class="tool" data-bind="click: saveConfig">Save</a>
                         <a class="tool" data-bind="click: cancelEditingConfig">Cancel</a>
@@ -138,7 +139,7 @@
                     <a class="draft-warning" data-bind="
                         click: $root.setModeDraft,
                         visible: $root.liveMode">
-                        <span class="tool draft-publish draft-warning">!</span>Unpublished edits exist</a>
+                        <span class="tool draft-publish draft-warning">!</span>Unpublished changes exist</a>
 
                     <div data-bind="visible: !$root.liveMode()">
                         <a class="tool draft-publish" data-bind="
@@ -176,7 +177,7 @@
     </script>
 
     <script type="text/html" id="template_article">
-        <div class="trail u-cf" data-bind="
+        <div class="article u-cf" data-bind="
             css: {
                 editingMeta: state.editingMeta,
                 underDrag: state.underDrag
@@ -186,13 +187,13 @@
                 <img draggable="false" data-bind="
                     attr: {src: fields.thumbnail, title: props.id}" />
             </a>
-            <div class="trail__meta" data-bind="text: humanDate"></div>
-            <div class="trail__remove" data-bind="click: $parent.omitItem">
+            <div class="article__date" data-bind="text: humanDate"></div>
+            <div class="article__remove" data-bind="click: $parent.omitItem">
                 <i class="icon-trash icon-white"></i>
             </div>
 
             <div data-bind="if: state.editingMeta">
-                <div class="image_tweaks">
+                <div class="image__overrides">
                     <a data-bind="
                         click: toggleImageToneHide,
                         css: {selected: meta.imageTone() === 'hide'}">Hide</a>
@@ -201,7 +202,7 @@
                         click: toggleImageToneHighlight,
                         css: {selected: meta.imageTone() === 'highlight'}">Highlight</a>
                 </div>
-                <div class="trail_tweaks u-cf">
+                <div class="article__overrides u-cf">
                     <input class="headline-input" type="text" data-bind="
                         value: headlineInput,
                         event: {blur: saveMetaEdit},
@@ -229,7 +230,7 @@
                             template: {name: 'template_article', foreach: items}"></div>
 
                     </div>
-                    <div class="supporting-message">Supporting content &raquo;</div>
+                    <div class="supporting-message">Supporting links &raquo;</div>
                     <div class="tools">
                         <a class="tool" data-bind="click: stopMetaEdit">Close</a>
                     </div>
@@ -237,12 +238,12 @@
             </div>
 
             <div data-bind="if: !state.editingMeta()">
-                <a class="trail_stats u-cf" target="ophan" data-bind="attr: {href: 'http://dashboard.ophan.co.uk/graph/breakdown?path=/' + props.id()}">
+                <a class="article_stats u-cf" target="ophan" data-bind="attr: {href: 'http://dashboard.ophan.co.uk/graph/breakdown?path=/' + props.id()}">
                     <div class="pageviews" data-bind="if: totalHitsFormatted()"><span data-bind="text: totalHitsFormatted"></span></div>
                     <div class="pageviews-graph" data-bind="if: state.pageViewsSeries(), sparkline: state.pageViewsSeries"></div>
                 </a>
 
-                <div class="content" data-bind="click: startMetaEdit,">
+                <div class="article_content" data-bind="click: startMetaEdit,">
                     <a class="headline" target="article" data-bind="
                         text: meta.headline() || fields.headline(),
                         attr: {href: props.id()}"></a>

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -270,7 +270,7 @@ a, a:hover {
     text-decoration: none;
 }
 
-.trailtext {
+div.trailtext {
     padding-right: 50px;
     box-sizing: border-box;
     width: 100%;
@@ -453,6 +453,7 @@ button {
     font-weight: bold;
     position: absolute;
     bottom: -14px;
+    right: 1px;
 }
 
 .pageviews-graph canvas {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -14,6 +14,10 @@ body {
     user-select: none;
 }
 
+p {
+    margin: 0;
+}
+
 a {
     text-decoration: none;
     cursor: pointer;
@@ -252,7 +256,7 @@ a {
 
 .headline {
     font-size: 15px;
-    line-height: 18px;
+    line-height: 17px;
     color: #000000;
     cursor: move;
 }
@@ -260,6 +264,23 @@ a {
 .headline:hover {
     color: #f89406;
     text-decoration: none;
+}
+
+.trailText {
+    padding-right: 50px;
+    box-sizing: border-box;
+    width: 100%;
+    display: inline-block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    word-break: break-all;
+    word-wrap: break-word;
+    height: 13px;
+    line-height: 16px;
+    font-size: 12px;
+    color: #999999;
+    margin: 2px 0 0 0;
 }
 
 .trail .trail__meta {
@@ -301,7 +322,9 @@ a {
 }
 
 .trail_tweaks {
-    margin: 1px 0 0 80px;;
+    position: relative;
+    margin: 1px 0 0 80px;
+    padding: 0 55px 0 0;
     color: #CCCCCC;
 }
 
@@ -313,7 +336,6 @@ a {
 }
 
 .trail_tweaks a {
-    display: inline-block;
     font-size: 12px;
     line-height: 13px;
 }
@@ -323,14 +345,56 @@ a {
     border-left: none;
 }
 
+.image_tweaks {
+    position: absolute;
+    top: 49px;
+    font-size: 10px;
+    line-height: 14px;
+}
+
+.image_tweaks a {
+    color: #999999;
+}
+
+.image_tweaks a:hover,
+.image_tweaks a.selected {
+    color: #333333;
+}
+
+.revert {
+    position: absolute;
+    right: 10px;
+}
+
+.revert--headline {
+    top: 7px;
+}
+
+.revert--trailtext {
+    top: 30px;
+}
+
 select,
 input[type="text"] {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
-    height: 26px;
+    height: 23px;
     padding: 1px 5px;
     margin: 1px 0 0 0;
     color: #000000;
+}
+
+textarea {
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    width: 100%;
+    font-size: 12px;
+    line-height: 14px;
+    padding: 3px 5px 0px 5px;
+    min-height: 35px;
+    margin: 0;
+    color: #999999;
+    background: #eeeeee;
 }
 
 button {
@@ -583,17 +647,16 @@ button {
 }
 
 .supporting-count {
-    width: 125px;
-    margin: 3px 0 -2px 0;
-    font-size: 10px;
-    line-height: 12px;
-    color: #999999;
+    font-size: 15px;
+    line-height: 16px;
+    color: #CCCCCC;
     cursor: pointer;
 }
 
-.supporting-count strong {
-    font-size: 12px;
-    font-weight: bold;
+.supporting-count span {
+    display: inline-block;
+    margin: 0 2px;
+    color: #666666;
 }
 
 .trail .tools {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -103,10 +103,6 @@ a, a:hover {
     padding: 0 0 0 4px;
 }
 
-.collections .title {
-    padding-left: 4px;
-}
-
 .count {
     color: #CCCCCC;
     font-weight: normal;
@@ -158,11 +154,17 @@ a, a:hover {
     opacity: 0.5;
 }
 
+.list-header__collapser {
+    float: right;
+    margin: 2px 0 0 6px;
+    opacity: 0.75;
+}
+
 .list-header__timings {
     float: right;
     font-weight: normal;
     font-size: 10px;
-    color: #999999;
+    color: #666666;
 }
 
 .collections {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -248,7 +248,6 @@ a, a:hover {
 }
 
 .content {
-    font-size: 14px;
     margin: 0 100px 0 85px;
     line-height: 0;
 }
@@ -259,7 +258,7 @@ a, a:hover {
 }
 
 .headline {
-    font-size: 15px;
+    font-size: 14px;
     line-height: 16px;
     color: #000000;
     cursor: move;
@@ -597,7 +596,7 @@ button {
     color: #999999;
 }
 
-.list-header .tools {
+.collection .tools {
     margin: 0 0 2px 4px;
 }
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -662,15 +662,6 @@ button {
     color: #FFFFFF;
 }
 
-.supporting-count {
-    color: #CCCCCC;
-}
-
-.supporting-count span {
-    margin: 0 2px;
-    color: #666666;
-}
-
 .trail .tools {
     position: absolute;
     bottom: 2px;

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -19,13 +19,6 @@ a {
     cursor: pointer;
 }
 
-fieldset,
-input[type=text] {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    height: inherit;
-}
-
 #environment {
     line-height: 40px;
     position: absolute;
@@ -190,7 +183,7 @@ input[type=text] {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     overflow: hidden;
-    padding: 0 4px 3px 4px;;
+    padding: 0 2px 3px 4px;
     position: relative;
     background: #FFFFFF;
     border-top: 5px solid #FFFFFF;
@@ -330,15 +323,14 @@ input[type=text] {
     border-left: none;
 }
 
+select,
 input[type="text"] {
-    margin: 2px 0 0 0;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    height: 26px;
     padding: 1px 5px;
-    background: #ffffff;
+    margin: 1px 0 0 0;
     color: #000000;
-}
-
-select {
-    margin: 0;
 }
 
 button {
@@ -579,7 +571,7 @@ button {
 }
 
 .supporting {
-    margin: 4px -4px -4px -4px;
+    margin: 4px -2px -4px -4px;
 }
 
 .supporting-message {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -23,11 +23,6 @@ a, a:hover {
     cursor: pointer;
 }
 
-#environment {
-    line-height: 40px;
-    position: absolute;
-}
-
 .scrollable {
     overflow-y: scroll;
 }
@@ -195,7 +190,7 @@ a, a:hover {
     border-bottom: 1px solid #CCCCCC;
 }
 
-.trail {
+.article {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     overflow: hidden;
@@ -208,51 +203,47 @@ a, a:hover {
             transition: border-color 150ms;
 }
 
-.live-mode .trail {
+.live-mode .article {
     border-color: #EEFFEE;
     background: #EEFFEE;        
 }
 
-.supporting .trail {
+.supporting .article {
     border-color: #CCCCCC;
     background: #CCCCCC;
 }
 
-.trail.editingMeta {
+.article.editingMeta {
     background: #CCCCCC;
 }
 
-.trail.underDrag {
+.article.underDrag {
     border-top-color: #f89406; 
 }
 
-.editingMeta .trail.underDrag {
+.editingMeta .article.underDrag {
     border-top-color: #999999; 
 }
 
-.trail:last-child {
+.article:last-child {
     border-bottom: 0;
 }
 
-.trail.redundant {
-    opacity: 0.2;
-}
-
-.trail img {
+.article img {
     float: left;
     width: 75px;
     height: 45px;
     margin: 3px 0 0 0;
     background-color: #EEEEEE;
-    border-radius: 3px;
+    border-radius: 2px;
 }
 
-.content {
+.article_content {
     margin: 0 100px 0 85px;
     line-height: 0;
 }
 
-.content .icon-pencil {
+.article_content .icon-pencil {
     cursor: pointer;
     opacity: 0.5;
 }
@@ -290,23 +281,25 @@ div.trailtext {
     display: none;
 }
 
-.trail .trail__meta {
+.article__date {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     position: absolute;
-    top: 35px;
+    top: 3px;
     left: 4px;
     width: 75px;
+    height: 13px;
+    overflow: hidden;
     padding: 0 0 0 2px;
     color: #FFFFFF;
     font-size: 10px;
-    line-height: 13px;
+    line-height: 14px;
     background: rgba(0,0,0,0.2);
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-bottom-top-radius: 2px;
+    border-bottom-top-radius: 2px;
 }
 
-.trail .trail__remove {
+.article__remove {
     display: none;
     position: absolute;
     top: 3px;
@@ -320,39 +313,34 @@ div.trailtext {
     border-radius: 2px;
 }
 
-.droppable .trail:hover > .trail__remove {
+.droppable .article:hover > .article__remove {
     display: block;
 }
 
-.droppable .trail .trail__remove:hover {
+.droppable .article__remove:hover {
     background: #0077BB;
 }
 
-.trail_tweaks {
+.article__overrides {
     position: relative;
     margin: 1px 0 0 80px;
     padding: 0 55px 0 0;
     color: #CCCCCC;
 }
 
-.trail_tweaks input {
+.article__overrides input {
     z-index: 99;
     background: #eeeeee;
     width: 100%;
 
 }
 
-.trail_tweaks a {
+.article__overrides a {
     font-size: 12px;
     line-height: 13px;
 }
 
-.trail_tweaks a:first-child {
-    font-weight: bold;
-    border-left: none;
-}
-
-.image_tweaks {
+.image__overrides {
     position: absolute;
     top: 49px;
     font-size: 10px;
@@ -361,19 +349,19 @@ div.trailtext {
     font-size: 11px;
 }
 
-.supporting .image_tweaks {
+.supporting .image__overrides {
     display: none;
 }
 
-.image_tweaks a {
+.image__overrides a {
     color: #666666;
 }
 
-.image_tweaks a:hover {
+.image__overrides a:hover {
     color: #0088cc;
 }
 
-.image_tweaks a.selected {
+.image__overrides a.selected {
     color: #000000;
 }
 
@@ -409,7 +397,7 @@ textarea.trailtext {
     padding: 3px 5px 0px 5px;
     min-height: 35px;
     margin: 0;
-    color: #999999;
+    color: #333333;
     background: #eeeeee;
 }
 
@@ -429,11 +417,11 @@ button {
     border-bottom: 1px solid #CCCCCC;
 }
 
-.collection-config {
+.collection-overrides {
     margin: -6px 0 0 3px;
 }
 
-.trail_stats {
+.article_stats {
     position: absolute;
     right: 4px;
     height: 30px;
@@ -572,7 +560,7 @@ button {
     line-height: 20px;
     color: #FFFFFF;
     margin-top: 5px;
-    border-radius: 3px;
+    border-radius: 2px;
     border: 0;
     cursor: pointer;
 }
@@ -655,10 +643,10 @@ button {
     color: #FFFFFF;
 }
 
-.trail .tools {
+.article .tools {
     position: absolute;
-    bottom: 2px;
-    right: 3px;
+    bottom: 0;
+    right: 2px;
 }
 
 @media (max-width: 1100px) {
@@ -670,11 +658,11 @@ button {
     .finder {
         width: 40%;
     }
-    .finder .trail .content {
+    .finder .article .article_content {
         margin-right: 0;
     }
-    .finder .trail .trail_stats,
-    .finder .trail .trail__meta {
+    .finder .article .article_stats,
+    .finder .article__meta {
         display: none;
     }
 }
@@ -709,24 +697,24 @@ button {
 }
 
 @media (max-width: 525px) {
-    .trail .content {
+    .article .article_content {
         margin-right: 0;
     }
-    .trail .trail_stats {
+    .article .article_stats {
         display: none;
     }
 }
 
 @media (max-width: 350px) {
-    .trail .content {
+    .article .article_content {
         margin-left: 0;
         margin-right: 5px;
     }
-    .trail img,
-    .trail .trail__meta {
+    .article img,
+    .article__meta {
         display: none;
     }
-    .trail_tweaks {
+    .article__overrides {
         margin: 0;
     }
 }

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -137,7 +137,7 @@ a, a:hover {
     background-color: #f89406;
 }
 
-.editingMeta .droppable.underDrag {
+.open .droppable.underDrag {
     background-color: #999999;
 }
 
@@ -213,7 +213,7 @@ a, a:hover {
     background: #CCCCCC;
 }
 
-.article.editingMeta {
+.article.open {
     background: #CCCCCC;
 }
 
@@ -221,7 +221,7 @@ a, a:hover {
     border-top-color: #f89406; 
 }
 
-.editingMeta .article.underDrag {
+.open .article.underDrag {
     border-top-color: #999999; 
 }
 
@@ -645,7 +645,7 @@ button {
 
 .article .tools {
     position: absolute;
-    bottom: 0;
+    bottom: 2px;
     right: 2px;
 }
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -146,7 +146,6 @@ a, a:hover {
     color: #999999;
     overflow: hidden;
     padding: 5px 0 1px 0;
-    min-width: 300px;
     height: 20px;
 }
 
@@ -663,8 +662,7 @@ button {
     .finder .article .article_content {
         margin-right: 0;
     }
-    .finder .article .article_stats,
-    .finder .article__meta {
+    .finder .article .article_stats {
         display: none;
     }
 }
@@ -685,7 +683,7 @@ button {
     .collections {
         left: 0;
         width: 100%;
-        padding-left: 10px;
+        padding: 10px 0 0 10px;
     }
     .scrollable {
         overflow-y: inherit
@@ -713,7 +711,7 @@ button {
         margin-right: 5px;
     }
     .article img,
-    .article__meta {
+    .article__date {
         display: none;
     }
     .article__overrides {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -159,15 +159,15 @@ a, a:hover {
     height: 20px;
 }
 
+.list-header.collapsed {
+    opacity: 0.5;
+}
+
 .list-header__timings {
     float: right;
     font-weight: normal;
     font-size: 10px;
     color: #999999;
-}
-
-.list-header .count {
-    font-size: 16px;
 }
 
 .collections {
@@ -430,14 +430,7 @@ button {
 }
 
 .collection-config {
-    padding: 5px 7px 7px 7px;
-    font-size: 10px;
-    background: #CCCCCC;
-    color: #000000;
-}
-
-.collection-config.editable {
-    background-color: #eee;
+    margin: -6px 0 0 3px;
 }
 
 .trail_stats {
@@ -601,16 +594,16 @@ button {
     margin: 0 0 2px 4px;
 }
 
-.tools .tool.draft-warning {
+.tool.draft-warning {
     font-weight: bold;
     margin-right: 4px;
 }
 
-.tools .tool:first-child {
+.tool:first-child {
     background: #0088cc;
 }
 
-.tools .tool:first-child:hover {
+.tool:first-child:hover {
     background: #0077BB;
 }
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -372,8 +372,7 @@ button {
     color: #999999;
     font-weight: bold;
     position: absolute;
-    bottom: -12px;
-    right: 1px;
+    bottom: -14px;
 }
 
 .pageviews-graph canvas {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -112,6 +112,19 @@ a, a:hover {
     padding-left: 4px;
 }
 
+.count {
+    color: #CCCCCC;
+    font-weight: normal;
+}
+
+.count span {
+    margin: 0 2px;
+}
+
+.count span.non-zero {
+    color: #333333;
+}
+
 .droppable {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -143,19 +156,18 @@ a, a:hover {
     overflow: hidden;
     padding: 5px 0 1px 0;
     min-width: 300px;
-}
-
-.list-header__saving  {
-    color: #999999;
-    float: right;
-    font-size: 12px;
+    height: 20px;
 }
 
 .list-header__timings {
+    float: right;
     font-weight: normal;
     font-size: 10px;
     color: #999999;
-    padding: 0 0 0 4px;
+}
+
+.list-header .count {
+    font-size: 16px;
 }
 
 .collections {
@@ -226,15 +238,6 @@ a, a:hover {
     opacity: 0.2;
 }
 
-.trail-count {
-    position: absolute;
-    top: 16px;
-    left: 7px;
-    color: #FFFFFF;
-    font-size: 14px;
-    font-weight: bold;
-}
-
 .trail img {
     float: left;
     width: 75px;
@@ -245,7 +248,8 @@ a, a:hover {
 }
 
 .content {
-    margin: 1px 100px 0 80px;
+    font-size: 14px;
+    margin: 0 100px 0 85px;
     line-height: 0;
 }
 
@@ -659,10 +663,7 @@ button {
 }
 
 .supporting-count {
-    font-size: 12px;
-    line-height: 12px;
     color: #CCCCCC;
-    cursor: pointer;
 }
 
 .supporting-count span {
@@ -686,7 +687,7 @@ button {
         width: 40%;
     }
     .finder .trail .content {
-        margin: 0 0 0 80px;
+        margin-right: 0;
     }
     .finder .trail .trail_stats,
     .finder .trail .trail__meta {
@@ -725,7 +726,7 @@ button {
 
 @media (max-width: 525px) {
     .trail .content {
-        margin: 0 0 0 80px;
+        margin-right: 0;
     }
     .trail .trail_stats {
         display: none;
@@ -734,7 +735,8 @@ button {
 
 @media (max-width: 350px) {
     .trail .content {
-        margin: 5px 0 0 0;
+        margin-left: 0;
+        margin-right: 5px;
     }
     .trail img,
     .trail .trail__meta {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -18,7 +18,7 @@ p {
     margin: 0;
 }
 
-a {
+a, a:hover {
     text-decoration: none;
     cursor: pointer;
 }
@@ -134,7 +134,7 @@ a {
 }
 
 .pending {
-    opacity: 0.5;
+    opacity: 0.7;
     pointer-events: none;
 }
 
@@ -245,7 +245,7 @@ a {
 }
 
 .content {
-    margin: -1px 100px 0 80px;
+    margin: 1px 100px 0 80px;
     line-height: 0;
 }
 
@@ -256,9 +256,10 @@ a {
 
 .headline {
     font-size: 15px;
-    line-height: 17px;
+    line-height: 16px;
     color: #000000;
     cursor: move;
+    margin: 1px 0 0 0;
 }
 
 .headline:hover {
@@ -266,7 +267,7 @@ a {
     text-decoration: none;
 }
 
-.trailText {
+.trailtext {
     padding-right: 50px;
     box-sizing: border-box;
     width: 100%;
@@ -276,11 +277,14 @@ a {
     text-overflow: ellipsis;
     word-break: break-all;
     word-wrap: break-word;
-    height: 13px;
+    height: 15px;
     line-height: 16px;
     font-size: 12px;
     color: #999999;
-    margin: 2px 0 0 0;
+}
+
+.supporting .trailtext {
+    display: none;
 }
 
 .trail .trail__meta {
@@ -290,9 +294,9 @@ a {
     top: 35px;
     left: 4px;
     width: 75px;
-    padding: 0 0 0 3px;
+    padding: 0 0 0 2px;
     color: #FFFFFF;
-    font-size: 9px;
+    font-size: 10px;
     line-height: 13px;
     background: rgba(0,0,0,0.2);
     border-bottom-left-radius: 3px;
@@ -350,15 +354,24 @@ a {
     top: 49px;
     font-size: 10px;
     line-height: 14px;
+    color: #AAAAAA;
+    font-size: 11px;
+}
+
+.supporting .image_tweaks {
+    display: none;
 }
 
 .image_tweaks a {
-    color: #999999;
+    color: #666666;
 }
 
-.image_tweaks a:hover,
+.image_tweaks a:hover {
+    color: #0088cc;
+}
+
 .image_tweaks a.selected {
-    color: #333333;
+    color: #000000;
 }
 
 .revert {
@@ -384,7 +397,7 @@ input[type="text"] {
     color: #000000;
 }
 
-textarea {
+textarea.trailtext {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     width: 100%;
@@ -520,7 +533,6 @@ button {
 
 .linky:hover {
     color: #005580;
-    text-decoration: underline;
 }
 
 .toolbar {
@@ -647,14 +659,13 @@ button {
 }
 
 .supporting-count {
-    font-size: 15px;
-    line-height: 16px;
+    font-size: 12px;
+    line-height: 12px;
     color: #CCCCCC;
     cursor: pointer;
 }
 
 .supporting-count span {
-    display: inline-block;
     margin: 0 2px;
     color: #666666;
 }

--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -176,7 +176,7 @@ define([
                         }
 
                         if (targetList.parentType === 'Article') {
-                            targetList.parent.saveMetaEdit();
+                            targetList.parent.save();
                             return;
                         }
                         

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -38,14 +38,15 @@ define([
 
             this.fields = asObservableProps([
                 'headline',
-                'thumbnail',
                 'trailText',
+                'thumbnail',
                 'shortId']);
 
             this.fields.headline('...');
 
             this.meta = asObservableProps([
                 'headline',
+                'trailText',
                 'group']);
 
             this.state = asObservableProps([
@@ -65,15 +66,11 @@ define([
                 return numberWithCommas(this.state.totalHits());
             }, this);
 
-            this.headlineInput = ko.computed({
-                read: function() {
-                    return this.meta.headline() || this.fields.headline();
-                },
-                write: function(value) {
-                    this.meta.headline(value);
-                },
-                owner: this
-            });
+            this.headlineInput  = this.overrider('headline');
+            this.headlineRevert = this.reverter('headline');
+
+            this.trailTextInput  = this.overrider('trailText');
+            this.trailTextRevert = this.reverter('trailText');
 
             this.populate(opts);
 
@@ -95,6 +92,25 @@ define([
                 ophanApi.decorateItems(self.meta.supporting.items());
             }
         }
+
+        Article.prototype.overrider = function(key) {
+            return ko.computed({
+                read: function() {
+                    return this.meta[key]() || this.fields[key]();
+                },
+                write: function(value) {
+                    this.meta[key](value);
+                },
+                owner: this
+            });
+        };
+
+        Article.prototype.reverter = function(key) {
+            return function() {
+                this.meta[key](undefined);
+                this.saveMetaEdit();
+            };
+        };
 
         Article.prototype.populate = function(opts) {
             var self = this;
@@ -131,10 +147,12 @@ define([
             }, 200);
         };
 
+        /*
         Article.prototype.revertHeadline = function() {
             this.meta.headline(undefined);
             this.saveMetaEdit();
         };
+        */
 
         Article.prototype.get = function() {
             return {

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -150,7 +150,7 @@ define([
         Article.prototype.saveMetaEdit = function() {
             var self = this;
 
-            // defer, to let through any UI events, before they're blocked by the loadIsPending CSS:
+            // defer, to let through any UI events, before they're blocked by the "isPending" CSS:
             setTimeout(function() {
                 self.save();
             }, 200);
@@ -223,7 +223,7 @@ define([
                         draft:   !vars.state.liveMode()
                     }
                 );
-                this.parent.state.loadIsPending(true);
+                this.parent.setPending(true);
             }
         };
 

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -47,6 +47,7 @@ define([
             this.meta = asObservableProps([
                 'headline',
                 'trailText',
+                'imageTone',
                 'group']);
 
             this.state = asObservableProps([
@@ -108,17 +109,25 @@ define([
         Article.prototype.reverter = function(key) {
             return function() {
                 this.meta[key](undefined);
-                this.saveMetaEdit();
+                this.save();
             };
         };
 
         Article.prototype.populate = function(opts) {
-            var self = this;
-
             populateObservables(this.props,  opts);
             populateObservables(this.meta,   opts.meta);
             populateObservables(this.fields, opts.fields);
             populateObservables(this.state,  opts.state);
+        };
+
+        Article.prototype.toggleImageToneHide = function() {
+            this.meta.imageTone(this.meta.imageTone() === 'hide' ? undefined : 'hide');
+            this.save();
+        };
+
+        Article.prototype.toggleImageToneHighlight = function() {
+            this.meta.imageTone(this.meta.imageTone() === 'highlight' ? undefined : 'highlight');
+            this.save();
         };
 
         Article.prototype.startMetaEdit = function() {
@@ -146,13 +155,6 @@ define([
                 self.save();
             }, 200);
         };
-
-        /*
-        Article.prototype.revertHeadline = function() {
-            this.meta.headline(undefined);
-            this.saveMetaEdit();
-        };
-        */
 
         Article.prototype.get = function() {
             return {

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -54,7 +54,7 @@ define([
 
             this.state = asObservableProps([
                 'underDrag',
-                'editingMeta',
+                'open',
                 'shares',
                 'comments',
                 'totalHits',
@@ -111,7 +111,7 @@ define([
         Article.prototype.reverter = function(key) {
             return function() {
                 this.meta[key](undefined);
-                this.save();
+                this._save();
             };
         };
 
@@ -124,38 +124,29 @@ define([
 
         Article.prototype.toggleImageToneHide = function() {
             this.meta.imageTone(this.meta.imageTone() === 'hide' ? undefined : 'hide');
-            this.save();
+            this._save();
         };
 
         Article.prototype.toggleImageToneHighlight = function() {
             this.meta.imageTone(this.meta.imageTone() === 'highlight' ? undefined : 'highlight');
-            this.save();
+            this._save();
         };
 
-        Article.prototype.startMetaEdit = function() {
+        Article.prototype.open = function() {
             var self = this;
 
             if (this.uneditable) { return; }
 
             _.defer(function(){
-                self.state.editingMeta(true);
+                self.state.open(true);
             });
         };
 
-        Article.prototype.stopMetaEdit = function() {
+        Article.prototype.close = function() {
             var self = this;
             _.defer(function(){
-                self.state.editingMeta(false);
+                self.state.open(false);
             });
-        };
-
-        Article.prototype.saveMetaEdit = function() {
-            var self = this;
-
-            // defer, to let through any UI events, before they're blocked by the "isPending" CSS:
-            setTimeout(function() {
-                self.save();
-            }, 200);
         };
 
         Article.prototype.get = function() {
@@ -199,7 +190,7 @@ define([
                 .value();
         };
 
-        Article.prototype.save = function() {
+        Article.prototype._save = function() {
             var self = this;
 
             if (!this.parent) {
@@ -207,8 +198,8 @@ define([
             }
 
             if (this.parentType === 'Article') {
-                this.parent.save();
-                this.stopMetaEdit();
+                this.parent._save();
+                this.close();
                 return;
             }
 
@@ -226,6 +217,15 @@ define([
                 );
                 this.parent.setPending(true);
             }
+        };
+
+        Article.prototype.save = function() {
+            var self = this;
+
+            // defer, to let through UI events before they're blocked by the "isPending" CSS:
+            setTimeout(function() {
+                self._save();
+            }, 200);
         };
 
         return Article;

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -175,16 +175,15 @@ define([
                 // reject whitespace-only strings:
                 .filter(function(p){ return _.isString(p[1]) ? p[1].replace(/\s*/g, '').length > 0 : true; })
                 // for sublinks reject anything that isn't a headline
-                .filter(function(p){ return self.parentType === 'Collection' || p[0] === 'headline'; })
+                .filter(function(p){ return p[0] === 'headline' || self.parentType !== 'Article'; })
                 // reject vals that don't differ from the props (if any) that they're overwriting:
                 .filter(function(p){ return _.isUndefined(self.props[p[0]]) || self.props[p[0]]() !== p[1]; })
-                // serialise supporting
+                // serialise the supporting links
                 .map(function(p) {
                     if (p[0] === 'supporting') {
-                        // but only on first level Articles, i.e. those whose parent is a Collection
-                        return [p[0], self.parentType === 'Collection' ? _.map(p[1].items(), function(item) {
+                        return [p[0], _.map(p[1].items(), function(item) {
                             return item.get();
-                        }) : []];
+                        })];
                     }
                     return [p[0], p[1]];
                 })

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -174,15 +174,17 @@ define([
                 .filter(function(p){ return !_.isUndefined(p[1]); })
                 // reject whitespace-only strings:
                 .filter(function(p){ return _.isString(p[1]) ? p[1].replace(/\s*/g, '').length > 0 : true; })
+                // for sublinks reject anything that isn't a headline
+                .filter(function(p){ return self.parentType === 'Collection' || p[0] === 'headline'; })
                 // reject vals that don't differ from the props (if any) that they're overwriting:
                 .filter(function(p){ return _.isUndefined(self.props[p[0]]) || self.props[p[0]]() !== p[1]; })
                 // serialise supporting
                 .map(function(p) {
                     if (p[0] === 'supporting') {
-                        // but only on first level Articles, i.e. those whose parent isn't an Article
-                        return [p[0], self.parentType === 'Article' ? [] : _.map(p[1].items(), function(item) {
+                        // but only on first level Articles, i.e. those whose parent is a Collection
+                        return [p[0], self.parentType === 'Collection' ? _.map(p[1].items(), function(item) {
                             return item.get();
-                        })];
+                        }) : []];
                     }
                     return [p[0], p[1]];
                 })

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -137,10 +137,11 @@ define([
             url: vars.CONST.apiBase + '/collection/' + this.id
         })
         .then(function(resp) {
+            var dontPopulate = opts.isRefresh && (self.isPending() || self.response.lastUpdated === self.collectionMeta.lastUpdated());
+
             self.response = resp;
             self.state.hasDraft(_.isArray(self.response.draft));
 
-            var dontPopulate = opts.isRefresh && (self.isPending() || self.response.lastUpdated === self.collectionMeta.lastUpdated());
             if (!dontPopulate) {
                 self.populateLists();
             }

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -82,6 +82,7 @@ define([
 
     Collection.prototype.toggleCollapsed = function() {
         this.state.collapsed(!this.state.collapsed());
+        this.closeAllArticles();
     };
 
     Collection.prototype.toggleEditingConfig = function(e) {

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -45,14 +45,22 @@ define([
 
         this.state  = asObservableProps([
             'hasDraft',
-            'loadIsPending',
+            'pending',
             'editingConfig',
             'count',
             'timeAgo']);
 
-        this.state.loadIsPending(true);
+        this.setPending(true);
         this.load();
     }
+
+    Collection.prototype.setPending = function(bool) {
+        this.state.pending(!!bool);
+    };
+
+    Collection.prototype.isPending = function() {
+        return !!this.state.pending();
+    };
 
     Collection.prototype.createGroups = function(groupNames) {
         var self = this;
@@ -88,7 +96,7 @@ define([
     Collection.prototype.processDraft = function(goLive) {
         var self = this;
 
-        this.state.loadIsPending(true);
+        this.setPending(true);
 
         authedAjax.request({
             type: 'post',
@@ -105,7 +113,7 @@ define([
     Collection.prototype.drop = function(item) {
         var self = this;
 
-        self.state.loadIsPending(true);
+        self.setPending(true);
 
         authedAjax.request({
             type: 'delete',
@@ -132,7 +140,7 @@ define([
             self.response = resp;
             self.state.hasDraft(_.isArray(self.response.draft));
 
-            var dontPopulate = opts.isRefresh && (self.state.loadIsPending() || self.response.lastUpdated === self.collectionMeta.lastUpdated());
+            var dontPopulate = opts.isRefresh && (self.isPending() || self.response.lastUpdated === self.collectionMeta.lastUpdated());
             if (!dontPopulate) {
                 self.populateLists();
             }
@@ -143,7 +151,7 @@ define([
             }
         })
         .always(function() {
-            self.state.loadIsPending(false);
+            self.setPending(false);
         });
     };
 
@@ -198,7 +206,7 @@ define([
     };
 
     Collection.prototype.refresh = function() {
-        if (vars.state.uiBusy || this.state.loadIsPending()) { return; }
+        if (vars.state.uiBusy || this.setPending()) { return; }
         this.load({
             isRefresh: true
         });
@@ -208,7 +216,7 @@ define([
         var self = this;
 
         this.state.editingConfig(false);
-        this.state.loadIsPending(true);
+        this.setPending(true);
 
         authedAjax.request({
             url: vars.CONST.apiBase + '/collection/' + this.id,

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -103,9 +103,9 @@ define([
             url: vars.CONST.apiBase + '/collection/' + this.id,
             data: JSON.stringify(goLive ? {publish: true} : {discard: true})
         })
-            .then(function() {
-                self.load();
-            });
+        .then(function() {
+            self.load();
+        });
 
         this.state.hasDraft(false);
     };
@@ -123,7 +123,8 @@ define([
                 live:   vars.state.liveMode(),
                 draft: !vars.state.liveMode()
             })
-        }).then(function() {
+        })
+        .then(function() {
             self.load();
         });
     };
@@ -227,9 +228,10 @@ define([
                     displayName: this.collectionMeta.displayName()
                 }
             })
-        }).then(function(){
-                self.load();
-            });
+        })
+        .then(function(){
+            self.load();
+        });
     };
 
     Collection.prototype.getTimeAgo = function(date) {

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -44,6 +44,7 @@ define([
             'updatedEmail']);
 
         this.state  = asObservableProps([
+            'collapsed',
             'hasDraft',
             'pending',
             'editingConfig',
@@ -76,7 +77,11 @@ define([
         }).reverse(); // because groupNames is assumed to be in ascending order of importance, yet should render in descending order
     };
 
-    Collection.prototype.toggleEditingConfig = function() {
+    Collection.prototype.toggleCollapsed = function() {
+        this.state.collapsed(!this.state.collapsed());
+    };
+
+    Collection.prototype.toggleEditingConfig = function(e) {
         this.state.editingConfig(!this.state.editingConfig());
     };
 

--- a/facia-tool/public/javascripts/models/list-manager.js
+++ b/facia-tool/public/javascripts/models/list-manager.js
@@ -153,6 +153,7 @@ define([
 
         model.liveMode.subscribe(function() {
             _.each(model.collections(), function(collection) {
+                collection.closeAllArticles();
                 collection.populateLists();
             });
         });

--- a/facia-tool/public/javascripts/models/list-manager.js
+++ b/facia-tool/public/javascripts/models/list-manager.js
@@ -116,7 +116,7 @@ define([
                 model.collections().forEach(function(list, index){
                     setTimeout(function(){
                         list.refresh();
-                    }, index * period / (model.collections().length + 1)); // stagger requests
+                    }, index * period / (model.collections().length || 1)); // stagger requests
                 });
             }, period);
         });

--- a/facia-tool/public/javascripts/modules/authed-ajax.js
+++ b/facia-tool/public/javascripts/modules/authed-ajax.js
@@ -14,7 +14,7 @@ define(['modules/vars'], function(vars) {
     }
 
     function updateCollection(method, collection, data) {
-        collection.state.loadIsPending(true);
+        collection.setPending(true);
 
         return request({
             url: vars.CONST.apiBase + '/collection/' + collection.id,

--- a/facia-tool/public/javascripts/utils/full-trim.js
+++ b/facia-tool/public/javascripts/utils/full-trim.js
@@ -1,5 +1,5 @@
 define(function() {
     return function(str){
-        return str ? str.replace(/(?:(?:^|\n)\s+|\s+(?:$|\n))/g,'').replace(/\s+/g,' ') : undefined;
+        return ('' + str).split(/\s+/).filter(function(s) { return s; }).join(' ');
     };
 });


### PR DESCRIPTION
Trailtext and image controls are available on all first-level items (ie. not on supporting content). 

![fronts-tool](https://f.cloud.github.com/assets/1147913/1853032/4871beee-7705-11e3-8d87-477fb4edc1de.png)

The highlighted item uses all the possible overrides, producing the following json: 

```
{
    "id" : "uk-news/2014/jan/06/flood-warnings-continue-rain-storms",
    "meta" : {
      "trailText" : "Environment secretary accused of 'buck passing', while vast waves and strong winds batter coast",
      "headline" : "Flood warnings continue as UK hit by more storms",
      "supporting" : [ {
        "id" : "news/2014/jan/06/best-pictures-of-the-day-live",
        "meta" : {
          "headline" : "In pictures"
        }
      }, {
        "id" : "environment/2014/jan/06/britain-wild-weather-rain-storms-floods",
        "meta" : {
          "headline" : "Britain's wild weather"
        }
      } ],
      "imageTone" : "hide",
      "group" : "0"
    }
  }
```
