### PR TITLE
Remove unnecessary webpage schema meta data from template

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -18,8 +18,7 @@
                         @article.cricketMatch.map { id =>
                             <div class="after-headline">
                                 <a class="cta-small c-neutral1" href="@LinkTo{/sport@id}" data-link-name="view scorecard: @id"
-                                    itemprop="significantLink"
-                                    id="schema-WebPage">View full scorecard<i class="i i-sport-arrow-small"></i></a>
+                                    itemprop="significantLink">View full scorecard<i class="i i-sport-arrow-small"></i></a>
                             </div>
                         }
                     }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -10,7 +10,7 @@ be sure to apply any necessary changes to non-shared code there too.
 <head>
     @fragments.head(metaData, projectName, head, curlPaths)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top">
 
     @fragments.message(metaData)
     @fragments.header(metaData)

--- a/identity/app/views/ethicalAwards/complete.scala.html
+++ b/identity/app/views/ethicalAwards/complete.scala.html
@@ -8,7 +8,7 @@
     @fragments.commonCssSetup(projectName)
     @fragments.commonJavaScriptSetup(metaData)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top">
 
     <div id="preload-1">
         <h2 class="formstack-heading formstack-heading--first">Thank you for nominating</h2>

--- a/identity/app/views/filmAwards/complete.scala.html
+++ b/identity/app/views/filmAwards/complete.scala.html
@@ -8,7 +8,7 @@
     @fragments.commonCssSetup(projectName)
     @fragments.commonJavaScriptSetup(metaData)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top">
 
     <div id="preload-1">
         <h2 class="formstack-heading formstack-heading--first">Thank you for nominating</h2>

--- a/identity/app/views/formstack/formstackComplete.scala.html
+++ b/identity/app/views/formstack/formstackComplete.scala.html
@@ -8,7 +8,7 @@
     @fragments.commonCssSetup(projectName)
     @fragments.commonJavaScriptSetup(metaData)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top">
 
     <div id="preload-1">
         <h2 class="formstack-heading formstack-heading--first">Thank you for your submission</h2>

--- a/identity/app/views/formstack/formstackForm.scala.html
+++ b/identity/app/views/formstack/formstackForm.scala.html
@@ -8,7 +8,7 @@
     @fragments.commonCssSetup(projectName)
     @fragments.commonJavaScriptSetup(metaData)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top">
 
     <div id="preload-1">
         <div data-formstack-id="@formstackForm.formReference" class="is-hidden">

--- a/identity/app/views/formstack/formstackFormNotFound.scala.html
+++ b/identity/app/views/formstack/formstackFormNotFound.scala.html
@@ -8,7 +8,7 @@
     @fragments.commonCssSetup(projectName)
     @fragments.commonJavaScriptSetup(metaData)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top">
 
     <div id="preload-1">
         <h2 class="formstack-heading formstack-heading--first">Form not found</h2>

--- a/identity/app/views/identityMain.scala.html
+++ b/identity/app/views/identityMain.scala.html
@@ -5,7 +5,7 @@
 <head>
     @fragments.head(metaData, projectName, head)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage" itemref="schema-WebPage">
+<body id="top">
 
     @fragments.message(metaData)
     @fragments.identityHeader(metaData)


### PR DESCRIPTION
All of our pages schemas were made invalid by something that is used in football live blogs only. The untestable SEO impact of this live blog tweak does not justify making all other pages invalid.

/cc @rich-nguyen
