### PR TITLE
Add loading state to containers show more button

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -551,6 +551,14 @@ $show-more-icon: (
     height: 32px,
     space-between: 2px // to avoid overlaps/bleeding on zoom
 );
+
+@-webkit-keyframes spin {
+    0%   { -webkit-transform: rotate(0deg); }
+    25%  { -webkit-transform: rotate(90deg); }
+    50%  { -webkit-transform: rotate(180deg); }
+    75%  { -webkit-transform: rotate(270deg); }
+    100% { -webkit-transform: rotate(360deg); }
+}
 .collection__show-more {
     display: block;
     border: none;
@@ -563,6 +571,7 @@ $show-more-icon: (
     margin-left: -1 * map-get($show-more-icon, width) / 2;
     padding: 0;
     overflow: hidden;
+    -webkit-transform: translateZ(0);
 
     &:hover,
     &:focus,
@@ -574,6 +583,9 @@ $show-more-icon: (
     .i {
         display: block;
         margin-bottom: map-get($show-more-icon, space-between); // a bit of space between icons to avoid
+    }
+    &[disabled] {
+        -webkit-animation: spin 3s cubic-bezier(0.680, -0.550, 0.265, 1.550) forwards infinite;
     }
 }
 .collection__show-more__icon {


### PR DESCRIPTION
We lacked a loading state on our "show more" buttons for connections that are slow to get our content. Here's a cool one. Not too gimmicky I hope!

The animated gif does not do it justice, but here is what it's kind of supposed to look like:

![loader2](https://f.cloud.github.com/assets/85783/2346717/2dbe9914-a545-11e3-8976-44bb1b30e019.gif)
