### PR TITLE
Links fixes

### DIFF
--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -129,11 +129,21 @@
 
 
 /**
- * underlines text
+ * Fakes text underline with a border
  */
 
 .u-underline {
-    text-decoration: underline;
+    text-decoration: none !important;
+    border-bottom: 1px solid $c-neutral4;
+    @include transition(border-color .15s ease-out);
+
+    &:hover,
+    &:focus {
+        border-color: mix($c-newsDefault, $c-neutral4, 50%);
+    }
+    &:active {
+        border-color: $c-newsAccent;
+    }
 }
 
 

--- a/common/app/assets/stylesheets/base/_links.scss
+++ b/common/app/assets/stylesheets/base/_links.scss
@@ -10,5 +10,6 @@ a,
     }
     &:active {
         color: $c-newsAccent;
+        text-decoration: none;
     }
 }

--- a/common/app/assets/stylesheets/module/containers/_features.scss
+++ b/common/app/assets/stylesheets/module/containers/_features.scss
@@ -142,4 +142,7 @@
             text-decoration: underline;
         }
     }
+    .item__link:active .item__title {
+        text-decoration: none;
+    }
 }

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -146,6 +146,11 @@
             text-decoration: underline;
         }
     }
+    &:active {
+        .item__title {
+            text-decoration: none;
+        }
+    }
 }
 .fromage__link:visited,
 .fromage__link:visited .item__title,

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -140,6 +140,8 @@
 
     &:hover,
     &:focus {
+       text-decoration: none;
+
         .item__title {
             text-decoration: underline;
         }

--- a/common/app/assets/stylesheets/module/facia/_linkslist.scss
+++ b/common/app/assets/stylesheets/module/facia/_linkslist.scss
@@ -74,6 +74,9 @@
     &:visited {
         color: $c-neutral2;
     }
+    &:active {
+        color: $c-neutral1;
+    }
 }
 
 

--- a/common/app/assets/stylesheets/module/facia/_supporting.scss
+++ b/common/app/assets/stylesheets/module/facia/_supporting.scss
@@ -34,7 +34,11 @@
     margin: 0;
     @include fs-headline(1);
     color: $c-neutral1;
-}
-.supporting__action:visited {
-    color: $c-neutral2;
+
+    &:visited {
+        color: $c-neutral2;
+    }
+    &:active {
+        color: $c-neutral1;
+    }
 }


### PR DESCRIPTION
- [fix] Prevent hover effect to be a double underline in Firefox
- [new] Remove effects on links triggered on touch / scroll
- [new] Use borders instead of underline for in body links

Thanks to @Nico3333fr for the tip with the `:active` state.
## Before

![screen shot 2014-02-25 at 21 11 32](https://f.cloud.github.com/assets/85783/2263073/6ea53c84-9e61-11e3-8ffe-60cfc127ac6e.PNG)
## After

![screen shot 2014-02-25 at 21 11 22](https://f.cloud.github.com/assets/85783/2263074/7248281a-9e61-11e3-82a8-324e5e06f2b2.PNG)
## In body links with border:
### Normal

![screen shot 2014-02-26 at 14 35 34](https://f.cloud.github.com/assets/85783/2270873/8449f862-9ef3-11e3-876e-06c8e0dd570c.PNG)
### Hover

![screen shot 2014-02-26 at 14 35 41](https://f.cloud.github.com/assets/85783/2270868/74e8a2ce-9ef3-11e3-883c-3ec96e0cc379.PNG)
### Active

![screen shot 2014-02-26 at 14 36 00](https://f.cloud.github.com/assets/85783/2270869/777e4a34-9ef3-11e3-9168-68d04f9aa8c2.PNG)

![ ](http://s1.developerslife.ru/public/images/gifs/8a0180a4-1ef0-4ac3-b67d-12fa8fb497a7.gif)
