### PR TITLE
Facia contentapi 404

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -119,11 +119,19 @@ object ContentApiMetrics {
     "Elastic Content api calls that timeout"
   )
 
+  object ContentApi404Metric extends CountMetric(
+    "404",
+    "content-api-404-responses",
+    "Content API 404 responses",
+    "Number of times the Content API has responded with a 404"
+  )
+
   val all: Seq[Metric] = Seq(
     HttpTimingMetric,
     HttpTimeoutCountMetric,
     ElasticHttpTimeoutCountMetric,
-    ElasticHttpTimingMetric
+    ElasticHttpTimingMetric,
+    ContentApi404Metric
   )
 }
 

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -150,15 +150,24 @@ trait ParseCollection extends ExecutionContexts with Logging {
         }
         val response = ContentApi.item(collectionItem.id, edition).showFields("all").response
 
-        response.onFailure{case t: Throwable => log.warn("%s: %s".format(collectionItem.id, t.toString))}
+        val content = response.map(_.content).recover {
+          case apiError: com.gu.openplatform.contentapi.ApiError if apiError.httpStatus == 404 => {
+            log.warn(s"Content API Error: 404 for ${collectionItem.id}")
+            None
+          }
+          case t: Throwable => {
+            log.warn("%s: %s".format(collectionItem.id, t.toString))
+            throw t
+          }
+        }
         supportingAsContent.onFailure{case t: Throwable => log.warn("Supporting links: %s: %s".format(collectionItem.id, t.toString))}
 
         for {
           contentList <- foldListFuture
-          itemResponse <- response
+          itemResponse <- content
           supporting <- supportingAsContent
         } yield {
-          itemResponse.content.map(Content(_, supporting, collectionItem.metaData)).map(_ +: contentList).getOrElse(contentList)
+          itemResponse.map(Content(_, supporting, collectionItem.metaData)).map(_ +: contentList).getOrElse(contentList)
         }
       }
       val sorted = results map { _.sortBy(t => collectionItems.indexWhere(_.id == t.id))}


### PR DESCRIPTION
In this PR, when an item from the content API results in a 404 response, we do not let this take down the collection in facia. This happens when things either get deleted or taken down.

Also added a metric to track 404s from the content API.

@ironsidevsquincy 
