### PR TITLE
Underline auto-generated tag links

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -336,6 +336,7 @@ class TagLinker(article: Article)(implicit val edition: Edition) extends HtmlCle
           tagLink.attr("href", LinkTo(keyword.url, edition))
           tagLink.text(keyword.name)
           tagLink.attr("data-link-name", "auto-linked-tag")
+          tagLink.addClass("u-underline")
 
           p.html(p.html().replaceFirst(keyword.name, tagLink.toString))
         }


### PR DESCRIPTION
/cc @cantlin Sorry - forgot I fixed this last week and didn't raise a pull request. Blame hackday.

![anigif_enhanced-buzz-27927-1388776392-0](https://f.cloud.github.com/assets/84996/1983553/e5692d26-8417-11e3-8a15-b8b5833d52a7.gif)
