### PR TITLE
Prevent right most popular from overlapping footer

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -98,7 +98,7 @@
                     }
                 </div>
                 <div class="article__secondary-column" aria-hidden="true">
-                    <div class="article__secondary-column__inner@if(storyPackage.nonEmpty) { article__secondary-column__inner--has-read-next}">
+                    <div class="article__secondary-column__inner@if(storyPackage.nonEmpty) { article__secondary-column__inner--fill-vertically}">
                         <div class="js-sticky-upper sticky-upper--social" data-id="mpu-ad-slot"></div>
                         <div class="u-table">
                             <div class="u-table__row">

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -98,7 +98,7 @@
                     }
                 </div>
                 <div class="article__secondary-column" aria-hidden="true">
-                    <div class="article__secondary-column__inner">
+                    <div class="article__secondary-column__inner@if(storyPackage.nonEmpty) { article__secondary-column__inner--has-read-next}">
                         <div class="js-sticky-upper sticky-upper--social" data-id="mpu-ad-slot"></div>
                         <div class="u-table">
                             <div class="u-table__row">

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -504,7 +504,7 @@ video {
         display: table-cell;
         width: $a-rightCol-width;
     }
-    .article__secondary-column__inner {
+    .article__secondary-column__inner--has-read-next {
         top: 0;
         bottom: 0;
         position: absolute;

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -504,7 +504,7 @@ video {
         display: table-cell;
         width: $a-rightCol-width;
     }
-    .article__secondary-column__inner--has-read-next {
+    .article__secondary-column__inner--fill-vertically {
         top: 0;
         bottom: 0;
         position: absolute;


### PR DESCRIPTION
This fixes some clearing issues with the article right hand column and more importantly prevent the new right most popular component from overlapping the footer.

/cc @kaelig 
#### Before

![screenshot from 2014-01-14 12 43 36](https://f.cloud.github.com/assets/80089/1910545/c6d39c3e-7d19-11e3-83a8-cd27ed663bd5.png)
#### After

![screenshot from 2014-01-14 12 43 20](https://f.cloud.github.com/assets/80089/1910546/caf1d59c-7d19-11e3-890b-099365a16441.png)
