### PR TITLE
Stop infinite redirects

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -51,9 +51,20 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   def sectionFromR1Path(path: String): Option[String] = {
     val r1Url = s"""www.theguardian.com/([\\w\\d-]+)/(.*)/[0|1]?,.*""".r
     path match {
-      case r1Url(section, path) => Option(s"/${section}")
+      case r1Url(s, path) => Option(s"/${s}")
       case _ => None
     } 
+  }
+
+  def linksToItself(path: String, destination: String): Boolean = {
+    val r1Url = s"""www.theguardian.com/([\\w\\d-]+)/(.*)""".r
+    path match {
+      case r1Url(s, r1path) => {
+        destination contains r1path
+      } 
+      case _ => false
+    } 
+     
   }
 
   def lookup(path: String) = Action { implicit request =>

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -14,7 +14,9 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   def isRedirect(path: String): Option[String] = {
     val redirects = DynamoDB.destinationFor(path)
     log.info(s"Checking '${path}' is a redirect in DynamoDB: ${!redirects.isEmpty}")
-    redirects
+    redirects.filterNot { url => 
+      linksToItself(path, url) 
+    }
   }
 
   def isArchived(path: String): Option[String] = {

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -81,4 +81,9 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
     controllers.ArchiveController.isGallery("arts/gallery/0,") should be (Some("arts/pictures/0,"))
   }
 
+  if should
+  "http://www.theguardian.com/books/worldliteraturetour/page/0,,2021886,.html"
+  "http://books.theguardian.com/worldliteraturetour/page/0,,2021886,.html"
+
+
 }

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -81,9 +81,10 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
     controllers.ArchiveController.isGallery("arts/gallery/0,") should be (Some("arts/pictures/0,"))
   }
 
-  if should
-  "http://www.theguardian.com/books/worldliteraturetour/page/0,,2021886,.html"
-  "http://books.theguardian.com/worldliteraturetour/page/0,,2021886,.html"
-
+  it should "test a redirect doesn't not link to itself" in Fake {
+    val path = "www.theguardian.com/books/worldliteraturetour/page/0,,2021886,.html"
+    val dest = "http://books.theguardian.com/worldliteraturetour/page/0,,2021886,.html"
+    controllers.ArchiveController.linksToItself(path, dest) should be (true)
+  }
 
 }


### PR DESCRIPTION
Some of the data we put in to DynamoDB contains redirect destinations that match the request url, i.e. a redirect loop.

When we find a record like this it's more helpful to continue to the next step in the archive chain and have a fish around S3 for the file.
