### PR TITLE
No longer automatically add edition to every Ajax request

### DIFF
--- a/common/app/assets/javascripts/modules/navigation/top-stories.js
+++ b/common/app/assets/javascripts/modules/navigation/top-stories.js
@@ -2,12 +2,14 @@ define([
     'common/common',
     'common/utils/ajax',
     'bonzo',
-    'common/modules/lazyload'
+    'common/modules/lazyload',
+    'common/utils/config'
 ], function (
     common,
     ajax,
     bonzo,
-    LazyLoad
+    LazyLoad,
+    config
 ) {
 
     function TopStories() {
@@ -16,7 +18,7 @@ define([
 
         this.load = function (config, context) {
 
-            var url = '/top-stories/trails.json?page-size=10&view=link',
+            var url = '/top-stories/trails.json?page-size=10&view=link&_edition=' + config.page.edition,
                 container = context.querySelector('.nav-popup-topstories');
 
             if(container) {

--- a/common/app/assets/javascripts/utils/ajax.js
+++ b/common/app/assets/javascripts/utils/ajax.js
@@ -12,16 +12,8 @@ define([
         throw new Error("Edition has not been initialised yet");
     };
 
-    function appendEdition(params) {
-        var delimiter = params.url.indexOf('?') > -1 ? '&' : '?';
-        params.url = params.url + delimiter + '_edition=' + edition;
-        return params;
-    }
 
     function ajax(params) {
-
-        params = appendEdition(params);
-
         if (!params.url.match('^https?://')) {
             params.url = makeAbsolute(params.url);
         }

--- a/common/test/assets/javascripts/spec/Ajax.spec.js
+++ b/common/test/assets/javascripts/spec/Ajax.spec.js
@@ -18,43 +18,27 @@ define(['common/common', 'common/utils/ajax'], function (common, ajax) {
             ajax.reqwest.restore();
         });
 
-        it("should add the edition as an additional query parameter to the url", function () {
-            // added to existing list of parameters
-            ajax({
-                url: "http://apis.guardian.co.uk/test-url?a=b"
-            });
-            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("http://apis.guardian.co.uk/test-url?a=b&_edition=UK");
-        });
-
-        it("should add the edition as the first query parameter to the url", function () {
-            // added as first parameter
-            ajax({
-                url: "http://apis.guardian.co.uk/test-url"
-            });
-            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("http://apis.guardian.co.uk/test-url?_edition=UK");
-        });
-
         it("should proxy calls to reqwest", function () {
             expect(ajax.reqwest.callCount).toBe(0);
             ajax({
                 url: "/foo"
             });
             expect(ajax.reqwest.callCount).toBe(1);
-            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("http://m.guardian.co.uk/foo?_edition=UK");
+            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("http://m.guardian.co.uk/foo");
         });
 
         it("should not touch a url that is already absolute", function () {
             ajax({
                 url: "http://apis.guardian.co.uk/test-url"
             });
-            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("http://apis.guardian.co.uk/test-url?_edition=UK");
+            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("http://apis.guardian.co.uk/test-url");
         });
 
         it("should not touch a url that is already absolute (https)", function () {
             ajax({
                 url: "https://apis.guardian.co.uk/test-url"
             });
-            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("https://apis.guardian.co.uk/test-url?_edition=UK");
+            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("https://apis.guardian.co.uk/test-url");
         });
     });
 

--- a/common/test/assets/javascripts/spec/CommercialLoader.spec.js
+++ b/common/test/assets/javascripts/spec/CommercialLoader.spec.js
@@ -72,7 +72,7 @@
        
 
         it("Passes section and keyword to a travel component from the commercial server", function() {
-            server.respondWith("/commercial/travel/offers.json?seg=new&s=s&k=a&k=b&k=c&_edition=UK", [200, {}, '{ "html": "<b>advert</b>" }']);
+            server.respondWith("/commercial/travel/offers.json?seg=new&s=s&k=a&k=b&k=c", [200, {}, '{ "html": "<b>advert</b>" }']);
             runs(function() {
                 new CommercialComponent(options).travel(adSlot);
             });
@@ -93,7 +93,7 @@
             // a repeat user
             localStorage.setItem('gu.history', history)
             
-            server.respondWith("/commercial/masterclasses.json?seg=repeat&s=s&_edition=UK", [200, {}, '{ "html": "<b>advert</b>" }']);
+            server.respondWith("/commercial/masterclasses.json?seg=repeat&s=s", [200, {}, '{ "html": "<b>advert</b>" }']);
             runs(function() {
                 new CommercialComponent(options).masterclasses(adSlot);
             });
@@ -108,7 +108,7 @@
         
         // OAS can inject a url in to the advert code to track clicks on the component 
         it("Injects an OAS tracker URL in to the response", function() {
-            server.respondWith("/commercial/jobs.json?seg=new&s=s&k=a&k=b&k=c&_edition=UK", [200, {}, '{ "html": "<b>%OASToken% - %OASToken%</b>" }']);
+            server.respondWith("/commercial/jobs.json?seg=new&s=s&k=a&k=b&k=c", [200, {}, '{ "html": "<b>%OASToken% - %OASToken%</b>" }']);
             runs(function() {
                 options.oastoken = '123';
                 new CommercialComponent(options).jobs(adSlot);

--- a/common/test/assets/javascripts/spec/FootballTables.spec.js
+++ b/common/test/assets/javascripts/spec/FootballTables.spec.js
@@ -42,7 +42,7 @@ define(['common/common', 'common/utils/ajax',  'qwery', 'common/modules/sport/fo
         // json test needs to be run asynchronously
         it("should request the given competitions from the tables api", function(){
 
-            server.respondWith('/football/api/competitiontable.json?&competitionId=100&_edition=UK', [200, {}, '{ "html": "<p>foo</p>" }']);
+            server.respondWith('/football/api/competitiontable.json?&competitionId=100', [200, {}, '{ "html": "<p>foo</p>" }']);
 
             runs(function(){
                 new FootballTable({
@@ -58,7 +58,7 @@ define(['common/common', 'common/utils/ajax',  'qwery', 'common/modules/sport/fo
 
         xit("should prepend a succesful table request to the DOM", function() {
 
-            server.respondWith('/football/api/competitiontable.json?&competitionId=100&_edition=UK', [200, {}, '{ "html": "<p>foo</p>" }']);
+            server.respondWith('/football/api/competitiontable.json?&competitionId=100', [200, {}, '{ "html": "<p>foo</p>" }']);
 
             runs(function(){
                 new FootballTable({
@@ -76,7 +76,7 @@ define(['common/common', 'common/utils/ajax',  'qwery', 'common/modules/sport/fo
 
         it("should fail silently if no response is returned from table request", function() {
 
-            server.respondWith('/football/api/competitiontable?&competitionId=100&_edition=UK', [200, {}, '{ "html": "<p>foo</p>" }']);
+            server.respondWith('/football/api/competitiontable?&competitionId=100', [200, {}, '{ "html": "<p>foo</p>" }']);
 
             runs(function(){
                 new FootballTable({

--- a/common/test/assets/javascripts/spec/Popular.spec.js
+++ b/common/test/assets/javascripts/spec/Popular.spec.js
@@ -28,7 +28,7 @@ define(['common/common', 'bonzo', 'common/utils/ajax', 'common/modules/onward/po
         it("should request the most popular feed and graft it on to the dom", function(){
 
             var section = 'culture';
-            server.respondWith('/most-read/' + section + '.json?_edition=UK', [200, {}, '{ "html": "<b>popular</b>" }']);
+            server.respondWith('/most-read/' + section + '.json', [200, {}, '{ "html": "<b>popular</b>" }']);
 
             appendTo = document.querySelector('.js-popular');
 
@@ -47,7 +47,7 @@ define(['common/common', 'bonzo', 'common/utils/ajax', 'common/modules/onward/po
 
         it('should not pass section if section is "global"', function(){
 
-            server.respondWith('/most-read.json?_edition=UK', [200, {}, '{ "html": "<b>popular</b>" }']);
+            server.respondWith('/most-read.json', [200, {}, '{ "html": "<b>popular</b>" }']);
 
             appendTo = document.querySelector('.js-popular');
 

--- a/common/test/assets/javascripts/spec/Related.spec.js
+++ b/common/test/assets/javascripts/spec/Related.spec.js
@@ -32,7 +32,7 @@ define(['common/common', 'common/utils/ajax', 'common/modules/onward/related', '
 
             var pageId = 'some/news';
 
-            server.respondWith('/related/' + pageId + '.json?_edition=UK', [200, {}, '{ "html": "<b>1</b>" }']);
+            server.respondWith('/related/' + pageId + '.json', [200, {}, '{ "html": "<b>1</b>" }']);
 
             appendTo = document.querySelector('.js-related');
 

--- a/common/test/assets/javascripts/spec/Sequence.spec.js
+++ b/common/test/assets/javascripts/spec/Sequence.spec.js
@@ -30,7 +30,7 @@ define(['common/utils/mediator', 'common/utils/ajax', 'common/modules/onward/seq
             server = sinon.fakeServer.create();
             server.autoRespond = true;
             server.autoRespondAfter = 20;
-            server.respondWith('/uk/news.json?_edition=UK', [200, {}, response]);
+            server.respondWith('/uk/news.json', [200, {}, response]);
             //Set up storage
             setStorageItem('context.path', 'uk/news', 'sessionStorage');
             setStorageItem('context.name', 'uk news', 'sessionStorage');
@@ -65,7 +65,7 @@ define(['common/utils/mediator', 'common/utils/ajax', 'common/modules/onward/seq
             server = sinon.fakeServer.create();
             server.autoRespond = true;
             server.autoRespondAfter = 20;
-            server.respondWith('/most-read/sport.json?_edition=UK', [200, {}, response]);
+            server.respondWith('/most-read/sport.json', [200, {}, response]);
 
             runs(function() {
                 sequence.init();

--- a/common/test/assets/javascripts/spec/identity/Api.spec.js
+++ b/common/test/assets/javascripts/spec/identity/Api.spec.js
@@ -72,7 +72,7 @@ define([
             Id.getUserFromApi(apiCallback);
 
             expect(apiCallback.getCall(0).args[0]).toBe(expectedUser);
-            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("https://idapi.theguardian.com/user/me?_edition=undefined");
+            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("https://idapi.theguardian.com/user/me");
             expect(ajax.reqwest.getCall(0).args[0]["type"]).toBe("jsonp");
             expect(ajax.reqwest.getCall(0).args[0]["crossOrigin"]).toBe(true);
         });
@@ -103,7 +103,7 @@ define([
             Id.getUserFromApi(apiCallback);
 
             expect(apiCallback.getCall(0).args[0]).toBe(expectedUser);
-            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("https://idapi.theguardian.com/user/me?_edition=undefined");
+            expect(ajax.reqwest.getCall(0).args[0]["url"]).toBe("https://idapi.theguardian.com/user/me");
             expect(ajax.reqwest.getCall(0).args[0]["type"]).toBe("jsonp");
             expect(ajax.reqwest.getCall(0).args[0]["crossOrigin"]).toBe(true);
         });

--- a/common/test/assets/javascripts/spec/onward/popular-fronts.spec.js
+++ b/common/test/assets/javascripts/spec/onward/popular-fronts.spec.js
@@ -47,7 +47,7 @@ define(['common/modules/onward/popular-fronts', 'bonzo', 'common/$', 'bean', 'he
 
         it('should call correct most-read endpoint', function() {
             var section = 'sport';
-            server.respondWith('/most-read/' + section + '.json?_edition=UK', [200, {}, response]);
+            server.respondWith('/most-read/' + section + '.json', [200, {}, response]);
             popular.render({
                 page: {
                     section: section


### PR DESCRIPTION
Once, long ago when we were young and innocent (now we are just young), the world seemed like a simple place and in our naivety we saw a time where everything was editionalised/editionalized and lived in harmony on 2 separate domains www.guardian.co.uk & www.guardiannews.com.

It came to pass that this was all utter bull$&%t and a lot less things were editionalised/editionalized than the legends foretold. However the valiant folk persisted in putting an edition parameter on all requests, thus diluting the one true cache.

One day a handsome prince came and slew the evil edition parameter and they all lived happily ever after.

The end.
