### PR TITLE
Fix concurrent publish

### DIFF
--- a/facia-tool/app/tools/FaciaApi.scala
+++ b/facia-tool/app/tools/FaciaApi.scala
@@ -48,7 +48,12 @@ object FaciaApi extends FaciaApiRead with FaciaApiWrite {
     newBlock
   }
 
-  def publishBlock(id: String, identity: Identity): Option[Block] = getBlock(id) map (updateIdentity(_, identity)) map { block => putBlock(id, block.copy(live = block.draft.getOrElse(Nil), draft = None), identity)}
+  def publishBlock(id: String, identity: Identity): Option[Block] =
+    getBlock(id)
+      .filter(_.draft.isDefined)
+      .map(updateIdentity(_, identity))
+      .map { block => putBlock(id, block.copy(live = block.draft.getOrElse(Nil), draft = None), identity)}
+
   def discardBlock(id: String, identity: Identity): Option[Block] = getBlock(id) map (updateIdentity(_, identity)) map { block => putBlock(id, block.copy(draft = None), identity)}
   def archive(id: String, block: Block, update: JsValue, identity: Identity): Unit = {
     val newBlock: Block = block.copy(diff = Some(update))

--- a/facia-tool/app/tools/FaciaApi.scala
+++ b/facia-tool/app/tools/FaciaApi.scala
@@ -54,7 +54,11 @@ object FaciaApi extends FaciaApiRead with FaciaApiWrite {
       .map(updateIdentity(_, identity))
       .map { block => putBlock(id, block.copy(live = block.draft.get, draft = None), identity)}
 
-  def discardBlock(id: String, identity: Identity): Option[Block] = getBlock(id) map (updateIdentity(_, identity)) map { block => putBlock(id, block.copy(draft = None), identity)}
+  def discardBlock(id: String, identity: Identity): Option[Block] =
+    getBlock(id)
+      .map (updateIdentity(_, identity))
+      .map { block => putBlock(id, block.copy(draft = None), identity)}
+
   def archive(id: String, block: Block, update: JsValue, identity: Identity): Unit = {
     val newBlock: Block = block.copy(diff = Some(update))
     S3FrontsApi.archive(id, Json.prettyPrint(Json.toJson(newBlock)), identity)

--- a/facia-tool/app/tools/FaciaApi.scala
+++ b/facia-tool/app/tools/FaciaApi.scala
@@ -52,7 +52,7 @@ object FaciaApi extends FaciaApiRead with FaciaApiWrite {
     getBlock(id)
       .filter(_.draft.isDefined)
       .map(updateIdentity(_, identity))
-      .map { block => putBlock(id, block.copy(live = block.draft.getOrElse(Nil), draft = None), identity)}
+      .map { block => putBlock(id, block.copy(live = block.draft.get, draft = None), identity)}
 
   def discardBlock(id: String, identity: Identity): Option[Block] = getBlock(id) map (updateIdentity(_, identity)) map { block => putBlock(id, block.copy(draft = None), identity)}
   def archive(id: String, block: Block, update: JsValue, identity: Identity): Unit = {


### PR DESCRIPTION
There is a state between the frontend of facia-tool and the backend of facia-tool where editors have two versions of the tool open, and hitting publish at the same time, which subsequently empties the collection as we are publishing on an empty draft and using `getOrElse(Nil)`.

We always have to be careful around draft as sometimes it does not exist, and this is from the effort to handle empty drafts. Now we only publish drafts that are `isDefined`.
