### PR TITLE
Container titles are deported to the left at wide breakpoint

### DIFF
--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -140,3 +140,12 @@
 .u-underline {
     text-decoration: underline;
 }
+
+
+/**
+ * Prevent line breaks
+ */
+
+.u-nobr {
+    white-space: nowrap;
+}

--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -25,6 +25,42 @@
     @include mq(desktop) {
         @include rem((width: gs-span(12)));
     }
+    @include mq(wide) {
+        @include rem((width: gs-span(16)));
+        .container {
+            padding-left: (gs-span(4) + $gs-gutter);
+        }
+        .container__title {
+            margin-left: (gs-span(4) + $gs-gutter) * -1;
+        }
+        .container__title__label {
+            display: block;
+            max-width: (gs-span(3) + $gs-gutter);
+        }
+        .container__toggle {
+            right: (gs-span(12) + $gs-gutter);
+            min-width: 40px;
+        }
+        .collection {
+            margin-top: -42px;
+        }
+        .container--news {
+            .container__title {
+                display: block;
+            }
+            .collection {
+                margin-top: 0;
+            }
+            .container__title:first-child + .collection-wrapper {
+                margin-top: -52px;
+
+                .fromage,
+                .fromage__container {
+                    border-top-width: 0;
+                }
+            }
+        }
+    }
 }
 
 @import "module/facia/_extends";

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -1,4 +1,9 @@
 .container--news {
+    .container__title {
+        display: none;
+        color: $c-neutral1;
+        margin-bottom: 0;
+    }
     .item {
         display: block;
         margin-top: 0;
@@ -293,4 +298,11 @@
     &.show-more--hidden:before {
         display: none;
     }
+}
+
+.today {
+    color: $c-neutral2;
+}
+.today__dayofweek {
+    color: $c-neutral1;
 }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -18,22 +18,25 @@ $c-live: #e81818;
     }
 }
 .container__title {
-    @include f-header;
-}
-.container__title {
-    @include fs-header(5, $size-only: true);
+    @include fs-header(5);
     border-top-style: solid;
     border-top-color: $c-newsAccent;
-    padding: $gs-baseline/3 $gs-gutter/5;
     border-top-width: $gs-baseline/3;
+    @include rem((
+        padding: $gs-baseline/3 $gs-gutter/5,
+        min-height: gs-height(1) - $gs-baseline*(2/3)
+    ));;
     background-color: $c-newsDefault;
-    min-height: gs-height(1) - $gs-baseline*(2/3);
     color: #ffffff;
 
     @include mq(tablet) {
         min-height: 0;
-        padding: 0;
-        margin-bottom: $gs-baseline;
+        padding-left: 0;
+        padding-right: 0;
+        @include rem((
+            padding-top: $gs-baseline/6,
+            margin-bottom: $gs-baseline
+        ));
         border-top-width: $item-top-border-height;
         background-color: transparent !important;
         line-height: 1em;
@@ -94,11 +97,16 @@ $c-live: #e81818;
         }
     }
     @include mq(tablet) {
+        top: $gs-baseline/2;
         text-align: right;
         color: $c-neutral2;
 
         i {
             display: none;
+        }
+        &:hover,
+        &:focus {
+            color: $c-neutral1;
         }
     }
 }

--- a/common/app/views/fragments/containers/comment.scala.html
+++ b/common/app/views/fragments/containers/comment.scala.html
@@ -12,9 +12,9 @@
                 @title.map { title =>
                     <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                         @config.href.map { href =>
-                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                            <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
                         }.getOrElse{
-                            @Html(title)
+                            <span class="container__title__label u-text-hyphenate">@Html(title)</span>
                         }
                     </h2>
                 }

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -12,9 +12,9 @@
                 @title.map { title =>
                     <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                         @config.href.map { href =>
-                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                            <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
                         }.getOrElse{
-                            @Html(title)
+                            <span class="container__title__label u-text-hyphenate">@Html(title)</span>
                         }
                     </h2>
                 }

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -1,5 +1,7 @@
 @(config: Config, collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
+@import org.joda.time.DateTime
+
 @defining(config.displayName.orElse(collection.displayName)) { title =>
 
     @defining(templateDeduping(8, collection.items)) { items =>
@@ -11,20 +13,11 @@
 
                 <div class="container__title">
                     <span class="container__title__label today u-text-hyphenate">
-                        <script>
-                            var today = new Date(),
-                                weekday = new Array('Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'),
-                                dayOfWeek = weekday[today.getDay()],
-                                months = new Array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'),
-                                curMonth = months[today.getMonth()],
-                                curYear = today.getFullYear(),
-                                dayOfMonth = today.getDate();
-                        </script>
-                        <span class="today__dayofweek"><script>document.write(dayOfWeek)</script></span>
+                        <span class="today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</span>
                         <span class="u-nobr">
-                            <span class="today__dayofmonth"><script>document.write(dayOfMonth)</script></span>
-                            <span class="today__month"><script>document.write(curMonth)</script></span>
-                            <span class="today__year"><script>document.write(curYear)</script></span>
+                            <span class="today__dayofmonth js-dayofmonth">@Format(DateTime.now(), "d")</span>
+                            <span class="today__month">@Format(DateTime.now(), "MMMM")</span>
+                            <span class="today__year">@Format(DateTime.now(), "yyyy")</span>
                         </span>
                     </span>
                 </div>

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -9,15 +9,25 @@
                      data-id="@config.id"
                      data-type="@style.containerType">
 
-                @title.map { title =>
-                    <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
-                        @config.href.map { href =>
-                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                        }.getOrElse{
-                            @Html(title)
-                        }
-                    </h2>
-                }
+                <div class="container__title">
+                    <span class="container__title__label today u-text-hyphenate">
+                        <script>
+                            var today = new Date(),
+                                weekday = new Array('Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'),
+                                dayOfWeek = weekday[today.getDay()],
+                                months = new Array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'),
+                                curMonth = months[today.getMonth()],
+                                curYear = today.getFullYear(),
+                                dayOfMonth = today.getDate();
+                        </script>
+                        <span class="today__dayofweek"><script>document.write(dayOfWeek)</script></span>
+                        <span class="u-nobr">
+                            <span class="today__dayofmonth"><script>document.write(dayOfMonth)</script></span>
+                            <span class="today__month"><script>document.write(curMonth)</script></span>
+                            <span class="today__year"><script>document.write(curYear)</script></span>
+                        </span>
+                    </span>
+                </div>
 
                 @fragments.collections.rowPattern(config, items, style, containerIndex)
 

--- a/common/app/views/fragments/containers/section.scala.html
+++ b/common/app/views/fragments/containers/section.scala.html
@@ -12,9 +12,9 @@
                 @title.map { title =>
                     <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                         @config.href.map { href =>
-                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                            <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
                         }.getOrElse{
-                            @Html(title)
+                            <span class="container__title__label u-text-hyphenate">@Html(title)</span>
                         }
                     </h2>
                 }

--- a/common/app/views/fragments/containers/sport.scala.html
+++ b/common/app/views/fragments/containers/sport.scala.html
@@ -12,9 +12,9 @@
                 @title.map { title =>
                     <h2 class="container__title tone-@style.tone tone-background tone-accent-border">
                         @config.href.map { href =>
-                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                            <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
                         }.getOrElse{
-                            @Html(title)
+                            <span class="container__title__label u-text-hyphenate">@Html(title)</span>
                         }
                     </h2>
                 }


### PR DESCRIPTION
The way the date is displayed is really very dirty (document.write ftw!). If that's an issue I'm happy to revisit it but we need it to appear as quickly as possible and not to pop into the user's face. Server side is an option but is not very global. Maybe per-edition date (although US has many timezones… so which to chose?).

![screencapture-localhost-9000-uk](https://f.cloud.github.com/assets/85783/2019153/9cd588d4-881d-11e3-8f05-c035e07ee62a.png)

![ ](http://media.giphy.com/media/gzF11hEJtMq9W/giphy.gif)
