### PR TITLE
Fix a discrepancy in the way redirects and S3 R1 files are represented

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -23,11 +23,11 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   }
 
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
-  def normalise(path: String) = {
+  def normalise(path: String, zeros: String = "") = {
     val r1ArtifactUrl = """www.theguardian.com/(.*)/[0|1]?,[\d]*,(-?\d+),[\d]*(.*)""".r
     path match {
       case r1ArtifactUrl(path, artifactOrContextId, extension) => {
-        val normalisedUrl = s"www.theguardian.com/${path}/0,,${artifactOrContextId},.html"
+        val normalisedUrl = s"www.theguardian.com/${path}/0,,${artifactOrContextId},${zeros}.html"
         Some(normalisedUrl)
       }
       case _ => None
@@ -42,7 +42,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
     destination match { 
       case Some(_) => Redirect(destination.get, 301)
       case _ => {
-        val s3content = isArchived(path)
+        val s3content = isArchived(normalise(path, zeros = "00").getOrElse(path))
         s3content match {
           case Some(_) => Ok(views.html.archive(s3content)).as("text/html")
           case _ => NotFound

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -61,5 +61,15 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
       case (key, value) => controllers.ArchiveController.normalise(key) should be (value)
     }
   }
+  
+  // r1 curio (all the redirects have their 00's removed, all the s3 archived files don't)
+  it should "return a normalised r1 path with suffixed zeros" in Fake {
+    val tests = Map[String, Option[String]](
+      "www.theguardian.com/books/reviews/travel/0,,343395,00.html" -> Some("www.theguardian.com/books/reviews/travel/0,,343395,00.html")
+    ) 
+    tests foreach {
+      case (key, value) => controllers.ArchiveController.normalise(key, zeros = "00") should be (value)
+    }
+  }
 
 }


### PR DESCRIPTION
Not nice, but responsive for quite a lot of 404s on the archive server.
