### PR TITLE
News container: load only images that are needed

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -21,7 +21,10 @@
         }
     }
     .item__media-wrapper {
-        display: none;
+        &,
+        .item__image-container {
+            display: none;
+        }
     }
     .item--has-image {
         .item__media-wrapper,
@@ -101,16 +104,19 @@
     }
     .l-row--items-4 {
         .item__standfirst,
-        .item__media-wrapper {
+        .item__media-wrapper,
+        .item__image-container {
             display: none;
         }
         .item--imageadjust-highlight {
-            .item__media-wrapper {
+            .item__media-wrapper,
+            .item__image-container {
                 display: block;
             }
         }
         @include mq(tablet) {
             .item--has-image .item__media-wrapper,
+            .item--has-image .item__image-container,
             .item--has-no-image .item__standfirst {
                 display: block;
             }

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -20,11 +20,9 @@
             border-top-style: solid;
         }
     }
-    .item__media-wrapper {
-        &,
-        .item__image-container {
-            display: none;
-        }
+    .item__media-wrapper,
+    .item__image-container {
+        display: none;
     }
     .item--has-image {
         .item__media-wrapper,

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -257,7 +257,10 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
    ===========================================================================*/
 
 .fromage__media-wrapper--first {
-    display: none;
+    &,
+    .fromage__image-container {
+        display: none;
+    }
 }
 .fromage__media-wrapper--second {
     float: left;
@@ -274,10 +277,16 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
 }
 @include mq(tablet) {
     .fromage__media-wrapper--first {
-        display: block;
+        &,
+        .fromage__image-container {
+            display: block;
+        }
     }
     .fromage__media-wrapper--second {
-        display: none;
+        &,
+        .fromage__image-container {
+            display: none;
+        }
     }
 }
 
@@ -285,7 +294,8 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
     .fromage__container {
         border-top-width: 0;
     }
-    .fromage__media-wrapper {
+    .fromage__media-wrapper,
+    .fromage__image-container {
         display: none;
     }
     .fromage__link {
@@ -425,10 +435,16 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
         }
     }
     .fromage__media-wrapper--first {
-        display: block;
+        &,
+        .fromage__image-container {
+            display: block;
+        }
     }
     .fromage__media-wrapper--second {
-        display: none;
+        &,
+        .fromage__image-container {
+            display: none;
+        }
     }
 }
 

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -66,7 +66,7 @@
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <a href="@LinkTo{@trail.url}" data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
-                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
+                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
                                 </div>
                             </div>
                         </a>


### PR DESCRIPTION
Hide the image containers so that the responsive image script does not add img tags to places they are not needed.

Should reduce the number of loaded images by ~7 on mobile.

![ ](http://1.bp.blogspot.com/-PL2pz2Xsc3Q/Ut1Xwi6HvKI/AAAAAAABFWg/4hLDY-WZVsk/s1600/twitter-in-real-life.gif)
