### PR TITLE
Remove :hover on show more button

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -427,12 +427,6 @@ $c-live: #e81818;
     .show-more__hover--show { display: none; } // Nested to override global styles
 }
 
-.collection__show-more:hover,
-.collection__show-more:focus {
-    .show-more__hover--hide { display: none; }
-    .show-more__hover--show { display: inline-block; }
-}
-
 // Thumbnail element order:
 // 1. Title
 // 2. Image + standfirst


### PR DESCRIPTION
Fixes a bug where iOS6 and below capture the :hover event and blocks the click event on the button.

This is a temporary fix before we can properly deal with the issues raised in #3018

![ ](http://media.giphy.com/media/i0X9IoMYrLhBe/giphy.gif)
