### PR TITLE
Reduce the number of Audience Science segments to the first 70

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science.js
@@ -10,7 +10,7 @@ define([
 
     function getSegments() {
         var segments = storage.local.get('gu.ads.audsci');
-        return (segments) ? segments : [];
+        return (segments) ? segments.slice(0,70) : [];
     }
 
     function load(config) {


### PR DESCRIPTION
This is because DFP has a URL max length.
