### PR TITLE
Extend id-profile-navigation switch indefinitely

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -208,7 +208,7 @@ object Switches extends Collections {
 
   val IdentityProfileNavigationSwitch = Switch("Feature Switches", "id-profile-navigation",
     "If this switch is on you will see the link in the topbar taking you through to the users profile or sign in..",
-    safeState = On, sellByDate = endOfQ4
+    safeState = On, sellByDate = never
   )
 
   val ClientSideErrorSwitch = Switch("Feature Switches", "client-side-errors",


### PR DESCRIPTION
Feels like it's probably reasonable to have this switch, in case Identity ever went down.
