### PR TITLE
Change email-signup-ab test styling

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -643,7 +643,6 @@ video {
 
 .email-signup {
     background-color: #ffffff;
-    border-top: 1px solid $c-neutral3;
     padding: 4px 0 10px 0;
     margin-bottom: 16px;
     position: relative;
@@ -680,6 +679,7 @@ video {
     }
 
     @include mq(leftCol) {
+        border-top: 1px solid $c-neutral3;
         .email-signup__title {
             @include fs-data(3);
             padding-top: 4px;


### PR DESCRIPTION
This small change prevents a border from appearing at breakpoints below `leftCol`.

It only affects the current email-signup ab test module.
