### PR TITLE
Prevent ad slots from getting out of the layout - fixes #2824

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -1,5 +1,6 @@
 .ad-slot {
     width: 100%;
+    overflow-x: hidden;
     padding: 10px 0 4px 0;
     text-align: center;
     min-height: 56px;


### PR DESCRIPTION
320px wide Inline ad slots have been creating extra space by trying to get out of the main column (which is 300px wide on iPhone portrait).  Same on tablets with big ads.

This prevents ads from messing with the layout (see below).

![screen shot 2014-01-31 at 11 28 22](https://f.cloud.github.com/assets/85783/2049965/d287ba16-8a6a-11e3-99d2-5da5f36370e3.PNG)
![screen shot 2014-01-31 at 11 25 26](https://f.cloud.github.com/assets/85783/2049966/d6584dea-8a6a-11e3-95ac-8995bc122964.PNG)

![screen shot 2014-01-31 at 11 34 30](https://f.cloud.github.com/assets/85783/2050003/b1d20fd2-8a6b-11e3-9c7c-4c4289a86310.PNG)

![ ](http://s1.developerslife.ru/public/images/gifs/3b2ee065-6ac4-4d6b-ba83-6e7a801ef412.gif)
