### PR TITLE
Fix typograph on left and right hand cards

### DIFF
--- a/common/app/assets/stylesheets/module/experiments/_ab-inline-link-card.scss
+++ b/common/app/assets/stylesheets/module/experiments/_ab-inline-link-card.scss
@@ -113,6 +113,8 @@
     margin-bottom: 0;
 }
 .card__headline {
+    font-family: $serifheadline !important;
+    font-weight: normal !important;
     font-size: 20px !important;
     font-size: 2.0rem !important;
     line-height: 24px !important;


### PR DESCRIPTION
This ensures left and right hand cards alongside articles use the correct typography. It seems it was being overridden by a global `h3` element selector, therefore we need to be more specific.

/cc @kaelig 
