### PR TITLE
Squash tables

### DIFF
--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -1,4 +1,5 @@
 $table-baseline: 4px;
+$table-gutter: 4px;
 
 table {
     width: 100%;
@@ -60,14 +61,14 @@ td {
         color: $c-neutral1;
         font-weight: 800;
         @include rem((
-            padding: $table-baseline*2 $table-baseline*3
+            padding: $table-baseline*2 $table-gutter*3
         ));
     }
 
     td {
         border-top: 1px solid darken($c-neutral8, 4%);
         @include rem((
-            padding: $gs-baseline $table-baseline*3
+            padding: $gs-baseline $table-gutter*3
         ));
     }
 

--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -1,3 +1,5 @@
+$table-baseline: 4px;
+
 table {
     width: 100%;
 }
@@ -22,10 +24,12 @@ td {
 
 @mixin table--small {
     th,
-    td {
+    td,
+    thead td {
         @include fs-data(4);
-        padding-left: 8px;
-        padding-right: 8px;
+        @include rem((
+            padding: $table-baseline*2
+        ));
     }
 }
 
@@ -48,7 +52,6 @@ td {
     th,
     td {
         @include fs-data(5);
-        @include rem((padding: $gs-baseline ($gs-gutter+4)/2));
         vertical-align: top;
     }
 
@@ -56,10 +59,16 @@ td {
     thead td {
         color: $c-neutral1;
         font-weight: 800;
+        @include rem((
+            padding: $table-baseline*2 $table-baseline*3
+        ));
     }
 
     td {
         border-top: 1px solid darken($c-neutral8, 4%);
+        @include rem((
+            padding: $gs-baseline $table-baseline*3
+        ));
     }
 
     abbr {


### PR DESCRIPTION
The space to content ratio on tables on mobile is a little distorted.
We have now moved to a more vertically compacted table layout to allow for this.
## Notes

I am using a new table-baseline unit as having `($gs-baseline/3)+4` made it really hard to actually know what was going on. 

I am not sure if we are going to be using smaller units else where, but if so, we might want to abstract this.
## Look
### Before

![squashtablebefore](https://f.cloud.github.com/assets/31692/2311116/bb714456-a2ec-11e3-8896-124bcc25757f.png)
### After

![squashtableafter](https://f.cloud.github.com/assets/31692/2311119/c13e9488-a2ec-11e3-8615-62ca84989914.png)
# 

![So very exciting](http://stream1.gifsoup.com/view2/3976994/squash-o.gif)
