### PR TITLE
Remove length validation from signin password field

### DIFF
--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -13,6 +13,7 @@ import play.api.mvc.SimpleResult
 import scala.concurrent.Future
 import services._
 import utils.SafeLogging
+import form.Mappings.{idEmail, idPassword}
 
 @Singleton
 class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
@@ -27,9 +28,9 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
 
   val registrationForm = Form(
     Forms.tuple(
-      "user.primaryEmailAddress" -> Forms.text,
+      "user.primaryEmailAddress" -> idEmail,
       "user.publicFields.username" -> Forms.text,
-      "user.password" -> Forms.text,
+      "user.password" -> idPassword,
       "receive_gnm_marketing" -> Forms.boolean,
       "receive_third_party_marketing" -> Forms.boolean
     )

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -11,7 +11,7 @@ import idapiclient.IdApiClient
 import play.api.i18n.Messages
 import idapiclient.EmailPassword
 import utils.SafeLogging
-import form.Mappings.{idEmail, idPassword}
+import form.Mappings.{idEmail}
 import scala.concurrent.Future
 
 
@@ -29,7 +29,7 @@ class SigninController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
     Forms.tuple(
       "email" -> idEmail
         .verifying(Constraints.nonEmpty),
-      "password" -> idPassword
+      "password" -> Forms.text
         .verifying(Constraints.nonEmpty),
       "keepMeSignedIn" -> Forms.boolean
     )

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -37,7 +37,7 @@
 
                     @inputField(Username(registrationForm("user.publicFields.username"), '_label -> "Username", '_help -> "Between 6 and 20 characters, letters and numbers only", ('tabindex, 2)))
 
-                    @inputField(Password(registrationForm("user.password"), '_label -> "Password", '_help -> "Between 6 and 20 characters", 'class -> "js-register-password js-password-strength", ('tabindex, 3)))
+                    @inputField(Password(registrationForm("user.password"), '_label -> "Password", '_help -> "Between 6 and 20 characters", 'class -> "js-register-password js-password-strength", ('tabindex, 3), ('maxlength, 20)))
 
                     <li class="form-field form-field--no-margin">
                         <label class="check-label" for="@registrationForm("receive_gnm_marketing").id">


### PR DESCRIPTION
This small change removes the signin password field length validation to allow legacy users with abnormal length passwords to sign in.

The validation remains in place for registration and password reset.

![6u2xad6](https://f.cloud.github.com/assets/1170410/2229155/1151d262-9ae8-11e3-8ce7-f3d5f12b14b1.gif)
