### PR TITLE
Make in-text calls to actions more obvious

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -234,9 +234,9 @@ Loader.prototype.renderDiscussionClosedMessage = function() {
 Loader.prototype.renderSignin = function() {
     var url = Id.getUrl() +'/{1}?returnUrl='+ window.location.href;
     this.getElem('commentBox').innerHTML =
-        '<div class="d-bar d-bar--signin">Open for comments. <a href="'+
+        '<div class="d-bar d-bar--signin">Open for comments. <a class="u-underline" href="'+
             url.replace('{1}', 'signin') +'">Sign in</a> or '+
-            '<a href="'+ url.replace('{1}', 'register') +'">create your Guardian account</a> '+
+            '<a class="u-underline" href="'+ url.replace('{1}', 'register') +'">create your Guardian account</a> '+
             'to join the discussion.'+
         '</div>';
 };

--- a/identity/app/views/email_verified.scala.html
+++ b/identity/app/views/email_verified.scala.html
@@ -9,7 +9,7 @@
         @if(state.isValidated){
             <h1 class="identity-title">Thank you! Your email address has been validated.</h1>
             <p>You will now be able to comment.</p>
-            <p><a href="@LinkTo{/}" data-link-name="Home">Return to the homepage</a> or <a href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="Edit profile">edit your profile</a>.</p>
+            <p><a class="u-underline" href="@LinkTo{/}" data-link-name="Home">Return to the homepage</a> or <a class="u-underline" href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="Edit profile">edit your profile</a>.</p>
         }else {
             @if(state.isExpired){
                 <h1 class="identity-title">Your email confirmation link has expired.</h1>

--- a/identity/app/views/password/password_reset_confirmation.scala.html
+++ b/identity/app/views/password/password_reset_confirmation.scala.html
@@ -6,7 +6,7 @@
 }{
 <div class="identity-wrapper monocolumn-wrapper">
     <h1 class="identity-title">Your password has been changed</h1>
-    <p><a href="@idUrlBuilder.buildUrl("/signin", idRequest)" data-link-name="Sign in after reset">Sign in to your account</a>.</p>
+    <p><a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)" data-link-name="Sign in after reset">Sign in to your account</a>.</p>
 
     @registrationFooter(page, idRequest, idUrlBuilder)
 </div>

--- a/identity/app/views/password/request_password_reset.scala.html
+++ b/identity/app/views/password/request_password_reset.scala.html
@@ -31,7 +31,7 @@
     </form>
 
     <div class="identity-section">
-        <a href="#unlink-password" data-toggle="js-unlink-password" data-link-name="Unlink password">Unlinked the Guardian from Facebook, Twitter or Google and want to sign in?</a>
+        <a class="u-underline" href="#unlink-password" data-toggle="js-unlink-password" data-link-name="Unlink password">Unlinked the Guardian from Facebook, Twitter or Google and want to sign in?</a>
         <p class="identity-section__text js-unlink-password is-off">Use the email address field to send a reset link to your registered Facebook, Twitter or Google email. You will then be able to add a password to your account.</p>
     </div>
 

--- a/identity/app/views/password/reset_password_request_new_token.scala.html
+++ b/identity/app/views/password/reset_password_request_new_token.scala.html
@@ -32,7 +32,7 @@
 
     <div class="identity-section">
         <h2 class="identity-section__head">Something else?</h2>
-        <p class="identity-section__text"><a href="mailto:userhelp@@theguardian.com?subject=Account%20help" data-link-name="Email Userhelp">Email Userhelp</a> who'll be able to help you.</p>
+        <p class="identity-section__text"><a class="u-underline" href="mailto:userhelp@@theguardian.com?subject=Account%20help" data-link-name="Email Userhelp">Email Userhelp</a> who'll be able to help you.</p>
     </div>
 
     @registrationFooter(page, idRequest, idUrlBuilder)

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -9,7 +9,7 @@
 }{
 <div class="identity-wrapper monocolumn-wrapper">
     <h1 class="identity-title">Create your Guardian account</h1>
-    <p>Already have an account? <a href="@idUrlBuilder.buildUrl("/signin", idRequest)">Sign in</a>.</p>
+    <p>Already have an account? <a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)">Sign in</a>.</p>
 
     <form class="form js-register-form" novalidate action="@idUrlBuilder.buildUrl("/register", idRequest)" role="main" method="post">
         @if(registrationForm.globalError.isDefined) {

--- a/identity/app/views/signin.scala.html
+++ b/identity/app/views/signin.scala.html
@@ -8,7 +8,7 @@
 }{
 <div class="identity-wrapper monocolumn-wrapper">
     <h1 class="identity-title">Sign in to the Guardian</h1>
-    <p>Don't have an account? <a href="@idUrlBuilder.buildUrl("/register", idRequest)">Register now</a>.</p>
+    <p>Don't have an account? <a class="u-underline" href="@idUrlBuilder.buildUrl("/register", idRequest)">Register now</a>.</p>
 
     <form class="form js-signin-form" novalidate action="@idUrlBuilder.buildUrl("/signin", idRequest)" role="main" method="post">
         @if(signinForm.globalError.isDefined) {


### PR DESCRIPTION
This PR improves accessibility of in-text calls to action, making them more obvious (a blue link being barely visible when inside a context of dark text).

Has an impact on discussion and identity only.

![screen shot 2014-03-24 at 14 49 25](https://f.cloud.github.com/assets/85783/2500543/8923f46c-b363-11e3-8711-3bdb09b22d86.PNG)

![screen shot 2014-03-24 at 14 36 29](https://f.cloud.github.com/assets/85783/2500550/93b27a66-b363-11e3-9adf-930962d1ab14.PNG)

![ ](http://media1.giphy.com/media/kMkHbjHIIhiMw/200.gif)
