### PR TITLE
Force thumbnails on news container links list

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_linkslist.scss
+++ b/common/app/assets/stylesheets/module/facia/_linkslist.scss
@@ -70,20 +70,29 @@
             margin-bottom: get-font-size($fs-headlines, 1)
         ));
     }
-    @include mq(desktop) {
-        .linkslist--with-images & {
-            @include rem((
-                // Force min height of 3 baselines on all items
-                min-height: get-line-height($fs-headlines, 1) * 3,
-            ));
-        }
-    }
+
 
     &:visited {
         color: $c-neutral2;
     }
     &:active {
         color: $c-neutral1;
+    }
+}
+
+.linkslist--with-images {
+    @include mq(desktop) {
+        .linkslist__action {
+            @include rem((
+                // Force min height of 3 baselines on all items
+                min-height: get-line-height($fs-headlines, 1) * 3,
+            ));
+        }
+        .linkslist__label {
+            // Make sure 3 lines is the maximum so that elements are balanced
+            // between columns
+            @include text-clamp(3, get-line-height($fs-headlines, 1));
+        }
     }
 }
 

--- a/common/app/views/fragments/collections/news.scala.html
+++ b/common/app/views/fragments/collections/news.scala.html
@@ -47,11 +47,11 @@
                         <ul class="l-columns linkslist linkslist--with-images">
                             @items.zipWithIndex.map{ case (trail, index) =>
                                 @trail match {
-                                    case l: LiveBlog if l.isLive         => { @fragments.items.linksList.live(l, baguetteCount + index + 6) }
-                                    case g: Gallery                      => { @fragments.items.linksList.gallery(g, baguetteCount + index + 6) }
-                                    case v: Video                        => { @fragments.items.linksList.video(v, baguetteCount + index + 6) }
-                                    case c if VisualTone(c) == "comment" => { @fragments.items.linksList.comment(c, baguetteCount + index + 6) }
-                                    case t                               => { @fragments.items.linksList.standard(t, baguetteCount + index + 6) }
+                                    case l: LiveBlog if l.isLive         => { @fragments.items.linksList.live(l, baguetteCount + index + 6, Some("highlight")) }
+                                    case g: Gallery                      => { @fragments.items.linksList.gallery(g, baguetteCount + index + 6, Some("highlight")) }
+                                    case v: Video                        => { @fragments.items.linksList.video(v, baguetteCount + index + 6, Some("highlight")) }
+                                    case c if VisualTone(c) == "comment" => { @fragments.items.linksList.comment(c, baguetteCount + index + 6, Some("highlight")) }
+                                    case t                               => { @fragments.items.linksList.standard(t, baguetteCount + index + 6, Some("highlight")) }
                                 }
                             }
                         </ul>

--- a/common/app/views/fragments/items/linksList/comment.scala.html
+++ b/common/app/views/fragments/items/linksList/comment.scala.html
@@ -10,8 +10,10 @@
                 }
             }
         }
-        <span class="i i-quote-orange linkslist__icon"></span>
-        @RemoveOuterParaHtml(trail.headline)
+        <span class="linkslist__label">
+            <span class="i i-quote-orange linkslist__icon"></span>
+            @RemoveOuterParaHtml(trail.headline)
+        </span>
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/gallery.scala.html
+++ b/common/app/views/fragments/items/linksList/gallery.scala.html
@@ -10,8 +10,10 @@
                 }
             }
         }
-        <span class="i i-gallery-yellow-small linkslist__icon"></span>
-        @RemoveOuterParaHtml(trail.headline)
+        <span class="linkslist__label">
+            <span class="i i-gallery-yellow-small linkslist__icon"></span>
+            @RemoveOuterParaHtml(trail.headline)
+        </span>
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/live.scala.html
+++ b/common/app/views/fragments/items/linksList/live.scala.html
@@ -10,8 +10,10 @@
                 }
             }
         }
-        <span class="item__live-indicator">Live</span>
-        @RemoveOuterParaHtml(trail.headline)
+        <span class="linkslist__label">
+            <span class="item__live-indicator">Live</span>
+            @RemoveOuterParaHtml(trail.headline)
+        </span>
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/standard.scala.html
+++ b/common/app/views/fragments/items/linksList/standard.scala.html
@@ -10,7 +10,9 @@
                 }
             }
         }
-        @RemoveOuterParaHtml(trail.headline)
+        <span class="linkslist__label">
+            @RemoveOuterParaHtml(trail.headline)
+        </span>
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/video.scala.html
+++ b/common/app/views/fragments/items/linksList/video.scala.html
@@ -10,8 +10,10 @@
                 }
             }
         }
-        <span class="i i-video-yellow-small linkslist__icon"></span>
-        @RemoveOuterParaHtml(trail.headline)
+        <span class="linkslist__label">
+            <span class="i i-video-yellow-small linkslist__icon"></span>
+            @RemoveOuterParaHtml(trail.headline)
+        </span>
     </a>
 </li>
 }


### PR DESCRIPTION
Because lots of pages use the news container we need to force the optimal looking version of it which is when there are images in the links list on desktop.

Otherwise we'd have lots of white space in there.

Also: clamping the text to 3 lines in webkit to prevent bad distribution of items across columns.
## Before

![screen shot 2014-02-28 at 17 21 34](https://f.cloud.github.com/assets/85783/2296298/ddafe2ae-a09c-11e3-9df9-41d6ecb1939e.PNG)
## After

![screen shot 2014-02-28 at 17 22 30](https://f.cloud.github.com/assets/85783/2296301/eda549f6-a09c-11e3-8c36-d7cf7a0b6f81.PNG)

![ ](http://media.giphy.com/media/Cksb4iyLwSV8Y/giphy.gif)
