### PR TITLE
Remove duplicate fb open graph url tag

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -134,7 +134,6 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   }
   override def openGraph: List[(String, Any)] = super.openGraph ++ List(
     "og:title" -> webTitle,
-    "og:url" -> webUrl,
     "og:description" -> trailText.map(StripHtmlTagsAndUnescapeEntities(_)).getOrElse("")
   )
 


### PR DESCRIPTION
It seems a recent refactor of the Facebook opengraph meta data introduced a duplicate entry of the url tag. 

This was causing the facebook bot to do weird things.

/cc @ironsidevsquincy @kungpochicken
