### PR TITLE
Spacing and colour are the same on all headings with a border on top

### DIFF
--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -65,7 +65,7 @@
                     </div>
                 </div>
                 <div class="article__secondary-column" aria-hidden="true">
-                    <h2 class="article__meta-heading tone-colour">Share this video</h2>
+                    <h2 class="article__meta-heading">Share this video</h2>
                     @fragments.social(video, "next to content")
                 </div>
             </div>

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -630,6 +630,7 @@ $replyIndent: 26px;
     color: $c-neutral1;
     border-top: 1px dotted $c-neutral3;
     margin-bottom: 0;
+    padding-top: $baseline/2;
 }
 
 .discussion__comments--top-comments {

--- a/common/app/assets/stylesheets/module/containers/_related.scss
+++ b/common/app/assets/stylesheets/module/containers/_related.scss
@@ -4,9 +4,9 @@
 
     @include mq(rightCol) {
 
-        .page-sub-header {
+        .related__header {
             border-top: 1px solid $c-neutral4;
-            padding-top: 5px;
+            padding-top: $baseline/2;
             padding-bottom: 0;
             margin-bottom: 0;
         }

--- a/common/app/assets/stylesheets/module/onward/_popular.scss
+++ b/common/app/assets/stylesheets/module/onward/_popular.scss
@@ -15,7 +15,7 @@
         .tabs__tab:first-child {
             width: 100%;
             border-top: none;
-            padding: 5px $gs-baseline/1.5 $gs-baseline/3 0;
+            padding: $gs-baseline/3 $gs-gutter/4 $gs-baseline/3 0;
 
             a {
                 padding: 0;


### PR DESCRIPTION
- [fix] Space between border and text is the same on all sub headings ("Share this…", "All comments", "Most popular"…)
- [fix] "Share this video" is the same colour (dark grey) as "Share this article"

![ ](http://1.bp.blogspot.com/-Zucyo6sBoJk/UtwIc9qgkUI/AAAAAAABFVE/WatCjofbxbw/s1600/getting-cuddly.gif)
