### PR TITLE
Right hand col meta headings fixes

### DIFF
--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -192,14 +192,7 @@ a.edition {
     ));
 }
 
-.component__heading {
-    @include fs-header(1);
-    @include rem((
-        padding-top: $gs-baseline/3,
-        margin-bottom: $gs-baseline/2
-    ));
-    border-top: 1px dotted $c-neutral1;
-}
+.component__heading {}
 
 .component--rhc {
     margin-top: $gs-baseline*3;

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -466,6 +466,7 @@
         padding-top: ($gs-baseline/3),
         padding-bottom: ($gs-baseline/3)*4
     ));
+    margin-bottom: 0;
     border-top: 1px dotted $c-neutral5;
 }
 

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -461,7 +461,7 @@
 }
 
 .article__meta-heading {
-    @include fs-header(2);
+    @include fs-header(1);
     @include rem((
         padding-top: ($gs-baseline/3),
         padding-bottom: ($gs-baseline/3)*4

--- a/common/app/assets/stylesheets/module/football/_stats.scss
+++ b/common/app/assets/stylesheets/module/football/_stats.scss
@@ -5,7 +5,7 @@
 .match-stats__caption {
     @include fs-data(5);
     @include rem((
-        margin: ($gs-baseline/3)*4 0 $gs-baseline/1.5
+        margin-bottom: $gs-baseline/1.5
     ));
     color: $c-neutral1;
     font-weight: 400;
@@ -109,6 +109,9 @@
 .bar-fight {
     .match-stats__caption {
         float: left;
+        @include rem((
+            margin-top: ($gs-baseline/3)*4
+        ));
     }
 }
 

--- a/common/app/assets/stylesheets/module/onward/_right-hand-most-popular.scss
+++ b/common/app/assets/stylesheets/module/onward/_right-hand-most-popular.scss
@@ -2,17 +2,6 @@
     clear: left;
 }
 
-.right-most-popular__title {
-    @include rem((
-        height: gs-height(1)
-    ));
-    padding-top: $gs-baseline/3;
-    margin-bottom: $gs-baseline/1.5;
-    border-top: 1px dotted $c-neutral5;
-    @include fs-header(2);
-    @include box-sizing(border-box);
-}
-
 .right-most-popular-item {
     clear: left;
     @include rem((

--- a/onward/app/views/fragments/rightMostPopular.scala.html
+++ b/onward/app/views/fragments/rightMostPopular.scala.html
@@ -1,7 +1,7 @@
 @(popular: model.MostPopular)(implicit request: RequestHeader)
 
 <div class="right-most-popular right-most-popular--image" data-component="right-most-popular">
-    <h3 class="right-most-popular__title">Most popular</h3>
+    <h3 class="article__meta-heading">Most popular</h3>
     <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular">
         @popular.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>
             <li class="right-most-popular-item" data-link-name="trail | @row.rowNum">

--- a/onward/app/views/fragments/rightMostPopularGeo.scala.html
+++ b/onward/app/views/fragments/rightMostPopularGeo.scala.html
@@ -1,7 +1,7 @@
 @(popular: model.MostPopular, country: Option[String], countryCode: String)(implicit request: RequestHeader)
 
 <div class="right-most-popular right-most-popular--image" data-component="geo-most-popular">
-    <h3 class="right-most-popular__title">Most popular @{country.map{ name => s"in ${name}"}}</h3>
+    <h3 class="article__meta-heading">Most popular @{country.map{ name => s"in ${name}"}}</h3>
     <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular geo @countryCode">
         @popular.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>
             <li class="right-most-popular-item" data-link-name="trail | @row.rowNum">

--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -10,7 +10,7 @@
             "match-stats--darken-away" -> ColourTools.isLight(away.teamColour)
         ))">
 
-    <h3 class="component__heading">Match stats</h3>
+    <h3 class="component__heading article__meta-heading">Match stats</h3>
 
     <h4 class="match-stats__caption">Goal attempts</h4>
     <dl class="match-stats goal-attempts u-cf">


### PR DESCRIPTION
As discussed with Chris P, this PR normalises the size and appearance of headings in the right hand side column.

Note that now, right hand side headings size is now 16px (was 18px).

![ ](http://media.giphy.com/media/x1UGz8vzNSyMo/giphy.gif)
