### PR TITLE
Update Sass 3.3.0 to 3.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "sass", "~> 3.3.0"
+gem "sass", "~> 3.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rake (10.1.1)
-    sass (3.3.0)
-      rake
+    sass (3.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  sass (~> 3.3.0)
+  sass (~> 3.3.1)


### PR DESCRIPTION
Sass 3.3.1 fixes a dependency issue with the Listen gem. Should fix problems for people using Sass' cli watcher.

To watch files directly with Sass:

```
sass -I common/app/assets/stylesheets/components/sass-mq --watch common/app/assets/stylesheets/:static/target/stylesheets/
```

![ ](http://media.giphy.com/media/KnhBjaI9loKIM/giphy.gif)
