### PR TITLE
Fix vertical spacing around lead ad slot

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -44,12 +44,11 @@
 }
 .top-banner-ad-container {
     min-height: 70px;
-    @include rem((
-        padding: ($gs-baseline/6)*5 0 ($gs-baseline/3) 0
-    ));
 
     @include mq(faciaLeftCol) {
         @include rem((
+            padding-top: $gs-baseline/2,
+            padding-bottom: $gs-baseline/2,
             width: gs-span(14)
         ));
         margin: 0 auto;


### PR DESCRIPTION
- [fix] Removes an unexpected amount of space around the lead ad on mobile
- [new] Slightly smaller top vertical space at higher breakpoints to match the bottom space

![screen shot 2014-03-24 at 15 06 09](https://f.cloud.github.com/assets/85783/2500773/f1d8c4f4-b365-11e3-83bc-a7971845b0d5.PNG)

![screen shot 2014-03-24 at 15 03 15](https://f.cloud.github.com/assets/85783/2500774/f4843792-b365-11e3-86f8-6f11d4d222ea.PNG)

![ ](http://media2.giphy.com/media/TW1oEbaZ6HRYY/200.gif)
