### PR TITLE
Change expired content copy

### DIFF
--- a/common/app/views/expired.scala.html
+++ b/common/app/views/expired.scala.html
@@ -5,7 +5,7 @@
         <article id="article" class="article" itemprop="mainContentOfPage" role="main">
             <div class="article__inner article__inner--head">
                 <header class="article__head">
-                    <h1 class="article__headline ">Sorry - the page you are looking for has been removed</h1>
+                    <h1 class="article__headline ">Sorry - this page has been removed.</h1>
                 </header>
             </div>
             <div class="article__columning-wrapper">
@@ -13,12 +13,12 @@
                     <div class="js-article__container article__container u-cf">
                         <div class="article-body from-content-api" itemprop="articleBody">
                             <div class="from-content-api">
-                                <p>This may be because of a legal objection, a rights consideration or for another reason. If you would like to contact someone about the page, you could email:
-                                    <ul>
-                                        <li>The reader&apos;s editor: <a  href="mailto:reader@@theguardian.com">reader@@theguardian.com</a> </li>
-                                        <li>User help: <a  href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a> </li>
-                                    </ul>
-                                </p>
+                                <p>This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.<p>
+                                <p>For further information, please contact:</p>
+                                <ul>
+                                    <li>The Readers&apos; editor: <a  href="mailto:reader@@theguardian.com">reader@@theguardian.com</a> </li>
+                                    <li>Userhelp: <a  href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a> </li>
+                                </ul>
                             </div>
                         </div>
                     </div>

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -536,7 +536,7 @@ object VisualTone {
 }
 
 object RenderOtherStatus {
-  def gonePage(implicit request: RequestHeader) = model.Page(request.path, "news", "Gone", "GFE:Gone")
+  def gonePage(implicit request: RequestHeader) = model.Page(request.path, "news", "This page has been removed", "GFE:Gone")
   def apply(result: SimpleResult)(implicit request: RequestHeader) = result.header.status match {
     case 404 => NoCache(NotFound)
     case 410 if request.isJson => Cached(60)(JsonComponent(gonePage, "status" -> "GONE"))


### PR DESCRIPTION
This simply changes the title and copy for the 410 expired content page as per request from Katherine Le Ruez.

/cc @gklopper @cantlin 

![screenshot from 2014-01-29 10 02 42](https://f.cloud.github.com/assets/80089/2028358/091996a2-88cd-11e3-8515-ea6bd896e2a4.png)
