### PR TITLE
Align local nav border with other containers on desktop

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -146,13 +146,13 @@
     .nav__item:last-child .nav__link { border-right: none; }
 }
 
+
 /* Local navigation
    ========================================================================== */
 
 .localnav-container {
     display: none;
     background-color: #ffffff;
-    border-bottom: 1px solid $c-neutral6;
 
     @include mq(tablet) {
         display: block;
@@ -164,14 +164,12 @@
     height: 52px;
     overflow: hidden;
     padding: 0;
-    margin: 0 $gs-gutter/2;
+    margin: 0 $gs-gutter;
+    border-bottom: 1px solid $c-neutral6;
 
-    @include mq(mobileLandscape) {
-        margin-left: $gs-gutter;
-        margin-right: $gs-gutter;
+    @include mq(tablet) {
+        display: block;
     }
-
-    @include mq(tablet) { display: block; }
 
     .nav__item {
         float: left;
@@ -201,7 +199,6 @@
 
     .nav__item:first-child .nav__link { padding-left: 0; }
 }
-
 
 .localnav--small {
     background-color: #fff;


### PR DESCRIPTION
(look closely at the grey borders)
## Before

(first line is longer than the second)

![screen shot 2014-01-24 at 13 15 07](https://f.cloud.github.com/assets/85783/1994917/98587248-84f9-11e3-91a4-d5645067777a.PNG)
## After

(both lines are aligned)

![screen shot 2014-01-24 at 13 14 59](https://f.cloud.github.com/assets/85783/1994918/9b1cd1fe-84f9-11e3-8e87-68dec089cd9a.PNG)

![ ](http://media.giphy.com/media/UE23INMuQtGGk/giphy.gif)
