### PR TITLE
Set root font size in px - Fixes layout issues in IE11

### DIFF
--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -8,15 +8,13 @@
 html {
     font-family: $serif;
 
-    // font-size: 62.5%; // Set baseline font size to 10px
-    //                   // This is used as a baseline for rem (root ems) values
+    // Set baseline font size to 10px
+    // This is used as a baseline for rem (root ems) values
+    font-size: 62.5%;
 
-    // @Kaelig on 05/02/2014:
-    // IE11 appears to have maths issues and sets the root font size to 9.93px
-    // instead of 10px. This has deep layout implications.
-    // Reverting to a px value until we find a fix for IE11,
-    // which means we are discarding any text size user preference.
-    font-size: 10px;
+    // For IE11 to do the math properly
+    // See http://bit.ly/1g4X0bX — thanks @7studio and @dawitti
+    font-size: calc(1em * .625);
 }
 body {
     color: #545454;

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -7,8 +7,16 @@
 
 html {
     font-family: $serif;
-    font-size: 62.5%; // Set baseline font size to 10px
-                      // This is used as a baseline for rem (root ems) values
+
+    // font-size: 62.5%; // Set baseline font size to 10px
+    //                   // This is used as a baseline for rem (root ems) values
+
+    // @Kaelig on 05/02/2014:
+    // IE11 appears to have maths issues and sets the root font size to 9.93px
+    // instead of 10px. This has deep layout implications.
+    // Reverting to a px value until we find a fix for IE11,
+    // which means we are discarding any text size user preference.
+    font-size: 10px;
 }
 body {
     color: #545454;


### PR DESCRIPTION
Fixes rendering issues on IE11.

See https://connect.microsoft.com/IE/feedback/details/816709/ie-11-calculating-font-sizes-wrong-when-setting-the-bodys-font-size-in-relative-units

> If you set
> 
> ```
> body {
>     font-size: 62.5%;
> }
> ```
> 
> The calculated font size should be `10px`, but it is `9.93px` in IE11

Thanks @7studio and @dawitti

![ ](http://media.giphy.com/media/g8qNjmVyhNfOw/giphy.gif)
