### PR TITLE
Let user know where nginx was found when doing setup

### DIFF
--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,6 +1,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
 
+echo "nginxHome=$nginxHome"
+
 sudo mkdir -p $nginxHome/sites-enabled
 sudo ln -fs $DIR/frontend.conf $nginxHome/sites-enabled/frontend.conf
 sudo ln -fs $DIR/frontend-test.crt $nginxHome/frontend-test.crt


### PR DESCRIPTION
Users need to know where the nginx folder is to configure the 'sites-enabled' bit - it's nice to let them know where it is.
