### PR TITLE
Fix content type in facia

### DIFF
--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -44,7 +44,7 @@ object GalleryController extends Controller with Logging with ExecutionContexts 
       .showExpired(true)
       .showFields("all")
       .response.map{response =>
-        val gallery = response.content.filter { _.isGallery } map { new Gallery(_) }
+        val gallery = response.content.filter { _.isGallery } map { Gallery(_) }
         val storyPackage = response.storyPackage map { Content(_) }
 
         val model = gallery map { g => GalleryPage(g, storyPackage.filterNot(_.id == g.id), index, isTrail) }

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -38,7 +38,7 @@ object InteractiveController extends Controller with Logging with ExecutionConte
       .response
 
     val result = response map { response =>
-      val interactive = response.content map { new Interactive(_) }
+      val interactive = response.content map { Interactive(_) }
       val storyPackage = response.storyPackage map { Content(_) }
 
       val model = interactive map { i => InteractivePage(i, storyPackage.filterNot(_.id == i.id), index, isTrail) }

--- a/applications/app/controllers/VideoController.scala
+++ b/applications/app/controllers/VideoController.scala
@@ -33,7 +33,7 @@ object VideoController extends Controller with Logging with ExecutionContexts {
 
     val result = response map { response =>
       val storyPackage = response.storyPackage map { Content(_) }
-      val videoOption = response.content filter { _.isVideo } map { new Video(_) }
+      val videoOption = response.content filter { _.isVideo } map { Video(_) }
       val model = videoOption map { video => VideoPage(video, storyPackage.filterNot(_.id == video.id)) }
 
       ModelOrResult(model, response)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -12,7 +12,9 @@ import views.support.StripHtmlTagsAndUnescapeEntities
 import com.gu.openplatform.contentapi.model.{Content => ApiContent,Element =>ApiElement}
 import play.api.libs.json.JsValue
 
-class Content protected (val delegate: ApiContent) extends Trail with MetaData {
+class Content protected (val apiContent: ApiContentWithMeta) extends Trail with MetaData {
+
+  lazy val delegate: ApiContent = apiContent.delegate
 
   lazy val publication: String = fields.get("publication").getOrElse("")
   lazy val lastModified: DateTime = fields("lastModified").parseISODateTime
@@ -51,9 +53,7 @@ class Content protected (val delegate: ApiContent) extends Trail with MetaData {
   // Inherited from Trail
   override lazy val webPublicationDate: DateTime = delegate.webPublicationDate
   override lazy val linkText: String = webTitle
-  override def headline: String = fields("headline")
   override lazy val url: String = SupportedUrl(delegate)
-  override def trailText: Option[String] = fields.get("trailText")
   override lazy val section: String = delegate.sectionId.getOrElse("")
   override lazy val sectionName: String = delegate.sectionName.getOrElse("")
   override lazy val thumbnailPath: Option[String] = fields.get("thumbnail").map(ImgSrc(_, Naked))
@@ -127,31 +127,39 @@ class Content protected (val delegate: ApiContent) extends Trail with MetaData {
   override def elements: Seq[Element] = delegate.elements
       .map(_.zipWithIndex.map{ case (element, index) =>  Element(element, index)})
       .getOrElse(Nil)
+
+  override lazy val headline: String = apiContent.metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(fields("headline"))
+  override lazy val trailText: Option[String] = apiContent.metaData.get("trailText").flatMap(_.asOpt[String]).orElse(fields.get("trailText"))
+  override lazy val group: Option[String] = apiContent.metaData.get("group").flatMap(_.asOpt[String])
+  override lazy val imageAdjust: Option[String] = apiContent.metaData.get("imageAdjust").flatMap(_.asOpt[String])
+  override lazy val isBreaking: Boolean = apiContent.metaData.get("isBreaking").flatMap(_.asOpt[Boolean]).getOrElse(false)
 }
 
 object Content {
 
-  def apply(delegate: ApiContent): Content = {
-    delegate match {
+  def apply(apiContent: ApiContentWithMeta): Content = {
+    apiContent.delegate match {
       // liveblog / article comes at the top of this list - it might be tagged with other types, but if so is treated as an article
-      case liveBlog if delegate.isLiveBlog => new LiveBlog(delegate)
-      case article if delegate.isArticle || delegate.isSudoku => new Article(delegate)
-      case gallery if delegate.isGallery => new Gallery(delegate)
-      case video if delegate.isVideo => new Video(delegate)
-      case picture if delegate.isImageContent => new ImageContent(delegate)
-      case _ => new Content(delegate)
+      case liveBlog if apiContent.delegate.isLiveBlog => new LiveBlog(apiContent)
+      case article if apiContent.delegate.isArticle || apiContent.delegate.isSudoku => new Article(apiContent)
+      case gallery if apiContent.delegate.isGallery => new Gallery(apiContent)
+      case video if apiContent.delegate.isVideo => new Video(apiContent)
+      case picture if apiContent.delegate.isImageContent => new ImageContent(apiContent)
+      case _ => new Content(apiContent)
     }
   }
 
   def apply(delegate: ApiContent, supporting: List[Content], metaData: Option[Map[String, JsValue]]): Content = {
     metaData match {
-      case Some(meta) => new ContentWithMetaData(delegate, supporting, meta)
-      case _ => apply(delegate)
+      case Some(meta) => apply(ApiContentWithMeta(delegate, supporting, meta))
+      case _ => apply(ApiContentWithMeta(delegate))
     }
   }
+
+  def apply(delegate: ApiContent): Content = apply(ApiContentWithMeta(delegate))
 }
 
-class Article(content: ApiContent) extends Content(content) {
+class Article(content: ApiContentWithMeta) extends Content(content) {
   lazy val body: String = delegate.safeFields.getOrElse("body","")
   lazy val contentType = "Article"
   lazy val isReview = tones.exists(_.id == "tone/reviews")
@@ -190,7 +198,7 @@ class Article(content: ApiContent) extends Content(content) {
   ) ++ mainPicture.flatMap(_.largestImage.map( "twitter:image:src" -> _.path ))
 }
 
-class LiveBlog(content: ApiContent) extends Article(content) {
+class LiveBlog(content: ApiContentWithMeta) extends Article(content) {
   private lazy val soupedBody = Jsoup.parseBodyFragment(body).body()
   lazy val blockCount: Int = soupedBody.select(".block").size()
   lazy val summary: Option[String] = soupedBody.select(".is-summary").headOption.map(_.toString)
@@ -202,7 +210,7 @@ class LiveBlog(content: ApiContent) extends Article(content) {
   )
 }
 
-class Video(content: ApiContent) extends Content(content) {
+class Video(content: ApiContentWithMeta) extends Content(content) {
 
   private implicit val ordering = EncodingOrdering
 
@@ -231,7 +239,11 @@ class Video(content: ApiContent) extends Content(content) {
   ) ++ tags.map("video:tag" -> _.name)
 }
 
-class Gallery(content: ApiContent) extends Content(content) {
+object Video {
+  def apply(delegate: ApiContent): Video = new Video(ApiContentWithMeta(delegate))
+}
+
+class Gallery(content: ApiContentWithMeta) extends Content(content) {
 
   def apply(index: Int): ImageAsset = galleryImages(index).largestImage.get
 
@@ -268,14 +280,22 @@ class Gallery(content: ApiContent) extends Content(content) {
   }
 }
 
-class Interactive(content: ApiContent) extends Content(content) {
+object Gallery {
+  def apply(delegate: ApiContent): Gallery = new Gallery(ApiContentWithMeta(delegate))
+}
+
+class Interactive(content: ApiContentWithMeta) extends Content(content) {
   lazy val contentType = "Interactive"
   lazy val body: String = delegate.safeFields("body")
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
   override lazy val metaData: Map[String, Any] = super.metaData + ("content-type" -> contentType)
 }
 
-class ImageContent(content: ApiContent) extends Content(content) {
+object Interactive {
+  def apply(delegate: ApiContent): Interactive = new Interactive(ApiContentWithMeta(delegate))
+}
+
+class ImageContent(content: ApiContentWithMeta) extends Content(content) {
 
   lazy val contentType = "ImageContent"
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
@@ -286,13 +306,4 @@ class ImageContent(content: ApiContent) extends Content(content) {
   ) ++ mainPicture.flatMap(_.largestImage.map( "twitter:image:src" -> _.path ))
 }
 
-class ContentWithMetaData(
-                           content: ApiContent,
-                           override val supporting: List[Content],
-                           metaData: Map[String, JsValue]) extends Content(content) {
-  override lazy val headline: String = metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(super.headline)
-  override lazy val trailText: Option[String] = metaData.get("trailText").flatMap(_.asOpt[String]).orElse(super.trailText)
-  override lazy val group: Option[String] = metaData.get("group").flatMap(_.asOpt[String])
-  override lazy val imageAdjust: Option[String] = metaData.get("imageAdjust").flatMap(_.asOpt[String])
-  override lazy val isBreaking: Boolean = metaData.get("isBreaking").flatMap(_.asOpt[Boolean]).getOrElse(false)
-}
+case class ApiContentWithMeta(delegate: ApiContent, supporting: List[Content] = Nil, metaData: Map[String, JsValue] = Map.empty)


### PR DESCRIPTION
This removes `ContentWithMetaData` which was used as an extra type along side `Video`, `Article`, etc. and adds `ApiContentWithMeta`. 

The problem with this was with the way it was created in `Content.apply`. If an item had meta data that has come from `facia-tool`, it would be the type `ContentMetaData`. Otherwise it would follow the normal path of going through the original `Content.apply` and be the type of either `Video`, `Article`, etc.
This meant that if a content had meta data, it could not have it AND be a `Video` (for example).

What we want is to have the type `Video` and to have potentially meta data from `facia-tool`. The best way I could see to do this was to wrap `Content` (known as `ApiContent` in `content.scala`) in a type that would hold these extra fields. Seeing as this object is a part of another library, then I was forced to wrap.

The other solution would have been passing in `metaData` and `supporting` everywhere, which would be more messy.

Since `Video`, `Interactive` and `Gallery` are created in some controllers, there are new companion objects for creating these from an `ApoContent/Content` type.
