### PR TITLE
Fix bug when requesting trailPicture with aspect ratio 

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -63,10 +63,12 @@ object Page {
 trait Elements {
 
   // Find a main picture crop which matches this aspect ratio.
-  def trailPicture(aspectWidth: Int, aspectHeight: Int): Option[ImageContainer] = trailPicture.flatMap{ main =>
-    val correctCrops = main.imageCrops.filter(image => image.aspectRatioWidth == aspectWidth && image.aspectRatioHeight == aspectHeight)
-    correctCrops.headOption.map{ head => ImageContainer(correctCrops, main.delegate, head.index) }
-  }
+  def trailPicture(aspectWidth: Int, aspectHeight: Int): Option[ImageContainer] =
+    (thumbnail.find(_.imageCrops.exists(_.width >= 620)) ++ mainPicture ++ thumbnail)
+      .find(_.imageCrops.exists{ crop => crop.aspectRatioWidth == aspectWidth && crop.aspectRatioHeight == aspectHeight })
+      .map { image =>
+        ImageContainer(image.imageCrops, image.delegate, image.index)
+      }
 
   // trail picture is used on index pages (i.e. Fronts and tag pages)
   def trailPicture: Option[ImageContainer] = thumbnail.find(_.imageCrops.exists(_.width >= 620))


### PR DESCRIPTION
Bug occurs if, say, we have a thumbnail > 620 which is not of the aspect ratio we want, and a main image which is. In that case, no image is served. Correct behaviour is to display the main image

Bug due to using `trailPicture` before finding crop with correct aspect ratio
