### PR TITLE
News container: bump size of text down and float image to be 50% width

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -60,10 +60,12 @@
             @include vertical-item-separator; // Restore inter-item separator
         }
     }
-
+    .item__title {
+        @include fs-headline(1, true);
+    }
     .l-row--items-2 {
         .item__title {
-            @include fs-headline(2, true);
+            @include fs-headline(1, true);
             @include rem((
                 margin-bottom: 14px
             ));

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -102,7 +102,7 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
 }
 
 .fromage__title {
-    @include fs-headline(3);
+    @include fs-headline(2);
     @include rem((
         margin-bottom: $gs-baseline + 2px
     ));
@@ -265,14 +265,12 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
 .fromage__media-wrapper--second {
     float: left;
     clear: both;
+    width: 50%;
+    @include box-sizing(border-box);
 
     @include rem((
-        margin-top: 4px,
-        margin-right: $gs-gutter/2
-    ));
-
-    @include rem((
-        width: 122px
+        margin-top: 3px,
+        padding-right: $gs-gutter/2
     ));
 }
 @include mq(tablet) {
@@ -296,7 +294,7 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
     }
     .fromage__media-wrapper,
     .fromage__image-container {
-        display: none;
+        display: none !important;
     }
     .fromage__link {
         @include mq(tablet) {
@@ -316,7 +314,7 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
         }
     }
     .fromage__title {
-        @include fs-headline(4, true);
+        @include fs-headline(3, true);
 
         @include mq(tablet) {
             @include fs-headline(5, true);


### PR DESCRIPTION
![screen shot 2014-01-23 at 17 51 43](https://f.cloud.github.com/assets/85783/1987409/4bfb588e-8459-11e3-83f0-52e812f0f875.PNG)

![ ](http://2.bp.blogspot.com/-HVffp3BML3I/UrcDHdwwwjI/AAAAAAAAAPI/zI8xDG2LA00/s1600/z_power5_zooming_medres_10_fadeout.gif)
