### PR TITLE
DIscussion JS breaking - show link

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -99,9 +99,9 @@ Loader.prototype.ready = function() {
     var self = this,
         topCommentsElem = this.getElem('topComments');
 
-    this.topLoadingElem = bonzo.create('<div class="preload-msg">Loading comments…<div class="is-updating"></div></div>')[0];
+    this.topLoadingElem = bonzo.create('<div class="preload-msg">Loading comments… <a href="/discussion'+ this.getDiscussionId() +'" class="accessible-link">Trouble loading?</a><div class="is-updating"></div></div>')[0];
     bonzo(this.topLoadingElem).insertAfter(topCommentsElem);
-
+    
     this.on('user:loaded', function(user) {
         this.topComments = new TopComments(self.context, self.mediator, {
             discussionId: this.getDiscussionId(),

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -154,6 +154,11 @@
 .preload-msg {
     @include rem((padding: 50px 50px 250px 50px));
     text-align: center;
+
+    .accessible-link {
+        display: block;
+        @include fs-data(2);
+    }
 }
 
 .preload-msg .is-updating {


### PR DESCRIPTION
If JS breaks or connection drops, you still have a link to discussion.
[Based on a conversation we had earlier](https://github.com/guardian/frontend/issues/3074).
## Looky!

![accessible link](https://f.cloud.github.com/assets/31692/2206368/0e4bcd18-9960-11e3-90fc-ddbd702f3257.png)

![Talktalktalktalktalk](http://richardwiseman.files.wordpress.com/2013/09/laugh-my-favourite-gif-ever-imgur.gif)
