### PR TITLE
Commercial hover underline fix

### DIFF
--- a/commercial/app/views/jobs.scala.html
+++ b/commercial/app/views/jobs.scala.html
@@ -23,7 +23,7 @@
     }
     <div class="commercial__foot">
         @jobs.take(1).map { job =>
-            <a class="commercial__link" href="%OASToken%http://jobs.theguardian.com/%OmnitureToken%">Find your next @job.mainIndustry job on Guardian Jobs <i class="i i-double-arrow-right-blue"></i></a>
+            <a class="commercial__link" href="%OASToken%http://jobs.theguardian.com/%OmnitureToken%">Find your next @job.mainIndustry job on Guardian Jobs<i class="i i-double-arrow-right-blue"></i></a>
         }
     </div>
 </div>

--- a/commercial/app/views/jobs_large.scala.html
+++ b/commercial/app/views/jobs_large.scala.html
@@ -17,7 +17,7 @@
             </a>
         </h3>
         @jobs.take(1).map { job =>
-            <a class="commercial__link" href="%OASToken%http://jobs.theguardian.com/">View all @job.mainIndustry jobs <i class="i i-double-arrow-right-white"></i></a>
+            <a class="commercial__link" href="%OASToken%http://jobs.theguardian.com/">View all @job.mainIndustry jobs<i class="i i-double-arrow-right-white"></i></a>
         }
     </div>
     <div class="commercial__body">

--- a/commercial/app/views/masterclasses.scala.html
+++ b/commercial/app/views/masterclasses.scala.html
@@ -25,6 +25,6 @@
         </ul>
     </div>
     <div class="commercial__foot">
-        <a class="commercial__link" href="%OASToken%http://theguardian.com/guardian-masterclasses/masterclasses-calendar%OmnitureToken%">More courses from Guardian Masterclasses <i class="i i-double-arrow-right-blue"></i></a>
+        <a class="commercial__link" href="%OASToken%http://theguardian.com/guardian-masterclasses/masterclasses-calendar%OmnitureToken%">More courses from Guardian Masterclasses<i class="i i-double-arrow-right-blue"></i></a>
     </div>
 </div>

--- a/commercial/app/views/masterclasses_large.scala.html
+++ b/commercial/app/views/masterclasses_large.scala.html
@@ -16,7 +16,7 @@
                 <span>Guardian <span class="em">Masterclasses</span></span>
             </a>
         </h3>
-        <a class="commercial__link" href="http://www.theguardian.com/guardian-masterclasses">All courses <i class="i i-double-arrow-right-white"></i></a>
+        <a class="commercial__link" href="http://www.theguardian.com/guardian-masterclasses">All courses<i class="i i-double-arrow-right-white"></i></a>
     </div>
     <div class="commercial__body">
         <ul class="lineitems">

--- a/commercial/app/views/soulmates.scala.html
+++ b/commercial/app/views/soulmates.scala.html
@@ -26,6 +26,6 @@
         </ul>
     </div>
     <div class="commercial__foot">
-        <a class="commercial__link" href="%OASToken%http://soulmates.theguardian.com/%OmnitureToken%">Join Guardian Soulmates <i class="i i-double-arrow-right-blue"></i></a>
+        <a class="commercial__link" href="%OASToken%http://soulmates.theguardian.com/%OmnitureToken%">Join Guardian Soulmates<i class="i i-double-arrow-right-blue"></i></a>
     </div>
 </div>

--- a/commercial/app/views/travelOffers.scala.html
+++ b/commercial/app/views/travelOffers.scala.html
@@ -37,6 +37,6 @@
             <input value="Search" name="go" class="submit-input" type="submit" />
             <input value="%JustOmnitureToken%" name="INTCMP" type="hidden" />
         </form>
-        <a class="commercial__link" href="%OASToken%http://www.guardianholidayoffers.co.uk/%OmnitureToken%">More from Guardian Holiday Offers <i class="i i-double-arrow-right-white"></i></a>
+        <a class="commercial__link" href="%OASToken%http://www.guardianholidayoffers.co.uk/%OmnitureToken%">More from Guardian Holiday Offers<i class="i i-double-arrow-right-white"></i></a>
     </div>
 </div>

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -55,6 +55,7 @@
     .i {
         position: relative;
         top: 2px;
+        margin-left: 4px;
     }
     .commercial__head & {
         @include rem((


### PR DESCRIPTION
- [fix] Whitespace between text and icon is not underlined when hovering commercial links
## Before

![screen shot 2014-01-18 at 14 42 46](https://f.cloud.github.com/assets/85783/1953658/c307c432-81c3-11e3-91bc-446e013fb3b4.PNG)
## After

![screen shot 2014-01-18 at 14 43 08](https://f.cloud.github.com/assets/85783/1953660/c78a153c-81c3-11e3-928a-340c40894231.PNG)

![ ](http://s1.developerslife.ru/public/images/gifs/a6a94a5e-e57c-45d9-98cc-59aeb643ddb3.gif)
