### PR TITLE
Hide ad slot if JS is off or browser does not cut the mustard

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -35,6 +35,9 @@
             display: block;
         }
     }
+    .no-js & {
+        display: none;
+    }
 }
 
 .ad-slot__wrapper {


### PR DESCRIPTION
Gets rid of the white spaces in the flux of content when JS is turned off or browsers won't show ads because they don't cut the mustard.

![ ](http://media.giphy.com/media/L1kmEnKq8eQyA/giphy.gif)
