### PR TITLE
Fix tonal styling across templates

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -85,7 +85,7 @@
 
 @fragments.storyPackagePlaceholder(storyPackage)
 
-@fragments.mostPopularPlaceholder(gallery.section)
+@fragments.mostPopularPlaceholder(gallery.section, VisualTone(gallery))
 
 
 <div class="gallery-overlay-bg"></div>

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -58,5 +58,5 @@
 
     @fragments.storyPackagePlaceholder(storyPackage)
 
-    @fragments.mostPopularPlaceholder(image.section)
+    @fragments.mostPopularPlaceholder(image.section, VisualTone(image))
 }

--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -75,6 +75,6 @@
 
     @fragments.storyPackagePlaceholder(page.storyPackage)
 
-    @fragments.mostPopularPlaceholder(video.section)
+    @fragments.mostPopularPlaceholder(video.section, VisualTone(video))
 
 }

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -116,7 +116,7 @@
 
     @fragments.storyPackagePlaceholder(storyPackage)
 
-    @fragments.mostPopularPlaceholder(article.section)
+    @fragments.mostPopularPlaceholder(article.section, VisualTone(article))
 
     <div id="dfp-commercial-component" class="ad-slot__dfp ad-slot__commercial-component" data-name="merchandising" data-size="888,88"></div>
 }

--- a/common/app/views/fragments/localNav.scala.html
+++ b/common/app/views/fragments/localNav.scala.html
@@ -5,7 +5,7 @@
     @defining(localNav.links.find(_.currentFor(metaData))){ currentSublink =>
 
 
-        <div class="localnav--small tone-news tone-accent-border is-hidden js-localnav--small">
+        <div class="localnav--small tone-@VisualTone(metaData) tone-accent-border is-hidden js-localnav--small">
             <div class="localnav__inner u-cf">
                 <button class="u-button-reset localnav__cta" data-link-name="Popup Localnav" data-toggle="nav-popup--localnav">
                     <span class="control tone-border">

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -1,7 +1,7 @@
-@(section: String)(implicit request: RequestHeader)
+@(section: String, tone: String = "news")(implicit request: RequestHeader)
 
 @defining(Some(section).filter{ section => section.nonEmpty && !section.equals("global")}.map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
-    <div class="article-wrapper monocolumn-wrapper tone-feature" data-component="popular-in-section">
+    <div class="article-wrapper monocolumn-wrapper tone-@tone" data-component="popular-in-section">
         <div class="js-popular article__popular container--popular no-indent-article__zone">
             <h2 class="article__zone tone-border">
                 <a class="most-viewed-no-js tone-colour" href="@LinkTo{@url}" data-link-name="Most viewed @section">Most popular

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -669,10 +669,8 @@ object VisualTone {
   private val commentMappings = Seq(
     "tone/comment",
     "tone/letters",
-    "tone/obituaries",
     "tone/profiles",
-    "tone/editorials",
-    "tone/analysis"
+    "tone/editorials"
   )
 
   private val featureMappings = Seq(


### PR DESCRIPTION
This corrects some regressions with tonal styling:
- [new] remove obituaries and analysis from the comment tone mapping (request from editorial)
- [fix] Use correct tone on secondary navigation at mobile breakpoints
- [fix] Use correct tone on most popular component in footer at mobile breakpoints

![Touch the rainbow](http://media3.giphy.com/media/IV420aEx7aE1y/giphy.gif)
### Before

![screenshot from 2014-03-18 14 55 27](https://f.cloud.github.com/assets/80089/2449055/6f8e4364-aead-11e3-8e18-ca95000ca4b1.png)
### After

![screenshot from 2014-03-18 14 55 38](https://f.cloud.github.com/assets/80089/2449057/72d1d59a-aead-11e3-9f99-cc69cd768d8d.png)
