### PR TITLE
Display a top tonal border on first story on tablet to desktop

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -117,6 +117,10 @@
     }
     .collection-wrapper:first-child .fromage {
         border-top-width: 0;
+
+        @include mq(tablet, wide) {
+            border-top-width: 2px;
+        }
     }
     .container__title {
         display: none;


### PR DESCRIPTION
Fixes a regression introduced this morning.
## Before

![screen shot 2014-02-04 at 17 29 53](https://f.cloud.github.com/assets/85783/2078782/0e585c8a-8dc2-11e3-8af5-8c57ea98eec2.PNG)
## After

![screen shot 2014-02-04 at 17 30 12](https://f.cloud.github.com/assets/85783/2078784/10cbf1fc-8dc2-11e3-87b1-8b66f9121bd2.PNG)

![ ](http://media.giphy.com/media/YWQoG6uCrBiyQ/giphy.gif)
