### PR TITLE
Extend facebook-autosignin feature switch indefinitely

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -218,7 +218,7 @@ object Switches extends Collections {
 
   val FacebookAutoSigninSwitch = Switch("Feature Switches", "facebook-autosignin",
     "If this switch is on then users who have previously authorized the guardian app in facebook and who have not recently signed out are automatically signed in.",
-    safeState = Off, sellByDate = endOfQ4
+    safeState = Off, sellByDate = never
   )
 
   val IdentityFormstackSwitch = Switch("Feature Switches", "id-formstack",


### PR DESCRIPTION
@jamesgorrie and @chrisfinch have shown me that the switch still has effect here:

https://github.com/guardian/frontend/blob/cd94607f9/common/app/assets/javascripts/bootstraps/common.js#L413

...so I no longer want to remove the switch! (#3687)

(because Facebook is obviously a 3rd party system and we want to be able to turn off dependencies on those quickly)
