### PR TITLE
Fix page meta data for new fronts

### DIFF
--- a/facia/app/controllers/FrontPage.scala
+++ b/facia/app/controllers/FrontPage.scala
@@ -122,6 +122,58 @@ object FrontPage {
       )
     },
 
+    new FrontPage(isNetworkFront = false) {
+      override val id = "business/companies"
+      override val section = "business"
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Business"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Business",
+        "content-type" -> "Section",
+        "is-front" -> isNetworkFront
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "world/asia"
+      override val section = "world"
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:World"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "World",
+        "content-type" -> "Section",
+        "is-front" -> isNetworkFront
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "lifeandstyle/love-and-sex"
+      override val section = "lifeandstyle"
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Life and style"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Life and style",
+        "content-type" -> "Section",
+        "is-front" -> isNetworkFront
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "lifeandstyle/home-and-garden"
+      override val section = "lifeandstyle"
+      override val webTitle = "The Guardian"
+      override lazy val analyticsName = "GFE:Life and style"
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Life and style",
+        "content-type" -> "Section",
+        "is-front" -> isNetworkFront
+      )
+    },
+
     //TODO important this one is last for matching purposes
     new FrontPage(isNetworkFront = true) {
       override val id = ""

--- a/facia/app/controllers/FrontPage.scala
+++ b/facia/app/controllers/FrontPage.scala
@@ -131,7 +131,7 @@ object FrontPage {
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Business",
         "content-type" -> "Section",
-        "is-front" -> isNetworkFront
+        "is-front" -> true
       )
     },
 
@@ -144,7 +144,7 @@ object FrontPage {
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "World",
         "content-type" -> "Section",
-        "is-front" -> isNetworkFront
+        "is-front" -> true
       )
     },
 
@@ -157,7 +157,7 @@ object FrontPage {
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Life and style",
         "content-type" -> "Section",
-        "is-front" -> isNetworkFront
+        "is-front" -> true
       )
     },
 
@@ -170,7 +170,7 @@ object FrontPage {
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Life and style",
         "content-type" -> "Section",
-        "is-front" -> isNetworkFront
+        "is-front" -> true
       )
     },
 


### PR DESCRIPTION
`pageId` and `section` in the javascript metaData were coming out empty.
This just adds new `FrontPage`s for `business/companies`, `world/asia`, `lifeandstyle/love-and-sex` and `lifeandstyle/home-and-garden`.

@ironsidevsquincy Could you have a careful look at this?
I am not so sure about doing this, as this list could just grow and grow, I think we need a better solution for the long term. But in the meantime I think it should be fine while we test this out.
I am also unsure about `analyticsName` and `keywords`.
