### PR TITLE
Tweak styling for new byline pics

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -191,8 +191,9 @@
 
     @include mq(leftCol) {
         @include rem((
+            height: $gs-row-height,
             padding-top: 2px,
-            margin-bottom: $gs-baseline
+            padding-bottom: $gs-baseline
         ));
         border-top: 1px dotted $c-neutral5;
 
@@ -358,8 +359,9 @@
     overflow: hidden;
     @include rounded-corners(50%);
     background-color: $c-neutral7;
-    
+
     @include mq(leftCol) {
+        position: relative;
         width: gs-span(2);
         height: gs-span(2); //This is intentionally square
         margin-right: 0;
@@ -367,9 +369,17 @@
             margin-bottom: $gs-baseline,
         ));
     }
+}
 
-    img {
-        width: 100%;
+.byline-img__img {
+    width: 100%;
+
+    @include mq(leftCol) {
+        position: absolute;
+        width: auto;
+        height: 110%;
+        bottom: -14px;
+        left: -15%;
     }
 }
 

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -374,6 +374,7 @@
 .byline-img__img {
     width: 100%;
 
+    //This centres the image within its container
     @include mq(leftCol) {
         position: absolute;
         width: auto;

--- a/common/app/views/fragments/meta/bylineImage.scala.html
+++ b/common/app/views/fragments/meta/bylineImage.scala.html
@@ -3,7 +3,7 @@
 @tags.contributors.headOption.map { profile =>
     @profile.contributorLargeImagePath.map{ image =>
         <div class="byline-img">
-            <img src="@image" alt="@profile.name" />
+            <img class="byline-img__img" src="@image" alt="@profile.name" />
         </div>
     }
 }


### PR DESCRIPTION
Chris P and Matt from imaging have done some great work to normalize all of the large byline pics. We can now guarantee that a person will be centred in the image regardless of which direction they are facing.

To enable this i've had to tweak the CSS for byline images.

Next change will be to ensure PNGs get resized, as we are currently serving these at 600px into a 140px container :/
#### Before

![screenshot from 2014-03-14 12 35 46](https://f.cloud.github.com/assets/80089/2420697/260089b2-ab76-11e3-8ea4-9360545aa6de.png)
#### After

![screenshot from 2014-03-14 12 35 24](https://f.cloud.github.com/assets/80089/2420698/27bdbaae-ab76-11e3-8dfa-1b187d45d51a.png)
