### PR TITLE
Football front fixture repeating bug

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -40,13 +40,10 @@ define([
 
         showFrontFixtures: function(context) {
             // wrap the return sports stats component in an 'item'
-            var prependTo = bonzo.create('<li class="item item--sport-stats item--sport-stats-tall"></li>');
+            var prependTo = bonzo.create('<div class="fromage tone-accent-border tone-news unstyled"></div>');
             mediator.on('modules:footballfixtures:render', function() {
-                var $collection = $('.container--sport .collection', context);
-                $('.item:first-child', $collection[0])
-                    .after(prependTo);
-                $collection.removeClass('collection--without-sport-stats')
-                    .addClass('collection--with-sport-stats');
+                bonzo($('.collection-wrapper', context).get(1))
+                    .append(prependTo);
             });
             new FootballFixtures({
                 prependTo: prependTo,


### PR DESCRIPTION
Goto http://gu.com/football and make sure you're small enough to be considered mobile.
Fixtures are repeated.

This was due to the fronts changing their DOM structure.
This is definitely just a fix for a short while, we will be looking at how to make this a lot more robust.

![Soooo many](http://images3.wikia.nocookie.net/__cb20130707154816/epicrapbattlesofhistory/images/4/4d/03_26_30_129_299647_UNOPT_safe_pinkie_pie_animated_too_many_pinkie_pies_seizure_warning_extreme_speed_animation.gif)
