### PR TITLE
Ad labelling ab test

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -222,7 +222,7 @@ define([
         },
 
         loadAdverts: function (config) {
-            if(!userPrefs.isOff('adverts') && config.switches && config.switches.adverts && !config.page.blockVideoAds && !config.page.shouldHideAdverts) {
+            if(!userPrefs.isOff('adverts') && config.switches.adverts && !config.page.blockVideoAds && !config.page.shouldHideAdverts) {
                 var resizeCallback = function() {
                     hasBreakpointChanged(Adverts.reload);
                 };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -222,8 +222,7 @@ define([
         },
 
         loadAdverts: function (config) {
-            if(!userPrefs.isOff('adverts') && config.switches && config.switches.adverts
-                && !config.page.blockVideoAds && !config.page.shouldHideAdverts) {
+            if(!userPrefs.isOff('adverts') && config.switches && config.switches.adverts && !config.page.blockVideoAds && !config.page.shouldHideAdverts) {
                 var resizeCallback = function() {
                     hasBreakpointChanged(Adverts.reload);
                 };
@@ -243,6 +242,7 @@ define([
                         hasBreakpointChanged(function() {
                             articleBodyAdverts.reload();
                             Adverts.reload();
+                            mediator.emit('modules:adverts:reloaded');
                         });
                     };
                 }

--- a/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
@@ -28,8 +28,8 @@ define([
         inlineAdLimit: null,
         wordsPerAd: 350,
         minWordsInParagraph: 120,
-        inlineAdTemplate: '<div class="ad-slot ad-slot--inline" data-base="%slot%" data-median="%slot%"><div class="ad-label">Advertisement</div><div class="ad-container"></div></div>',
-        mpuAdTemplate: '<div class="ad-slot ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="%slot%" data-median="%slot%"><div class="ad-label">Advertisement</div><div class="ad-container"></div></div>'
+        inlineAdTemplate: '<div class="ad-slot ad-slot--inline" data-base="%slot%" data-median="%slot%"><div class="ad-slot__label">Advertisement</div><div class="ad-container"></div></div>',
+        mpuAdTemplate: '<div class="ad-slot ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="%slot%" data-median="%slot%"><div class="ad-slot__label">Advertisement</div><div class="ad-container"></div></div>'
     };
 
     ArticleBodyAdverts.prototype.inlineAdsPlaced = 0;

--- a/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
@@ -28,8 +28,8 @@ define([
         inlineAdLimit: null,
         wordsPerAd: 350,
         minWordsInParagraph: 120,
-        inlineAdTemplate: '<div class="ad-slot ad-slot--inline" data-base="%slot%" data-median="%slot%"><div class="ad-container"></div></div>',
-        mpuAdTemplate: '<div class="ad-slot ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="%slot%" data-median="%slot%"><div class="ad-container"></div></div>'
+        inlineAdTemplate: '<div class="ad-slot ad-slot--inline" data-base="%slot%" data-median="%slot%"><div class="ad-label">Advertisement</div><div class="ad-container"></div></div>',
+        mpuAdTemplate: '<div class="ad-slot ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="%slot%" data-median="%slot%"><div class="ad-label">Advertisement</div><div class="ad-container"></div></div>'
     };
 
     ArticleBodyAdverts.prototype.inlineAdsPlaced = 0;

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -7,7 +7,8 @@ define([
     //Current tests
     'common/modules/experiments/tests/aa',
     'common/modules/experiments/tests/gravity-recommendations',
-    'common/modules/experiments/tests/identity-email-signup'
+    'common/modules/experiments/tests/identity-email-signup',
+    'common/modules/experiments/tests/ad-labels'
 ], function (
     common,
     store,
@@ -16,13 +17,15 @@ define([
 
     Aa,
     GravityRecommendations,
-    EmailSignup
+    EmailSignup,
+    AdLabels
     ) {
 
     var TESTS = [
             new Aa(),
             new GravityRecommendations(),
-            new EmailSignup()
+            new EmailSignup(),
+            new AdLabels()
        ],
        participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
@@ -1,3 +1,4 @@
+/*global guardian */
 define([
     'common/$',
     'common/utils/mediator'
@@ -19,11 +20,15 @@ define([
         this.variants = [
             {
                 id: 'control',
-                test: function(context, config) {}
+                test: function(context, config) {
+                    guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha1.com';
+                }
             },
             {
                 id: 'ShowAdLabels',
                 test: function (context, config) {
+                    guardian.config.page.oasSiteIdHost = 'www.theguardian-alpha2.com';
+
                     $('.ad-slot').addClass('ad-slot__show-label');
 
                     // Re-apply the class when ads are reloaded on window resize

--- a/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
@@ -15,7 +15,7 @@ define([
         this.audienceOffset = 0.4;
         this.description = 'Testing if putting labels next to ads impacts the CTR';
         this.canRun = function(config) {
-            return config.page.contentType === 'Article' && config.switches && config.switches.adverts;
+            return config.page.contentType === 'Article' && config.switches.adverts;
         };
         this.variants = [
             {

--- a/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
@@ -10,7 +10,7 @@ define([
 
         this.id = 'AdLabels';
         this.expiry = '2014-02-24';
-        this.audience = 0.1;
+        this.audience = 0.3;
         this.audienceOffset = 0.4;
         this.description = 'Testing if putting labels next to ads impacts the CTR';
         this.canRun = function(config) {

--- a/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/ad-labels.js
@@ -1,0 +1,37 @@
+define([
+    'common/$',
+    'common/utils/mediator'
+], function(
+    $,
+    mediator
+    ) {
+
+    return function() {
+
+        this.id = 'AdLabels';
+        this.expiry = '2014-02-24';
+        this.audience = 0.1;
+        this.audienceOffset = 0.4;
+        this.description = 'Testing if putting labels next to ads impacts the CTR';
+        this.canRun = function(config) {
+            return config.page.contentType === 'Article' && config.switches && config.switches.adverts;
+        };
+        this.variants = [
+            {
+                id: 'control',
+                test: function(context, config) {}
+            },
+            {
+                id: 'ShowAdLabels',
+                test: function (context, config) {
+                    $('.ad-slot').addClass('ad-slot__show-label');
+
+                    // Re-apply the class when ads are reloaded on window resize
+                    mediator.on('modules:adverts:reloaded', function() {
+                        $('.ad-slot').addClass('ad-slot__show-label');
+                    });
+                }
+            }
+        ];
+    };
+});

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -19,7 +19,7 @@
     .ad-slot__label {
         height: 34px;
         background-color: #F8F8F8;
-        padding: 0 4px;
+        padding: 0 $baseline*2;
         border-top: 1px solid #E4E4E4;
         @include box-sizing(border-box);
 

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -15,6 +15,28 @@
     iframe {
         margin: 0 auto;
     }
+
+    .ad-label {
+        height: 34px;
+        background-color: #F8F8F8;
+        padding-left: 4px;
+        border-top: 1px solid #E4E4E4;
+        @include box-sizing(border-box);
+
+        color: $c-neutral2;
+        font-family: $sans-serif;
+        @include font-size(12, 20);
+        text-align: left;
+        -webkit-font-smoothing: antialiased;
+        display: none;
+    }
+
+    &.ad-slot__show-label {
+
+        .ad-label {
+            display: block;
+        }
+    }
 }
 .ad-container {
     display: inline-block;
@@ -48,8 +70,30 @@
 }
 
 .ad-slot--inline {
+    padding: 0;
+
     .ad-container {
         line-height: 0;
+    }
+
+    .ad-label {
+        max-width: 300px;
+        margin: 0 auto;
+
+        @include mq(mobileLandscape, tablet) {
+            position: absolute;
+            width: 100%;
+            height: 50px;
+            margin: 0 !important;
+            z-index: -1;
+        }
+    }
+
+    &.ad-slot__show-label {
+
+        @include mq(mobileLandscape, tablet) {
+            text-align: right;
+        }
     }
 
     @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -17,18 +17,18 @@
     }
 
     .ad-slot__label {
-        height: 34px;
-        background-color: #F8F8F8;
-        padding: 0 $baseline*2;
-        border-top: 1px solid #E4E4E4;
+        display: none;
         @include box-sizing(border-box);
+        height: 34px;
+        background-color: $c-neutral8;
+        padding: 0 $baseline*2;
+        border-top: 1px solid $c-neutral5;
 
         color: $c-neutral2;
         font-family: $sans-serif;
         @include font-size(12, 20);
         text-align: right;
         -webkit-font-smoothing: antialiased;
-        display: none;
     }
 
     &.ad-slot__show-label {
@@ -97,7 +97,6 @@
             position: absolute;
             width: 100%;
             height: 50px;
-            margin: 0 !important;
             z-index: -1;
             text-align: left;
         }

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -16,28 +16,34 @@
         margin: 0 auto;
     }
 
-    .ad-label {
+    .ad-slot__label {
         height: 34px;
         background-color: #F8F8F8;
-        padding-left: 4px;
+        padding: 0 4px;
         border-top: 1px solid #E4E4E4;
         @include box-sizing(border-box);
 
         color: $c-neutral2;
         font-family: $sans-serif;
         @include font-size(12, 20);
-        text-align: left;
+        text-align: right;
         -webkit-font-smoothing: antialiased;
         display: none;
     }
 
     &.ad-slot__show-label {
 
-        .ad-label {
+        .ad-slot__label {
             display: block;
         }
     }
 }
+
+.ad-slot__wrapper {
+    max-width: 100%;
+    display: inline-block;
+}
+
 .ad-container {
     display: inline-block;
     width: auto;
@@ -59,6 +65,13 @@
     @include mq(tablet) {
         background-color: #ffffff;
     }
+
+    @include mq($to: tablet) {
+        .ad-slot__label {
+            height: auto;
+            border: none;
+        }
+    }
 }
 
 .parts__head {
@@ -76,7 +89,7 @@
         line-height: 0;
     }
 
-    .ad-label {
+    .ad-slot__label {
         max-width: 300px;
         margin: 0 auto;
 
@@ -86,6 +99,7 @@
             height: 50px;
             margin: 0 !important;
             z-index: -1;
+            text-align: left;
         }
     }
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -204,7 +204,7 @@ object Switches extends Collections {
     "If switched on then all embeds will be shown inside article bodies",
     safeState = Off, sellByDate = new DateMidnight(2014, 2, 28)
   )
-  
+
   val ReleaseMessageSwitch = Switch("Feature Switches", "release-message",
     "If this is switched on users will be messaged that they are inside the alpha/beta/whatever release",
     safeState = Off, sellByDate = endOfQ4
@@ -312,6 +312,11 @@ object Switches extends Collections {
   val ABGravityRecommendations = Switch("A/B Tests", "ab-gravity-recommendations",
     "Enables gravity beacon code on the site",
     safeState = Off, sellByDate = new DateMidnight(2014, 2, 24)
+  )
+
+  val ABAdLabels = Switch("A/B Tests", "ab-ad-labels",
+    "Testing if putting labels next to ads impacts the CTR",
+    safeState = Off, sellByDate = new DateMidnight(2014, 2, 27)
   )
 
   val TagLinking = Switch("Feature Switches", "tag-linking",
@@ -424,6 +429,7 @@ object Switches extends Collections {
     ABAa,
     ABGravityRecommendations,
     ABEmailSignup,
+    ABAdLabels,
     NetworkFrontUkAlpha,
     NetworkFrontUsAlpha,
     NetworkFrontAuAlpha,

--- a/common/app/views/fragments/adSlot.scala.html
+++ b/common/app/views/fragments/adSlot.scala.html
@@ -8,5 +8,8 @@ take ad clicks with a pinch of salt.
      data-base="@baseSlot"
      data-median="@medianSlot"
      data-extended="@extendedSlot">
-     <div class="ad-container"></div>
+     <div class="ad-slot__wrapper">
+         <div class="ad-slot__label">Advertisement</div>
+         <div class="ad-container"></div>
+     </div>
 </div>


### PR DESCRIPTION
- AB test to measure the impact on CTR when ads are labelled
- 30% traffic allocation
- Measuring by using difference ad servers (alpha1/alpha2)
- Only run when ads are switched on and viewing an article

Desktop:
![ad-label-desktop](https://f.cloud.github.com/assets/1148714/2127981/48122b7e-9275-11e3-8c97-d62d0e21599c.png)

Mobile:
![ad-label-mobile](https://f.cloud.github.com/assets/1148714/2127982/4821b0f8-9275-11e3-8580-4cedda2c7e3f.png)
