### PR TITLE
Prevent top ad slot from overflowing out of the page

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -23,7 +23,6 @@
         background-color: $c-neutral8;
         padding: 0 $baseline*2;
         border-top: 1px solid $c-neutral5;
-
         color: $c-neutral2;
         font-family: $sans-serif;
         @include font-size(12, 20);
@@ -32,7 +31,6 @@
     }
 
     &.ad-slot__show-label {
-
         .ad-slot__label {
             display: block;
         }
@@ -75,6 +73,7 @@
     }
 
     @include mq(faciaLeftCol) {
+        width: auto;
         margin-left: gs-span(2) + $gs-gutter;
         text-align: left;
     }
@@ -82,6 +81,7 @@
 
 .parts__head {
     z-index: 1002;
+
     &.is-sticky {
         top: 0;
         @include sticky;
@@ -111,7 +111,6 @@
     }
 
     &.ad-slot__show-label {
-
         @include mq(mobileLandscape, tablet) {
             text-align: right;
         }


### PR DESCRIPTION
Fixes this bug: (red outline was added in the inspector to show the overflow in the screenshot)

![screen shot 2014-02-18 at 15 11 12](https://f.cloud.github.com/assets/85783/2196411/eefd3d2c-98ae-11e3-80f5-87bcab9aac00.PNG)

![ ](http://1.bp.blogspot.com/-aIfeP1FkCTw/UwIdcPFZZfI/AAAAAAABGBg/00c1mK00tGE/s1600/fish-prank.gif)
