### PR TITLE
Make the second nav item a 'child' of the first.

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -86,7 +86,8 @@ to apply any necessary changes to non-shared code there too.
                     @* Secondary nav *@
                     @Navigation.localNav(navigation, page).map { localNav =>
                         @defining(localNav.find(_.currentFor(page))){ currentSublink =>
-                            <div class="localnav-container gs-container u-cf">
+                            <div class="localnav-container gs-container u-cf"
+                                @currentSublink.map{ s => itemprop="child" itemscope itemtype="http://data-vocabulary.org/Breadcrumb" }>
                                 <ul class="nav nav--local" data-link-name="Local Navigation">
                                     @localNav.map { nav =>
                                         <li class="nav__item @currentSublink.filter(_.href == nav.href).map{ current => is-active }">


### PR DESCRIPTION
Google does not seem to be picking up our breadcrumbs...

I have done some poking around the dark corners of the internet and I think it is because our nav is two tiered instead of a simple list.

I have added the 'child' markup so that google now sees the nav slightly differently.

**_How it is seen now...**_
![breadcrumbs2](https://f.cloud.github.com/assets/76709/2344375/9648397e-a520-11e3-82cb-1743c94d08e6.png)
....................................................................
**_How it used to be seen...**_
![breadcrumbs](https://f.cloud.github.com/assets/76709/2344376/9d78fe9a-a520-11e3-8e73-e6f2ff72f2ae.png)
