### PR TITLE
Restore quote icon in hinted layout

### DIFF
--- a/common/app/assets/stylesheets/module/experiments/_layout-hints.scss
+++ b/common/app/assets/stylesheets/module/experiments/_layout-hints.scss
@@ -27,11 +27,13 @@
     font-style: normal;
     color: $c-neutral2;
 
-    &:before {
-        display: block;
-        content: ' ';
-        @extend %i;
-        @extend %i-quote-blue;
+    @if ($svg-support) {
+        &:before {
+            content: '';
+            display: block;
+            @extend %i-quote-blue;
+            @extend %svg-i-quote-blue;
+        }
     }
 }
 


### PR DESCRIPTION
/cc @phamann I restored the quote icon in pulled quotes. no-svg was not supported in your version so I did the same here.

![screen shot 2014-03-03 at 17 40 24](https://f.cloud.github.com/assets/85783/2312344/ec9db768-a2fa-11e3-9f49-1407a435f4be.PNG)

![ ](http://media.giphy.com/media/5xe6ZLq1DSclq/giphy.gif)
