### PR TITLE
Tweak padding and width of pagination legend

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_pagination.scss
+++ b/common/app/assets/stylesheets/module/facia/_pagination.scss
@@ -6,6 +6,15 @@
     text-align: center;
     @include fs-data(4);
     border-top: 1px solid $c-neutral5;
+
+    @include mq(leftCol) {
+        float: right;
+        width: gs-span(12);
+    }
+
+    @include mq(wide) {
+        width: gs-span(13);
+    }
 }
 
 .pagination__links {
@@ -46,8 +55,5 @@
 
 .pagination_legend {
     float: left;
-    @include rem((
-        padding-left: $gs-gutter
-    ));
 }
 

--- a/common/app/assets/stylesheets/module/facia/_pagination.scss
+++ b/common/app/assets/stylesheets/module/facia/_pagination.scss
@@ -9,16 +9,21 @@
 
     @include mq(leftCol) {
         float: right;
-        width: gs-span(12);
+        @include rem((
+            width: gs-span(12)
+        ))
     }
 
     @include mq(wide) {
-        width: gs-span(13);
+        @include rem((
+            width: gs-span(13)
+        ))
     }
 }
 
 .pagination__links {
     width: 100%;
+
     @include mq(tablet) {
         float: right;
         @include rem((


### PR DESCRIPTION
This corrects the left hand padding and overall width of the pagination component as per the original designs supplied by Kat.

/cc @gklopper 
#### Before tablet

![screenshot from 2014-03-06 08 56 20](https://f.cloud.github.com/assets/80089/2343359/78bd6fae-a50d-11e3-9f09-d3556147a271.png)
#### Before desktop

![screenshot from 2014-03-06 08 55 58](https://f.cloud.github.com/assets/80089/2343360/7af46822-a50d-11e3-9d43-754103474a6c.png)
#### After tablet

![screenshot from 2014-03-06 08 56 38](https://f.cloud.github.com/assets/80089/2343361/7f39f08c-a50d-11e3-95af-a4e1699b0384.png)
#### After desktop

![screenshot from 2014-03-06 08 56 54](https://f.cloud.github.com/assets/80089/2343362/80c3fc18-a50d-11e3-9b82-d00533dc154f.png)
