### PR TITLE
Fronts: Moving traffic over to alphas

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -2,7 +2,7 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET        /humans.txt                                                                                               controllers.Assets.at(path="/public", file="humans.txt")
+GET         /humans.txt                                                                                              controllers.Assets.at(path="/public", file="humans.txt")
 
 # For dev machines
 GET         /assets/internal/*file                                                                                   controllers.Assets.at(path="/public", file)
@@ -47,7 +47,7 @@ GET         /recent/card.json                                                   
 
 GET         /preference/platform/:platform                                                                           controllers.ChangeViewController.render(platform, page)
 GET         /preference/edition/:edition                                                                             controllers.ChangeEditionController.render(edition)
-GET         /preference/$networkFront<uk|au|us>alpha/:optaction                                                      controllers.ChangeAlphaController.render(networkFront, optaction, page)
+GET         /preference/front-alphas/:optAction                                                                      controllers.ChangeAlphaController.render(optAction, page)
 
 GET         /cards/opengraph/*path.json                                                                              controllers.CardController.opengraph(path)
 

--- a/facia/app/assets/javascripts/bootstraps/facia.js
+++ b/facia/app/assets/javascripts/bootstraps/facia.js
@@ -97,33 +97,14 @@ define([
         },
 
         displayAlphaMessage: function(config) {
-            if (config.page.contentType === 'Network Front') {
+            if (config.page.contentType === 'Network Front' && /^.*-alpha$/.test(config.page.pageId)) {
                 var page = window.location.pathname.replace('-alpha', ''),
-                    preferenceUrl = '/preference' + page + 'alpha/[OPT]?page=' + page + '%3Ftime=' + (new Date().getTime()),
-                    msg,
-                    messageId = 'facia-alpha';
-                if (config.page.pageId === "") {
-                    // only run on 5% of (mobile) users
-                    var isAChosenOne = parseInt(mvtCookie.getMvtValue(), 10) < (mvtCookie.MAX_INT * 0.05) && detect.getMobileOS(),
-                        alphaSwitch = {
-                            '/uk': 'networkFrontUkAlpha',
-                            '/us': 'networkFrontUsAlpha',
-                            '/au': 'networkFrontAuAlpha'
-                        }[page];
-                    if ((isAChosenOne && config.switches[alphaSwitch] === true) || window.location.hash === '#show-alpha-opt-in') {
-                        msg =
-                            '<p class="site-message__message">' +
-                                'We’re trying out some new things on our website and would love your feedback. <a href="' +
-                                    preferenceUrl.replace('[OPT]', 'optin') + '">Click here</a> to explore a test version of the site.' +
-                            '</p>';
-                        new Message(messageId).show(msg);
-                    }
-                } else {
-                    var userZoomSurvey = {
+                    preferenceUrl = '/preference/front-alphas/opt-out?page=' + page + '%3Ftime=' + (new Date().getTime()),
+                    userZoomSurvey = {
                         '/us': 'MSBDMTBTMTE1',
                         '/au': 'MSBDMTBTMTE2',
                         '/uk': 'MSBDMTBTMTE3'
-                    }[page];
+                    }[page],
                     msg =
                         '<p class="site-message__message">' +
                             'You’re viewing a test version of the Guardian website.' +
@@ -138,15 +119,13 @@ define([
                             ) +
                             '<li class="site-message__actions__item">' +
                                 '<i class="i i-back"></i>' +
-                                '<a class="js-main-site-link" rel="nofollow" href="' + preferenceUrl.replace('[OPT]', 'optout') + '"' +
+                                '<a class="js-main-site-link" rel="nofollow" href="' + preferenceUrl + '"' +
                                     'data-link-name="opt-out">Opt-out and return to the standard site</a>' +
                             '</li>' +
                         '</ul>';
-                    var opts = {
-                        permanent: true
-                    };
-                    new Message(messageId, opts).show(msg);
-                }
+                new Message('facia-alpha', {
+                    permanent: true
+                }).show(msg);
             }
         }
     };

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -46,9 +46,8 @@ class FaciaController extends Controller with Logging with ExecutionContexts {
   private def getPathForUkAlpha(path: String, request: RequestHeader): String =
     Seq("uk", "us", "au").find { page =>
       path == page &&
-        Option(Edition(request)) == Edition.byId(page) &&
         Switches.byName(s"network-front-${page}-alpha").exists(_.isSwitchedOn) &&
-        request.headers.get(s"X-Gu-${page.capitalize}-Alpha").exists(_.toLowerCase == "true")
+        request.headers.get(s"X-Gu-Front-Alphas").exists(_.toLowerCase == "true")
     }.map{ page =>
       s"$page-alpha"
     }.getOrElse(path)

--- a/onward/app/controllers/ChangeAlphaController.scala
+++ b/onward/app/controllers/ChangeAlphaController.scala
@@ -4,11 +4,11 @@ import play.api.mvc._
 
 object ChangeAlphaController extends Controller with PreferenceController {
 
-  def render(networkFront: String, optaction: String, redirectUrl: String) = Action { implicit request =>
-    val abCookieName: String = s"GU_${networkFront.toUpperCase()}_ALPHA"
-    optaction match {
-      case "optin"  => switchTo(abCookieName -> "true", redirectUrl)
-      case "optout" => switchTo(abCookieName -> "false", redirectUrl)
+  def render(optAction: String, redirectUrl: String) = Action { implicit request =>
+    val abCookieName: String = "GU_FRONT_ALPHAS"
+    optAction match {
+      case "opt-in"  => switchTo(Seq(abCookieName -> "true", "GU_VIEW" -> ""), redirectUrl)
+      case "opt-out" => switchTo(Seq(abCookieName -> "false", "GU_VIEW" -> ""), redirectUrl)
       case _ => NotFound("unknown action")
     }
   }

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -30,7 +30,7 @@ GET        /recent/card.json                                      controllers.Re
 
 GET        /preference/platform/:platform                         controllers.ChangeViewController.render(platform, page)
 GET        /preference/edition/:edition                           controllers.ChangeEditionController.render(edition)
-GET        /preference/$networkFront<uk|au|us>alpha/:optaction    controllers.ChangeAlphaController.render(networkFront, optaction, page)
+GET        /preference/front-alphas/:optAction                    controllers.ChangeAlphaController.render(optAction, page)
 
 # Experimental
 GET        /cards/opengraph/*path.json                            controllers.CardController.opengraph(path)


### PR DESCRIPTION
Simplify logic, as looking for `X-Gu-Front-Alphas` header and auto opting in (so no opt-in message anymore)

see https://github.com/guardian/fastly-edge-cache/pull/118
