### PR TITLE
Revert undo - fixing football score links

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -53,7 +53,14 @@ define([
                 scoreContainer.innerHTML = '';
                 scoreBoard.render(scoreContainer);
 
-                // TODO (jamesgorrie): The stats component should travel with this lot. Two calls is a bit crap
+                $('.score-summary').addClass('u-fauxlink').each(function(el) {
+                    bean.on(el, 'click', function() {
+                        $('.tabs__tab a').first().each(function(el) {
+                            window.location = el.getAttribute('href');
+                        });
+                    });
+                });
+
                 if (!match.id) {
                     var statsUrl = $('.tab--stats a', context).attr('href').replace(/^.*\/\/[^\/]+/, ''),
                         statsContainer = bonzo.create('<div class="match-stats__container"></div>'),
@@ -104,8 +111,10 @@ define([
         });
 
         // Binding
-        bean.on(context, 'click', '.table tr[data-link-to]', function() {
-            window.location = this.getAttribute('data-link-to');
+        bean.on(context, 'click', '.table tr[data-link-to]', function(e) {
+            if (!e.target.getAttribute('href')) {
+                window.location = this.getAttribute('data-link-to');
+            }
         });
 
         bean.on(context, 'change', $('form.football-leagues')[0], function() {

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -48,21 +48,25 @@ define([
             }
 
             matchInfo.fetch().then(function(resp) {
-                $('.after-header', context).append(resp.nav);
-                scoreBoard.template = config.page.isLiveBlog ? resp.matchSummary : resp.scoreSummary;
-                scoreContainer.innerHTML = '';
-                scoreBoard.render(scoreContainer);
-
-                $('.score-summary').addClass('u-fauxlink').each(function(el) {
-                    bean.on(el, 'click', function() {
-                        $('.tabs__tab a').first().each(function(el) {
-                            window.location = el.getAttribute('href');
-                        });
-                    });
+                var $nav = $.create(resp.nav).first().each(function(nav) {
+                    if (match.id || $('.tabs__tab', nav).length > 2) {
+                        $('.after-header', context).append(nav);
+                    }
                 });
 
                 if (!match.id) {
-                    var statsUrl = $('.tab--stats a', context).attr('href').replace(/^.*\/\/[^\/]+/, ''),
+                    scoreContainer.innerHTML = '';
+                    scoreBoard.template = config.page.isLiveBlog ? resp.matchSummary : resp.scoreSummary;
+                    scoreBoard.render(scoreContainer);
+
+                    $('.tab--min-by-min a', $nav).first().each(function(el) {
+                        bonzo(scoreBoard.elem).addClass('u-fauxlink');
+                        bean.on(scoreBoard.elem, 'click', function() {
+                            window.location = el.getAttribute('href');
+                        });
+                    });
+
+                    var statsUrl = $('.tab--stats a', $nav).attr('href').replace(/^.*\/\/[^\/]+/, ''),
                         statsContainer = bonzo.create('<div class="match-stats__container"></div>'),
                         matchStats = new MatchStats(statsUrl);
 

--- a/common/app/assets/stylesheets/module/football/_live-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_live-summary.scss
@@ -3,6 +3,7 @@
 }
 
 .score__loading--live {
+    min-height: 165px;
     text-align: center;
 
     .is-updating {
@@ -18,7 +19,6 @@
     @include rem((
         margin: $gs-baseline 0 (-$gs-baseline/2)
     ));
-    color: $c-newsDefault;
 
     @include mq($from: tablet) {
         @include fs-headline(4, true);


### PR DESCRIPTION
[Reopening this](https://github.com/guardian/frontend/pull/3649).
Apologies.

So what should happen:
- **On match report:** If we have minute-by-minute - link to it, show tabs ([🐵](http://m.thegulocal.com/football/2014/mar/23/manchester-united-wayne-rooney-west-ham)).
- **On match report:** If we only have a match report - don't link, don't show tabs([🐵](http://m.thegulocal.com/football/2014/mar/22/cardiff-city-liverpool-premier-league-match-report)).
- **On stats:** Show report and min-by-min if we have it ([🐵](http://m.thegulocal.com/football/match/2014/mar/22/cardiffcity-v-liverpool)).

🐵 = local link

![Silly man](http://courses.cs.washington.edu/courses/cse190m/08sp/labs/6-midterm_review/images/sillywalks.gif)
