### PR TITLE
Chrome 34 detects the correct breakpoint

### DIFF
--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -296,6 +296,18 @@
     }
 }
 
+// Hide content visually, still readable by screen readers
+@mixin u-h {
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+}
+
 // Clamps a block of text to a certain number of lines,
 // followed by an ellipsis in Webkit and Blink based browsers
 // Reference: http://dropshado.ws/post/1015351370/webkit-line-clamp
@@ -305,8 +317,8 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: $lines;
 
-// Fallback for non-Webkit browsers
-// (won't show `…` at the end of the block)
+    // Fallback for non-Webkit browsers
+    // (won't show `…` at the end of the block)
     @if $line-height {
         @include rem((max-height: $line-height * $lines));
     }

--- a/common/app/assets/stylesheets/base/_base.scss
+++ b/common/app/assets/stylesheets/base/_base.scss
@@ -16,7 +16,8 @@ body {
 
 body:after {
     content: "mobile";
-    display: none;
+    @include u-h;
+
     @include mq(tablet) {
         content: "tablet";
     }

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -1,17 +1,6 @@
 /* Accessible hidden content.
    ========================================================================== */
 
-@mixin u-h {
-    border: 0 !important;
-    clip: rect(0 0 0 0) !important;
-    height: 1px !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    position: absolute !important;
-    width: 1px !important;
-}
-
 .u-h {
     @include u-h;
 }


### PR DESCRIPTION
Fixes [a bug](http://codepen.io/kaelig/pen/BDaqc) where Chrome 34 would not compute the styles of a hidden pseudo element, making the detect.js script bug. Meaning lots of layout decisions would be wrong in Chrome 34.

@michaelmcnamara can you cross browser test this to make sure there was no regression involved in the process?

![ ](http://1.bp.blogspot.com/-wLDHAATaruE/UuzcMSmyNlI/AAAAAAABFoQ/JpcSL6GyAwk/s1600/dog-loves-watching-tennis.gif)
