### PR TITLE
Comment cancel

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comment-box.js
+++ b/common/app/assets/javascripts/modules/discussion/comment-box.js
@@ -8,246 +8,253 @@ define([
     bonzo,
     DiscussionApi,
     Component
-) {
+    ) {
 
-/**
- * @constructor
- * @extends Component
- * @param {Element=} context
- * @param {Object} mediator
- * @param {Object=} options
- */
-function CommentBox(context, mediator, options) {
-    this.context = context || document;
-    this.mediator = mediator;
-    this.setOptions(options);
-}
-Component.define(CommentBox);
-
-/**
- * @type {boolean}
- * @override
- */
-CommentBox.prototype.useBem = true;
-
-/**
- * @type {string}
- * @override
- */
-CommentBox.prototype.templateName = 'comment-box';
-
-/**
- * @type {string}
- * @override
- */
-CommentBox.prototype.componentClass = 'd-comment-box';
-
-/**
- * @type {Object.<string.string>}
- * @override
- */
-CommentBox.prototype.classes = {
-    bodyExpanded: 'd-comment-box__body--expanded'
-};
-
-/**
- * @type {Object.<string.string>}
- * @override
- */
-CommentBox.prototype.errorMessages = {
-    EMPTY_COMMENT_BODY: 'Please write a comment.',
-    COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
-    ENHANCE_YOUR_CALM: 'You can only post one comment every minute. Please try again in a moment.',
-    USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
-    API_ERROR: 'Sorry, there was a problem posting your comment.'
-};
-
-/**
- * @type {Object.<string.*>}
- */
-CommentBox.prototype.defaultOptions = {
-    discussionId: null,
-    apiRoot: null,
-    maxLength: 5000,
-    premod: false,
-    focus: false,
-    state: 'top-level',
-    replyTo: null,
-    cancelable: false
-};
-
-/**
- * @type {Array.<string>}
- */
-CommentBox.prototype.errors = [];
-
-/** @oevrride */
-CommentBox.prototype.prerender = function() {
-    if (!this.options.premod) {
-        this.getElem('premod').parentNode.removeChild(this.getElem('premod'));
+    /**
+     * @constructor
+     * @extends Component
+     * @param {Element=} context
+     * @param {Object} mediator
+     * @param {Object=} options
+     */
+    function CommentBox(context, mediator, options) {
+        this.context = context || document;
+        this.mediator = mediator;
+        this.setOptions(options);
     }
+    Component.define(CommentBox);
 
-    if (this.options.state === 'response') {
-        this.getElem('submit').innerHTML = 'Post reply';
-    }
+    /**
+     * @type {boolean}
+     * @override
+     */
+    CommentBox.prototype.useBem = true;
 
-    if (this.options.replyTo) {
-        var elem = document.createElement('label');
-        elem.setAttribute('for', 'reply-to-'+ this.options.replyTo.commentId);
-        elem.className = 'label '+ this.getClass('reply-to', true);
-        elem.innerHTML = 'to '+ this.options.replyTo.author;
-        this.getElem('body').id = 'reply-to-'+ this.options.replyTo.commentId;
-        bonzo(elem).insertAfter(this.getElem('submit'));
-    }
+    /**
+     * @type {string}
+     * @override
+     */
+    CommentBox.prototype.templateName = 'comment-box';
 
-    if (this.options.cancelable) {
-        var beforeElem = this.getElem('reply-to') ? this.getElem('reply-to') : this.getElem('submit');
-        bonzo(bonzo.create('<div class="u-fauxlink '+ this.getClass('cancel', true) +'" role="button">Cancel</div>')).insertAfter(beforeElem);
-    }
-};
+    /**
+     * @type {string}
+     * @override
+     */
+    CommentBox.prototype.componentClass = 'd-comment-box';
 
-/** @override */
-CommentBox.prototype.ready = function() {
-    if (this.getDiscussionId() === null) {
-        throw new Error('CommentBox: You need to set the "data-discussion-key" on your element');
-    }
+    /**
+     * @type {Object.<string.string>}
+     * @override
+     */
+    CommentBox.prototype.classes = {
+        bodyExpanded: 'd-comment-box__body--expanded'
+    };
 
-    var commentBody = this.getElem('body'),
-        submitButton = this.getElem('submit');
+    /**
+     * @type {Object.<string.string>}
+     * @override
+     */
+    CommentBox.prototype.errorMessages = {
+        EMPTY_COMMENT_BODY: 'Please write a comment.',
+        COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
+        ENHANCE_YOUR_CALM: 'You can only post one comment every minute. Please try again in a moment.',
+        USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
+        API_ERROR: 'Sorry, there was a problem posting your comment.'
+    };
 
-    this.setFormState();
+    /**
+     * @type {Object.<string.*>}
+     */
+    CommentBox.prototype.defaultOptions = {
+        discussionId: null,
+        apiRoot: null,
+        maxLength: 5000,
+        premod: false,
+        focus: false,
+        state: 'top-level',
+        replyTo: null,
+        cancelable: false
+    };
 
-    // TODO (jamesgorrie): Could definitely use the this.on and make the default context this
-    bean.on(this.context, 'submit', [this.elem], this.postComment.bind(this));
-    bean.on(this.context, 'change keyup', [commentBody], this.setFormState.bind(this));
-    bean.on(commentBody, 'focus', this.setExpanded.bind(this)); // this isn't delegated as bean doesn't support it
-    this.on('click', this.getClass('cancel'), this.destroy);
+    /**
+     * @type {Array.<string>}
+     */
+    CommentBox.prototype.errors = [];
 
-    this.setState(this.options.state);
+    /** @oevrride */
+    CommentBox.prototype.prerender = function() {
+        if (!this.options.premod) {
+            this.getElem('premod').parentNode.removeChild(this.getElem('premod'));
+        }
 
-    if (this.options.focus) {
-        this.getElem('body').focus();
-    }
-};
+        if (this.options.state === 'response') {
+            this.getElem('submit').innerHTML = 'Post reply';
+        }
 
-/**
- * @param {Event}
- */
-CommentBox.prototype.postComment = function(e) {
-    var body = this.getElem('body'),
-        comment = {
-            body: this.getElem('body').value
-        };
+        if (this.options.replyTo) {
+            var elem = document.createElement('label');
+            elem.setAttribute('for', 'reply-to-'+ this.options.replyTo.commentId);
+            elem.className = 'label '+ this.getClass('reply-to', true);
+            elem.innerHTML = 'to '+ this.options.replyTo.author;
+            this.getElem('body').id = 'reply-to-'+ this.options.replyTo.commentId;
+            bonzo(elem).insertAfter(this.getElem('submit'));
+        }
+    };
 
-    e.preventDefault();
-    this.getElem('messages').innerHTML = '';
-    this.errors = [];
+    /** @override */
+    CommentBox.prototype.ready = function() {
+        if (this.getDiscussionId() === null) {
+            throw new Error('CommentBox: You need to set the "data-discussion-key" on your element');
+        }
 
-    if (comment.body === '') {
-        this.error('EMPTY_COMMENT_BODY');
-    }
+        var commentBody = this.getElem('body'),
+            submitButton = this.getElem('submit');
 
-    else if (comment.body.length > this.options.maxLength) {
-        this.error('COMMENT_TOO_LONG', '<b>Comments must be shorter than '+ this.options.maxLength +' characters.</b> Yours is currently '+ (comment.body.length-this.options.maxLength) +' characters too long.');
-    }
+        this.setFormState();
 
-    if (this.options.replyTo) {
-        comment.replyTo = this.options.replyTo;
-    }
+        // TODO (jamesgorrie): Could definitely use the this.on and make the default context this
+        bean.on(this.context, 'submit', [this.elem], this.postComment.bind(this));
+        bean.on(this.context, 'change keyup', [commentBody], this.setFormState.bind(this));
+        bean.on(commentBody, 'focus', this.setExpanded.bind(this)); // this isn't delegated as bean doesn't support it
+        this.on('click', this.getClass('cancel'), this.cancel);
 
-    if (this.errors.length === 0) {
-        this.setFormState(true);
-        DiscussionApi
-            .postComment(this.getDiscussionId(), comment)
-            .then(this.success.bind(this, comment), this.fail.bind(this));
-    }
-};
+        this.setState(this.options.state);
 
-/**
- * TODO (jamesgorrie): Perhaps change error states to use bit operators
- * @param {string} type
- * @param {string} message Overrides the default message
- */
-CommentBox.prototype.error = function(type, message) {
-    message = message || this.errorMessages[type];
-    var error = bonzo.create(
-        '<div class="d-discussion__error '+ this.getClass('error', true) +'">'+
-            '<i class="i i-alert"></i>'+
-            '<span class="d-discussion__error-text">'+ message +'</span>'+
-        '</div>'
-    )[0];
-    this.getElem('messages').appendChild(error);
-    this.errors.push(type);
-};
+        if (this.options.focus) {
+            this.getElem('body').focus();
+        }
+    };
 
-/**
-* @param {Object} comment
- * @param {Object} resp
- */
-CommentBox.prototype.success = function(comment, resp) {
-    comment.id = parseInt(resp.message, 10);
-    this.getElem('body').value = '';
-    this.setFormState();
-    this.emit('post:success', comment);
-    this.mediator.emit('discussion:commentbox:post:success', comment);
-};
+    /**
+     * @param {Event}
+     */
+    CommentBox.prototype.postComment = function(e) {
+        var body = this.getElem('body'),
+            comment = {
+                body: this.getElem('body').value
+            };
 
-/**
- * TODO (jamesgorrie); Make this more robust
- * @param {Reqwest=} resp (optional)
- */
-CommentBox.prototype.fail = function(xhr) {
-    var response;
-    // if our API is down, it returns HTML
-    // this is not so good for JSON.parse
-    try { response = JSON.parse(xhr.responseText); }
+        e.preventDefault();
+        this.getElem('messages').innerHTML = '';
+        this.errors = [];
+
+        if (comment.body === '') {
+            this.error('EMPTY_COMMENT_BODY');
+        }
+
+        else if (comment.body.length > this.options.maxLength) {
+            this.error('COMMENT_TOO_LONG', '<b>Comments must be shorter than '+ this.options.maxLength +' characters.</b> Yours is currently '+ (comment.body.length-this.options.maxLength) +' characters too long.');
+        }
+
+        if (this.options.replyTo) {
+            comment.replyTo = this.options.replyTo;
+        }
+
+        if (this.errors.length === 0) {
+            this.setFormState(true);
+            DiscussionApi
+                .postComment(this.getDiscussionId(), comment)
+                .then(this.success.bind(this, comment), this.fail.bind(this));
+        }
+    };
+
+    /**
+     * TODO (jamesgorrie): Perhaps change error states to use bit operators
+     * @param {string} type
+     * @param {string} message Overrides the default message
+     */
+    CommentBox.prototype.error = function(type, message) {
+        message = message || this.errorMessages[type];
+        var error = bonzo.create(
+            '<div class="d-discussion__error '+ this.getClass('error', true) +'">'+
+                '<i class="i i-alert"></i>'+
+                '<span class="d-discussion__error-text">'+ message +'</span>'+
+                '</div>'
+        )[0];
+        this.getElem('messages').appendChild(error);
+        this.errors.push(type);
+    };
+
+    /**
+     * @param {Object} comment
+     * @param {Object} resp
+     */
+    CommentBox.prototype.success = function(comment, resp) {
+        comment.id = parseInt(resp.message, 10);
+        this.getElem('body').value = '';
+        this.setFormState();
+        this.emit('post:success', comment);
+        this.mediator.emit('discussion:commentbox:post:success', comment);
+    };
+
+    /**
+     * TODO (jamesgorrie); Make this more robust
+     * @param {Reqwest=} resp (optional)
+     */
+    CommentBox.prototype.fail = function(xhr) {
+        var response;
+        // if our API is down, it returns HTML
+        // this is not so good for JSON.parse
+        try { response = JSON.parse(xhr.responseText); }
         catch (e) { response = {}; }
 
-    this.setFormState();
+        this.setFormState();
 
-    if (xhr.status === 420) {
-        this.error('ENHANCE_YOUR_CALM');
-    } else if (this.errorMessages[response.errorCode]) {
-        this.error(response.errorCode);
-    } else {
-        this.error('API_ERROR');
-    }
-};
+        if (xhr.status === 420) {
+            this.error('ENHANCE_YOUR_CALM');
+        } else if (this.errorMessages[response.errorCode]) {
+            this.error(response.errorCode);
+        } else {
+            this.error('API_ERROR');
+        }
+    };
+
+    /**
+     * @param {Event}
+     * Destroy the box if reply, removes text if top level
+     */
+    CommentBox.prototype.cancel = function(e) {
+        if (this.hasState('top-level')) {
+            this.getElem('body').value = '';
+            this.setFormState();
+        } else {
+            this.destroy();
+        }
+    };
+
+    /**
+     * TODO: remove the replace, get the Scala to be better
+     * @return {string}
+     */
+    CommentBox.prototype.getDiscussionId = function() {
+        return this.options.discussionId || this.elem.getAttribute('data-discussion-key').replace('discussion', '');
+    };
+
+    /**
+     * Set the form to be postable or not dependant on the comment
+     * @param {Boolean|Event=} disabled (optional)
+     */
+    CommentBox.prototype.setFormState = function(disabled) {
+        disabled = typeof disabled === 'boolean' ? disabled : false;
+
+        var commentBody = this.getElem('body'),
+            submitButton = this.getElem('submit');
+
+        if (disabled || commentBody.value.length === 0) {
+            submitButton.setAttribute('disabled', 'disabled');
+        } else {
+            submitButton.removeAttribute('disabled');
+        }
+    };
+
+    /**
+     * @param {Event=} e (optional)
+     */
+    CommentBox.prototype.setExpanded = function(e) {
+        this.setState('expanded');
+    };
 
 
-/**
- * TODO: remove the replace, get the Scala to be better
- * @return {string}
- */
-CommentBox.prototype.getDiscussionId = function() {
-    return this.options.discussionId || this.elem.getAttribute('data-discussion-key').replace('discussion', '');
-};
-
-/**
- * Set the form to be postable or not dependant on the comment
- * @param {Boolean|Event=} disabled (optional)
- */
-CommentBox.prototype.setFormState = function(disabled) {
-    disabled = typeof disabled === 'boolean' ? disabled : false;
-
-    var commentBody = this.getElem('body'),
-        submitButton = this.getElem('submit');
-
-    if (disabled || commentBody.value.length === 0) {
-        submitButton.setAttribute('disabled', 'disabled');
-    } else {
-        submitButton.removeAttribute('disabled');
-    }
-};
-
-/**
- * @param {Event=} e (optional)
- */
-CommentBox.prototype.setExpanded = function(e) {
-    this.setState('expanded', 'body');
-};
-
-
-return CommentBox;
+    return CommentBox;
 
 }); // define

--- a/common/app/assets/javascripts/modules/discussion/comment-box.js
+++ b/common/app/assets/javascripts/modules/discussion/comment-box.js
@@ -8,253 +8,253 @@ define([
     bonzo,
     DiscussionApi,
     Component
-    ) {
+) {
 
-    /**
-     * @constructor
-     * @extends Component
-     * @param {Element=} context
-     * @param {Object} mediator
-     * @param {Object=} options
-     */
-    function CommentBox(context, mediator, options) {
-        this.context = context || document;
-        this.mediator = mediator;
-        this.setOptions(options);
+/**
+ * @constructor
+ * @extends Component
+ * @param {Element=} context
+ * @param {Object} mediator
+ * @param {Object=} options
+ */
+function CommentBox(context, mediator, options) {
+    this.context = context || document;
+    this.mediator = mediator;
+    this.setOptions(options);
+}
+Component.define(CommentBox);
+
+/**
+ * @type {boolean}
+ * @override
+ */
+CommentBox.prototype.useBem = true;
+
+/**
+ * @type {string}
+ * @override
+ */
+CommentBox.prototype.templateName = 'comment-box';
+
+/**
+ * @type {string}
+ * @override
+ */
+CommentBox.prototype.componentClass = 'd-comment-box';
+
+/**
+ * @type {Object.<string.string>}
+ * @override
+ */
+CommentBox.prototype.classes = {
+    bodyExpanded: 'd-comment-box__body--expanded'
+};
+
+/**
+ * @type {Object.<string.string>}
+ * @override
+ */
+CommentBox.prototype.errorMessages = {
+    EMPTY_COMMENT_BODY: 'Please write a comment.',
+    COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
+    ENHANCE_YOUR_CALM: 'You can only post one comment every minute. Please try again in a moment.',
+    USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
+    API_ERROR: 'Sorry, there was a problem posting your comment.'
+};
+
+/**
+ * @type {Object.<string.*>}
+ */
+CommentBox.prototype.defaultOptions = {
+    discussionId: null,
+    apiRoot: null,
+    maxLength: 5000,
+    premod: false,
+    focus: false,
+    state: 'top-level',
+    replyTo: null,
+    cancelable: false
+};
+
+/**
+ * @type {Array.<string>}
+ */
+CommentBox.prototype.errors = [];
+
+/** @oevrride */
+CommentBox.prototype.prerender = function() {
+    if (!this.options.premod) {
+        this.getElem('premod').parentNode.removeChild(this.getElem('premod'));
     }
-    Component.define(CommentBox);
 
-    /**
-     * @type {boolean}
-     * @override
-     */
-    CommentBox.prototype.useBem = true;
+    if (this.options.state === 'response') {
+        this.getElem('submit').innerHTML = 'Post reply';
+    }
 
-    /**
-     * @type {string}
-     * @override
-     */
-    CommentBox.prototype.templateName = 'comment-box';
+    if (this.options.replyTo) {
+        var elem = document.createElement('label');
+        elem.setAttribute('for', 'reply-to-'+ this.options.replyTo.commentId);
+        elem.className = 'label '+ this.getClass('reply-to', true);
+        elem.innerHTML = 'to '+ this.options.replyTo.author;
+        this.getElem('body').id = 'reply-to-'+ this.options.replyTo.commentId;
+        bonzo(elem).insertAfter(this.getElem('submit'));
+    }
+};
 
-    /**
-     * @type {string}
-     * @override
-     */
-    CommentBox.prototype.componentClass = 'd-comment-box';
+/** @override */
+CommentBox.prototype.ready = function() {
+    if (this.getDiscussionId() === null) {
+        throw new Error('CommentBox: You need to set the "data-discussion-key" on your element');
+    }
 
-    /**
-     * @type {Object.<string.string>}
-     * @override
-     */
-    CommentBox.prototype.classes = {
-        bodyExpanded: 'd-comment-box__body--expanded'
-    };
+    var commentBody = this.getElem('body'),
+        submitButton = this.getElem('submit');
 
-    /**
-     * @type {Object.<string.string>}
-     * @override
-     */
-    CommentBox.prototype.errorMessages = {
-        EMPTY_COMMENT_BODY: 'Please write a comment.',
-        COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
-        ENHANCE_YOUR_CALM: 'You can only post one comment every minute. Please try again in a moment.',
-        USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
-        API_ERROR: 'Sorry, there was a problem posting your comment.'
-    };
+    this.setFormState();
 
-    /**
-     * @type {Object.<string.*>}
-     */
-    CommentBox.prototype.defaultOptions = {
-        discussionId: null,
-        apiRoot: null,
-        maxLength: 5000,
-        premod: false,
-        focus: false,
-        state: 'top-level',
-        replyTo: null,
-        cancelable: false
-    };
+    // TODO (jamesgorrie): Could definitely use the this.on and make the default context this
+    bean.on(this.context, 'submit', [this.elem], this.postComment.bind(this));
+    bean.on(this.context, 'change keyup', [commentBody], this.setFormState.bind(this));
+    bean.on(commentBody, 'focus', this.setExpanded.bind(this)); // this isn't delegated as bean doesn't support it
+    this.on('click', this.getClass('cancel'), this.cancel);
 
-    /**
-     * @type {Array.<string>}
-     */
-    CommentBox.prototype.errors = [];
+    this.setState(this.options.state);
 
-    /** @oevrride */
-    CommentBox.prototype.prerender = function() {
-        if (!this.options.premod) {
-            this.getElem('premod').parentNode.removeChild(this.getElem('premod'));
-        }
+    if (this.options.focus) {
+        this.getElem('body').focus();
+    }
+};
 
-        if (this.options.state === 'response') {
-            this.getElem('submit').innerHTML = 'Post reply';
-        }
+/**
+ * @param {Event}
+ */
+CommentBox.prototype.postComment = function(e) {
+    var body = this.getElem('body'),
+        comment = {
+            body: this.getElem('body').value
+        };
 
-        if (this.options.replyTo) {
-            var elem = document.createElement('label');
-            elem.setAttribute('for', 'reply-to-'+ this.options.replyTo.commentId);
-            elem.className = 'label '+ this.getClass('reply-to', true);
-            elem.innerHTML = 'to '+ this.options.replyTo.author;
-            this.getElem('body').id = 'reply-to-'+ this.options.replyTo.commentId;
-            bonzo(elem).insertAfter(this.getElem('submit'));
-        }
-    };
+    e.preventDefault();
+    this.getElem('messages').innerHTML = '';
+    this.errors = [];
 
-    /** @override */
-    CommentBox.prototype.ready = function() {
-        if (this.getDiscussionId() === null) {
-            throw new Error('CommentBox: You need to set the "data-discussion-key" on your element');
-        }
+    if (comment.body === '') {
+        this.error('EMPTY_COMMENT_BODY');
+    }
 
-        var commentBody = this.getElem('body'),
-            submitButton = this.getElem('submit');
+    else if (comment.body.length > this.options.maxLength) {
+        this.error('COMMENT_TOO_LONG', '<b>Comments must be shorter than '+ this.options.maxLength +' characters.</b> Yours is currently '+ (comment.body.length-this.options.maxLength) +' characters too long.');
+    }
 
-        this.setFormState();
+    if (this.options.replyTo) {
+        comment.replyTo = this.options.replyTo;
+    }
 
-        // TODO (jamesgorrie): Could definitely use the this.on and make the default context this
-        bean.on(this.context, 'submit', [this.elem], this.postComment.bind(this));
-        bean.on(this.context, 'change keyup', [commentBody], this.setFormState.bind(this));
-        bean.on(commentBody, 'focus', this.setExpanded.bind(this)); // this isn't delegated as bean doesn't support it
-        this.on('click', this.getClass('cancel'), this.cancel);
+    if (this.errors.length === 0) {
+        this.setFormState(true);
+        DiscussionApi
+            .postComment(this.getDiscussionId(), comment)
+            .then(this.success.bind(this, comment), this.fail.bind(this));
+    }
+};
 
-        this.setState(this.options.state);
+/**
+ * TODO (jamesgorrie): Perhaps change error states to use bit operators
+ * @param {string} type
+ * @param {string} message Overrides the default message
+ */
+CommentBox.prototype.error = function(type, message) {
+    message = message || this.errorMessages[type];
+    var error = bonzo.create(
+        '<div class="d-discussion__error '+ this.getClass('error', true) +'">'+
+            '<i class="i i-alert"></i>'+
+            '<span class="d-discussion__error-text">'+ message +'</span>'+
+            '</div>'
+    )[0];
+    this.getElem('messages').appendChild(error);
+    this.errors.push(type);
+};
 
-        if (this.options.focus) {
-            this.getElem('body').focus();
-        }
-    };
+/**
+ * @param {Object} comment
+ * @param {Object} resp
+ */
+CommentBox.prototype.success = function(comment, resp) {
+    comment.id = parseInt(resp.message, 10);
+    this.getElem('body').value = '';
+    this.setFormState();
+    this.emit('post:success', comment);
+    this.mediator.emit('discussion:commentbox:post:success', comment);
+};
 
-    /**
-     * @param {Event}
-     */
-    CommentBox.prototype.postComment = function(e) {
-        var body = this.getElem('body'),
-            comment = {
-                body: this.getElem('body').value
-            };
+/**
+ * TODO (jamesgorrie); Make this more robust
+ * @param {Reqwest=} resp (optional)
+ */
+CommentBox.prototype.fail = function(xhr) {
+    var response;
+    // if our API is down, it returns HTML
+    // this is not so good for JSON.parse
+    try { response = JSON.parse(xhr.responseText); }
+    catch (e) { response = {}; }
 
-        e.preventDefault();
-        this.getElem('messages').innerHTML = '';
-        this.errors = [];
+    this.setFormState();
 
-        if (comment.body === '') {
-            this.error('EMPTY_COMMENT_BODY');
-        }
+    if (xhr.status === 420) {
+        this.error('ENHANCE_YOUR_CALM');
+    } else if (this.errorMessages[response.errorCode]) {
+        this.error(response.errorCode);
+    } else {
+        this.error('API_ERROR');
+    }
+};
 
-        else if (comment.body.length > this.options.maxLength) {
-            this.error('COMMENT_TOO_LONG', '<b>Comments must be shorter than '+ this.options.maxLength +' characters.</b> Yours is currently '+ (comment.body.length-this.options.maxLength) +' characters too long.');
-        }
-
-        if (this.options.replyTo) {
-            comment.replyTo = this.options.replyTo;
-        }
-
-        if (this.errors.length === 0) {
-            this.setFormState(true);
-            DiscussionApi
-                .postComment(this.getDiscussionId(), comment)
-                .then(this.success.bind(this, comment), this.fail.bind(this));
-        }
-    };
-
-    /**
-     * TODO (jamesgorrie): Perhaps change error states to use bit operators
-     * @param {string} type
-     * @param {string} message Overrides the default message
-     */
-    CommentBox.prototype.error = function(type, message) {
-        message = message || this.errorMessages[type];
-        var error = bonzo.create(
-            '<div class="d-discussion__error '+ this.getClass('error', true) +'">'+
-                '<i class="i i-alert"></i>'+
-                '<span class="d-discussion__error-text">'+ message +'</span>'+
-                '</div>'
-        )[0];
-        this.getElem('messages').appendChild(error);
-        this.errors.push(type);
-    };
-
-    /**
-     * @param {Object} comment
-     * @param {Object} resp
-     */
-    CommentBox.prototype.success = function(comment, resp) {
-        comment.id = parseInt(resp.message, 10);
+/**
+ * @param {Event}
+ * Destroy the box if reply, removes text if top level
+ */
+CommentBox.prototype.cancel = function(e) {
+    if (this.hasState('top-level')) {
         this.getElem('body').value = '';
         this.setFormState();
-        this.emit('post:success', comment);
-        this.mediator.emit('discussion:commentbox:post:success', comment);
-    };
+    } else {
+        this.destroy();
+    }
+};
 
-    /**
-     * TODO (jamesgorrie); Make this more robust
-     * @param {Reqwest=} resp (optional)
-     */
-    CommentBox.prototype.fail = function(xhr) {
-        var response;
-        // if our API is down, it returns HTML
-        // this is not so good for JSON.parse
-        try { response = JSON.parse(xhr.responseText); }
-        catch (e) { response = {}; }
+/**
+ * TODO: remove the replace, get the Scala to be better
+ * @return {string}
+ */
+CommentBox.prototype.getDiscussionId = function() {
+    return this.options.discussionId || this.elem.getAttribute('data-discussion-key').replace('discussion', '');
+};
 
-        this.setFormState();
+/**
+ * Set the form to be postable or not dependant on the comment
+ * @param {Boolean|Event=} disabled (optional)
+ */
+CommentBox.prototype.setFormState = function(disabled) {
+    disabled = typeof disabled === 'boolean' ? disabled : false;
 
-        if (xhr.status === 420) {
-            this.error('ENHANCE_YOUR_CALM');
-        } else if (this.errorMessages[response.errorCode]) {
-            this.error(response.errorCode);
-        } else {
-            this.error('API_ERROR');
-        }
-    };
+    var commentBody = this.getElem('body'),
+        submitButton = this.getElem('submit');
 
-    /**
-     * @param {Event}
-     * Destroy the box if reply, removes text if top level
-     */
-    CommentBox.prototype.cancel = function(e) {
-        if (this.hasState('top-level')) {
-            this.getElem('body').value = '';
-            this.setFormState();
-        } else {
-            this.destroy();
-        }
-    };
+    if (disabled || commentBody.value.length === 0) {
+        submitButton.setAttribute('disabled', 'disabled');
+    } else {
+        submitButton.removeAttribute('disabled');
+    }
+};
 
-    /**
-     * TODO: remove the replace, get the Scala to be better
-     * @return {string}
-     */
-    CommentBox.prototype.getDiscussionId = function() {
-        return this.options.discussionId || this.elem.getAttribute('data-discussion-key').replace('discussion', '');
-    };
-
-    /**
-     * Set the form to be postable or not dependant on the comment
-     * @param {Boolean|Event=} disabled (optional)
-     */
-    CommentBox.prototype.setFormState = function(disabled) {
-        disabled = typeof disabled === 'boolean' ? disabled : false;
-
-        var commentBody = this.getElem('body'),
-            submitButton = this.getElem('submit');
-
-        if (disabled || commentBody.value.length === 0) {
-            submitButton.setAttribute('disabled', 'disabled');
-        } else {
-            submitButton.removeAttribute('disabled');
-        }
-    };
-
-    /**
-     * @param {Event=} e (optional)
-     */
-    CommentBox.prototype.setExpanded = function(e) {
-        this.setState('expanded');
-    };
+/**
+ * @param {Event=} e (optional)
+ */
+CommentBox.prototype.setExpanded = function(e) {
+    this.setState('expanded');
+};
 
 
-    return CommentBox;
+return CommentBox;
 
 }); // define

--- a/common/app/assets/javascripts/modules/discussion/comment-box.js
+++ b/common/app/assets/javascripts/modules/discussion/comment-box.js
@@ -169,7 +169,7 @@ CommentBox.prototype.error = function(type, message) {
         '<div class="d-discussion__error '+ this.getClass('error', true) +'">'+
             '<i class="i i-alert"></i>'+
             '<span class="d-discussion__error-text">'+ message +'</span>'+
-            '</div>'
+        '</div>'
     )[0];
     this.getElem('messages').appendChild(error);
     this.errors.push(type);
@@ -196,7 +196,7 @@ CommentBox.prototype.fail = function(xhr) {
     // if our API is down, it returns HTML
     // this is not so good for JSON.parse
     try { response = JSON.parse(xhr.responseText); }
-    catch (e) { response = {}; }
+        catch (e) { response = {}; }
 
     this.setFormState();
 

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -861,8 +861,7 @@ $replyIndent: 26px;
     margin-bottom: $baseline*4;
 }
 
-.d-comment-box { 
-
+.d-comment-box {
     @include mq($comment-meta-breakpoint) {
         margin-left: 160px;
     }
@@ -871,6 +870,16 @@ $replyIndent: 26px;
     }
     @include mq(wide) {
         margin-left:  $a-leftColWide-width + $gs-gutter;
+    }
+}
+
+.d-comment-box--expanded {
+    .d-comment-box__body {
+        height: 150px;
+    }
+
+    .d-comment-box__cancel {
+        display: inline-block;
     }
 }
 
@@ -887,10 +896,6 @@ $replyIndent: 26px;
     resize: vertical;
     width: 100%;
     word-break: break-word;
-}
-
-.d-comment-box__body--expanded {
-    height: 150px;
 }
 
 .d-comment-box__add-comment {
@@ -913,6 +918,7 @@ $replyIndent: 26px;
 
 .d-comment-box__cancel {
     color: $c-neutral2;
+    display: none;
     float: right;
     margin-top: $baseline*3;
 }

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -62,10 +62,10 @@ $replyIndent: 26px;
 .d-discussion__show-more {
     padding-top: $baseline*2;
     @include fs-data(5);
-    position: relative;    
+    position: relative;
     line-height: 30px;
 
-    &:hover span { text-decoration: underline; }    
+    &:hover span { text-decoration: underline; }
 }
 
 .d-discussion__show-more-button {
@@ -251,9 +251,10 @@ $replyIndent: 26px;
 }
 
 .d-comment__body {
-    color: $c-neutral1;
     @include fs-data(5);
-    @include rem((line-height: 23px)); 
+    @include rem((line-height: 23px));
+
+    color: $c-neutral1;
     min-height: 2.5em;
     position: relative;
     z-index: 2;
@@ -262,10 +263,10 @@ $replyIndent: 26px;
         min-height: 3.5em;
     }
 }
- 
+
 /* Recommend
    ======================================================= */
-   
+
 .d-comment__recommend {
     position: absolute;
     right: 0;
@@ -277,7 +278,7 @@ $replyIndent: 26px;
     }
 }
 
-.d-comment__recommend-button {    
+.d-comment__recommend-button {
     @include icon-button(18px, -6px);
     background-color: $c-neutral4;
     margin-right: 2px;
@@ -295,7 +296,7 @@ $replyIndent: 26px;
     height: 18px;
     @include rounded-corners(18px);
     position: absolute;
-    top: 0; 
+    top: 0;
     left: 0;
     background-color: $c-neutral4;
 }
@@ -347,7 +348,7 @@ $replyIndent: 26px;
 
 .d-comment__recommend--user-recommended {
 
-    .d-comment__recommend-button, .d-comment__recommend-pulse {        
+    .d-comment__recommend-button, .d-comment__recommend-pulse {
         @include transition(background-color 0.25s ease-in-out);
         background-color: $c-commentDefault;
     }
@@ -472,7 +473,7 @@ $replyIndent: 26px;
         @include mq(tablet) {
             margin-top: $baseline*2;
         }
-    }   
+    }
     .d-comment__recommend {
         top: $baseline;
     }
@@ -491,7 +492,7 @@ $replyIndent: 26px;
     .d-comment__meta-text { margin-left: 0; position: static; }
     .d-comment__timestamp { margin-top: -4px; }
 
-    
+
 
 
 }
@@ -518,7 +519,7 @@ $replyIndent: 26px;
 }
 
 .js-show-more-replies {
-    
+
     margin-left: $replyIndent;
 
     @include mq($comment-meta-breakpoint) {
@@ -563,7 +564,7 @@ $replyIndent: 26px;
 }
 
 .discussion__comments--top-comments {
-    
+
     .d-thread { // for the max-height fade effect
         position: relative;
         overflow: hidden;
@@ -604,7 +605,7 @@ $replyIndent: 26px;
     .show-more__container--newer, .show-more__container--older { display: none; }
 
     .d-comment__actions { display: none; }
-    .d-comment__content { 
+    .d-comment__content {
         background-color: $c-neutral7;
         padding: $baseline*2 $baseline*3;
         margin-bottom: $baseline*3;
@@ -616,8 +617,8 @@ $replyIndent: 26px;
             content: "";
             bottom: -20px;
             left: 20px;
-            width: 0; 
-            height: 0; 
+            width: 0;
+            height: 0;
             border-right: 20px solid transparent;
             border-top: 20px solid $c-neutral7;
             border-right-style: inset;
@@ -642,7 +643,7 @@ $replyIndent: 26px;
         }
     }
     .d-discussion__comment-count { display: none; }
-    
+
     .d-image-fade {
         background-color: #fff;
         display: block;
@@ -856,7 +857,7 @@ $replyIndent: 26px;
 /* Comment Box
    ========================================================================== */
 
-.d-bar {    
+.d-bar {
     color: $c-neutral1;
     margin-bottom: $baseline*4;
 }
@@ -875,7 +876,7 @@ $replyIndent: 26px;
 
 .d-comment-box--expanded {
     .d-comment-box__body {
-        height: 150px;
+        height: gs-height(3);
     }
 
     .d-comment-box__cancel {
@@ -890,7 +891,7 @@ $replyIndent: 26px;
 .d-comment-box__body {
     @include box-sizing(border-box);
     border: 1px solid $c-neutral3;
-    height: 50px;
+    height: gs-height(1.5);
     margin: $baseline*2 0;
     padding: $baseline*2 $gutter/2;
     resize: vertical;

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -28,8 +28,8 @@ id.apiClientToken=frontend-dev-client-token
 id.webapp.url=https://id.thegulocal.com
 
 # Discussion
-discussion.apiRoot=http://discussion.release.dev-guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion.release.dev-guardianapis.com/discussion-api
+discussion.apiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
+discussion.secureApiRoot=https://discussion.code.dev-guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -28,8 +28,8 @@ id.apiClientToken=frontend-dev-client-token
 id.webapp.url=https://id.thegulocal.com
 
 # Discussion
-discussion.apiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion.code.dev-guardianapis.com/discussion-api
+discussion.apiRoot=http://discussion.release.dev-guardianapis.com/discussion-api
+discussion.secureApiRoot=https://discussion.release.dev-guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com

--- a/discussion/app/views/fragments/commentBox.scala.html
+++ b/discussion/app/views/fragments/commentBox.scala.html
@@ -10,5 +10,6 @@
         </div>
         <textarea name="body" class="textarea d-comment-box__body" placeholder="Join the discussion…"></textarea>
         <button type="submit" class="submit-input d-comment-box__submit">Post your comment</button>
+        <div class="u-fauxlink d-comment-box__cancel" role="button">Cancel</div>
     </div>
 </form>


### PR DESCRIPTION
# Open: Discussion

When writing a comment, I would like an easier way than holding backspace to clear my comment.
User, meet the cancel button.
## Looky

![cancel-comment](https://f.cloud.github.com/assets/31692/1887469/02a34ba2-79fe-11e3-94f6-4de7b3c590bc.png)

![ABORT!](http://stream1.gifsoup.com/view2/3604847/abort-o.gif)
