### PR TITLE
Fix tag combiner content type

### DIFF
--- a/facia/app/services/repositories.scala
+++ b/facia/app/services/repositories.scala
@@ -20,6 +20,19 @@ case class IndexPage(page: MetaData, trails: Seq[Content])
 
 trait Index extends ConciergeRepository with QueryDefaults {
 
+  def normaliseTag(tag: String): String = {
+    val conversions: Map[String, String] =
+      Map("content" -> "type")
+
+    conversions.foldLeft(tag){
+      case (newTag, (from, to)) =>
+        if (newTag.startsWith(s"$from/"))
+          newTag.replace(from, to)
+        else
+          newTag
+    }
+  }
+
   def index(edition: Edition, leftSide: String, rightSide: String, page: Int): Future[Either[IndexPage, SimpleResult]] = {
 
     val section = leftSide.split('/').head

--- a/facia/app/services/repositories.scala
+++ b/facia/app/services/repositories.scala
@@ -38,17 +38,21 @@ trait Index extends ConciergeRepository with QueryDefaults {
     val section = leftSide.split('/').head
 
     // if the first tag is just one part then change it to a section tag...
-    val firstTag = leftSide match {
-      case SinglePart(wordsForUrl) => s"$wordsForUrl/$wordsForUrl"
-      case other => other
-    }
+    val firstTag = normaliseTag(
+      leftSide match {
+        case SinglePart(wordsForUrl) => s"$wordsForUrl/$wordsForUrl"
+        case other => other
+      }
+    )
 
     // if the second tag is just one part then it is in the same section as the first tag...
-    val secondTag = rightSide match {
-      case SinglePart(wordsForUrl) => s"$section/$wordsForUrl"
-      case SeriesInSameSection(series) => s"$section/$series"
-      case other => other
-    }
+    val secondTag = normaliseTag(
+      rightSide match {
+        case SinglePart(wordsForUrl) => s"$section/$wordsForUrl"
+        case SeriesInSameSection(series) => s"$section/$series"
+        case other => other
+      }
+    )
 
     val promiseOfResponse = SwitchingContentApi().search(edition)
       .tag(s"$firstTag,$secondTag")

--- a/facia/test/IndexControllerTest.scala
+++ b/facia/test/IndexControllerTest.scala
@@ -105,4 +105,19 @@ class IndexControllerTest extends FlatSpec with Matchers {
     status(result) should be (302)
     header("Location", result).get should endWith ("/books+tone/reviews")
   }
+
+  "Normalise tags" should "convert content/gallery to type/gallery" in {
+    val tag = "content/gallery"
+    val result = controllers.IndexController.normaliseTag(tag)
+    result should be ("type/gallery")
+  }
+
+  it should "not touch other tags that don't match content exactly" in {
+    val tags = Seq("conten/gallery", "contentt/gallery", "content",
+                  "type/gallery", "media/media", "media", "content", "type")
+    tags.map{ tag =>
+      val result = controllers.IndexController.normaliseTag(tag)
+      result should be (tag)
+    }
+  }
 }


### PR DESCRIPTION
This fixes a tag combiner bug I found through google for when a URL comes in with a tag `content/xyz`.
This is represented in the Content API as `type/xyz`, so it 404s currently.

For example, have your preference set to NGW, and search in google for `the guardian gallery`, and you will get a lot of 404 results, as they point to a tag with `content/gallery`.

Instead of transparently converting it, a long term solution would be to redirect it somehow. But this would probably happen after `R2`. (_gets switched off_)

@gklopper I could have just used regex here, but I don't like regex /much/.
