### PR TITLE
getBreakpoint bug: Make sure document.body exists

### DIFF
--- a/common/app/assets/javascripts/utils/detect.js
+++ b/common/app/assets/javascripts/utils/detect.js
@@ -203,7 +203,7 @@ define([
 
     function getBreakpoint() {
         // default to mobile
-        var breakpoint = window.getComputedStyle(document.body, ':after').getPropertyValue('content') || 'mobile';
+        var breakpoint = (document.body && window.getComputedStyle(document.body, ':after').getPropertyValue('content')) || 'mobile';
         // firefox seems to wrap the value in quotes
         return breakpoint.replace(/^"([^"]*)"$/, "$1");
     }

--- a/common/test/assets/javascripts/spec/Detect.spec.js
+++ b/common/test/assets/javascripts/spec/Detect.spec.js
@@ -114,7 +114,7 @@ define(['common/utils/detect', 'bonzo'], function(detect, bonzo) {
         var breakpointName = 'a-breakpoint',
             style;
 
-        beforeEach(function () {
+        beforeEach(function() {
             // add css to page
             style = bonzo(bonzo.create('<style type="text/css"></style>'))
                 .html('body:after{ content: "' + breakpointName + '"}')
@@ -128,6 +128,11 @@ define(['common/utils/detect', 'bonzo'], function(detect, bonzo) {
 
         it("should be able to get current breakpoint", function() {
             expect(detect.getBreakpoint()).toBe(breakpointName);
+        });
+
+        it('shoule return "mobile" if no css value', function() {
+            style.remove();
+            expect(detect.getBreakpoint()).toBe('mobile');
         });
 
     });


### PR DESCRIPTION
Sometimes failed in IE, `document.body` wasn't ready(?)
