### PR TITLE
Add switch and config for SPDY services endpoint

### DIFF
--- a/common/app/assets/javascripts/utils/ajax.js
+++ b/common/app/assets/javascripts/utils/ajax.js
@@ -27,7 +27,7 @@ define([
         edition = config.page.edition;
 
         makeAbsolute = function (url) {
-            return config.page.ajaxUrl + url;
+            return ('switches' in config && config.switches.spdyServices) ?  config.page.ajaxSpdyUrl + url : config.page.ajaxUrl + url;
         };
     };
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -126,6 +126,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       else configuration.getStringProperty("ajax.url").getOrElse("")
     lazy val corsOrigins: Seq[String] = configuration.getStringProperty("ajax.cors.origin").map(_.split(",")
       .map(_.trim).toSeq).getOrElse(Nil)
+    lazy val spdyUrl = configuration.getStringProperty("ajax.spdyUrl").getOrElse("")
   }
 
   object id {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -126,7 +126,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       else configuration.getStringProperty("ajax.url").getOrElse("")
     lazy val corsOrigins: Seq[String] = configuration.getStringProperty("ajax.cors.origin").map(_.split(",")
       .map(_.trim).toSeq).getOrElse(Nil)
-    lazy val spdyUrl = configuration.getStringProperty("ajax.spdyUrl").getOrElse("")
+    lazy val spdyUrl: String = configuration.getStringProperty("ajax.spdyUrl").getOrElse("")
   }
 
   object id {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -84,7 +84,6 @@ object Switches extends Collections {
   )
 
 
-
   // Advertising Switches
 
   val AdvertSwitch = Switch("Advertising", "adverts",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -425,7 +425,6 @@ object Switches extends Collections {
     DoubleCacheTimesSwitch,
     RelatedContentSwitch,
     SpdyServicesSwitch,
-    SpdyServicesSwitch,
     AdvertSwitch,
     VideoAdvertSwitch,
     AudienceScienceSwitch,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -78,6 +78,12 @@ object Switches extends Collections {
     safeState = Off, sellByDate = endOfQ4
   )
 
+  val SpdyServicesSwitch = Switch("Performance Switches", "spdy-services",
+    "If this switch is on, all api endpoints will route through Akamai's SPDY service.",
+    safeState = Off, sellByDate = new DateMidnight(2014,2,28)
+  )
+
+
 
   // Advertising Switches
 
@@ -418,6 +424,8 @@ object Switches extends Collections {
     AutoRefreshSwitch,
     DoubleCacheTimesSwitch,
     RelatedContentSwitch,
+    SpdyServicesSwitch,
+    SpdyServicesSwitch,
     AdvertSwitch,
     VideoAdvertSwitch,
     AudienceScienceSwitch,

--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -13,6 +13,7 @@
         )},
         "edition": "@Edition(request).id",
         "ajaxUrl": "@Configuration.ajax.url",
+        "ajaxSpdyUrl": "@Configuration.ajax.spdyUrl",
         "isDev": @play.Play.isDev(),
         "oasHost": "oas.theguardian.com",
         "oasUrl": "@Configuration.oas.url",

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -17,6 +17,7 @@ football.api.host=http://football-stats-stub.appspot.com/2012-10-20/16-05
 
 ajax.url=http://code.api.nextgen.guardianapps.co.uk
 ajax.secureUrl=https://code.api-secure.nextgen.guardianapps.co.uk
+ajax.spdyUrl=services.code.dev-guardianapps.co.uk
 
 # no spaces
 ajax.cors.origin=http://m.code.dev-theguardian.com,https://profile.code.dev-theguardian.com

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -17,7 +17,7 @@ football.api.host=http://football-stats-stub.appspot.com/2012-10-20/16-05
 
 ajax.url=http://code.api.nextgen.guardianapps.co.uk
 ajax.secureUrl=https://code.api-secure.nextgen.guardianapps.co.uk
-ajax.spdyUrl=services.code.dev-guardianapps.co.uk
+ajax.spdyUrl=https://services.code.dev-guardianapps.co.uk
 
 # no spaces
 ajax.cors.origin=http://m.code.dev-theguardian.com,https://profile.code.dev-theguardian.com

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -15,6 +15,7 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 # uncomment to test cors locally
 #ajax.url=http://localhost:9000
 #ajax.secureUrl=http://m.thegulocal.com
+#ajax.spdyUrl=http://localhost:9000
 ajax.cors.origin=http://m.random.com,http://127.0.0.1:9000,http://www.random.com,http://m.thegulocal.com,https://profile.thegulocal.com,http://localhost:9000
 
 # Admin switches

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -16,6 +16,7 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 
 ajax.url=http://localhost:9000
 ajax.secureUrl=http://localhost:9000
+ajax.spdyUrl=http://localhost:9000
 
 # Admin switches
 admin.config.file=DEFINFRA/config/front.json

--- a/common/conf/env/GUDEV.properties
+++ b/common/conf/env/GUDEV.properties
@@ -16,6 +16,7 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 
 ajax.url=http://localhost:9000
 ajax.secureUrl=http://localhost:9000
+ajax.spdyUrl=http://localhost:9000
 
 # Admin switches
 admin.config.file=GUDEV/config/front.json

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -14,6 +14,7 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 
 ajax.url=http://api.nextgen.guardianapps.co.uk
 ajax.secureUrl=https://api-secure.nextgen.guardianapps.co.uk
+ajax.spdyUrl=services.guardianapps.co.uk
 
 # no spaces
 ajax.cors.origin=http://www.theguardian.com,http://m.guardian.co.uk,http://m.guardiannews.com,https://profile.theguardian.com

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -14,7 +14,7 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 
 ajax.url=http://api.nextgen.guardianapps.co.uk
 ajax.secureUrl=https://api-secure.nextgen.guardianapps.co.uk
-ajax.spdyUrl=services.guardianapps.co.uk
+ajax.spdyUrl=https://services.guardianapps.co.uk
 
 # no spaces
 ajax.cors.origin=http://www.theguardian.com,http://m.guardian.co.uk,http://m.guardiannews.com,https://profile.theguardian.com

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -21,7 +21,7 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // There is a document (that would have been shared with you) that contains all
     // the properties needed to run this project. Make sure you update it if there 
     // are any required changes, update the hash below, and off you go.
-    hash should be ("17da268edd30594f5e2a449edb218037")
+    hash should be ("a589723f879c692967a6671e23aaad08")
 
   }
 }


### PR DESCRIPTION
This adds a new ajax property of `spdyUrl` and a correlating feature switch. When the switch is active all of our ajax requests will be routed through our test Akamai account which has the SPDY HTTP protocol enabled on it.
