### PR TITLE
Football filter navigation links are readable

### DIFF
--- a/common/app/assets/stylesheets/module/football/_filter.scss
+++ b/common/app/assets/stylesheets/module/football/_filter.scss
@@ -14,6 +14,12 @@
         @include rem((
             line-height: 21px
         ));
+        -webkit-font-smoothing: antialiased;
+
+        &:link,
+        &:visited {
+            color: #ffffff;
+        }
     }
 
     .cta {


### PR DESCRIPTION
Fixing a regression induced by navigation changes.
## Before

![screen shot 2014-03-07 at 12 12 19](https://f.cloud.github.com/assets/85783/2356713/c3eb6208-a5f1-11e3-91df-237856bb78e9.PNG)
## After

![screen shot 2014-03-07 at 12 12 12](https://f.cloud.github.com/assets/85783/2356715/c6885f5c-a5f1-11e3-9b4f-db0e6cdf3f20.PNG)

![ ](http://media.giphy.com/media/g1MPXY9zCbsvC/giphy.gif)
