### PR TITLE
Remove low speed connection image display conditions

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -360,17 +360,6 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
       }
     }
 
-    scenario("Primary image upgrades to high resolution") {
-
-      Given("I am on an article")
-      HtmlUnit("/film/2012/nov/11/margin-call-cosmopolis-friends-with-kids-dvd-review") { browser =>
-        import browser._
-
-        Then("the primary image's 'data-force-upgrade' attribute should be 'true'")
-        findFirst("#article figure .js-image-upgrade").getAttribute("data-force-upgrade") should be("")
-      }
-    }
-
     scenario("Hide main picture if video is at start of article") {
       Given("I am on an article with a video at the start of the body")
       HtmlUnit("/society/2013/mar/26/failing-hospitals-nhs-jeremy-hunt") { browser =>

--- a/common/app/assets/javascripts/modules/ui/images.js
+++ b/common/app/assets/javascripts/modules/ui/images.js
@@ -12,11 +12,8 @@ define(['common/$', 'common/utils/to-array', 'bonzo', 'common/utils/mediator', '
                 };
 
             toArray(context.getElementsByClassName('js-image-upgrade')).forEach(function(container) {
-                var $container = bonzo(container),
-                    forceUpgradeAttr = $container.attr('data-force-upgrade'),
-                    forceUpdgradeBreakpoints = forceUpgradeAttr !== null ? forceUpgradeAttr.split(' ') : [],
-                    isForceUpgrade = forceUpdgradeBreakpoints.indexOf(breakpoint) !== -1 || forceUpgradeAttr === '';
-                if (($('html').hasClass('connection--low') && !isForceUpgrade) || $container.css('display') === 'none') {
+                var $container = bonzo(container);
+                if ($container.css('display') === 'none') {
                     return;
                 }
                 imager.init([container], options);

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -157,12 +157,6 @@
 .supporting__action:visited {
     color: $c-neutral2;
 }
-.fromage__media-wrapper,
-.fromage__image-container {
-    .js-off & {
-        display: none !important;
-    }
-}
 .fromage__media-wrapper {
     @include mq(tablet) {
         float: left;

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -238,14 +238,10 @@ $c-live: #e81818;
     }
 }
 .item__image-container {
-    display: none;
     position: relative;
     margin-top: 4px;
     padding-bottom: 60%;
 
-    &.inlined-image {
-        display: block;
-    }
     .responsive-img {
         width: 100%;
         height: 100%;

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -242,6 +242,10 @@ $c-live: #e81818;
     margin-top: 4px;
     padding-bottom: 60%;
 
+    .js-off & {
+        display: none;
+    }
+
     .responsive-img {
         width: 100%;
         height: 100%;

--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -1,10 +1,6 @@
 $item-top-border-height: 2px;
 
 @mixin image-meta {
-    .connection--not-low & .item__image-container,
-    .connection--low & .item__standfirst {
-        display: block;
-    }
     @include mq(desktop) {
         &.item--force-image-upgrade .item__standfirst {
             display: none
@@ -50,7 +46,7 @@ $item-top-border-height: 2px;
 }
 @mixin card-mobile-image {
     @include image-meta;
-    .connection--not-low & .item__title {
+    .item__title {
         @include rem((
             padding-top: $gs-baseline/3,
             margin-bottom: $gs-baseline/3
@@ -87,14 +83,9 @@ $item-top-border-height: 2px;
     }
 }
 @mixin card-half-width-image {
-    .connection--not-low & {
-        @include rem((
-            min-height: gs-height(5)
-        ));
-        .item__image-container {
-            display: block;
-        }
-    }
+    @include rem((
+        min-height: gs-height(5)
+    ));
 }
 @mixin card($with-image: false) {
     @include rem((
@@ -122,7 +113,7 @@ $item-top-border-height: 2px;
     .item__title {
         @include fs-headline(5, $size-only: true);
     }
-    .connection--not-low &.item--has-image .item__title {
+    &.item--has-image .item__title {
         @include rem((
             margin-top: $gs-baseline
         ));
@@ -145,15 +136,13 @@ $item-top-border-height: 2px;
     @include image-meta;
     .item__title {
         @include fs-headline(5, $size-only: true);
-    }
-    .connection--not-low & .item__title {
         @include rem((
             margin-top: $gs-baseline*(2/3)
         ));
     }
 }
 @mixin card-full-width {
-    .connection--not-low &.item--has-image {
+    &.item--has-image {
         @include rem((
             min-height: gs-height(6),
             padding-left: gs-span(6) + $gs-gutter*1.5
@@ -166,7 +155,7 @@ $item-top-border-height: 2px;
         @include fs-header(5, $size-only: true);
     }
     @include image-meta;
-    .connection--not-low & .item__image-container {
+    .item__image-container {
         margin-top: 0;
         @include rem((
             width: gs-span(6),
@@ -187,12 +176,12 @@ $item-top-border-height: 2px;
     .item__title {
         @include fs-headline(4, $size-only: true);
     }
-    .connection--not-low & .item__title {
+    .item__title {
         @include rem((
             margin-top: $gs-baseline*(2/3)
         ));
     }
-    .connection--not-low & .item__image-container {
+    .item__image-container {
         margin-top: 0;
     }
 }

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -106,24 +106,6 @@
                 }
             }
         }
-        function isConnectionLow() {
-            var connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
-            if (connection.type === 3
-                || connection.type === 4
-                || /^[23]g$/.test(connection.type)
-            ) {
-                return true;
-            }
-            var perf = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
-            if (perf && perf.timing) {
-                var start_time =  perf.timing.requestStart || perf.timing.fetchStart || perf.timing.navigationStart,
-                    end_time = perf.timing.responseEnd;
-                if (start_time && end_time) {
-                    return (end_time - start_time) > 3000;
-                }
-            }
-            return false;
-        }
         function containersAb(switches) {
             // are we on a front
             var isFront = /^\/(pressed\/)?(uk|us|au)$/.exec(window.location.pathname);
@@ -153,9 +135,8 @@
             }
         }
 
-        @* we want this to happen ASAP to avoid FOUC *@
-        var connectionClass = 'connection--' + (isConnectionLow() ? '' : 'not-') + 'low';
-        var htmlClassNames = connectionClass;
+        @* we want to add/remove classes to HTML ASAP to avoid FOUC *@
+        var htmlClassNames = "";
 
         @* http://modernizr.com/download/#-svg *@
         function hasSvgSupport() {

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -3,7 +3,7 @@
 
 @image.map{ picture =>
     <figure itemprop="associatedMedia primaryImageOfPage" itemscope itemtype="http://schema.org/ImageObject" class="media-primary media-content">
-        <div class="js-image-upgrade" data-src="@ImgSrc.imager(picture, Item620).map(Html(_))" data-force-upgrade>
+        <div class="js-image-upgrade" data-src="@ImgSrc.imager(picture, Item620).map(Html(_))">
             <img src="@Item220.bestFor(picture).map(Html(_))"
                  class="maxed main-image responsive-img"
                  itemprop="contentURL"

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -7,7 +7,7 @@
     <div class="item__container">
         <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
             @fragments.items.elements.title(trail, index, 0)
-            @fragments.items.elements.image(trail, forceUpgrade = true, inlineImage = true, maxWidth = 940)
+            @fragments.items.elements.image(trail, inlineImage = true, maxWidth = 940)
         </a>
     </div>
 

--- a/common/app/views/fragments/items/elements/image.scala.html
+++ b/common/app/views/fragments/items/elements/image.scala.html
@@ -1,4 +1,4 @@
-@(trail: Trail, inlineImage: Boolean = false, forceUpgrade: Boolean = false, maxWidth: Int = 620)(implicit request: RequestHeader)
+@(trail: Trail, inlineImage: Boolean = false, maxWidth: Int = 620)(implicit request: RequestHeader)
 
 @if(trail.imageAdjust != "hide") {
     @trail.trailPicture(5,3).map{ imageContainer =>
@@ -6,8 +6,7 @@
             <div class="item__media-wrapper">
                 <div
                     class="item__image-container js-image-upgrade @if(inlineImage){inlined-image}"
-                    data-src="@imgSrc"
-                    @if(forceUpgrade){data-force-upgrade="desktop wide"}>
+                    data-src="@imgSrc">
                     @if(inlineImage){
                         @Item300.bestFor(imageContainer).map{ url =>
                             <img src="@url" class="responsive-img" alt="" />

--- a/common/app/views/fragments/items/feature.scala.html
+++ b/common/app/views/fragments/items/feature.scala.html
@@ -14,7 +14,7 @@
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="item__media-wrapper">
-                                <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                                <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                     @if(inlineImages){
                                         @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                     }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -13,7 +13,7 @@
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="fromage__media-wrapper fromage__media-wrapper--first">
-                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
+                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
                                     @if(imageAdjust == "highlight") {
                                         @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                     } else {
@@ -36,7 +36,7 @@
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <a href="@LinkTo{@trail.url}" data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
-                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc" data-force-upgrade="desktop wide">
+                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
                                     @Item220.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 </div>
                             </div>

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -10,7 +10,7 @@
         <div class="item__container">
 
             <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
-                @fragments.items.elements.image(trail, forceUpgrade = isFirstContainer, inlineImage = containerIndex == 0 && index < 4)
+                @fragments.items.elements.image(trail, inlineImage = containerIndex == 0 && index < 4)
                 @fragments.items.elements.title(trail, index, containerIndex)
             </a>
 

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -18,7 +18,7 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -16,7 +16,7 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }

--- a/common/app/views/fragments/items/thumbnail.scala.html
+++ b/common/app/views/fragments/items/thumbnail.scala.html
@@ -11,7 +11,7 @@
 
             <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                 @fragments.items.elements.title(trail, index, containerIndex)
-                @fragments.items.elements.image(trail, forceUpgrade = isFirstContainer, inlineImage = containerIndex == 0 && index < 4)
+                @fragments.items.elements.image(trail, inlineImage = containerIndex == 0 && index < 4)
             </a>
 
             @trail.trailText.map { text =>

--- a/common/app/views/fragments/items/thumbnailGallery.scala.html
+++ b/common/app/views/fragments/items/thumbnailGallery.scala.html
@@ -19,7 +19,7 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }

--- a/common/app/views/fragments/items/thumbnailVideo.scala.html
+++ b/common/app/views/fragments/items/thumbnailVideo.scala.html
@@ -17,7 +17,7 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc" @if(isFirstContainer){ data-force-upgrade="desktop wide"}>
+                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }

--- a/common/test/assets/javascripts/spec/Images.spec.js
+++ b/common/test/assets/javascripts/spec/Images.spec.js
@@ -3,13 +3,10 @@ define(['common/modules/ui/images', 'helpers/fixtures', 'common/$', 'bonzo', 'co
     describe('Images', function() {
 
         var fixturesId = 'images-fixtures',
-            lowClassName = 'connection--low',
-            notLowClassName = 'connection--not-low',
             dataSrc = '/item-{width}/cat.jpg',
             imgClass = 'js-image-upgrade';
 
         beforeEach(function() {
-            $('html').addClass(notLowClassName);
             fixtures.render({
                 id: fixturesId,
                 fixtures: [1, 2, 3].map(function(value, i) {
@@ -19,7 +16,6 @@ define(['common/modules/ui/images', 'helpers/fixtures', 'common/$', 'bonzo', 'co
         });
 
         afterEach(function() {
-            $('html').removeClass([lowClassName, notLowClassName].join(' '));
             mediator.removeAllListeners();
             fixtures.clean(fixturesId);
         });
@@ -34,57 +30,12 @@ define(['common/modules/ui/images', 'helpers/fixtures', 'common/$', 'bonzo', 'co
             })
         });
 
-        it('should not upgrade when connection is low', function() {
-            $('html')
-                .removeClass(notLowClassName)
-                .addClass(lowClassName);
-            images.upgrade();
-            expect($('.' + imgClass + ' img').length).toEqual(0);
-        });
-
         it('should not upgrade image with display "none"', function() {
             var hiddenImg = $('.' + imgClass + ':first-child')
                 .css('display', 'none');
             images.upgrade();
             expect($('.' + imgClass + ' img').length).toEqual(2);
             expect($('img', hiddenImg).length).toEqual(0);
-
-        });
-
-        describe('force upgrade', function() {
-
-            var forceUpgradeAttr = 'data-force-upgrade';
-            it('should force upgrade if "' + forceUpgradeAttr + '" attribute exists', function() {
-                $('html')
-                    .removeClass(notLowClassName)
-                    .addClass(lowClassName);
-                // add data-force-upgrade attrs
-                ['desktop wide', 'tablet desktop', 'mobile'].forEach(function(breakpoints, i) {
-                    $('.' + imgClass + ':nth-child(' + (i + 1) + ')').attr(forceUpgradeAttr, '');
-                });
-                images.upgrade();
-                expect($('.' + imgClass + ' img').length).toEqual(3);
-            });
-
-            it('should force upgrade at certain breakpoints if set in attribute', function() {
-                var $style = bonzo(bonzo.create('<style></style>'))
-                    .html('body:after { content: "desktop"; }')
-                    .appendTo('head');
-                $('html')
-                    .removeClass(notLowClassName)
-                    .addClass(lowClassName);
-                // add data-force-upgrade attrs
-                ['desktop wide', 'tablet desktop', 'mobile'].forEach(function(breakpoints, i) {
-                    $('.' + imgClass + ':nth-child(' + (i + 1) + ')').attr(forceUpgradeAttr, breakpoints);
-                });
-                images.upgrade();
-                // first two should be forced to upgrade
-                expect($('.' + imgClass + ':nth-child(1) img').length).toEqual(1);
-                expect($('.' + imgClass + ':nth-child(2) img').length).toEqual(1);
-                // but not the third
-                expect($('.' + imgClass + ':nth-child(3) img').length).toEqual(0);
-                $style.remove();
-            });
 
         });
 


### PR DESCRIPTION
- [new] Remove low speed connection image display condition
- [fix] Display top story inlined image when JS is off, browser does not cut the mustard or connection is Low

If a low speed connection was detected, we would not show images.

Although very clever, this condition brought more CSS complexity and made it harder to develop locally (since a low speed connection was often detected).

Considering the already existing complexity of the new facia containers, we can't satisfy both these cases properly without adding a large amount of extra code and testing overhead.

This PR upgrades all images whether you have a high speed connection or not.

If you're on a 3G connection (or worse), the mobile network operators will compress images to make sure  you get them fast anyway.
# JS Off or no CTM
## Before

![screen shot 2014-02-28 at 13 09 54](https://f.cloud.github.com/assets/85783/2294017/c2cfa7c6-a079-11e3-95eb-f032ae7e0c69.PNG)
![screen shot 2014-02-28 at 13 10 09](https://f.cloud.github.com/assets/85783/2294018/c51319d2-a079-11e3-8de4-89c8cadc2e56.PNG)
## After

![screen shot 2014-02-28 at 13 09 16](https://f.cloud.github.com/assets/85783/2294021/d484820c-a079-11e3-9296-bdf2f5a20732.PNG)

![screen shot 2014-02-28 at 13 09 44](https://f.cloud.github.com/assets/85783/2294023/d71aba9a-a079-11e3-8b9d-bafb197ee87f.PNG)

![ ](http://media.giphy.com/media/HZDyq4xY0rIqs/giphy.gif)
