### PR TITLE
Prevent page reflow with comment counts

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -13,7 +13,9 @@
             <header class="article__head">
                 @fragments.headline(gallery.headline)
 
-                <div class="js-comment-count"></div>
+                @if(gallery.isCommentable) {
+                    <div class="article__head__comment-count js-comment-count"></div>
+                }
             </header>
         </div>
         <div class="article__columning-wrapper">

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -16,7 +16,9 @@
 
                     @fragments.standfirst(image)
 
-                    <div class="js-comment-count"></div>
+                    @if(image.isCommentable) {
+                        <div class="article__head__comment-count js-comment-count"></div>
+                    }
                 </header>
 
                 <div class="after-header"></div>

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -14,7 +14,9 @@
             <div class="article__inner article__inner--head">
                 <header class="article__head">
                     @fragments.headline(video.headline)
-                    <div class="js-comment-count"></div>
+                    @if(video.isCommentable) {
+                        <div class="article__head__comment-count js-comment-count"></div>
+                    }
                 </header>
             </div>
             <div class="article__columning-wrapper">

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -27,8 +27,9 @@
 
                     @fragments.standfirst(article)
 
-                    <div class="js-comment-count"></div>
-
+                    @if(article.isCommentable) {
+                        <div class="article__head__comment-count js-comment-count"></div>
+                    }
                 </header>
 
                 @fragments.witnessCallToAction(article)

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -24,7 +24,9 @@
                     }
 
                     @fragments.standfirst(article)
-                    <div class="js-comment-count"></div>
+                    @if(article.isCommentable) {
+                        <div class="article__head__comment-count js-comment-count"></div>
+                    }
                 </header>
 
                 @fragments.witnessCallToAction(article)

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -161,6 +161,12 @@
     }
 }
 
+.article__head__comment-count {
+    @include rem((
+        height: 16px + $gs-baseline //font-size + $gs-baseline
+    ))
+}
+
 .article__dateline {
     position: relative;
     color: $c-neutral2;

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -165,6 +165,9 @@
     @include rem((
         height: 16px + $gs-baseline //font-size + $gs-baseline
     ))
+    @include mq(tablet) {
+        display: none;
+    }
 }
 
 .article__dateline {

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -164,7 +164,7 @@
 .article__head__comment-count {
     @include rem((
         height: 16px + $gs-baseline //font-size + $gs-baseline
-    ))
+    ));
     @include mq(tablet) {
         display: none;
     }


### PR DESCRIPTION
This simply applies a fixed height to the comment count container in the article head. This prevents the page from reflowing when the count is injected with JS at a later point.

Thank you to @kaelig for reporting this issue. 
