### PR TITLE
Update Sass to 3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "sass", "~> 3.3.0.rc.2"
+gem "sass", "~> 3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.9.3)
-    listen (1.1.6)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-      rb-kqueue (>= 0.2)
-    rb-fsevent (0.9.3)
-    rb-inotify (0.9.2)
-      ffi (>= 0.5.0)
-    rb-kqueue (0.2.0)
-      ffi (>= 0.5.0)
-    sass (3.3.0.rc.2)
-      listen (~> 1.1.0)
+    rake (10.1.1)
+    sass (3.3.0)
+      rake
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  sass (~> 3.3.0.rc.2)
+  sass (~> 3.3.0)


### PR DESCRIPTION
I did a diff between the CSS compiled from Sass 3.3.0-rc.2 and Sass 3.3.0. Files are all the same but global.css. In which case the rules are the same but some media queries are reordered. I couldn't find any regressions.

More about Sass 3.3: http://blog.sass-lang.com/posts/184094-sass-33-is-released

![ ](http://media.giphy.com/media/idxxRzZlSHzSU/giphy.gif)
![ ](http://media.giphy.com/media/idxxRzZlSHzSU/giphy.gif)
![ ](http://media.giphy.com/media/idxxRzZlSHzSU/giphy.gif)
![ ](http://media.giphy.com/media/idxxRzZlSHzSU/giphy.gif)
![ ](http://media.giphy.com/media/idxxRzZlSHzSU/giphy.gif)
