### PR TITLE
Added simple casperJS tests for signin and register on NGW

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -602,6 +602,9 @@ module.exports = function (grunt) {
             facia: {
                 src: ['integration-tests/casper/tests/facia/*.spec.js']
             },
+            identity: {
+                src: ['integration-tests/casper/tests/identity/*.spec.js']
+            },
             open: {
                 src: ['integration-tests/casper/tests/open/*.spec.js']
             }

--- a/integration-tests/casper/tests/identity/register.spec.js
+++ b/integration-tests/casper/tests/identity/register.spec.js
@@ -1,0 +1,30 @@
+/* global document */
+'use strict';
+
+/**
+ * Signin page tests
+ */
+
+ casper.test.setUp(function() {
+    casper.start(idHost +'register?view=mobile');
+});
+
+
+ casper.test.begin("Register page loads and key elements are present", function(test) {
+    casper.then(function testKeyEventsToggle() {
+        casper.waitForSelector(".identity-wrapper", function() {
+            test.assertTitle('Register', 'expected: register form components');
+            test.assertVisible('.social-signin', 'expected to see social sign in buttons on register page');
+            test.done();
+
+        }, function timeout(){
+            casper.capture(screens + 'register_page_failure.png');
+            test.fail("Failed to find elements on register page");
+        });
+    });
+});
+
+
+casper.run(function() {
+    this.test.renderResults(true, 0, this.cli.get('xunit') + 'identity.xml');
+});

--- a/integration-tests/casper/tests/identity/signin.spec.js
+++ b/integration-tests/casper/tests/identity/signin.spec.js
@@ -7,10 +7,11 @@
 
  casper.test.setUp(function() {
     casper.start(idHost +'signin?view=mobile');
+    console.log(environment);
 });
 
 
- casper.test.begin("Page loads and key elements are present", function(test) {
+ casper.test.begin("Signin page loads and key elements are present", function(test) {
     casper.then(function testKeyEventsToggle() {
         casper.waitForSelector(".identity-wrapper", function() {
             test.assertTitle('Sign in', 'expected: Sign in');

--- a/integration-tests/casper/tests/identity/signin.spec.js
+++ b/integration-tests/casper/tests/identity/signin.spec.js
@@ -1,0 +1,30 @@
+/* global document */
+'use strict';
+
+/**
+ * Signin page tests
+ */
+
+ casper.test.setUp(function() {
+    casper.start(idHost +'signin?view=mobile');
+});
+
+
+ casper.test.begin("Page loads and key elements are present", function(test) {
+    casper.then(function testKeyEventsToggle() {
+        casper.waitForSelector(".identity-wrapper", function() {
+            test.assertTitle('Sign in', 'expected: Sign in');
+            test.assertVisible('.social-signin', 'expected to see social sign in buttons');
+            test.done();
+
+        }, function timeout(){
+            casper.capture(screens + 'signin_page_failure.png');
+            test.fail("Failed to find elements on signin page");
+        });
+    });
+});
+
+
+casper.run(function() {
+    this.test.renderResults(true, 0, this.cli.get('xunit') + 'identity.xml');
+});

--- a/integration-tests/casper/tests/identity/signin.spec.js
+++ b/integration-tests/casper/tests/identity/signin.spec.js
@@ -7,7 +7,6 @@
 
  casper.test.setUp(function() {
     casper.start(idHost +'signin?view=mobile');
-    console.log(environment);
 });
 
 

--- a/integration-tests/casper/tests/shared.js
+++ b/integration-tests/casper/tests/shared.js
@@ -6,6 +6,11 @@ host = {
     code:   'http://m.code.dev-theguardian.com/',
     prod:   'http://www.theguardian.com/'
 }[environment];
+idHost = {
+    dev:    'https://profile.thegulocal.com/',
+    code:   'https://profile.code.dev-theguardian.com/',
+    prod:   'https://profile.theguardian.com/'
+}[environment];
 
 viewports = {
 	mobile:  {width: 320, height: 480},


### PR DESCRIPTION
@jamesgorrie helped to change shared.js to cater for the "profile." subdomain.

Added identity to the grunt file.

Created very simple tests for checking signin and registration components show on their pages.
