### PR TITLE
fix for gallery lightbox image sizes

### DIFF
--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -332,8 +332,6 @@ define([
                 if (itemIndex === index) {
                     bonzo(el).addClass('gallery__item--active');
 
-                    self.alignNavArrows();
-
                     self.currentImageNode = el;
                 } else {
                     bonzo(el).removeClass('gallery__item--active');
@@ -431,26 +429,18 @@ define([
 
             if (mode === 'fullimage') {
                 // Size all images to the height of the screen
-                $images.css({'height': contentHeight + 'px', 'width': 'auto'});
+                $images.css({'max-height': contentHeight + 'px', 'width': 'auto', 'max-width': '100%'});
                 $items.css('height', contentHeight+'px');
             } else {
                 // Lets the default stylesheets do the work here
                 $images.removeAttr('style');
                 $items.removeAttr('style');
             }
-
-            self.alignNavArrows();
         };
 
         this.jumpToContent = function() {
             window.scrollTo(0, overlay.headerNode.offsetHeight);
         };
-
-        this.alignNavArrows = function() {
-            // Match arrows to the height of image, minus height of the caption control to prevent overlap
-            $navArrows.css('height', ($images[currentImage-1].offsetHeight - captionControlHeight) + 'px');
-        };
-
 
         // Swipe methods
         this.setupSwipe = function() {
@@ -477,7 +467,6 @@ define([
                     }
                 });
 
-                self.alignNavArrows();
                 swipeActive = true;
             });
         };


### PR DESCRIPTION
- limiting gallery lightbox images to their original size or to the width of the window.
- removing nav arrow alignment as it causes the nav arrows to jump around when really they should stay in the same place
## Before

![image](https://f.cloud.github.com/assets/960919/2411672/1ba095e0-aaca-11e3-810b-1fa719c9f683.png)
## After

![image](https://f.cloud.github.com/assets/960919/2411679/2f5f1f34-aaca-11e3-9602-ff548d3102a9.png)
