### PR TITLE
Fronts: ab test containers

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -10,7 +10,8 @@ define([
     'common/modules/experiments/tests/ad-labels',
     'common/modules/experiments/tests/onward-inline-elements',
     'common/modules/experiments/tests/article-truncation',
-    'common/modules/experiments/tests/geo-most-popular'
+    'common/modules/experiments/tests/geo-most-popular',
+    'common/modules/experiments/tests/uk-containers'
 ], function (
     common,
     store,
@@ -21,7 +22,8 @@ define([
     AdLabels,
     InlineElements,
     ArticleTruncation,
-    GeoMostPopular
+    GeoMostPopular,
+    UkContainers
 ) {
 
     var TESTS = [
@@ -30,7 +32,8 @@ define([
             new AdLabels(),
             new InlineElements(),
             new ArticleTruncation(),
-            new GeoMostPopular()
+            new GeoMostPopular(),
+            new UkContainers()
        ],
        participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -128,22 +128,18 @@ define([
     // Finds variant in specific tests and runs it
     function run(test, config, context) {
 
-
         if (isParticipating(test) && testCanBeRun(test, config)) {
-
             var participations = getParticipations(),
                 variantId = participations[test.id].variant;
-                test.variants.some(function(variant) {
-                    if (variant.id === variantId) {
-                        variant.test(context, config);
-                        return true;
-                    }
+            test.variants.some(function(variant) {
+                if (variant.id === variantId) {
+                    variant.test(context, config);
+                    return true;
+                }
             });
-
-        }
-
-        if (test.always) {
-            test.always();
+            if (variantId === 'notintest' && test.notInTest) {
+                test.notInTest();
+            }
         }
     }
 

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -128,18 +128,23 @@ define([
     // Finds variant in specific tests and runs it
     function run(test, config, context) {
 
-        if (!isParticipating(test) || !testCanBeRun(test, config)) {
-            return false;
+
+        if (isParticipating(test) && testCanBeRun(test, config)) {
+
+            var participations = getParticipations(),
+                variantId = participations[test.id].variant;
+                test.variants.some(function(variant) {
+                    if (variant.id === variantId) {
+                        variant.test(context, config);
+                        return true;
+                    }
+            });
+
         }
 
-        var participations = getParticipations(),
-            variantId = participations[test.id].variant;
-            test.variants.some(function(variant) {
-                if (variant.id === variantId) {
-                    variant.test(context, config);
-                    return true;
-                }
-        });
+        if (test.always) {
+            test.always();
+        }
     }
 
     function allocateUserToTest(test, config) {

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -72,5 +72,8 @@ define([
                 }
             }
         ];
+        this.always = function() {
+            show();
+        };
     };
 });

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -63,7 +63,7 @@ define([
             {
                 id: 'variant-one',
                 test: function (context, config) {
-                    renderFront('uk-alpha');
+                    renderFront('uk-variant-one');
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -61,9 +61,9 @@ define([
                 test: function(context, config) { }
             },
             {
-                id: 'variant-one',
+                id: 'uk-alpha',
                 test: function (context, config) {
-                    renderFront('uk-variant-one');
+                    renderFront('uk-alpha');
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -17,22 +17,20 @@ define([
 
     function show() {
         // remove hiding class
-        $('.facia-container').removeClass('facia-container--ab');
+        $('html').removeClass('ab-uk-containers');
     }
 
     function renderFront(frontId) {
-        // hide containers
-        $('.facia-container').addClass('facia-container--ab');
         ajax({
             url: '/' + frontId + '.json',
             type: 'json',
             crossOrigin: true
         })
             .then(function(resp) {
-                // remove old containers, leaving the first one
-                $('.container:nth-child(n+2)').remove();
+                // remove old containers
+                $('.facia-container > *').remove();
                 // add new containers
-                $('.facia-container > *:nth-child(n+2)', bonzo.create('<div>' + resp.html + '</div>'))
+                $('.facia-container > *', bonzo.create('<div>' + resp.html + '</div>'))
                     .appendTo(qwery('.facia-container')[0]);
                 // upgrades images
                 mediator.emit('ui:images:upgrade');
@@ -63,7 +61,9 @@ define([
         this.variants = [
             {
                 id: 'control',
-                test: function(context, config) { }
+                test: function(context, config) {
+                    show();
+                }
             },
             {
                 id: 'uk-alpha',

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -4,13 +4,15 @@ define([
     'qwery',
     'bonzo',
     'common/utils/ajax',
-    'common/utils/mediator'
+    'common/utils/mediator',
+    'common/modules/adverts/adverts'
 ], function(
     $,
     qwery,
     bonzo,
     ajax,
-    mediator
+    mediator,
+    adverts
 ) {
 
     function show() {
@@ -32,8 +34,11 @@ define([
                 // add new containers
                 $('.facia-container > *:nth-child(n+2)', bonzo.create('<div>' + resp.html + '</div>'))
                     .appendTo(qwery('.facia-container')[0]);
-                // upgrade images
+                // upgrades images
                 mediator.emit('ui:images:upgrade');
+                // reload ads
+                adverts.reload();
+                // ui stuff
                 mediator.emit('ui:collection-show-more:add');
                 mediator.emit('ui:container-toggle:add');
             })

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -51,7 +51,7 @@ define([
     return function() {
 
         this.id = 'UkContainers';
-        this.expiry = '2014-03-01';
+        this.expiry = '2014-03-08';
         this.audience = 0.1;
         this.audienceOffset = 0.0;
         this.description = 'Testing different combination of containers on the UK network front';

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -13,6 +13,11 @@ define([
     mediator
 ) {
 
+    function show() {
+        // remove hiding class
+        $('.facia-container').removeClass('facia-container--ab');
+    }
+
     return function() {
 
         this.id = 'UkContainers';
@@ -26,35 +31,35 @@ define([
         this.variants = [
             {
                 id: 'control',
-                test: function(context, config) {
-                    // remove hiding class
-                    $('.facia-container').removeClass('facia-container--ab');
-                }
+                test: function(context, config) { }
             },
             {
-                id: 'testOne',
+                id: 'variantOne',
                 test: function (context, config) {
+                    // hide containers
+                    $('.facia-container').addClass('facia-container--ab');
                     ajax({
                         url: '/uk-alpha.json',
                         type: 'json',
                         crossOrigin: true
-                    }).then(
-                        function(response) {
+                    })
+                        .then(function(resp) {
                             // remove old containers
                             $('.container:nth-child(n+2)').remove();
-                            // remove hiding class
-                            $('.facia-container').removeClass('facia-container--ab');
                             // add new containers
-                            $('.facia-container > *', bonzo.create('<div>' + response.html + '</div>'))
+                            $('.facia-container > *:nth-child(n+2)', bonzo.create('<div>' + resp.html + '</div>'))
                                 .appendTo(qwery('.facia-container')[0]);
+                            // upgrade images
                             mediator.emit('ui:images:upgrade');
-                        },
-                        function(req) {
-                            // remove hiding class
-                            $('.facia-container').removeClass('facia-container--ab');
-                            mediator.emit('module:error', 'Failed to get uk front', 'common/modules/autoupdate.js');
-                        }
-                    );
+                            mediator.emit('ui:collection-show-more:add');
+                            mediator.emit('ui:container-toggle:add');
+                        })
+                        .fail(function(req) {
+                            mediator.emit('module:error', 'Failed to get uk front', 'experiments/tests/uk-containers.js');
+                        })
+                        .always(function(req) {
+                            show();
+                        });
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -18,15 +18,42 @@ define([
         $('.facia-container').removeClass('facia-container--ab');
     }
 
+    function renderFront(frontId) {
+        // hide containers
+        $('.facia-container').addClass('facia-container--ab');
+        ajax({
+            url: '/' + frontId + '.json',
+            type: 'json',
+            crossOrigin: true
+        })
+            .then(function(resp) {
+                // remove old containers, leaving the first one
+                $('.container:nth-child(n+2)').remove();
+                // add new containers
+                $('.facia-container > *:nth-child(n+2)', bonzo.create('<div>' + resp.html + '</div>'))
+                    .appendTo(qwery('.facia-container')[0]);
+                // upgrade images
+                mediator.emit('ui:images:upgrade');
+                mediator.emit('ui:collection-show-more:add');
+                mediator.emit('ui:container-toggle:add');
+            })
+            .fail(function(req) {
+                mediator.emit('module:error', 'Failed to get uk front "' + frontId + '"', 'experiments/tests/uk-containers.js');
+            })
+            .always(function(req) {
+                show();
+            });
+    }
+
     return function() {
 
         this.id = 'UkContainers';
-        this.expiry = '2014-03-24';
-        this.audience = 1;
+        this.expiry = '2014-03-01';
+        this.audience = 0.1;
         this.audienceOffset = 0.0;
         this.description = 'Testing different combination of containers on the UK network front';
         this.canRun = function(config) {
-            return window.location.pathname === '/pressed/uk';
+            return ['/pressed/uk', '/uk'].indexOf(window.location.pathname) > -1;
         };
         this.variants = [
             {
@@ -34,32 +61,9 @@ define([
                 test: function(context, config) { }
             },
             {
-                id: 'variantOne',
+                id: 'variant-one',
                 test: function (context, config) {
-                    // hide containers
-                    $('.facia-container').addClass('facia-container--ab');
-                    ajax({
-                        url: '/uk-alpha.json',
-                        type: 'json',
-                        crossOrigin: true
-                    })
-                        .then(function(resp) {
-                            // remove old containers
-                            $('.container:nth-child(n+2)').remove();
-                            // add new containers
-                            $('.facia-container > *:nth-child(n+2)', bonzo.create('<div>' + resp.html + '</div>'))
-                                .appendTo(qwery('.facia-container')[0]);
-                            // upgrade images
-                            mediator.emit('ui:images:upgrade');
-                            mediator.emit('ui:collection-show-more:add');
-                            mediator.emit('ui:container-toggle:add');
-                        })
-                        .fail(function(req) {
-                            mediator.emit('module:error', 'Failed to get uk front', 'experiments/tests/uk-containers.js');
-                        })
-                        .always(function(req) {
-                            show();
-                        });
+                    renderFront('uk-alpha');
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -1,0 +1,61 @@
+/*global guardian */
+define([
+    'common/$',
+    'qwery',
+    'bonzo',
+    'common/utils/ajax',
+    'common/utils/mediator'
+], function(
+    $,
+    qwery,
+    bonzo,
+    ajax,
+    mediator
+) {
+
+    return function() {
+
+        this.id = 'UkContainers';
+        this.expiry = '2014-03-24';
+        this.audience = 1;
+        this.audienceOffset = 0.0;
+        this.description = 'Testing different combination of containers on the UK network front';
+        this.canRun = function(config) {
+            return window.location.pathname === '/pressed/uk';
+        };
+        this.variants = [
+            {
+                id: 'control',
+                test: function(context, config) {
+                    // remove hiding class
+                    $('.facia-container').removeClass('facia-container--ab');
+                }
+            },
+            {
+                id: 'testOne',
+                test: function (context, config) {
+                    ajax({
+                        url: '/uk-alpha.json',
+                        type: 'json',
+                        crossOrigin: true
+                    }).then(
+                        function(response) {
+                            // remove old containers
+                            $('.container:nth-child(n+2)').remove();
+                            // remove hiding class
+                            $('.facia-container').removeClass('facia-container--ab');
+                            // add new containers
+                            $('.facia-container > *', bonzo.create('<div>' + response.html + '</div>'))
+                                .appendTo(qwery('.facia-container')[0]);
+                        },
+                        function(req) {
+                            // remove hiding class
+                            $('.facia-container').removeClass('facia-container--ab');
+                            mediator.emit('module:error', 'Failed to get uk front', 'common/modules/autoupdate.js');
+                        }
+                    );
+                }
+            }
+        ];
+    };
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -47,6 +47,7 @@ define([
                             // add new containers
                             $('.facia-container > *', bonzo.create('<div>' + response.html + '</div>'))
                                 .appendTo(qwery('.facia-container')[0]);
+                            mediator.emit('ui:images:upgrade');
                         },
                         function(req) {
                             // remove hiding class

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -39,6 +39,7 @@ define([
                 // ui stuff
                 mediator.emit('ui:collection-show-more:add');
                 mediator.emit('ui:container-toggle:add');
+                mediator.emit('fragment:ready:dates');
             })
             .fail(function(req) {
                 mediator.emit('module:error', 'Failed to get uk front "' + frontId + '"', 'experiments/tests/uk-containers.js');

--- a/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/uk-containers.js
@@ -72,7 +72,7 @@ define([
                 }
             }
         ];
-        this.always = function() {
+        this.notInTest = function() {
             show();
         };
     };

--- a/common/app/assets/javascripts/modules/ui/images.js
+++ b/common/app/assets/javascripts/modules/ui/images.js
@@ -30,6 +30,9 @@ define(['common/$', 'common/utils/to-array', 'bonzo', 'common/utils/mediator', '
                 },
                 'window:orientationchange': function(e) {
                     images.upgrade();
+                },
+                'ui:images:upgrade': function(e) {
+                    images.upgrade();
                 }
             });
         }

--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -82,8 +82,12 @@
         }
     }
 
-    .js-on &.facia-container--ab .container:nth-child(n+2) {
-        display: none;
+    .ab-uk-containers & {
+        min-height: 500px;
+
+        > * {
+            display: none;
+        }
     }
 }
 

--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -81,6 +81,10 @@
             ));
         }
     }
+
+    .js-on &.facia-container--ab .container:nth-child(n+2) {
+        display: none;
+    }
 }
 
 @import "module/facia/_extends";

--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -82,12 +82,8 @@
         }
     }
 
-    .ab-uk-containers & {
-        min-height: 500px;
-
-        > * {
-            display: none;
-        }
+    .ab-uk-containers & > * {
+        visibility: hidden;
     }
 }
 

--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -82,8 +82,18 @@
         }
     }
 
-    .ab-uk-containers & > * {
-        visibility: hidden;
+    .is-updating {
+        display: none;
+        margin: 100px auto 0;
+    }
+    .ab-uk-containers & > {
+        * {
+            visibility: hidden;
+        }
+        .is-updating {
+            display: block;
+            visibility: visible;
+        }
     }
 }
 

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -13,7 +13,7 @@ $c-live: #e81818;
         ));
     }
 }
-.container:first-child {
+.container:nth-child(2) {
     margin-top: 0;
 }
 .container__border {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -360,7 +360,7 @@ object Switches extends Collections {
   )
 
   val ABUkContainers = Switch("A/B Tests", "ab-uk-containers",
-    "If this is switched on an A/B test runs to prove the effectiveness of truncatiung articles.",
+    "If this is switched on an A/B test runs that tries a variation of the containers on the UK network front.",
     safeState = Off, sellByDate = new DateMidnight(2014, 3, 8)
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -357,6 +357,10 @@ object Switches extends Collections {
   val GeoMostPopular = Switch("A/B Tests", "ab-geo-most-popular",
     "If this is switched on an A/B test runs to test if locally popular articles yield better click-through.",
     safeState = Off, sellByDate = new DateMidnight(2014, 3, 14)
+
+  val ABUkContainers = Switch("A/B Tests", "ab-uk-containers",
+    "If this is switched on an A/B test runs to prove the effectiveness of truncatiung articles.",
+    safeState = On, sellByDate = new DateMidnight(2014, 3, 24)
   )
 
   // Sport Switch
@@ -502,6 +506,7 @@ object Switches extends Collections {
     ShowAllArticleEmbedsSwitch,
     ImageServerSwitch,
     FrontPressJobSwitch
+    ABUkContainers
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -360,7 +360,7 @@ object Switches extends Collections {
 
   val ABUkContainers = Switch("A/B Tests", "ab-uk-containers",
     "If this is switched on an A/B test runs to prove the effectiveness of truncatiung articles.",
-    safeState = On, sellByDate = new DateMidnight(2014, 3, 24)
+    safeState = Off, sellByDate = new DateMidnight(2014, 3, 1)
   )
 
   // Sport Switch

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -357,6 +357,7 @@ object Switches extends Collections {
   val GeoMostPopular = Switch("A/B Tests", "ab-geo-most-popular",
     "If this is switched on an A/B test runs to test if locally popular articles yield better click-through.",
     safeState = Off, sellByDate = new DateMidnight(2014, 3, 14)
+  )
 
   val ABUkContainers = Switch("A/B Tests", "ab-uk-containers",
     "If this is switched on an A/B test runs to prove the effectiveness of truncatiung articles.",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -360,7 +360,7 @@ object Switches extends Collections {
 
   val ABUkContainers = Switch("A/B Tests", "ab-uk-containers",
     "If this is switched on an A/B test runs to prove the effectiveness of truncatiung articles.",
-    safeState = Off, sellByDate = new DateMidnight(2014, 3, 1)
+    safeState = Off, sellByDate = new DateMidnight(2014, 3, 8)
   )
 
   // Sport Switch

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -506,7 +506,7 @@ object Switches extends Collections {
     DogpileSwitch,
     ShowAllArticleEmbedsSwitch,
     ImageServerSwitch,
-    FrontPressJobSwitch
+    FrontPressJobSwitch,
     ABUkContainers
   )
 

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -132,12 +132,12 @@
                 var front = isFront[2],
                     capitalisedFront = front.slice(0, 1).toUpperCase() + front.slice(1),
                     participations = JSON.parse(localStorage.getItem('gu.ab.participations')),
-                    isNotParticipating =
+                    notInAlphaVariant =
                         participations &&
                         participations.value[capitalisedFront + 'Containers'] &&
-                        participations.value[capitalisedFront + 'Containers'].variant === 'notintest';
-                // only run if we're in the test, and switch is on
-                if (!isNotParticipating && switches['ab' + capitalisedFront + 'Containers']) {
+                        ['notintest', 'control'].indexOf(participations.value[capitalisedFront + 'Containers'].variant) > -1;
+                // only run if we're in the alpha variant, and switch is on
+                if (!notInAlphaVariant && switches['ab' + capitalisedFront + 'Containers']) {
                     document.documentElement.className += (' ab-' + front + '-containers');
                 }
             }

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -125,6 +125,23 @@
             }
             return false;
         }
+        function containersAb(switches) {
+            // are we on a front
+            var isFront = /^\/(pressed\/)?(uk|us|au)$/.exec(window.location.pathname);
+            if (isFront) {
+                var front = isFront[2],
+                    capitalisedFront = front.slice(0, 1).toUpperCase() + front.slice(1),
+                    participations = JSON.parse(localStorage.getItem('gu.ab.participations')),
+                    isNotParticipating =
+                        participations &&
+                        participations.value[capitalisedFront + 'Containers'] &&
+                        participations.value[capitalisedFront + 'Containers'].variant === 'notintest';
+                // only run if we're in the test, and switch is on
+                if (!isNotParticipating && switches['ab' + capitalisedFront + 'Containers']) {
+                    document.documentElement.className += (' ab-' + front + '-containers');
+                }
+            }
+        }
 
         @* we want this to happen ASAP to avoid FOUC *@
         var connectionClass = 'connection--' + (isConnectionLow() ? '' : 'not-') + 'low';
@@ -159,6 +176,8 @@
         }
 
         guardian.config = @fragments.javaScriptConfig(item);
+
+        containersAb(guardian.config.switches);
 
         // must be set before the Omniture file is parsed
         window.s_account = guardian.config.page.omnitureAccount;

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -134,7 +134,7 @@
                     participations = JSON.parse(localStorage.getItem('gu.ab.participations')),
                     notInAlphaVariant =
                         participations &&
-                        participations.value &&
+                        participations.value &&a
                         participations.value[capitalisedFront + 'Containers'] &&
                         ['notintest', 'control'].indexOf(participations.value[capitalisedFront + 'Containers'].variant) > -1;
                 // only run if we're in the alpha variant, and switch is on

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -134,6 +134,7 @@
                     participations = JSON.parse(localStorage.getItem('gu.ab.participations')),
                     notInAlphaVariant =
                         participations &&
+                        participations.value &&
                         participations.value[capitalisedFront + 'Containers'] &&
                         ['notintest', 'control'].indexOf(participations.value[capitalisedFront + 'Containers'].variant) > -1;
                 // only run if we're in the alpha variant, and switch is on

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -178,8 +178,8 @@ GET         /onward/recently-published                                          
 # Facia
 GET         /                                                                                                        controllers.FaciaController.editionRedirect(path = "")
 GET         /$path<(culture|sport|australia|commentisfree|business|money)>                                           controllers.FaciaController.editionRedirect(path)
-GET         /$path<([\d\w-]+)$>                                                                                      controllers.FaciaController.renderEditionFront(path)
-GET         /$path<([\d\w-]+)$>.json                                                                                 controllers.FaciaController.renderEditionFrontJson(path)
+GET         /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>                                                           controllers.FaciaController.renderEditionFront(path)
+GET         /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>.json
 GET         /$path<((uk|us|au)/)?(culture|sport|australia|commentisfree|business|money)>                             controllers.FaciaController.renderEditionSectionFront(path)
 GET         /$path<((uk|us|au)/)?(culture|sport|australia|commentisfree|business|money)>.json                        controllers.FaciaController.renderEditionSectionFrontJson(path)
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -178,8 +178,8 @@ GET         /onward/recently-published                                          
 # Facia
 GET         /                                                                                                        controllers.FaciaController.editionRedirect(path = "")
 GET         /$path<(culture|sport|australia|commentisfree|business|money)>                                           controllers.FaciaController.editionRedirect(path)
-GET         /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>                                                           controllers.FaciaController.renderEditionFront(path)
-GET         /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>.json                                                      controllers.FaciaController.renderEditionFrontJson(path)
+GET         /$path<([\d\w-]+)$>                                                                                      controllers.FaciaController.renderEditionFront(path)
+GET         /$path<([\d\w-]+)$>.json                                                                                 controllers.FaciaController.renderEditionFrontJson(path)
 GET         /$path<((uk|us|au)/)?(culture|sport|australia|commentisfree|business|money)>                             controllers.FaciaController.renderEditionSectionFront(path)
 GET         /$path<((uk|us|au)/)?(culture|sport|australia|commentisfree|business|money)>.json                        controllers.FaciaController.renderEditionSectionFrontJson(path)
 

--- a/facia/app/assets/javascripts/bootstraps/facia.js
+++ b/facia/app/assets/javascripts/bootstraps/facia.js
@@ -12,9 +12,7 @@ define([
     'modules/ui/container-show-more',
     'modules/ui/container-toggle',
     'common/modules/sport/football/fixtures',
-    'common/modules/sport/cricket',
-    'common/modules/ui/message',
-    'common/modules/analytics/mvt-cookie'
+    'common/modules/sport/cricket'
 ], function (
     $,
     mediator,
@@ -27,28 +25,41 @@ define([
     ContainerShowMore,
     ContainerToggle,
     FootballFixtures,
-    cricket,
-    Message,
-    mvtCookie
+    cricket
     ) {
 
     var modules = {
 
         showCollectionShowMore: function () {
-            mediator.on('page:front:ready', function(config, context) {
-                $('.container', context).each(function(container) {
+            var collectionShowMoreAdd = function(config, context) {
+                var c = context || document;
+                $('.container', c).each(function(container) {
                     $('.js-collection--show-more', container).each(function(collection) {
                         new CollectionShowMore(collection).addShowMore();
                     });
                 });
-                $('.js-container--show-more', context).each(function(container) {
+                $('.js-container--show-more', c).each(function(container) {
                     new ContainerShowMore(container).addShowMore();
                 });
+            };
+            mediator.addListeners({
+                'page:front:ready': collectionShowMoreAdd,
+                'ui:collection-show-more:add':  collectionShowMoreAdd
             });
         },
 
         showContainerToggle: function () {
-            mediator.on('page:front:ready', function(config, context) {
+            var containerToggleAdd = function(config, context) {
+                var c = context || document;
+                $('.js-container--toggle', c).each(function(container) {
+                    new ContainerToggle(container).addToggle();
+                });
+            };
+            mediator.addListeners({
+                'page:front:ready': containerToggleAdd,
+                'ui:container-toggle:add':  containerToggleAdd
+            });
+            mediator.on(/page:front:ready|ui:container-toggle:add/, function(config, context) {
                 $('.js-container--toggle', context).each(function(container) {
                     new ContainerToggle(container).addToggle();
                 });

--- a/facia/app/assets/javascripts/modules/ui/container-show-more.js
+++ b/facia/app/assets/javascripts/modules/ui/container-show-more.js
@@ -78,7 +78,6 @@ define([
                 .addClass(this._className)
                 .map(function(item) { return item; });
             this._renderButton();
-            // remove class
             this._$container.removeClass('js-container--show-more');
         };
 

--- a/facia/app/assets/javascripts/modules/ui/container-show-more.js
+++ b/facia/app/assets/javascripts/modules/ui/container-show-more.js
@@ -78,6 +78,8 @@ define([
                 .addClass(this._className)
                 .map(function(item) { return item; });
             this._renderButton();
+            // remove class
+            this._$container.removeClass('js-container--show-more');
         };
 
     };

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -2,6 +2,7 @@
 
 @if(faciaTrailblock.collections.nonEmpty) {
     <div class="facia-container monocolumn-wrapper monocolumn-wrapper--no-limit" data-link-name="Front" role="main">
+        <span class="is-updating"></span>
         @defining(faciaTrailblock.collections.filter(_._2.items.nonEmpty)) { collections =>
             @defining(collections.filter(c => (c._1.collectionType == Some("features") || c._1.collectionType == Some("news/people")))) { adCollections =>
                 @collections.zipWithIndex.map{ case(block, index) =>

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -11,7 +11,7 @@ GET        /                                                                cont
 GET        /$path<(culture|sport|australia|commentisfree|business|money)>   controllers.FaciaController.editionRedirect(path)
 
 #Facia Press
-GET        /pressed/*path          controllers.FaciaController.renderFaciaPress(path)
+GET        /pressed/*path                                                   controllers.FaciaController.renderFaciaPress(path)
 
 # Editionalised pages
 GET        /$path<([\d\w-]+)$>                                              controllers.FaciaController.renderEditionFront(path)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -14,8 +14,8 @@ GET        /$path<(culture|sport|australia|commentisfree|business|money)>   cont
 GET        /pressed/*path                                                   controllers.FaciaController.renderFaciaPress(path)
 
 # Editionalised pages
-GET        /$path<([\d\w-]+)$>                                              controllers.FaciaController.renderEditionFront(path)
-GET        /$path<([\d\w-]+)$>.json                                         controllers.FaciaController.renderEditionFrontJson(path)
+GET        /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>                   controllers.FaciaController.renderEditionFront(path)
+GET        /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>.json              controllers.FaciaController.renderEditionFrontJson(path)
 GET        /$path<(\w+/)?([\d\w-]*)>                                        controllers.FaciaController.renderEditionSectionFront(path)
 GET        /$path<(\w+/)?([\d\w-]*)>.json                                   controllers.FaciaController.renderEditionSectionFrontJson(path)
 

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -14,8 +14,8 @@ GET        /$path<(culture|sport|australia|commentisfree|business|money)>   cont
 GET        /pressed/*path          controllers.FaciaController.renderFaciaPress(path)
 
 # Editionalised pages
-GET        /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>                   controllers.FaciaController.renderEditionFront(path)
-GET        /$path<(us|uk|au|us-alpha|uk-alpha|au-alpha)?>.json              controllers.FaciaController.renderEditionFrontJson(path)
+GET        /$path<([\d\w-]+)$>                                              controllers.FaciaController.renderEditionFront(path)
+GET        /$path<([\d\w-]+)$>.json                                         controllers.FaciaController.renderEditionFrontJson(path)
 GET        /$path<(\w+/)?([\d\w-]*)>                                        controllers.FaciaController.renderEditionSectionFront(path)
 GET        /$path<(\w+/)?([\d\w-]*)>.json                                   controllers.FaciaController.renderEditionSectionFrontJson(path)
 


### PR DESCRIPTION
It's much better if we use our existing AB framework to compare uk/uk-alpha/whatever

I've created a test which pulls in `uk-alpha` and replaces the page with it

As it's client-side, there is a brief flash of an empty page before it's populated.
Also, if the app js fails, user is potentially left with a blank page

Will test this on code first

![1287507909_soccer-fight](https://f.cloud.github.com/assets/74132/2246955/c5751f6e-9d69-11e3-992c-2c7b9d5489d6.gif)
