### PR TITLE
If switch is on, facia-tool should use contentapi's elastic search

### DIFF
--- a/facia-tool/app/controllers/FaciaContentApiProxy.scala
+++ b/facia-tool/app/controllers/FaciaContentApiProxy.scala
@@ -6,6 +6,7 @@ import implicits.Strings
 import play.api.mvc._
 import play.api.libs.ws.WS
 import model.Cached
+import conf.Switches._
 
 object FaciaContentApiProxy extends Controller with Logging with AuthLogging with ExecutionContexts with Strings {
 
@@ -15,7 +16,12 @@ object FaciaContentApiProxy extends Controller with Logging with AuthLogging wit
        "%s=%s".format(p._1, p._2.head.urlEncoded)
     }.mkString("&")
 
-    val url = s"${Configuration.contentApi.host}/$path?$queryString&api-key=${Configuration.contentApi.key}"
+    val contentApiHost = if(ElasticSearchSwitch.isSwitchedOn) {
+      Configuration.contentApi.elasticSearchHost
+    } else {
+      Configuration.contentApi.host
+    }
+    val url = s"$contentApiHost/$path?$queryString&api-key=${Configuration.contentApi.key}"
 
     log("Proxying tag API query to: %s" format url, request)
 


### PR DESCRIPTION
![1360259409_camel_attack](https://f.cloud.github.com/assets/74132/2344422/4eef0aa2-a521-11e3-9c1a-e7c7fefd343d.gif)
