### PR TITLE
Reduce FOUC when initializing identity

### DIFF
--- a/common/app/assets/javascripts/bootstraps/identity.js
+++ b/common/app/assets/javascripts/bootstraps/identity.js
@@ -27,9 +27,7 @@ define([
             Id.init(config);
             // Used to show elements that need signin. Use .sign-in-required
             if (Id.isUserLoggedIn()) {
-                $('html').addClass('id--signed-in');
-            } else {
-                $('html').addClass('id--signed-out');
+                document.documentElement.className = document.documentElement.className.replace(/\bid--signed-out\b/, 'id--signed-in');
             }
         },
         initFormstack: function () {

--- a/common/app/assets/javascripts/modules/navigation/profile.js
+++ b/common/app/assets/javascripts/modules/navigation/profile.js
@@ -29,7 +29,6 @@ define([
 
     /** @type {Object.<string.*>} */
     Profile.CONFIG = {
-        signinText: 'Sign in',
         eventName: 'modules:profilenav',
         classes: {
             container: 'js-profile-nav',

--- a/common/app/assets/javascripts/modules/navigation/profile.js
+++ b/common/app/assets/javascripts/modules/navigation/profile.js
@@ -52,7 +52,7 @@ define([
     /** */
     Profile.prototype.init = function() {
         var self = this;
-        
+
         this.setFragmentFromCookie();
     };
 
@@ -63,9 +63,9 @@ define([
             $popup = bonzo(this.dom.popup);
 
         $container.removeClass('js-hidden');
-        $content.html(user ? user.displayName : Profile.CONFIG.signinText);
 
         if (user) {
+            $content.text(user.displayName);
             $container.addClass('is-signed-in');
             $popup.html(
                 '<ul class="nav nav--columns nav--top-border-off nav--additional-sections" data-link-name="Sub Sections">'+

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -6,7 +6,7 @@ be sure to apply any necessary changes to non-shared code there too.
 -->*@
 
 <!DOCTYPE html>
-<html class="js-off" lang="en-GB">
+<html class="js-off id--signed-out" lang="en-GB">
 <head>
     @fragments.head(metaData, projectName, head, curlPaths)
 </head>

--- a/identity/app/views/ethicalAwards/complete.scala.html
+++ b/identity/app/views/ethicalAwards/complete.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off" lang="en-GB">
+<html class="js-off id--signed-out" lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>

--- a/identity/app/views/filmAwards/complete.scala.html
+++ b/identity/app/views/filmAwards/complete.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off" lang="en-GB">
+<html class="js-off id--signed-out" lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>

--- a/identity/app/views/formstack/formstackComplete.scala.html
+++ b/identity/app/views/formstack/formstackComplete.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off" lang="en-GB">
+<html class="js-off id--signed-out" lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>

--- a/identity/app/views/formstack/formstackForm.scala.html
+++ b/identity/app/views/formstack/formstackForm.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off" lang="en-GB">
+<html class="js-off id--signed-out" lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>

--- a/identity/app/views/formstack/formstackFormNotFound.scala.html
+++ b/identity/app/views/formstack/formstackFormNotFound.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off" lang="en-GB">
+<html class="js-off id--signed-out" lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>

--- a/identity/app/views/identityMain.scala.html
+++ b/identity/app/views/identityMain.scala.html
@@ -1,7 +1,7 @@
 @(metaData: MetaData, switches: Seq[com.gu.management.Switchable], projectName: Option[String] = Some(conf.Configuration.environment.projectName))(head: Html)(body: Html)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off" lang="en-GB">
+<html class="js-off id--signed-out" lang="en-GB">
 <head>
     @fragments.head(metaData, projectName, head)
 </head>


### PR DESCRIPTION
- Prevent a page reflow for signed off users
- Touch the DOM only to insert the user name. Not to re-add the "Sign in" label

![ ](http://media.giphy.com/media/LoY6SGwMbq9Nu/giphy.gif)
