### PR TITLE
Update content api put

### DIFF
--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -83,11 +83,11 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
   private def generateItems(items: List[Trail]): List[Item] =
     items.map { trail =>
       Item(trail.id, trail.meta.map(_.map {
-            case (id, jsValue) if id == "group" => (id, jsValue.asOpt[BigDecimal].map(JsNumber.apply).getOrElse(jsValue))
+            case ("group", jsValue) => ("group", jsValue.asOpt[BigDecimal].map(JsNumber.apply).getOrElse(jsValue))
             //TODO: These are in transition and will be removed
-            case ("imageAdjust", jsValue) => ("imageAdjustment", jsValue)
-            case ("meta", jsValue) => ("metadata", jsValue)
-            case ("supporting", jsValue) => ("supportingContent", jsValue)
+            case json@("imageAdjust", jsValue) => json
+            case json@("meta", jsValue) => json
+            case json@("supporting", jsValue) => json
             case j  => j
           }
         )

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -16,7 +16,7 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
 
   case class Item(
                    id: String,
-                   meta: Option[Map[String, JsValue]]
+                   metadata: Option[Map[String, JsValue]]
                    )
 
   case class ContentApiPut(

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -23,7 +23,7 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
                             `type`: String,
                             displayName: Option[String],
                             groups: Seq[String],
-                            curated: Seq[Item],
+                            curatedContent: Seq[Item],
                             backfill: Option[String],
                             lastModified: String,
                             modifiedBy: String

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -84,6 +84,10 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
     items.map { trail =>
       Item(trail.id, trail.meta.map(_.map {
             case (id, jsValue) if id == "group" => (id, jsValue.asOpt[BigDecimal].map(JsNumber.apply).getOrElse(jsValue))
+            //TODO: These are in transition and will be removed
+            case ("imageAdjust", jsValue) => ("imageAdjustment", jsValue)
+            case ("meta", jsValue) => ("metadata", jsValue)
+            case ("supporting", jsValue) => ("supportingContent", jsValue)
             case j  => j
           }
         )


### PR DESCRIPTION
The keys have been changed in meta in the content api.

`curated` is now `curatedContent`
`imageAdjust` is now `imageAdjustment`
`meta` is now `metadata`
`supporting` is now `supportingContent`

This is only temporary. As a wider change to conform everywhere will take place.

@stephanfowler 
