### PR TITLE
Put DFP slots behind a switch

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -95,7 +95,10 @@
                                                 <h2 class="article__meta-heading">Share this article</h2>
                                                 @fragments.social(article, "next to content")
                                             </div>
-                                            <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">Advertisement</div><div class="ad-container"></div></div>
+                                            @if(OASAdvertSwitch.isSwitchedOn) {
+                                                <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">
+                                                    Advertisement</div><div class="ad-container"></div></div>
+                                            }
                                             @if(DFPAdvertSwitch.isSwitchedOn) {
                                                 <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
                                                     <div id="mpu-ad-slot" class="ad-container"></div>
@@ -123,7 +126,9 @@
 
     @fragments.mostPopularPlaceholder(article.section, VisualTone(article))
 
-    <div class="ad-slot__dfp ad-slot__commercial-component" data-name="merchandising" data-mobile="888,88" data-label="false" data-refresh="false">
-        <div id="dfp-commercial-component" class="ad-container"></div>
-    </div>
+    @if(DFPAdvertSwitch.isSwitchedOn) {
+        <div class="ad-slot__dfp ad-slot__commercial-component" data-name="merchandising" data-mobile="888,88" data-label="false" data-refresh="false">
+            <div id="dfp-commercial-component" class="ad-container"></div>
+        </div>
+    }
 }

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -99,7 +99,7 @@
                                                 <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">
                                                     Advertisement</div><div class="ad-container"></div></div>
                                             }
-                                            @if(DFPAdvertSwitch.isSwitchedOn) {
+                                            @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
                                                 <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
                                                     <div id="mpu-ad-slot" class="ad-container"></div>
                                                 </div>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -96,9 +96,11 @@
                                                 @fragments.social(article, "next to content")
                                             </div>
                                             <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">Advertisement</div><div class="ad-container"></div></div>
-                                            <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
-                                                <div id="mpu-ad-slot" class="ad-container"></div>
-                                            </div>
+                                            @if(DFPAdvertSwitch.isSwitchedOn) {
+                                                <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
+                                                    <div id="mpu-ad-slot" class="ad-container"></div>
+                                                </div>
+                                            }
                                         </div>
                                         <div class="js-components"></div>
                                     </div>

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -94,7 +94,7 @@
                                                 <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">
                                                     Advertisement</div><div class="ad-container"></div></div>
                                             }
-                                            @if(DFPAdvertSwitch.isSwitchedOn) {
+                                            @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
                                                 <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
                                                     <div id="mpu-ad-slot" class="ad-container"></div>
                                                 </div>

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -91,9 +91,11 @@
                                                 @fragments.social(article, "next to content")
                                             </div>
                                             <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">Advertisement</div><div class="ad-container"></div></div>
-                                            <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
-                                                <div id="mpu-ad-slot" class="ad-container"></div>
-                                            </div>
+                                            @if(DFPAdvertSwitch.isSwitchedOn) {
+                                                <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
+                                                    <div id="mpu-ad-slot" class="ad-container"></div>
+                                                </div>
+                                            }
                                         </div>
                                         <div class="js-components"></div>
                                     </div>

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -90,7 +90,10 @@
                                                 <h2 class="article__meta-heading">Share this live blog</h2>
                                                 @fragments.social(article, "next to content")
                                             </div>
-                                            <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">Advertisement</div><div class="ad-container"></div></div>
+                                            @if(OASAdvertSwitch.isSwitchedOn) {
+                                                <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">
+                                                    Advertisement</div><div class="ad-container"></div></div>
+                                            }
                                             @if(DFPAdvertSwitch.isSwitchedOn) {
                                                 <div class="ad-slot__dfp ad-slot--mpu-banner-ad" data-name="right" data-tabletlandscape="300,250">
                                                     <div id="mpu-ad-slot" class="ad-container"></div>


### PR DESCRIPTION
Call to DFP happens whenever there are DFP slots on the page so these shouldn't be shown unless switch is on.
