### PR TITLE
Prevent Sequence init for Identity pages

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -346,7 +346,9 @@ define([
                         }
                     });
                 }
-                sequence.init('/' + config.page.pageId);
+                if (config.page.section !== 'identity') {
+                    sequence.init('/' + config.page.pageId);
+                }
             });
         },
 


### PR DESCRIPTION
As previously discussed with @phamann.

A few problems otherwise - Chrome won't allow a `Access-Control-Allow-Origin` request to https://api-secure.nextgen.guardianapps.co.uk/most-read/identity.json?_edition=UK - Firefox allows it but it's a 500 anyway.
