### PR TITLE
Fronts: 'live' card ab test

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -14,7 +14,8 @@ define([
     'common/modules/experiments/tests/au-containers',
     'common/modules/experiments/tests/fronts-latest-reviews-card',
     'common/modules/experiments/tests/fronts-cartoon-card',
-    'common/modules/experiments/tests/fronts-missed-card'
+    'common/modules/experiments/tests/fronts-missed-card',
+    'common/modules/experiments/tests/fronts-live-card'
 ], function (
     common,
     store,
@@ -29,7 +30,8 @@ define([
     AuContainers,
     FrontsLatestReviewsCard,
     FrontsCartoonCard,
-    FrontsMissedCard
+    FrontsMissedCard,
+    FrontsLiveCard
 ) {
 
     var TESTS = [
@@ -42,7 +44,8 @@ define([
             new AuContainers(),
             new FrontsLatestReviewsCard(),
             new FrontsCartoonCard(),
-            new FrontsMissedCard()
+            new FrontsMissedCard(),
+            new FrontsLiveCard()
        ],
        participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
@@ -3,20 +3,16 @@ define([
     'bonzo',
     'qwery',
     'common/utils/detect',
-    'common/utils/get-property'
+    'common/utils/get-property',
+    'common/utils/template'
 ], function(
     reqwest,
     bonzo,
     qwery,
     detect,
-    getProperty
+    getProperty,
+    template
 ) {
-
-    function fillTemplate(template, params) {
-        return Object.keys(params).reduce(function(template, token) {
-            return template.replace('{{' + token + '}}', params[token]);
-        }, template);
-    }
 
     return function() {
 
@@ -50,7 +46,7 @@ define([
                             var $card = getProperty(resp, 'response.results', [])
                                     .map(function(result) {
                                         return bonzo(bonzo.create(
-                                            fillTemplate(
+                                            template(
                                                 '<div class="container__card tone-comment tone-accent-border" data-link-name="card | cartoon">' +
                                                     '<h3 class="container__card__title tone-colour">Cartoon</h3>' +
                                                     '<a href="{{url}}" data-link-name="article" class="card__item card__item__link">' +

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
@@ -1,14 +1,14 @@
 define([
-    'reqwest',
     'bonzo',
     'qwery',
+    'common/utils/ajax',
     'common/utils/detect',
     'common/utils/get-property',
     'common/utils/template'
 ], function(
-    reqwest,
     bonzo,
     qwery,
+    ajax,
     detect,
     getProperty,
     template
@@ -38,7 +38,7 @@ define([
             {
                 id: 'cartoon',
                 test: function (context, config) {
-                    reqwest({
+                    ajax({
                         url: 'http://content.guardianapis.com/search?tag=theguardian%2Fseries%2Fguardiancommentcartoon&page-size=1&show-fields=thumbnail',
                         type: 'jsonp'
                     })

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
@@ -39,7 +39,7 @@ define([
                 id: 'cartoon',
                 test: function (context, config) {
                     reqwest({
-                        url: 'http://content.guardianapis.com/search?tag=theguardian%2Fseries%2Fguardiancommentcartoon&page-size=1&show-fields=all',
+                        url: 'http://content.guardianapis.com/search?tag=theguardian%2Fseries%2Fguardiancommentcartoon&page-size=1&show-fields=thumbnail',
                         type: 'jsonp'
                     })
                         .then(function(resp) {
@@ -55,8 +55,8 @@ define([
                                                     '</a>' +
                                                 '</div>',
                                                 {
-                                                    headline: result.webTitle,
-                                                    url: result.webUrl.replace(/https?:\/\/[^/]*/, ''),
+                                                    headline : result.webTitle,
+                                                    url      : result.webUrl.replace(/https?:\/\/[^/]*/, ''),
                                                     thumbnail: result.fields.thumbnail
                                                 }
                                             )
@@ -64,7 +64,7 @@ define([
                                     })
                                     .shift()
                                     .appendTo(qwery('.container--commentanddebate').shift()),
-                                yPosition = 379 - $card.dim().height;
+                                yPosition = 383 - $card.dim().height;
                             $card.css('top', yPosition + 'px');
                         });
                 }

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
@@ -39,8 +39,8 @@ define([
                 id: 'cartoon',
                 test: function (context, config) {
                     ajax({
-                        url       : 'tagged.json?tag=theguardian/series/guardiancommentcartoon',
-                        type      : 'json',
+                        url        : 'tagged.json?tag=theguardian/series/guardiancommentcartoon',
+                        type       : 'json',
                         crossDomain: true
                     })
                         .then(function(resp) {

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-cartoon-card.js
@@ -39,11 +39,12 @@ define([
                 id: 'cartoon',
                 test: function (context, config) {
                     ajax({
-                        url: 'http://content.guardianapis.com/search?tag=theguardian%2Fseries%2Fguardiancommentcartoon&page-size=1&show-fields=thumbnail',
-                        type: 'jsonp'
+                        url       : 'tagged.json?tag=theguardian/series/guardiancommentcartoon',
+                        type      : 'json',
+                        crossDomain: true
                     })
                         .then(function(resp) {
-                            var $card = getProperty(resp, 'response.results', [])
+                            var $card = getProperty(resp, 'trails', [])
                                     .map(function(result) {
                                         return bonzo(bonzo.create(
                                             template(
@@ -57,7 +58,7 @@ define([
                                                 {
                                                     headline : result.webTitle,
                                                     url      : result.webUrl.replace(/https?:\/\/[^/]*/, ''),
-                                                    thumbnail: result.fields.thumbnail
+                                                    thumbnail: result.thumbnail
                                                 }
                                             )
                                         ));

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
@@ -39,17 +39,18 @@ define([
                 id: 'latest-reviews',
                 test: function (context, config) {
                     ajax({
-                        url: 'http://content.guardianapis.com/search?tag=tone%2Freviews%2Cculture%2Fculture&page-size=3&show-fields=starRating',
-                        type: 'jsonp'
+                        url        : '/tagged.json?tag=tone/reviews,culture/culture',
+                        type       : 'json',
+                        crossOrigin: true
                     })
                         .then(function(resp) {
-                            var reviews = getProperty(resp, 'response.results', [])
+                            var reviews = getProperty(resp, 'trails', [])
                                 .map(function(result, index) {
                                     return template(
                                         '<li data-link-name="trail | {{index}}" class="card__item">' +
                                             '<a href="{{url}}" class="card__item__link" data-link-name="article">' +
                                                 '<h4 class="card__item__title">{{section}}: {{headline}}</h4>' +
-                                                ((result.fields.starRating !== undefined) ?
+                                                ((result.starRating !== undefined) ?
                                                     '<span class="stars s-{{rating}}" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">' +
                                                         '<meta itemprop="worstRating" content="1" />' +
                                                         '<span itemprop="ratingValue">{{rating}}</span> /' +
@@ -61,7 +62,7 @@ define([
                                             headline: result.webTitle,
                                             url     : result.webUrl.replace(/https?:\/\/[^/]*/, ''),
                                             section : result.sectionName,
-                                            rating  : result.fields.starRating,
+                                            rating  : result.starRating,
                                             index   : index + 1
                                         }
                                     );

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
@@ -1,14 +1,14 @@
 define([
-    'reqwest',
     'bonzo',
     'qwery',
+    'common/utils/ajax',
     'common/utils/detect',
     'common/utils/get-property',
     'common/utils/template'
 ], function(
-    reqwest,
     bonzo,
     qwery,
+    ajax,
     detect,
     getProperty,
     template
@@ -38,7 +38,7 @@ define([
             {
                 id: 'latest-reviews',
                 test: function (context, config) {
-                    reqwest({
+                    ajax({
                         url: 'http://content.guardianapis.com/search?tag=tone%2Freviews%2Cculture%2Fculture&page-size=3&show-fields=starRating',
                         type: 'jsonp'
                     })

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
@@ -3,20 +3,16 @@ define([
     'bonzo',
     'qwery',
     'common/utils/detect',
-    'common/utils/get-property'
+    'common/utils/get-property',
+    'common/utils/template'
 ], function(
     reqwest,
     bonzo,
     qwery,
     detect,
-    getProperty
+    getProperty,
+    template
 ) {
-
-    function fillTemplate(template, params) {
-        return Object.keys(params).reduce(function(template, token) {
-            return template.replace('{{' + token + '}}', params[token]);
-        }, template);
-    }
 
     return function() {
 
@@ -51,7 +47,7 @@ define([
                             getProperty(resp, 'response.results', []).forEach(function(result, index) {
                                 var starRating = result.fields.starRating;
                                 reviews.push(
-                                    fillTemplate(
+                                    template(
                                         '<li data-link-name="trail | {{index}}" class="card__item">' +
                                             '<a href="{{url}}" class="card__item__link" data-link-name="article">' +
                                                 '<h4 class="card__item__title">{{section}}: {{title}}</h4>' +
@@ -75,7 +71,7 @@ define([
                             });
                             var $card = bonzo(
                                     bonzo.create(
-                                        fillTemplate(
+                                        template(
                                             '<div class="container__card tone-feature tone-accent-border" data-link-name="card | latest reviews">' +
                                                 '<h3 class="container__card__title tone-colour">Latest reviews</h3>' +
                                                 '<ul class="unstyled">{{reviews}}</ul>' +

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-latest-reviews-card.js
@@ -43,15 +43,13 @@ define([
                         type: 'jsonp'
                     })
                         .then(function(resp) {
-                            var reviews = [];
-                            getProperty(resp, 'response.results', []).forEach(function(result, index) {
-                                var starRating = result.fields.starRating;
-                                reviews.push(
-                                    template(
+                            var reviews = getProperty(resp, 'response.results', [])
+                                .map(function(result, index) {
+                                    return template(
                                         '<li data-link-name="trail | {{index}}" class="card__item">' +
                                             '<a href="{{url}}" class="card__item__link" data-link-name="article">' +
-                                                '<h4 class="card__item__title">{{section}}: {{title}}</h4>' +
-                                                ((starRating !== undefined) ?
+                                                '<h4 class="card__item__title">{{section}}: {{headline}}</h4>' +
+                                                ((result.fields.starRating !== undefined) ?
                                                     '<span class="stars s-{{rating}}" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">' +
                                                         '<meta itemprop="worstRating" content="1" />' +
                                                         '<span itemprop="ratingValue">{{rating}}</span> /' +
@@ -60,16 +58,15 @@ define([
                                             '</a>' +
                                         '</li>',
                                         {
-                                            url: result.webUrl.replace(/https?:\/\/[^/]*/, ''),
-                                            title: result.webTitle,
-                                            section: result.sectionName,
-                                            rating: result.fields.starRating,
-                                            index: index + 1
+                                            headline: result.webTitle,
+                                            url     : result.webUrl.replace(/https?:\/\/[^/]*/, ''),
+                                            section : result.sectionName,
+                                            rating  : result.fields.starRating,
+                                            index   : index + 1
                                         }
-                                    )
-                                );
-                            });
-                            var $card = bonzo(
+                                    );
+                                }),
+                                $card = bonzo(
                                     bonzo.create(
                                         template(
                                             '<div class="container__card tone-feature tone-accent-border" data-link-name="card | latest reviews">' +
@@ -80,7 +77,7 @@ define([
                                         )
                                     )
                                 ).appendTo(qwery('.container--features').shift()),
-                                yPosition = 513 - $card.dim().height;
+                                yPosition = 518 - $card.dim().height;
                             $card.css('top', yPosition + 'px');
                         });
                 }

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-live-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-live-card.js
@@ -1,14 +1,14 @@
 define([
-    'reqwest',
     'bonzo',
     'qwery',
+    'common/utils/ajax',
     'common/utils/detect',
     'common/utils/get-property',
     'common/utils/template'
 ], function(
-    reqwest,
     bonzo,
     qwery,
+    ajax,
     detect,
     getProperty,
     template
@@ -38,7 +38,7 @@ define([
             {
                 id: 'live',
                 test: function (context, config) {
-                    reqwest({
+                    ajax({
                         url: 'http://content.guardianapis.com/search?tag=tone%2Fminutebyminute&page-size=3&show-fields=liveBloggingNow',
                         type: 'jsonp'
                     })

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-live-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-live-card.js
@@ -39,16 +39,17 @@ define([
                 id: 'live',
                 test: function (context, config) {
                     ajax({
-                        url: 'http://content.guardianapis.com/search?tag=tone%2Fminutebyminute&page-size=3&show-fields=liveBloggingNow',
-                        type: 'jsonp'
+                        url        : '/tagged.json?tag=tone/minutebyminute',
+                        type       : 'json',
+                        crossOrigin: true
                     })
                         .then(function(resp) {
-                            var items = getProperty(resp, 'response.results', []).map(function(result, index) {
+                            var items = getProperty(resp, 'trails', []).map(function(result, index) {
                                     return template(
                                         '<li data-link-name="trail | {{index}}" class="card__item">' +
                                             '<a href="{{url}}" class="card__item__link" data-link-name="article">' +
                                                 '<h4 class="card__item__title">' +
-                                                    ((result.fields.liveBloggingNow === 'true') ?
+                                                    ((result.liveBloggingNow === 'true') ?
                                                         '<span class="item__live-indicator">Live</span> ' : '') +
                                                     '{{headline}}' +
                                             '   </h4>' +

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-live-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-live-card.js
@@ -1,0 +1,45 @@
+define([
+    'reqwest',
+    'common/utils/detect',
+    'common/utils/template'
+], function(
+    reqwest,
+    detect,
+    template
+) {
+
+    return function() {
+
+        this.id = 'FrontsLiveCard';
+        this.start = '2014-02-28';
+        this.expiry = '2014-03-08';
+        this.author = 'Darren Hurley';
+        this.description = 'Add a live card to the news container';
+        this.audience = 0.1;
+        this.audienceOffset = 0.0;
+        this.successMeasure = 'Click-through for the page as a whole.';
+        this.audienceCriteria = 'Users who are not on desktop or bigger, on the network front.';
+        this.dataLinkNames = 'card | live | trail | {{index}}';
+        this.idealOutcome = 'Click-through for the front increases, i.e. the card does not detract from the page\'s CTR.';
+        this.canRun = function(config) {
+            return ['desktop', 'wide'].indexOf(detect.getBreakpoint()) > -1 && config.page.isFront && config.page.pageId === '';
+        };
+        this.variants = [
+            {
+                id: 'control',
+                test: function(context, config) { }
+            },
+            {
+                id: 'latest-reviews',
+                test: function (context, config) {
+                    reqwest({
+                        url: 'http://content.guardianapis.com/search?tag=tone%2Freviews%2Cculture%2Fculture&page-size=3&show-fields=starRating',
+                        type: 'jsonp'
+                    })
+                        .then(function(resp) {
+                        });
+                }
+            }
+        ];
+    };
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-missed-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-missed-card.js
@@ -16,12 +16,6 @@ define([
     template
 ) {
 
-    function fillTemplate(template, params) {
-        return Object.keys(params).reduce(function(template, token) {
-            return template.replace('{{' + token + '}}', params[token]);
-        }, template);
-    }
-
     var editionMappings = {
         'UK': 'GB',
         'US': 'US',
@@ -82,7 +76,7 @@ define([
                                     bonzo.create(
                                         template(
                                             '<div class="container__card container__card--missed tone-news tone-accent-border" data-link-name="card | missed">' +
-                                                '<h3 class="container__card__title tone-colour">You may have missed…</h3>' +
+                                                '<h3 class="container__card__title tone-colour">You may have missed</h3>' +
                                                 '<ul class="unstyled">{{articles}}</ul>' +
                                             '</div>',
                                             {

--- a/common/app/assets/javascripts/modules/experiments/tests/fronts-missed-card.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/fronts-missed-card.js
@@ -4,14 +4,16 @@ define([
     'common/utils/ajax',
     'common/utils/detect',
     'common/modules/onward/history',
-    'common/utils/get-property'
+    'common/utils/get-property',
+    'common/utils/template'
 ], function(
     bonzo,
     qwery,
     ajax,
     detect,
     History,
-    getProperty
+    getProperty,
+    template
 ) {
 
     function fillTemplate(template, params) {
@@ -63,7 +65,7 @@ define([
                                     })
                                     .slice(0, 3)
                                     .map(function(article, index) {
-                                        return fillTemplate(
+                                        return template(
                                             '<li data-link-name="trail | {{index}}" class="card__item">' +
                                                 '<a href="{{url}}" class="card__item__link" data-link-name="article">' +
                                                     '<h4 class="card__item__title">{{headline}}</h4>' +
@@ -78,7 +80,7 @@ define([
                                     }),
                                 $card = bonzo(
                                     bonzo.create(
-                                        fillTemplate(
+                                        template(
                                             '<div class="container__card container__card--missed tone-news tone-accent-border" data-link-name="card | missed">' +
                                                 '<h3 class="container__card__title tone-colour">You may have missed…</h3>' +
                                                 '<ul class="unstyled">{{articles}}</ul>' +

--- a/common/app/assets/javascripts/utils/template.js
+++ b/common/app/assets/javascripts/utils/template.js
@@ -1,0 +1,9 @@
+define(function() {
+
+    return function template(tmpl, params) {
+        return Object.keys(params).reduce(function(tmpl, token) {
+            return tmpl.replace('{{' + token + '}}', params[token]);
+        }, tmpl);
+    };
+
+});

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -191,7 +191,8 @@
 .card__item__link {
     display: block;
 }
-.container__card--missed {
+.container__card--missed,
+.container__card--live {
     .card__item {
         &:after {
             content: "";

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -165,6 +165,11 @@
     @include mq(faciaLeftCol) {
         display: block;
     }
+
+    .item__live-indicator {
+        @include font-size(10px, 12px);
+        top: -2px;
+    }
 }
 .container__card__title {
     margin-bottom: 0;

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -12,7 +12,7 @@ import com.gu.openplatform.contentapi.model.ItemResponse
 trait QueryDefaults extends implicits.Collections with ExecutionContexts {
 
   //NOTE - do NOT add body to this list
-  val trailFields = "headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl,commentCloseDate"
+  val trailFields = "headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl,commentCloseDate,starRating"
 
   val references = "pa-football-competition,pa-football-team,witness-assignment,esa-cricket-match"
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -50,6 +50,7 @@ GET         /preference/edition/:edition                                        
 GET         /preference/front-alphas/:optAction                                                                      controllers.ChangeAlphaController.render(optAction, page)
 
 GET         /cards/opengraph/*path.json                                                                              controllers.CardController.opengraph(path)
+GET         /tagged.json                                                                                             controllers.TaggedContentController.renderJson(tag: String)
 
 # Sport
 GET         /sport/cricket/match/:matchId.json                                                                       controllers.CricketMatchController.renderMatchIdJson(matchId)

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -1,0 +1,57 @@
+package controllers
+
+import common._
+import model._
+import play.api.mvc.{ RequestHeader, Controller, Action }
+import services._
+import play.api.libs.json.{Json, JsArray}
+import scala.concurrent.Future
+import conf.SwitchingContentApi
+import com.gu.openplatform.contentapi.ApiError
+
+object TaggedContentController extends Controller with Related with Logging with ExecutionContexts {
+
+  def renderJson(tag: String) = Action.async { implicit request =>
+    tagWhitelist.find(_ == tag).map { tag =>
+      lookup(tag, Edition(request)) map {
+        case Nil    => JsonNotFound()
+        case trails => render(trails)
+      }
+    } getOrElse(Future { BadRequest })
+  }
+
+  private def render(trails: Seq[Content])(implicit request: RequestHeader) = Cached(300) {
+    JsonComponent(
+      "trails" -> JsArray(trails.map { trail =>
+        Json.obj(
+          ("webTitle", trail.webTitle),
+          ("webUrl", trail.webUrl),
+          ("sectionName", trail.sectionName),
+          ("thumbnail", trail.thumbnailPath),
+          ("starRating", trail.starRating)
+        )
+      })
+    )
+  }
+
+  private val tagWhitelist: Seq[String] = Seq(
+    "tone/minutebyminute",
+    "tone/reviews,culture/culture",
+    "theguardian/series/guardiancommentcartoon"
+  )
+
+  private def lookup(tag: String, edition: Edition)(implicit request: RequestHeader): Future[Seq[Content]] = {
+    log.info(s"Fetching tagged stories for edition ${edition.id}")
+    SwitchingContentApi().search(edition)
+      .tag(tag)
+      .pageSize(3)
+      .response
+      .map { response =>
+        response.results map { Content(_) }
+    }.recover{case ApiError(404, message) =>
+      log.info(s"Got a 404 while calling content api: $message")
+      Nil
+    }
+  }
+
+}

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -28,3 +28,4 @@ GET        /preference/front-alphas/:optAction      controllers.ChangeAlphaContr
 
 # Experimental
 GET        /cards/opengraph/*path.json              controllers.CardController.opengraph(path)
+GET        /tagged.json                             controllers.TaggedContentController.renderJson(tag: String)


### PR DESCRIPTION
Latest 3 `tone/minutebyminute` tagged pieces

![screen shot 2014-03-05 at 17 48 10](https://f.cloud.github.com/assets/74132/2336349/888a6b50-a48e-11e3-8af4-dd71bcb328fb.jpeg)

Also tidied up duplications of populating an HTML template
