### PR TITLE
Put to ContentApi on collection config update

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -139,6 +139,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
 
   def pressCollection(id: String) = AjaxExpiringAuthentication { request =>
     pressCollectionId(id)
+    notifyContentApi(id)
     NoCache(Ok)
   }
 

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -137,7 +137,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     }
   }
 
-  def pressCollection(id: String) = AjaxExpiringAuthentication { request =>
+  def updateCollection(id: String) = AjaxExpiringAuthentication { request =>
     pressCollectionId(id)
     notifyContentApi(id)
     NoCache(Ok)

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -21,7 +21,7 @@ GET           /configuration             controllers.FaciaToolController.configE
 
 POST          /collection/publish/*id    controllers.FaciaToolController.publishCollection(id)
 POST          /collection/discard/*id    controllers.FaciaToolController.discardCollection(id)
-POST          /collection/press/*id      controllers.FaciaToolController.pressCollection(id)
+POST          /collection/update/*id     controllers.FaciaToolController.updateCollection(id)
 
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
 POST          /edits                     controllers.FaciaToolController.collectionEdits

--- a/facia-tool/public/javascripts/models/config/main.js
+++ b/facia-tool/public/javascripts/models/config/main.js
@@ -110,7 +110,7 @@ define([
 
         function pressCollection(collection) {
             return authedAjax.request({
-                url: vars.CONST.apiBase + '/collection/press/' + collection.id,
+                url: vars.CONST.apiBase + '/collection/update/' + collection.id,
                 type: 'post'
             });
         }


### PR DESCRIPTION
We need to push collections to ContentApi whenever they're configured. Currently they only get pushed on curation, meaning that backfill-only collections never get pushed to ContentApi and thus are unavailable to apps.
