### PR TITLE
Content Api Exception counting

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -309,7 +309,7 @@ object FaciaToolMetrics {
     DraftPublishCount, ContentApiPutSuccess, ContentApiPutFailure,
     FrontPressSuccess, FrontPressFailure, FrontPressCronSuccess,
     FrontPressCronFailure
-  )
+  ) ++ ContentApiMetrics.all
 }
 
 object CommercialMetrics {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -8,6 +8,7 @@ import model.diagnostics.CloudWatch
 import java.io.File
 import java.util.concurrent.atomic.AtomicLong
 import com.amazonaws.services.cloudwatch.model.Dimension
+import common.FaciaToolMetrics.InvalidContentExceptionMetric
 
 trait TimingMetricLogging extends Logging { self: TimingMetric =>
   override def measure[T](block: => T): T = {
@@ -228,7 +229,8 @@ object FaciaMetrics {
 
   val all: Seq[Metric] = Seq(
     JsonParsingErrorCount,
-    S3AuthorizationError
+    S3AuthorizationError,
+    InvalidContentExceptionMetric
   )
 }
 
@@ -304,11 +306,18 @@ object FaciaToolMetrics {
     "Number of times facia-tool has has a failure in pressing"
   )
 
+  object InvalidContentExceptionMetric extends SimpleCountMetric(
+    "facia",
+    "facia-invalid-content",
+    "Facia InvalidContent count",
+    "Number of times facia/facia-tool has thrown InvalidContent exceptions"
+  )
+
   val all: Seq[Metric] = Seq(
     ApiUsageCount, ProxyCount, ExpiredRequestCount,
     DraftPublishCount, ContentApiPutSuccess, ContentApiPutFailure,
     FrontPressSuccess, FrontPressFailure, FrontPressCronSuccess,
-    FrontPressCronFailure
+    FrontPressCronFailure, InvalidContentExceptionMetric
   ) ++ ContentApiMetrics.all
 }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -137,14 +137,14 @@ object ContentApiMetrics {
     "Number of times the Content API has responded with a 404"
   )
 
-  object ContentApiJsonParseException extends SimpleCountMetric(
+  object ContentApiJsonParseExceptionMetric extends SimpleCountMetric(
     "exception",
     "content-api-parse-exception",
     "Content API Parse Exceptions",
     "Number of times the Content API client has thrown a ParseException"
   )
 
-  object ContentApiJsonMappingException extends SimpleCountMetric(
+  object ContentApiJsonMappingExceptionMetric extends SimpleCountMetric(
     "exception",
     "content-api-mapping-exception",
     "Content API Mapping Exceptions",
@@ -158,8 +158,8 @@ object ContentApiMetrics {
     ElasticHttpTimeoutCountMetric,
     ElasticHttpTimingMetric,
     ContentApi404Metric,
-    ContentApiJsonParseException,
-    ContentApiJsonMappingException
+    ContentApiJsonParseExceptionMetric,
+    ContentApiJsonMappingExceptionMetric
   )
 }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -137,12 +137,29 @@ object ContentApiMetrics {
     "Number of times the Content API has responded with a 404"
   )
 
+  object ContentApiJsonParseException extends SimpleCountMetric(
+    "exception",
+    "content-api-parse-exception",
+    "Content API Parse Exceptions",
+    "Number of times the Content API client has thrown a ParseException"
+  )
+
+  object ContentApiJsonMappingException extends SimpleCountMetric(
+    "exception",
+    "content-api-mapping-exception",
+    "Content API Mapping Exceptions",
+    "Number of times the Content API client has thrown a MappingException"
+  )
+
+
   val all: Seq[Metric] = Seq(
     HttpTimingMetric,
     HttpTimeoutCountMetric,
     ElasticHttpTimeoutCountMetric,
     ElasticHttpTimingMetric,
-    ContentApi404Metric
+    ContentApi404Metric,
+    ContentApiJsonParseException,
+    ContentApiJsonMappingException
   )
 }
 

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -242,14 +242,10 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
   def validateContent(content: Content): Content = {
     Try {
       //These will throw if they don't exist because of unsafe Map.apply
-      content.headline.isEmpty &&
-        content.shortUrl.isEmpty
-    } match {
-      case Success(_) => content
-      case Failure(_) => {
-        throw new InvalidContent(content.id)
-      }
-    }
+      content.headline.isEmpty
+      content.shortUrl.isEmpty
+      content
+    }.getOrElse(throw new InvalidContent(content.id))
   }
 
 }

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -178,7 +178,11 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
           itemResponse <- content
           supporting <- supportingAsContent
         } yield {
-          itemResponse.map(Content(_, supporting, collectionItem.metaData)).map(_ +: contentList).getOrElse(contentList)
+          itemResponse
+            .map(Content(_, supporting, collectionItem.metaData))
+            .map(validateContent)
+            .map(_ +: contentList)
+            .getOrElse(contentList)
         }
       }
       val sorted = results map { _.sortBy(t => collectionItems.indexWhere(_.id == t.id))}

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -159,11 +159,11 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
             None
           }
           case jsonParseError: net.liftweb.json.JsonParser.ParseException => {
-            ContentApiMetrics.ContentApiJsonParseException.increment()
+            ContentApiMetrics.ContentApiJsonParseExceptionMetric.increment()
             throw jsonParseError
           }
           case mappingException: net.liftweb.json.MappingException => {
-            ContentApiMetrics.ContentApiJsonMappingException.increment()
+            ContentApiMetrics.ContentApiJsonMappingExceptionMetric.increment()
             throw mappingException
           }
           case t: Throwable => {

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -245,7 +245,10 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
       content.headline.isEmpty
       content.shortUrl.isEmpty
       content
-    }.getOrElse(throw new InvalidContent(content.id))
+    }.getOrElse {
+      FaciaToolMetrics.InvalidContentExceptionMetric.increment()
+      throw new InvalidContent(content.id)
+    }
   }
 
 }

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -241,7 +241,7 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
 
   def validateContent(content: Content): Content = {
     Try {
-      //These will throw because if they don't exist because of unsafe Map.apply
+      //These will throw if they don't exist because of unsafe Map.apply
       content.headline.isEmpty &&
         content.shortUrl.isEmpty
     } match {

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -225,4 +225,17 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
     newSearch
   } getOrElse Future(Result(Nil, Nil, Nil, Nil))
 
+  def validateContent(content: Content): Content = {
+    Try {
+      //These will throw because if they don't exist because of unsafe Map.apply
+      content.headline.isEmpty &&
+        content.shortUrl.isEmpty
+    } match {
+      case Success(_) => content
+      case Failure(_) => {
+        throw new InvalidContent(content.id)
+      }
+    }
+  }
+
 }

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -208,7 +208,12 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
           case (query, (key, value)) => query.stringParam(key, value)
         }.showFields(showFieldsQuery)
         newSearch.response map { r =>
-          Result(Nil, Nil, Nil, r.results.map(Content(_)))
+          Result(
+            curated           = Nil,
+            editorsPicks      = Nil,
+            mostViewed        = Nil,
+            contentApiResults = r.results.map(Content(_)).map(validateContent)
+          )
         }
       }
       case Path(id)  => {
@@ -220,7 +225,12 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
           case (query, (key, value)) => query.stringParam(key, value)
         }.showFields(showFieldsQuery)
         newSearch.response map { r =>
-          Result(Nil, r.editorsPicks.map(Content(_)), r.mostViewed.map(Content(_)), r.results.map(Content(_)))
+          Result(
+            curated           = Nil,
+            editorsPicks      = r.editorsPicks.map(Content(_)).map(validateContent),
+            mostViewed        = r.mostViewed.map(Content(_)).map(validateContent),
+            contentApiResults = r.results.map(Content(_)).map(validateContent)
+          )
         }
       }
     }

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -10,7 +10,7 @@ import play.api.libs.ws.Response
 import scala.concurrent.Future
 import scala.Some
 import contentapi.QueryDefaults
-import scala.util.{Success, Failure, Try}
+import scala.util.Try
 
 object Path {
   def unapply[T](uri: String) = Some(uri.split('?')(0))

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -28,7 +28,8 @@ object Global extends FaciaToolLifecycle with GlobalSettings with CloudWatchAppl
     ("solr-content-api-timeouts", ContentApiMetrics.HttpTimeoutCountMetric.getAndReset.toDouble),
     ("content-api-404", ContentApiMetrics.ContentApi404Metric.getAndReset.toDouble),
     ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
-    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble)
+    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble),
+    ("content-api-invalid-content-exceptions", FaciaToolMetrics.InvalidContentExceptionMetric.getAndReset.toDouble)
   )
 
   override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration = {

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -26,7 +26,9 @@ object Global extends FaciaToolLifecycle with GlobalSettings with CloudWatchAppl
     ("solr-content-api-calls", ContentApiMetrics.HttpTimingMetric.getAndReset.toDouble),
     ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
     ("solr-content-api-timeouts", ContentApiMetrics.HttpTimeoutCountMetric.getAndReset.toDouble),
-    ("content-api-404", ContentApiMetrics.ContentApi404Metric.getAndReset.toDouble)
+    ("content-api-404", ContentApiMetrics.ContentApi404Metric.getAndReset.toDouble),
+    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseException.getAndReset.toDouble),
+    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingException.getAndReset.toDouble)
   )
 
   override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration = {

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -27,8 +27,8 @@ object Global extends FaciaToolLifecycle with GlobalSettings with CloudWatchAppl
     ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
     ("solr-content-api-timeouts", ContentApiMetrics.HttpTimeoutCountMetric.getAndReset.toDouble),
     ("content-api-404", ContentApiMetrics.ContentApi404Metric.getAndReset.toDouble),
-    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseException.getAndReset.toDouble),
-    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingException.getAndReset.toDouble)
+    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
+    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble)
   )
 
   override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration = {

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -15,7 +15,9 @@ object Global extends WithFilters(RequestMeasurementMetrics.asFilters: _*) with 
     ("elastic-content-api-calls", ContentApiMetrics.ElasticHttpTimingMetric.getAndReset.toDouble),
     ("solr-content-api-calls", ContentApiMetrics.HttpTimingMetric.getAndReset.toDouble),
     ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
-    ("solr-content-api-timeouts", ContentApiMetrics.HttpTimeoutCountMetric.getAndReset.toDouble)
+    ("solr-content-api-timeouts", ContentApiMetrics.HttpTimeoutCountMetric.getAndReset.toDouble),
+    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseException.getAndReset.toDouble),
+    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingException.getAndReset.toDouble)
   )
 
 }

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -1,4 +1,4 @@
-import common.{ContentApiMetrics, FaciaMetrics, CloudWatchApplicationMetrics}
+import common.{FaciaToolMetrics, ContentApiMetrics, FaciaMetrics, CloudWatchApplicationMetrics}
 import conf.{Management, RequestMeasurementMetrics}
 import controllers.front._
 import dev.DevParametersLifecycle
@@ -17,7 +17,8 @@ object Global extends WithFilters(RequestMeasurementMetrics.asFilters: _*) with 
     ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
     ("solr-content-api-timeouts", ContentApiMetrics.HttpTimeoutCountMetric.getAndReset.toDouble),
     ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
-    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble)
+    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble),
+    ("content-api-invalid-content-exceptions", FaciaToolMetrics.InvalidContentExceptionMetric.getAndReset.toDouble)
   )
 
 }

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -16,8 +16,8 @@ object Global extends WithFilters(RequestMeasurementMetrics.asFilters: _*) with 
     ("solr-content-api-calls", ContentApiMetrics.HttpTimingMetric.getAndReset.toDouble),
     ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
     ("solr-content-api-timeouts", ContentApiMetrics.HttpTimeoutCountMetric.getAndReset.toDouble),
-    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseException.getAndReset.toDouble),
-    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingException.getAndReset.toDouble)
+    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
+    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble)
   )
 
 }


### PR DESCRIPTION
This adds exception counting for `net.liftweb.json.JsonParser.ParseException` and `net.liftweb.json.MappingException` to the calls to the content API for `facia` and `facia-tool`.

I have been seeing these two exceptions come up a good few times in the log. Even before we bumped the version to `2.9`.

Another problem we are seeing is that things like `fields` of an `ItemResponse` which comes back from the content api client is turning out empty (along with `tags` and `elements`).
After pressing this, facia will try to get things like `headline` which doesn't exist, and throw an `NoSuchElementException` exception.
Instead of pressing it in a bad state, this method will throw if it can't get the fields for any reason, and interrupt the press job.
