### PR TITLE
Hide storypackge at desktop breakpoint if only has one item

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_related.scss
+++ b/common/app/assets/stylesheets/module/containers/_related.scss
@@ -33,6 +33,10 @@
                 }
             }
         }
+
+        &.more-on-this-story--one-item {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
As we show the first item of curated story packages in the right hand column at desktop breakpoints we should hide the story-package to avoid duplication.
#### Before

![screenshot from 2014-01-13 12 31 54](https://f.cloud.github.com/assets/80089/1900320/124537de-7c4f-11e3-8473-47e52f388cfe.png)
#### After

![screenshot from 2014-01-13 12 32 16](https://f.cloud.github.com/assets/80089/1900322/17eda0c2-7c4f-11e3-8708-fd6f31cdc722.png)
