### PR TITLE
Handle archive encoded urls

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -29,9 +29,9 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   } 
 
   // arts/gallery/image/0,,-126 -> arts/pictures/image/0,,-126
-  /*def isGallery(path: String) = {
-    path.replace("/gallery/", "/pictures/") 
-  }*/
+  def isGallery(path: String): Option[String] = {
+    if (path contains "/gallery/") Some(path.replace("/gallery/", "/pictures/")) else None
+  }
 
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
   def normalise(path: String, zeros: String = ""): Option[String] = {
@@ -59,6 +59,10 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
       }.orElse {
         isArchived(normalise(path, zeros = "00").getOrElse(path)).map {
           body => Ok(views.html.archive(s"${body}")).as("text/html")
+        }
+      }.orElse {
+        isGallery(path).map {
+          url => Redirect(s"http://${url}", 301) 
         }
       }.getOrElse(NotFound)
       

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -7,7 +7,7 @@ import views.support._
 import services.S3
 import services.DynamoDB
 import play.api.templates.Html
-import java.net.{URLDecoder, URLEncoder}
+import java.net.URLDecoder
 
 object ArchiveController extends Controller with Logging with ExecutionContexts {
  

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -11,22 +11,27 @@ import java.net.{URLDecoder, URLEncoder}
 
 object ArchiveController extends Controller with Logging with ExecutionContexts {
  
-  def isRedirect(path: String) = {
+  def isRedirect(path: String): Option[String] = {
     val redirects = DynamoDB.destinationFor(path)
     log.info(s"Checking '${path}' is a redirect in DynamoDB: ${!redirects.isEmpty}")
     redirects
   }
 
-  def isArchived(path: String) = {
+  def isArchived(path: String): Option[String] = {
     val archive = services.S3Archive.getHtml(path)
     log.info(s"Checking '${path}' is a archived in S3: ${!archive.isEmpty}")
     archive
   }
 
-  def isEncoded(path: String) = {
+  def isEncoded(path: String): Option[String] = {
     val decodedPath = URLDecoder.decode(path, "UTF-8")
     if (decodedPath != path) Some(decodedPath) else None
   } 
+
+  // arts/gallery/image/0,,-126 -> arts/pictures/image/0,,-126
+  /*def isGallery(path: String) = {
+    path.replace("/gallery/", "/pictures/") 
+  }*/
 
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
   def normalise(path: String, zeros: String = "") = {
@@ -39,28 +44,19 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
       case _ => None
     }
   }
-  
+ 
+  // TODO - 1) fix URLs with JSOUP, 2) , 3)
+
   def lookup(path: String) = Action { implicit request =>
    
-    val encoded = isEncoded(path)
-
-    // is it a redirect -> 301, if not is it archived -> 200, if not then 404
-    encoded match {
-      case Some(_) => Redirect(s"http://${encoded.get}", 301)
-      case _ => {
-        val destination = isRedirect(normalise(path).getOrElse(path))
-        destination match { 
-          case Some(_) => Redirect(destination.get, 301)
-          case _ => {
-            val s3content = isArchived(normalise(path, zeros = "00").getOrElse(path))
-            s3content match {
-              case Some(_) => Ok(views.html.archive(s3content)).as("text/html")
-              case _ => NotFound
-            }
-          } 
-        }
-      }
-    }
+    isEncoded(path)
+      .map { url => Redirect(s"http://${url}", 301) }
+      .orElse { isRedirect(normalise(path).getOrElse(path)) }
+      .map { url => Redirect(s"${url}", 301) }
+      .orElse { isArchived(normalise(path, zeros = "00").getOrElse(path)) }
+      .map { body =>  Ok(views.html.archive(body)).as("text/html") }
+      .getOrElse(NotFound)
+  
   }
 
 }

--- a/archive/app/views/archive.scala.html
+++ b/archive/app/views/archive.scala.html
@@ -1,2 +1,2 @@
-@(html: Option[String])
-@Html(html.get)
+@(html: String)
+@Html(html)

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -77,4 +77,8 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
     controllers.ArchiveController.isEncoded("foo") should be (None)
   }
 
+  it should "test a string contains an old gallery" in Fake {
+    controllers.ArchiveController.isGallery("arts/gallery/0,") should be (Some("arts/pictures/0,"))
+  }
+
 }

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -71,5 +71,10 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
       case (key, value) => controllers.ArchiveController.normalise(key, zeros = "00") should be (value)
     }
   }
+  
+  it should "test a string is url encoded" in Fake {
+    controllers.ArchiveController.isEncoded("foo%2Cfoo") should be (Some("foo,foo"))
+    controllers.ArchiveController.isEncoded("foo") should be (None)
+  }
 
 }


### PR DESCRIPTION
About 5% of the r1 requests come through with their paths as encoded strings. It seems unfair to penalise them. This bounces them to the correct version.
