### PR TITLE
Fix double-header issue on culture/sport

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -13,7 +13,7 @@ $c-live: #e81818;
         ));
     }
 }
-.container:nth-child(2) {
+.container--first {
     margin-top: 0;
 }
 .container__border {
@@ -68,7 +68,7 @@ $c-live: #e81818;
     color: inherit;
 }
 @include mq($to: tablet) {
-    .has-localnav .container:first-child {
+    .has-localnav .container--first {
         .container__title,
         .container__border {
             display: none;

--- a/common/app/views/fragments/containers/comment.scala.html
+++ b/common/app/views/fragments/containers/comment.scala.html
@@ -8,7 +8,8 @@
                 class="@RenderClasses(Map(
                     "container" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/commentanddebate.scala.html
+++ b/common/app/views/fragments/containers/commentanddebate.scala.html
@@ -9,7 +9,8 @@
                     "container" -> true,
                     "container--row-pattern" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -9,7 +9,8 @@
                     "container" -> true,
                     "container--row-pattern" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -11,7 +11,8 @@
                     "container" -> true,
                     "container--row-pattern" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/people.scala.html
+++ b/common/app/views/fragments/containers/people.scala.html
@@ -9,7 +9,8 @@
                     "container" -> true,
                     "container--row-pattern" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/popular.scala.html
+++ b/common/app/views/fragments/containers/popular.scala.html
@@ -4,7 +4,10 @@
 
     @if(collection.items.nonEmpty) {
         <section
-            class="@RenderClasses("container", s"container--${style.containerType}")"
+            class="@RenderClasses(Map(
+                "container" -> true,
+                s"container--${style.containerType}" -> true,
+                "container--first" -> (containerIndex == 0)))"
             data-link-name="block | @config.id"
             data-id="@config.id"
             data-type="@style.containerType">

--- a/common/app/views/fragments/containers/section.scala.html
+++ b/common/app/views/fragments/containers/section.scala.html
@@ -8,7 +8,8 @@
                 class="@RenderClasses(Map(
                     "container" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/special.scala.html
+++ b/common/app/views/fragments/containers/special.scala.html
@@ -9,7 +9,8 @@
                     "container" -> true,
                     "container--row-pattern" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/sport.scala.html
+++ b/common/app/views/fragments/containers/sport.scala.html
@@ -8,7 +8,8 @@
                 class="@RenderClasses(Map(
                     "container" -> true,
                     s"container--${style.containerType}" -> true,
-                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty)))"
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType">

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -2,7 +2,12 @@
 
 @if(collection.items.nonEmpty) {
     <section
-        class="@RenderClasses("container", "container--row-pattern", "container--news", "container--tag")"
+        class="@RenderClasses(Map(
+            "container" -> true,
+            "container--row-pattern" -> true,
+            "container--news" -> true,
+            "container--tag" -> true,
+            "container--first" -> (containerIndex == 0)))"
         data-link-name="block | @config.id"
         data-id="@config.id"
         data-type="@style.containerType">


### PR DESCRIPTION
Due to using `first-child`, now the first container is no longer the first child

cc: @gklopper 
