### PR TITLE
Remove facia agents

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -384,12 +384,6 @@ object Switches extends Collections {
     safeState = On, new DateMidnight().minusDays(1)
   )
 
-  // Facia
-  val PressedFacia = Switch("Facia", "pressed-facia",
-    "If this switch is on then it will use pressed JSON for all requests",
-    safeState = Off, sellByDate = never
-  )
-
   // Facia Tool Switches
   val ToolDisable = Switch("Facia Tool", "facia-tool-disable",
     "If this is switched on then the fronts tool is disabled",
@@ -495,7 +489,6 @@ object Switches extends Collections {
     FaciaToolPressSwitch,
     DogpileSwitch,
     ShowAllArticleEmbedsSwitch,
-    PressedFacia,
     FrontPressJobSwitch,
     LayoutHintsSwitch,
     HelveticaEasterEggSwitch,

--- a/facia/app/conf/context.scala
+++ b/facia/app/conf/context.scala
@@ -5,7 +5,7 @@ import com.gu.management.{ PropertiesPage, StatusPage, ManifestPage, ManagementP
 import com.gu.management.play.{ Management => GuManagement }
 import com.gu.management.logback.LogbackLevelPage
 import com.gu.management.HttpRequest
-import controllers.front.{CollectionAgent, ConfigAgent}
+import controllers.front.ConfigAgent
 
 object Management extends GuManagement {
   val applicationName = "frontend-facia"

--- a/facia/app/conf/context.scala
+++ b/facia/app/conf/context.scala
@@ -17,8 +17,7 @@ object Management extends GuManagement {
     StatusPage(applicationName, metrics),
     new PropertiesPage(Configuration.toString),
     new LogbackLevelPage(applicationName),
-    new ConfigAgentStatus,
-    new CollectionAgentStatus
+    new ConfigAgentStatus
   )
 }
 
@@ -26,10 +25,4 @@ class ConfigAgentStatus extends ManagementPage {
   val path: String = "/management/configagentstatus"
   override lazy val linktext = "/management/configagentstatus - ONLY use for debugging"
   def get(request: HttpRequest) = PlainTextResponse(ConfigAgent.contentsAsJsonString)
-}
-
-class CollectionAgentStatus extends ManagementPage {
-  val path: String = "/management/collectionagentstatus"
-  override lazy val linktext = "/management/collectionagentstatus - ONLY use for debugging"
-  def get(request: HttpRequest) = PlainTextResponse(CollectionAgent.contentsAsJsonString)
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -5,7 +5,7 @@ import front._
 import model._
 import conf._
 import play.api.mvc._
-import play.api.libs.json.{JsArray, Json}
+import play.api.libs.json.Json
 import Switches.EditionRedirectLoggingSwitch
 import views.support.{TemplateDeduping, NewsContainer}
 import scala.concurrent.Future
@@ -14,7 +14,6 @@ import play.api.templates.Html
 
 class FaciaController extends Controller with Logging with ExecutionContexts with implicits.Collections {
 
-  val front: Front = Front
   val EditionalisedKey = """^\w\w(/.*)?$""".r
 
   implicit def getTemplateDedupingInstance: TemplateDeduping = TemplateDeduping()

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -51,39 +51,11 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
   def renderCollectionJson(id: String) = renderCollection(id)
 
   def renderFront(path: String) =
-    if (!ConfigAgent.getPathIds.contains(path)) {
+    if (!ConfigAgent.getPathIds.contains(path))
       IndexController.render(path)
-    }
-    else {
-      if (Switches.PressedFacia.isSwitchedOn)
-        renderFrontPress(path)
-      else
-        DogpileAction { implicit request =>
-          Future {
-            val editionalisedPath = editionPath(getPathForUkAlpha(path, request), Edition(request))
+    else
+      renderFrontPress(path)
 
-            FrontPage(editionalisedPath).flatMap { frontPage =>
-
-              // get the trailblocks
-              val faciaPageOption: Option[FaciaPage] = front(editionalisedPath)
-              faciaPageOption map { faciaPage =>
-                if (request.isRss) {
-                  Cached(frontPage) {
-                    Ok(TrailsToRss(Some(frontPage.webTitle), faciaPage.collections.map(_._2).flatMap(_.items).toSeq.distinctBy(_.id)))
-                  }.as("text/xml; charset=utf-8")
-                } else {
-                  Cached(frontPage) {
-                    if (request.isJson)
-                      JsonFront(frontPage, faciaPage)
-                    else
-                      Ok(views.html.front(frontPage, faciaPage))
-                  }
-                }
-              }
-            }.getOrElse(Cached(60)(NotFound))
-          }
-        }
-    }
 
   def renderFrontPress(path: String) = DogpileAction { implicit request =>
 
@@ -109,36 +81,7 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
 
   }
 
-  def renderCollection(id: String) =
-    if (Switches.PressedFacia.isSwitchedOn)
-      renderCollectionPressed(id)
-    else
-    DogpileAction { implicit request =>
-      Future{
-        if (ConfigAgent.getAllCollectionIds.contains(id)) {
-          CollectionAgent.getCollection(id) map { collection =>
-            if (request.isRss) {
-              Cached(60) {
-                val config: Config = ConfigAgent.getConfig(id).getOrElse(Config(""))
-                Ok(TrailsToRss(config.displayName, collection.items))
-              }.as("text/xml; charset=utf-8")
-            } else {
-              val html = views.html.fragments.collections.standard(Config(id), collection.items, NewsContainer(showMore = false), 1)
-              Cached(60) {
-                if (request.isJson)
-                  JsonCollection(html, collection)
-                else
-                  Ok(html)
-              }
-            }
-          } getOrElse ServiceUnavailable
-        }
-        else
-          Cached(60)(NotFound)
-      }
-    }
-
-  def renderCollectionPressed(id: String) = DogpileAction { implicit request =>
+  def renderCollection(id: String) = DogpileAction { implicit request =>
     getPressedCollection(id).map { collectionOption =>
       collectionOption.map { collection =>
         if (request.isRss) {

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -14,18 +14,6 @@ import scala.collection.immutable.SortedMap
 import akka.agent.Agent
 import org.joda.time.DateTime
 
-object Path {
-  def unapply[T](uri: String) = Some(uri.split('?')(0))
-  def apply[T](uri: String) = uri.split('?')(0)
-}
-
-object Seg {
-  def unapply(path: String): Option[List[String]] = path.split("/").toList match {
-    case "" :: rest => Some(rest)
-    case all => Some(all)
-  }
-}
-
 object ConfigAgent extends ConfigAgentTrait with ExecutionContexts {
   val configAgent: Agent[JsValue] = AkkaAgent[JsValue](FaciaDefaults.getDefaultConfig)
 }

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -1,18 +1,9 @@
 package controllers.front
 
 import common._
-import conf.{ SwitchingContentApi=>ContentApi, Configuration }
-import model._
-import play.api.libs.json.Json._
 import play.api.libs.json._
-import play.api.libs.ws.{ WS, Response }
-import play.api.libs.json.JsObject
-import services.{ParseCollection, ConfigAgentTrait, SecureS3Request, S3FrontsApi}
-import scala.concurrent.Future
-import common.FaciaMetrics.S3AuthorizationError
-import scala.collection.immutable.SortedMap
+import services.ConfigAgentTrait
 import akka.agent.Agent
-import org.joda.time.DateTime
 
 object ConfigAgent extends ConfigAgentTrait with ExecutionContexts {
   val configAgent: Agent[JsValue] = AkkaAgent[JsValue](FaciaDefaults.getDefaultConfig)

--- a/facia/app/controllers/front/FaciaAgent.scala
+++ b/facia/app/controllers/front/FaciaAgent.scala
@@ -26,44 +26,6 @@ object Seg {
   }
 }
 
-object CollectionAgent extends ParseCollection {
-  private val collectionAgent = AkkaAgent[Map[String, Collection]](Map.empty)
-
-  def getCollection(id: String): Option[Collection] = collectionAgent.get().get(id)
-
-  def updateCollection(id: String, config: Config, edition: Edition, isWarmedUp: Boolean): Unit = {
-    getCollection(id, config, edition, isWarmedUp) foreach { collection => updateCollection(id, collection) }
-  }
-
-  def updateCollection(id: String, collection: Collection): Unit = collectionAgent.send { _.updated(id, collection) }
-
-  def updateCollectionById(id: String): Unit = updateCollectionById(id, isWarmedUp=true)
-
-  def updateCollectionById(id: String, isWarmedUp: Boolean): Unit = {
-    val config: Config = ConfigAgent.getConfig(id).getOrElse(Config(id))
-    val edition = Edition.byId(id.take(2)).getOrElse(Edition.defaultEdition)
-    //TODO: Refactor isWarmedUp into method by ID
-    updateCollection(id, config, edition, isWarmedUp=isWarmedUp)
-  }
-
-  def close(): Unit = collectionAgent.close()
-
-  def contentsAsJsonString: String = {
-    val contents: SortedMap[String, Seq[String]] = SortedMap(collectionAgent.get().mapValues{v => v.items.map(_.url)}.toSeq:_*)
-    Json.prettyPrint(Json.toJson(contents))
-  }
-}
-
-object QueryAgents {
-
-  def items(id: String): Option[List[(Config, Collection)]] = ConfigAgent.getConfigForId(id).map { configList => configList flatMap { config =>
-      CollectionAgent.getCollection(config.id) map { (config, _) }
-    }
-  } filter(_.exists(_._2.items.nonEmpty))
-
-  def apply(id: String): Option[FaciaPage] = items(id).map(FaciaPage(id, _))
-}
-
 object ConfigAgent extends ConfigAgentTrait with ExecutionContexts {
   val configAgent: Agent[JsValue] = AkkaAgent[JsValue](FaciaDefaults.getDefaultConfig)
 }

--- a/facia/app/controllers/front/Front.scala
+++ b/facia/app/controllers/front/Front.scala
@@ -12,14 +12,6 @@ class Front extends Logging {
     if (editions.contains(sectionId)) "" else sectionId
   }
 
-  def refreshCollections(): Unit = ConfigAgent.getAllCollectionIds.foreach { collectionId => CollectionAgent.updateCollectionById(collectionId, isWarmedUp=false) }
-
-  def refreshJobs() = Seq(() => {
-      ConfigAgent.refresh()}
-  ) ++ ConfigAgent.getAllCollectionIds.map{ collectionId => () => CollectionAgent.updateCollectionById(collectionId) }
-
-  def apply(path: String): Option[FaciaPage] = QueryAgents(path)
-
 }
 
 object Front extends Front

--- a/facia/app/controllers/front/FrontLifecycle.scala
+++ b/facia/app/controllers/front/FrontLifecycle.scala
@@ -1,8 +1,7 @@
 package controllers.front
 
-import common.{AkkaAsync, Jobs}
+import common.Jobs
 import play.api.GlobalSettings
-import scala.concurrent.duration._
 
 trait FrontLifecycle extends GlobalSettings {
   override def onStart(app: play.api.Application) {

--- a/facia/app/controllers/front/FrontLifecycle.scala
+++ b/facia/app/controllers/front/FrontLifecycle.scala
@@ -12,23 +12,13 @@ trait FrontLifecycle extends GlobalSettings {
 
     Jobs.deschedule("FrontRefreshJob")
     Jobs.schedule("FrontRefreshJob", "0 * * * * ?") {
-
-      // stagger refresh jobs to avoid dogpiling the api
-      Front.refreshJobs().zipWithIndex.foreach{ case (job, index) =>
-        val sec = (index * 2) % 60
-        AkkaAsync.after(sec.seconds){
-          job()
-        }
-      }
+      ConfigAgent.refresh()
     }
-
-    Front.refreshCollections()
   }
 
   override def onStop(app: play.api.Application) {
     Jobs.deschedule("FrontRefreshJob")
     ConfigAgent.close()
-    CollectionAgent.close()
     super.onStop(app)
   }
 }

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -14,11 +14,6 @@ class FaciaControllerTest extends FlatSpec with Matchers with BeforeAndAfterAll 
 
   val responsiveRequest = FakeRequest().withHeaders("host" -> "www.theguardian.com")
 
-  object Front extends TestFront
-  object FaciaController extends FaciaController {
-    override val front = Front
-  }
-
   ignore should "200 when content type is front" in Fake {
     val result = FaciaController.renderFront("uk")(TestRequest())
     status(result) should be(200)


### PR DESCRIPTION
Agents, it's not you, it's me. The latency is **great**, but sometimes I can't help but feel you are empty inside.
It's over.
# 

I am happy to make this PR! I have even thought about getting a `gif`.

This PR removes:
- `PressedFacia` switch
- `CollectionAgent`, the agent we were using to hold fronts in memory

There are a few things I am going to come back to, in this pull request (It's late on friday now):
- Move `ParseCollection` from common to `facia-tool`, which is the only place it is used at the moment
- Think about removing `object Front` and `class Front` from `facia`
- Probably lots of other knock on hoovering

@gklopper @ironsidevsquincy 
