### PR TITLE
Articles can be tagged as Advertisement Features now.

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -51,6 +51,8 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     }
   }
 
+  lazy val isAdvertisementFeature: Boolean = tags.exists(_.id == "tone/advertisementfeatures")
+
   lazy val shouldHideAdverts: Boolean = fields.get("shouldHideAdverts").exists(_.toBoolean)
 
   lazy val witnessAssignment = delegate.references.find(_.`type` == "witness-assignment")


### PR DESCRIPTION
I've done the work to get the tag "tone/advertisementfeatures" up on PROD, so this addition just adds a nice interface. 
