### PR TITLE
Ad space before the footer

### DIFF
--- a/common/app/assets/stylesheets/module/_footer.scss
+++ b/common/app/assets/stylesheets/module/_footer.scss
@@ -30,7 +30,8 @@
 
 .footer {
     @include rem((
-        padding: 0 0 ($gs-baseline/3)*4
+        padding: 0 0 ($gs-baseline/3)*4,
+        margin-top: $gs-baseline*3
     ));
     background: $c-neutral8;
 


### PR DESCRIPTION
When removing the bottom ad slot, all space was removed between containers and the footer.
## Before

![screen shot 2014-03-25 at 15 07 12](https://f.cloud.github.com/assets/85783/2513355/5769e4dc-b42f-11e3-9c56-18fb9aafc845.PNG)
## After

![screen shot 2014-03-25 at 15 07 06](https://f.cloud.github.com/assets/85783/2513356/59fd7e48-b42f-11e3-85e0-a55743a0ff85.PNG)

![ ](http://media.giphy.com/media/8G33Vvy3x8PQI/giphy.gif)
