### PR TITLE
Remove unnecessary variables in detect spec test

### DIFF
--- a/common/test/assets/javascripts/spec/Detect.spec.js
+++ b/common/test/assets/javascripts/spec/Detect.spec.js
@@ -1,8 +1,5 @@
 define(['common/utils/detect', 'bonzo'], function(detect, bonzo) {
 
-    var windowWidth = window.innerWidth,
-        windowHeight = window.innerHeight;
-
     describe("Breakpoint", function() {
 
         it("should default to 'mobile' breakpoint", function(){


### PR DESCRIPTION
Found that while looking at how to call detect.getBreakpoint.

![ ](http://2.bp.blogspot.com/-U5M5RStqDOA/UtOJAUrjhUI/AAAAAAABFBI/zYs_Tzs_NwU/s1600/A+pussy+getting+head.gif)
