### PR TITLE
Onward JS bug 

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/tests/onward-related.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/onward-related.js
@@ -21,7 +21,7 @@ define([
         this.idealOutcome = 'Measurable increase in page view per visit for whitelisted content, and increase in trail CTR over story packages.';
 
         this.canRun = function(config) {
-            return config.page.contentType.match(/Gallery|Article|ImageContent|Video/);
+            return config.page.contentType && config.page.contentType.match(/Gallery|Article|ImageContent|Video/);
         };
         this.variants = [
             {


### PR DESCRIPTION
Spotted as football auto-pages have not contentType.
I assume this will be similar to most of the automated pages.

![Got it!](http://i.imgur.com/JVizSND.gif)
