### PR TITLE
Remove layout trashing when a page has a local navigation

### DIFF
--- a/common/app/assets/javascripts/modules/navigation/sections.js
+++ b/common/app/assets/javascripts/modules/navigation/sections.js
@@ -72,20 +72,11 @@ define([
                 for(var i=0, l=visibleItems.length; i < l; i++) {
                     bonzo(popupItems[i]).addClass('u-h');
                 }
-            },
-
-            // there is not a 'no JavaScript' version of this.
-            upgradeLocalNav: function(context) {
-                if (context.querySelector('.js-localnav--small')) {
-                    common.$g('#preloads').addClass('has-localnav');
-                    common.$g('.js-localnav--small').removeClass('is-hidden');
-                }
             }
         };
 
         this.init = function (context) {
             this.view.bindings(context);
-            this.view.upgradeLocalNav(context);
         };
      }
 

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -69,14 +69,7 @@
 .container__title a {
     color: inherit;
 }
-@include mq($to: tablet) {
-    .has-localnav .container--first {
-        .container__title,
-        .container__border {
-            display: none;
-        }
-    }
-}
+
 .container__updated {
     display: block;
     @include fs-headline(1);

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -65,11 +65,10 @@
             @include fs-headline(2, $size-only: true);
         }
     }
+    a {
+        color: inherit;
+    }
 }
-.container__title a {
-    color: inherit;
-}
-
 .container__updated {
     display: block;
     @include fs-headline(1);
@@ -79,29 +78,31 @@
     position: relative;
     @include box-sizing(border-box);
     width: 100%;
+
     @include mq(faciaLeftCol) {
         .i--clock {
             display: none;
         }
     }
     @include mq(wide) {
+        @include rem((
+            padding-left: $gs-gutter/2
+        ));
+
         .i--clock {
             display: block;
         }
-        padding-left: 40px;
     }
     time {
         display: block;
     }
 }
-
 .container__toggle,
 .item__live-indicator,
 .item__meta,
 .collection__show-more {
     @include f-data;
 }
-
 .container__toggle {
     position: absolute;
     @include rem((
@@ -154,7 +155,6 @@
         left: gs-span(15) + $gs-gutter;
     }
 }
-
 .collection {
     font-size: 0;
     overflow: hidden;
@@ -179,7 +179,6 @@
         display: inline-block;
         vertical-align: top;
     }
-
 }
 .item__link {
     display: block;
@@ -195,11 +194,9 @@
             color: $c-neutral2;
         }
     }
-
     &:active {
         color: $c-neutral1;
     }
-
     &:hover {
         .item__cta {
             background-color: rgba($c-neutral2, 1);
@@ -400,7 +397,6 @@
         top: 30%;
         left: 30%;
     }
-
     p {
         width: 0;
         height: 0;
@@ -463,7 +459,6 @@ $cta-icon-gap: 2px;
         margin-top: -1 * (map-get($video-cta-icon, height) / 2);
     }
 }
-
 .item--dark {
     .item__container,
     .item__meta {
@@ -498,6 +493,7 @@ $cta-icon-gap: 2px;
         color: #9c9c9c; //Darkest we can go to pass accessiblity
     }
 }
+
 $show-more-icon: (
     width: 32px,
     height: 32px,
@@ -511,6 +507,7 @@ $show-more-icon: (
     75%  { -webkit-transform: rotate(270deg); }
     100% { -webkit-transform: rotate(360deg); }
 }
+
 .collection__show-more {
     display: block;
     border: none;

--- a/common/app/assets/stylesheets/module/nav/_localnav.scss
+++ b/common/app/assets/stylesheets/module/nav/_localnav.scss
@@ -1,7 +1,7 @@
 /* Local navigation - Global container overrides
    ========================================================================== */
 
-#preloads.has-localnav {
+.js-on .has-localnav {
     .ad-slot-top-banner-ad {
         padding-top: 5px;
         background-color: #eeeeee;
@@ -23,6 +23,15 @@
     }
     .article__head {
         border-top: 0;
+    }
+
+    @include mq($to: tablet) {
+        .container--first {
+            .container__title,
+            .container__border {
+                display: none;
+            }
+        }
     }
 }
 

--- a/common/app/views/fragments/localNav.scala.html
+++ b/common/app/views/fragments/localNav.scala.html
@@ -5,7 +5,7 @@
     @defining(localNav.links.find(_.currentFor(metaData))){ currentSublink =>
 
 
-        <div class="localnav--small tone-@VisualTone(metaData) tone-accent-border is-hidden js-localnav--small">
+        <div class="localnav--small tone-@VisualTone(metaData) tone-accent-border js-visible js-localnav--small">
             <div class="localnav__inner u-cf">
                 <button class="u-button-reset localnav__cta" data-link-name="Popup Localnav" data-toggle="nav-popup--localnav">
                     <span class="control tone-border">

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -9,7 +9,10 @@
 <head>
     @fragments.head(metaData, projectName, head, curlPaths)
 </head>
-<body id="top" itemscope itemtype="http://schema.org/WebPage">
+<body
+    @Navigation.topLevelItem(Edition(request).navigation(metaData), metaData).filter(_.links.nonEmpty).map{ localNav => class="has-localnav" }
+    id="top"
+    itemscope itemtype="http://schema.org/WebPage">
 
     @if(AdvertSwitch.isSwitchedOn && LeadAdTopPageSwitch.isSwitchedOn) {
         <div class="top-banner-ad-container top-banner-ad-container--above-header">


### PR DESCRIPTION
The `has-localnav` class is now added directly in the HTML instead of via JavaScript.

This is okay since local navigation is no longer a test.

![ ](http://media.giphy.com/media/12lPDSEeDIIR0I/giphy.gif)
