### PR TITLE
Film Awards - banner on container page [#IDN-1693]

### DIFF
--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -191,13 +191,19 @@
     padding: 0;
 }
 
+.film-awards-banner {
+  background-color: #000000;
+  height: 90px;
+  margin-bottom: - $baseline*8;
+}
+
 .ethical-awards-banner {
     background-color: #294100;
     height: 90px;
     margin-bottom: - $baseline*8;
 }
 
-.ethical-awards-banner__image {
+.ethical-awards-banner__image, .film-awards-banner__image {
     display: block;
     margin: 0 auto;
     width: 480px;

--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -192,9 +192,9 @@
 }
 
 .film-awards-banner {
-  background-color: #000000;
-  height: 90px;
-  margin-bottom: - $baseline*8;
+    background-color: #000000;
+    height: 90px;
+    margin-bottom: - $baseline*8;
 }
 
 .ethical-awards-banner {
@@ -203,7 +203,8 @@
     margin-bottom: - $baseline*8;
 }
 
-.ethical-awards-banner__image, .film-awards-banner__image {
+.ethical-awards-banner__image,
+.film-awards-banner__image {
     display: block;
     margin: 0 auto;
     width: 480px;

--- a/identity/app/views/filmAwards/form.scala.html
+++ b/identity/app/views/filmAwards/form.scala.html
@@ -2,6 +2,9 @@
 
 @identityMain(metaData, conf.Switches.all) {
 } {
+    <div class="film-awards-banner hide-on-mobile">
+        <img class="film-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/15/1389783803763/film-awards-banner.png" alt="The Guardian Film Awards" />
+    </div>
     <div class="identity-wrapper monocolumn-wrapper">
         <iframe src="@idUrlBuilder.buildUrl(s"/form/$formId")" class="js-formstack-iframe formstack-iframe is-hidden"></iframe>
     </div>

--- a/identity/app/views/filmAwards/form.scala.html
+++ b/identity/app/views/filmAwards/form.scala.html
@@ -3,7 +3,7 @@
 @identityMain(metaData, conf.Switches.all) {
 } {
     <div class="film-awards-banner hide-on-mobile">
-        <img class="film-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/15/1389783803763/film-awards-banner.png" alt="The Guardian Film Awards" />
+        <img class="film-awards-banner__image" src="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/15/1389790307027/film-awards-banner.png" alt="The Guardian Film Awards" />
     </div>
     <div class="identity-wrapper monocolumn-wrapper">
         <iframe src="@idUrlBuilder.buildUrl(s"/form/$formId")" class="js-formstack-iframe formstack-iframe is-hidden"></iframe>


### PR DESCRIPTION
https://jira.gutools.co.uk/browse/IDN-1693

This adds a [banner image](https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/1/15/1389783803763/film-awards-banner.png) to the Film Awards container page, which is launching tomorrow (requires you to be signed-in):

https://profile.code.dev-theguardian.com/film-awards/1657876-tOfqZ3Kxj2
https://profile.theguardian.com/film-awards/1657876-tOfqZ3Kxj2

The banner will be much like the Ethical Awards banner, visible here:

https://profile.theguardian.com/film-awards/1657876-tOfqZ3Kxj2
