### PR TITLE
Growth hacking: Facebook: Publisher metadata

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -268,6 +268,7 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
     "article:published_time" -> webPublicationDate,
     "article:modified_time" -> lastModified,
     "article:section" -> sectionName,
+    "article:publisher" -> "https://www.facebook.com/theguardian",
     "og:image" -> openGraphImage
   ) ++ tags.map("article:tag" -> _.name) ++
     tags.filter(_.isContributor).map("article:author" -> _.webUrl)


### PR DESCRIPTION
Adding this tag relates our content back to our Facebook page and should generate a Like button for the Page on posts from our domain.
