### PR TITLE
Temporaily remove live blog read more button #2539

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -72,9 +72,6 @@
                                         @BodyCleaner(article, blockGroup)
                                     </div>
                                 }
-                                <button class="h u-button-reset cta cta--read-more" data-link-name="live blog | read more">
-                                    Read more <i class="i i-swipe-arrow cta--read-more__icon"></i>
-                                </button>
                             }  else {
                                 @BodyCleaner(article, article.body)
                             }


### PR DESCRIPTION
This temporarily removes the "Read more" button and the foot of live blog articles, as it seems it is currently redundant. All content is being shown, and the JS which once controlled this functionality has vanished into thin air.

 Whilst I investigate this issue further, I thought it would be best to remove the button as it was confusing @kaelig and most likely some users.  
