### PR TITLE
sprinkle data-component-names in article components

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -4,7 +4,7 @@
 @defining((model.article, model.storyPackage)) { case (article, storyPackage) =>
 
     <h2 class="article__zone left-col-deport tone-@VisualTone(article) tone-accent-border">
-        <span class="left-col-deport__body">
+        <span class="left-col-deport__body" data-component="article-meta">
             <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>
         </span>
     </h2>
@@ -62,7 +62,7 @@
 
                     @fragments.contentMeta(article)
 
-                    <div class="js-article__container article__container u-cf">
+                    <div class="js-article__container article__container u-cf" data-component="article-body">
                         <div class="article-body u-cf from-content-api js-article__body"
                         itemprop="@if(article.isReview){reviewBody} else {articleBody}">
                             @BodyCleaner(article, article.body)
@@ -86,7 +86,7 @@
                                 <div class="u-table__cell u-table__cell--top">
                                     <div class="mpu-context js-right-hand-component">
                                         <div class="mpu-container js-mpu-ad-slot">
-                                            <div class="social-wrapper social-wrapper--aside">
+                                            <div class="social-wrapper social-wrapper--aside" data-component="article-share">
                                                 <h2 class="article__meta-heading">Share this article</h2>
                                                 @fragments.social(article, "next to content")
                                             </div>
@@ -103,7 +103,7 @@
         </article>
 
         @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {
-            <div class="article__inner js-comments">
+            <div class="article__inner js-comments" data-component="article-comments" data-component="discussion">
                 @fragments.discussion(article.isClosedForComments, article.shortUrlId)
             </div>
         }

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -103,7 +103,7 @@
         </article>
 
         @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {
-            <div class="article__inner js-comments" data-component="article-comments" data-component="discussion">
+            <div class="article__inner js-comments" data-component="discussion">
                 @fragments.discussion(article.isClosedForComments, article.shortUrlId)
             </div>
         }

--- a/common/app/assets/javascripts/modules/onward/right-outbrain-recommendations.js
+++ b/common/app/assets/javascripts/modules/onward/right-outbrain-recommendations.js
@@ -33,7 +33,7 @@ define([
     RightOutbrainRecommendations.prototype.classes = { items: 'items' };
     RightOutbrainRecommendations.prototype.useBem = true;
 
-    RightOutbrainRecommendations.prototype.template = '<div class="right-recommended"><h3 class="right-recommended__title">Recommended for you</h3>' +
+    RightOutbrainRecommendations.prototype.template = '<div class="right-recommended" data-component="right-outbrain-recommendations"><h3 class="right-recommended__title">Recommended for you</h3>' +
         '<ul class="right-recommended__items u-unstyled"></ul></div></div>';
 
     RightOutbrainRecommendations.prototype.fetch = function(config) {

--- a/common/app/assets/javascripts/modules/onward/right-recommended.js
+++ b/common/app/assets/javascripts/modules/onward/right-recommended.js
@@ -51,7 +51,7 @@ define([
     RightRecommendedForYou.prototype.classes = { items: 'items' };
     RightRecommendedForYou.prototype.useBem = true;
 
-    RightRecommendedForYou.prototype.template = '<div class="right-recommended data-component="right-gravity-recommendations"><h3 class="right-recommended__title">Recommended for you</h3>' +
+    RightRecommendedForYou.prototype.template = '<div class="right-recommended" data-comsponent="right-gravity-recommendations"><h3 class="right-recommended__title">Recommended for you</h3>' +
         '<ul class="right-recommended__items u-unstyled"></ul></div></div>';
 
     RightRecommendedForYou.prototype.fetch = function() {

--- a/common/app/assets/javascripts/modules/onward/right-recommended.js
+++ b/common/app/assets/javascripts/modules/onward/right-recommended.js
@@ -51,7 +51,7 @@ define([
     RightRecommendedForYou.prototype.classes = { items: 'items' };
     RightRecommendedForYou.prototype.useBem = true;
 
-    RightRecommendedForYou.prototype.template = '<div class="right-recommended"><h3 class="right-recommended__title">Recommended for you</h3>' +
+    RightRecommendedForYou.prototype.template = '<div class="right-recommended data-component="right-gravity-recommendations"><h3 class="right-recommended__title">Recommended for you</h3>' +
         '<ul class="right-recommended__items u-unstyled"></ul></div></div>';
 
     RightRecommendedForYou.prototype.fetch = function() {

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,7 +1,7 @@
 @(page: MetaData)(implicit request: RequestHeader)
 @import conf.Switches._
 
-<footer class="footer u-cf" data-link-name="footer">
+<footer class="footer u-cf" data-link-name="footer" data-component="footer">
     <div class="footer__primary">
         <div id="footer-nav">
             <div class="footer__banner u-cf">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -22,7 +22,7 @@ to apply any necessary changes to non-shared code there too.
                     </a>
                 </div>
                 @if(SearchSwitch.isSwitchedOn) {
-                    <div class="top-nav__item">
+                    <div class="top-nav__item" data-component="search">
                         <a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax data-link-name="Search icon" 
                            class="control control--search js-search-toggle" data-toggle="nav-popup--search">
                            <span class="u-h">Search</span>
@@ -33,7 +33,7 @@ to apply any necessary changes to non-shared code there too.
                         </a>
                     </div>
                 }
-                <div class="top-nav__item hide-on-mobile">
+                <div class="top-nav__item hide-on-mobile" data-component="edition">
                     <div class="preheader__editions">
                         <dl class="editions">
                             <dt class="editions__title">
@@ -55,7 +55,7 @@ to apply any necessary changes to non-shared code there too.
                     </div>
                 </div>
                 @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
-                    <div class="top-nav__item">
+                    <div class="top-nav__item" data-component="identity-profile">
                         <div class="js-profile-nav js-hidden">
                             <a href="@Configuration.id.url/signin" data-link-name="User profile" data-toggle="nav-popup--profile"
                                class="control control--profile">
@@ -100,7 +100,7 @@ to apply any necessary changes to non-shared code there too.
             *@
             <div itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
                 @* Top level nav *@
-                <div class="nav-container u-cf">
+                <div class="nav-container u-cf" data-component="navigation">
                     <div class="gs-container">
                         <ul class="nav nav--global" data-link-name="Sections">
                             @navigation.map { nav =>

--- a/common/app/views/fragments/headline.scala.html
+++ b/common/app/views/fragments/headline.scala.html
@@ -1,2 +1,2 @@
 @(headline: String, classes: List[String] = Nil)(implicit request: RequestHeader)
-<h1 itemprop="headline"  data-component="title" class="article__headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>
+<h1 itemprop="headline" data-component="title" class="article__headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>

--- a/common/app/views/fragments/headline.scala.html
+++ b/common/app/views/fragments/headline.scala.html
@@ -1,2 +1,2 @@
 @(headline: String, classes: List[String] = Nil)(implicit request: RequestHeader)
-<h1 itemprop="headline" class="article__headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>
+<h1 itemprop="headline"  data-component="title" class="article__headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>

--- a/common/app/views/fragments/headline.scala.html
+++ b/common/app/views/fragments/headline.scala.html
@@ -1,2 +1,2 @@
 @(headline: String, classes: List[String] = Nil)(implicit request: RequestHeader)
-<h1 itemprop="headline" data-component="title" class="article__headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>
+<h1 itemprop="headline" class="article__headline @if(classes.nonEmpty){ @classes.mkString(" ")}">@Html(headline)</h1>

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -2,7 +2,7 @@
 @import views.support.{ImgSrc, Item220, Item620}
 
 @image.map{ picture =>
-    <figure itemprop="associatedMedia primaryImageOfPage" itemscope itemtype="http://schema.org/ImageObject" class="media-primary media-content">
+    <figure itemprop="associatedMedia primaryImageOfPage" itemscope itemtype="http://schema.org/ImageObject" class="media-primary media-content" data-component="image">
         <div class="js-image-upgrade" data-src="@ImgSrc.imager(picture, Item620).map(Html(_))">
             <img src="@Item220.bestFor(picture).map(Html(_))"
                  class="maxed responsive-img"

--- a/common/app/views/fragments/meta/byline.scala.html
+++ b/common/app/views/fragments/meta/byline.scala.html
@@ -1,5 +1,5 @@
 @(byline: Option[String], tags: Tags)
 
 @byline.map { text =>
-    <p class="byline" data-link-name="byline">@ContributorLinks(text, tags.contributors)</p>
+    <p class="byline" data-link-name="byline" data-component="meta-byline">@ContributorLinks(text, tags.contributors)</p>
 }

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -1,7 +1,7 @@
 @(section: String)(implicit request: RequestHeader)
 
 @defining(Some(section).filter{ section => section.nonEmpty && !section.equals("global")}.map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
-    <div class="article-wrapper monocolumn-wrapper tone-feature">
+    <div class="article-wrapper monocolumn-wrapper tone-feature" data-component="popular-in-section">
         <div class="js-popular article__popular container--popular no-indent-article__zone">
             <h2 class="article__zone tone-border">
                 <a class="most-viewed-no-js tone-colour" href="@LinkTo{@url}" data-link-name="Most viewed @section">Most popular

--- a/common/app/views/fragments/relatedTrails.scala.html
+++ b/common/app/views/fragments/relatedTrails.scala.html
@@ -1,7 +1,7 @@
-@(trails: Seq[Trail], heading: String, visibleTrails: Int = 5)(implicit request: RequestHeader)
+@(trails: Seq[Trail], heading: String, visibleTrails: Int = 5, dataComponent: String = "")(implicit request: RequestHeader)
 
 @defining(trails.length){ numTrails =>
-    <div class="facia-container facia-container--layout-article monocolumn-wrapper monocolumn-wrapper--no-limit">
+    <div class="facia-container facia-container--layout-article monocolumn-wrapper monocolumn-wrapper--no-limit" @if(!dataComponent.isEmpty){data-component="@dataComponent"}>
         <div class="container container--row-pattern">
             <div class="container__border hide-on-mobile"></div>
             <h2 id="related-content-head" class="container__title">

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,7 +1,7 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
 @* live with empty standfirst as it is used to hook things into the page with javascript *@
-<div class="article__standfirst" itemprop="description" data-link-name="standfirst">
+<div class="article__standfirst" itemprop="description" data-link-name="standfirst" data-component="standfirst">
     @content.standfirst.map { s =>
         @withJsoup(BulletCleaner(s))(
             InBodyLinkCleaner("in standfirst link")(Edition(request))

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -2,7 +2,7 @@
 
 @if(storyPackage.nonEmpty) {
     <aside role="complementary" class="related more-on-this-story@if(storyPackage.size == 1){ more-on-this-story--one-item}">
-    @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 15)
+    @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 15, dataComponent = "related-content")
     </aside>
 }
 <aside class="related js-related" role="complementary"></aside>

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -2,7 +2,7 @@
 
 @if(storyPackage.nonEmpty) {
     <aside role="complementary" class="related more-on-this-story@if(storyPackage.size == 1){ more-on-this-story--one-item}">
-    @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 15, dataComponent = "related-content")
+    @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 15, dataComponent = "story-package")
     </aside>
 }
-<aside class="related js-related" role="complementary"></aside>
+<aside class="related js-related" role="complementary" data-component="related-content"></aside>

--- a/onward/app/views/fragments/rightMostPopular.scala.html
+++ b/onward/app/views/fragments/rightMostPopular.scala.html
@@ -1,6 +1,6 @@
 @(popular: model.MostPopular)(implicit request: RequestHeader)
 
-<div class="right-most-popular right-most-popular--image">
+<div class="right-most-popular right-most-popular--image" data-component="right-most-popular">
     <h3 class="right-most-popular__title">Most popular</h3>
     <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular">
         @popular.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>

--- a/onward/app/views/fragments/rightMostPopularGeo.scala.html
+++ b/onward/app/views/fragments/rightMostPopularGeo.scala.html
@@ -1,6 +1,6 @@
 @(popular: model.MostPopular, country: Option[String], countryCode: String)(implicit request: RequestHeader)
 
-<div class="right-most-popular right-most-popular--image">
+<div class="right-most-popular right-most-popular--image" data-component="geo-most-popular">
     <h3 class="right-most-popular__title">Most popular @{country.map{ name => s"in ${name}"}}</h3>
     <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular geo @countryCode">
         @popular.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>


### PR DESCRIPTION
Sprinkles data-component tags throughout the article dom for use with the module-register

Global nav
- search
- edition
- identity-profile
- article-meta

Global Furniture
- title
- image
- standfirst
- footer

Article specific stuff
- popular-in-section
- right-outbrain-recommendations
- right-gravity-recommendation
- right-most-popular
- geo-most-popular
