### PR TITLE
Changed the size of the merchandising slot

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -117,5 +117,5 @@
 
     @fragments.mostPopularPlaceholder(article.section)
 
-    <div id="dfp-commercial-component" class="ad-slot__dfp ad-slot__commercial-component" data-name="merchandising" data-size="900,250"></div>
+    <div id="dfp-commercial-component" class="ad-slot__dfp ad-slot__commercial-component" data-name="merchandising" data-size="901,250"></div>
 }

--- a/commercial/app/views/books/bestsellers.scala.html
+++ b/commercial/app/views/books/bestsellers.scala.html
@@ -19,7 +19,7 @@
                     <ul class="u-unstyled list">
                     @books.map { book =>
                         <li class="list__item">
-                            <a href="@book.buyUrl" class="list__link" data-link-name="merchandising-bookshop-v0_1_2014-03-12-low-@{book.isbn}-@{book.author}-@{book.title}">
+                            <a href="@book.buyUrl" class="list__link" data-link-name="merchandising-bookshop-v0_7_2014-03-12-low-@{book.isbn}-@{book.author}-@{book.title}">
                                 <span class="list__count">@book.position</span>
                             @book.jacketUrl.map { url =>
                                 <div class="list__img js-image-upgrade" data-src="@url"></div>

--- a/common/app/assets/javascripts/modules/commercial/loader.js
+++ b/common/app/assets/javascripts/modules/commercial/loader.js
@@ -62,7 +62,7 @@ define([
         this.postLoadEvents = {
             books: function(el) {
                 bean.on(el, 'click', '.commercial__search__submit', function() {
-                    var str = 'merchandising-bookshop-v0_1_2014-03-12-low-'+ el.querySelector('.commercial__search__input').value,
+                    var str = 'merchandising-bookshop-v0_7_2014-03-12-low-'+ el.querySelector('.commercial__search__input').value,
                         val = (conf.contentType) ? conf.contentType + ':' + str : str;
 
                     s.linkTrackVars = 'eVar22,eVar37,events';


### PR DESCRIPTION
This is to avoid other ads being served into the same slot.

IMO, we shouldn't be doing this but it's a quick fix. Rez is currently looking at DFP to see how we can only serve one ad into a generic sized slot. 

Also added a change the omniture tracking for the books component

// @phamann 
