### PR TITLE
Change the source used to generate lists of teams

### DIFF
--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -23,7 +23,7 @@ case class Competition(
 
   lazy val matchDates = matches.map(_.date.toDateMidnight).distinct
 
-  lazy val teams = matches.flatMap { m => Seq(m.homeTeam, m.awayTeam) }.distinctBy(_.id).sortBy(_.name)
+  lazy val teams = leagueTable.map(_.team).sortBy(_.name)
 
   lazy val descriptionFullyLoaded = startDate.isDefined
 }


### PR DESCRIPTION
This corrects the lists displayed at /football/teams which was previously showing teams in the wrong leagues and in multiple leagues at once.

Before (there are 23 premier league teams and many teams appear in multiple leagues (e.g. QPR)
![bad-teams](https://f.cloud.github.com/assets/29761/1994210/e4818f9e-84e8-11e3-99f5-d9493fea0895.png)

and after the fix, correct leagues
![fixed-teams](https://f.cloud.github.com/assets/29761/1994211/ebc70f5e-84e8-11e3-85ac-b0948b06d243.png)
