### PR TITLE
Firefox reorders correctly the image on top of the title

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -220,8 +220,6 @@
             .item__media-wrapper {
                 -webkit-order: -1;
                 order: -1;
-                -webkit-flex: 1 1 0;
-                flex: 1 1 0;
                 margin-right: 0;
             }
         }


### PR DESCRIPTION
Fixes a bug in Firefox in single column mode where the image would overlap the rest of an item in the news container.
## Before

![screen shot 2014-02-12 at 10 16 01](https://f.cloud.github.com/assets/85783/2147219/d3640562-93ce-11e3-9dd6-fcad84d19dbd.PNG)
## After

![screen shot 2014-02-12 at 10 15 52](https://f.cloud.github.com/assets/85783/2147221/d6395cc4-93ce-11e3-99e9-39977f312155.PNG)

![ ](http://2.bp.blogspot.com/-Kwbh0NDELTQ/UvnbmMFnLlI/AAAAAAABF7A/NHhK1C7Zt0c/s1600/Ferrari-F1-pit-stop-perfection.gif)
