### PR TITLE
Email signup component refactor

### DIFF
--- a/common/app/assets/javascripts/modules/identity/email-signup.js
+++ b/common/app/assets/javascripts/modules/identity/email-signup.js
@@ -14,37 +14,62 @@ define([
 
     var EmailSignup = function (context) {
 
-        var container = context.querySelector(".email-signup");
+        var container = context.querySelector(this.getClass("ES_ROOT"));
 
-        this.DOM = {
-            container: container,
-            button: container.querySelector(".email-signup__link"),
-            loader: container.querySelector(".is-updating"),
-            title: container.querySelector(".email-signup__title")
+        if (container && container.querySelector(this.getClass("ES_INNER"))) {
+
+            this.DOM = {
+                container: container,
+                button: container.querySelector(this.getClass("ES_LINK")),
+                loader: container.querySelector(this.getClass("ES_LOADER")),
+                title: container.querySelector(this.getClass("ES_TITLE"))
+            };
+
+            this.emailHash = "#email-subscribe";
+            this.storageKey = "gu.emails.subsriptions";
+            this.storageData = Storage.local.get(this.storageKey) || {listIds: []};
+            this.listId = this.DOM.button ? this.DOM.button.getAttribute("data-list-id") : null;
+
+            for (var key in this.DOM) {
+                if (this.DOM.hasOwnProperty(key)) {
+                    this.DOM["$" + key] = bonzo(this.DOM[key]);
+                }
+            }
+
+            if (this.canRun()) {
+                this.DOM.$container.removeClass("is-hidden");
+                if (!this.checkHash(window.location.hash)) {
+                    var click = function (event) {
+                        event.preventDefault();
+                        this.requestEmailSignup();
+                    };
+                    bean.on(this.DOM.button, "click", click.bind(this));
+                }
+            }
+        }
+
+    };
+
+    EmailSignup.prototype.canRun = function () {
+        return  this.DOM.container && // container exists
+                (
+                    this.DOM.container.children && // container has children prop
+                    this.DOM.container.children.length > 0 // children prop has elements
+                ) &&
+                this.listId && // List id exists
+                !this.checkStorage(this.listId); // user not already signed up to email
+    };
+
+    EmailSignup.prototype.getClass = function (className) {
+        this.config = this.config || {};
+        this.config.classes = this.config.classes || {
+            "ES_ROOT": ".email-signup",
+            "ES_INNER": ".email-signup__inner",
+            "ES_LINK": ".email-signup__link",
+            "ES_LOADER": ".is-updating",
+            "ES_TITLE": ".email-signup__title"
         };
-
-        this.emailHash = "#email-subscribe";
-        this.storageKey = "gu.emails.subsriptions";
-        this.storageData = Storage.local.get(this.storageKey) || {listIds: []};
-        this.listId = this.DOM.button.getAttribute("data-list-id");
-
-        for (var key in this.DOM) {
-            if (this.DOM.hasOwnProperty(key)) {
-                this.DOM["$" + key] = bonzo(this.DOM[key]);
-            }
-        }
-
-        if (this.DOM.container && (this.DOM.container.children && this.DOM.container.children.length > 0) && !this.checkStorage(this.listId)) {
-            this.DOM.$container.removeClass("is-hidden");
-            if (!this.checkHash(window.location.hash)) {
-                var click = function (event) {
-                    event.preventDefault();
-                    this.requestEmailSignup();
-                };
-                bean.on(this.DOM.button, "click", click.bind(this));
-            }
-        }
-
+        return this.config.classes[className];
     };
 
     /*

--- a/common/app/assets/javascripts/modules/identity/email-signup.js
+++ b/common/app/assets/javascripts/modules/identity/email-signup.js
@@ -50,6 +50,9 @@ define([
 
     };
 
+    /*
+     *  Determines if the component should run.
+     */
     EmailSignup.prototype.canRun = function () {
         return  this.DOM.container && // container exists
                 (
@@ -60,6 +63,9 @@ define([
                 !this.checkStorage(this.listId); // user not already signed up to email
     };
 
+    /*
+     *  Accessor/creator for the classname config
+     */
     EmailSignup.prototype.getClass = function (className) {
         this.config = this.config || {};
         this.config.classes = this.config.classes || {


### PR DESCRIPTION
This pull request draws out the classes used in the email signup component in to a separate config object. It also adds some extra checks to see if the component can run and draws these out in to an internal `canRun()` function.

These changes also address some outside edge cases where an error could be generated under the right circumstances (eg: If the component is active and the play app generates the right markup but no email `listId` was found). cc @phamann here.

This work will be continued by making use of the `component.js` module **_if**_ the email signup is picked up for production after this test is over.
