### PR TITLE
Remove dev subdomain when setting cookies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -772,7 +772,9 @@ module.exports = function (grunt) {
     grunt.registerTask('test:unit', function(app) {
         grunt.config.set('karma.options.singleRun', (singleRun === false) && app ? false : true);
         // Target common when no app is specified, because karma can only test what has been js-compiled.
-        grunt.task.run('karma' + (app ? ':' + app : ':common'));
+        var actualApp = app || 'common';
+        grunt.task.run('copy:javascript-' + actualApp);
+        grunt.task.run('karma:' + actualApp);
     });
 
     // Analyse tasks

--- a/common/app/assets/javascripts/utils/cookies.js
+++ b/common/app/assets/javascripts/utils/cookies.js
@@ -18,10 +18,8 @@ define(function () {
         }
 
         var domain = document.domain;
-
-        if (domain.substr(0,4) === "www.") {
-            domain = domain.substr(3);
-        }
+        // remove www (and dev bit, for localhost set up with dev.theguardian.com domain)
+        domain.replace(/www|dev/, '');
 
         document.cookie = name + "=" + value + "; path=/; expires=" + expires.toUTCString() + "; domain=" + domain + ";";
     }

--- a/common/app/assets/javascripts/utils/cookies.js
+++ b/common/app/assets/javascripts/utils/cookies.js
@@ -19,7 +19,7 @@ define(function () {
 
         var domain = document.domain;
         // remove www (and dev bit, for localhost set up with dev.theguardian.com domain)
-        domain.replace(/www|dev/, '');
+        domain.replace(/^(www|dev)\./, '.');
 
         document.cookie = name + "=" + value + "; path=/; expires=" + expires.toUTCString() + "; domain=" + domain + ";";
     }


### PR DESCRIPTION
I've set up `dev.theguardian.com` on my localhost, to get cookies working
Therefore need to remove `dev` when setting cookie's domain

Also, need to copy js before running tests, so added to `test:unit` target
