### PR TITLE
Update link to Observer Ethical Awards nomination page

### DIFF
--- a/identity/app/views/ethicalAwards/complete.scala.html
+++ b/identity/app/views/ethicalAwards/complete.scala.html
@@ -13,7 +13,7 @@
     <div id="preload-1">
         <h2 class="formstack-heading formstack-heading--first">Thank you for nominating</h2>
         <p>Remember to keep an eye out for the reader voted shortlist March. Winners will be announced at our awards ceremony in June.</p>
-        <p><a href="http://www.theguardian.com/observer-ethical-awards/observer-ethical-awards-2014-categories" target="_top">Vote again</a>.</p>
+        <p><a href="http://www.theguardian.com/observer-ethical-awards/nominate-now" target="_top">Vote again</a>.</p>
     </div>
 
 </body>


### PR DESCRIPTION
This page is currently offline, but we've confirmed this is what they want...
