### PR TITLE
Removed Discussion switches (except needed ones)

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -92,7 +92,7 @@ define([
 
             common.mediator.on('page:article:ready', function(config, context) {
                 if (config.page.commentable && config.switches.discussion) {
-                    var discussionLoader = new DiscussionLoader(context, common.mediator, {}, config.switches.discussionTopComments);
+                    var discussionLoader = new DiscussionLoader(context, common.mediator);
                     discussionLoader.attachToDefault();
                 }
             });

--- a/common/app/assets/javascripts/bootstraps/imagecontent.js
+++ b/common/app/assets/javascripts/bootstraps/imagecontent.js
@@ -10,7 +10,7 @@ define([
         initDiscussion: function() {
             mediator.on("page:imagecontent:ready", function(config, context) {
                 if (config.page.commentable) {
-                    var discussionLoader = new DiscussionLoader(context, mediator, {}, config.switches.discussionTopComments);
+                    var discussionLoader = new DiscussionLoader(context, mediator);
                     discussionLoader.attachToDefault();
                 }
             });

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -38,11 +38,10 @@ define([
  * @param {Object} mediator
  * @param {Object=} options
  */
-var Loader = function(context, mediator, options, topCommentsSwitch) {
+var Loader = function(context, mediator, options) {
     this.context = context || document;
     this.mediator = mediator;
     this.setOptions(options);
-    this.topCommentsSwitch = topCommentsSwitch; // Pass through topComments switch
 };
 Component.define(Loader);
 
@@ -103,7 +102,7 @@ Loader.prototype.ready = function() {
         this.topComments = new TopComments(self.context, self.mediator, {
             discussionId: this.getDiscussionId(),
             user: self.user
-        }, this.topCommentsSwitch);
+        });
 
         this.topComments
             .fetch(topCommentsElem)

--- a/common/app/assets/javascripts/modules/discussion/top-comments.js
+++ b/common/app/assets/javascripts/modules/discussion/top-comments.js
@@ -28,11 +28,10 @@ being signed off.
 
 ================================================================= */
 
-var TopComments = function(context, mediator, options, topCommentsSwitch) {
+var TopComments = function(context, mediator, options) {
     this.context = context || document;
     this.mediator = mediator;
     this.setOptions(options);
-    this.topCommentsSwitch = topCommentsSwitch;
 };
 Component.define(TopComments);
 
@@ -106,7 +105,7 @@ TopComments.prototype.fetch = function(parent) {
     }).then(
         function render(resp) {
             // Success: Render Top or Regular comments
-            if (resp.currentCommentCount > 0 && self.topCommentsSwitch) {
+            if (resp.currentCommentCount > 0) {
 
                 // Render Top Comments
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -139,30 +139,15 @@ object Switches extends Collections {
   // Discussion Switches
 
   val DiscussionSwitch = Switch("Discussion", "discussion",
-    "If this switch is on, comments are displayed on articles.",
-    safeState = Off, sellByDate = endOfQ4
-  )
-
-  val DiscussionCommentRecommend = Switch("Discussion", "discussion-comment-recommend",
-    "If this switch is on, users can recommend comments",
-    safeState = Off, sellByDate = endOfQ4
-  )
-
-  val DiscussionPostCommentSwitch = Switch("Discussion", "discussion-post-comment",
-    "If this switch is on, users will be able to post comments",
-    safeState = Off, sellByDate = endOfQ4
-  )
-
-  val DiscussionTopCommentsSwitch = Switch("Discussion", "discussion-top-comments",
-    "If this switch is on, users will see top comments if there are any",
-    safeState = Off, sellByDate = new DateMidnight(2014, 2, 15)
+    "If this switch is on, comments are displayed on articles. Turn this off if the Discussion API is blowing up.",
+    safeState = Off, sellByDate = never
   )
 
   // Open
 
   val OpenCtaSwitch = Switch("Open", "open-cta",
-    "If this switch is on, will see a CTA to comments on the right hand side",
-    safeState = Off, sellByDate = new DateMidnight(2014, 2, 15)
+    "If this switch is on, will see a CTA to comments on the right hand side. Turn this off if the Open API is blowing up.",
+    safeState = Off, sellByDate = never
   )
 
   // Feature Switches
@@ -359,8 +344,6 @@ object Switches extends Collections {
     VideoAdvertSwitch,
     AudienceScienceSwitch,
     DiscussionSwitch,
-    DiscussionPostCommentSwitch,
-    DiscussionTopCommentsSwitch,
     OpenCtaSwitch,
     FontSwitch,
     NetworkFrontAppealSwitch,


### PR DESCRIPTION
As per the new decomposition of switches.

Open and Discussion main switches are still required as, if the API goes down, it's best to be able to stop all calls to the endpoints.

![Lights out](http://27.media.tumblr.com/tumblr_lrlse6fruj1qkahb5o1_500.gif)
