### PR TITLE
Added MPU and inline ads on tablet

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -254,7 +254,8 @@ define([
                     // Limiting inline ads to 1 until support for different inline
                     // ads is enabled
                     var articleBodyAdverts = new ArticleBodyAdverts({
-                        inlineAdLimit: 1
+                        inlineAdLimit: 1,
+                        wordCount: config.page.wordCount
                     });
 
                     // Add the body adverts to the article page

--- a/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
@@ -46,8 +46,8 @@ define([
             template          = this.config.inlineAdTemplate,
             article           = document.getElementsByClassName('js-article__container')[0];
 
-        // Placed is the number of adverts currently placed inline. This is more accurate than
-        // using the `i` from the each function
+        // `adsPlaced` is the number of adverts currently placed inline. This is more accurate than
+        // using the `i` from the each function as that can skip ads depending on content length
         if(adPlacedAtBeginning) {
             adsPlaced++;
             limit++;

--- a/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
@@ -27,20 +27,35 @@ define([
     ArticleBodyAdverts.prototype.config = {
         inlineAdLimit: null,
         nthParagraph: 7,
+        wordCountThreshold: 200,
         inlineAdTemplate: '<div class="ad-slot ad-slot--inline" data-base="%slot%" data-median="%slot%"><div class="ad-container"></div></div>',
         mpuAdTemplate: '<div class="ad-slot ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="%slot%" data-median="%slot%"><div class="ad-container"></div></div>'
     };
 
     // inserts a few inline advert slots in to the page
-    ArticleBodyAdverts.prototype.createInlineAdSlots = function(id) {
-        var paragraphSelector = 'p:nth-of-type('+ this.config.nthParagraph +'n)',
+    ArticleBodyAdverts.prototype.createInlineAdSlots = function(id, adPlacedAtBeginning) {
+
+        // Prevent any inline ads being showed on short articles
+        if(this.config.wordCount && this.config.wordCount < this.config.wordCountThreshold) {
+            return false;
+        }
+
+        var adsPlaced         = 0,
+            paragraphSelector = 'p:nth-of-type('+ this.config.nthParagraph +'n)',
             limit             = this.config.inlineAdLimit,
             template          = this.config.inlineAdTemplate,
             article           = document.getElementsByClassName('js-article__container')[0];
 
+        // Placed is the number of adverts currently placed inline. This is more accurate than
+        // using the `i` from the each function
+        if(adPlacedAtBeginning) {
+            adsPlaced++;
+            limit++;
+        }
+
         $(paragraphSelector, article).each(function(el, i) {
             var $el = $(el),
-                cls = (i % 2 === 0) ? 'is-odd' : 'is-even';
+                cls = (adsPlaced % 2 === 0) ? '' : 'is-even';
 
             /*
              - Checks if limit is set and if so, checks it hasn't been exceeded
@@ -48,11 +63,13 @@ define([
              - Checks if the text length is below 120 characters - helps prevent against empty paragraphs
                and paragraphs being used instead of order/unordered lists
              */
-            if(limit !== null && limit < (i + 1) || $el.next()[0] === undefined || $el.text().length < 120) {
+            if(limit !== null && limit < (adsPlaced + 1) || $el.next()[0] === undefined || $el.text().length < 120) {
                 return false;
             }
 
             bonzo(bonzo.create(template.replace(/%slot%/g, id))).addClass(cls).insertBefore($el);
+
+            adsPlaced++;
         });
     };
 
@@ -60,6 +77,13 @@ define([
         var template = this.config.mpuAdTemplate;
 
         $('.js-mpu-ad-slot .social-wrapper').after(bonzo.create(template.replace(/%slot%/g, id))[0]);
+    };
+
+    ArticleBodyAdverts.prototype.createAdSlotAtTopOfArticle = function(id) {
+        var template = this.config.inlineAdTemplate;
+
+        var el = bonzo(bonzo.create(template.replace(/%slot%/g, id)));
+        el.prependTo($('.js-article__container .article-body p')[0]);
     };
 
     ArticleBodyAdverts.prototype.destroy = function() {
@@ -77,6 +101,11 @@ define([
         if((/wide|desktop/).test(breakpoint)) {
             this.createInlineAdSlots('Middle1');
             this.createMpuAdSlot('Middle');
+        }
+
+        if((/tablet/).test(breakpoint)) {
+            this.createAdSlotAtTopOfArticle('Middle');
+            this.createInlineAdSlots('Middle1', true);
         }
 
         if((/mobile/).test(breakpoint)) {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -78,6 +78,7 @@
 
     @include mq(tablet) {
         width: auto;
+        height: auto;
         float: right;
         padding-top: $baseline;
         padding-left: $gs-gutter;

--- a/common/test/assets/javascripts/spec/ArticleBodyAdverts.spec.js
+++ b/common/test/assets/javascripts/spec/ArticleBodyAdverts.spec.js
@@ -51,10 +51,10 @@ define([ 'common/common',
 
             it("Should destroy the ads", function() {
                 articleBodyAdverts.init();
-                expect(document.querySelectorAll('.ad-slot--mpu-banner-ad, .ad-slot--inline').length).toBe(3);
+                expect($('.ad-slot--mpu-banner-ad, .ad-slot--inline').length).toBe(3);
 
                 articleBodyAdverts.destroy();
-                expect(document.querySelectorAll('.ad-slot--mpu-banner-ad, .ad-slot--inline').length).toBe(0);
+                expect($('.ad-slot--mpu-banner-ad, .ad-slot--inline').length).toBe(0);
             });
 
             describe('When setting a limit of 1 inline ad', function() {
@@ -62,7 +62,7 @@ define([ 'common/common',
                 it("Should insert only 1 inline ad container to the content", function() {
                     articleBodyAdverts.config.inlineAdLimit = 1;
                     articleBodyAdverts.init();
-                    expect(document.querySelectorAll('.ad-slot--inline').length).toBe(1);
+                    expect($('.ad-slot--inline').length).toBe(1);
                 });
             });
         });


### PR DESCRIPTION
- Moving the MPU ad to the top of the article content
- Only showing inline ads if the article length is 200+ words

![inline-ad-top--tablet](https://f.cloud.github.com/assets/1148714/1984569/751b0c30-842e-11e3-860f-faad798f1a33.png)
