### PR TITLE
Added a base ad name for the features and people containers

### DIFF
--- a/common/app/views/fragments/collections/features.scala.html
+++ b/common/app/views/fragments/collections/features.scala.html
@@ -19,7 +19,7 @@
                 }
                 @style.adSlot.map { adSlot =>
                     <li class="l-row__item l-row__item--mpu-300 hide-on-mobile">
-                        <div class="ad-slot ad-slot--mpu-banner-ad hide-on-mobile" data-link-name="ad slot mpu-banner-ad" data-median="@adSlot.medianName">
+                        <div class="ad-slot ad-slot--mpu-banner-ad hide-on-mobile" data-link-name="ad slot mpu-banner-ad" data-base="@adSlot.baseName" data-median="@adSlot.medianName">
                             <div class="ad-container"></div>
                         </div>
                     </li>

--- a/common/app/views/fragments/collections/people.scala.html
+++ b/common/app/views/fragments/collections/people.scala.html
@@ -19,7 +19,7 @@
                 }
                 @style.adSlot.map { adSlot =>
                     <li class="l-row__item l-row__item--mpu-300 hide-on-mobile">
-                        <div class="ad-slot ad-slot--mpu-banner-ad hide-on-mobile" data-link-name="ad slot mpu-banner-ad" data-median="@adSlot.medianName">
+                        <div class="ad-slot ad-slot--mpu-banner-ad hide-on-mobile" data-link-name="ad slot mpu-banner-ad" data-base="@adSlot.baseName" data-median="@adSlot.medianName">
                             <div class="ad-container"></div>
                         </div>
                     </li>


### PR DESCRIPTION
Added a `data-base` ad slot for the MPUs.

At the moment they aren't rendering on tablets (portrait). This is because the width that determines whether base/median ad should be loaded is 810px. This is so we don't get ads in the top slot that are too width for the tablet.

// @kaelig @ironsidevsquincy 
