### PR TITLE
Validate JS on .js file changes only

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -12,7 +12,7 @@ fi
 cssValidateResult=$?
 
 # Validate JS
-JS_SRC_PATTERN="\.js"
+JS_SRC_PATTERN="\.js$"
 git diff --cached --name-only | if grep "$JS_SRC_PATTERN"
 then
     grunt validate:js


### PR DESCRIPTION
We were triggering a JS validation when .json files were changed.

![screen shot 2014-03-13 at 14 10 54](https://f.cloud.github.com/assets/85783/2410287/ab5abf1c-aabb-11e3-9b62-e1ecce045af9.PNG)

![ ](http://media.giphy.com/media/9Sxp3YOKKFEBi/giphy.gif)
