### PR TITLE
Fix new header for identity pages

### DIFF
--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -2,6 +2,11 @@
 /* Identity and registration
    ========================================================================== */
 
+.identity-header {
+    height: 133px;
+    border-bottom: 2px solid #214583;
+}
+
 .identity-wrapper {
     margin-left: auto;
     margin-right: auto;

--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -2,9 +2,15 @@
 /* Identity and registration
    ========================================================================== */
 
-.identity-header {
-    height: 133px;
-    border-bottom: 2px solid #214583;
+#header.identity-header {
+    height: 44px;
+    background-color: #ffffff;
+
+    @include mq(tablet) {
+        height: 133px;
+        border-bottom: 2px solid #214583;
+        background: $c-neutral8;
+    }
 }
 
 .identity-wrapper {

--- a/identity/app/views/fragments/identityHeader.scala.html
+++ b/identity/app/views/fragments/identityHeader.scala.html
@@ -1,7 +1,7 @@
 @(page: MetaData)(implicit request: RequestHeader)
 @import conf.Switches.{SearchSwitch, ReleaseMessageSwitch, IdentityProfileNavigationSwitch}
 
-<header id="header" role="banner" data-link-name="global navigation: header" itemscope itemtype="http://schema.org/Organization">
+<header id="header" role="banner" data-link-name="global navigation: header" itemscope itemtype="http://schema.org/Organization" class="identity-header">
     <div class="header-pre">
         <div class="header-pre__inner gs-container u-cf">
             <div class="top-nav">


### PR DESCRIPTION
Currently look like this:

![screen shot 2014-03-07 at 07 57 44](https://f.cloud.github.com/assets/1170410/2355460/d4c0208a-a5da-11e3-96a5-dd80522b9585.png)

Changed to look like this:

![new_header](https://f.cloud.github.com/assets/1170410/2355462/dc7e508a-a5da-11e3-91c2-b45220430bf6.png)
