### PR TITLE
OAS and DFP top ad slots are mutually exclusive

### DIFF
--- a/common/app/views/fragments/adSlot.scala.html
+++ b/common/app/views/fragments/adSlot.scala.html
@@ -1,21 +1,27 @@
 @(id: String, baseSlot: String, medianSlot: String, extendedSlot: String)
-@*<!--
-although we do put a data-link-name attribute on here any ad that iframes itself will be untrackable via this, so
-take ad clicks with a pinch of salt.
--->*@
-<div class="ad-slot__oas ad-slot--@id"
-     data-link-name="ad slot @id"
-     data-base="@baseSlot"
-     data-median="@medianSlot"
-     data-extended="@extendedSlot">
-     <div class="ad-slot__inner">
-         <div class="ad-slot__label">Advertisement</div>
-         <div class="ad-container"></div>
-     </div>
-</div>
+@import conf.Switches._
 
-<div class="ad-slot__dfp ad-slot--@id" data-name="top" data-mobile="300,50|320,50" data-tabletportrait="728,90" data-tabletlandscape="900,250">
-     <div class="ad-slot__inner">
-         <div id="dfp-ad-@id" class="ad-container"></div>
-     </div>
-</div>
+@if(OASAdvertSwitch.isSwitchedOn && (!DFPAdvertSwitch.isSwitchedOn || LoadOnlyCommercialComponents.isSwitchedOn)) {
+    @*<!--
+    although we do put a data-link-name attribute on here any ad that iframes itself will be untrackable via this, so
+    take ad clicks with a pinch of salt.
+    -->*@
+    <div class="ad-slot__oas ad-slot--@id"
+         data-link-name="ad slot @id"
+         data-base="@baseSlot"
+         data-median="@medianSlot"
+         data-extended="@extendedSlot">
+         <div class="ad-slot__inner">
+             <div class="ad-slot__label">Advertisement</div>
+             <div class="ad-container"></div>
+         </div>
+    </div>
+} else {
+    @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
+        <div class="ad-slot__dfp ad-slot--@id" data-name="top" data-mobile="300,50|320,50" data-tabletportrait="728,90" data-tabletlandscape="900,250">
+             <div class="ad-slot__inner">
+                 <div id="dfp-ad-@id" class="ad-container"></div>
+             </div>
+        </div>
+    }
+}

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -11,8 +11,7 @@
 </head>
 <body id="top" itemscope itemtype="http://schema.org/WebPage">
 
-    @fragments.message(metaData)
-    @if(LeadAdTopPageSwitch.isSwitchedOn) {
+    @if(AdvertSwitch.isSwitchedOn && LeadAdTopPageSwitch.isSwitchedOn) {
         <div class="top-banner-ad-container top-banner-ad-container--above-header">
             @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
         </div>
@@ -24,9 +23,11 @@
             <div id="preload-1" class="preload">
                 <div class="parts">
                     <div class="parts__head">
-                        <div class="top-banner-ad-container@if(LeadAdTopPageSwitch.isSwitchedOn){ top-banner-ad-container--below-header}">
-                            @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
-                        </div>
+                        @if(AdvertSwitch.isSwitchedOn) {
+                            <div class="top-banner-ad-container@if(LeadAdTopPageSwitch.isSwitchedOn){ top-banner-ad-container--below-header}">
+                                @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
+                            </div>
+                        }
                         @fragments.localNav(metaData)
                     </div>
                     <div class="parts__body">


### PR DESCRIPTION
Kind of unnecessary to have separate switches for OAS and DFP (one should be the default), but as we'll be getting rid of the OAS code soon, not going to simplify it

Also, make sure `AdvertSwitch` is on before even displaying the slot

Related to https://github.com/guardian/frontend/issues/3597
