### PR TITLE
Do not kick off initial refresh of agents in test mode

### DIFF
--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -44,12 +44,15 @@ class FootballStatsPlugin(app: PlayApp) extends Plugin {
     }
 
     // Have all these run once at load, then on the scheduled times
-    AkkaAsync.after(1.seconds){
-      Competitions.refreshCompetitionData()
-      Competitions.refreshMatchDay()
-      LiveBlogAgent.refresh()
-      Competitions.competitionIds.foreach(Competitions.refreshCompetitionAgent)
-      TeamMap.refresh()
+    // Do not kick off initial refresh in test, because the agents will be dead before it happens
+    if (!play.api.Play.isTest(app)) {
+      AkkaAsync.after(5.seconds){
+        Competitions.refreshCompetitionData()
+        Competitions.refreshMatchDay()
+        LiveBlogAgent.refresh()
+        Competitions.competitionIds.foreach(Competitions.refreshCompetitionAgent)
+        TeamMap.refresh()
+      }
     }
   }
 


### PR DESCRIPTION
This is important because the agents will be dead before the refresh job executes.
