### PR TITLE
Revert "Merge pull request #3014 from guardian/breaking-news-label"

### DIFF
--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -48,7 +48,7 @@
                 }
                 <h1 class="fromage__title">
                     @if(trail.isBreaking){
-                        <span class="item__live-indicator">Breaking</span>
+                        <span class="item__live-indicator">Breaking News</span>
                     }
                     @if(trail.isLive && !trail.isBreaking){
                         <span class="item__live-indicator">Live</span>

--- a/common/app/views/fragments/items/rowPattern/thumbnailGallery.scala.html
+++ b/common/app/views/fragments/items/rowPattern/thumbnailGallery.scala.html
@@ -26,7 +26,7 @@
                 <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                     <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
                         @if(trail.isBreaking){
-                            <span class="item__live-indicator">Breaking</span>
+                            <span class="item__live-indicator">Breaking News</span>
                         }
                         @if(trail.isLive && !trail.isBreaking){
                             <span class="item__live-indicator">Live</span>

--- a/common/app/views/fragments/items/rowPattern/thumbnailVideo.scala.html
+++ b/common/app/views/fragments/items/rowPattern/thumbnailVideo.scala.html
@@ -26,7 +26,7 @@
                 <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                     <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
                         @if(trail.isBreaking){
-                            <span class="item__live-indicator">Breaking</span>
+                            <span class="item__live-indicator">Breaking News</span>
                         }
                         @if(trail.isLive && !trail.isBreaking){
                             <span class="item__live-indicator">Live</span>

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -36,7 +36,7 @@
                 }
                 <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
                     @if(trail.isBreaking){
-                        <span class="item__live-indicator">Breaking</span>
+                        <span class="item__live-indicator">Breaking News</span>
                     }
                     @if(trail.isLive && !trail.isBreaking){
                         <span class="item__live-indicator">Live</span>

--- a/common/app/views/fragments/items/thumbnail.scala.html
+++ b/common/app/views/fragments/items/thumbnail.scala.html
@@ -20,7 +20,7 @@
         <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
             <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
                 @if(trail.isBreaking){
-                    <span class="item__live-indicator">Breaking</span>
+                    <span class="item__live-indicator">Breaking News</span>
                 }
                 @if(trail.isLive && !trail.isBreaking){
                     <span class="item__live-indicator">Live</span>


### PR DESCRIPTION
This reverts commit f1de9417272b64e5e65911c1f5fef1ec3f953e49, reversing
changes made to 14ec88eac72c0f2e775620453bb259ab1e1565e9.

Changing back the "Breaking" label to "Breaking News" as per Editorial's request.

![ ](http://media.giphy.com/media/143vPc6b08locw/giphy.gif)
