### PR TITLE
Hairline between features 2 and 3 goes all the way vertically

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_features.scss
+++ b/common/app/assets/stylesheets/module/containers/_features.scss
@@ -39,6 +39,14 @@
                     @include fs-headline(1, true);
                 }
             }
+            .collection__item:nth-child(2) {
+                // Hairline takes the full height of the 2nd row
+                &:after {
+                    left: auto;
+                    right: 0;
+                    background: #ffffff;
+                }
+            }
             .item--has-image .item__media-wrapper,
             .item--has-image .item__image-container {
                 display: block;

--- a/common/app/assets/stylesheets/module/containers/_special.scss
+++ b/common/app/assets/stylesheets/module/containers/_special.scss
@@ -27,9 +27,13 @@
                 .item__image-container {
                     display: block;
                 }
-            }
-            .item--gallery,
-            .item--video {
+                .item__title--has-icon-mobile {
+                    padding-left: 0;
+
+                    .i {
+                        display: none;
+                    }
+                }
                 .item__media-wrapper {
                     width: 50%;
                     float: left;


### PR DESCRIPTION
- [fix] Hairline between features 2 and 3 goes all the way vertically
- [fix] Remove small icon in special container video items
## Before

![screen shot 2014-02-19 at 17 04 23](https://f.cloud.github.com/assets/85783/2209131/fb790c50-9987-11e3-90f1-3c24b6ee209e.PNG)

![screen shot 2014-02-19 at 17 14 16](https://f.cloud.github.com/assets/85783/2209222/50d7feb2-9989-11e3-945b-24a71845eb92.PNG)
## After

![screen shot 2014-02-19 at 17 03 56](https://f.cloud.github.com/assets/85783/2209133/fe235136-9987-11e3-8627-ea3014299d32.PNG)

![screen shot 2014-02-19 at 17 14 11](https://f.cloud.github.com/assets/85783/2209223/5485e498-9989-11e3-92a6-ff24c706a7e0.PNG)

Thanks @Vilderness for spotting this!

![ ](http://media.giphy.com/media/PDwtT0eYm4E4E/giphy.gif)
