### PR TITLE
Ethical awards banner

### DIFF
--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -190,3 +190,15 @@
     margin: 0;
     padding: 0;
 }
+
+.ethical-awards-banner {
+    background-color: #294100;
+    height: 90px;
+    margin-bottom: - $baseline*8;
+}
+
+.ethical-awards-banner__image {
+    display: block;
+    margin: 0 auto;
+    width: 480px;
+}

--- a/identity/app/views/ethicalAwards/form.scala.html
+++ b/identity/app/views/ethicalAwards/form.scala.html
@@ -2,6 +2,9 @@
 
 @identityMain(metaData, conf.Switches.all) {
 } {
+    <div class="ethical-awards-banner hide-on-mobile">
+        <img class="ethical-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/10/1389373843574/ethical-awards-ecover-banner.png" alt="The Observer Ethical Awards">
+    </div>
     <div class="identity-wrapper monocolumn-wrapper">
         <iframe src="@idUrlBuilder.buildUrl(s"/form/$formId")" class="js-formstack-iframe formstack-iframe is-hidden"></iframe>
     </div>

--- a/identity/app/views/ethicalAwards/form.scala.html
+++ b/identity/app/views/ethicalAwards/form.scala.html
@@ -3,7 +3,7 @@
 @identityMain(metaData, conf.Switches.all) {
 } {
     <div class="ethical-awards-banner hide-on-mobile">
-        <img class="ethical-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/10/1389373843574/ethical-awards-ecover-banner.png" alt="The Observer Ethical Awards">
+        <img class="ethical-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/10/1389373843574/ethical-awards-ecover-banner.png" alt="The Observer Ethical Awards" />
     </div>
     <div class="identity-wrapper monocolumn-wrapper">
         <iframe src="@idUrlBuilder.buildUrl(s"/form/$formId")" class="js-formstack-iframe formstack-iframe is-hidden"></iframe>

--- a/identity/app/views/ethicalAwards/form.scala.html
+++ b/identity/app/views/ethicalAwards/form.scala.html
@@ -3,7 +3,7 @@
 @identityMain(metaData, conf.Switches.all) {
 } {
     <div class="ethical-awards-banner hide-on-mobile">
-        <img class="ethical-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/10/1389373843574/ethical-awards-ecover-banner.png" alt="The Observer Ethical Awards" />
+        <img class="ethical-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/14/1389697731897/ethical-awards-ecover-banner.png" alt="The Observer Ethical Awards" />
     </div>
     <div class="identity-wrapper monocolumn-wrapper">
         <iframe src="@idUrlBuilder.buildUrl(s"/form/$formId")" class="js-formstack-iframe formstack-iframe is-hidden"></iframe>


### PR DESCRIPTION
Will show against all the Ethical Awards pages:

CODE links:
Retailer of the year: https://profile.code.dev-theguardian.com/ethical-awards/1645439-tOfqZ3Kxj2
Campaigner of the year: https://profile.code.dev-theguardian.com/ethical-awards/1645466-Tu4y4EFX8s
Local hero: https://profile.code.dev-theguardian.com/ethical-awards/1645469-Tu4y4EFX8s
Arts & culture: https://profile.code.dev-theguardian.com/ethical-awards/1645481-tOfqZ3Kxj2
Sustainable fashion: https://profile.code.dev-theguardian.com/ethical-awards/1645532-tOfqZ3Kxj2
Travel: https://profile.code.dev-theguardian.com/ethical-awards/1645527-Tu4y4EFX8s
The Great OEA Energy Race: https://profile.code.dev-theguardian.com/ethical-awards/1645537-tOfqZ3Kxj2
Young Green Champions: https://profile.code.dev-theguardian.com/ethical-awards/1645561-tOfqZ3Kxj2
The Community Energy Project Award: https://profile.code.dev-theguardian.com/ethical-awards/1645606-tOfqZ3Kxj2
Best in business: https://profile.code.dev-theguardian.com/ethical-awards/1645615-tOfqZ3Kxj2
