### PR TITLE
Ensure imager JS uses unique class

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -368,7 +368,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers  w
         import browser._
 
         Then("the primary image's 'data-force-upgrade' attribute should be 'true'")
-        findFirst("#article figure .item__image-container").getAttribute("data-force-upgrade") should be("")
+        findFirst("#article figure .js-image-upgrade").getAttribute("data-force-upgrade") should be("")
       }
     }
 

--- a/common/app/assets/javascripts/modules/ui/images.js
+++ b/common/app/assets/javascripts/modules/ui/images.js
@@ -11,7 +11,7 @@ define(['common/$', 'common/utils/to-array', 'bonzo', 'common/utils/mediator', '
                     replacementDelay: 0
                 };
 
-            toArray(context.getElementsByClassName('item__image-container')).forEach(function(container) {
+            toArray(context.getElementsByClassName('js-image-upgrade')).forEach(function(container) {
                 var $container = bonzo(container),
                     forceUpgradeAttr = $container.attr('data-force-upgrade'),
                     forceUpdgradeBreakpoints = forceUpgradeAttr !== null ? forceUpgradeAttr.split(' ') : [],

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -3,7 +3,7 @@
 
 @image.map{ picture =>
     <figure itemprop="associatedMedia primaryImageOfPage" itemscope itemtype="http://schema.org/ImageObject" class="media-primary media-content">
-        <div data-src="@ImgSrc.imager(picture, Item620)" data-force-upgrade>
+        <div class="js-image-upgrade" data-src="@ImgSrc.imager(picture, Item620)" data-force-upgrade>
             <img src="@Item220.bestFor(picture)"
                  class="maxed main-image responsive-img"
                  itemprop="contentURL"

--- a/common/app/views/fragments/items/gallery.scala.html
+++ b/common/app/views/fragments/items/gallery.scala.html
@@ -16,7 +16,7 @@
                                 <p>Expand</p>
                                 <i class="i i-expand-white"></i>
                             </div>
-                            <div class="item__image-container @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -16,7 +16,7 @@
                 @trail.trailPicture(5,3).map{ imageContainer =>
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <div class="item__media-wrapper">
-                            <div class="item__image-container @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }

--- a/common/app/views/fragments/items/video.scala.html
+++ b/common/app/views/fragments/items/video.scala.html
@@ -16,7 +16,7 @@
                                 <p>Play</p>
                                 <i class="i i-play"></i>
                             </div>
-                            <div class="item__image-container @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }

--- a/common/test/assets/javascripts/spec/Images.spec.js
+++ b/common/test/assets/javascripts/spec/Images.spec.js
@@ -6,7 +6,7 @@ define(['common/modules/ui/images', 'helpers/fixtures', 'common/$', 'bonzo', 'co
             lowClassName = 'connection--low',
             notLowClassName = 'connection--not-low',
             dataSrc = '/item-{width}/cat.jpg',
-            imgClass = 'item__image-container';
+            imgClass = 'js-image-upgrade';
 
         beforeEach(function() {
             $('html').addClass(notLowClassName);


### PR DESCRIPTION
This refactors imager to use `js-image-upgrade` class instead of being tightly coupled to `item__image-container`

/cc @ironsidevsquincy 
