### PR TITLE
Magic match links

### DIFF
--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -51,6 +51,7 @@
 }
 
 .football-teams {
+    color: inherit;
     position: relative;
 }
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -97,6 +97,9 @@ GET         /football/match/:year/:month/:day/$home<[\w\d-\.]+>-v-$away<[\w\d-\.
 GET         /football/match/:matchId.json                                                                            football.controllers.MatchController.renderMatchIdJson(matchId)
 GET         /football/match/:matchId                                                                                 football.controllers.MatchController.renderMatchId(matchId)
 
+GET         /football/match-redirect/:year/:month/:day/:homeTeamId/:awayTeamId                                       football.controllers.MoreOnMatchController.redirectToMatch(year,month,day,homeTeamId,awayTeamId)
+GET         /football/match-redirect/:matchId                                                                        football.controllers.MoreOnMatchController.redirectToMatchId(matchId)
+
 # Admin
 GET         /login                                                                                                   controllers.admin.Login.login
 POST        /login                                                                                                   controllers.admin.Login.loginPost

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -64,6 +64,6 @@ object MatchController extends Controller with Football with Requests with Loggi
     }
 
     // we do not keep historical data, so just redirect old stuff to the results page (see also MatchController)
-    response.getOrElse(Future { Found("/football/results") })
+    response.getOrElse(Future.successful(Found("/football/results")))
   }
 }

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -63,7 +63,7 @@ object MatchController extends Controller with Football with Requests with Loggi
       }
     }
 
-    // we do not keep historical data, so just redirect old stuff to the results page
+    // we do not keep historical data, so just redirect old stuff to the results page (see also MatchController)
     response.getOrElse(Future { Found("/football/results") })
   }
 }

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -96,7 +96,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
   }
 
   def redirectToMatch(year: String, month: String, day: String, home: String, away: String) = Action.async { implicit request =>
-    val contentDate = DateTimeFormat.forPattern("yyyyMMMdd").parseDateTime(year + month + day).toDateMidnight
+    val contentDate = dateFormat.parseDateTime(year + month + day).toDateMidnight
     val maybeMatch = Competitions().matchFor(interval(contentDate), home, away)
     canonicalRedirectForMatch(maybeMatch, request)
   }
@@ -106,6 +106,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
       loadMoreOn(request, theMatch).map { related =>
         val (matchReport, minByMin, preview, stats) = fetchRelatedMatchContent(theMatch, related)
         val canonicalPage = matchReport.orElse(minByMin).orElse { if (theMatch.isFixture) preview else None }.getOrElse(stats)
+        print(canonicalPage)
         Cached(60)(TemporaryRedirect(canonicalPage.url))
       }
     }.getOrElse {

--- a/sport/app/football/implicits/Football.scala
+++ b/sport/app/football/implicits/Football.scala
@@ -95,6 +95,7 @@ trait Football extends Collections {
     override lazy val thumbnail: Option[ImageElement] = None
     override lazy val mainPicture = None
     override lazy val url: String = MatchUrl(m)
+    lazy val smartUrl: String = MatchUrl.smartUrl(m)
     override lazy val webUrl: String = ""
     override lazy val section: String = "football"
     override lazy val webPublicationDate: DateTime = m.date

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -3,6 +3,7 @@ package model
 import common._
 import conf.SwitchingContentApi
 import pa._
+import org.joda.time.DateTime
 
 
 case class Team(team: FootballTeam, tag: Option[Tag], shortName: Option[String]) extends FootballTeam {
@@ -139,12 +140,15 @@ object TeamName {
 // if we have tags for the matches we can make a sensible url for it
 object MatchUrl {
   def apply(theMatch: FootballMatch): String = {
-    val home = TeamMap(theMatch.homeTeam).tag.flatMap(_.url)
-    val away = TeamMap(theMatch.awayTeam).tag.flatMap(_.url)
-    (home, away) match {
-      case (Some(homeTeam), Some(awayTeam)) =>
-        s"/football/match/${theMatch.date.toString("yyyy/MMM/dd").toLowerCase}/${homeTeam.replace("/football/", "")}-v-${awayTeam.replace("/football/", "")}"
-      case _ => s"/football/match/${theMatch.id}"
-    }
+    (for {
+      homeTeam <- TeamMap(theMatch.homeTeam).tag.flatMap(_.url)
+      awayTeam <- TeamMap(theMatch.awayTeam).tag.flatMap(_.url)
+    } yield {
+      s"/football/match/${theMatch.date.toString("yyyy/MMM/dd").toLowerCase}/${homeTeam.replace("/football/", "")}-v-${awayTeam.replace("/football/", "")}"
+    }).getOrElse(s"/football/match/${theMatch.id}")
+  }
+
+  def smartUrl(theMatch: FootballMatch): String = {
+    s"/football/match-redirect/${theMatch.id}"
   }
 }

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -6,7 +6,6 @@
         <tr>
             <th class="match__status">Match status / kick off time</th>
             <th class="match__details">Match details</th>
-            <th class="match__report">Reports</th>
         </tr>
     </thead>
 
@@ -32,7 +31,7 @@
                     }
                 </td>
                 <td class="football-match__teams table-column--main">
-                    <div class="football-teams u-cf">
+                    <a href="@LinkTo{@theMatch.smartUrl}" class="unstyled football-teams u-cf">
                         <div class="football-match__team football-match__team--home football-team">
                             <div class="football-team__name">@theMatch.homeTeam.name</div>
                             <div class="football-team__score">@theMatch.homeTeam.score</div>
@@ -54,10 +53,7 @@
                         </div>
 
                         <div class="football-teams__battleline"></div>
-                    </div>
-                </td>
-                <td class="football-match__report">
-                    <a href="@LinkTo{@theMatch.smartUrl}" data-link-name="stats" data-match-id="@theMatch.id">Match stats</a>
+                    </a>
                 </td>
             </tr>
         }

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -12,7 +12,7 @@
 
     <tbody>
         @matchesList.map{ theMatch =>
-            <tr data-link-to="@LinkTo{@theMatch.url}"
+            <tr data-link-to="@LinkTo{@theMatch.smartUrl}"
                 data-match-id="@theMatch.id"
                 data-score-home="@theMatch.homeTeam.score"
                 data-score-away="@theMatch.awayTeam.score"
@@ -57,7 +57,7 @@
                     </div>
                 </td>
                 <td class="football-match__report">
-                    <a href="@LinkTo{@theMatch.url}" data-link-name="stats" data-match-id="@theMatch.id">Match stats</a>
+                    <a href="@LinkTo{@theMatch.smartUrl}" data-link-name="stats" data-match-id="@theMatch.id">Match stats</a>
                 </td>
             </tr>
         }

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -52,3 +52,5 @@ GET        /football/match/:year/:month/:day/$home<[\w\d-\.]+>-v-$away<[\w\d-\.]
 GET        /football/match/:matchId.json                                                       football.controllers.MatchController.renderMatchIdJson(matchId)
 GET        /football/match/:matchId                                                            football.controllers.MatchController.renderMatchId(matchId)
 
+GET        /football/match-redirect/:year/:month/:day/:homeTeamId/:awayTeamId                  football.controllers.MoreOnMatchController.redirectToMatch(year,month,day,homeTeamId,awayTeamId)
+GET        /football/match-redirect/:matchId                                                   football.controllers.MoreOnMatchController.redirectToMatchId(matchId)


### PR DESCRIPTION
We now have intelligent links to what a reader might actually be looking for.

**Before:** We sent readers the stats page for that match ([🐵](http://www.theguardian.com/football/match/3713194))

**After**:
- Is there a match report? Yes? Send you there.
- Is there a minute by minute? Yes? Send you there.
- Is there a Match preview and we haven't started yet? Yes? Send you there.
- No? Nothing? To the stats with you.

Details of that algorithm [are here](https://github.com/guardian/frontend/compare/magic-match-links?expand=1#diff-1290a98b5c1618b098443751b7e1f36dR108)

![Magic](http://www.picgifs.com/graphics/m/magic/graphics-magic-699248.gif)
