### PR TITLE
Fix conditional comment and CSS loading logic

### DIFF
--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -1,5 +1,10 @@
 @(projectName: Option[String])(implicit request: RequestHeader)
-<!--[if (gt IE 9) | (IEMobile)]><!-->
+@*
+  - Include all browsers [<!-->]
+  - Exclude IE < 10 [(gt IE 9)]
+  - Include IE Mobile [|(IEMobile)]
+*@
+<!--[if (gt IE 9)|(IEMobile)]><!-->
 @if(play.Play.isDev()) {
     <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse(".default") + ".css")" />
 } else {
@@ -8,11 +13,19 @@
     </style>
 }
 <!--<![endif]-->
-<!--[if (lt IE 9) & (!IEMobile)]>
+@*
+  - Include IE < 9 [(lt IE 9)]
+  - Exclude IE Mobile [&(!IEMobile)]
+*@
+<!--[if (lt IE 9)&(!IEMobile)]>
     <link rel="stylesheet" type="text/css" href="@Static("stylesheets/webfonts.css")" />
     <link rel="stylesheet" type="text/css" href="@Static(Static.css.headOldIE(projectName))" />
 <![endif]-->
-<!--[if (IE 9) & (!IEMobile)]>
+@*
+  - Include IE 9 [(IE 9)]
+  - Exclude IE Mobile [&(!IEMobile)]
+*@
+<!--[if (IE 9)&(!IEMobile)]>
     <link rel="stylesheet" type="text/css" href="@Static(Static.css.headIE9(projectName))" />
 <![endif]-->
 
@@ -26,11 +39,28 @@
     .stars, .stars:after { background-image: url(@Static("images/star-sprite.png")); }
 </style>
 
-<!--[if (lt IE 9) & (!IEMobile)]>
+@*
+  - Include IE 9 [(IE 9)]
+  - Exclude IE Mobile [&(!IEMobile)]
+*@
+<!--[if (IE 9)&(!IEMobile)]>
+    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/ie9.global.css")" />
+<![endif]-->
+
+@*
+  - Include IE < 9 [(lt IE 9)]
+  - Exclude IE Mobile [&(!IEMobile)]
+*@
+<!--[if (lt IE 9)&(!IEMobile)]>
     <link rel="stylesheet" type="text/css" href="@Static("stylesheets/old-ie.global.css")" />
 <![endif]-->
-<!--[if (IE 9) & (!IEMobile)]>
-    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/ie9.global.css")" />
+
+@*
+  - Include IE Mobile [IEMobile]
+  - Note: does not include IE10 on Windows Phone 8 (which does not support conditional comments)
+*@
+<!--[if IEMobile]>
+    <link rel="stylesheet" type="text/css" href="@Static("stylesheets/global.css")" />
 <![endif]-->
 
 <style class="initial" data-cache-name="WebEgyptian" data-cache-file-woff="@Static("fonts/WebEgyptian.woff.json")" data-cache-file-ttf="@Static("fonts/WebEgyptian.ttf.json")"></style>

--- a/common/app/views/fragments/loadCss.scala.html
+++ b/common/app/views/fragments/loadCss.scala.html
@@ -2,16 +2,15 @@
 @import conf.Switches._
 
 @if(CssFromStorageSwitch.isSwitchedOn && !play.Play.isDev()) {
-
-    <noscript>
-        <!--[if (gt IE 9) | (IEMobile)]><!-->
+    @*
+      - Include any browser [<!-->]
+      - Exclude IE < 10 [(gt IE 9)]
+          - As a result, no IE mobile should parse this code
+    *@
+    <!--[if (gt IE 9)]><!-->
+        <noscript>
             <link rel="stylesheet" id="global-css" type="text/css" href="@Static("stylesheets/global.css")" />
-        <!--<![endif]-->
-    </noscript>
-    <!--[if (gt IE 9) | (IEMobile)]>
-        <link rel="stylesheet" type="text/css" href="@Static("stylesheets/global.css")" />
-    <![endif]-->
-    <!--[if (gt IE 9) & (!IEMobile)]><!-->
+        </noscript>
         <script>
             (function() {
                 function injectElement(e) {
@@ -64,15 +63,19 @@
 
                 if(guardian.isModernBrowser && !guardian.css.loaded && 'withCredentials' in new XMLHttpRequest() && !/W(indows Phone|PDesktop)/.test(navigator.userAgent)) {
                     loadCssWithAjax();
-                } else if(!guardian.isModernBrowser || !('withCredentials' in new XMLHttpRequest())){
+                } else {
                     loadCssWithLink();
                 }
             })();
         </script>
     <!--<![endif]-->
 } else {
-    <!--[if (gt IE 9) | (IEMobile)]><!-->
+    @*
+      - Include any browser [<!-->]
+      - Exclude IE < 10 [(gt IE 9)]
+      - Exclude IE Mobile [&(!IEMobile)]
+    *@
+    <!--[if (gt IE 9)&(!IEMobile)]><!-->
         <link rel="stylesheet" id="global-css" type="text/css" href="@Static("stylesheets/global.css")" />
     <!--<![endif]-->
-
 }


### PR DESCRIPTION
- [new] Document conditional comments
- [fix] fall back to loading CSS with a link through our JS loader in IE Mobile that cuts the mustard

/cc @phamann @mstorijo 

![ ](http://media.giphy.com/media/5bWwzEt5TCvzG/giphy.gif)
