### PR TITLE
Effective Measure tag for Australians

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/au/effective-measure.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/au/effective-measure.js
@@ -1,0 +1,13 @@
+define([], function() {
+
+    var effectiveMeasureUrl = "js!" + (document.location.protocol === 'https:' ? 'https://au-ssl' : 'http://au-cdn') + '.effectivemeasure.net/em.js';
+
+    function load() {
+        require([effectiveMeasureUrl], function() {});
+    }
+    
+    return {
+        load: load
+    };
+
+});

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/container.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/container.js
@@ -4,11 +4,13 @@
 define([
     'common/modules/analytics/commercial/tags/common/audience-science',
     'common/modules/analytics/commercial/tags/common/imrworldwide',
-    'common/modules/analytics/commercial/tags/au/amaa'
+    'common/modules/analytics/commercial/tags/au/amaa',
+    'common/modules/analytics/commercial/tags/au/effective-measure'
 ], function(
     AudienceScience,
     IMRWorldwide,
-    Amaa
+    Amaa,
+    EffectiveMeasure
 ) {
 
     function init(config) {
@@ -19,6 +21,10 @@ define([
 
                 if (config.switches.amaa) {
                     Amaa.load();
+                }
+                
+                if (config.switches.effectiveMeasure) {
+                    EffectiveMeasure.load();
                 }
 
                 break;

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -105,6 +105,9 @@ object Switches extends Collections {
     "Enable the AMAA audience segment tracking.",
     safeState = Off, sellByDate = endOfQ4)
 
+  val EffectiveMeasureSwitch = Switch("Commercial Tags", "effective-measure",
+    "Enable the Effective Measure audience segment tracking.",
+    safeState = Off, sellByDate = endOfQ4)
 
   // Commercial Feeds
 
@@ -436,6 +439,7 @@ object Switches extends Collections {
     OphanSwitch,
     ContentApiPutSwitch,
     AmaaSwitch,
+    EffectiveMeasureSwitch,
     ImrWorldwideSwitch,
     DiagnosticsRequestLogging,
     DiagnosticsJavascriptErrorLogging,


### PR DESCRIPTION
"The second [tag] is for Effective Measure which provides an opportunity to obtain audience and campaign data for our Australian audience which we desperately need in the absence of other data at this point in time!  Ian Gibb (Commercial Insight) has already initiated discussions with both the provider and our Producer (Madhvi Pankhania) and we are now awaiting next steps."

3 month trail. Contact Matt Kopka & Sam Yee.

Dave Boxall had to remove the host name from ScanSafe. He says, "Its not uncommon for analytics firms to get a bit grey in reputation. Quantcast did indeed fall foul of this. I am comfortable going live but there is a risk of future blacklist at which point users may get site warnings they may attribute to us."
