### PR TITLE
Apply correct styling for `<pre>` elements

### DIFF
--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -163,6 +163,12 @@
     }
 }
 
+.from-content-api pre {
+    overflow-x: auto;
+    // Unset from `.from-content-api`
+    word-wrap: normal;
+}
+
 
 /* Bullet points
    ========================================================================== */

--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -164,7 +164,6 @@
 }
 
 .from-content-api pre {
-    overflow-x: auto;
     // Unset from `.from-content-api`
     word-wrap: normal;
 }


### PR DESCRIPTION
Beforehand, `<pre>` elements would inherit the [`word-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-wrap) property of
the `.from-content-api` CSS class, which is set to `break-word`.

We don’t want this behaviour for `<pre>` elements: text inside `<pre>` elements
should not be wrapped, and instead the user can scroll horizontally to view the
full line. This mirrors the behaviour in R2 frontend.
