### PR TITLE
Prevent overlap between global nav items and burger icon

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -118,7 +118,12 @@
         padding: 0 $gs-gutter
     ));
 
-    @include mq(tablet) { display: block; }
+    @include mq(tablet) {
+        display: block;
+        @include rem((
+            padding-right: gs-span(1)
+        ));
+    }
 
     .nav__item {
         position: relative;


### PR DESCRIPTION
Thanks to Patrick S. for reporting this.
### Before

![screen shot 2014-03-03 at 14 41 48](https://f.cloud.github.com/assets/85783/2310332/120bc4d6-a2e2-11e3-9097-26be2e1ca758.PNG)
### After

![screen shot 2014-03-03 at 14 42 03](https://f.cloud.github.com/assets/85783/2310335/189b28a0-a2e2-11e3-8280-38dbce4e09cf.PNG)

![ ](http://media1.giphy.com/media/jMTGp9G2zGFYQ/200.gif)
