### PR TITLE
gallery fix

### DIFF
--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -195,7 +195,7 @@ define([
                 self.next();
                 self.trackInteraction('keyboard:next');
             } else if (e.keyCode === 27) { // esc
-                overlay.hide();
+                overlay.close();
             }
         };
 

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -149,7 +149,7 @@ define([
                 self.layout();
             });
 
-            mediator.on('modules:overlay:close', function() {
+            mediator.on('modules:overlay:hide', function() {
                 // Remove events
                 bean.off(overlay.toolbarNode, 'click');
                 bean.off(overlay.bodyNode, 'click touchmove touchend');
@@ -195,7 +195,7 @@ define([
                 self.next();
                 self.trackInteraction('keyboard:next');
             } else if (e.keyCode === 27) { // esc
-                overlay.close();
+                overlay.hide();
             }
         };
 

--- a/common/app/assets/javascripts/modules/ui/overlay.js
+++ b/common/app/assets/javascripts/modules/ui/overlay.js
@@ -36,11 +36,15 @@ define([
         // Setup events
         bean.on(this.node, 'click', '.js-overlay-close', function(e) {
             e.preventDefault();
-            self.hide();
-            common.mediator.emit('modules:overlay:close', self);
+            self.close();
         });
 
     }
+
+    Overlay.prototype.close = function() {
+        this.hide();
+        common.mediator.emit('modules:overlay:close', this);
+    };
 
     Overlay.prototype.showLoading = function() {
         this.setBody(this.loadingHtml);

--- a/common/app/assets/javascripts/modules/ui/overlay.js
+++ b/common/app/assets/javascripts/modules/ui/overlay.js
@@ -36,15 +36,11 @@ define([
         // Setup events
         bean.on(this.node, 'click', '.js-overlay-close', function(e) {
             e.preventDefault();
-            self.close();
+            self.hide();
+            common.mediator.emit('modules:overlay:close', this);
         });
 
     }
-
-    Overlay.prototype.close = function() {
-        this.hide();
-        common.mediator.emit('modules:overlay:close', this);
-    };
 
     Overlay.prototype.showLoading = function() {
         this.setBody(this.loadingHtml);

--- a/common/app/assets/javascripts/modules/ui/overlay.js
+++ b/common/app/assets/javascripts/modules/ui/overlay.js
@@ -37,7 +37,7 @@ define([
         bean.on(this.node, 'click', '.js-overlay-close', function(e) {
             e.preventDefault();
             self.hide();
-            common.mediator.emit('modules:overlay:close', this);
+            common.mediator.emit('modules:overlay:close', self);
         });
 
     }


### PR DESCRIPTION
Using the escape button to close a gallery wasn't sending the close event, meaning event handlers weren't unbound and duplicate events were bound on reopening.
