### PR TITLE
Facia tweaks Wednesday

### DIFF
--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -49,6 +49,9 @@ $a-leftCol-width:     gs-span(2); // Grows to 3 columns on wide viewports
 $a-leftCol-trigger:   gs-span(13) + $gs-gutter*2; // 1060px
 $a-leftColWide-width: gs-span(3); // Grows to 3 columns on wide viewports
 
+// Facia breakpoints
+$facia-leftCol-trigger: gs-span(14) + $gs-gutter*2; // 1140px
+
 $mq-breakpoints: (
     mobile:  gs-span(4)  + $gs-gutter,   // 320px
     tablet:  gs-span(9)  + $gs-gutter*2, // 740px
@@ -61,7 +64,10 @@ $mq-breakpoints: (
 
     // Article layout
     rightCol: $a-rightCol-trigger,
-    leftCol: $a-leftCol-trigger
+    leftCol: $a-leftCol-trigger,
+
+    // Facia layout
+    faciaLeftCol: $facia-leftCol-trigger
 );
 
 

--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -25,29 +25,37 @@
     @include mq(desktop) {
         @include rem((width: gs-span(12)));
     }
-    @include mq(wide) {
-        @include rem((width: gs-span(16)));
+    @include mq(faciaLeftCol) {
+        @include rem((width: gs-span(14)));
 
         .container__title {
-            float: left;
-            @include rem((
-                width: gs-span(3) + $gs-gutter,
-                margin-right: gs-span(1) + $gs-gutter
-            ));
+            margin-bottom: 0;
         }
         .container__body {
             overflow: hidden;
-        }
-        .container__toggle {
             @include rem((
-                right: gs-span(12) + $gs-gutter,
-                min-width: 40px
+                margin-left: gs-span(2) + $gs-gutter
             ));
         }
         .container--news {
             .container__title {
                 display: block;
             }
+        }
+    }
+    @include mq(wide) {
+        @include rem((width: gs-span(16)));
+
+        .container__title {
+            float: left;
+            @include rem((
+                width: gs-span(3),
+                margin-right: $gs-gutter
+            ));
+        }
+        .container__body {
+            margin-left: 0;
+            @include rem((width: gs-span(12)));
         }
     }
 }

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -111,14 +111,14 @@
     .container__border {
         display: none;
 
-        @include mq(wide) {
+        @include mq(faciaLeftCol) {
             display: block;
         }
     }
     .collection-wrapper:first-child .fromage {
         border-top-width: 0;
 
-        @include mq(tablet, wide) {
+        @include mq(tablet, faciaLeftCol) {
             border-top-width: 2px;
         }
     }

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -288,6 +288,11 @@
 .today__dayofweek {
     color: $c-newsDefault;
 }
+@include mq(wide) {
+    .today__sub {
+        display: block;
+    }
+}
 
 
 /**

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -340,7 +340,7 @@ $c-neutral2-contrasted: darken($c-neutral2, 3%);
     .fromage__standfirst {
         @include mq(desktop) {
             @include rem((
-                max-width: gs-span(7)
+                max-width: gs-span(8)
             ));
         }
     }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -102,7 +102,7 @@ $c-live: #e81818;
         }
     }
     @include mq(tablet) {
-        @include rem((top: $gs-baseline/2));
+        top: 0;
         text-align: right;
         color: $c-neutral2;
 

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -17,8 +17,8 @@
 
                 <h2 class="container__title">
                     <span class="container__title__label today u-text-hyphenate">
-                        <b class="today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</b><br />
-                        <span class="u-nobr">
+                        <b class="today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</b>
+                        <span class="u-nobr today__sub">
                             <span class="today__dayofmonth js-dayofmonth">@Format(DateTime.now(), "d")</span>
                             <span class="today__month">@Format(DateTime.now(), "MMMM")</span>
                             <span class="today__year">@Format(DateTime.now(), "yyyy")</span>

--- a/common/app/views/fragments/containers/people.scala.html
+++ b/common/app/views/fragments/containers/people.scala.html
@@ -7,6 +7,7 @@
             <section class="container container--row-pattern container--@style.containerType @if(containerIndex > 0 && title.nonEmpty){js-container--toggle} js-container-add-show-more"
                      data-link-name="block | @config.id"
                      data-id="@config.id"
+                     data-tone="@style.tone"
                      data-type="@style.containerType">
 
                 <div class="container__border tone-@style.tone tone-accent-border"></div>


### PR DESCRIPTION
- [fix] People container show more button has the correct colour
- [fix] Title and standfirst can be a bit longer on desktop and up (capped at 8 columns instead of 7)
- [new] Facia containers: new intermediate breakpoint (cf infra)

![screen shot 2014-02-06 at 17 54 05](https://f.cloud.github.com/assets/85783/2101934/d6e2cd8e-8f57-11e3-942a-9d04afe071f1.PNG)

![screen shot 2014-02-06 at 17 54 13](https://f.cloud.github.com/assets/85783/2101940/daf4e268-8f57-11e3-822c-527a59c47a36.PNG)

![screen shot 2014-02-06 at 17 54 34](https://f.cloud.github.com/assets/85783/2101942/dcfd4db6-8f57-11e3-98bb-10772c61aee7.PNG)

![screen shot 2014-02-06 at 17 54 48](https://f.cloud.github.com/assets/85783/2101943/deccd756-8f57-11e3-83e2-5f68e3fb7051.PNG)

![ ](http://media.giphy.com/media/EyIPL8j0LgYso/giphy.gif)
