### PR TITLE
303 response for alpha preference

### DIFF
--- a/core-navigation/app/controllers/ChangeAlphaController.scala
+++ b/core-navigation/app/controllers/ChangeAlphaController.scala
@@ -7,8 +7,8 @@ object ChangeAlphaController extends Controller with PreferenceController {
   def render(networkFront: String, optaction: String, redirectUrl: String) = Action { implicit request =>
     val abCookieName: String = s"GU_${networkFront.toUpperCase()}_ALPHA"
     optaction match {
-      case "optin"  => switchTo(abCookieName -> "true", redirectUrl)
-      case "optout" => switchTo(abCookieName -> "false", redirectUrl)
+      case "optin"  => switchTo303(abCookieName -> "true", redirectUrl)
+      case "optout" => switchTo303(abCookieName -> "false", redirectUrl)
       case _ => NotFound("unknown action")
     }
   }

--- a/core-navigation/app/controllers/PreferenceController.scala
+++ b/core-navigation/app/controllers/PreferenceController.scala
@@ -18,4 +18,10 @@ trait PreferenceController extends Results {
       .withCookies(Cookie(cookie._1, cookie._2, maxAge = Some(5184000))) // 60 days, this is seconds
     )
   } else Forbidden("will not redirect there")
+
+  def switchTo303(cookie: (String, String), url: String)(implicit request: RequestHeader) = if (allowedUrl(url)){
+    NoCache(SeeOther(url)
+      .withCookies(Cookie(cookie._1, cookie._2, maxAge = Some(5184000))) // 60 days, this is seconds
+    )
+  } else Forbidden("will not redirect there")
 }


### PR DESCRIPTION
302 _seems_ to cause certain clients (iphone) to use the browser cache of the `Location` url

Trying a 303, can't really test this except on prod, as needs to go through fastly

Only trying on the alpha preference endpoints for now
