### PR TITLE
Add user timing to app

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -6,6 +6,7 @@ define([
     'common/utils/detect',
     'common/utils/config',
     'common/utils/context',
+    'common/utils/userTiming',
 
     'common/modules/analytics/errors',
     'common/modules/ui/fonts',
@@ -29,6 +30,7 @@ define([
     detect,
     config,
     Context,
+    userTiming,
 
     Errors,
     Fonts,
@@ -88,6 +90,9 @@ define([
     };
 
     var routes = function() {
+
+        userTiming.mark("App Begin");
+
         domReady(function() {
             var context = document.getElementById('preload-1');
 
@@ -142,6 +147,9 @@ define([
 
             mediator.on('page:ready', pageRoute);
             mediator.emit('page:ready', config, context);
+
+            // Mark the end of synchronous execution.
+            userTiming.mark("App End");
         });
     };
 

--- a/common/app/assets/javascripts/utils/userTiming.js
+++ b/common/app/assets/javascripts/utils/userTiming.js
@@ -1,0 +1,16 @@
+define([
+], function () {
+
+    var perf = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
+
+    function mark(label) {
+
+        if (perf && perf.mark) {
+             perf.mark("gu." + label);
+        }
+    }
+
+    return {
+        mark: mark
+    };
+});

--- a/common/app/assets/javascripts/utils/userTiming.js
+++ b/common/app/assets/javascripts/utils/userTiming.js
@@ -1,10 +1,10 @@
-define(function () {
+define( function() {
 
     var perf = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
 
     function mark(label) {
 
-        if (perf && perf.mark) {
+        if (perf && 'mark' in perf) {
              perf.mark("gu." + label);
         }
     }

--- a/common/app/assets/javascripts/utils/userTiming.js
+++ b/common/app/assets/javascripts/utils/userTiming.js
@@ -1,5 +1,4 @@
-define([
-], function () {
+define(function () {
 
     var perf = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
 


### PR DESCRIPTION
Based on this blog (!!!), we should be able to view more detail about our application performance in webpagetest.org if used mark from the user timing API.

http://blog.patrickmeenan.com/2013/07/measuring-performance-of-user-experience.html
