### PR TITLE
Prevent images with another ratio than 5/3 to break out of their container

### DIFF
--- a/common/app/assets/stylesheets/module/onward/_right-recommended.scss
+++ b/common/app/assets/stylesheets/module/onward/_right-recommended.scss
@@ -61,6 +61,7 @@
     height: $gs-baseline*6;
     padding-top: 3px;
     margin-right: $gs-gutter/2;
+    overflow: hidden;
 
     img {
       width: 100%;


### PR DESCRIPTION
Outbrain seems to return square images. This fixes the case where it was interfering with the layout. 
## Before

![screen shot 2014-02-23 at 14 10 53](https://f.cloud.github.com/assets/85783/2240475/937627e0-9c94-11e3-97a9-0a4093579af1.PNG)
## After

![screen shot 2014-02-23 at 14 10 49](https://f.cloud.github.com/assets/85783/2240476/9683ca5a-9c94-11e3-941b-7a681597868f.PNG)

![ ](http://media.giphy.com/media/13y1jWA5jbaW7C/giphy.gif)
