### PR TITLE
Live matches on football clockwatch 

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -94,7 +94,7 @@ define([
     }
 
     function loaded(elem) {
-        $('.preload-msg', elem).remove();
+        $('.loading', elem).remove();
     }
 
     return {

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -72,7 +72,6 @@ define([
             });
         });
 
-
         // Binding
         bean.on(context, 'click', '.table tr[data-link-to]', function() {
             window.location = this.getAttribute('data-link-to');

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -59,12 +59,12 @@ define([
 
         page.isLiveClockwatch(function() {
             var ml = new MatchList('live', 'premierleague'),
-                $img = $('.media-primary'),
+                $img = $('.media-primary').addClass('u-h'),
                 matchListContainer = bonzo.create('<div class="football-match__list" data-link-name="football-matches-clockwatch"></div>');
 
             loading(matchListContainer, 'Fetching today\'s matches…', { text: 'Impatient?', href: '/football/live' });
 
-            $img.addClass('u-h').after(matchListContainer);
+            $('.article__meta-container').before(matchListContainer);
             ml.fetch(matchListContainer).fail(function() {
                 $img.removeClass('u-h');
             }).always(function() {

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -85,10 +85,10 @@ define([
 
     function loading(elem, message, link) {
         bonzo(elem).append(bonzo.create(
-            '<div class="preload-msg">'+
+            '<div class="loading">'+
                 '<div class="loading__message">'+ (message||'Loading…') +'</div>'+
-                (link ? '<a href="'+ link.href +'" class="accessible-link">'+ link.text +'</a>' : '') +
-                '<div class="is-updating"></div>'+
+                (link ? '<a href="'+ link.href +'" class="loading__link">'+ link.text +'</a>' : '') +
+                '<div class="loading__animation"></div>'+
             '</div>'
         ));
     }

--- a/common/app/assets/javascripts/modules/component.js
+++ b/common/app/assets/javascripts/modules/component.js
@@ -8,7 +8,7 @@ define([
     qwery,
     bonzo,
     ajax
-) {
+    ) {
 
     /**
      * TODO (jamesgorrie):
@@ -58,6 +58,16 @@ define([
     /** @type {Object.<string.*>} */
     Component.prototype.defaultOptions = {};
 
+    /** @type {String} */
+    Component.prototype.responseDataKey = 'html';
+
+    /** @type {Boolean} */
+    Component.prototype.autoupdated = false;
+
+    /** @type {Number} in seconds */
+    Component.prototype.updateEvery = 60;
+
+
     /**
      * Uses the this.componentClass
      * TODO (jamesgorrie): accept strings etc Also what to do with multiple objects?
@@ -89,13 +99,41 @@ define([
     };
 
     /**
+     * Throws an error if this is already attached to the DOM
+     */
+    Component.prototype.checkAttached = function() {
+        if (this.rendered) {
+            throw new ComponentError('Already rendered');
+        }
+    };
+
+    /**
      * @param {Element} parent
-     * @param {string} key element to lookup from the response
+     * @param {String} key
+     * @return {Reqwest}
      */
     Component.prototype.fetch = function(parent, key) {
         this.checkAttached();
-        var self = this,
-            endpoint = this.endpoint,
+
+        this.responseDataKey = key || 'html';
+        var self = this;
+
+        return this._fetch().then(function render(resp) {
+            self.elem = bonzo.create(resp[self.responseDataKey])[0];
+            self._prerender();
+
+            if (!self.destroyed) {
+                bonzo(parent).append(self.elem);
+                self._ready();
+            }
+        });
+    };
+
+    /**
+     * @return Reqwest
+     */
+    Component.prototype._fetch = function() {
+        var endpoint = this.endpoint,
             opt;
 
         for (opt in this.options) {
@@ -107,26 +145,7 @@ define([
             type: 'json',
             method: 'get',
             crossOrigin: true
-        }).then(
-            function render(resp) {
-                self.elem = bonzo.create(resp[key || 'html'])[0];
-                self._prerender();
-
-                if (!self.destroyed) {
-                    bonzo(parent).append(self.elem);
-                    self._ready();
-                }
-            }
-        );
-    };
-
-    /**
-     * Throws an error if this is already attached to the DOM
-     */
-    Component.prototype.checkAttached = function() {
-        if (this.rendered) {
-            throw new ComponentError('Already rendered');
-        }
+        });
     };
 
     /**
@@ -135,6 +154,7 @@ define([
     Component.prototype._ready = function() {
         if (!this.destroyed) {
             this.rendered = true;
+            this._autoupdate();
             this.ready();
         }
     };
@@ -145,6 +165,27 @@ define([
     Component.prototype._prerender = function() {
         this.elems = {};
         this.prerender();
+    };
+
+    /**
+     * Check if we should auto update, if so, do so
+     */
+    Component.prototype._autoupdate = function() {
+        var self = this,
+            t;
+
+        function update() {
+            self._fetch().then(function(resp) {
+                self.autoupdate(bonzo.create(resp[self.responseDataKey])[0], resp);
+                if (self.autoupdated) {
+                    t = setTimeout(update, self.updateEvery*1000);
+                }
+            });
+        }
+
+        if (this.autoupdated) {
+            t = setTimeout(update, this.updateEvery*1000);
+        }
     };
 
     /**
@@ -160,6 +201,18 @@ define([
      * This function is made to be overridden
      */
     Component.prototype.ready = function() {};
+
+    /**
+     * @param {Element} elem new element
+     * @param {Object.<string.*>} resp
+     */
+    Component.prototype.autoupdate = function(elem, resp) {
+        var oldElem = this.elem;
+        this.elem = elem;
+
+        this._prerender();
+        bonzo(oldElem).replaceWith(this.elem);
+    };
 
     /**
      * Once we're done with it, remove event bindings etc

--- a/common/app/assets/javascripts/modules/component.js
+++ b/common/app/assets/javascripts/modules/component.js
@@ -176,7 +176,7 @@ define([
 
         function update() {
             self._fetch().then(function(resp) {
-                self.autoupdate(bonzo.create(resp[self.responseDataKey])[0], resp);
+                self.autoupdate(bonzo.create(resp[self.responseDataKey])[0]);
                 if (self.autoupdated) {
                     t = setTimeout(update, self.updateEvery*1000);
                 }
@@ -204,9 +204,8 @@ define([
 
     /**
      * @param {Element} elem new element
-     * @param {Object.<string.*>} resp
      */
-    Component.prototype.autoupdate = function(elem, resp) {
+    Component.prototype.autoupdate = function(elem) {
         var oldElem = this.elem;
         this.elem = elem;
 

--- a/common/app/assets/javascripts/modules/sport/football/match-list.js
+++ b/common/app/assets/javascripts/modules/sport/football/match-list.js
@@ -15,7 +15,7 @@ component.define(MatchList);
 
 MatchList.prototype.endpoint = '/';
 MatchList.prototype.autoupdated = true;
-MatchList.prototype.updateEvery = 45;
+MatchList.prototype.updateEvery = 10;
 
 MatchList.prototype.prerender = function() {
     var elem = this.elem;

--- a/common/app/assets/javascripts/modules/sport/football/match-list.js
+++ b/common/app/assets/javascripts/modules/sport/football/match-list.js
@@ -1,0 +1,56 @@
+define([
+    'common/modules/component',
+    'common/$',
+    'bonzo',
+    'common/utils/mediator'
+], function(
+    component,
+    $,
+    bonzo,
+    mediator
+) {
+
+var MatchList = function(type, filter) {
+    this.endpoint += ['football', filter, type].filter(function(e) { return e; }).join('/') +'.json';
+};
+component.define(MatchList);
+
+MatchList.prototype.endpoint = '/';
+MatchList.prototype.autoupdated = true;
+MatchList.prototype.updateEvery = 45;
+
+MatchList.prototype.prerender = function() {
+    var elem = this.elem;
+    $('.football-team__form', elem).remove();
+    $('.date-divider', elem).remove();
+    $(this.elem).addClass('table--small');
+
+    if ($('.table__caption', this.elem).length === 0) {
+        bonzo(bonzo.create('<caption class="table__caption">Scores</caption>')).each(function(el) {
+            $('.football-matches', elem).prepend(el);
+        });
+    }
+};
+
+MatchList.prototype.autoupdate = function(elem, resp) {
+    var updated = $('.football-match', elem),
+        self = this,
+        $match, $updated;
+
+    $('.football-match', this.elem).each(function(match, i) {
+        $match = bonzo(match).removeClass('football-match--updated');
+        $updated = bonzo(updated[i]);
+
+        ['score-home', 'score-away', 'match-status'].forEach(function(state) {
+            state = 'data-'+ state;
+            if ($updated.attr(state) !== $match.attr(state)) {
+                $match.replaceWith($updated.addClass('football-match--updated'));
+                self.prerender();
+            }
+        });
+    });
+};
+
+return MatchList;
+
+}); // define

--- a/common/app/assets/javascripts/modules/sport/football/match-list.js
+++ b/common/app/assets/javascripts/modules/sport/football/match-list.js
@@ -24,7 +24,7 @@ MatchList.prototype.prerender = function() {
     $(this.elem).addClass('table--small');
 
     if ($('.table__caption', this.elem).length === 0) {
-        bonzo(bonzo.create('<caption class="table__caption">Scores</caption>')).each(function(el) {
+        bonzo(bonzo.create('<caption class="table__caption">Live scores</caption>')).each(function(el) {
             $('.football-matches', elem).prepend(el);
         });
     }

--- a/common/app/assets/javascripts/modules/sport/football/match-list.js
+++ b/common/app/assets/javascripts/modules/sport/football/match-list.js
@@ -1,13 +1,11 @@
 define([
     'common/modules/component',
     'common/$',
-    'bonzo',
-    'common/utils/mediator'
+    'bonzo'
 ], function(
     component,
     $,
-    bonzo,
-    mediator
+    bonzo
 ) {
 
 var MatchList = function(type, filter) {
@@ -32,7 +30,7 @@ MatchList.prototype.prerender = function() {
     }
 };
 
-MatchList.prototype.autoupdate = function(elem, resp) {
+MatchList.prototype.autoupdate = function(elem) {
     var updated = $('.football-match', elem),
         self = this,
         $match, $updated;

--- a/common/app/assets/javascripts/modules/sport/football/page.js
+++ b/common/app/assets/javascripts/modules/sport/football/page.js
@@ -34,7 +34,7 @@ function isClockwatch(yes) {
 
 function isLiveClockwatch(yes) {
     isClockwatch(function() {
-        if (config.page.live) {
+        if (config.page.isLive) {
             return yes();
         }
     });

--- a/common/app/assets/javascripts/modules/sport/football/page.js
+++ b/common/app/assets/javascripts/modules/sport/football/page.js
@@ -1,0 +1,51 @@
+define([
+    'common/$',
+    'common/utils/config'
+], function(
+    $,
+    config
+) {
+
+function isMatch(yes) {
+    var teams = config.referencesOfType('paFootballTeam'),
+        footballMatch = config.page.footballMatch;
+
+    if (footballMatch ||
+        ((config.hasTone("Match reports") || config.page.isLiveBlog) && teams.length === 2)) {
+        return yes(footballMatch || {
+            date: config.webPublicationDateAsUrlPart(),
+            teams: teams
+        });
+    }
+}
+
+function isCompetition(yes) {
+    var competition = ($('.js-football-competition').attr('data-link-name') || '').replace('keyword: ', '');
+    if (competition) {
+        return yes(competition);
+    }
+}
+
+function isClockwatch(yes) {
+    if (config.hasSeries('Clockwatch')) {
+        return yes();
+    }
+}
+
+function isLiveClockwatch(yes) {
+    isClockwatch(function() {
+        if (config.page.live) {
+            return yes();
+        }
+    });
+}
+
+return {
+    isMatch: isMatch,
+    isCompetition: isCompetition,
+    isClockwatch: isClockwatch,
+    isLiveClockwatch: isLiveClockwatch
+};
+
+}); // define
+

--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -26,7 +26,8 @@ td {
     border-top: 2px solid $c-newsAccent;
     color: $c-neutral1;
 
-    caption {
+    caption,
+    .table__caption{
         @include fs-header(2);
         @include rem((
             padding-top: $gs-baseline/4,
@@ -34,6 +35,7 @@ td {
         ));
         border-top: 1px dotted $c-neutral5;
         color: $c-neutral1;
+        font-weight: 400;
         text-align: left;
     }
 

--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -33,9 +33,10 @@ td {
             padding-top: $gs-baseline/4,
             padding-bottom: $gs-baseline
         ));
+        
         border-top: 1px dotted $c-neutral5;
         color: $c-neutral1;
-        font-weight: 400;
+        font-weight: normal;
         text-align: left;
     }
 

--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -27,7 +27,7 @@ td {
     color: $c-neutral1;
 
     caption,
-    .table__caption{
+    .table__caption {
         @include fs-header(2);
         @include rem((
             padding-top: $gs-baseline/4,

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -242,18 +242,20 @@ a.edition {
 /* Ajax loading helpers
    ========================================================================== */
 
+.loading,
 .preload-msg {
     @include rem((
         padding: 50px 50px 250px 50px
     ));
     text-align: center;
 
+    .loading__link,
     .accessible-link {
         display: inline-block;
         @include fs-data(2);
     }
 }
-
+.loading .loading__animation,
 .preload-msg .is-updating {
     display: block;
     @include rem((

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -249,7 +249,7 @@ a.edition {
     text-align: center;
 
     .accessible-link {
-        display: block;
+        display: inline-block;
         @include fs-data(2);
     }
 }

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -1,5 +1,6 @@
 .football-matches {
     margin-bottom: $gs-baseline*2;
+    position: relative;
 }
 
 .football-match {
@@ -24,11 +25,20 @@
 }
 
 .football-match--live {
+    font-weight: 900;
+
     .football-match__status {
         colour: $c-newsAccent;
-        font-weight: 900;
     }
 }
+
+.football-match--updated {
+    .football-team__score,
+    .football-teams__battleline {
+        color: $c-newsAccent;
+    }
+}
+
 
 .football-match__report {
     position: absolute;
@@ -61,7 +71,7 @@
 
     .football-team__score {
         @include rem((
-            right: $gs-gutter/2
+            right: ($gs-gutter/4)+1
         ));
     }
 }
@@ -75,7 +85,7 @@
 
     .football-team__score {
         @include rem((
-            left: $gs-gutter/2
+            left: ($gs-gutter/4)+1
         ));
     }
 }
@@ -118,6 +128,10 @@
             content: "v";
         }
     }
+}
+
+.js-on .football-matches tr {
+    cursor: pointer;
 }
 
 /* Footnotes */

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -39,7 +39,6 @@
     }
 }
 
-
 .football-match__report {
     position: absolute;
     right: 0;

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -181,9 +181,6 @@ GET         /collection/*id/rss                                                 
 GET         /collection/*id.json                                                                                     controllers.FaciaController.renderCollectionJson(id)
 GET         /collection/*id                                                                                          controllers.FaciaController.renderCollection(id)
 
-# Tag combiners
-GET        /$leftSide<[^+]+>+*rightSide                                                                              controllers.IndexController.renderCombiner(leftSide, rightSide)
-
 # Editionalised pages
 GET         /$path<[^/]+(/[^/]+)?>/rss                                                                               controllers.FaciaController.renderFrontRss(path)
 GET         /$path<[^/]+(/[^/]+)?>.json                                                                              controllers.FaciaController.renderFrontJson(path)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -17,9 +17,6 @@ GET        /collection/*id/rss                                     controllers.F
 GET        /collection/*id.json                                    controllers.FaciaController.renderCollectionJson(id)
 GET        /collection/*id                                         controllers.FaciaController.renderCollection(id)
 
-# Tag combiners
-GET        /$leftSide<[^+]+>+*rightSide                            controllers.IndexController.renderCombiner(leftSide, rightSide)
-
 # Editionalised pages
 GET        /*path/rss                                              controllers.FaciaController.renderFrontRss(path)
 GET        /*path.json                                             controllers.FaciaController.renderFrontJson(path)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -17,6 +17,9 @@ GET        /collection/*id/rss                                     controllers.F
 GET        /collection/*id.json                                    controllers.FaciaController.renderCollectionJson(id)
 GET        /collection/*id                                         controllers.FaciaController.renderCollection(id)
 
+# Tag combiners
+GET        /$leftSide<[^+]+>+*rightSide                            controllers.IndexController.renderCombiner(leftSide, rightSide)
+
 # Editionalised pages
 GET        /*path/rss                                              controllers.FaciaController.renderFrontRss(path)
 GET        /*path.json                                             controllers.FaciaController.renderFrontJson(path)

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -85,6 +85,12 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
 
       renderFormat(htmlResponse, jsonResponse, page)
 
-    }.getOrElse(Redirect("/football/tables"))
+    }.getOrElse(
+      if(request.isJson) {
+        JsonNotFound()
+      } else {
+        Redirect("/football/tables")
+      }
+    )
   }
 }

--- a/sport/app/football/controllers/LiveMatchesController.scala
+++ b/sport/app/football/controllers/LiveMatchesController.scala
@@ -37,7 +37,7 @@ object LiveMatchesController extends MatchListController with CompetitionLiveFil
   def matchDayComponent = Action { implicit request =>
     val matches = new MatchDayList(Competitions())
     val page = new Page("football", "football", "Today's matches", "GFE:Football:automatic:live matches")
-    Cached(page) {
+    Cached(10) {
       JsonComponent(page, football.views.html.matchList.matchesComponent(matches))
     }
   }

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -17,7 +17,7 @@ trait MatchListController extends Controller with Requests {
     datePattern.parseDateTime(s"$year$month$day").toDateMidnight
 
   protected def renderMatchList(page: Page, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader) = {
-    Cached(60) {
+    Cached(10) {
       if (request.isJson)
         JsonComponent(
           "html" -> football.views.html.matchList.matchesComponent(matchesList),

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -17,7 +17,7 @@ trait MatchListController extends Controller with Requests {
     datePattern.parseDateTime(s"$year$month$day").toDateMidnight
 
   protected def renderMatchList(page: Page, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader) = {
-    Cached(page) {
+    Cached(60) {
       if (request.isJson)
         JsonComponent(
           "html" -> football.views.html.matchList.matchesComponent(matchesList),

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -13,6 +13,11 @@
     <tbody>
         @matchesList.map{ theMatch =>
             <tr data-link-to="@LinkTo{@theMatch.url}"
+                data-match-id="@theMatch.id"
+                data-score-home="@theMatch.homeTeam.score"
+                data-score-away="@theMatch.awayTeam.score"
+                data-match-status="@MatchStatus(theMatch.matchStatus)"
+                id="football-match-@theMatch.id"
                 class="@RenderClasses(Map(
                     "football-match" -> true,
                     "football-match--live" -> theMatch.isLive,
@@ -52,7 +57,7 @@
                     </div>
                 </td>
                 <td class="football-match__report">
-                    <a href="@LinkTo{@theMatch.url}" data-link-name="stats" data-match-id="@theMatch.id">Match report</a>
+                    <a href="@LinkTo{@theMatch.url}" data-link-name="stats" data-match-id="@theMatch.id">Match stats</a>
                 </td>
             </tr>
         }


### PR DESCRIPTION
## What?

When you're reading a clockwatch liveblog, live matches for that day are shown instead of the main image.
This is only the case for Premier League for now.
## Notes
- Component.js has been updated to have an autoupdate as it already has it's own fetching skills, I thought it best to just extend them.
- In terms of the UI for auto updating - we have opted for a post-update cue as things won't happen every 60 seconds (probably, unless Man U is busy loosing).
## Looky

![clock-watch-matches](https://f.cloud.github.com/assets/31692/2436296/03c7bb9e-add9-11e3-88ac-80d26089e78d.png)
Note on above - "Scores caption is actually "Live scores"

---

![Clock watching](http://www.kutri.org/SmashAlarmClock.gif)
