### PR TITLE
Hotfix to football fronts having tonnes of tables

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -69,17 +69,14 @@ define([
         },
 
         showCompetitionData: function(competition) {
-            // wrap the return sports stats component in an 'item'
-            var fixtures = bonzo.create('<li class="item item--sport-stats item--sport-stats-tall"></li>'),
-                table = bonzo.create('<li class="item item--sport-stats item--sport-table"></li>');
+            var fixtures = bonzo.create('<div class="fromage tone-accent-border tone-news unstyled item--sport-stats"></div>'),
+                table = bonzo.create('<div class="fromage tone-accent-border tone-news unstyled item--sport-stats"></div>');
             mediator.on('modules:footballfixtures:render', function() {
-                var $collection = $('.container--sport .collection', context);
-                $('.item:first-child', $collection[0])
-                    .after(fixtures);
-                $collection.removeClass('collection--without-sport-stats')
-                    .addClass('collection--with-sport-stats')
+                bonzo($('.collection-wrapper', context).get(1))
+                    .append(fixtures)
                     .append(table);
             });
+
             new FootballFixtures({
                 prependTo: fixtures,
                 attachMethod: 'append',
@@ -149,7 +146,8 @@ define([
         lazyLoadCss('football', config);
 
         // not worth over complicating for the time being
-        bean.on(context, 'click', qwery('.table tr[data-link-to]'), function(e) {
+        var trs = $('.table tr[data-link-to]').css({ 'cursor': 'pointer' }).map(function(elem) { return elem; });
+        bean.on(context, 'click', trs, function(e) {
             window.location = this.getAttribute('data-link-to');
         });
 

--- a/common/app/assets/stylesheets/module/football/_tables.scss
+++ b/common/app/assets/stylesheets/module/football/_tables.scss
@@ -56,3 +56,8 @@
     @include mq($to: tablet) { @include table-football--small; }
     &.table--small { @include table-football--small; }
 }
+
+// Hack for fronts until we tidy them up properly
+.fromage .table {
+    border-top-color: $c-neutral3;
+}


### PR DESCRIPTION
Football seems to have been caught in the superb release of the new fronts as we are a little old.
This should fix it for now.

@mr-mr and the football team are going to be looking at the proper logic behind this soon.
## Looky

![competition-tables](https://f.cloud.github.com/assets/31692/2308333/227f5e8e-a2bc-11e3-9d1b-6453a01c9fd4.png)
# 

![Fixing it](http://24.media.tumblr.com/tumblr_mdrqfr6q641rlst82o1_500.gif)
