### PR TITLE
Fronts: hide images in comment container

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_comment.scss
+++ b/common/app/assets/stylesheets/module/containers/_comment.scss
@@ -57,6 +57,12 @@
         .item:nth-child(4) {
             @include card-image;
         }
+        .item:nth-child(n+5) {
+            .item__image-container,
+            .item__media-wrapper {
+                display: none;
+            }
+        }
         .collection--show-more {
             .item:nth-child(n+5) {
                 display: none;
@@ -65,8 +71,15 @@
     }
     @include mq(desktop) {
         @include first-row(3);
+
         .item:first-child {
             @include card-double-width;
+        }
+        .item:nth-child(n+6) {
+            .item__image-container,
+            .item__media-wrapper {
+                display: none;
+            }
         }
         .item:nth-child(3) {
             @include card-image;

--- a/common/app/assets/stylesheets/module/containers/_sport.scss
+++ b/common/app/assets/stylesheets/module/containers/_sport.scss
@@ -1,8 +1,18 @@
 .container--sport {
     @include mq($to: tablet) {
         @include first-row(1);
+
+        .item__image-container,
+        .item__media-wrapper {
+            display: none;
+        }
         .item:first-child {
             @include card-mobile($with-image: true);
+
+            .item__image-container,
+            .item__media-wrapper {
+                display: block;
+            }
         }
         .collection--without-sport-stats {
             .item:nth-child(n+2):nth-child(-n+5) {
@@ -50,6 +60,13 @@
     }
     @include mq(tablet, desktop) {
         @include first-row(2);
+
+        .item:nth-child(n+7) {
+            .item__image-container,
+            .item__media-wrapper {
+                display: none;
+            }
+        }
         .collection--without-sport-stats {
             .item:nth-child(2),
             .item:nth-child(n+4):nth-child(-n+6) {
@@ -74,8 +91,15 @@
     }
     @include mq(desktop) {
         @include first-row(3);
+
         .item:nth-child(3) {
             @include card-image;
+        }
+        .item:nth-child(n+6) {
+            .item__image-container,
+            .item__media-wrapper {
+                display: none;
+            }
         }
         .collection--without-sport-stats {
             .item:nth-child(2) {


### PR DESCRIPTION
![screen shot 2014-03-11 at 12 38 00](https://f.cloud.github.com/assets/74132/2385215/9342e492-a91a-11e3-8cd3-0244e1b273ed.jpeg)

Note, doesn't look like we're using the sports container anymore
