### PR TITLE
Clean up adslot CSS

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -116,7 +116,7 @@
 
     @fragments.mostPopularPlaceholder(article.section)
 
-    <div class="ad-slot ad-slot__commercial-component" data-base="Bottom3" data-median="Bottom3"><div class="ad-container"></div></div>
+    <div class="ad-slot ad-slot--commercial-component" data-base="Bottom3" data-median="Bottom3"><div class="ad-container"></div></div>
 
     <script type="text/template" id="tmpl-right-ear">@fragments.onwardRightEar()</script>
 }

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -5,9 +5,10 @@
     text-align: center;
     min-height: 56px;
 
-    //For expandables
+    // For expandables
     position: relative;
     z-index: 1000;
+
     @include mq(desktopAd) {
         min-height: 96px;
     }
@@ -30,27 +31,19 @@
         -webkit-font-smoothing: antialiased;
     }
 
-    &.ad-slot__show-label {
-        .ad-slot__label {
-            display: block;
-        }
-    }
     .no-js & {
         display: none;
     }
 }
-
-.ad-slot__wrapper {
+.ad-slot__inner {
     max-width: 100%;
     display: inline-block;
 }
-
 .ad-container {
     display: inline-block;
     width: auto;
     margin: 0 auto !important;
 }
-
 .top-banner-ad-container {
     min-height: 70px;
 
@@ -61,7 +54,6 @@
         margin: 0 auto;
     }
 }
-
 .ad-slot--top-banner-ad {
     background-color: #f0f0f0;
 
@@ -83,16 +75,13 @@
         text-align: left;
     }
 }
-
 .parts__head {
     z-index: 1002;
-
-    &.is-sticky {
-        top: 0;
-        @include sticky;
-    }
 }
-
+.mpu-context {
+    // Provides context to sticky positioned blocks
+    height: 100%;
+}
 .ad-slot--inline {
     min-width: 300px;
     max-width: 100%;
@@ -101,7 +90,6 @@
     .ad-container {
         line-height: 0;
     }
-
     .ad-slot__label {
         max-width: 300px;
         margin: 0 auto;
@@ -115,12 +103,6 @@
         }
     }
 
-    &.ad-slot__show-label {
-        @include mq(mobileLandscape, tablet) {
-            text-align: right;
-        }
-    }
-
     @include mq(tablet) {
         width: auto;
         height: auto;
@@ -129,12 +111,6 @@
         float: right;
     }
 }
-
-.mpu-context {
-    // Provides context to sticky positioned blocks
-    height: 100%;
-}
-
 .ad-slot--mpu-banner-ad {
     padding-top: 29px; // Align with bottom of image
     padding-bottom: 37px;
@@ -142,8 +118,7 @@
     height: 250px;
     overflow: hidden;
 }
-
-.ad-slot__commercial-component {
+.ad-slot--commercial-component {
     width: 100%;
     min-height: initial;
     padding: 0 0 $gs-baseline 0;

--- a/common/app/views/fragments/adSlot.scala.html
+++ b/common/app/views/fragments/adSlot.scala.html
@@ -8,7 +8,7 @@ take ad clicks with a pinch of salt.
      data-base="@baseSlot"
      data-median="@medianSlot"
      data-extended="@extendedSlot">
-     <div class="ad-slot__wrapper">
+     <div class="ad-slot__inner">
          <div class="ad-slot__label">Advertisement</div>
          <div class="ad-container"></div>
      </div>


### PR DESCRIPTION
- Remove unused `.is-sticky` and `.ad-slot__show-label` classes
- Apply CSS coding conventions

![ ](http://media.giphy.com/media/6gYfpSqCVtWUw/giphy.gif)
