### PR TITLE
Cap the number of fronts

### DIFF
--- a/facia-tool/public/javascripts/models/config/main.js
+++ b/facia-tool/public/javascripts/models/config/main.js
@@ -61,7 +61,7 @@ define([
                 model.fronts.unshift(front);
                 front.toggleOpen();
             } else {
-                window.alert('The maximum number of fronts (' + vars.CONST.maxFronts + ') has been exceeded. Please delete one first, by removing all it\'s collections.');
+                window.alert('The maximum number of fronts (' + vars.CONST.maxFronts + ') has been exceeded. Please delete one first, by removing all its collections.');
             }
         };
 

--- a/facia-tool/public/javascripts/models/config/main.js
+++ b/facia-tool/public/javascripts/models/config/main.js
@@ -53,11 +53,16 @@ define([
         }, this);
 
         model.createFront = function() {
-            var front =  new Front();
+            var front;
 
-            model.newFront(front);
-            model.fronts.unshift(front);
-            front.toggleOpen();
+            if (vars.model.fronts().length <= vars.CONST.maxFronts) {
+                front =  new Front();
+                model.newFront(front);
+                model.fronts.unshift(front);
+                front.toggleOpen();
+            } else {
+                window.alert('The maximum number of fronts (' + vars.CONST.maxFronts + ') has been exceeded. Please delete one first, by removing all it\'s collections.');
+            }
         };
 
         model.createCollection = function() {

--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -15,6 +15,8 @@ define(['knockout'], function(ko) {
             'comment/section'
         ],
 
+        maxFronts: 100,
+
         groups: ["standard,big,very big,huge"],
 
         viewer: 'http://s3-eu-west-1.amazonaws.com/facia/responsive-viewer.html',


### PR DESCRIPTION
The limit is initially 100. If you try to add more using the configuration tool, you'll get: 

![fronts-tool](https://f.cloud.github.com/assets/1147913/2268552/96574b68-9ecb-11e3-9b4e-4c8fbe552ad8.png)
