### PR TITLE
Fix indentiation and typo in public_profile.scala.html template

### DIFF
--- a/identity/app/views/public_profile.scala.html
+++ b/identity/app/views/public_profile.scala.html
@@ -58,7 +58,7 @@
                             }else{
                                 <i class="i i-id-alert"></i>
                                 <p class="form__note">
-                                    Please confirm your email address to post comments.<br>
+                                    Please confirm your email address to post comments.<br />
                                     <a class="js-id-send-validation-email" data-link-name="Resend verification email">Send validation email</a>
                                 </p>
                             }

--- a/identity/app/views/public_profile.scala.html
+++ b/identity/app/views/public_profile.scala.html
@@ -58,8 +58,8 @@
                             }else{
                                 <i class="i i-id-alert"></i>
                                 <p class="form__note">
-                                Please confirm your email address to post comments.</br>
-                                <a class="js-id-send-validation-email" data-link-name="Resend verification email">Send validation email</a>
+                                    Please confirm your email address to post comments.<br>
+                                    <a class="js-id-send-validation-email" data-link-name="Resend verification email">Send validation email</a>
                                 </p>
                             }
                         </li>


### PR DESCRIPTION
This pull request makes a small fix referred too in an earlier PR that didn't get addressed before the PR was merged;

The comment can be found here: https://github.com/guardian/frontend/pull/2910
