### PR TITLE
Wrap gallery item in one link

### DIFF
--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -54,8 +54,12 @@ define([
                 bean.on(context, 'click', self.selector, function(e) {
                     e.preventDefault();
 
-                    var el = (e.currentTarget.nodeName === "A") ? e.currentTarget : e.currentTarget.querySelector('a');
-                    var galleryUrl = el.getAttribute('href');
+                    var currentTarget = e.currentTarget,
+                        galleryUrl = $(currentTarget).attr('data-gallery-url');
+                    if (!galleryUrl) {
+                        var el = (currentTarget.nodeName === "A") ? currentTarget : currentTarget.querySelector('a');
+                        galleryUrl = el.getAttribute('href');
+                    }
 
                     // Go to a specific image if it's in the query string. eg: index=3
                     if (galleryUrl.indexOf('index=') !== -1) {

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -522,8 +522,6 @@ $c-live: #e81818;
 }
 
 .item__media-wrapper--has-icon {
-    z-index: 9999;
-
     .item__cta {
         position: absolute;
         @include rem((

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -513,24 +513,10 @@ $c-live: #e81818;
     }
 
     &.collection__item--content-type-gallery,
-    &.collection__item--content-type-video{
+    &.collection__item--content-type-video {
         &,
         .item__meta {
             background: $c-neutral1;
-        }
-        .item__container {
-            border-top-width: 2px;
-            border-top-style: solid;
-        }
-        .item__link {
-            border-top: 0;
-
-            &:first-child {
-                @include rem((margin-top: $gs-baseline/3));
-            }
-        }
-        .item__image-container {
-            margin: 0;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -535,26 +535,26 @@ $c-live: #e81818;
     }
 }
 
-.item__gallery-lightbox {
-    position: absolute;
-    width: 100%;
-    top: 0;
-    left: 0;
+.item__media-wrapper--has-icon {
+    z-index: 9999;
 
-    &:before {
-        content: "";
-        display: block;
-        padding-top: 60%;
-    }
     .item__cta {
         position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
         @include rem((
-            padding-top: 8px,
-            padding-left: 8px
+            top: 8px,
+            left: 8px
         ));
+    }
+    &:hover {
+        .item__cta--gallery {
+            background-color: $c-neutral1;
+
+            .i {
+                display: none;
+            }
+            .i--hover {
+                display: block;
+            }
+        }
     }
 }

--- a/common/app/views/fragments/items/gallery.scala.html
+++ b/common/app/views/fragments/items/gallery.scala.html
@@ -15,39 +15,27 @@
 
         <div class="item__container tone-accent-border">
 
-            @trail.trailPicture(5,3).map{ imageContainer =>
-                @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                    <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border gallerythumbs" data-link-name="article">
-                        <div class="item__media-wrapper">
-                            <div class="item__cta item__cta--gallery">
-                                <p>Expand</p>
-                                <i class="i i-camera-black-large i--default"></i>
-                                <i class="i i-camera-yellow-large i--hover"></i>
-                            </div>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@Html(imgSrc)" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+            <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
+                <div class="item__media-wrapper item__media-wrapper--has-icon gallerythumbs" data-gallery-url="@LinkTo{@trail.url}">
+                    <div class="item__cta item__cta--gallery">
+                        <p>Expand</p>
+                        <i class="i i-camera-black-large i--default"></i>
+                        <i class="i i-camera-yellow-large i--hover"></i>
+                    </div>
+                    @trail.trailPicture(5,3).map{ imageContainer =>
+                        @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@Html(url)" class="responsive-img" alt="" /> }
                                 }
                             </div>
-                        </div>
-                    </a>
-                }
-            }.getOrElse{
-                <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border gallerythumbs" data-link-name="article">
-                    <div class="item__media-wrapper">
-                        <div class="item__cta item__cta--gallery">
-                            <p>Expand</p>
-                            <i class="i i-camera-black-large i--default"></i>
-                            <i class="i i-camera-yellow-large i--hover"></i>
-                        </div>
+                        }
+                    }.getOrElse{
                         <div class="item__image-container">
                             <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                         </div>
-                    </div>
-                </a>
-            }
-
-            <a href="@LinkTo{@trail.url}" class="item__link">
+                    }
+                </div>
                 <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
                     <span class="item__title-type">Gallery </span>
                     @RemoveOuterParaHtml(trail.headline)
@@ -59,11 +47,12 @@
             }
 
             <div class="item__meta">
-                <time class="item__timestamp js-item__timestamp"
-                      itemprop="datePublished"
-                      datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-                      data-timestamp="@trail.webPublicationDate.getMillis"
-                      data-relativeformat="short">
+                <time
+                    class="item__timestamp js-item__timestamp"
+                    itemprop="datePublished"
+                    datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                    data-timestamp="@trail.webPublicationDate.getMillis"
+                    data-relativeformat="short">
                     <i class="i i-clock-grey"></i>
                     <span class="timestamp__text"><span class="u-h">Published: </span>@Format(trail.webPublicationDate, "d MMM y")</span>
                 </time>

--- a/common/app/views/fragments/items/gallery.scala.html
+++ b/common/app/views/fragments/items/gallery.scala.html
@@ -13,7 +13,7 @@
         @trail.discussionId.map{ id => data-discussion-id="@id" }
         data-discussion-closed="@trail.isClosedForComments">
 
-        <div class="item__container tone-accent-border">
+        <div class="item__container">
 
             <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                 <div class="item__media-wrapper item__media-wrapper--has-icon gallerythumbs" data-gallery-url="@LinkTo{@trail.url}">

--- a/common/app/views/fragments/items/rowPattern/thumbnailGallery.scala.html
+++ b/common/app/views/fragments/items/rowPattern/thumbnailGallery.scala.html
@@ -33,7 +33,7 @@
                         }
                         @RemoveOuterParaHtml(trail.headline)
                     </h@if(isFirstContainer && index == 0){1}else{2}>
-                    <div class="item__media-wrapper">
+                    <div class="item__media-wrapper item__media-wrapper--has-icon gallerythumbs" data-gallery-url="@LinkTo{@trail.url}">
                         <div class="item__cta item__cta--gallery">
                             <p>Expand</p>
                             <i class="i i-camera-black-large i--default"></i>

--- a/common/app/views/fragments/items/rowPattern/thumbnailGallery.scala.html
+++ b/common/app/views/fragments/items/rowPattern/thumbnailGallery.scala.html
@@ -21,7 +21,7 @@
             @trail.discussionId.map{ id => data-discussion-id="@id" }
             data-discussion-closed="@trail.isClosedForComments">
 
-            <div class="item__container tone-accent-border">
+            <div class="item__container">
 
                 <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                     <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">

--- a/common/app/views/fragments/items/rowPattern/thumbnailVideo.scala.html
+++ b/common/app/views/fragments/items/rowPattern/thumbnailVideo.scala.html
@@ -21,7 +21,7 @@
             @trail.discussionId.map{ id => data-discussion-id="@id" }
             data-discussion-closed="@trail.isClosedForComments">
 
-            <div class="item__container tone-accent-border">
+            <div class="item__container">
 
                 <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                     <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">

--- a/common/app/views/fragments/items/video.scala.html
+++ b/common/app/views/fragments/items/video.scala.html
@@ -13,7 +13,7 @@
         @trail.discussionId.map{ id => data-discussion-id="@id" }
         data-discussion-closed="@trail.isClosedForComments">
 
-        <div class="item__container tone-accent-border">
+        <div class="item__container">
 
             <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                 <div class="item__media-wrapper item__media-wrapper--has-icon">

--- a/common/app/views/fragments/items/video.scala.html
+++ b/common/app/views/fragments/items/video.scala.html
@@ -15,37 +15,26 @@
 
         <div class="item__container tone-accent-border">
 
-            @trail.trailPicture(5,3).map{ imageContainer =>
-                @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                    <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
-                        <div class="item__media-wrapper">
-                            <div class="item__cta item__cta--video">
-                                <p>Play</p>
-                                <i class="i i-play-black"></i>
-                            </div>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@Html(imgSrc)" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+            <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
+                <div class="item__media-wrapper item__media-wrapper--has-icon">
+                    <div class="item__cta item__cta--video">
+                        <p>Play</p>
+                        <i class="i i-play-black"></i>
+                    </div>
+                    @trail.trailPicture(5,3).map{ imageContainer =>
+                        @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@Html(url)" class="responsive-img" alt="" /> }
                                 }
                             </div>
-                        </div>
-                    </a>
-                }
-            }.getOrElse{
-                <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
-                    <div class="item__media-wrapper">
-                        <div class="item__cta item__cta--video">
-                            <p>Play</p>
-                            <i class="i i-play-black"></i>
-                        </div>
+                        }
+                    }.getOrElse{
                         <div class="item__image-container">
                             <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                         </div>
-                    </div>
-                </a>
-            }
-
-            <a href="@LinkTo{@trail.url}" class="item__link">
+                    }
+                </div>
                 <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
                     <span class="item__title-type">Video </span>
                     @RemoveOuterParaHtml(trail.headline)
@@ -57,11 +46,12 @@
             }
 
             <div class="item__meta">
-                <time class="item__timestamp js-item__timestamp"
-                      itemprop="datePublished"
-                      datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-                      data-timestamp="@trail.webPublicationDate.getMillis"
-                      data-relativeformat="short">
+                <time
+                    class="item__timestamp js-item__timestamp"
+                    itemprop="datePublished"
+                    datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                    data-timestamp="@trail.webPublicationDate.getMillis"
+                    data-relativeformat="short">
                     <i class="i i-clock-grey"></i>
                     <span class="timestamp__text"><span class="u-h">Published: </span>@Format(trail.webPublicationDate, "d MMM y")</span>
                 </time>


### PR DESCRIPTION
![media-icons](https://f.cloud.github.com/assets/74132/2075098/b1853194-8d86-11e3-83f8-c9774ef59078.jpg)

Upshot is it's consistent with how the other items work

Downside is the link is underlined when user hovers over the launch-gallery-in-page icon. UX fail. Though there are a few fails around here (play icon doesn't have the same interaction), and only effects mouse users, i.e. desktop. 
