### PR TITLE
Turn full words in body keywords into links

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -488,7 +488,7 @@ class TagLinker(article: Article)(implicit val edition: Edition) extends HtmlCle
           tagLink.attr("data-link-name", "auto-linked-tag")
           tagLink.addClass("u-underline")
 
-          p.html(p.html().replaceFirst(keyword.name, tagLink.toString))
+          p.html(p.html().replaceFirst(" " + keyword.name + " ", " " + tagLink.toString + " "))
         }
       }
     }


### PR DESCRIPTION
See http://www.theguardian.com/world/2014/mar/21/eu-mobilises-trade-war-russia-crimea-ukraine

"Europe" keyword was detected in a paragraph, but "Europe" in "**Europe**an" was turned into a link. This PR fixes that behaviour.
## Before

![screen shot 2014-03-24 at 11 28 29](https://f.cloud.github.com/assets/85783/2498571/16efd714-b348-11e3-82b7-31b187f5afef.PNG)
## After

![screen shot 2014-03-24 at 11 28 20](https://f.cloud.github.com/assets/85783/2498572/199898fc-b348-11e3-8962-c63b336a4c55.PNG)

![ ](http://media.giphy.com/media/FB41CON30OeqI/giphy.gif)
