### PR TITLE
Facia tweaks Tuesday

### DIFF
--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -36,6 +36,7 @@
             ));
         }
         .container__body {
+            overflow: hidden;
             display: table-cell;
             width: 100000px;
             max-width: 100%;

--- a/common/app/assets/stylesheets/module/containers/_commentanddebate.scss
+++ b/common/app/assets/stylesheets/module/containers/_commentanddebate.scss
@@ -1,9 +1,10 @@
 .container--commentanddebate {
     .container__body {
-        @include mq(wide) {
-            @include rem((
-                padding-top: $gs-baseline/3
-            ));
+        @include rem((
+            padding-top: $gs-baseline/3
+        ));
+        @include mq(tablet, wide) {
+            padding-top: 0;
         }
     }
     .l-row--items-3 {

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -98,6 +98,13 @@
                 display: block;
             }
         }
+        .item--has-no-image {
+            .item__title {
+                @include mq(desktop) {
+                    @include fs-headline(2, true);
+                }
+            }
+        }
     }
 }
 .container--news {

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -127,9 +127,6 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
             margin-bottom: $gs-baseline
         ));
     }
-    @include mq(desktop) {
-        @include fs-headline(2, true);
-    }
 }
 .fromage__standfirst {
     @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -154,50 +154,50 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
         position: static;
         @include fs-data(3, true);
     }
+}
 
-    .fromage__timestamp,
-    .trail__count {
-        position: relative;
-        float: left;
+.fromage__timestamp,
+.trail__count {
+    position: relative;
+    float: left;
 
-        i {
-            position: absolute;
-            left: 0;
-            top: 2px;
-            margin: 0;
-        }
-    }
-    .fromage__timestamp {
-        min-width: gs-span(1) - 16;
-        padding-right: $gs-gutter/2;
-        padding-left: 14px;
-
-        i {
-            left: 0;
-            @include mq(tablet) {
-                top: 2px;
-            }
-        }
-    }
-    .trail__count {
-        padding-left: 28px;
-        top: 0;
-
-        a {
-            line-height: inherit;
-            color: inherit;
-        }
-        i {
-            left: $gs-gutter/2 - 1;
-        }
+    i {
+        position: absolute;
+        left: 0;
+        top: 2px;
+        margin: 0;
     }
 }
 .fromage__timestamp {
-    min-width: 44px;
-    padding-right: 10px;
-    padding-left: 14px;
     position: relative;
     float: left;
+
+    @include rem((
+        min-width: 50px - $gs-gutter/2 - 14px,
+        padding-right: $gs-gutter/2,
+        padding-left: 14px
+    ));
+
+    i {
+        left: 0;
+        @include mq(tablet) {
+            top: 2px;
+        }
+    }
+}
+.trail__count {
+    @include rem((
+        padding-left: 18px
+    ));
+    top: 0;
+
+    a {
+        line-height: inherit;
+        color: inherit;
+    }
+    i {
+        left: 0;
+    }
 }
 
 

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -264,7 +264,7 @@ $c-live: #e81818;
     }
     .item__timestamp {
         @include rem((
-            min-width: gs-span(1) - 16,
+            min-width: 50px - $gs-gutter/2 - 14px,
             padding-right: $gs-gutter/2,
             padding-left: 14px
         ));
@@ -283,7 +283,7 @@ $c-live: #e81818;
     }
     .trail__count {
         @include rem((
-            padding-left: 28px
+            padding-left: 18px
         ));
         top: 0;
 
@@ -294,7 +294,7 @@ $c-live: #e81818;
         i {
             @include rem((
                 top: 3px,
-                left: $gs-gutter/2 - 1
+                left: 0
             ));
         }
     }


### PR DESCRIPTION
According to Kat's feedback:
- Properly size meta items on fronts
- Headline of an item with no image in a row of four is bigger on desktop
- Add space between container title and avatar in comment and debate container
- Hide left separators in collections on wide viewport
- Top story standfirst text size is always headline 2

![ ](https://31.media.tumblr.com/fb43a7440cb68effabc1e94e4a6867d2/tumblr_inline_mzodg3sjJW1raprkq.gif)
