### PR TITLE
Add switch and logic to route images through Akamai SPDY service

### DIFF
--- a/common/app/assets/javascripts/utils/ajax.js
+++ b/common/app/assets/javascripts/utils/ajax.js
@@ -27,7 +27,7 @@ define([
         edition = config.page.edition;
 
         makeAbsolute = function (url) {
-            return ('switches' in config && config.switches.spdyServices) ?  config.page.ajaxSpdyUrl + url : config.page.ajaxUrl + url;
+            return ('switches' in config && config.switches.spdyAjaxServices) ?  config.page.ajaxSpdyUrl + url : config.page.ajaxUrl + url;
         };
     };
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -145,7 +145,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
   object images {
     lazy val path = configuration.getMandatoryStringProperty("images.path")
-    lazy val servicePath = configuration.getStringProperty("image.service.path").getOrElse("http://ak.i.guim.co.uk")
+    lazy val spdyPath = configuration.getStringProperty("images.spdyPath").getOrElse("https://services.guardianapps.co.uk/static")
   }
 
   object assets {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -78,9 +78,14 @@ object Switches extends Collections {
     safeState = Off, sellByDate = endOfQ4
   )
 
-  val SpdyServicesSwitch = Switch("Performance Switches", "spdy-services",
-    "If this switch is on, all api endpoints will route through Akamai's SPDY service.",
+  val SpdyAjaxServicesSwitch = Switch("Performance Switches", "spdy-ajax-services",
+    "If this switch is on, all ajax api endpoints will route through Akamai's SPDY service.",
     safeState = Off, sellByDate = new DateMidnight(2014,2,28)
+  )
+
+  val SpdyImageServicesSwitch = Switch("Performance Switches", "spdy-image-services",
+    "If this switch is on, all image endpoints will route through Akamai's SPDY service.",
+    safeState = On, sellByDate = new DateMidnight(2014,2,28)
   )
 
 
@@ -423,7 +428,8 @@ object Switches extends Collections {
     AutoRefreshSwitch,
     DoubleCacheTimesSwitch,
     RelatedContentSwitch,
-    SpdyServicesSwitch,
+    SpdyAjaxServicesSwitch,
+    SpdyImageServicesSwitch,
     AdvertSwitch,
     VideoAdvertSwitch,
     AudienceScienceSwitch,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -85,7 +85,7 @@ object Switches extends Collections {
 
   val SpdyImageServicesSwitch = Switch("Performance Switches", "spdy-image-services",
     "If this switch is on, all image endpoints will route through Akamai's SPDY service.",
-    safeState = On, sellByDate = new DateMidnight(2014,2,28)
+    safeState = Off, sellByDate = new DateMidnight(2014,2,28)
   )
 
 

--- a/common/app/views/support/images.scala
+++ b/common/app/views/support/images.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import model.{ImageContainer, ImageAsset}
-import conf.Switches.ImageServerSwitch
+import conf.Switches.{ImageServerSwitch, SpdyImageServicesSwitch}
 import java.net.URI
 import conf.Configuration
 import play.api.templates.Html
@@ -66,8 +66,7 @@ object Profile {
 
 object ImgSrc {
 
-  val imageHost = Configuration.images.path
-  val imageServiceHost = Configuration.images.servicePath
+  def imageHost = if(SpdyImageServicesSwitch.isSwitchedOn) Configuration.images.spdyPath else Configuration.images.path
 
   def apply(url: String, imageType: Profile): String = {
     val uri = new URI(url.trim)

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -5,6 +5,7 @@
 assets.path=http://aws-frontend-static.s3.amazonaws.com/CODE/frontend-static/
 assets.securePath=https://aws-frontend-static.s3.amazonaws.com/CODE/frontend-static/
 images.path=http://i.guimcode.co.uk.global.prod.fastly.net
+images.spdyPath=https://services.code.dev-guardianapps.co.uk/static
 static.path=http://static.guim.co.uk
 static.securePath=https://static-secure.guim.co.uk
 

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -4,6 +4,7 @@
 assets.path=http://assets.guim.co.uk/
 assets.securePath=https://assets-secure.guim.co.uk/
 images.path=http://i.guim.co.uk
+images.spdyPath=https://services.guardianapps.co.uk/static
 static.path=http://static.guim.co.uk
 static.securePath=https://static-secure.guim.co.uk
 debug.enabled=false


### PR DESCRIPTION
Once this is merged we will test running images and ajax endpoints concurrently through the SPDY service.

/cc @gklopper @rich-nguyen 
