### PR TITLE
Add Host header to nginx conf

### DIFF
--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -3,6 +3,7 @@ server {
 
     location / {
         proxy_pass http://localhost:9000/;
+        proxy_set_header Host $host;
     }
 }
 


### PR DESCRIPTION
The Host header wasn't being picked up by the play app.
We need to set it explicitly in the nginx config.

This is particularly useful in the `routes` reflection and [abosulteUrl lookup](https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/java/play/mvc/Call.java#L45)

![Header In!](http://a.gifb.in/112011/1320956249_long_header_goal__58_m.gif)
