### PR TITLE
Live-Better: Write to Data Extension in ExactTarget

### DIFF
--- a/identity/app/conf/IdentityConfiguration.scala
+++ b/identity/app/conf/IdentityConfiguration.scala
@@ -1,5 +1,21 @@
 package conf
 
 import common.GuardianConfiguration
+import com.gu.email.exacttarget.ExactTargetFactory
+import java.net.URI
+import utils.SafeLogging
 
-class IdentityConfiguration extends GuardianConfiguration("frontend", webappConfDirectory = "env")
+class IdentityConfiguration extends GuardianConfiguration("frontend", webappConfDirectory = "env") with SafeLogging {
+
+  object exacttarget {
+    lazy val factory = for {
+      accountName <- configuration.getStringProperty("exacttarget.accountname")
+      password <- configuration.getStringProperty("exacttarget.password")
+      endpointUrl <- configuration.getStringProperty("exacttarget.endpoint")
+    } yield {
+      logger.info(s"Found configuration for ExactTarget with endpoint $endpointUrl")
+      new ExactTargetFactory(accountName, password, new URI(endpointUrl))
+    }
+  }
+
+}

--- a/identity/app/controllers/ExactTargetController.scala
+++ b/identity/app/controllers/ExactTargetController.scala
@@ -1,0 +1,64 @@
+package controllers
+
+import play.api.mvc._
+import common.ExecutionContexts
+import services.{IdRequestParser, ReturnUrlVerifier}
+import com.google.inject.{Inject, Singleton}
+import utils.SafeLogging
+import scala.collection.convert.wrapAsJava._
+import conf.IdentityConfiguration
+import play.api.libs.ws._
+import model.diagnostics.CloudWatch
+import exacttarget.{SubscriptionDef, DataExtId}
+
+@Singleton
+class ExactTargetController @Inject()(
+                                       conf: IdentityConfiguration,
+                                       returnUrlVerifier: ReturnUrlVerifier,
+                                       idRequestParser: IdRequestParser,
+                                       authAction: actions.AuthAction)
+  extends Controller with ExecutionContexts with SafeLogging {
+
+  def cloudWatchCount(id: String) { CloudWatch.put("ExactTarget", Map(id -> 1d)) }
+
+  def subscribe(subscriptionDefId: String, returnUrl: String) = authAction.apply {
+    implicit request =>
+      cloudWatchCount(s"sub-$subscriptionDefId-request")
+
+      idRequestParser(request).returnUrl match {
+        case Some(verifiedReturnUrl) =>
+          val user = request.user
+          for {
+            exactTargetFactory <- conf.exacttarget.factory
+            emailAddress: String <- Option(user.getPrimaryEmailAddress) if !emailAddress.isEmpty
+            subscriptionDef <- SubscriptionDef.All.get(subscriptionDefId)
+          } {
+            val automaticParameters = Map("EmailAddress" -> emailAddress, "Field_A" -> user.getId)
+
+            val dataExtId = subscriptionDef.dataExtension
+            val parameters = subscriptionDef.parameters ++ automaticParameters
+
+            val triggeredEmailRequest =
+              exactTargetFactory.createRequest(emailAddress, parameters, "Create", dataExtId.businessUnitId, dataExtId.customerKey)
+
+            WS.url(exactTargetFactory.endPoint.toString).withHeaders(
+              "Content-Type" -> "text/xml; charset=utf-8",
+              "SOAPAction" -> triggeredEmailRequest.getSoapAction
+            ).post(triggeredEmailRequest.getSoapEnvelopeString).onSuccess {
+              case resp =>
+                (resp.xml \\ "CreateResponse" \ "Results") map {
+                  subscriberNode =>
+                    val statusCode = (subscriberNode \ "StatusCode").text.trim
+                    val statusMessage = (subscriberNode \ "StatusMessage").text.trim
+                    cloudWatchCount(s"sub-$subscriptionDefId-et-api-response-$statusCode")
+                    logger.info(s"CreateResponse - $statusCode : $statusMessage")
+                }
+            }
+          }
+
+          SeeOther(verifiedReturnUrl)
+        case None =>
+          SeeOther(returnUrlVerifier.defaultReturnUrl)
+      }
+  }
+}

--- a/identity/app/exacttarget/SubscriptionDef.scala
+++ b/identity/app/exacttarget/SubscriptionDef.scala
@@ -1,0 +1,15 @@
+package exacttarget
+
+
+case class DataExtId(businessUnitId: String, customerKey: String)
+
+case class SubscriptionDef(dataExtension: DataExtId, parameters: Map[String, String])
+
+object SubscriptionDef {
+  val liveBetter= DataExtId(businessUnitId="1058977", customerKey="1806")
+
+  val liveBetterSubDefs =
+    (1 to 6).map(n => s"lb$n" -> SubscriptionDef(liveBetter, Map(s"LB_Chal_$n" -> "true"))).toMap
+  
+  val All: Map[String, SubscriptionDef] = liveBetterSubDefs
+}

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -24,3 +24,4 @@ GET     /film-awards/:formReference                     @controllers.FilmAwardsC
 GET     /form/complete                                  @controllers.FormstackController.complete
 GET     /form/:formReference                            @controllers.FormstackController.formstackForm(formReference: String)
 
+GET     /et/subscribe/:subDefId                         @controllers.ExactTargetController.subscribe(subDefId: String, returnUrl: String)

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -85,7 +85,8 @@ object Frontend extends Build with Prototypes {
       "net.liftweb" %% "lift-json" % "2.5",
       "commons-httpclient" % "commons-httpclient" % "3.1",
       "net.databinder.dispatch" %% "dispatch-core" % "0.11.0",
-      "org.slf4j" % "slf4j-ext" % "1.7.5"
+      "org.slf4j" % "slf4j-ext" % "1.7.5",
+      "com.gu" %% "exact-target-client" % "2.23"
     )
   )
 


### PR DESCRIPTION
This is functional code, though we'll also need to be able to control the parameters through the request.

Uses the Play WS http-client for calling Exact Target, rather than Apache.
