### PR TITLE
Support absolute URL as data-interactive attribute

### DIFF
--- a/common/app/assets/javascripts/modules/interactive/loader.js
+++ b/common/app/assets/javascripts/modules/interactive/loader.js
@@ -6,15 +6,25 @@ define([
 
     function Interactive(el, context, config) {
 
-        var url = config.page.interactiveUrl + el.getAttribute('data-interactive'),
-            element = el;
-        
+        var interactiveAttr = el.getAttribute('data-interactive'),
+            element = el,
+            bootUrl;
+
+        // Backward compatibility with relative paths.
+        // data-interactive attributes should be absolute from now
+        // onwards.
+        if (/^https?:\/\//.test(interactiveAttr)) {
+            bootUrl = interactiveAttr;
+        } else {
+            bootUrl = config.page.interactiveUrl + interactiveAttr + '/boot.js';
+        }
+
         this.init = function () {
 
             // The contract here is that the interactive module MUST return an object
             // with a method called 'boot'.
 
-            require(url + '/boot.js', function (interactive) {
+            require(bootUrl, function (interactive) {
 
                 // We pass the standard context and config here, but also inject the
                 // mediator so the external interactive can respond to our events.

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -349,7 +349,8 @@ object InBodyElementCleaner extends HtmlCleaner {
     "element-video",
     "element-image",
     "element-witness",
-    "element-comment"
+    "element-comment",
+    "element-interactive"
   )
 
   override def clean(document: Document): Document = {

--- a/common/test/assets/javascripts/spec/Interactive.spec.js
+++ b/common/test/assets/javascripts/spec/Interactive.spec.js
@@ -5,10 +5,14 @@ define([ 'common/common',
 
         describe("Interactive", function() {
             
-            var i, conf = {
+            var conf = {
                     id: 'interactive',
                     fixtures: [
-                                '<figure class="interactive" data-interactive="path/to/interactive">' +
+                                // Legacy using relative URL
+                                '<figure class="interactive legacy" data-interactive="path/to/interactive">' +
+                                '  <caption>Description of the interactive</caption>' +
+                                '</figure>',
+                                '<figure class="interactive new" data-interactive="http://interactive.guim.co.uk/embed/path/to/interactive/boot.js">' +
                                 '  <caption>Description of the interactive</caption>' +
                                 '</figure>'
                               ]
@@ -22,17 +26,43 @@ define([ 'common/common',
 
             beforeEach(function() {
                 fixtures.render(conf);
-                i = new Interactive(document.querySelector('figure.interactive'), document, config);
             });
 
-            it("Should exist", function() {
-                expect(i).toBeDefined();
+            describe('Legacy (relative URLs)', function() {
+                var i;
+
+                beforeEach(function() {
+                    i = new Interactive(document.querySelector('figure.interactive.legacy'), document, config);
+                });
+
+                it("Should exist", function() {
+                    expect(i).toBeDefined();
+                });
+
+                it("Should load the interactive resource relatively defined in the data-attribute", function() {
+                    require = jasmine.createSpy();
+                    i.init();
+                    expect(require.mostRecentCall.args[0]).toBe('http://foo/path/to/interactive/boot.js');
+                });
             });
-            
-            it("Should load the interactive resource defined in the data-attribute", function() {
-                require = jasmine.createSpy();
-                i.init();
-                expect(require.mostRecentCall.args[0]).toBe('http://foo/path/to/interactive/boot.js');
+
+
+            describe('New (absolute URLs)', function() {
+                var i;
+
+                beforeEach(function() {
+                    i = new Interactive(document.querySelector('figure.interactive.new'), document, config);
+                });
+
+                it("Should exist", function() {
+                    expect(i).toBeDefined();
+                });
+
+                it("Should load the interactive resource defined in the data-attribute", function() {
+                    require = jasmine.createSpy();
+                    i.init();
+                    expect(require.mostRecentCall.args[0]).toBe('http://interactive.guim.co.uk/embed/path/to/interactive/boot.js');
+                });
             });
 
         });


### PR DESCRIPTION
This is part of my work on getting interactives into Composer using the data-interactive/boot.js design we've been discussing (for about a decade) with @commuterjoy. This PR also whitelists element-interactives, as per the recent PR by @rich-nguyen.

Disclaimer: I've updated the tests, but I've not tried running the update code against a real interactive piece of content.
