### PR TITLE
Add password strength meter on reset password form

### DIFF
--- a/identity/app/views/password/reset_password.scala.html
+++ b/identity/app/views/password/reset_password.scala.html
@@ -22,7 +22,7 @@
             <div class="fieldset__fields">
                 <ul class="unstyled">
 
-                    @inputField(Password(resetPasswordForm("password"), '_label -> "New Password", '_help -> "Between 6 and 20 characters", 'autofocus -> true))
+                    @inputField(Password(resetPasswordForm("password"), '_label -> "New Password", '_help -> "Between 6 and 20 characters", 'autofocus -> true, 'class -> "js-register-password js-password-strength"))
 
                     @inputField(Password(resetPasswordForm("password-confirm"), '_label -> "Repeat password"))
 


### PR DESCRIPTION
We already have this on the 'register' page, just adding it to the 'password reset' page.
