### PR TITLE
Formstack composer

### DIFF
--- a/common/app/assets/javascripts/bootstraps/identity.js
+++ b/common/app/assets/javascripts/bootstraps/identity.js
@@ -1,8 +1,9 @@
 define([
 	'common/$',
     'common/modules/identity/forms',
-    'common/modules/identity/formstack',
-    'common/modules/identity/formstack-iframe',
+    'common/modules/identity/formstack', // oldskool inside
+    'common/modules/identity/formstack-iframe', // oldskool outside
+    'common/modules/identity/formstack-iframe-embed', // newskool inside
     'common/modules/identity/password-strength',
     'common/modules/identity/validation-email',
     'common/modules/identity/api',
@@ -16,6 +17,7 @@ define([
     Identity,
     Formstack,
     FormstackIframe,
+    FormstackEmbedIframe,
     PasswordStrength,
     ValidationEmail,
     Id,
@@ -39,8 +41,18 @@ define([
                 var attr = 'data-formstack-id';
                 $('[' + attr + ']').each(function(el) {
                     var id = el.getAttribute(attr);
-                    new Formstack(el, id, context, config).init();
+
+                    var isEmbed = el.className.match(/\bformstack-embed\b/);
+
+                    if (isEmbed) {
+                        new FormstackEmbedIframe(el, id, context, config).init();
+                    } else {
+                        new Formstack(el, id, context, config).init();
+                    }
+
                 });
+
+                // Load old js if necessary
                 $('.js-formstack-iframe').each(function(el) {
                     new FormstackIframe(el, context, config).init();
                 });

--- a/identity/app/controllers/FormstackController.scala
+++ b/identity/app/controllers/FormstackController.scala
@@ -21,13 +21,17 @@ class FormstackController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
 
   val page = IdentityPage("/form", "Form", "formstack")
 
-  def formstackForm(formReference: String) = authAction.async { implicit request =>
+  def formstackForm(formReference: String, composer: Boolean) = authAction.async { implicit request =>
     if (Switches.IdentityFormstackSwitch.isSwitchedOn) {
       FormstackForm.extractFromSlug(formReference).map { formstackForm =>
         formStackApi.checkForm(formstackForm).map {
           case Right(_) => {
             logger.trace(s"Rendering formstack form ${formstackForm.formId}")
-            Ok(views.html.formstack.formstackForm(page, formstackForm))
+            if (composer) {
+              Ok(views.html.formstack.formstackFormComposer(page, formstackForm))
+            } else {
+              Ok(views.html.formstack.formstackForm(page, formstackForm))
+            }
           }
           case Left(errors) => {
             logger.warn(s"Unable to render formstack form ${formstackForm.formReference}, $errors")

--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -1,0 +1,20 @@
+@(metaData: model.MetaData, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+<html class="js-off id--signed-out" lang="en-GB">
+<head>
+    <meta charset="utf-8" />
+    <title>@Html(metaData.webTitle)</title>
+    @fragments.commonCssSetup(projectName)
+    @fragments.commonJavaScriptSetup(metaData)
+</head>
+<body id="top">
+
+    <div id="preload-1">
+        <div data-formstack-id="@formstackForm.formReference" class="is-hidden formstack-embed">
+            <script src="https://www.formstack.com/forms/js.php?@formstackForm.formReference"></script>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -25,6 +25,7 @@ GET     /ethical-awards/:formReference                  @controllers.EthicalAwar
 GET     /film-awards/complete                           @controllers.FilmAwardsController.complete
 GET     /film-awards/:formReference                     @controllers.FilmAwardsController.filmAwardsForm(formReference: String)
 GET     /form/complete                                  @controllers.FormstackController.complete
-GET     /form/:formReference                            @controllers.FormstackController.formstackForm(formReference: String)
+GET     /form/:formReference                            @controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = false)
+GET     /form/embed/:formReference                      @controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = true)
 
 GET     /et/subscribe/:subDefId                         @controllers.ExactTargetController.subscribe(subDefId: String, returnUrl: String)


### PR DESCRIPTION
# Formstack composer

This changeset adds code that allows the new-style formstack embeds from composer (as interactives) to run alongside the old style formstack pages provided currently by nextgen-identity.

This pull request introduces some code duplication for the two implementations but once the current run of formstack pages have run their course in production and the competitions are over the old style code can be removed leaving only the new implementation.

This PR goes together with [this one from composer](https://github.com/guardian/flexible-content/pull/727) and another from [interactive boot-scripts](https://github.com/guardian/interactive-boot-scripts) (proper link coming soon).

This whole piece should then allow composer users to paste in formstack form URL's and then have them rendered inline on content pages in the same way as the current interactives.

Come see me if you have any questions.
