### PR TITLE
Remove extra hide-on-mobile-inline class

### DIFF
--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -37,14 +37,6 @@
     }
 }
 
-.hide-on-mobile-inline {
-    display: none !important;
-
-    @include mq(tablet) {
-        display: inline !important;
-    }
-}
-
 .is-invisible {
     visibility: hidden;
 }


### PR DESCRIPTION
For some reason it was there twice (probably a bad merge).

![ ](http://media.giphy.com/media/tuWwKRXnNGarK/giphy.gif)
