### PR TITLE
Add identity to history filename

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -14,6 +14,7 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import sun.misc.BASE64Encoder
 import com.amazonaws.auth.AWSSessionCredentials
+import controllers.Identity
 
 trait S3 extends Logging {
 
@@ -102,9 +103,9 @@ object S3FrontsApi extends S3 {
   def putMasterConfig(json: String) =
     putPublic(s"$location/config/config.json", json, "application/json")
 
-  def archiveMasterConfig(json: String) = {
+  def archiveMasterConfig(json: String, identity: Identity) = {
     val now = DateTime.now
-    putPublic(s"${location}/history/config/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.json", json, "application/json")
+    putPublic(s"${location}/history/config/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.${identity.email}.json", json, "application/json")
   }
 
   private def getListing(prefix: String, dropText: String): List[String] = {

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -107,7 +107,7 @@ trait UpdateActions extends Logging {
     }
 
   def putMasterConfig(config: Config, identity: Identity): Option[Config] = {
-    FaciaApi.archiveMasterConfig(config)
+    FaciaApi.archiveMasterConfig(config, identity)
     FaciaApi.putMasterConfig(config, identity)
   }
 

--- a/facia-tool/app/tools/FaciaApi.scala
+++ b/facia-tool/app/tools/FaciaApi.scala
@@ -58,7 +58,7 @@ object FaciaApi extends FaciaApiRead with FaciaApiWrite {
   def putMasterConfig(config: Config, identity: Identity): Option[Config] = {
     Try(S3FrontsApi.putMasterConfig(Json.prettyPrint(Json.toJson(config)))).map(_ => config).toOption
   }
-  def archiveMasterConfig(config: Config): Unit = S3FrontsApi.archiveMasterConfig(Json.prettyPrint(Json.toJson(config)))
+  def archiveMasterConfig(config: Config, identity: Identity): Unit = S3FrontsApi.archiveMasterConfig(Json.prettyPrint(Json.toJson(config)), identity)
 
   def updateIdentity(block: Block, identity: Identity): Block = block.copy(lastUpdated = DateTime.now.toString, updatedBy = identity.fullName, updatedEmail = identity.email)
 }


### PR DESCRIPTION
Names in filenames = easier scanning for culprits:

![fronts-tool](https://f.cloud.github.com/assets/1147913/2271753/2c0d55ee-9efe-11e3-9e64-418f87607d0e.png)
