### PR TITLE
Fix top spacing of top stories titles

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -25,6 +25,8 @@
     }
     .item__title {
         @include fs-headline(2, $size-only: true);
+        padding-top: 0;
+
         @include rem((
             margin-bottom: $gs-baseline + 2px
         ));
@@ -318,10 +320,11 @@
 .fromage--imageadjust-highlight {
     .item__title {
         @include rem((
-            margin-top: $gs-baseline/3
+            padding-top: $gs-baseline/3
         ));
         @include mq(tablet) {
             @include fs-headline(5, true);
+            padding-top: 0;
         }
         @include mq(desktop) {
             @include fs-headline(6, true);

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -146,7 +146,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   override lazy val headline: String = apiContent.metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(fields("headline"))
   override lazy val trailText: Option[String] = apiContent.metaData.get("trailText").flatMap(_.asOpt[String]).orElse(fields.get("trailText"))
   override lazy val group: Option[String] = apiContent.metaData.get("group").flatMap(_.asOpt[String])
-  override lazy val imageAdjust: Option[String] = apiContent.metaData.get("imageAdjust").flatMap(_.asOpt[String])
+  override lazy val imageAdjust: String = apiContent.metaData.get("imageAdjust").flatMap(_.asOpt[String]).getOrElse("default")
   override lazy val isBreaking: Boolean = apiContent.metaData.get("isBreaking").flatMap(_.asOpt[Boolean]).getOrElse(false)
   override lazy val supporting: List[Content] = apiContent.supporting
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -25,6 +25,6 @@ trait Trail extends Elements with Tags with FaciaFields {
 trait FaciaFields {
   def group: Option[String] = None
   def supporting: List[Trail] = Nil
-  def imageAdjust: Option[String] = None
+  def imageAdjust: String = "default"
   def isBreaking: Boolean = false
 }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -1,6 +1,6 @@
 @(trail: Trail, index: Int, imageAdjustOverride: Option[String] = None)(implicit request: RequestHeader)
 
-@defining((VisualTone(trail), imageAdjustOverride.orElse(trail.imageAdjust))) { case (tone, imageAdjust) =>
+@defining((VisualTone(trail), imageAdjustOverride.getOrElse(trail.imageAdjust))) { case (tone, imageAdjust) =>
     <div
         class="@GetClasses.forFromage(trail, imageAdjust)"
         @trail.discussionId.map{ id => data-discussion-id="@id" }
@@ -14,7 +14,7 @@
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="fromage__media-wrapper fromage__media-wrapper--first">
                                 <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
-                                    @if(imageAdjust == Some("highlight")) {
+                                    @if(imageAdjust == "highlight") {
                                         @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                     } else {
                                         @Item220.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
@@ -31,7 +31,7 @@
                     <p class="fromage__byline tone-colour">@Html(byLine)</p>
                 }
             }
-            @if(imageAdjust == None) {
+            @if(imageAdjust == "default") {
                 @trail.trailPicture(5,3).map{ imageContainer =>
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <a href="@LinkTo{@trail.url}" data-link-name="article">

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -675,39 +675,41 @@ object GetClasses {
         case _: Video   => "item--video"
         case _          => ""
       },
-      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) => if (firstContainer) {"item--force-image-upgrade"} else {""},
-      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) => if (trail.isLive) {"item--live"} else {""},
-      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) => if (forceHasImage == false && (trail.trailPicture(5,3).isEmpty || trail.imageAdjust == Some("hide"))){
-        "item--has-no-image"
-      }else{
-        "item--has-image"
-      },
-      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) => trail.imageAdjust.map{ adjustValue =>
-        s"item--imageadjust-$adjustValue"
-      }.getOrElse("")
+      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) =>
+        if (firstContainer) "item--force-image-upgrade" else "",
+      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) =>
+        if (trail.isLive) "item--live" else "",
+      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) =>
+        if (forceHasImage == false && (trail.trailPicture(5,3).isEmpty || trail.imageAdjust == "hide")){
+          "item--has-no-image"
+        }else{
+          "item--has-image"
+        },
+      (trail: Trail, firstContainer: Boolean, forceHasImage: Boolean) =>
+        if (forceHasImage || !trail.trailPicture(5,3).isEmpty) s"item--imageadjust-${trail.imageAdjust}" else ""
     )
     val classes = f.foldLeft(baseClasses){case (cl, fun) => cl :+ fun(trail, firstContainer, forceHasImage)}
     RenderClasses(classes:_*)
   }
 
-  def forFromage(trail: Trail, imageAdjust: Option[String]): String = {
+  def forFromage(trail: Trail, imageAdjust: String): String = {
     val baseClasses: Seq[String] = Seq(
       "fromage",
       s"fromage--volume-${trail.group.getOrElse("0")}",
       s"tone-${VisualTone(trail)}",
       "tone-accent-border"
     )
-    val f: Seq[(Trail, Option[String]) => String] = Seq(
-      (trail: Trail, imageAdjust: Option[String]) => if (trail.isLive) {"item--live"} else {""},
-      (trail: Trail, imageAdjust: Option[String]) =>
-        if (trail.trailPicture(5,3).isEmpty || imageAdjust == Some("hide")){
+    val f: Seq[(Trail, String) => String] = Seq(
+      (trail: Trail, imageAdjust: String) =>
+        if (trail.isLive) "item--live" else "",
+      (trail: Trail, imageAdjust: String) =>
+        if (trail.trailPicture(5,3).isEmpty || imageAdjust == "hide"){
           "fromage--has-no-image"
         }else{
           "fromage--has-image"
         },
-      (trail: Trail, imageAdjust: Option[String]) => imageAdjust.map{ adjustValue =>
-        s"fromage--imageadjust-$adjustValue"
-      }.getOrElse("")
+      (trail: Trail, imageAdjust: String) =>
+        if (!trail.trailPicture(5,3).isEmpty) s"fromage--imageadjust-$imageAdjust" else ""
     )
     val classes = f.foldLeft(baseClasses){case (cl, fun) => cl :+ fun(trail, imageAdjust)}
     RenderClasses(classes:_*)


### PR DESCRIPTION
- [fix] ImageAdjust default value is "default"
- [fix] Restore normal spacing on top of top story titles
- [fix] Images have a left spacing when top story has a background
## Before/After

![spacing](https://f.cloud.github.com/assets/85783/2206935/f2981f98-996b-11e3-9dd3-32c0c482a535.gif)

![ ](http://media.giphy.com/media/M7QWj7OKTSJq0/giphy.gif)
