### PR TITLE
Add logic to check if team coluors are light/dark

### DIFF
--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -6,8 +6,8 @@
 @defining((page.lineUp.homeTeam, page.lineUp.awayTeam, page.lineUp)){ case (home, away, lineUp) =>
 <div class="@RenderClasses(Map(
             "c-match-stats" -> true,
-            "match-stats--darken-home" -> (home.teamColour == "#FFFFFF"),
-            "match-stats--darken-away" -> (away.teamColour == "#FFFFFF")
+            "match-stats--darken-home" -> ColourTools.isLight(home.teamColour),
+            "match-stats--darken-away" -> ColourTools.isLight(away.teamColour)
         ))">
 
     <h3 class="component__heading">Match stats</h3>
@@ -15,37 +15,37 @@
     <h4 class="match-stats__caption">Goal attempts</h4>
     <dl class="match-stats goal-attempts u-cf">
         <dt class="goal-attempts__label goal-attempts__label--off-target-home"><span class="u-h">@home.name </span>Off target</dt>
-        <dd class="goal-attempts__off-target goal-attempts__off-target--home" style="background-color: @colourCheck(home.teamColour);">@home.shotsOff</dd>
+        <dd class="goal-attempts__off-target goal-attempts__off-target--home" style="background-color: @ColourTools.darkenWhite(home.teamColour);">@home.shotsOff</dd>
         <dt class="goal-attempts__label goal-attempts__label--off-target-away"><span class="u-h">@away.name </span>Off target</dt>
-        <dd class="goal-attempts__off-target goal-attempts__off-target--away" style="background-color: @colourCheck(away.teamColour);">@away.shotsOff</dd>
+        <dd class="goal-attempts__off-target goal-attempts__off-target--away" style="background-color: @ColourTools.darkenWhite(away.teamColour);">@away.shotsOff</dd>
 
         <dt class="goal-attempts__label goal-attempts__label--on-target-home"><span class="u-h">@home.name </span>On target</dt>
-        <dd class="goal-attempts__on-target goal-attempts__on-target--home" style="background-color: @colourCheck(home.teamColour);">@home.shotsOn</dd>
+        <dd class="goal-attempts__on-target goal-attempts__on-target--home" style="background-color: @ColourTools.darkenWhite(home.teamColour);">@home.shotsOn</dd>
         <dt class="goal-attempts__label goal-attempts__label--on-target-away"><span class="u-h">@away.name </span>On target</dt>
-        <dd class="goal-attempts__on-target goal-attempts__on-target--away" style="background-color: @colourCheck(away.teamColour);">@away.shotsOn</dd>
+        <dd class="goal-attempts__on-target goal-attempts__on-target--away" style="background-color: @ColourTools.darkenWhite(away.teamColour);">@away.shotsOn</dd>
     </dl>
 
     <dl class="u-cf match-stats bar-fight">
         <dt class="match-stats__caption">Possession</dt>
         @defining(PercentMaker(lineUp.homeTeamPossession, lineUp.awayTeamPossession)){ case (homePercent, awayPercent) =>
-            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @colourCheck(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@homePercent%</dd>
-            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @colourCheck(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@awayPercent%</dd>
+            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @ColourTools.darkenWhite(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@homePercent%</dd>
+            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @ColourTools.darkenWhite(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@awayPercent%</dd>
         }
         <dt class="match-stats__caption">Corners</dt>
         @defining(PercentMaker(home.corners, away.corners)){ case (homePercent, awayPercent) =>
-            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @colourCheck(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@home.corners</dd>
-            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @colourCheck(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@away.corners</dd>
+            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @ColourTools.darkenWhite(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@home.corners</dd>
+            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @ColourTools.darkenWhite(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@away.corners</dd>
         }
         <dt class="match-stats__caption">Fouls</dt>
         @defining(PercentMaker(home.fouls, away.fouls)){ case (homePercent, awayPercent) =>
-            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @colourCheck(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@home.fouls</dd>
-            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @colourCheck(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@away.fouls</dd>
+            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @ColourTools.darkenWhite(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@home.fouls</dd>
+            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @ColourTools.darkenWhite(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@away.fouls</dd>
         }
 
         <dt class="match-stats__caption">Offsides</dt>
         @defining(PercentMaker(home.offsides, away.offsides)){ case (homePercent, awayPercent) =>
-            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @colourCheck(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@home.offsides</dd>
-            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @colourCheck(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@away.offsides</dd>
+            <dd class="bar-fight__bar bar-fight__bar--home" style="background-color: @ColourTools.darkenWhite(home.teamColour); width: @NudgePercent(homePercent, awayPercent)%;">@home.offsides</dd>
+            <dd class="bar-fight__bar bar-fight__bar--away" style="background-color: @ColourTools.darkenWhite(away.teamColour); width: @NudgePercent(awayPercent, homePercent)%;">@away.offsides</dd>
         }
     </dl>
 </div>

--- a/sport/app/football/views/support.scala
+++ b/sport/app/football/views/support.scala
@@ -64,10 +64,19 @@ object MatchStatus extends Logging {
 
 }
 
-object colourCheck {
-  def apply(colour: String) = {
+object ColourTools {
+  def darkenWhite(colour: String) = {
     if (colour == "#FFFFFF") "#EEEEEE"
     else colour
+  }
+
+  def isLight(colour: String) = {
+    val hex = colour.dropWhile('#' == _)
+    val r = Integer.parseInt(hex.take(2), 16)
+    val g = Integer.parseInt(hex.drop(2).take(2), 16)
+    val b = Integer.parseInt(hex.drop(4).take(2), 16)
+    val yiq = ((r*299) + (g*587) + (b*114)) / 1000
+    yiq > 128
   }
 }
 

--- a/sport/test/football/views/ColourToolsTest.scala
+++ b/sport/test/football/views/ColourToolsTest.scala
@@ -3,7 +3,7 @@ package football.views
 import org.scalatest.{ShouldMatchers, FunSuite}
 import views.ColourTools
 
-class colourCheckTest extends FunSuite with ShouldMatchers {
+class ColourToolsTest extends FunSuite with ShouldMatchers {
   test("Whtie should be a light colour") {
     ColourTools.isLight("ffffff") should equal(true)
   }

--- a/sport/test/football/views/colourCheckTest.scala
+++ b/sport/test/football/views/colourCheckTest.scala
@@ -1,0 +1,24 @@
+package football.views
+
+import org.scalatest.{ShouldMatchers, FunSuite}
+import views.colourCheck
+
+class colourCheckTest extends FunSuite with ShouldMatchers {
+  test("Whtie should be a light colour") {
+    colourCheck.isLight("ffffff") should equal(true)
+  }
+
+  test("black should be a dark colour") {
+    colourCheck.isLight("000000") should equal(false)
+  }
+
+  test("Marginal colours should be correctly identified") {
+    colourCheck.isLight("333333") should equal(false)
+    colourCheck.isLight("00ccff") should equal(true)
+    colourCheck.isLight("ff00ff") should equal(false)
+  }
+
+  test("drops the leading # if present") {
+    colourCheck.isLight("#ffffff") should equal(true)
+  }
+}

--- a/sport/test/football/views/colourCheckTest.scala
+++ b/sport/test/football/views/colourCheckTest.scala
@@ -1,24 +1,24 @@
 package football.views
 
 import org.scalatest.{ShouldMatchers, FunSuite}
-import views.colourCheck
+import views.ColourTools
 
 class colourCheckTest extends FunSuite with ShouldMatchers {
   test("Whtie should be a light colour") {
-    colourCheck.isLight("ffffff") should equal(true)
+    ColourTools.isLight("ffffff") should equal(true)
   }
 
   test("black should be a dark colour") {
-    colourCheck.isLight("000000") should equal(false)
+    ColourTools.isLight("000000") should equal(false)
   }
 
   test("Marginal colours should be correctly identified") {
-    colourCheck.isLight("333333") should equal(false)
-    colourCheck.isLight("00ccff") should equal(true)
-    colourCheck.isLight("ff00ff") should equal(false)
+    ColourTools.isLight("333333") should equal(false)
+    ColourTools.isLight("00ccff") should equal(true)
+    ColourTools.isLight("ff00ff") should equal(false)
   }
 
   test("drops the leading # if present") {
-    colourCheck.isLight("#ffffff") should equal(true)
+    ColourTools.isLight("#ffffff") should equal(true)
   }
 }


### PR DESCRIPTION
Chooses the correct text colour based on the team colour so the text
will be legible.

Before:
![light-colour-stats](https://f.cloud.github.com/assets/29761/2485482/93498e6c-b119-11e3-8ca7-c2a3d1a927fa.png)

After:
![fixedstatstextcolour](https://f.cloud.github.com/assets/29761/2485493/b4c9a9fa-b119-11e3-8483-47ac77994686.png)
