### PR TITLE
Make article profile image mobile first

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -351,6 +351,7 @@
 }
 
 .byline-img {
+    position: relative;
     width: gs-span(1);
     height: 60px; //Intentionally off grid
     @include rem((
@@ -361,7 +362,6 @@
     background-color: $c-neutral7;
 
     @include mq(leftCol) {
-        position: relative;
         width: gs-span(2);
         height: gs-span(2); //This is intentionally square
         margin-right: 0;
@@ -372,15 +372,15 @@
 }
 
 .byline-img__img {
-    width: 100%;
-
+    position: absolute;
+    width: auto;
     //This centres the image within its container
+    height: 110%;
+    bottom: -6px;
+    left: -15%;
+
     @include mq(leftCol) {
-        position: absolute;
-        width: auto;
-        height: 110%;
         bottom: -14px;
-        left: -15%;
     }
 }
 


### PR DESCRIPTION
I seemed to have ignored the mobile breakpoint when refactoring the profile images last week.

/cc @paulrobertlloyd 
### before

![screenshot from 2014-03-17 17 25 54](https://f.cloud.github.com/assets/80089/2439085/75a29e26-adf9-11e3-87b3-323ab63f6852.png)
### after

![screenshot from 2014-03-17 17 26 19](https://f.cloud.github.com/assets/80089/2439090/7e86d566-adf9-11e3-96fc-a447b0c04cf1.png)
