### PR TITLE
Facia serve tag and section

### DIFF
--- a/facia/app/controllers/IndexController.scala
+++ b/facia/app/controllers/IndexController.scala
@@ -1,0 +1,64 @@
+package controllers
+
+import common._
+import model._
+import play.api.mvc._
+import services.{Index, IndexPage}
+import views.support.TemplateDeduping
+
+
+trait IndexController extends Controller with Index with Logging with Paging with ExecutionContexts {
+
+  implicit def getTemplateDedupingInstance: TemplateDeduping = TemplateDeduping()
+
+  def renderCombiner(leftSide: String, rightSide: String) = DogpileAction { implicit request =>
+    logGoogleBot(request)
+    index(Edition(request), leftSide, rightSide, extractPage(request)).map {
+      case Left(page) => renderFaciaFront(page)
+      case Right(other) => other
+    }
+  }
+
+
+  private def logGoogleBot(request: Request[AnyContent]) = {
+    request.headers.get("User-Agent").filter(_.contains("Googlebot")).foreach { bot =>
+      log.info(s"GoogleBot => ${request.uri}")
+    }
+  }
+
+  def renderJson(path: String) = render(path)
+
+  def render(path: String) = DogpileAction { implicit request =>
+    logGoogleBot(request)
+    index(Edition(request), path, extractPage(request)) map {
+      case Left(model) => renderFaciaFront(model)
+      case Right(other) => other
+    }
+  }
+
+  def renderTrailsJson(path: String) = renderTrails(path)
+  def renderTrails(path: String) = DogpileAction { implicit request =>
+    index(Edition(request), path, extractPage(request)) map {
+      case Left(model) => renderTrailsFragment(model)
+      case Right(notFound) => notFound
+    }
+  }
+
+  private def renderFaciaFront(model: IndexPage)(implicit request: RequestHeader) = {
+    Cached(model.page){
+      if (request.isJson)
+        JsonComponent(
+          "html" -> views.html.fragments.indexBody(model)
+        )
+      else
+        Ok(views.html.index(model))
+    }
+  }
+
+  private def renderTrailsFragment(model: IndexPage)(implicit request: RequestHeader) = {
+    val response = () => views.html.fragments.trailblocks.headline(model.trails, numItemsVisible = model.trails.size)
+    renderFormat(response, response, model.page)
+  }
+}
+
+object IndexController extends IndexController

--- a/facia/app/services/repositories.scala
+++ b/facia/app/services/repositories.scala
@@ -1,0 +1,140 @@
+package services
+
+import model._
+import conf.SwitchingContentApi
+import model.Section
+import common._
+import com.gu.openplatform.contentapi.model.{SearchResponse, ItemResponse}
+import org.joda.time.DateTime
+import org.scala_tools.time.Implicits._
+import contentapi.QueryDefaults
+//import controllers.ImageContentPage
+import scala.concurrent.Future
+import play.api.mvc.{RequestHeader, SimpleResult}
+import com.gu.openplatform.contentapi.ApiError
+
+object IndexPagePagination {
+  def pageSize: Int = 20 //have a good think before changing this
+}
+
+case class IndexPage(page: MetaData, trails: Seq[Content])
+
+trait Index extends ConciergeRepository with QueryDefaults {
+
+  def index(edition: Edition, leftSide: String, rightSide: String, page: Int): Future[Either[IndexPage, SimpleResult]] = {
+
+    val section = leftSide.split('/').head
+
+    // if the first tag is just one part then change it to a section tag...
+    val firstTag = leftSide match {
+      case SinglePart(wordsForUrl) => s"$wordsForUrl/$wordsForUrl"
+      case other => other
+    }
+
+    // if the second tag is just one part then it is in the same section as the first tag...
+    val secondTag = rightSide match {
+      case SinglePart(wordsForUrl) => s"$section/$wordsForUrl"
+      case SeriesInSameSection(series) => s"$section/$series"
+      case other => other
+    }
+
+    val promiseOfResponse = SwitchingContentApi().search(edition)
+      .tag(s"$firstTag,$secondTag")
+      .page(page)
+      .pageSize(IndexPagePagination.pageSize)
+      .response.map {response =>
+        val trails = response.results map { Content(_) }
+        trails match {
+          case Nil => Right(NotFound)
+          case head :: _ =>
+            //we can use .head here as the query is guaranteed to return the 2 tags
+            val tag1 = head.tags.find(_.id == firstTag).head
+            val tag2 = head.tags.find(_.id == secondTag).head
+            val pageName = s"${tag1.name} + ${tag2.name}"
+            val page = Page(s"$leftSide+$rightSide", tag1.section, pageName,
+              s"GFE:${tag1.section}:$pageName", pagination = pagination(response))
+
+            Left(IndexPage(page, trails))
+        }
+    }
+
+    promiseOfResponse.recover(convertApiExceptions)
+      //this is the best handle we have on a wrong 'page' number
+      .recover{ case ApiError(400, _) => Right(Found(s"/$leftSide+$rightSide")) }
+  }
+
+  private def pagination(response: ItemResponse) = Some(Pagination(
+    response.currentPage.getOrElse(1),
+    response.pages.getOrElse(1),
+    response.total.getOrElse(0)
+  ))
+
+  private def pagination(response: SearchResponse) = Some(Pagination(
+    response.currentPage,
+    response.pages,
+    response.total
+  ))
+
+  def index(edition: Edition, path: String, pageNum: Int)(implicit request: RequestHeader): Future[Either[IndexPage, SimpleResult]] = {
+    val promiseOfResponse = SwitchingContentApi().item(path, edition)
+      .page(pageNum)
+      .pageSize(IndexPagePagination.pageSize)
+      .showEditorsPicks(pageNum == 1) //only show ed pics on first page
+      .response.map {
+      response =>
+        val page = response.tag.flatMap(t => tag(response, pageNum))
+          .orElse(response.section.flatMap(t => section(response)))
+        ModelOrResult(page, response)
+    }
+    promiseOfResponse.recover(convertApiExceptions)
+      //this is the best handle we have on a wrong 'page' number
+      .recover{ case ApiError(400, _) => Right(Found(s"/$path")) }
+  }
+
+
+
+  private def section(response: ItemResponse) = {
+      val section = response.section.map{Section(_, pagination(response))}
+      val editorsPicks = response.editorsPicks.map(Content(_))
+      val editorsPicksIds = editorsPicks.map(_.id)
+      val latestContent = response.results.map(Content(_)).filterNot(c => editorsPicksIds contains c.id)
+      val trails = editorsPicks ++ latestContent
+      section.map(IndexPage(_, trails))
+  }
+
+  private def tag(response: ItemResponse, page: Int) = {
+    val tag = response.tag map { new Tag(_, pagination(response)) }
+    val leadContentCutOff = DateTime.now - leadContentMaxAge
+    val editorsPicks = response.editorsPicks.map(Content(_))
+    val leadContent = if (editorsPicks.isEmpty && page == 1) //only promote lead content on first page
+      response.leadContent.take(1).map(Content(_)).filter(_.webPublicationDate > leadContentCutOff)
+    else
+      Nil
+
+    val latest: Seq[Content] = response.results.map(Content(_)).filterNot(c => leadContent.map(_.id).exists(_ == c.id))
+    val allTrails = (leadContent ++ editorsPicks ++ latest).distinctBy(_.id)
+    tag map { IndexPage(_, allTrails) }
+  }
+
+  // for some reason and for the life of me I cannot figure it out, this does not compile if these
+  // are at the top of the file :(
+  val SinglePart = """([\w\d\.-]+)""".r
+  val SeriesInSameSection = """(series/[\w\d\.-]+)""".r
+}
+
+//trait ImageQuery extends ConciergeRepository with QueryDefaults {
+//
+//  def image(edition: Edition, path: String): Future[Either[ImageContentPage, SimpleResult]]= {
+//    log.info(s"Fetching image content: $path for edition ${edition.id}")
+//    val response = SwitchingContentApi().item(path, edition)
+//      .showExpired(true)
+//      .showFields("all")
+//      .response.map { response =>
+//      val mainContent: Option[Content] = response.content.filter { c => c.isImageContent } map {Content(_)}
+//      val storyPackage: List[Trail] = response.storyPackage map { Content(_) }
+//      mainContent.map { content => Left(ImageContentPage(content,storyPackage)) }.getOrElse(Right(NotFound))
+//    }
+//
+//    response recover convertApiExceptions
+//  }
+//}

--- a/facia/app/services/repositories.scala
+++ b/facia/app/services/repositories.scala
@@ -121,20 +121,3 @@ trait Index extends ConciergeRepository with QueryDefaults {
   val SinglePart = """([\w\d\.-]+)""".r
   val SeriesInSameSection = """(series/[\w\d\.-]+)""".r
 }
-
-//trait ImageQuery extends ConciergeRepository with QueryDefaults {
-//
-//  def image(edition: Edition, path: String): Future[Either[ImageContentPage, SimpleResult]]= {
-//    log.info(s"Fetching image content: $path for edition ${edition.id}")
-//    val response = SwitchingContentApi().item(path, edition)
-//      .showExpired(true)
-//      .showFields("all")
-//      .response.map { response =>
-//      val mainContent: Option[Content] = response.content.filter { c => c.isImageContent } map {Content(_)}
-//      val storyPackage: List[Trail] = response.storyPackage map { Content(_) }
-//      mainContent.map { content => Left(ImageContentPage(content,storyPackage)) }.getOrElse(Right(NotFound))
-//    }
-//
-//    response recover convertApiExceptions
-//  }
-//}

--- a/facia/app/services/repositories.scala
+++ b/facia/app/services/repositories.scala
@@ -8,7 +8,6 @@ import com.gu.openplatform.contentapi.model.{SearchResponse, ItemResponse}
 import org.joda.time.DateTime
 import org.scala_tools.time.Implicits._
 import contentapi.QueryDefaults
-//import controllers.ImageContentPage
 import scala.concurrent.Future
 import play.api.mvc.{RequestHeader, SimpleResult}
 import com.gu.openplatform.contentapi.ApiError

--- a/facia/app/views/fragments/indexBody.scala.html
+++ b/facia/app/views/fragments/indexBody.scala.html
@@ -1,0 +1,11 @@
+@(index: services.IndexPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
+
+<div class="facia-container facia-container--layout-front monocolumn-wrapper monocolumn-wrapper--no-limit" data-link-name="Front" role="main">
+
+    @fragments.containers.tag(index.page, Config(s"${index.page.id}/news/regular-stories", displayName = Some(index.page.webTitle)), Collection(index.trails), NewsContainer(showMore = false), containerIndex = 0, pagination = index.page.pagination)
+
+    <section class="no-indent-article__zone">
+        @fragments.footballNav(index.page)
+    </section>
+
+</div>

--- a/facia/app/views/index.scala.html
+++ b/facia/app/views/index.scala.html
@@ -1,0 +1,7 @@
+@(index: services.IndexPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
+
+@main(index.page, projectName = Option("facia")){  }{
+
+    @fragments.indexBody(index)
+
+}

--- a/facia/test/FaciaFeatureTest.scala
+++ b/facia/test/FaciaFeatureTest.scala
@@ -1,24 +1,39 @@
 package test
 
-import org.scalatest.Matchers
-import org.scalatest.{ GivenWhenThen, FeatureSpec }
+import org.scalatest.{BeforeAndAfter, Matchers, GivenWhenThen, FeatureSpec}
 import collection.JavaConversions._
+import conf.Switches
 
-class FaciaFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
+class FaciaFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with BeforeAndAfter {
 
+  before {
+    Switches.PressedFacia.switchOn()
+  }
 
   feature("Facia") {
 
     // Scenarios
 
-    ignore("Display the news container") {
+    scenario("Display the news container") {
 
       Given("I am on the UK network front")
       HtmlUnit("/uk") { browser =>
         import browser._
 
-        Then("I should see the new container")
+        browser.webDriver.getPageSource.length should be > 0
+        Then("I should see the news container")
         $("section[data-id='uk/news/regular-stories']").length should be(1)
+      }
+    }
+
+    scenario("Render a tag page if it is not in config.json") {
+
+      Given("I go to a tag page")
+      HtmlUnit("/sport/cycling") { browser =>
+        import browser._
+
+        Then("I should see only the tag and most popular")
+        $("section[data-id='sport/cycling/news/regular-stories']").length should be(1)
       }
     }
 

--- a/facia/test/IndexControllerTest.scala
+++ b/facia/test/IndexControllerTest.scala
@@ -1,0 +1,108 @@
+package test
+
+import play.api.test._
+import play.api.test.Helpers._
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+
+class IndexControllerTest extends FlatSpec with Matchers {
+
+  val section = "books"
+  val callbackName = "aFunction"
+
+  "Index Controller" should "200 when content type is front" in Fake {
+    val result = controllers.IndexController.render(section)(TestRequest(s"/$section"))
+    status(result) should be(200)
+  }
+
+  it should "return JSONP when callback is supplied to front" in Fake {
+    val fakeRequest = TestRequest(s"/$section?callback=$callbackName")
+      .withHeaders("host" -> "localhost:9000")
+
+    val result = controllers.IndexController.render(section)(fakeRequest)
+    status(result) should be(200)
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
+    contentAsString(result) should startWith(s"""$callbackName({\"html\"""")
+  }
+
+  it should "return JSON when .json format is supplied to front" in Fake {
+    val fakeRequest = TestRequest(s"/$section.json")
+      .withHeaders("host" -> "localhost:9000")
+      .withHeaders("Origin" -> "http://www.theorigin.com")
+
+    val result = controllers.IndexController.render(section)(fakeRequest)
+    status(result) should be(200)
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
+    contentAsString(result) should startWith("{\"html\"")
+  }
+
+  it should "internal redirect when content type is not front" in Fake {
+    val result = controllers.IndexController.render("world/video/2012/feb/10/inside-tibet-heart-protest-video")(TestRequest("/world/video/2012/feb/10/inside-tibet-heart-protest-video"))
+    status(result) should be(200)
+    header("X-Accel-Redirect", result).get should be("/type/video/world/video/2012/feb/10/inside-tibet-heart-protest-video")
+  }
+
+  it should "200 when content type is front trails" in Fake {
+    val result = controllers.IndexController.renderTrails(section)(TestRequest(s"/$section"))
+    status(result) should be(200)
+  }
+
+  it should "redirect when content api says it is on the wrong web url" in Fake {
+
+    val result = controllers.IndexController.render("type/video")(TestRequest("/type/video"))
+
+    status(result) should be (302)
+    header("Location", result).get should be ("/video")
+  }
+
+  // ignore while content api fixes a field in elastic search...
+  ignore should "correctly redirect short urls to other servers" in Fake {
+
+    val result = controllers.IndexController.render("p/3jdag")(TestRequest("/p/3jdag"))
+
+    status(result) should be (302)
+    header("Location", result).get should be ("/music/2013/oct/11/david-byrne-internet-content-world")
+  }
+
+  it should "return JSONP when callback is supplied to front trails" in Fake {
+    val fakeRequest = FakeRequest(GET, s"$section/trails?callback=$callbackName")
+      .withHeaders("host" -> "localhost:9000")
+
+    val result = controllers.IndexController.renderTrails(section)(fakeRequest)
+    status(result) should be(200)
+    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
+    contentAsString(result) should startWith(s"""$callbackName({\"html\"""")
+  }
+
+  it should "return JSON when .json format is supplied to front trails" in Fake {
+    val fakeRequest = FakeRequest(GET, s"$section/trails.json")
+      .withHeaders("host" -> "localhost:9000")
+      .withHeaders("Origin" -> "http://www.theorigin.com")
+
+    val result = controllers.IndexController.renderTrails(section)(fakeRequest)
+    status(result) should be(200)
+    header("Content-Type", result).get should be("application/json; charset=utf-8")
+    contentAsString(result) should startWith("{\"html\"")
+  }
+
+  it should "redirect tag to first page if pagination goes beyond last page" in {
+
+    val request = FakeRequest(GET, "/sport/cycling?page=10000")
+    val result = controllers.IndexController.render("/sport/cycling")(request)
+
+    // temporary as this page may well exist tomorrow
+    status(result) should be (302)
+    header("Location", result).get should endWith ("/sport/cycling")
+
+  }
+
+  it should "redirect tag combiner to first page if pagination goes beyond last page" in {
+
+    val request = FakeRequest(GET, "/books+tone/reviews?page=10000")
+    val result = controllers.IndexController.renderCombiner("books", "tone/reviews")(request)
+
+    // temporary as this page may well exist tomorrow
+    status(result) should be (302)
+    header("Location", result).get should endWith ("/books+tone/reviews")
+  }
+}

--- a/facia/test/SectionTemplateTest.scala
+++ b/facia/test/SectionTemplateTest.scala
@@ -1,0 +1,20 @@
+package test
+
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+import scala.collection.JavaConversions._
+
+class SectionTemplateTest extends FlatSpec with Matchers {
+
+  it should "render front title" in HtmlUnit("/uk-news") { browser =>
+    import browser._
+    $(".container__title").first.getText should be ("UK news")
+  }
+
+  it should "render section navigation" in  HtmlUnit("/books") { browser =>
+      import browser._
+      val navigation = findFirst("[itemtype='http://data-vocabulary.org/Breadcrumb']")
+      navigation.findFirst("[itemprop='url']").getAttribute("href") should endWith ("/uk/culture")
+      navigation.find("[itemprop='url']")(1).getAttribute("href") should endWith ("/books")
+  }
+}

--- a/facia/test/TagFeatureTest.scala
+++ b/facia/test/TagFeatureTest.scala
@@ -1,0 +1,123 @@
+package test
+
+import org.scalatest.{ FeatureSpec, GivenWhenThen }
+import org.scalatest.Matchers
+import collection.JavaConversions._
+import conf.{Switches, Configuration}
+import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
+
+class TagFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
+
+  feature("Tag Pages trail size") {
+
+    scenario("Tag pages should show at least 20 trails (includes  leadContent if present)") {
+
+      Given("I visit a tag page")
+
+      HtmlUnit("/technology/askjack") { browser =>
+        import browser._
+        val trails = $(".fromage, .collection__item, .linkslist__item")
+        trails.length should be(20)
+      }
+
+    }
+
+  }
+
+  feature("Contributor pages") {
+
+    scenario("Should display the profile images") {
+
+      Given("I visit the 'Jemima Kiss' contributor page")
+      Switches.ImageServerSwitch.switchOn()
+
+      HtmlUnit("/profile/jemimakiss") { browser =>
+        import browser._
+        Then("I should see her profile image")
+        val profileImage = findFirst(".profile__img img")
+        profileImage.getAttribute("src") should be(s"${Configuration.images.path}/sys-images/Media/Columnists/Columnists/2013/11/8/1383915783233/Jemima-Kiss-2-003.jpg?width=140&height=140&quality=95")
+      }
+    }
+
+    scenario("Should not not display profiles where they don't exist") {
+      Given("I visit the 'Sam Jones' contributor page")
+      HtmlUnit("/profile/samjones") { browser =>
+        import browser._
+        Then("I should not see her profile image")
+        val profileImages = find(".profile__img img")
+        profileImages.length should be(0)
+      }
+
+    }
+  }
+
+  feature("Tag Pages Football Nav") {
+
+    scenario("Tags that are football competitions that have teams, link to that place on the teams page") {
+
+      Given("I visit the 'Premier League' tag page")
+
+      HtmlUnit("/football/premierleague") { browser =>
+        import browser._
+        val teamsPageLink = findFirst("ul.nav a[data-link-name='teams']")
+        teamsPageLink.getAttribute("href") should endWith("/football/teams#premierleague")
+      }
+
+    }
+
+    scenario("Tags that are football compeitions but don't have teams don't link to the teams page") {
+
+      Given("I visit the 'Capital One Cup' tag page")
+
+      HtmlUnit("/football/capital-one-cup") { browser =>
+        import browser._
+        val teamsPageLinks = $("ul.nav a[data-link-name='teams']")
+        teamsPageLinks.length should be(0)
+      }
+
+      Given("I visit the 'Scottish League Cup' tag page")
+
+      HtmlUnit("/football/cis-insurance-cup") { browser =>
+        import browser._
+        val teamsPageLinks = $("ul.nav a[data-link-name='teams']")
+        teamsPageLinks.length should be(0)
+      }
+
+    }
+
+    scenario("Pagination") {
+
+      Given("I visit the 'Cycling' tag page")
+
+      HtmlUnit("/sport/cycling") { browser =>
+        import browser._
+
+        val linksOnFirstPage = findFirst(".container__body").find("a").map(_.getAttribute("href"))
+        linksOnFirstPage.size should be > 10
+        findByRel($("link"), "next").head.getAttribute("href") should endWith ("/sport/cycling?page=2")
+        findByRel($("link"), "prev") should be (None)
+
+        Then("I should be able to navigate to the 'next' page")
+        findFirst(".pagination").findFirst("[rel=next]").click()
+        val linksOnNextPage = findFirst(".container__body").find("a").map(_.getAttribute("href"))
+        linksOnNextPage.size should be > 10
+
+        findByRel($("link"), "next").head.getAttribute("href") should endWith ("/sport/cycling?page=3")
+        findByRel($("link"), "prev").head.getAttribute("href") should endWith ("/sport/cycling")
+
+        linksOnNextPage.foreach( linksOnFirstPage should not contain _ )
+
+        And("The title should reflect the page number")
+        findFirst("title").getText should include ("| Page 2 of")
+
+        And("I should be able to navigate to the 'previous' page")
+        findFirst(".pagination").findFirst("[rel=prev]").click()
+        val linksOnPreviousPage = findFirst(".container__body").find("a").map(_.getAttribute("href"))
+        linksOnPreviousPage should equal (linksOnFirstPage)
+      }
+    }
+  }
+
+  //I'm not having a happy time with the selectors on links...
+  private def findByRel(elements: FluentList[FluentWebElement], rel: String) = elements.toSeq.find(_.getAttribute("rel") == rel)
+}

--- a/facia/test/TagTemplateTest.scala
+++ b/facia/test/TagTemplateTest.scala
@@ -1,0 +1,13 @@
+package test
+
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+
+class TagTemplateTest extends FlatSpec with Matchers {
+
+  it should "render tag headline" in HtmlUnit("/world/turkey") { browser =>
+    import browser._
+
+    $(".container__title").first.getText should be ("Turkey")
+  }
+}


### PR DESCRIPTION
This is the initial move of the code from `applications` to `facia`, in order for `facia` to start serving Section and Tag pages.

It's mainly a move of `IndexController.scala`, and `repositories.scala` which contains `trait Index`, `case class IndexPage` and `object IndexPagePagination`.

`renderFront` in `FaciaController` checks to see if it can handle the incoming path by checking what is inside the `config.json` file. If it is there, it will continue to serve it as a page from `FaciaController`, otherwise it passes on the request to `IndexController`.

There are a few things to do after this PR;
- Remove anything unnecessary from the new code
- Sort out `routes` file in `facia` and `dev-build`

I would rather make these changes in separate smaller PRs as the routes are a bit fiddly. It all seems to work fine for the time being. I was worried about perhaps `IndexController` having the same name in two places, but this didn't seem to harm anything, with the only place I can really seeing it being a problem being in `dev-build`. If it is a problem I will rename it to `FaciaIndexController`.

One thing that is different between the files is the removal of `trait ImageQuery` from `repositories.scala`.

@gklopper 
