### PR TITLE
Added a 'DogpileAction'.

### DIFF
--- a/applications/app/controllers/IndexController.scala
+++ b/applications/app/controllers/IndexController.scala
@@ -13,7 +13,7 @@ trait IndexController extends Controller with Index with Logging with Paging wit
 
   implicit def getTemplateDedupingInstance: TemplateDeduping = TemplateDeduping()
 
-  def renderCombiner(leftSide: String, rightSide: String) = Action.async{ implicit request =>
+  def renderCombiner(leftSide: String, rightSide: String) = DogpileAction { implicit request =>
     index(Edition(request), leftSide, rightSide).map {
       case Left(page) => renderFaciaFront(page)
       case Right(other) => other
@@ -22,7 +22,7 @@ trait IndexController extends Controller with Index with Logging with Paging wit
 
   def renderJson(path: String) = render(path)
 
-  def render(path: String) = Action.async { implicit request =>
+  def render(path: String) = DogpileAction { implicit request =>
     index(Edition(request), path) map {
       case Left(model) => renderFaciaFront(model)
       case Right(other) => other
@@ -30,7 +30,7 @@ trait IndexController extends Controller with Index with Logging with Paging wit
   }
 
   def renderTrailsJson(path: String) = renderTrails(path)
-  def renderTrails(path: String) = Action.async { implicit request =>
+  def renderTrails(path: String) = DogpileAction { implicit request =>
     index(Edition(request), path) map {
       case Left(model) => renderTrailsFragment(model)
       case Right(notFound) => notFound

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -21,14 +21,14 @@ case class LiveBlogPage(article: LiveBlog, storyPackage: List[Trail]) extends Ar
 
 object ArticleController extends Controller with Logging with ExecutionContexts {
 
-  def renderArticle(path: String) = Action.async { implicit request =>
+  def renderArticle(path: String) = DogpileAction { implicit request =>
     lookup(path) map {
       case Left(model) => render(model)
       case Right(other) => RenderOtherStatus(other)
     }
   }
 
-  def renderLatestFrom(path: String, lastUpdateBlockId: String) = Action.async { implicit request =>
+  def renderLatestFrom(path: String, lastUpdateBlockId: String) = DogpileAction { implicit request =>
     lookup(path) map {
       case Right(other) => RenderOtherStatus(other)
       case Left(model) =>

--- a/common/app/common/DogpileAction.scala
+++ b/common/app/common/DogpileAction.scala
@@ -1,0 +1,53 @@
+package common
+
+import play.api.mvc._
+import scala.concurrent.Future
+import java.util.concurrent.TimeUnit
+import com.google.common.cache.CacheBuilder
+import PerformanceMetrics._
+import conf.Switches
+import Switches.DogpileSwitch
+
+object DogpileAction extends ExecutionContexts {
+
+  private val dogpile = CacheBuilder.newBuilder()
+    .concurrencyLevel(4)
+    .maximumSize(500)
+    .expireAfterWrite(2, TimeUnit.SECONDS)
+    .build[String, Future[SimpleResult]]()
+
+  def apply(block: Request[AnyContent] => Future[SimpleResult]): Action[AnyContent] = Action.async{ request =>
+
+    if (DogpileSwitch.isSwitchedOn) {
+      val key = defaultKey(request)
+
+      val maybeResult = Option(dogpile.getIfPresent(key))
+
+      maybeResult.foreach(r => dogPileHitMetric.increment())
+
+      maybeResult.getOrElse{
+        val result = block(request)
+        dogpile.put(key, result)
+        result.onComplete{ case _ => dogpile.invalidate(key) }
+        dogPileMissMetric.increment()
+        result
+      }
+    } else {
+      block(request)
+    }
+  }
+
+  private def defaultKey(request: Request[AnyContent]): String = {
+    val headers = request.headers.toSimpleMap
+
+    // this is set upstream, and is used in case of e.g. AB tests
+    val upstreamCacheKey = headers.getOrElse("X-Gu-Cache-Key", "")
+
+    val edition = Edition(request).id
+
+    //The complete request URI, containing both path and query string.
+    val uri = request.uri
+
+    s"$uri $edition $upstreamCacheKey"
+  }
+}

--- a/common/app/common/DogpileAction.scala
+++ b/common/app/common/DogpileAction.scala
@@ -7,8 +7,9 @@ import com.google.common.cache.CacheBuilder
 import PerformanceMetrics._
 import conf.Switches
 import Switches.DogpileSwitch
+import implicits.Requests
 
-object DogpileAction extends ExecutionContexts {
+object DogpileAction extends ExecutionContexts with Requests {
 
   private val dogpile = CacheBuilder.newBuilder()
     .concurrencyLevel(4)
@@ -43,11 +44,14 @@ object DogpileAction extends ExecutionContexts {
     // this is set upstream, and is used in case of e.g. AB tests
     val upstreamCacheKey = headers.getOrElse("X-Gu-Cache-Key", "")
 
+    //Trequest.uri includes both path and query string.
+    val url = s"${request.host}${request.uri}"
+
+    // these 2 are possibly (probably) not necessary (they should be implicit to the key parts above)
+    // however I'm putting them in for now just to be safe
+    val isJson = request.isJson
     val edition = Edition(request).id
 
-    //The complete request URI, containing both path and query string.
-    val uri = request.uri
-
-    s"$uri $edition $upstreamCacheKey"
+    s"$edition $upstreamCacheKey $isJson $url"
   }
 }

--- a/common/app/common/DogpileAction.scala
+++ b/common/app/common/DogpileAction.scala
@@ -12,6 +12,7 @@ import implicits.Requests
 object DogpileAction extends ExecutionContexts with Requests {
 
   private val dogpile = CacheBuilder.newBuilder()
+    //http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/cache/CacheBuilder.html#concurrencyLevel(int)
     .concurrencyLevel(4)
     .maximumSize(500)
     .expireAfterWrite(2, TimeUnit.SECONDS)

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -6,6 +6,7 @@ import conf.RequestMeasurementMetrics
 import java.lang.management.ManagementFactory
 import model.diagnostics.CloudWatch
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 
 trait TimingMetricLogging extends Logging { self: TimingMetric =>
   override def measure[T](block: => T): T = {
@@ -325,6 +326,23 @@ object Metrics {
   lazy val faciaTool = FaciaToolMetrics.all
 }
 
+case class SimpleCountMetric(namespace: String, name: String) {
+  val count = new AtomicLong(0)
+  def increment() { count.incrementAndGet() }
+}
+
+object PerformanceMetrics {
+  val dogPileHitMetric = SimpleCountMetric(
+    "performance",
+    "dogpile-hits"
+  )
+
+  val dogPileMissMetric = SimpleCountMetric(
+    "performance",
+    "dogpile-miss"
+  )
+}
+
 trait CloudWatchApplicationMetrics extends GlobalSettings {
 
   def applicationName: String
@@ -345,8 +363,10 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
       (s"$applicationName-build-number", SystemMetrics.BuildNumberMetric.getValue().toDouble),
 
       (s"$applicationName-free-disk-space", SystemMetrics.FreeDiskSpaceMetric.getValue()),
-      (s"$applicationName-total-disk-space", SystemMetrics.TotalDiskSpaceMetric.getValue())
+      (s"$applicationName-total-disk-space", SystemMetrics.TotalDiskSpaceMetric.getValue()),
 
+      (s"$applicationName-dogpile-hits", PerformanceMetrics.dogPileHitMetric.count.getAndSet(0).toDouble),
+      (s"$applicationName-dogpile-miss", PerformanceMetrics.dogPileMissMetric.count.getAndSet(0).toDouble)
     )
 
     CloudWatch.put("ApplicationSystemMetrics", metrics)

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -48,6 +48,11 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
+  val DogpileSwitch = Switch("Performance Switches", "dogpile",
+    "If switched on this will enable the anti-dogpile cache, which will help absorb large spikes on single pieces of content e.g. live blogs",
+    safeState = Off, sellByDate = new DateMidnight(2014, 2, 28)
+  )
+
   val DoubleCacheTimesSwitch = Switch("Performance Switches", "double-cache-times",
     "Doubles the cache time of every endpoint. Turn on to help handle exceptional load.",
     safeState = On, sellByDate = never
@@ -437,7 +442,8 @@ object Switches extends Collections {
     LCMortgageFeedSwitch,
     GuBookshopFeedsSwitch,
     ImageServiceSwitch,
-    NetworkFrontOptIn
+    NetworkFrontOptIn,
+    DogpileSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -8,248 +8,8 @@ import play.api.mvc._
 import play.api.libs.json.{JsArray, Json}
 import Switches.EditionRedirectLoggingSwitch
 import views.support.{TemplateDeduping, NewsContainer}
-
-abstract class FrontPage(val isNetworkFront: Boolean) extends MetaData
-
-object FrontPage {
-
-  private val fronts = Seq(
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "australia"
-      override val section = "australia"
-      override val webTitle = "The Guardian"
-      override lazy val analyticsName = "GFE:Network Front"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "sport"
-      override val section = "sport"
-      override val webTitle = "Sport"
-      override lazy val analyticsName = "GFE:sport"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Sport",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "money"
-      override val section = "money"
-      override val webTitle = "Money"
-      override lazy val analyticsName = "GFE:money"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Money",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "commentisfree"
-      override val section = "commentisfree"
-      override val webTitle = "Comment is free"
-      override lazy val analyticsName = "GFE:commentisfree"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Comment is free",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "business"
-      override val section = "business"
-      override val webTitle = "Business"
-      override lazy val analyticsName = "GFE:business"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Business",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "culture"
-      override val section = "culture"
-      override val webTitle = "Culture"
-      override lazy val analyticsName = "GFE:culture"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Culture",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "film"
-      override val section = "film"
-      override val webTitle = "Film"
-      override lazy val analyticsName = "GFE:film"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Film",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "football"
-      override val section = "football"
-      override val webTitle = "Football"
-      override lazy val analyticsName = "GFE:football"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Football",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "technology"
-      override val section = "technology"
-      override val webTitle = "Technology"
-      override lazy val analyticsName = "GFE:technology"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Technology",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "travel"
-      override val section = "travel"
-      override val webTitle = "Travel"
-      override lazy val analyticsName = "GFE:travel"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Travel",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "world/nsa"
-      override val section = "world"
-      override val webTitle = "NSA"
-      override lazy val analyticsName = "GFE:world/nsa"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "NSA",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "world/edward-snowden"
-      override val section = "world"
-      override val webTitle = "Edward Snowden"
-      override lazy val analyticsName = "GFE:world/edward-snowden"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Edward Snowden",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "football/arsenal"
-      override val section = "football"
-      override val webTitle = "Arsenal"
-      override lazy val analyticsName = "GFE:football/arsenal"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Arsenal",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = false) {
-      override val id = "artanddesign/photography"
-      override val section = "artanddesign"
-      override val webTitle = "Photography"
-      override lazy val analyticsName = "GFE:artanddesign/photography"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Photography",
-        "content-type" -> "Section",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = true) {
-      override val id = "uk-alpha"
-      override val section = ""
-      override val webTitle = "The Guardian"
-      override lazy val analyticsName = "GFE:Network Front"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = true) {
-      override val id = "au-alpha"
-      override val section = ""
-      override val webTitle = "The Guardian"
-      override lazy val analyticsName = "GFE:Network Front"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = true) {
-      override val id = "us-alpha"
-      override val section = ""
-      override val webTitle = "The Guardian"
-      override lazy val analyticsName = "GFE:Network Front"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    },
-
-    //TODO important this one is last for matching purposes
-    new FrontPage(isNetworkFront = true) {
-      override val id = ""
-      override val section = ""
-      override val webTitle = "The Guardian"
-      override lazy val analyticsName = "GFE:Network Front"
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    }
-  )
-
-  def apply(path: String): Option[FrontPage] = fronts.find(f => path.endsWith(f.id))
-
-}
-
+import scala.concurrent.Future
+import play.api.templates.Html
 
 class FaciaController extends Controller with Logging with ExecutionContexts {
 
@@ -283,11 +43,11 @@ class FaciaController extends Controller with Logging with ExecutionContexts {
     Cached(60)(Redirect(redirectPath))
   }
 
-  def getPathForUkAlpha(path: String, request: RequestHeader): String =
+  private def getPathForUkAlpha(path: String, request: RequestHeader): String =
     Seq("uk", "us", "au").find { page =>
       path == page &&
         Option(Edition(request)) == Edition.byId(page) &&
-        Switches.byName(s"network-front-${page}-alpha").map(_.isSwitchedOn).getOrElse(false) &&
+        Switches.byName(s"network-front-${page}-alpha").exists(_.isSwitchedOn) &&
         request.headers.get(s"X-Gu-${page.capitalize}-Alpha").exists(_.toLowerCase == "true")
     }.map{ page =>
       s"$page-alpha"
@@ -304,8 +64,8 @@ class FaciaController extends Controller with Logging with ExecutionContexts {
   def renderEditionCollection(id: String) = renderCollection(id)
   def renderEditionCollectionJson(id: String) = renderCollection(id)
 
-  def renderFront(path: String) = Action { implicit request =>
-
+  def renderFront(path: String) = DogpileAction { implicit request =>
+    Future{
       //For UK alpha only
       val newPath = getPathForUkAlpha(path, request)
 
@@ -313,56 +73,67 @@ class FaciaController extends Controller with Logging with ExecutionContexts {
 
       FrontPage(editionalisedPath).flatMap { frontPage =>
 
-        // get the trailblocks
+      // get the trailblocks
         val faciaPageOption: Option[FaciaPage] = front(editionalisedPath)
         faciaPageOption map { faciaPage =>
           Cached(frontPage) {
-            if (request.isJson) {
-              val html = views.html.fragments.frontBody(frontPage, faciaPage)
-              JsonComponent(
-                "html" -> html,
-                "trails" -> JsArray(faciaPage.collections.filter(_._1.contentApiQuery.isDefined).take(1).flatMap(_._2.items.map(TrailToJson(_)))),
-                "config" -> Json.parse(views.html.fragments.javaScriptConfig(frontPage).body)
-              )
-            }
+            if (request.isJson)
+              JsonFront(frontPage, faciaPage)
             else
               Ok(views.html.front(frontPage, faciaPage))
           }
         }
       }.getOrElse(Cached(60)(NotFound))
+    }
   }
 
-  def renderCollection(id: String) = Action { implicit request =>
-    if (ConfigAgent.getAllCollectionIds.contains(id)) {
-      CollectionAgent.getCollection(id) map { collection =>
-        val html = views.html.fragments.collections.standard(Config(id), collection.items, NewsContainer(false), 1)
-        Cached(60) {
-          if (request.isJson) {
-            JsonComponent(
-              "html" -> html,
-              "trails" -> JsArray(collection.items.map(TrailToJson(_)))
-            )
+  def renderCollection(id: String) = DogpileAction { implicit request =>
+    Future{
+      if (ConfigAgent.getAllCollectionIds.contains(id)) {
+        CollectionAgent.getCollection(id) map { collection =>
+          val html = views.html.fragments.collections.standard(Config(id), collection.items, NewsContainer(showMore = false), 1)
+          Cached(60) {
+            if (request.isJson)
+              JsonCollection(html, collection)
+            else
+              Ok(html)
           }
-          else
-            Ok(html)
-        }
-      } getOrElse(ServiceUnavailable)
+        } getOrElse ServiceUnavailable
+      }
+      else
+        Cached(60)(NotFound)
     }
-    else
-      Cached(60)(NotFound)
   }
 
-  def renderCollectionRss(id: String) = Action { implicit request =>
-    if (ConfigAgent.getAllCollectionIds.contains(id)) {
-      CollectionAgent.getCollection(id) map { collection =>
-        Cached(60) {
-          val config: Config = ConfigAgent.getConfig(id).getOrElse(Config(""))
-          Ok(TrailsToRss(config.displayName, collection.items))
-        }.as("text/xml; charset=utf-8")
-      } getOrElse(ServiceUnavailable)
+
+  private object JsonCollection{
+    def apply(html: Html, collection: Collection)(implicit request: RequestHeader) = JsonComponent(
+      "html" -> html,
+      "trails" -> JsArray(collection.items.map(TrailToJson(_)))
+    )
+  }
+
+  private object JsonFront{
+    def apply(frontPage: FrontPage, faciaPage: FaciaPage)(implicit request: RequestHeader) = JsonComponent(
+      "html" -> views.html.fragments.frontBody(frontPage, faciaPage),
+      "trails" -> JsArray(faciaPage.collections.filter(_._1.contentApiQuery.isDefined).take(1).flatMap(_._2.items.map(TrailToJson(_)))),
+      "config" -> Json.parse(views.html.fragments.javaScriptConfig(frontPage).body)
+    )
+  }
+
+  def renderCollectionRss(id: String) = DogpileAction { implicit request =>
+    Future{
+      if (ConfigAgent.getAllCollectionIds.contains(id)) {
+        CollectionAgent.getCollection(id) map { collection =>
+          Cached(60) {
+            val config: Config = ConfigAgent.getConfig(id).getOrElse(Config(""))
+            Ok(TrailsToRss(config.displayName, collection.items))
+          }.as("text/xml; charset=utf-8")
+        } getOrElse ServiceUnavailable
+      }
+      else
+        Cached(60)(NotFound)
     }
-    else
-      Cached(60)(NotFound)
   }
 
 }

--- a/facia/app/controllers/FrontPage.scala
+++ b/facia/app/controllers/FrontPage.scala
@@ -1,0 +1,246 @@
+package controllers
+
+import model.MetaData
+
+
+abstract class FrontPage(val isNetworkFront: Boolean) extends MetaData
+
+object FrontPage {
+
+  private val fronts = Seq(
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "australia"
+      override val section = "australia"
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Network Front"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "content-type" -> "Network Front",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "sport"
+      override val section = "sport"
+      override val webTitle = "Sport"
+      override lazy val analyticsName = "GFE:sport"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Sport",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "money"
+      override val section = "money"
+      override val webTitle = "Money"
+      override lazy val analyticsName = "GFE:money"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Money",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "commentisfree"
+      override val section = "commentisfree"
+      override val webTitle = "Comment is free"
+      override lazy val analyticsName = "GFE:commentisfree"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Comment is free",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "business"
+      override val section = "business"
+      override val webTitle = "Business"
+      override lazy val analyticsName = "GFE:business"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Business",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "culture"
+      override val section = "culture"
+      override val webTitle = "Culture"
+      override lazy val analyticsName = "GFE:culture"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Culture",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "film"
+      override val section = "film"
+      override val webTitle = "Film"
+      override lazy val analyticsName = "GFE:film"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Film",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "football"
+      override val section = "football"
+      override val webTitle = "Football"
+      override lazy val analyticsName = "GFE:football"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Football",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "technology"
+      override val section = "technology"
+      override val webTitle = "Technology"
+      override lazy val analyticsName = "GFE:technology"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Technology",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "travel"
+      override val section = "travel"
+      override val webTitle = "Travel"
+      override lazy val analyticsName = "GFE:travel"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Travel",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "world/nsa"
+      override val section = "world"
+      override val webTitle = "NSA"
+      override lazy val analyticsName = "GFE:world/nsa"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "NSA",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "world/edward-snowden"
+      override val section = "world"
+      override val webTitle = "Edward Snowden"
+      override lazy val analyticsName = "GFE:world/edward-snowden"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Edward Snowden",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "football/arsenal"
+      override val section = "football"
+      override val webTitle = "Arsenal"
+      override lazy val analyticsName = "GFE:football/arsenal"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Arsenal",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "artanddesign/photography"
+      override val section = "artanddesign"
+      override val webTitle = "Photography"
+      override lazy val analyticsName = "GFE:artanddesign/photography"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Photography",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = true) {
+      override val id = "uk-alpha"
+      override val section = ""
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Network Front"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "content-type" -> "Network Front",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = true) {
+      override val id = "au-alpha"
+      override val section = ""
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Network Front"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "content-type" -> "Network Front",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = true) {
+      override val id = "us-alpha"
+      override val section = ""
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Network Front"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "content-type" -> "Network Front",
+        "is-front" -> true
+      )
+    },
+
+    //TODO important this one is last for matching purposes
+    new FrontPage(isNetworkFront = true) {
+      override val id = ""
+      override val section = ""
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Network Front"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "content-type" -> "Network Front",
+        "is-front" -> true
+      )
+    }
+  )
+
+  def apply(path: String): Option[FrontPage] = fronts.find(f => path.endsWith(f.id))
+
+}
+


### PR DESCRIPTION
This is designed to soak up large numbers of hits on a single page (e.g. end of live football match, election of Pope). If the application is currently fetching and rendering that page, then this action will await that result instead of duplicating the effort.

Here is a graph of me putting this under 'siege' on my local machine...
![dogpile](https://f.cloud.github.com/assets/76709/2060209/a79a8fdc-8c03-11e3-84cb-d979966bf131.png)
