### PR TITLE
Facia tool: batch edits

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -86,10 +86,10 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     request.body.asJson flatMap (_.asOpt[Map[String, UpdateList]]) map {
       case update: Map[String, UpdateList] => {
         val identity: Identity = Identity(request).get
-        update.flatMap {
+        update.collect {
           case (verb, updateList) if verb == "update" => UpdateActions.updateCollectionList(updateList.id, updateList, identity)
           case (verb, updateList) if verb == "delete" => UpdateActions.updateCollectionFilter(updateList.id, updateList, identity)
-        }
+        }.flatten
         Ok
       }
       case _ => NotFound

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -87,8 +87,8 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
       case update: Map[String, UpdateList] => {
         val identity: Identity = Identity(request).get
         update.flatMap {
-          case (verb, updateList) if verb == "update" => UpdateActions.updateCollectionList(id, updateList, identity)
-          case (verb, updateList) if verb == "delete" => UpdateActions.updateCollectionFilter(id, updateList, identity)
+          case (verb, updateList) if verb == "update" => UpdateActions.updateCollectionList(updateList.id, updateList, identity)
+          case (verb, updateList) if verb == "delete" => UpdateActions.updateCollectionFilter(updateList.id, updateList, identity)
         }
         Ok
       }

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -92,7 +92,10 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
           case (verb, updateList) if verb == "update" => UpdateActions.updateCollectionList(updateList.id, updateList, identity)
           case (verb, updateList) if verb == "remove" => UpdateActions.updateCollectionFilter(updateList.id, updateList, identity)
         }.flatten.map(b => (b.id, b)).toMap
-        Ok(Json.toJson(updatedCollections)).as("application/json")
+        if (updatedCollections.nonEmpty)
+          Ok(Json.toJson(updatedCollections)).as("application/json")
+        else
+          NotFound
       }
       case _ => NotFound
     } getOrElse NotFound

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -88,7 +88,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
         val identity: Identity = Identity(request).get
         update.collect {
           case (verb, updateList) if verb == "update" => UpdateActions.updateCollectionList(updateList.id, updateList, identity)
-          case (verb, updateList) if verb == "delete" => UpdateActions.updateCollectionFilter(updateList.id, updateList, identity)
+          case (verb, updateList) if verb == "remove" => UpdateActions.updateCollectionFilter(updateList.id, updateList, identity)
         }.flatten
         Ok
       }

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -81,7 +81,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     } getOrElse NotFound
   }
 
-  def updateBlock(id: String): Action[AnyContent] = AjaxExpiringAuthentication { request =>
+  def collectionEdits(): Action[AnyContent] = AjaxExpiringAuthentication { request =>
     FaciaToolMetrics.ApiUsageCount.increment()
     request.body.asJson flatMap (_.asOpt[Map[String, UpdateList]]) map {
       case update: Map[String, UpdateList] => {

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -96,19 +96,6 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     } getOrElse NotFound
   }
 
-  def deleteTrail(id: String) = AjaxExpiringAuthentication { request =>
-    FaciaToolMetrics.ApiUsageCount.increment()
-    request.body.asJson flatMap (_.asOpt[UpdateList]) map {
-      case update: UpdateList => {
-        val identity = Identity(request).get
-        UpdateActions.updateCollectionFilter(id, update, identity)
-        notifyContentApi(id)
-        Ok
-      }
-      case _ => NotFound
-    } getOrElse NotFound
-  }
-
   def notifyContentApi(id: String): Unit = {
     Configuration.faciatool.contentApiPostEndpoint map { postUrl =>
       val url = "%s/collection/%s".format(postUrl, id)

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -23,7 +23,7 @@ case class Trail(
                   )
 
 
-case class UpdateList(item: String, position: Option[String], after: Option[Boolean], itemMeta: Option[Map[String, JsValue]], live: Boolean, draft: Boolean)
+case class UpdateList(id: String, item: String, position: Option[String], after: Option[Boolean], itemMeta: Option[Map[String, JsValue]], live: Boolean, draft: Boolean)
 case class CollectionMetaUpdate(displayName: Option[String])
 
 trait UpdateActions {

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -35,8 +35,10 @@ trait UpdateActions {
   def getBlock(id: String): Option[Block] = FaciaApi.getBlock(id)
 
   def insertIntoLive(update: UpdateList, block: Block): Block =
-    if (update.live)
-      block.copy(live=updateList(update, block.live))
+    if (update.live) {
+      val live = updateList(update, block.live)
+      block.copy(live=live, draft=block.draft.filter(_ != live))
+    }
     else
       block
 

--- a/facia-tool/app/views/fronts.scala.html
+++ b/facia-tool/app/views/fronts.scala.html
@@ -96,6 +96,22 @@
                 css: {collapsed: state.collapsed() || configMeta.uneditable()}">
 
                 <div data-bind="visible: !state.editingConfig()">
+
+                    <span class="tools" data-bind="visible: state.hasDraft">
+                        <a class="draft-warning" data-bind="
+                            click: $root.setModeDraft,
+                            visible: $root.liveMode">
+                            <span class="tool draft-publish draft-warning">!</span>Draft Exists</a>
+
+                        <span data-bind="visible: !$root.liveMode()">
+                            <a class="tool draft-publish" data-bind="
+                                click: publishDraft">Publish</a>
+
+                            <a class="tool draft-discard" data-bind="
+                                click: discardDraft">Discard</a>
+                        </span >
+                    </span>
+
                     <span class="title" data-bind="
                         text: configMeta.displayName() || collectionMeta.displayName() || configMeta.roleName() || id"></span>
 
@@ -145,26 +161,11 @@
 
             </div>
 
-            <div data-bind="if: !state.collapsed()">
-                <div class="tools" data-bind="visible: state.hasDraft">
-                    <a class="draft-warning" data-bind="
-                        click: $root.setModeDraft,
-                        visible: $root.liveMode">
-                        <span class="tool draft-publish draft-warning">!</span>Unpublished edits exist</a>
-
-                    <div data-bind="visible: !$root.liveMode()">
-                        <a class="tool draft-publish" data-bind="
-                            click: publishDraft">Publish container</a>
-
-                        <a class="tool draft-discard" data-bind="
-                            click: discardDraft">Discard changes</a>
-                    </div>
-                </div>
-
+            <!-- ko if: !state.collapsed() -->
                 <div data-bind="
                     css: {'pending': isPending()},
                     template: {name: 'template_groups', foreach: groups}"></div>
-            </div>
+            <!-- /ko -->
         </div>
     </script>
 

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -22,7 +22,7 @@ POST          /collection/publish/*id    controllers.FaciaToolController.publish
 POST          /collection/discard/*id    controllers.FaciaToolController.discardCollection(id)
 
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
-POST          /collection/*id            controllers.FaciaToolController.updateBlock(id)
+POST          /edits                     controllers.FaciaToolController.collectionEdits
 GET           /collection                controllers.FaciaToolController.listCollections
 GET           /config                    controllers.FaciaToolController.getConfig
 

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -23,7 +23,6 @@ POST          /collection/discard/*id    controllers.FaciaToolController.discard
 
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
 POST          /collection/*id            controllers.FaciaToolController.updateBlock(id)
-DELETE        /collection/*id            controllers.FaciaToolController.deleteTrail(id)
 GET           /collection                controllers.FaciaToolController.listCollections
 GET           /config                    controllers.FaciaToolController.getConfig
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -135,7 +135,6 @@ a, a:hover {
 }
 
 .pending {
-    opacity: 0.7;
     pointer-events: none;
 }
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -571,12 +571,18 @@ button {
     margin-bottom: 20px;
 }
 
+.toolbar .tool,
+.article__overrides .tool,
+.collection-overrides .tool {
+    margin-top: 5px;
+}
+
 .tool-select {
     float: left;
     font-weight: bold;
     font-size: 16px;
     color: #000000;
-    margin-right: 15px;
+    margin: 4px 15px 0 0;
     width: 150px;
 }
 
@@ -587,7 +593,6 @@ button {
     font-size: 12px;
     line-height: 20px;
     color: #FFFFFF;
-    margin-top: 5px;
     border-radius: 2px;
     border: 0;
     cursor: pointer;

--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -221,7 +221,7 @@ define([
                             collections.push(sourceList.parent);
                         }
 
-                        authedAjax.updateCollection(edits, collections);
+                        authedAjax.updateCollections(edits, collections);
                     });
                 }, false);
             }

--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -186,6 +186,8 @@ define([
                             return;
                         }
 
+                        targetList.parent.closeAllArticles();
+
                         itemMeta = sourceItem && sourceItem.meta ? sourceItem.meta : {};
 
                         if (targetList.parent.groups && targetList.parent.groups.length > 1) {

--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -164,7 +164,6 @@ define([
                     })
                     .done(function() {
                         var edits = {},
-                            collections = [],
                             itemMeta;
 
                         ophanApi.decorateItems([article]);
@@ -197,7 +196,7 @@ define([
                         }
 
                         edits.update = {
-                            id: targetList.parent.id,
+                            collection: targetList.parent,
                             item:     id,
                             position: position,
                             after:    isAfter,
@@ -205,7 +204,6 @@ define([
                             draft:   !vars.state.liveMode(),
                             itemMeta: _.isEmpty(itemMeta) ? undefined : itemMeta
                         };
-                        collections.push(targetList.parent);
 
                         // Is a delete also required?
                         if (sourceList &&
@@ -214,16 +212,17 @@ define([
                            !sourceList.keepCopy) {
 
                             removeMatchingItems(sourceList, id);
+
                             edits.remove = {
+                                collection: sourceList.parent,
                                 id:     sourceList.parent.id,
                                 item:   id,
                                 live:   vars.state.liveMode(),
                                 draft: !vars.state.liveMode()
                             };
-                            collections.push(sourceList.parent);
                         }
 
-                        authedAjax.updateCollections(edits, collections);
+                        authedAjax.updateCollections(edits);
                     });
                 }, false);
             }

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -213,17 +213,17 @@ define([
             }
 
             if (this.parentType === 'Collection') {
-                authedAjax.updateCollection(
-                    'post',
-                    this.parent,
-                    {
+                authedAjax.updateCollection({
+                    update: {
+                        id:       this.parent.id,
                         item:     self.props.id(),
                         position: self.props.id(),
                         itemMeta: self.getMeta(),
                         live:     vars.state.liveMode(),
                         draft:   !vars.state.liveMode()
                     }
-                );
+                }, [this.parent]);
+
                 this.parent.setPending(true);
             }
         };

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -200,11 +200,7 @@ define([
         };
 
         Article.prototype._save = function() {
-            var self = this;
-
-            if (!this.parent) {
-                return;
-            }
+            if (!this.parent) { return; }
 
             if (this.parentType === 'Article') {
                 this.parent._save();
@@ -215,14 +211,14 @@ define([
             if (this.parentType === 'Collection') {
                 authedAjax.updateCollections({
                     update: {
-                        id:       this.parent.id,
-                        item:     self.props.id(),
-                        position: self.props.id(),
-                        itemMeta: self.getMeta(),
-                        live:     vars.state.liveMode(),
-                        draft:   !vars.state.liveMode()
+                        collection: this.parent,
+                        item:       this.props.id(),
+                        position:   this.props.id(),
+                        itemMeta:   this.getMeta(),
+                        live:       vars.state.liveMode(),
+                        draft:     !vars.state.liveMode()
                     }
-                }, [this.parent]);
+                });
 
                 this.parent.setPending(true);
             }

--- a/facia-tool/public/javascripts/models/article.js
+++ b/facia-tool/public/javascripts/models/article.js
@@ -213,7 +213,7 @@ define([
             }
 
             if (this.parentType === 'Collection') {
-                authedAjax.updateCollection({
+                authedAjax.updateCollections({
                     update: {
                         id:       this.parent.id,
                         item:     self.props.id(),

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -167,8 +167,6 @@ define([
                 self.collectionMeta.updatedBy(raw.updatedEmail === config.email ? 'you' : raw.updatedBy);
                 self.state.timeAgo(self.getTimeAgo(raw.lastUpdated));
             }
-
-            self.state.hasDraft(_.isArray(raw.draft));
         })
         .fail(function() {
             self.setPending(false);
@@ -185,12 +183,13 @@ define([
         var self = this,
             list;
 
+        this.setPending(false);
+
         raw = raw ? raw : this.raw;
         this.raw = raw;
+        if (!raw) { return; }
 
-        if (!raw) {
-            return;
-        }
+        this.state.hasDraft(_.isArray(raw.draft));
 
         if (this.hasOpenArticles()) {
             this.state.hasConcurrentEdits(raw.updatedEmail !== config.email && self.state.lastUpdated());
@@ -219,6 +218,8 @@ define([
         this.state.count(list.length);
 
         this.decorate();
+
+        return this;
     };
 
     Collection.prototype.closeAllArticles = function() {

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -122,20 +122,15 @@ define([
     };
 
     Collection.prototype.drop = function(item) {
-        var self = this;
-
-        self.setPending(true);
+        this.setPending(true);
 
         authedAjax.updateCollections({
             remove: {
-                id:     self.id,
-                item:   item.props.id(),
-                live:   vars.state.liveMode(),
-                draft: !vars.state.liveMode()
+                collection: this,
+                item:       item.props.id(),
+                live:       vars.state.liveMode(),
+                draft:     !vars.state.liveMode()
             }
-        }, [self])
-        .then(function() {
-            self.load();
         });
     };
 

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -126,15 +126,14 @@ define([
 
         self.setPending(true);
 
-        authedAjax.request({
-            type: 'delete',
-            url: vars.CONST.apiBase + '/collection/' + self.id,
-            data: JSON.stringify({
-                item: item.props.id(),
+        authedAjax.updateCollection({
+            remove: {
+                id:     self.id,
+                item:   item.props.id(),
                 live:   vars.state.liveMode(),
                 draft: !vars.state.liveMode()
-            })
-        })
+            }
+        }, [self])
         .then(function() {
             self.load();
         });

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -213,8 +213,6 @@ define([
         this.state.count(list.length);
 
         this.decorate();
-
-        return this;
     };
 
     Collection.prototype.closeAllArticles = function() {

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -159,7 +159,7 @@ define([
             self.state.hasConcurrentEdits(false);
 
             if (raw.lastUpdated !== self.state.lastUpdated()) {
-                self.populateLists(raw);
+                self.populate(raw);
             }
 
             if (!self.state.editingConfig()) {
@@ -181,7 +181,7 @@ define([
         }, false);
     };
 
-    Collection.prototype.populateLists = function(raw) {
+    Collection.prototype.populate = function(raw) {
         var self = this,
             list;
 

--- a/facia-tool/public/javascripts/models/collection.js
+++ b/facia-tool/public/javascripts/models/collection.js
@@ -126,7 +126,7 @@ define([
 
         self.setPending(true);
 
-        authedAjax.updateCollection({
+        authedAjax.updateCollections({
             remove: {
                 id:     self.id,
                 item:   item.props.id(),

--- a/facia-tool/public/javascripts/models/list-manager.js
+++ b/facia-tool/public/javascripts/models/list-manager.js
@@ -154,7 +154,7 @@ define([
         model.liveMode.subscribe(function() {
             _.each(model.collections(), function(collection) {
                 collection.closeAllArticles();
-                collection.populateLists();
+                collection.populate();
             });
         });
 

--- a/facia-tool/public/javascripts/modules/authed-ajax.js
+++ b/facia-tool/public/javascripts/modules/authed-ajax.js
@@ -23,10 +23,13 @@ define(['modules/vars'], function(vars) {
             type: 'POST',
             data: JSON.stringify(edits)
         }).fail(function(xhr) {
-            window.console.log(['Failed: ', xhr.status, xhr.statusText, JSON.stringify(edits)].join(' '));
-        }).always(function() {
             _.each(collections, function(collection) {
                 collection.load();
+            });
+            window.console.log(['Failed: ', xhr.status, xhr.statusText, JSON.stringify(edits)].join(' '));
+        }).done(function(resp) {
+            _.each(collections, function(collection) {
+                collection.populate(resp[collection.id]);
             });
         });
     }

--- a/facia-tool/public/javascripts/modules/authed-ajax.js
+++ b/facia-tool/public/javascripts/modules/authed-ajax.js
@@ -13,9 +13,14 @@ define(['modules/vars'], function(vars) {
         });
     }
 
-    function updateCollections(edits, collections) {
-        _.each(collections, function(collection) {
-            collection.setPending(true);
+    function updateCollections(edits) {
+        var collections = [];
+
+        _.each(edits, function(edit) {
+            edit.collection.setPending(true);
+            edit.id = edit.collection.id;
+            collections.push(edit.collection);
+            delete edit.collection;
         });
 
         return request({
@@ -23,14 +28,9 @@ define(['modules/vars'], function(vars) {
             type: 'POST',
             data: JSON.stringify(edits)
         }).fail(function(xhr) {
-            _.each(collections, function(collection) {
-                collection.load();
-            });
-            window.console.log(['Failed: ', xhr.status, xhr.statusText, JSON.stringify(edits)].join(' '));
+            _.each(collections, function(collection) { collection.load(); });
         }).done(function(resp) {
-            _.each(collections, function(collection) {
-                collection.populate(resp[collection.id]);
-            });
+            _.each(collections, function(collection) { collection.populate(resp[collection.id]); });
         });
     }
 

--- a/facia-tool/public/javascripts/modules/authed-ajax.js
+++ b/facia-tool/public/javascripts/modules/authed-ajax.js
@@ -13,17 +13,21 @@ define(['modules/vars'], function(vars) {
         });
     }
 
-    function updateCollection(method, collection, data) {
-        collection.setPending(true);
+    function updateCollection(edits, collections) {
+        _.each(collections, function(collection) {
+            collection.setPending(true);
+        });
 
         return request({
-            url: vars.CONST.apiBase + '/collection/' + collection.id,
-            type: method,
-            data: JSON.stringify(data)
+            url: vars.CONST.apiBase + '/edits',
+            type: 'POST',
+            data: JSON.stringify(edits)
         }).fail(function(xhr) {
-            window.console.log(['Failed', method.toUpperCase(), ":", xhr.status, xhr.statusText, JSON.stringify(data)].join(' '));
+            window.console.log(['Failed: ', xhr.status, xhr.statusText, JSON.stringify(edits)].join(' '));
         }).always(function() {
-            collection.load();
+            _.each(collections, function(collection) {
+                collection.load();
+            });
         });
     }
 

--- a/facia-tool/public/javascripts/modules/authed-ajax.js
+++ b/facia-tool/public/javascripts/modules/authed-ajax.js
@@ -13,7 +13,7 @@ define(['modules/vars'], function(vars) {
         });
     }
 
-    function updateCollection(edits, collections) {
+    function updateCollections(edits, collections) {
         _.each(collections, function(collection) {
             collection.setPending(true);
         });
@@ -33,6 +33,6 @@ define(['modules/vars'], function(vars) {
 
     return {
         request: request,
-        updateCollection: updateCollection
+        updateCollections: updateCollections
     };
 });


### PR DESCRIPTION
To make future "front pressing" more atomic, batch the previously separate 'update' & 'remove' api requests that get triggered when an item is dragged between collections. 

Also, return the amended collection(s) in the response, and use them immediately in the frontend - rather than re-requesting them individually. Makes the UI much snappier. 
