### PR TITLE
Tables now align correctly with long names

### DIFF
--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -14,7 +14,7 @@ td {
     th,
     td,
     thead td {
-        @include fs-data(4);
+        @include fs-data(4, true);
         @include rem((
             padding: $table-baseline*2
         ));
@@ -64,6 +64,13 @@ td {
     }
 
     @include mq($to: tablet) { @include table--small; }
+    @include mq($to: desktop) {
+        th,
+        td,
+        thead td {
+            @include fs-data(4, true);
+        }
+    }
 }
 
 .table--small {

--- a/common/app/assets/stylesheets/module/football/_tables.scss
+++ b/common/app/assets/stylesheets/module/football/_tables.scss
@@ -19,7 +19,6 @@
         span {
             display: block;
             overflow: hidden;
-            text-overflow: ellipsis;
             white-space: nowrap;
             width: 100%;
         }
@@ -34,7 +33,7 @@
     }
 
     .table-column--main {
-        max-width: 90px;
+        max-width: 50px;
     }
 
     // This makes sure that all table columns are equally spaced


### PR DESCRIPTION
[Fix for this](https://github.com/guardian/frontend/issues/3405).
- Don't use ellipsis for shortening, it wastes space
- Use small text up until desktop, it's silly with data on tablet.

Makes me wonder if we should `mq` up our `fs-data` etc so things are consistently responsive hmm @kaelig ?

---

![FLIP!](http://1.bp.blogspot.com/-4bBarmC8Bzs/T15evpKc_4I/AAAAAAAACuA/B1XbTlUryYQ/s1600/anigif_enhanced-buzz-24252-1331327230-31.gif)
