### PR TITLE
Fix commercial healthcheck test

### DIFF
--- a/commercial/test/services/CommercialHealthcheckTest.scala
+++ b/commercial/test/services/CommercialHealthcheckTest.scala
@@ -1,3 +1,10 @@
 package services
 
-class CommercialHealthcheckTest extends HealthcheckTest("/commercial/jobs.json?seg=repeat&s=business&k=science")
+import model.commercial.masterclasses.MasterClassAgent
+
+class CommercialHealthcheckTest extends HealthcheckTest("/commercial/jobs.json?seg=repeat&s=business&k=science") {
+
+  override def prepareForTest() {
+    MasterClassAgent.getUpcoming
+  }
+}

--- a/common/test/services/HealthcheckTest.scala
+++ b/common/test/services/HealthcheckTest.scala
@@ -9,8 +9,11 @@ import scala.concurrent.Await
 
 abstract class HealthcheckTest(warmupUrl: String) extends FlatSpec with Matchers with UsesElasticSearch {
 
+  def prepareForTest() {}
+
   // you have to actually hit a url (in dev/ test mode) before the management plugin will start, hence warmup url
   "Healthchecks" should "pass" in HtmlWithManagement(warmupUrl){ browser =>
+    prepareForTest()
     Await.result(WS.url("http://localhost:18080/management/healthcheck").get(), 10.seconds).status should be (200)
   }
 }


### PR DESCRIPTION
An agent that the healthcheck depends on must hold some data before the test runs.
