### PR TITLE
Fix article meta continer when no byline is present

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -178,6 +178,12 @@
         ));
     }
 
+    .article__meta-container--no-byline & {
+        @include rem((
+            padding-top: $gs-baseline/3
+        ));
+    }
+
     @include mq(tablet) {
         padding-right: 0;
         @include fs-data(3, true);
@@ -189,6 +195,10 @@
             margin-bottom: $gs-baseline
         ));
         border-top: 1px dotted $c-neutral5;
+
+        .article__meta-container--no-byline & {
+            border-top: none;
+        }
     }
 
     @include mq(wide) {
@@ -364,6 +374,7 @@
 }
 
 .article__meta-container {
+    min-height: gs-height(1);
     position: relative;
     @include rem((
         margin-bottom: $gs-baseline

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -7,21 +7,19 @@
     }
 }
 
-@if(content.hasLargeContributorImage) {
-    <div class="media article__meta-container u-cf">
-         <div class="media__img meta__image">
+<div class="article__meta-container u-cf@if(content.byline.isEmpty){ article__meta-container--no-byline}">
+    @if(content.hasLargeContributorImage) {
+        <div class="media__img meta__image">
             @fragments.meta.bylineImage(content)
-         </div>
+        </div>
         <div class="media__body meta__body">
             @byline(content)
             @fragments.meta.dateline(content.webPublicationDate, secondary=true)
             <div class="js-comment-count"></div>
         </div>
-    </div>
-} else {
-    <div class="article__meta-container u-cf">
+    } else {
         @byline(content)
         @fragments.meta.dateline(content.webPublicationDate, secondary=true)
         <div class="js-comment-count"></div>
-    </div>
-}
+    }
+</div>


### PR DESCRIPTION
This fixes the meta container layout when no byline is present.
- Min-height sizing at mobile
- Remove double border at desktop

Thank you @kaelig for reporting.
### Before

![screenshot from 2014-03-05 09 53 02](https://f.cloud.github.com/assets/80089/2331630/76a91b94-a44c-11e3-933a-deceb40ab48c.png)
![screenshot from 2014-03-05 09 53 13](https://f.cloud.github.com/assets/80089/2331631/782410aa-a44c-11e3-96a8-d003c5bd03ee.png)
### After

![screenshot from 2014-03-05 09 53 21](https://f.cloud.github.com/assets/80089/2331633/7c6e39a6-a44c-11e3-8be6-970fd7404a9f.png)
![screenshot from 2014-03-05 09 53 34](https://f.cloud.github.com/assets/80089/2331634/7e1db006-a44c-11e3-835f-7ce78c82a4ad.png)
