### PR TITLE
Show more button: icon is closer to the text on iOS6

### DIFF
--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -68,6 +68,7 @@ $replyIndent: 26px;
 .d-discussion__show-more-button {
     @include icon-button(30px, -15px);
     position: absolute;
+    left: 0;
     background-color: $c-newsDefault;
 }
 .d-discussion__show-more-text {


### PR DESCRIPTION
For some reason on iOS6 the icon was aligned to the left.
## Before

![screen shot 2014-01-21 at 17 58 05](https://f.cloud.github.com/assets/85783/1966244/c8659cb2-82c5-11e3-83b0-e18d0aac439d.PNG)
## After

![screen shot 2014-01-21 at 17 57 56](https://f.cloud.github.com/assets/85783/1966794/58228124-82cd-11e3-9e1f-85ceca77d57f.PNG)
