### PR TITLE
Fix problems handling 410 and 404 from the content api

### DIFF
--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -151,6 +151,10 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
             log.warn(s"Content API Error: 404 for ${collectionItem.id}")
             None
           }
+          case apiError: com.gu.openplatform.contentapi.ApiError if apiError.httpStatus == 410 => {
+            log.warn(s"Content API Error: 410 for ${collectionItem.id}")
+            None
+          }
           case t: Throwable => {
             log.warn("%s: %s".format(collectionItem.id, t.toString))
             throw t

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -146,15 +146,24 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
         }
         val response = ContentApi().item(collectionItem.id, edition).showFields(showFieldsQuery).response
 
-        response.onFailure{case t: Throwable => log.warn("%s: %s".format(collectionItem.id, t.toString))}
+        val content = response.map(_.content).recover {
+          case apiError: com.gu.openplatform.contentapi.ApiError if apiError.httpStatus == 404 => {
+            log.warn(s"Content API Error: 404 for ${collectionItem.id}")
+            None
+          }
+          case t: Throwable => {
+            log.warn("%s: %s".format(collectionItem.id, t.toString))
+            throw t
+          }
+        }
         supportingAsContent.onFailure{case t: Throwable => log.warn("Supporting links: %s: %s".format(collectionItem.id, t.toString))}
 
         for {
           contentList <- foldListFuture
-          itemResponse <- response
+          itemResponse <- content
           supporting <- supportingAsContent
         } yield {
-          itemResponse.content.map(Content(_, supporting, collectionItem.metaData)).map(_ +: contentList).getOrElse(contentList)
+          itemResponse.map(Content(_, supporting, collectionItem.metaData)).map(_ +: contentList).getOrElse(contentList)
         }
       }
       val sorted = results map { _.sortBy(t => collectionItems.indexWhere(_.id == t.id))}

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -68,6 +68,7 @@ trait S3 extends Logging {
     val metadata = new ObjectMetadata()
     metadata.setCacheControl("no-cache,no-store")
     metadata.setContentType(contentType)
+    metadata.setContentLength(value.getBytes.length)
 
     val request = new PutObjectRequest(bucket, key, new StringInputStream(value), metadata).withCannedAcl(accessControlList)
 


### PR DESCRIPTION
This reintroduces code that somehow got lost. If we receive a 404 or a 410 from the content api in `getArticles` of `ParseCollection`, we just continue as normal and it will not be included in the list.

We have been seeing a lot of these error codes from the content API recently due to takedowns.

@ironsidevsquincy 

EDIT:
I have put back in the content length from #3154 using `getBytes` instead of `StringOps.length`
