### PR TITLE
Format keywords consistently in ad requests

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -10,7 +10,8 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/modules/analytics/commercial/tags/common/audience-science',
-    'common/modules/adverts/userAdTargeting'
+    'common/modules/adverts/userAdTargeting',
+    'common/modules/adverts/document-write'
 ], function (
     $,
     bonzo,
@@ -22,7 +23,8 @@ define([
     detect,
     mediator,
     AudienceScience,
-    UserAdTargeting
+    UserAdTargeting,
+    documentWrite
 ) {
 
     /**
@@ -97,9 +99,16 @@ define([
      */
     DFP.prototype.setPageTargetting = function() {
         var conf         = this.config.page,
-            keywords     = conf.keywords    ? conf.keywords.split(',')       : '',
             section      = conf.section     ? conf.section.toLowerCase()     : '',
-            contentType  = conf.contentType ? conf.contentType.toLowerCase() : '';
+            contentType  = conf.contentType ? conf.contentType.toLowerCase() : '',
+            keywords;
+        if (conf.keywords) {
+            keywords = conf.keywords.split(',').map(function (keyword) {
+                return documentWrite.formatKeyword(keyword);
+            })
+        } else {
+            keywords = '';
+        }
 
         googletag.pubads().setTargeting('a', AudienceScience.getSegments() || [])
                           .setTargeting('at', Cookies.get('adtest') || '')

--- a/common/app/assets/javascripts/modules/adverts/document-write.js
+++ b/common/app/assets/javascripts/modules/adverts/document-write.js
@@ -23,9 +23,13 @@ define([
         return guardian.config.page.oasSiteIdHost + '/' + id + 'oas.html';
     }
 
+    function formatKeyword(keyword) {
+        return keyword.replace(/\s/g, '-').toLowerCase();
+    }
+
     function getKeywords(config) {
         return config.keywords.split(',').map(function(keyword){
-            return 'k=' + encodeURIComponent(keyword.replace(/\s/g, '-').toLowerCase());
+            return 'k=' + encodeURIComponent(formatKeyword(keyword));
         }).join('&');
     }
 
@@ -119,7 +123,8 @@ define([
         load: load,
         generateUrl: generateUrl,
         getKeywords: getKeywords,
-        generateQueryString: generateQueryString
+        generateQueryString: generateQueryString,
+        formatKeyword: formatKeyword
     };
 
 });


### PR DESCRIPTION
Should now be consistent in calls to OAS and DFP for standard ads and video ads.
