### PR TITLE
Fix content API put fields

### DIFF
--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -36,7 +36,7 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
 
   def getCollectionUrlForWrite(id: String): Option[String] = endpoint
     .filter(_.startsWith("https://") || Play.isDev)
-    .map(_ + s"/collections/${id.replace('/', '-')}")
+    .map(_ + s"/collections/$id")
 
   def writeToContentapi(config: Config): Future[Response] = {
     (for {

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -4,7 +4,7 @@ import frontsapi.model.Trail
 import model.Config
 import scala.concurrent.Future
 import tools.FaciaApi
-import play.api.libs.json.{JsNumber, JsValue, Json}
+import play.api.libs.json.{JsNull, JsNumber, JsValue, Json}
 import play.api.libs.ws.{Response, WS}
 import common.{Logging, ExecutionContexts}
 import com.ning.http.client.Realm
@@ -82,17 +82,24 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
 
   private def generateItems(items: List[Trail]): List[Item] =
     items.map { trail =>
-      Item(trail.id, trail.meta.map(_.map {
-            case ("group", jsValue) => ("group", jsValue.asOpt[BigDecimal].map(JsNumber.apply).getOrElse(jsValue))
-            //TODO: These are in transition and will be removed
-            case json@("imageAdjust", jsValue) => json
-            case json@("meta", jsValue) => json
-            case json@("supporting", jsValue) => json
-            case j  => j
-          }
-        )
-      )
+    Item(trail.id, trail.meta.map(_.map(convertFields))
+    )
     }
+
+  //TODO: These are in transition and will be removed
+  def convertFields: PartialFunction[(String, JsValue), (String, JsValue)] = {
+    case ("group", jsValue) => ("group", jsValue.asOpt[BigDecimal].map(JsNumber.apply).getOrElse(jsValue))
+    case ("imageAdjust", jsValue) => ("imageAdjustment", jsValue)
+    case ("meta", jsValue)        => ("metadata", convertMeta(jsValue))
+    case ("supporting", jsValue)  => ("supportingContent", convertSupporting(jsValue))
+    case j  => j
+  }
+
+  def convertSupporting(meta: JsValue): JsValue =
+    meta.asOpt[List[JsValue]].map(_.map(convertMeta)).map(Json.toJson(_)).getOrElse(JsNull)
+
+  def convertMeta(meta: JsValue): JsValue =
+    meta.asOpt[Map[String, JsValue]].map(_.map(convertFields)).map(Json.toJson(_)).getOrElse(JsNull)
 
 }
 


### PR DESCRIPTION
We need all fields in the inner and outer JSON to have the new fieldnames.

Pretty much #3118, but with nesting. Somehow the old commits got lost.

EDIT:
We now no longer convert a collection ID to have dashes.
