### PR TITLE
Collection Parts

### DIFF
--- a/applications/app/controllers/IndexController.scala
+++ b/applications/app/controllers/IndexController.scala
@@ -6,9 +6,12 @@ import model._
 import play.api.mvc._
 import play.api.libs.json._
 import services.{Index, IndexPage}
+import views.support.TemplateDeduping
 
 
 trait IndexController extends Controller with Index with Logging with Paging with ExecutionContexts {
+
+  implicit def getTemplateDedupingInstance: TemplateDeduping = TemplateDeduping()
 
   def renderCombiner(leftSide: String, rightSide: String) = Action.async{ implicit request =>
     index(Edition(request), leftSide, rightSide).map {

--- a/applications/app/views/indexFacia.scala.html
+++ b/applications/app/views/indexFacia.scala.html
@@ -1,4 +1,4 @@
-@(index: services.IndexPage)(implicit request: RequestHeader)
+@(index: services.IndexPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 @import conf.Switches._
 @main(index.page, projectName = Option("facia")){ }{
     <div class="facia-container monocolumn-wrapper monocolumn-wrapper--no-limit" data-link-name="Front" role="main">

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -7,12 +7,16 @@ case class Config(
                    collectionTone: Option[String] = None,
                    href: Option[String] = None)
 
-case class Collection(items: Seq[Trail],
-                      displayName: Option[String])
+case class Collection(curated: Seq[Trail],
+                      editorsPicks: Seq[Trail],
+                      results: Seq[Trail],
+                      displayName: Option[String]) {
+
+  def items: Seq[Trail] = curated ++ editorsPicks.filterNot(ep => curated.exists(_.url == ep.url)) ++ results.filterNot (r => curated.exists(_.url == r.url))
+}
 
 object Collection {
-  def apply(items: Seq[Trail]): Collection = Collection(items, None)
-  def apply(items: Seq[Trail], name: String): Collection = Collection(items, Some(name))
+  def apply(curated: Seq[Trail], displayName: Option[String]): Collection = Collection(curated, Nil, Nil, displayName)
 }
 
 case class FaciaPage(

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -12,7 +12,10 @@ case class Collection(curated: Seq[Trail],
                       results: Seq[Trail],
                       displayName: Option[String]) {
 
-  def items: Seq[Trail] = curated ++ editorsPicks.filterNot(ep => curated.exists(_.url == ep.url)) ++ results.filterNot (r => curated.exists(_.url == r.url))
+  def items: Seq[Trail] =
+    curated ++
+    editorsPicks.filterNot(ep => curated.exists(_.url == ep.url)) ++
+    results.filterNot (r => curated.exists(_.url == r.url) || editorsPicks.exists(_.url == r.url))
 }
 
 object Collection {

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -12,7 +12,7 @@ case class Collection(curated: Seq[Trail],
                       results: Seq[Trail],
                       displayName: Option[String]) {
 
-  def items: Seq[Trail] =
+  lazy val items: Seq[Trail] =
     curated ++
     editorsPicks.filterNot(ep => curated.exists(_.url == ep.url)) ++
     results.filterNot (r => curated.exists(_.url == r.url) || editorsPicks.exists(_.url == r.url))

--- a/common/app/views/fragments/collections/rowPattern.scala.html
+++ b/common/app/views/fragments/collections/rowPattern.scala.html
@@ -1,28 +1,28 @@
-@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
+@(config: Config, items: Seq[Trail], style: Container, containerIndex: Int)(implicit request: RequestHeader)
 
 <ul class="unstyled l-row l-row--items-2 collection">
-    @collection.items.slice(0, 2).zipWithIndex.map{ case (trail, index) =>
+    @items.slice(0, 2).zipWithIndex.map{ case (trail, index) =>
         <li class="l-row__item collection__item collection__item--volume-@trail.group.getOrElse("0")">
             @fragments.items.standard(trail, index, containerIndex, "div")
         </li>
     }
 </ul>
 <ul class="unstyled l-row l-row--items-3 collection">
-    @collection.items.slice(2, 5).zipWithIndex.map{ case (trail, index) =>
+    @items.slice(2, 5).zipWithIndex.map{ case (trail, index) =>
         <li class="l-row__item collection__item collection__item--volume-@trail.group.getOrElse("0")">
             @fragments.items.standard(trail, index, containerIndex, "div")
         </li>
     }
 </ul>
 <ul class="unstyled l-row l-row--items-4 collection">
-    @collection.items.slice(5, 9).zipWithIndex.map{ case (trail, index) =>
+    @items.slice(5, 9).zipWithIndex.map{ case (trail, index) =>
         <li class="l-row__item collection__item collection__item--volume-@trail.group.getOrElse("0")">
             @fragments.items.standard(trail, index, containerIndex, "div")
         </li>
     }
 </ul>
 <ul class="l-columns linkslist">
-    @collection.items.slice(9, 22).zipWithIndex.map{ case (trail, index) =>
+    @items.slice(9, 22).zipWithIndex.map{ case (trail, index) =>
         <li class="l-columns__item linkslist__item">
             <a href="@LinkTo{@trail.url}" class="linkslist__action">
                 @RemoveOuterParaHtml(trail.headline)

--- a/common/app/views/fragments/collections/standard.scala.html
+++ b/common/app/views/fragments/collections/standard.scala.html
@@ -1,16 +1,16 @@
-@(config: Config, collection: Collection, style: Container, containerIndex: Int, showSize: Int = 4)(implicit request: RequestHeader)
+@(config: Config, items: Seq[Trail], style: Container, containerIndex: Int, showSize: Int = 4)(implicit request: RequestHeader)
 
 <ul class="unstyled collection collection--without-sport-stats @if(style.showMore){js-collection--show-more}"
      data-link-context-path="collection/@config.id"
      data-link-context-name="@config.displayName"
      data-tone="@style.tone"
-     data-can-show-more="@{collection.items.size > showSize}">
+     data-can-show-more="@{items.size > showSize}">
     @if(style.showMore) {
-        @collection.items.take(showSize).zipWithIndex.map{ case (trail, index) =>
+        @items.take(showSize).zipWithIndex.map{ case (trail, index) =>
             @fragments.items.standard(trail, index, containerIndex)
         }
     } else {
-        @collection.items.zipWithIndex.map{ case (trail, index) =>
+        @items.zipWithIndex.map{ case (trail, index) =>
             @fragments.items.standard(trail, index, containerIndex)
         }
     }

--- a/common/app/views/fragments/containers/comment.scala.html
+++ b/common/app/views/fragments/containers/comment.scala.html
@@ -1,26 +1,27 @@
-@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
+@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @defining(config.displayName.orElse(collection.displayName)) { title =>
 
-    @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
-                 data-link-name="block | @config.id"
-                 data-id="@config.id"
-                 data-type="@style.containerType">
+    @defining(templateDeduping(5, collection.items)) { items =>
+        @if(items.nonEmpty) {
+            <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
+                     data-link-name="block | @config.id"
+                     data-id="@config.id"
+                     data-type="@style.containerType">
 
-            @title.map { title =>
-                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
-                    @config.href.map { href =>
-                        <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                    }.getOrElse{
-                        @Html(title)
-                    }
-                </h2>
-            }
+                @title.map { title =>
+                    <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
+                        @config.href.map { href =>
+                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                        }.getOrElse{
+                            @Html(title)
+                        }
+                    </h2>
+                }
 
-            @fragments.collections.standard(config, collection, style, containerIndex, 5)
+                @fragments.collections.standard(config, items, style, containerIndex, 5)
 
-        </section>
+            </section>
+        }
     }
-
 }

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -1,26 +1,27 @@
-@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
+@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @defining(config.displayName.orElse(collection.displayName)) { title =>
 
-    @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
-                 data-link-name="block | @config.id"
-                 data-id="@config.id"
-                 data-type="@style.containerType">
+    @defining(templateDeduping(5, collection.items)) { items =>
+        @if(items.nonEmpty) {
+            <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
+                     data-link-name="block | @config.id"
+                     data-id="@config.id"
+                     data-type="@style.containerType">
 
-            @title.map { title =>
-                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
-                    @config.href.map { href =>
-                        <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                    }.getOrElse{
-                        @Html(title)
-                    }
-                </h2>
-            }
+                @title.map { title =>
+                    <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
+                        @config.href.map { href =>
+                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                        }.getOrElse{
+                            @Html(title)
+                        }
+                    </h2>
+                }
 
-            @fragments.collections.standard(config, collection, style, containerIndex, 4)
+                @fragments.collections.standard(config, items, style, containerIndex, 4)
 
-        </section>
+            </section>
+        }
     }
-
 }

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -1,26 +1,28 @@
-@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
+@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @defining(config.displayName.orElse(collection.displayName)) { title =>
 
-    @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
-                 data-link-name="block | @config.id"
-                 data-id="@config.id"
-                 data-type="@style.containerType">
+    @defining(templateDeduping(5, collection.items)) { items =>
+        @if(items.nonEmpty) {
+            <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
+                     data-link-name="block | @config.id"
+                     data-id="@config.id"
+                     data-type="@style.containerType">
 
-            @title.map { title =>
-                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
-                    @config.href.map { href =>
-                        <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                    }.getOrElse{
-                        @Html(title)
-                    }
-                </h2>
-            }
+                @title.map { title =>
+                    <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
+                        @config.href.map { href =>
+                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                        }.getOrElse{
+                            @Html(title)
+                        }
+                    </h2>
+                }
 
-            @fragments.collections.standard(config, collection, style, containerIndex, 9)
+                @fragments.collections.standard(config, items, style, containerIndex, 9)
 
-        </section>
+            </section>
+        }
     }
 
 }

--- a/common/app/views/fragments/containers/popular.scala.html
+++ b/common/app/views/fragments/containers/popular.scala.html
@@ -18,7 +18,7 @@
                 </h2>
             }
 
-            @fragments.collections.standard(config, collection, style, containerIndex, 10)
+            @fragments.collections.standard(config, collection.items, style, containerIndex, 10)
 
         </section>
     }

--- a/common/app/views/fragments/containers/section.scala.html
+++ b/common/app/views/fragments/containers/section.scala.html
@@ -1,26 +1,27 @@
-@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
+@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @defining(config.displayName.orElse(collection.displayName)) { title =>
 
-    @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
-                 data-link-name="block | @config.id"
-                 data-id="@config.id"
-                 data-type="@style.containerType">
+    @defining(templateDeduping(5, collection.items)) { items =>
+        @if(items.nonEmpty) {
+            <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
+                     data-link-name="block | @config.id"
+                     data-id="@config.id"
+                     data-type="@style.containerType">
 
-            @title.map { title =>
-                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
-                    @config.href.map { href =>
-                        <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                    }.getOrElse{
-                        @Html(title)
-                    }
-                </h2>
-            }
+                @title.map { title =>
+                    <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
+                        @config.href.map { href =>
+                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                        }.getOrElse{
+                            @Html(title)
+                        }
+                    </h2>
+                }
 
-            @fragments.collections.standard(config, collection, style, containerIndex, 4)
+                @fragments.collections.standard(config, items, style, containerIndex, 4)
 
-        </section>
+            </section>
+        }
     }
-
 }

--- a/common/app/views/fragments/containers/sport.scala.html
+++ b/common/app/views/fragments/containers/sport.scala.html
@@ -1,28 +1,29 @@
-@(page: model.MetaData, config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
+@(page: model.MetaData, config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @defining(config.displayName.orElse(collection.displayName)) { title =>
 
-    @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
-                 data-link-name="block | @config.id"
-                 data-id="@config.id"
-                 data-type="@style.containerType">
+    @defining(templateDeduping(5, collection.items)) { items =>
+        @if(items.nonEmpty) {
+            <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
+                     data-link-name="block | @config.id"
+                     data-id="@config.id"
+                     data-type="@style.containerType">
 
-            @title.map { title =>
-                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
-                    @config.href.map { href =>
-                        <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                    }.getOrElse{
-                        @Html(title)
-                    }
-                </h2>
-            }
+                @title.map { title =>
+                    <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
+                        @config.href.map { href =>
+                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                        }.getOrElse{
+                            @Html(title)
+                        }
+                    </h2>
+                }
 
-            @fragments.contributor(page)
+                @fragments.contributor(page)
 
-            @fragments.collections.standard(config, collection, style, containerIndex, 6)
+                @fragments.collections.standard(config, items, style, containerIndex, 6)
 
-        </section>
+            </section>
+        }
     }
-
 }

--- a/common/app/views/fragments/containers/topStories.scala.html
+++ b/common/app/views/fragments/containers/topStories.scala.html
@@ -1,26 +1,27 @@
-@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader)
+@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @defining(config.displayName.orElse(collection.displayName)) { title =>
 
-    @if(collection.items.nonEmpty) {
-        <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
-                 data-link-name="block | @config.id"
-                 data-id="@config.id"
-                 data-type="@style.containerType">
+    @defining(templateDeduping(5, collection.items)) { items =>
+        @if(items.nonEmpty) {
+            <section class="container container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle}"
+                     data-link-name="block | @config.id"
+                     data-id="@config.id"
+                     data-type="@style.containerType">
 
-            @title.map { title =>
-                <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
-                    @config.href.map { href =>
-                        <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                    }.getOrElse{
-                        @Html(title)
-                    }
-                </h2>
-            }
+                @title.map { title =>
+                    <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
+                        @config.href.map { href =>
+                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                        }.getOrElse{
+                            @Html(title)
+                        }
+                    </h2>
+                }
 
-            @fragments.collections.rowPattern(config, collection, style, containerIndex)
+                @fragments.collections.rowPattern(config, items, style, containerIndex)
 
-        </section>
+            </section>
+        }
     }
-
 }

--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -14,7 +14,7 @@ class TemplateDeduping extends implicits.Collections {
   }
 
   def take(numberWanted: Int, collection: Collection): Collection =
-    collection.copy(items = take(numberWanted, collection.items))
+    collection.copy(curated = take(numberWanted, collection.curated))
 
   def apply(numberWanted: Int, collection: Collection): Collection = take(numberWanted, collection)
   def apply(collection: Collection): Collection = take(collection.items.length, collection)

--- a/common/app/views/support/TemplateDeduping.scala
+++ b/common/app/views/support/TemplateDeduping.scala
@@ -13,11 +13,8 @@ class TemplateDeduping extends implicits.Collections {
     returnList.distinctBy(_.url)
   }
 
-  def take(numberWanted: Int, collection: Collection): Collection =
-    collection.copy(curated = take(numberWanted, collection.curated))
-
-  def apply(numberWanted: Int, collection: Collection): Collection = take(numberWanted, collection)
-  def apply(collection: Collection): Collection = take(collection.items.length, collection)
+  def apply(numberWanted: Int, collection: Collection): Seq[Trail] = take(numberWanted, collection.items)
+  def apply(collection: Collection): Seq[Trail] = take(collection.items.length, collection.items)
 
   def apply(numberWanted: Int, items: Seq[Trail]): Seq[Trail] = take(numberWanted, items)
   def apply(items: Seq[Trail]): Seq[Trail] = take(items.length, items)

--- a/docs/template-deduping.md
+++ b/docs/template-deduping.md
@@ -1,0 +1,20 @@
+## Template Deduping
+
+Deduping of items in the template work through a shared instance of `TemplateDeduping` for each request.
+This object is added implicitly when the templates get called. Make sure the implicit can resolve a `TemplateDeduping` instance from somewhere within the call context.
+
+Deduping is page wide, meaning that an item appearing at the top of the page may not appear at the bottom of the page.
+It works by explicitly specifying how many items you want to have deduped when calling. If no number is specified, then all items will be considered for deduping.
+
+For example, if you had two lists of 10 items each, and you asked each list to be deduped by 5. The first 5 of each list will not appear twice anywhere within what has been asked to be deduped. Outside of the 5, duplicates can occur.
+
+Do not forget that each request has it's own scope of `TemplateDeduping`. At the time of writing, `show more` were separate requests to `Facia` and would return what was already on the page; it is the javascript which dedupes at this stage.
+
+#### Example
+
+```
+@(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
+@defining(templateDeduping(5, collection.items)) { items =>
+
+}
+```

--- a/docs/template-deduping.md
+++ b/docs/template-deduping.md
@@ -10,6 +10,8 @@ For example, if you had two lists of 10 items each, and you asked each list to b
 
 Do not forget that each request has it's own scope of `TemplateDeduping`. At the time of writing, `show more` were separate requests to `Facia` and would return what was already on the page; it is the javascript which dedupes at this stage.
 
+Collections are also deduped individually for repetitions.
+
 #### Example
 
 ```

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,17 +1,15 @@
-@(front: FrontPage, faciaTrailblock: FaciaPage)(implicit request: RequestHeader)
+@(front: FrontPage, faciaTrailblock: FaciaPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 @import conf.Switches._
 @if(faciaTrailblock.collections.nonEmpty) {
     <div class="facia-container monocolumn-wrapper monocolumn-wrapper--no-limit" data-link-name="Front" role="main">
-        @defining {TemplateDeduping()} { dedupe: TemplateDeduping =>
-            @faciaTrailblock.collections.filter(_._2.items.nonEmpty).zipWithIndex.map{ case(block, index) =>
-                @GetContainer(faciaTrailblock.id, block._1) match {
-                    case style: NewsContainer       => { @containers.news(block._1,  dedupe(5, block._2), style, index) }
-                    case style: SportContainer      => { @containers.sport(front, block._1, dedupe(5, block._2), style, index) }
-                    case style: CommentContainer    => { @containers.comment(block._1,  dedupe(5, block._2), style, index) }
-                    case style: FeaturesContainer   => { @containers.features(block._1,  dedupe(5, block._2), style, index) }
-                    case style: TopStoriesContainer => { @containers.topStories(block._1,  dedupe(5, block._2), style, index) }
-                    case style                      => { @containers.section(block._1,  dedupe(5, block._2), style, index) }
-                }
+        @faciaTrailblock.collections.filter(_._2.items.nonEmpty).zipWithIndex.map{ case(block, index) =>
+            @GetContainer(faciaTrailblock.id, block._1) match {
+                case style: NewsContainer       => { @containers.news(block._1,  block._2, style, index) }
+                case style: SportContainer      => { @containers.sport(front, block._1, block._2, style, index) }
+                case style: CommentContainer    => { @containers.comment(block._1, block._2, style, index) }
+                case style: FeaturesContainer   => { @containers.features(block._1, block._2, style, index) }
+                case style: TopStoriesContainer => { @containers.topStories(block._1, block._2, style, index) }
+                case style                      => { @containers.section(block._1, block._2, style, index) }
             }
         }
     </div>

--- a/facia/app/views/front.scala.html
+++ b/facia/app/views/front.scala.html
@@ -1,4 +1,4 @@
-@(front: FrontPage, page: FaciaPage)(implicit request: RequestHeader)
+@(front: FrontPage, page: FaciaPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @main(front, projectName = Option("facia")){ }{
     @fragments.frontBody(front, page)


### PR DESCRIPTION
This splits out `Collection` into three parts: `curated`, `editorsPicks` and `results`, and keeps `items` as these lists added together with a little bit of deduping.
This is so that we have more flexibility with the `Collection` object, while still keeping the behaviour of `Collection.items`. We are merely giving more exposure to how the lists get added.

Because of this change, we needed to change how the template deduping worked. It now no longer deals with `Collection` instance, and instead only deals with or returns `Seq[Trail]`.
This means we also move away from creating an instance of `TemplateDeduping` in `frontBody`, and instead this is added as an implicit parameter to templates where it is needed. The only requirement now being an implicit instance resolving from the context in which the template is called.
This keeps the templates cleaner as we can call an instance of `TemplateDeduping` where we need it, instead of having to pass along the deduped trails everywhere we may need it.

@ironsidevsquincy 
