### PR TITLE
Change the default oas site id host to guardian-alpha.com

### DIFF
--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -16,7 +16,7 @@
         "isDev": @play.Play.isDev(),
         "oasHost": "oas.theguardian.com",
         "oasUrl": "@Configuration.oas.url",
-        "oasSiteIdHost": "www.theguardian.com",
+        "oasSiteIdHost": "www.theguardian-alpha.com",
         "idUrl": "@Configuration.id.url",
         "beaconUrl": "@Configuration.debug.beaconUrl",
         "renderTime": "@{(new DateTime).toISODateTimeNoMillisString}",


### PR DESCRIPTION
Change the default oas site id host to guardian-alpha.com

// @phamann @commuterjoy 
