### PR TITLE
Remove line clamping on lists with images

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_linkslist.scss
+++ b/common/app/assets/stylesheets/module/facia/_linkslist.scss
@@ -88,11 +88,6 @@
                 min-height: get-line-height($fs-headlines, 1) * 3,
             ));
         }
-        .linkslist__label {
-            // Make sure 3 lines is the maximum so that elements are balanced
-            // between columns
-            @include text-clamp(3, get-line-height($fs-headlines, 1));
-        }
     }
 }
 

--- a/common/app/views/fragments/items/linksList/comment.scala.html
+++ b/common/app/views/fragments/items/linksList/comment.scala.html
@@ -10,10 +10,8 @@
                 }
             }
         }
-        <span class="linkslist__label">
-            <span class="i i-quote-orange linkslist__icon"></span>
-            @RemoveOuterParaHtml(trail.headline)
-        </span>
+        <span class="i i-quote-orange linkslist__icon"></span>
+        @RemoveOuterParaHtml(trail.headline)
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/gallery.scala.html
+++ b/common/app/views/fragments/items/linksList/gallery.scala.html
@@ -10,10 +10,8 @@
                 }
             }
         }
-        <span class="linkslist__label">
-            <span class="i i-gallery-yellow-small linkslist__icon"></span>
-            @RemoveOuterParaHtml(trail.headline)
-        </span>
+        <span class="i i-gallery-yellow-small linkslist__icon"></span>
+        @RemoveOuterParaHtml(trail.headline)
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/live.scala.html
+++ b/common/app/views/fragments/items/linksList/live.scala.html
@@ -10,10 +10,8 @@
                 }
             }
         }
-        <span class="linkslist__label">
-            <span class="item__live-indicator">Live</span>
-            @RemoveOuterParaHtml(trail.headline)
-        </span>
+        <span class="item__live-indicator">Live</span>
+        @RemoveOuterParaHtml(trail.headline)
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/standard.scala.html
+++ b/common/app/views/fragments/items/linksList/standard.scala.html
@@ -10,9 +10,7 @@
                 }
             }
         }
-        <span class="linkslist__label">
-            @RemoveOuterParaHtml(trail.headline)
-        </span>
+        @RemoveOuterParaHtml(trail.headline)
     </a>
 </li>
 }

--- a/common/app/views/fragments/items/linksList/video.scala.html
+++ b/common/app/views/fragments/items/linksList/video.scala.html
@@ -10,10 +10,8 @@
                 }
             }
         }
-        <span class="linkslist__label">
-            <span class="i i-video-yellow-small linkslist__icon"></span>
-            @RemoveOuterParaHtml(trail.headline)
-        </span>
+        <span class="i i-video-yellow-small linkslist__icon"></span>
+        @RemoveOuterParaHtml(trail.headline)
     </a>
 </li>
 }


### PR DESCRIPTION
Fixes a nasty bug in Safari.
## Before (Safari)

![screen shot 2014-03-06 at 12 38 26](https://f.cloud.github.com/assets/85783/2345017/7006d7ae-a52d-11e3-902d-291fc886700a.PNG)
## After (Safari)

![screen shot 2014-03-06 at 12 38 08](https://f.cloud.github.com/assets/85783/2345018/72e683fc-a52d-11e3-8a61-3ddb5fae3a0c.PNG)

![ ](http://media.giphy.com/media/HPQnQK1dr5LgY/giphy.gif)
