### PR TITLE
Fixed alpha tracking when no ab test

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -136,36 +136,36 @@ define([
             s.prop47    = config.page.edition || '';
 
             var mvt = ab.makeOmnitureTag(config, document);
-            if (mvt.length > 0) {
 
-                s.prop51  = mvt;
-                s.eVar51  = mvt;
+            s.prop51  = mvt;
+            s.eVar51  = mvt;
 
-                var alphaTag = 'notAlpha,';
+            var alphaTag = 'notAlpha,';
 
-                // prefix all the MVT tests with the alpha user tag if present
-                if (Cookies.get('GU_ALPHA') === "2") {
-                    // This tag allows us to easily segment phase one, phase two, or phase one and two.
-                    alphaTag = 'r2alph2,';
+            // prefix all the MVT tests with the alpha user tag if present
+            if (Cookies.get('GU_ALPHA') === "2") {
+                // This tag allows us to easily segment phase one, phase two, or phase one and two.
+                alphaTag = 'r2alph2,';
 
-                    s.prop51  = alphaTag + s.prop51;
-                    s.eVar51  = alphaTag + s.eVar51;
+                s.prop51  = alphaTag + s.prop51;
+                s.eVar51  = alphaTag + s.eVar51;
 
-                } else if (Cookies.get('GU_ALPHA') === "true") {
-                    // A value of true means phase one.
-                    alphaTag = 'r2alpha,';
+            } else if (Cookies.get('GU_ALPHA') === "true") {
+                // A value of true means phase one.
+                alphaTag = 'r2alpha,';
 
-                    s.prop51  = alphaTag + s.prop51;
-                    s.eVar51  = alphaTag + s.eVar51;
-                }
+                s.prop51  = alphaTag + s.prop51;
+                s.eVar51  = alphaTag + s.eVar51;
+            }
 
-                // is user is viewing an alpha front
-                if (/^.+-alpha$/.test(config.page.pageId)) {
-                    var frontAlphaTag = config.page.pageId + ',';
-                    s.prop51  = frontAlphaTag + s.prop51;
-                    s.eVar51  = frontAlphaTag + s.eVar51;
-                }
+            // is user is viewing an alpha front
+            if (/^.+-alpha$/.test(config.page.pageId)) {
+                var frontAlphaTag = config.page.pageId + ',';
+                s.prop51  = frontAlphaTag + s.prop51;
+                s.eVar51  = frontAlphaTag + s.eVar51;
+            }
 
+            if (s.prop51) {
                 s.events = s.apl(s.events,'event58',',');
             }
 


### PR DESCRIPTION
We we're only adding the 'alpha' tracking to prop51 if the user was in an ab test

Obviously not right, now we add the alpha tracking regardless

Horrible diff, but basically removes the enclosing conditional

![1276852649_chilling-sloth](https://f.cloud.github.com/assets/74132/2196664/90c4104c-98b2-11e3-9854-38fe7a6b9006.gif)
