### PR TITLE
Update cut off date for user email verification

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comment-box.js
+++ b/common/app/assets/javascripts/modules/discussion/comment-box.js
@@ -94,7 +94,7 @@ CommentBox.prototype.defaultOptions = {
     switches: {
         discussionVerifiedEmailPosting: false // Off by default here and in backend
     },
-    priorToVerificationDate: new Date(1391904001337) // Sun Feb 09 2014 00:00:01 GMT+0000 (GMT)
+    priorToVerificationDate: new Date(1392719401337) // Tue Feb 18 2014 10:30:01 GMT
 };
 
 /**

--- a/common/test/assets/javascripts/spec/discussion/CommentBox.spec.js
+++ b/common/test/assets/javascripts/spec/discussion/CommentBox.spec.js
@@ -94,7 +94,7 @@ define([
             spyOn(commentBox, 'getUserData').andReturn({
                 displayName: "testy",
                 id: 1,
-                accountCreatedDate: new Date(1391904001338)
+                accountCreatedDate: new Date(1392719401338)
             });
 
             commentBox.attachTo(document.querySelector('.d-comment-box'));


### PR DESCRIPTION
To fit in with our launch plans for discussion user email verification the cut off date needs to be updated to Tue Feb 18 2014 10:30:01 GMT+0000 (GMT).

I've updated it here in the code and the test.

CF: https://github.com/guardian/d2/pull/70
