### PR TITLE
Fix visited state

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_features.scss
+++ b/common/app/assets/stylesheets/module/containers/_features.scss
@@ -122,6 +122,10 @@
     .item__standfirst {
         color: rgba(#ffffff, .8);
     }
+    .item__link:visited,
+    .item__link:visited .item__title {
+        color: mix(#ffffff, $c-features-secondary, 80%);
+    }
     .item__link {
         border-top: 0;
     }

--- a/common/app/assets/stylesheets/module/facia/_baguette.scss
+++ b/common/app/assets/stylesheets/module/facia/_baguette.scss
@@ -10,8 +10,16 @@
         border-top: 4px solid white;
     }
     .item__link {
-        color: #ffffff;
         border-top-style: none !important;
+    }
+    .supporting__action,
+    .item__link {
+        color: #ffffff;
+    }
+    .item__link:visited,
+    .item__link:visited .item__title,
+    .supporting__action:visited {
+        color: mix(#ffffff, $c-brandBlue, 80%);
     }
     .item__title {
         @include rem((
@@ -43,8 +51,5 @@
         @include rem((
             padding-left: $gs-gutter/4
         ));
-    }
-    .supporting__action {
-        color: #ffffff;
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_baguette.scss
+++ b/common/app/assets/stylesheets/module/facia/_baguette.scss
@@ -1,6 +1,6 @@
 .baguette {
     @include clearfix;
-    background-color: $c-newsDefault;
+    background-color: $c-brandBlue;
 
     @include rem((
         margin-bottom: $gs-baseline*2 !important,

--- a/common/app/assets/stylesheets/module/facia/_baguette.scss
+++ b/common/app/assets/stylesheets/module/facia/_baguette.scss
@@ -2,9 +2,11 @@
     @include clearfix;
     background-color: $c-brandBlue;
 
-    @include rem((
-        margin-bottom: $gs-baseline*2 !important,
-    ));
+    @include mq(tablet) {
+        @include rem((
+            margin-bottom: $gs-baseline*2 !important,
+        ));
+    }
 
     .item__container {
         border-top: 4px solid white;

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -132,7 +132,7 @@
    ========================================================================== */
 
 .fromage__link,
-.fromage__support__action {
+.supporting__action {
     color: $c-neutral1;
 }
 .fromage__link {
@@ -147,7 +147,7 @@
 }
 .fromage__link:visited,
 .fromage__link:visited .item__title,
-.fromage__support__action:visited {
+.supporting__action:visited {
     color: $c-neutral2;
 }
 .fromage__media-wrapper,
@@ -477,11 +477,13 @@
         color: #ffffff;
     }
     .fromage__link:visited,
-    .fromage__link:visited .item__title,
-    .fromage__support__action:visited {
-        color: rgba(#ffffff, .9);
+    .fromage__link:visited .item__title {
+        color: mix(#ffffff, $c-brandBlue, 80%);
     }
     .supporting {
         background-color: lighten($c-brandBlue, 7%);
+    }
+    .supporting__action:visited {
+        color: mix(#ffffff, lighten($c-brandBlue, 7%), 80%);
     }
 }


### PR DESCRIPTION
- [fix] Items with a dark background & light text have a proper visited state (instead of grey)
- [fix] Huge story (baguette) is now brand blue to follow the same colour code as the top story (fromage)
- [fix] Spacing between huge story and top story on mobile was too big

For some ridiculous reason `color: rgba(…)` won't work on visited links (at least in Webkit/Blink), so I used Sass' `mix($color-1, $color-2, $weight)` function to simulate a toned down white colour on dark backgrounds.

![ ](http://media.giphy.com/media/cC7kyUjnyj46k/giphy.gif)

![screen shot 2014-02-19 at 15 44 56](https://f.cloud.github.com/assets/85783/2208282/ff07ad9a-997d-11e3-93c9-a809656c66ca.PNG)

![screen shot 2014-02-19 at 15 45 19](https://f.cloud.github.com/assets/85783/2208267/cfe5f8e6-997d-11e3-9f6b-82352dc5e034.PNG)
