### PR TITLE
Foresee assets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -286,11 +286,20 @@ module.exports = function (grunt) {
         },
 
         copy: {
+            // 3rd party javascript applications
+            'vendor': {
+                files: [{
+                    expand: true,
+                    cwd: 'common/app/public/javascripts/vendor',
+                    src: ['**/foresee/**'],
+                    dest: staticTargetDir + 'javascripts/vendor'
+                }]
+            },
             'javascript-common': {
                 files: [{
                     expand: true,
                     cwd: 'common/app/public/javascripts',
-                    src: ['**/*.js', '**/foresee/**'],
+                    src: ['**/*.js'],
                     dest: staticTargetDir + 'javascripts'
                 }]
             },
@@ -682,6 +691,7 @@ module.exports = function (grunt) {
             'compile:flash',
             'clean:assets',
             'copy:headCss',
+            'copy:vendor',
             'hash'
         ]);
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -290,7 +290,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: 'common/app/public/javascripts',
-                    src: ['**/*.js'],
+                    src: ['**/*.js', '**/foresee/**'],
                     dest: staticTargetDir + 'javascripts'
                 }]
             },


### PR DESCRIPTION
Rather than create another directory here (Eg, common/app/public/vendor/..) I've put all these files inside the javascripts directory because it is a _javascript_ application with some asset dependencies. Ie. The entry point to these files is, `common/app/assets/javascripts/modules/analytics/foresee-survey.js`
