### PR TITLE
Start of fixing IDN-1736: 'Resend validation email' for logged-out users

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -7,9 +7,11 @@ import services.{IdentityUrlBuilder, IdRequestParser}
 import common.ExecutionContexts
 import utils.SafeLogging
 import model.IdentityPage
+import actions.AuthActionWithUser
 
 @Singleton
 class EmailVerificationController @Inject()( api: IdApiClient,
+                                             authActionWithUser: AuthActionWithUser,
                                              idRequestParser: IdRequestParser,
                                              idUrlBuilder: IdentityUrlBuilder)
   extends Controller with ExecutionContexts with SafeLogging {
@@ -34,6 +36,14 @@ class EmailVerificationController @Inject()( api: IdApiClient,
             case Right(ok) => validated
           }
           Ok(views.html.email_verified(validationState, page, idRequest, idUrlBuilder))
+      }
+  }
+
+  def resendEmailValidationEmail() = authActionWithUser.async {
+    implicit request =>
+      val idRequest = idRequestParser(request)
+      api.resendEmailValidationEmail(request.auth, idRequest.trackingData).map { _ =>
+        Ok(views.html.verificationEmailResent(request.user, page, idRequest, idUrlBuilder))
       }
   }
 }

--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -152,7 +152,7 @@ abstract class IdApi(val apiRootUrl: String, http: Http, jsonBodyParser: JsonBod
   }
 
   def resendEmailValidationEmail(auth: Auth, trackingParameters: TrackingData): Future[Response[Unit]] = {
-    val apiPath = urlJoin("user","send-validtion-email")
+    val apiPath = urlJoin("user","send-validation-email")
     val params = buildParams(tracking = Some(trackingParameters), auth = Some(auth))
     val response = http.GET(apiUrl(apiPath), params)
     response map jsonBodyParser.extractUnit

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -1,0 +1,12 @@
+@(user: com.gu.identity.model.User, page: MetaData, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader)
+
+@import views.html.fragments.registrationFooter
+
+@identityMain(page, Switches.all){
+}{
+    <div class="identity-wrapper monocolumn-wrapper">
+        <h1 class="identity-title">A fresh validation email has been sent to your account.</h1>
+        <p>Please check your email (@user.getPrimaryEmailAddress) and follow the enclosed link.</p>
+        @registrationFooter(page, idRequest, idUrlBuilder)
+    </div>
+}

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -20,6 +20,7 @@ GET     /account/edit                                   @controllers.PublicProfi
 POST    /public/edit                                    @controllers.PublicProfileController.submitPublicProfileForm
 POST    /account/edit                                   @controllers.PublicProfileController.submitAccountForm
 GET     /verify-email/:token                            @controllers.EmailVerificationController.verify(token: String)
+GET         /verify-email        @controllers.EmailVerificationController.resendEmailValidationEmail()
 
 GET     /ethical-awards/complete                        @controllers.EthicalAwardsController.complete
 GET     /ethical-awards/:formReference                  @controllers.EthicalAwardsController.ethicalAwardsForm(formReference: String)


### PR DESCRIPTION
We've had complaints that the 'Resend my verification email' button does nothing. This has been true if you are NOT signed in:

https://profile.theguardian.com/verify-email/useThisBrokenToken

...the button says resend email, but doesn't actually know who you are! So it can't send the mail.

This new page will require the user to be logged in, and we will direct verification-failing users at it if they're not signed in:

https://profile.theguardian.com/verify-email

Once logged in, it will immediately send a fresh verification email to the associated account.

https://jira.gutools.co.uk/browse/IDN-1736
