### PR TITLE
Move app entry point

### DIFF
--- a/common/app/assets/javascripts/bootstraps/go.js
+++ b/common/app/assets/javascripts/bootstraps/go.js
@@ -4,5 +4,7 @@ require([
 ], function(
     bootstrap
 ) {
-    bootstrap.go();
+    if (guardian.isModernBrowser) {
+        bootstrap.go();
+    }
 });

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -23,7 +23,8 @@
         css: {
             loaded: false,
             gallery: '@Static("stylesheets/gallery.css")'
-        }
+        },
+        config: @fragments.javaScriptConfig(item)
     },
     curl = {
         baseUrl: '@{Configuration.assets.path}javascripts',
@@ -42,6 +43,10 @@
     };
 
     (function(isModern) {
+
+        // must always be set before the Omniture file is parsed
+        window.s_account = guardian.config.page.omnitureAccount;
+
         if (!isModern) { return false; }
 
         @if(CssFromStorageSwitch.isSwitchedOn && !play.Play.isDev()) {
@@ -164,12 +169,7 @@
             loadCssFromStorage();
         }
 
-        guardian.config = @fragments.javaScriptConfig(item);
-
         containersAb(guardian.config.switches);
-
-        // must be set before the Omniture file is parsed
-        window.s_account = guardian.config.page.omnitureAccount;
 
     })(guardian.isModernBrowser);
 </script>

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -171,10 +171,8 @@
         // must be set before the Omniture file is parsed
         window.s_account = guardian.config.page.omnitureAccount;
 
-        var script = document.createElement('script');
-        script.async = 'async';
-        script.src = '@Static("javascripts/bootstraps/app.js")';
-
-        document.getElementsByTagName("head")[0].appendChild(script);
     })(guardian.isModernBrowser);
+</script>
+
+<script defer="defer" src="@Static("javascripts/bootstraps/app.js")">
 </script>

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -174,5 +174,4 @@
     })(guardian.isModernBrowser);
 </script>
 
-<script defer="defer" src="@Static("javascripts/bootstraps/app.js")">
-</script>
+<script defer="defer" src="@Static("javascripts/bootstraps/app.js")"></script>

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -27,9 +27,6 @@
     <link rel="dns-prefetch" href="//oas.theguardian.com" />
     <link rel="dns-prefetch" href="//beacon.www.theguardian.com" />
 
-    @* http://www.chromium.org/spdy/link-headers-and-server-hint/link-rel-subresource *@
-    <link rel="subresource" href="@Static("javascripts/bootstraps/app.js")" />
-
     @item.pagination.map{ pagination =>
         @pagination.next.map{ next => <link rel="next" href="@LinkTo(item.url)?page=@next" /> }
         @pagination.previous.map{ prev => <link rel="prev" href="@LinkTo(item.url)@if(prev != 1){?page=@prev}" /> }


### PR DESCRIPTION
Moving the app entry point. We are trying to measure the delay between the app beginning, and a component finishing. But currently, the app starts quite late.

Any resource that is in the document, rather than added to the doc through js, is more likely to be look-ahead-loaded by the preloader.

Surprisingly, it looks like async scripts execute later than defer script; the definition of the script execution ordering could permit that.

Pre-empting through subresources aren't reliable right now, they cause a duplicate resource call.

Browser support seemed fine for this change, but it's pretty tough to perf-test until prod...
