### PR TITLE
Don't show scalable icons if svg is not supported

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -227,15 +227,17 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
         & + & {
             border-left: 1px solid $c-neutral5;
 
-            .fromage__support__action {
-                @include rem((
-                    padding-left: $gs-gutter/4
-                ));
-            }
-            .action--has-icon {
-                @include rem((
-                    padding-left: $action-icon-width + ($action-icon-rightspace * 2)
-                ));
+            .svg & {
+                .fromage__support__action {
+                    @include rem((
+                        padding-left: $gs-gutter/4
+                    ));
+                }
+                .action--has-icon {
+                    @include rem((
+                        padding-left: $action-icon-width + ($action-icon-rightspace * 2)
+                    ));
+                }
             }
         }
     }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -216,6 +216,10 @@ $c-live: #e81818;
         width: 1.45em;
         height: 1em;
         background-size: contain;
+
+        // This is a scalable icon,
+        // it will only work if SVG is active
+        @include show-only-if-svg-is-supported;
     }
 }
 .item__byline {
@@ -440,15 +444,22 @@ $c-live: #e81818;
 }
 
 .action--has-icon {
-    @include rem((
-        padding-left: $action-icon-width + $action-icon-rightspace
-    ));
-
     .i {
-        float: left;
+        // This is a scalable icon,
+        // it will only work if SVG is active
+        @include show-only-if-svg-is-supported;
+    }
+    .svg & {
         @include rem((
-            margin-left: ($action-icon-width + $action-icon-rightspace) * -1
+            padding-left: $action-icon-width + $action-icon-rightspace
         ));
+
+        .i {
+            float: left;
+            @include rem((
+                margin-left: ($action-icon-width + $action-icon-rightspace) * -1
+            ));
+        }
     }
 }
 .action--tone-comment .i.i-quote-orange { // Chained selector to overrule icon code from global.css

--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -224,3 +224,7 @@ $item-top-border-height: 2px;
         margin-top: 0 !important;
     }
 }
+@mixin show-only-if-svg-is-supported {
+    display: none;
+    .svg & { display: block; }
+}


### PR DESCRIPTION
Some icons are used in multiple sizes (instead of having one icon per size).

Obviously scaling an SVG is easy but not the png sprite.

This hides scalable icons from browsers that don't support SVG.

Without this fix, there will be a blank space instead of icons where SVG is not supported.
## SVG

![screen shot 2014-02-03 at 17 46 45](https://f.cloud.github.com/assets/85783/2067450/67d4bb5e-8cfb-11e3-824e-3665c5a40145.PNG)
![screen shot 2014-02-03 at 17 46 39](https://f.cloud.github.com/assets/85783/2067451/6a577ef2-8cfb-11e3-8517-d4c20464a50c.PNG)
## No SVG

![screen shot 2014-02-03 at 17 46 22](https://f.cloud.github.com/assets/85783/2067455/71c6447a-8cfb-11e3-8e09-5966a1c364d3.PNG)

![screen shot 2014-02-03 at 17 46 30](https://f.cloud.github.com/assets/85783/2067453/6db86a34-8cfb-11e3-9a0d-d609130430f9.PNG)

![ ](http://4.bp.blogspot.com/-mQiBB-GTQys/Uu-1SsQdvWI/AAAAAAABFuo/-iEOE8H8Ggw/s1600/vliegtuig-landing-op-sint-maarten.gif)
