### PR TITLE
Fix logic for matchDay when no matches are today

### DIFF
--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -18,6 +18,8 @@ trait MatchesList extends Football with RichList {
   val date: DateMidnight
   val daysToDisplay: Int
 
+  lazy val isEmpty = allRelevantMatches.isEmpty
+
   def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean
 
   // ordering for the displayed matches
@@ -120,10 +122,11 @@ case class TeamResultsList(date: DateMidnight, competitions: CompetitionSupport,
 
 case class MatchDayList(competitions: CompetitionSupport) extends MatchDays {
   override val date = DateMidnight.now
-  override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean = true
+  override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean =
+    fMatch.date.toDateMidnight == date
 }
 case class CompetitionMatchDayList(competitions: CompetitionSupport, competitionId: String) extends MatchDays with CompetitionList {
   override val date = DateMidnight.now
   override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean =
-    competition.id == competitionId
+    fMatch.date.toDateMidnight == date && competition.id == competitionId
 }

--- a/sport/test/football/model/MatchDayListTest.scala
+++ b/sport/test/football/model/MatchDayListTest.scala
@@ -3,6 +3,7 @@ package football.model
 import org.scalatest._
 import implicits.Football
 import pa.FootballMatch
+import org.joda.time.{Duration, DateTimeUtils}
 
 
 class MatchDayListTest extends FreeSpec with ShouldMatchers with MatchTestData with Football with OptionValues {
@@ -41,5 +42,17 @@ class MatchDayListTest extends FreeSpec with ShouldMatchers with MatchTestData w
         else comp.id should equal("2")
       }
     }
+  }
+
+  "if there are no matches today" - {
+    DateTimeUtils.setCurrentMillisFixed(today.minusDays(20).getMillis)
+
+    val matches = new MatchDayList(competitions)
+
+    "should be empty" in {
+      matches.relevantMatches.size should equal(0)
+    }
+
+    DateTimeUtils.setCurrentMillisSystem()
   }
 }


### PR DESCRIPTION
The matchDay is different from other matchlist pages in that it should only ever be showing stuff that happens today. Other pages skip ahead to find the next relevant matches.

Fixes https://github.com/guardian/frontend/issues/3543
