### PR TITLE
Remove Middle ad slot form mobile breakpoints

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -94,7 +94,7 @@
                                                 @fragments.social(article, "next to content")
                                             </div>
                                             @if(OASAdvertSwitch.isSwitchedOn) {
-                                                <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">
+                                                <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="" data-median="Middle"><div class="ad-slot__label">
                                                     Advertisement</div><div class="ad-container"></div></div>
                                             }
                                             @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -80,7 +80,7 @@
                                                 @fragments.social(article, "next to content")
                                             </div>
                                             @if(OASAdvertSwitch.isSwitchedOn) {
-                                                <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="Middle" data-median="Middle"><div class="ad-slot__label">
+                                                <div class="ad-slot__oas ad-slot--mpu-banner-ad" data-link-name="ad slot mpu-banner-ad" data-base="" data-median="Middle"><div class="ad-slot__label">
                                                     Advertisement</div><div class="ad-container"></div></div>
                                             }
                                             @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {


### PR DESCRIPTION
This is was a regression caused by the recent advert refactoring. Am going to ship first thing in the morning.

The repetition of the fragment isn't quite DRY and should really be abstracted into a single template, but seeing as we are bout to ditch OAS i'm going to leave.

/cc @ironsidevsquincy @kenlim @kelvin-chappell 
