### PR TITLE
Remove unnecessary classnames added by the fonts loader

### DIFF
--- a/common/app/assets/javascripts/modules/ui/fonts.js
+++ b/common/app/assets/javascripts/modules/ui/fonts.js
@@ -18,10 +18,6 @@ define([
         this.view = {
             showFont: function(style, json) {
                 style.innerHTML = json.css;
-                var html = document.querySelector('html');
-                if (html.className.indexOf('font-' + json.name + '-loaded') < 0) {
-                    html.className += ' font-' + json.name + '-loaded';
-                }
             }
         };
 

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -102,7 +102,6 @@
                     if (cachedCss) {
                         style.innerHTML = cachedCss;
                         style.setAttribute('data-cache-full', 'true');
-                        document.querySelector('html').className += ' font-' + nameAndCacheKey[1] + '-loaded';
                     }
                 }
             }


### PR DESCRIPTION
Removes `font-WebEgyptian-loaded font-WebAgateSans-loaded` classes being added to the `<html>` element but not used.

![ ](http://media.giphy.com/media/kYuTpFluUrVio/giphy.gif)
