### PR TITLE
Restore some vertical space on top of footer

### DIFF
--- a/common/app/assets/stylesheets/module/_footer.scss
+++ b/common/app/assets/stylesheets/module/_footer.scss
@@ -37,7 +37,10 @@
    ========================================================================== */
 
 .footer {
-    @include rem((padding: 0 0 $baseline*4));
+    @include rem((
+        padding: 0 0 $baseline*4,
+        margin-top: $gs-baseline*2
+    ));
     background: $c-neutral7;
 
     .hide-in-footer {


### PR DESCRIPTION
After removing the bottom ad space, the bottom of the page got very busy. This PR adds some space between the content and the footer. 

![space-footer](https://f.cloud.github.com/assets/85783/2078185/bed6f0f6-8dba-11e3-9a13-1749c47972ee.gif)

![ ](http://s1.developerslife.ru/public/images/gifs/499790db-6663-46e7-be2c-dc0a28be3677.gif)
