### PR TITLE
Add empty alt attribute if one doesn't exits, when upgrading images

### DIFF
--- a/common/app/assets/javascripts/modules/ui/images.js
+++ b/common/app/assets/javascripts/modules/ui/images.js
@@ -33,9 +33,10 @@ function (
             // add empty alts if none exist
             containers.forEach(function(container) {
                 $('img', container).each(function(img) {
-                    var $img = bonzo(img),
-                        alt = $img.attr('alt') || '';
-                    $img.attr('alt', alt);
+                    var $img = bonzo(img);
+                    if ($img.attr('alt') === null) {
+                        $img.attr('alt', '');
+                    }
                 });
             });
         },

--- a/common/app/assets/javascripts/modules/ui/images.js
+++ b/common/app/assets/javascripts/modules/ui/images.js
@@ -1,21 +1,42 @@
-define(['common/$', 'common/utils/to-array', 'bonzo', 'common/utils/mediator', 'imager', 'common/utils/detect'], function ($, toArray, bonzo, mediator, imager, detect) {
+define([
+    'common/$',
+    'bonzo',
+    'common/utils/mediator',
+    'imager'
+],
+function (
+    $,
+    bonzo,
+    mediator,
+    imager
+) {
 
     var images = {
 
         upgrade: function(context) {
             context = context || document;
-            var breakpoint = detect.getBreakpoint(),
-                options = {
+            var options = {
                     availableWidths: [ 140, 220, 300, 460, 620, 700, 940 ],
                     strategy: 'container',
                     replacementDelay: 0
-                };
-
-            toArray(context.getElementsByClassName('js-image-upgrade')).forEach(function(container) {
-                if (bonzo(container).css('display') === 'none') {
-                    return;
-                }
-                imager.init([container], options);
+                },
+                containers = $('.js-image-upgrade', context).map(
+                    function(container) {
+                        return container;
+                    },
+                    // this is an optional filter function
+                    function(container) {
+                        return bonzo(container).css('display') !== 'none';
+                    }
+                );
+            imager.init(containers, options);
+            // add empty alts if none exist
+            containers.forEach(function(container) {
+                $('img', container).each(function(img) {
+                    var $img = bonzo(img),
+                        alt = $img.attr('alt') || '';
+                    $img.attr('alt', alt);
+                });
             });
         },
 

--- a/common/test/assets/javascripts/spec/Images.spec.js
+++ b/common/test/assets/javascripts/spec/Images.spec.js
@@ -39,6 +39,17 @@ define(['common/modules/ui/images', 'helpers/fixtures', 'common/$', 'bonzo', 'co
 
         });
 
+        it('should add an empty alt attribute if one doesn\'t exist', function() {
+            $('.' + imgClass)
+                .first()
+                .append('<img alt="foo" />');
+            images.upgrade();
+            expect($('.img-0 img').attr('alt')).toEqual('foo');
+            expect($('.img-1 img').attr('alt')).toEqual('');
+            expect($('.img-2 img').attr('alt')).toEqual('');
+
+        });
+
         describe('window events', function() {
 
             ['resize', 'orientationchange'].forEach(function(event) {


### PR DESCRIPTION
cc: @kaelig 

![1306491690_river_pole_vault_fail](https://f.cloud.github.com/assets/74132/2332872/25cfc4fc-a460-11e3-9e97-b56c658d6f46.gif)
