### PR TITLE
Adding IMR tracking to Australia.

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/container.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/container.js
@@ -27,6 +27,10 @@ define([
                     EffectiveMeasure.load();
                 }
 
+                if (config.switches.imrWorldwide) {
+                    IMRWorldwide.load();
+                }
+
                 break;
 
             default:

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -41,6 +41,8 @@ object Switches extends Collections {
   private lazy val never = new DateMidnight(2100, 1, 1)
   private lazy val endOfQ4 = new DateMidnight(2014, 4, 1)
 
+  // this is 3 months - at the end of this a decision is expected
+  // and one (or both) of the 2 needs to go.
   private lazy val profilingEvalDeadline = new DateMidnight(2014, 6, 4)
 
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -41,6 +41,9 @@ object Switches extends Collections {
   private lazy val never = new DateMidnight(2100, 1, 1)
   private lazy val endOfQ4 = new DateMidnight(2014, 4, 1)
 
+  private lazy val profilingEvalDeadline = new DateMidnight(2014, 6, 4)
+
+
   // Load Switches
 
   val AutoRefreshSwitch = Switch("Performance Switches", "auto-refresh",
@@ -106,14 +109,14 @@ object Switches extends Collections {
 
   val ImrWorldwideSwitch = Switch("Commercial Tags", "imr-worldwide",
     "Enable the IMR Worldwide audience segment tracking.",
-    safeState = Off, sellByDate = endOfQ4)
-
-  val AmaaSwitch = Switch("Commercial Tags", "amaa",
-    "Enable the AMAA audience segment tracking.",
-    safeState = Off, sellByDate = endOfQ4)
+    safeState = Off, sellByDate = profilingEvalDeadline)
 
   val EffectiveMeasureSwitch = Switch("Commercial Tags", "effective-measure",
     "Enable the Effective Measure audience segment tracking.",
+    safeState = Off, sellByDate = profilingEvalDeadline)
+
+  val AmaaSwitch = Switch("Commercial Tags", "amaa",
+    "Enable the AMAA audience segment tracking.",
     safeState = Off, sellByDate = endOfQ4)
 
   // Commercial Feeds


### PR DESCRIPTION
The Australian team is doing an evaluation between IMR and Effective Measure. 3 months of data should give them enough data to make a decision. These switches will turn themselves off at midnight, 4 June 2014.
