### PR TITLE
CSS optimisations & responsive image abstraction

### DIFF
--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -23,7 +23,7 @@
 
                     <div class="player media-content">
 
-                        <div class="media-proportional-container">
+                        <div class="u-responsive-ratio">
                             <video controls="controls" @video.mainPicture.map{ img =>  poster="@Item620.bestFor(img)" }>
                                 @video.encodings.map{ encoding =>
                                     <source src="@encoding.url" />

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -36,7 +36,7 @@
                     @if(!article.hasVideoAtTop) {
                         @if(article.hasMainVideo) {
                             @article.mainVideo.map{ mainVideo =>
-                                <div class="media-proportional-container">
+                                <div class="u-responsive-ratio">
                                     <video data-media-id="@mainVideo.id" class="gu-video" controls="controls">
                                         @for(url <- mainVideo.videoAssets.flatMap(_.url)) {
                                             <source src="@url"></source>

--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -281,12 +281,15 @@
 // Misc
 // =============================================================================
 
-@mixin fix-aspect-ratio($width, $height, $startingWidth: 100%) {
+@function aspect-ratio-height($x, $y, $startingWidth: 100%) {
+    @return ($y / $x) * $startingWidth;
+}
+
+@mixin fix-aspect-ratio($x, $y, $startingWidth: 100%) {
     // To get this working, position the child element
     // to 'absolute' in the top left corner
-    $height: ($height / $width) * $startingWidth;
     width: $startingWidth;
-    padding-bottom: $height;
+    padding-bottom: aspect-ratio-height($x, $y, $startingWidth: 100%);
     position: relative;
     overflow: hidden;
 }

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -67,6 +67,35 @@
 
 
 /**
+ * Responsive media (images, videos…)
+ *
+ * 1. Give the block an initial ratio of 5/3 to avoid FOUC
+ * 2. Stretch the contained media to the dimensions of its container
+ */
+
+.u-responsive-ratio {
+    @include fix-aspect-ratio(5, 3); // [1]
+
+    img,
+    object,
+    iframe,
+    video { // [2]
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+}
+
+// If you were to create a helper for a 16/9 responsive image format,
+// here is how you'd do it:
+// .u-responsive-ratio--hd {
+//     padding-bottom: aspect-ratio-height(16, 9);
+// }
+
+
+/**
  * Text hyphenation
  *
  * Break strings when their length exceeds the width of their container

--- a/common/app/assets/stylesheets/module/_video.scss
+++ b/common/app/assets/stylesheets/module/_video.scss
@@ -24,17 +24,3 @@ object {
 .gallery-byline {
     margin-top: ($gs-baseline/3)*4;
 }
-
-.media-proportional-container {
-    @include fix-aspect-ratio(5, 3);
-
-    object,
-    iframe,
-    video {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        top: 0;
-        left: 0;
-    }
-}

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -120,18 +120,8 @@
         ));
     }
 }
-.fromage__image-container {
-    position: relative;
-    padding-bottom: 60%;
+.fromage__image-container {}
 
-    .responsive-img {
-        width: 100%;
-        height: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
-    }
-}
 .fromage__standfirst {
     @include fs-headline(1);
     color: $c-neutral2;

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -240,20 +240,10 @@
     }
 }
 .item__image-container {
-    position: relative;
     margin-top: 4px;
-    padding-bottom: 60%;
 
     .js-off & {
         display: none;
-    }
-
-    .responsive-img {
-        width: 100%;
-        height: 100%;
-        position: absolute;
-        top: 0;
-        left: 0;
     }
 }
 

--- a/common/app/assets/stylesheets/module/facia/_linkslist.scss
+++ b/common/app/assets/stylesheets/module/facia/_linkslist.scss
@@ -156,18 +156,7 @@
             width: $action-image-width
         ));
     }
-    .linkslist__image-container {
-        position: relative;
-        padding-bottom: 60%;
-
-        .responsive-img {
-            width: 100%;
-            height: 100%;
-            position: absolute;
-            top: 0;
-            left: 0;
-        }
-    }
+    .linkslist__image-container {}
     .action--has-image.action--has-icon {
         .i {
             position: absolute;

--- a/common/app/views/fragments/items/elements/image.scala.html
+++ b/common/app/views/fragments/items/elements/image.scala.html
@@ -5,7 +5,7 @@
         @ImgSrc.imager(imageContainer, maxWidth).map { imgSrc =>
             <div class="item__media-wrapper">
                 <div
-                    class="item__image-container js-image-upgrade @if(inlineImage){inlined-image}"
+                    class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImage){inlined-image}"
                     data-src="@imgSrc">
                     @if(inlineImage){
                         @Item300.bestFor(imageContainer).map{ url =>

--- a/common/app/views/fragments/items/feature.scala.html
+++ b/common/app/views/fragments/items/feature.scala.html
@@ -14,7 +14,7 @@
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="item__media-wrapper">
-                                <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
+                                <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                     @if(inlineImages){
                                         @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                     }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -13,11 +13,11 @@
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="fromage__media-wrapper fromage__media-wrapper--first">
-                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
+                                <div class="fromage__image-container@if(imageAdjust == "highlight"){ js-image-upgrade inlined-image" data-src="@imgSrc}">
                                     @if(imageAdjust == "highlight") {
                                         @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                     } else {
-                                        @Item220.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                        @Item220.bestFor(imageContainer).map{ url => <img src="@url" alt="" /> }
                                     }
                                 </div>
                             </div>
@@ -36,8 +36,8 @@
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <a href="@LinkTo{@trail.url}" data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
-                                <div class="fromage__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
-                                    @Item220.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                <div class="fromage__image-container">
+                                    @Item220.bestFor(imageContainer).map{ url => <img src="@url" alt="" /> }
                                 </div>
                             </div>
                         </a>

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -13,7 +13,7 @@
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="fromage__media-wrapper fromage__media-wrapper--first">
-                                <div class="fromage__image-container@if(imageAdjust == "highlight"){ js-image-upgrade inlined-image" data-src="@imgSrc}">
+                                <div class="fromage__image-container u-responsive-ratio@if(imageAdjust == "highlight"){ js-image-upgrade inlined-image" data-src="@imgSrc}">
                                     @if(imageAdjust == "highlight") {
                                         @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                     } else {
@@ -36,7 +36,7 @@
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                         <a href="@LinkTo{@trail.url}" data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
-                                <div class="fromage__image-container">
+                                <div class="fromage__image-container u-responsive-ratio">
                                     @Item220.bestFor(imageContainer).map{ url => <img src="@url" alt="" /> }
                                 </div>
                             </div>

--- a/common/app/views/fragments/items/linksList/comment.scala.html
+++ b/common/app/views/fragments/items/linksList/comment.scala.html
@@ -6,7 +6,7 @@
         @if(imageAdjust == "highlight") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>
-                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container js-image-upgrade" data-src="@imgSrc"></div></div>
+                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container u-responsive-ratio js-image-upgrade" data-src="@imgSrc"></div></div>
                 }
             }
         }

--- a/common/app/views/fragments/items/linksList/gallery.scala.html
+++ b/common/app/views/fragments/items/linksList/gallery.scala.html
@@ -6,7 +6,7 @@
         @if(imageAdjust == "highlight") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>
-                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container js-image-upgrade" data-src="@imgSrc"></div></div>
+                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container u-responsive-ratio js-image-upgrade" data-src="@imgSrc"></div></div>
                 }
             }
         }

--- a/common/app/views/fragments/items/linksList/live.scala.html
+++ b/common/app/views/fragments/items/linksList/live.scala.html
@@ -6,7 +6,7 @@
         @if(imageAdjust == "highlight") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>
-                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container js-image-upgrade" data-src="@imgSrc"></div></div>
+                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container u-responsive-ratio js-image-upgrade" data-src="@imgSrc"></div></div>
                 }
             }
         }

--- a/common/app/views/fragments/items/linksList/standard.scala.html
+++ b/common/app/views/fragments/items/linksList/standard.scala.html
@@ -6,7 +6,7 @@
         @if(imageAdjust == "highlight") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>
-                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container js-image-upgrade" data-src="@imgSrc"></div></div>
+                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container u-responsive-ratio js-image-upgrade" data-src="@imgSrc"></div></div>
                 }
             }
         }

--- a/common/app/views/fragments/items/linksList/video.scala.html
+++ b/common/app/views/fragments/items/linksList/video.scala.html
@@ -6,7 +6,7 @@
         @if(imageAdjust == "highlight") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>
-                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container js-image-upgrade" data-src="@imgSrc"></div></div>
+                    <div class="linkslist__media-wrapper"><div class="linkslist__image-container u-responsive-ratio js-image-upgrade" data-src="@imgSrc"></div></div>
                 }
             }
         }

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -18,14 +18,14 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
+                            <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }
                             </div>
                         }
                     }.getOrElse{
-                        <div class="item__image-container">
+                        <div class="item__image-container u-responsive-ratio">
                             <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                         </div>
                     }

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -16,14 +16,14 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
+                            <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }
                             </div>
                         }
                     }.getOrElse{
-                        <div class="item__image-container">
+                        <div class="item__image-container u-responsive-ratio">
                             <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                         </div>
                     }

--- a/common/app/views/fragments/items/thumbnailGallery.scala.html
+++ b/common/app/views/fragments/items/thumbnailGallery.scala.html
@@ -19,14 +19,14 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
+                            <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }
                             </div>
                         }
                     }.getOrElse{
-                        <div class="item__image-container">
+                        <div class="item__image-container u-responsive-ratio">
                             <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                         </div>
                     }

--- a/common/app/views/fragments/items/thumbnailVideo.scala.html
+++ b/common/app/views/fragments/items/thumbnailVideo.scala.html
@@ -17,14 +17,14 @@
                     </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__image-container js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
+                            <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
                                 @if(inlineImages){
                                     @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
                                 }
                             </div>
                         }
                     }.getOrElse{
-                        <div class="item__image-container">
+                        <div class="item__image-container u-responsive-ratio">
                             <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                         </div>
                     }

--- a/common/app/views/fragments/trails/featured.scala.html
+++ b/common/app/views/fragments/trails/featured.scala.html
@@ -19,7 +19,7 @@
     @trail.trailPicture.map{ imageContainer =>
         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
             <a href="@LinkTo{@trail.url}"
-               class="trail__img item__image-container"
+               class="trail__img item__image-container u-responsive-ratio"
                aria-hidden="true"
                data-src="@Html(imgSrc)"
                @if(related){itemprop="relatedLink"} data-link-name="@rowNum | image" >

--- a/common/app/views/fragments/trails/thumbnail.scala.html
+++ b/common/app/views/fragments/trails/thumbnail.scala.html
@@ -16,7 +16,7 @@
     @trail.trailPicture.map { imageContainer =>
         @ImgSrc.imager(imageContainer, Item620).map{ imgSrc =>
             <a href="@LinkTo{@trail.url}"
-               class="trail__img item__image-container"
+               class="trail__img item__image-container u-responsive-ratio"
                data-link-name="@rowNum | image"
                aria-hidden="true"
                data-src="@Html(imgSrc)"

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -239,7 +239,7 @@ case class VideoEmbedCleaner(contentVideos: Seq[VideoElement]) extends HtmlClean
                 Sorry, your browser is unable to play this video.
               </object>""")
 
-        element.wrap("<div class=\"media-proportional-container\"></div>")
+        element.wrap("<div class=\"u-responsive-ratio\"></div>")
       })
     }
     document
@@ -413,7 +413,7 @@ case class InlineSlotGenerator(articleWordCount: Int) extends HtmlCleaner {
 
   private def isBlock(element: Element): Boolean = {
       (element.hasClass("img") && !element.hasClass("img--inline")) ||
-      element.hasClass("media-proportional-container") ||
+      element.hasClass("u-responsive-ratio") || // @Todo: be more specific - was "media-proportional-container"
       element.tagName == "video"
   }
 


### PR DESCRIPTION
- [new] `.u-responsive-ratio` helper to create 5:3 ratio placeholders
- [fix] Performance: prevent fromage normal images from upgrading/downgrading at all (since 220px is their original size we don't need to pass them to imager.js)

![ ](http://media2.giphy.com/media/cA9q5AUOWsnSg/200.gif)
