### PR TITLE
Fronts config: fronts displayName

### DIFF
--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -15,6 +15,7 @@ case class Config(
 
 case class Front(
                   collections: List[String],
+                  title: Option[String],
                   webTitle: Option[String]
                   )
 

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -15,7 +15,7 @@ case class Config(
 
 case class Front(
                   collections: List[String],
-                  title: Option[String],
+                  displayName: Option[String],
                   webTitle: Option[String]
                   )
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -144,9 +144,9 @@
                 <div class="cnf-front__inner">
                     <div data-bind="visible: state.openProps">
                         <div class="cnf-form" data-bind="">
-                                <label>title</label>
+                                <label>displayName</label>
                                 <input type="text" data-bind="
-                                    value: props.title"/>
+                                    value: props.displayName"/>
                                 <label>webTitle</label>
                                 <input type="text" data-bind="
                                     value: props.webTitle"/>
@@ -156,8 +156,8 @@
                     <div data-bind="visible: !state.openProps(), click: openProps">
                         <div class="cnf-form" data-bind="">
                             <div>
-                                <label>title</label>
-                                <span data-bind="text: props.title() || 'None!'"></span>
+                                <label>displayName</label>
+                                <span data-bind="text: props.displayName() || 'None!'"></span>
                             </div>
                             <div>
                                 <label>webTitle</label>

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -144,7 +144,10 @@
                 <div class="cnf-front__inner">
                     <div data-bind="visible: state.openProps">
                         <div class="cnf-form" data-bind="">
-                                <label>Title</label>
+                                <label>title</label>
+                                <input type="text" data-bind="
+                                    value: props.title"/>
+                                <label>webTitle</label>
                                 <input type="text" data-bind="
                                     value: props.webTitle"/>
                             <div class="tools"><span class="tool" data-bind="click: save">Save</span></div>
@@ -153,7 +156,11 @@
                     <div data-bind="visible: !state.openProps(), click: openProps">
                         <div class="cnf-form" data-bind="">
                             <div>
-                                <label>Title</label>
+                                <label>title</label>
+                                <span data-bind="text: props.title() || 'None!'"></span>
+                            </div>
+                            <div>
+                                <label>webTitle</label>
                                 <span data-bind="text: props.webTitle() || 'None!'"></span>
                             </div>
                         </div>

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -840,7 +840,7 @@ button {
 .cnf-form label {
     font-size: 12px;
     color: #999999;
-    width: 65px;
+    width: 75px;
     float: left;
     clear: left;
     margin: 1px 0 0 0;

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -37,6 +37,7 @@ define([
         });
 
         this.props  = asObservableProps([
+            'title',
             'webTitle']);
 
         populateObservables(this.props,  opts);

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -37,7 +37,7 @@ define([
         });
 
         this.props  = asObservableProps([
-            'title',
+            'displayName',
             'webTitle']);
 
         populateObservables(this.props,  opts);


### PR DESCRIPTION
Mainly for apps. Web doesn't need a display name for fronts.
