### PR TITLE
Handle empty response from most-read endpoint

### DIFF
--- a/common/app/assets/javascripts/modules/facia/popular.js
+++ b/common/app/assets/javascripts/modules/facia/popular.js
@@ -29,7 +29,7 @@ define([
                 crossOrigin: true
             }).then(
                 function(resp) {
-                    var container = bonzo.create(resp.faciaHtml)[0];
+                    var container = bonzo.create(resp.faciaHtml.trim())[0];
                     if (!container) {
                         return false;
                     }

--- a/common/app/assets/javascripts/modules/facia/popular.js
+++ b/common/app/assets/javascripts/modules/facia/popular.js
@@ -30,6 +30,9 @@ define([
             }).then(
                 function(resp) {
                     var container = bonzo.create(resp.faciaHtml)[0];
+                    if (!container) {
+                        return false;
+                    }
                     bonzo(container)
                         .insertAfter(insertAfter);
                     // add show more button

--- a/common/test/assets/javascripts/conf/common.js
+++ b/common/test/assets/javascripts/conf/common.js
@@ -1,6 +1,6 @@
 module.exports = function(config) {
     var settings = new require('./settings.js')(config);
 
-    settings.files.push({ pattern: 'common-test/spec/*.spec.js', included: false });
+    settings.files.push({ pattern: 'common-test/spec/**/*.spec.js', included: false });
     config.set(settings);
 }

--- a/common/test/assets/javascripts/conf/discussion.js
+++ b/common/test/assets/javascripts/conf/discussion.js
@@ -1,5 +1,5 @@
 module.exports = function(config) {
     var settings = new require('./settings.js')(config);
-    settings.files.push({ pattern: 'common-test/spec/discussion/**/*.js', included: false });
+    settings.files.push({ pattern: 'common-test/spec/discussion/**/*.spec.js', included: false });
     config.set(settings);
 }

--- a/common/test/assets/javascripts/conf/facia.js
+++ b/common/test/assets/javascripts/conf/facia.js
@@ -1,5 +1,5 @@
 module.exports = function(config) {
     var settings = new require('./settings.js')(config);
-    settings.files.push({ pattern: 'common-test/spec/facia/**/*.js', included: false });
+    settings.files.push({ pattern: 'common-test/spec/facia/**/*.spec.js', included: false });
     config.set(settings);
 }

--- a/common/test/assets/javascripts/conf/identity.js
+++ b/common/test/assets/javascripts/conf/identity.js
@@ -1,5 +1,5 @@
 module.exports = function(config) {
     var settings = new require('./settings.js')(config);
-    settings.files.push({ pattern: 'common-test/spec/identity/**/*.js', included: false });
+    settings.files.push({ pattern: 'common-test/spec/identity/**/*.spec.js', included: false });
     config.set(settings);
 }

--- a/common/test/assets/javascripts/spec/facia/popular.spec.js
+++ b/common/test/assets/javascripts/spec/facia/popular.spec.js
@@ -71,7 +71,7 @@ define(['common/modules/facia/popular', 'bonzo', 'common/$', 'bean', 'helpers/fi
         });
 
         it('should not display container if response is empty', function() {
-            server.respondWith([200, {}, JSON.stringify({ faciaHtml: '' })]);
+            server.respondWith([200, {}, JSON.stringify({ faciaHtml: "\n\n\n\n   \n\n\n" })]);
             popular.render({});
 
             waits(100);

--- a/common/test/assets/javascripts/spec/facia/popular.spec.js
+++ b/common/test/assets/javascripts/spec/facia/popular.spec.js
@@ -6,7 +6,7 @@ define(['common/modules/facia/popular', 'bonzo', 'common/$', 'bean', 'helpers/fi
             response = JSON.stringify({
                 faciaHtml: '<section class="container--popular"><ul>' + [1, 2, 3, 4].reduce(function(previousValue, itemNum) {
                     return previousValue + '<li>' +
-                            '<div class="item__image-container" data-src="item-{width}.jpg"></div>' +
+                            '<div class="js-image-upgrade" data-src="item-{width}.jpg"></div>' +
                             '<div class="js-item__timestamp"><div class="timestamp__text">1</div></div>' +
                         '</li>';
                 }, '') + '</section></ul>'
@@ -70,17 +70,13 @@ define(['common/modules/facia/popular', 'bonzo', 'common/$', 'bean', 'helpers/fi
             });
         });
 
-        it('dates should be relativised', function() {
+        it('should not display container if response is empty', function() {
+            server.respondWith([200, {}, JSON.stringify({ faciaHtml: '' })]);
             popular.render({});
 
-            waitsFor(function() {
-                return $('.container--popular').length;
-            }, 'popular container to be rendered', 100);
+            waits(100);
             runs(function() {
-                expect($('.timestamp__text').length).toEqual(4);
-                $('.timestamp__text').each(function(item) {
-                    expect(bonzo(item).text()).toEqual('1 Jan 1970');
-                });
+                expect($('.container--popular').length).toEqual(0);
             });
         });
 


### PR DESCRIPTION
Also, specs in common sub-directories weren't running; turned back on

n.b.: this is getting messy while we still haven't completely switched over to using app-scoped js - it would be could get this done soon
