### PR TITLE
Align supporting links to the grid

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_baguette.scss
+++ b/common/app/assets/stylesheets/module/facia/_baguette.scss
@@ -49,9 +49,23 @@
     .supporting__item {
         border-color: #ffffff;
     }
-    .supporting__item {
-        @include rem((
-            padding-left: $gs-gutter/4
-        ));
+    @include mq($to: tablet) {
+        .supporting__action {
+            @include rem((
+                margin-left: $gs-gutter/5
+            ));
+        }
+    }
+    @include mq(tablet) {
+        .supporting__item:first-child .supporting__action {
+            @include rem((
+                margin-left: $gs-gutter/5
+            ));
+        }
+        .supporting__item:last-child .supporting__action {
+            @include rem((
+                margin-right: $gs-gutter/5
+            ));
+        }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -336,14 +336,30 @@
 .fromage--volume-1,
 .fromage--volume-2 {
     .supporting__item {
-        border-top-color: #ffffff;
+        border-color: #ffffff;
 
-        @include rem((
-            padding-left: $gs-gutter/4
-        ));
+        @include mq($to: tablet) {
+            .supporting__action {
+                @include rem((
+                    margin-left: $gs-gutter/5
+                ));
+            }
+        }
         @include mq(tablet) {
             + .supporting__item {
                 border-left-color: #ffffff;
+            }
+            &:first-child {
+                .supporting__action {
+                    @include rem((
+                        margin-left: $gs-gutter/5
+                    ));
+                }
+            }
+            &:last-child .supporting__action {
+                @include rem((
+                    margin-right: $gs-gutter/5
+                ));
             }
         }
     }

--- a/common/app/assets/stylesheets/module/facia/_supporting.scss
+++ b/common/app/assets/stylesheets/module/facia/_supporting.scss
@@ -1,5 +1,12 @@
 .supporting {
     clear: both;
+
+    @include mq(tablet) {
+        @include rem((
+            margin-left: -$gs-gutter/2,
+            margin-right: -$gs-gutter/2
+        ));
+    }
 }
 .supporting-list {
     margin: 0;
@@ -19,13 +26,19 @@
     ));
     @include mq(tablet) {
         display: table-cell;
+        @include rem((
+            padding-right: $gs-gutter/2,
+            padding-left: $gs-gutter/2
+        ));
 
         & + & {
             border-left: 1px solid $c-neutral5;
 
-            @include rem((
-                padding-left: $gs-gutter/4
-            ));
+            .supporting__action {
+                @include rem((
+                    margin-left: -$gs-gutter/4
+                ));
+            }
         }
     }
 }


### PR DESCRIPTION
Aligns the sup links pattern with a 4-in-a-row container.
## Before

![screen shot 2014-03-25 at 18 32 21](https://f.cloud.github.com/assets/85783/2516275/1c8c16ba-b44c-11e3-9ff1-5899b91cf555.PNG)
## After

![screen shot 2014-03-25 at 18 33 00](https://f.cloud.github.com/assets/85783/2516278/1f2b05a2-b44c-11e3-9b0f-b212253bdc8b.PNG)

![ ](http://media.giphy.com/media/13UEljgpMWmgDu/giphy.gif)
