### PR TITLE
Fronts: image adjust tweaks

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -440,12 +440,13 @@ $cta-icon-gap: 2px;
         width: map-get($gallery-cta-icon, width);
         height: map-get($gallery-cta-icon, height);
         margin-left: -1 * (map-get($gallery-cta-icon, width) / 2);
-        margin-top: -1 * (map-get($gallery-cta-icon, height) / 2);
+        margin-top: -1 * ceil(map-get($gallery-cta-icon, height) / 2);
     }
     .item__cta--video & {
         width: map-get($video-cta-icon, width);
         height: map-get($video-cta-icon, height);
-        margin-left: -1 * (map-get($video-cta-icon, width) / 2);
+        // don't want icon to be exactly in the middle
+        margin-left: -1 * (map-get($video-cta-icon, width) / 3);
         margin-top: -1 * (map-get($video-cta-icon, height) / 2);
     }
 }

--- a/common/app/views/fragments/collections/news.scala.html
+++ b/common/app/views/fragments/collections/news.scala.html
@@ -41,7 +41,7 @@
         <div class="collection-wrapper">
             <ul class="unstyled l-row l-row--items-4 collection">
                 @items.zipWithIndex.map{ case (trail, index) =>
-                    @fragments.collections.items.standard(trail, index + 3, containerIndex)
+                    @fragments.collections.items.standard(trail, index + 4, containerIndex)
                 }
             </ul>
         </div>

--- a/common/app/views/fragments/collections/news.scala.html
+++ b/common/app/views/fragments/collections/news.scala.html
@@ -5,7 +5,7 @@
         @if(!trail.group.isEmpty){ @* Means this is a curated container *@
             @fragments.items.fromage(trail, 0)
         }else{ @* Not a curated container: we fake hierarchy *@
-            @fragments.items.fromage(trail, 0, 0, "highlight")
+            @fragments.items.fromage(trail, 0, Some("highlight"))
         }
     }
 </div>
@@ -13,11 +13,7 @@
     @if(items.nonEmpty) {
         <div class="collection-wrapper">
             @items.zipWithIndex.map{ case (trail, index) =>
-                @if(!trail.group.isEmpty){
-                    @fragments.items.fromage(trail, 1)
-                }else{
-                    @fragments.items.fromage(trail, 1, 0, "default")
-                }
+                @fragments.items.fromage(trail, 1)
             }
         </div>
     }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -14,9 +14,7 @@
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="fromage__media-wrapper fromage__media-wrapper--first">
                                 <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
-                                    @if(trail.imageAdjust == Some("highlight") || imageAdjustOverride == "highlight") {
-                                        @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
-                                    }
+                                    @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 </div>
                             </div>
                         }
@@ -45,7 +43,8 @@
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <a href="@LinkTo{@trail.url}" data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
-                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
+                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
+                                    @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 </div>
                             </div>
                         </a>

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -14,7 +14,11 @@
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="fromage__media-wrapper fromage__media-wrapper--first">
                                 <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
-                                    @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                    @if(trail.imageAdjust == Some("highlight") || imageAdjustOverride == "highlight") {
+                                        @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                    } else {
+                                        @Item220.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                    }
                                 </div>
                             </div>
                         }
@@ -44,7 +48,7 @@
                         <a href="@LinkTo{@trail.url}" data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
                                 <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
-                                    @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                    @Item220.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 </div>
                             </div>
                         </a>

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -1,20 +1,20 @@
-@(trail: Trail, index: Int, volumeOverride: Int = 0, imageAdjustOverride: String = "none")(implicit request: RequestHeader)
+@(trail: Trail, index: Int, imageAdjustOverride: Option[String] = None)(implicit request: RequestHeader)
 
-@defining((VisualTone(trail))) { case (tone) =>
+@defining((VisualTone(trail), imageAdjustOverride.orElse(trail.imageAdjust))) { case (tone, imageAdjust) =>
     <div
-        class="@GetClasses.forFromage(trail, volumeOverride, imageAdjustOverride)"
+        class="@GetClasses.forFromage(trail, imageAdjust)"
         @trail.discussionId.map{ id => data-discussion-id="@id" }
         data-discussion-closed="@trail.isClosedForComments"
         data-link-name="trail | @{index + 1}">
 
         <div class="fromage__container">
             <a href="@LinkTo{@trail.url}" class="fromage__link" data-link-name="article">
-                @if(trail.imageAdjust != Some("hide") && imageAdjustOverride != "hide") {
+                @if(imageAdjust != Some("hide")) {
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="fromage__media-wrapper fromage__media-wrapper--first">
                                 <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
-                                    @if(trail.imageAdjust == Some("highlight") || imageAdjustOverride == "highlight") {
+                                    @if(imageAdjust == Some("highlight")) {
                                         @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                     } else {
                                         @Item220.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
@@ -42,7 +42,7 @@
                     <p class="fromage__byline tone-colour">@Html(byLine)</p>
                 }
             }
-            @if(trail.imageAdjust != Some("hide") && trail.imageAdjust != Some("highlight") && imageAdjustOverride != "hide") {
+            @if(imageAdjust == None) {
                 @trail.trailPicture(5,3).map{ imageContainer =>
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <a href="@LinkTo{@trail.url}" data-link-name="article">

--- a/common/app/views/fragments/items/gallery.scala.html
+++ b/common/app/views/fragments/items/gallery.scala.html
@@ -1,6 +1,6 @@
 @(trail: Trail, index: Int, containerIndex: Int, element: String = "li")(implicit request: RequestHeader)
 
-@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 3)) { case (tone, isFirstContainer, inlineImages) =>
+@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 4)) { case (tone, isFirstContainer, inlineImages) =>
     <@element
         class="@GetClasses.forItem(trail, isFirstContainer)"
         data-link-name="trail | @{index + 1}">

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -1,6 +1,6 @@
 @(trail: Trail, index: Int, containerIndex: Int, element: String = "li")(implicit request: RequestHeader)
 
-@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 3)) { case (tone, isFirstContainer, inlineImages) =>
+@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 4)) { case (tone, isFirstContainer, inlineImages) =>
     <@element
         class="@GetClasses.forItem(trail, isFirstContainer)"
         data-link-name="trail | @{index + 1}"

--- a/common/app/views/fragments/items/thumbnail.scala.html
+++ b/common/app/views/fragments/items/thumbnail.scala.html
@@ -1,6 +1,6 @@
 @(trail: Trail, index: Int, containerIndex: Int, element: String = "li")(implicit request: RequestHeader)
 
-@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 3)) { case (tone, isFirstContainer, inlineImages) =>
+@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 4)) { case (tone, isFirstContainer, inlineImages) =>
     <@element
         class="@GetClasses.forItem(trail, isFirstContainer) item--thumbnail"
         data-link-name="trail | @{index + 1}"

--- a/common/app/views/fragments/items/thumbnailGallery.scala.html
+++ b/common/app/views/fragments/items/thumbnailGallery.scala.html
@@ -1,6 +1,6 @@
 @(trail: Gallery, index: Int, containerIndex: Int, element: String = "li")(implicit request: RequestHeader)
 
-@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 3)) { case (tone, isFirstContainer, inlineImages) =>
+@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 4)) { case (tone, isFirstContainer, inlineImages) =>
     <@element
         class="@GetClasses.forItem(trail, isFirstContainer) item--thumbnail"
         data-link-name="trail | @{index + 1}">

--- a/common/app/views/fragments/items/thumbnailVideo.scala.html
+++ b/common/app/views/fragments/items/thumbnailVideo.scala.html
@@ -1,6 +1,6 @@
 @(trail: Video, index: Int, containerIndex: Int, element: String = "li")(implicit request: RequestHeader)
 
-@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 3)) { case (tone, isFirstContainer, inlineImages) =>
+@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 4)) { case (tone, isFirstContainer, inlineImages) =>
     <@element
         class="@GetClasses.forItem(trail, isFirstContainer) item--thumbnail"
         data-link-name="trail | @{index + 1}">

--- a/common/app/views/fragments/items/video.scala.html
+++ b/common/app/views/fragments/items/video.scala.html
@@ -1,6 +1,6 @@
 @(trail: Trail, index: Int, containerIndex: Int, element: String = "li")(implicit request: RequestHeader)
 
-@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 3)) { case (tone, isFirstContainer, inlineImages) =>
+@defining((VisualTone(trail), containerIndex == 0, containerIndex == 0 && index < 4)) { case (tone, isFirstContainer, inlineImages) =>
     <@element
         class="@GetClasses.forItem(trail, isFirstContainer)"
         data-link-name="trail | @{index + 1}">

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -645,9 +645,11 @@ object GetClasses {
           "fromage--has-image"
         },
       (trail: Trail, volumeOverride: Int, imageAdjustOverride: String) =>
-        trail.imageAdjust.map{ adjustValue =>
-          s"fromage--imageadjust-$adjustValue"
-        }.getOrElse(""),
+        if (imageAdjustOverride != "none") {
+          s"fromage--imageadjust-${imageAdjustOverride}"
+        } else {
+          s"fromage--imageadjust-${trail.imageAdjust.getOrElse("default")}"
+        },
       (trail: Trail, volumeOverride: Int, imageAdjustOverride: String) =>
         if (volumeOverride != 0) {
           s"fromage--volume-${volumeOverride}"

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -629,35 +629,26 @@ object GetClasses {
     RenderClasses(classes:_*)
   }
 
-  def forFromage(trail: Trail, volumeOverride: Int, imageAdjustOverride: String): String = {
+  def forFromage(trail: Trail, imageAdjust: Option[String]): String = {
     val baseClasses: Seq[String] = Seq(
       "fromage",
+      s"fromage--volume-${trail.group.getOrElse("0")}",
       s"tone-${VisualTone(trail)}",
       "tone-accent-border"
     )
-    val f: Seq[(Trail, Int, String) => String] = Seq(
-      (trail: Trail, volumeOverride: Int, imageAdjustOverride: String) =>
-        if (trail.isLive) {"item--live"} else {""},
-      (trail: Trail, volumeOverride: Int, imageAdjustOverride: String) =>
-        if (trail.trailPicture(5,3).isEmpty || trail.imageAdjust == Some("hide") || imageAdjustOverride == "hide"){
+    val f: Seq[(Trail, Option[String]) => String] = Seq(
+      (trail: Trail, imageAdjust: Option[String]) => if (trail.isLive) {"item--live"} else {""},
+      (trail: Trail, imageAdjust: Option[String]) =>
+        if (trail.trailPicture(5,3).isEmpty || imageAdjust == Some("hide")){
           "fromage--has-no-image"
         }else{
           "fromage--has-image"
         },
-      (trail: Trail, volumeOverride: Int, imageAdjustOverride: String) =>
-        if (imageAdjustOverride != "none") {
-          s"fromage--imageadjust-${imageAdjustOverride}"
-        } else {
-          s"fromage--imageadjust-${trail.imageAdjust.getOrElse("default")}"
-        },
-      (trail: Trail, volumeOverride: Int, imageAdjustOverride: String) =>
-        if (volumeOverride != 0) {
-          s"fromage--volume-${volumeOverride}"
-        } else {
-          s"fromage--volume-${trail.group.getOrElse("0")}"
-        }
+      (trail: Trail, imageAdjust: Option[String]) => imageAdjust.map{ adjustValue =>
+        s"fromage--imageadjust-$adjustValue"
+      }.getOrElse("")
     )
-    val classes = f.foldLeft(baseClasses){case (cl, fun) => cl :+ fun(trail, volumeOverride, imageAdjustOverride)}
+    val classes = f.foldLeft(baseClasses){case (cl, fun) => cl :+ fun(trail, imageAdjust)}
     RenderClasses(classes:_*)
   }
 


### PR DESCRIPTION
- increase number of items with inline images to 4
- fix image adjust on first fromage item
- tweak position of video/gallery icon
- remove unused volume override

![screen shot 2014-02-15 at 14 34 37](https://f.cloud.github.com/assets/74132/2177969/5d752ade-964e-11e3-84d4-32a5e4d3f89d.jpeg)

![1340215198_dog_hangs_by_frisbee](https://f.cloud.github.com/assets/74132/2177988/71265af2-964f-11e3-8464-9761fdd12632.gif)
