### PR TITLE
popular in tag revival

### DIFF
--- a/common/app/assets/javascripts/modules/onward/related.js
+++ b/common/app/assets/javascripts/modules/onward/related.js
@@ -36,15 +36,15 @@ define([
         if (!config.switches.popularInTag) { return; }
         var whitelistedTags = [ // order matters here (first match wins)
             // sport tags
-            "sport/cricket", "sport/rugby-union", "sport/rugbyleague", "sport/formulaone",
-            "sport/tennis", "sport/cycling", "sport/motorsports", "sport/golf", "sport/horse-racing",
-            "sport/boxing", "sport/us-sport", "sport/australia-sport",
+            'sport/cricket', 'sport/rugby-union', 'sport/rugbyleague', 'sport/formulaone',
+            'sport/tennis', 'sport/cycling', 'sport/motorsports', 'sport/golf', 'sport/horse-racing',
+            'sport/boxing', 'sport/us-sport', 'sport/australia-sport',
             // football tags
-            "football/championsleague", "football/premierleague", "football/championship",
-            "football/europeanfootball", "football/world-cup-2014",
+            'football/championsleague', 'football/premierleague', 'football/championship',
+            'football/europeanfootball', 'football/world-cup-2014',
             // football team tags
-            "football/manchester-united", "football/chelsea", "football/arsenal",
-            "football/manchestercity", "football/tottenham-hotspur", "football/liverpool"
+            'football/manchester-united', 'football/chelsea', 'football/arsenal',
+            'football/manchestercity', 'football/tottenham-hotspur', 'football/liverpool'
         ];
         var pageTags = config.page.keywordIds.split(',');
 
@@ -68,7 +68,7 @@ define([
 
         } else if (config.switches && config.switches.relatedContent) {
             var popularInTag = this.popularInTagOverride(config),
-                componentName = !Related.overrideUrl && popularInTag ? 'related-popular-in-tag' : 'related-content';
+                componentName = (!Related.overrideUrl && popularInTag) ? 'related-popular-in-tag' : 'related-content';
             register.begin(componentName);
 
             container = context.querySelector('.js-related');

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -267,6 +267,11 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 4, 30)
   )
 
+  val PopularInTagSwitch = Switch("Feature Switches", "popular-in-tag",
+    "If this switch is turned on then popular-in-tag will override related content for the selected tags.",
+    safeState = Off, sellByDate = new DateMidnight(2014, 5, 14)
+  )
+
   // A/B Test Switches
 
   val ABExternalLinksNewWindow = Switch("A/B Tests", "ab-external-links-new-window",
@@ -384,6 +389,7 @@ object Switches extends Collections {
     LayoutHintsSwitch,
     HelveticaEasterEggSwitch,
     LeadAdTopPageSwitch,
+    PopularInTagSwitch,
     OmnitureVerificationSwitch,
     IndiaRegionSwitch,
     ABExternalLinksNewWindow,

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -5,5 +5,5 @@
     @fragments.relatedTrails(storyPackage, heading = "More on this story", visibleTrails = 15, dataComponent = "story-package")
     </aside>
 } else {
-	<aside class="related js-related" role="complementary" data-component="related-content"></aside>
+	<aside class="related js-related" role="complementary"></aside>
 }

--- a/dev-build/app/Global.scala
+++ b/dev-build/app/Global.scala
@@ -4,7 +4,7 @@ import controllers.front.FrontLifecycle
 import dev.DevParametersLifecycle
 import implicits.Requests
 import model.AdminLifecycle
-import feed.OnwardJourneyLifecycle
+import feed.{OnwardJourneyLifecycle, MostReadLifecycle}
 
 import play.api.mvc.{RequestHeader, EssentialAction, EssentialFilter, WithFilters}
 
@@ -59,3 +59,4 @@ with AdminLifecycle
 with DiagnosticsLifecycle
 with OnwardJourneyLifecycle
 with CommercialLifecycle
+with MostReadLifecycle

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -43,6 +43,8 @@ GET         /top-stories/trails                                                 
 GET         /top-stories/trails.json                                                                                 controllers.TopStoriesController.renderJsonTrails()
 GET         /related/*path.json                                                                                      controllers.RelatedController.renderJson(path)
 GET         /related/*path                                                                                           controllers.RelatedController.render(path)
+GET         /popular-in-tag/*tag.json                                                                                controllers.PopularInTag.renderJson(tag)
+
 
 GET         /preference/platform/:platform                                                                           controllers.ChangeViewController.render(platform, page)
 GET         /preference/edition/:edition                                                                             controllers.ChangeEditionController.render(edition)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -45,7 +45,6 @@ GET         /related/*path.json                                                 
 GET         /related/*path                                                                                           controllers.RelatedController.render(path)
 GET         /popular-in-tag/*tag.json                                                                                controllers.PopularInTag.renderJson(tag)
 
-
 GET         /preference/platform/:platform                                                                           controllers.ChangeViewController.render(platform, page)
 GET         /preference/edition/:edition                                                                             controllers.ChangeEditionController.render(edition)
 GET         /preference/front-alphas/:optAction                                                                      controllers.ChangeAlphaController.render(optAction, page)

--- a/onward/app/Global.scala
+++ b/onward/app/Global.scala
@@ -1,11 +1,12 @@
 import common.CloudWatchApplicationMetrics
 import conf.{Management, RequestMeasurementMetrics}
 import dev.DevParametersLifecycle
-import feed.OnwardJourneyLifecycle
+import feed.{MostReadLifecycle, OnwardJourneyLifecycle}
 import play.api.mvc.WithFilters
 
 object Global extends WithFilters(RequestMeasurementMetrics.asFilters: _*) with OnwardJourneyLifecycle
                                                                            with DevParametersLifecycle
-                                                                           with CloudWatchApplicationMetrics{
+                                                                           with CloudWatchApplicationMetrics
+                                                                           with MostReadLifecycle {
   override lazy val applicationName = Management.applicationName
 }

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -1,0 +1,34 @@
+package controllers
+
+import common._
+import model._
+import play.api.mvc.{ RequestHeader, Controller, Action }
+import services._
+
+object PopularInTag extends Controller with Related with Logging with ExecutionContexts {
+
+  def renderJson(path: String) = render(path)
+  def render(tag: String) = Action.async { implicit request =>
+    val edition = Edition(request)
+    getPopularInTag(edition, tag) map {
+      case Nil => JsonNotFound()
+      case trails => renderPopularInTag(trails, tag)
+    }
+  }
+
+  private def renderPopularInTag(trails: Seq[Trail], tagId: String)(implicit request: RequestHeader) = Cached(600) {
+
+    val containerTitle: String = trails.headOption.flatMap { content =>
+      content.tags.find(_.id == tagId).map( tag => s"Recent in ${tag.webTitle}")
+    }.getOrElse("Related content")
+
+    val html = views.html.fragments.relatedTrails(trails, containerTitle, 10)
+
+    if (request.isJson)
+      JsonComponent(
+        "html" -> html
+      )
+    else
+      Ok(html)
+  }
+}

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -12,17 +12,13 @@ object PopularInTag extends Controller with Related with Logging with ExecutionC
     val edition = Edition(request)
     getPopularInTag(edition, tag) map {
       case Nil => JsonNotFound()
-      case trails => renderPopularInTag(trails, tag)
+      case trails => renderPopularInTag(trails)
     }
   }
 
-  private def renderPopularInTag(trails: Seq[Trail], tagId: String)(implicit request: RequestHeader) = Cached(600) {
+  private def renderPopularInTag(trails: Seq[Trail])(implicit request: RequestHeader) = Cached(600) {
 
-    val containerTitle: String = trails.headOption.flatMap { content =>
-      content.tags.find(_.id == tagId).map( tag => s"Recent in ${tag.webTitle}")
-    }.getOrElse("Related content")
-
-    val html = views.html.fragments.relatedTrails(trails, containerTitle, 10)
+    val html = views.html.fragments.relatedTrails(trails, "Related content", 10)
 
     if (request.isJson)
       JsonComponent(

--- a/onward/app/feed/MostReadAgent.scala
+++ b/onward/app/feed/MostReadAgent.scala
@@ -1,0 +1,48 @@
+package feed
+
+import common._
+import play.api.libs.json.{JsArray, JsValue}
+import java.net.URL
+import services.OphanApi
+
+object MostReadAgent extends Logging with ExecutionContexts {
+
+  private val agent = AkkaAgent[Map[String, Int]](Map.empty)
+
+  def update() {
+    log.info("Refreshing most read.")
+
+    // limiting to sport/football section for popular/related ABTest
+    val ophanQuery = OphanApi.getMostReadInSection("sport,football", 2, 1000)
+
+    ophanQuery.map{ ophanResults =>
+
+      val mostRead: Seq[(String, Int)] = for {
+        item: JsValue <- ophanResults.asOpt[JsArray].map(_.value).getOrElse(Nil)
+        url <- (item \ "url").asOpt[String]
+        count <- (item \ "count").asOpt[Int]
+      } yield {
+        (UrlToContentPath(url), count)
+      }
+
+      agent.update(mostRead.toMap)
+    }
+  }
+
+  def stop() {
+    agent.close()
+  }
+
+  def getViewCount(id: String): Option[Int] = {
+    agent.get().get(id)
+  }
+
+  private def UrlToContentPath(url: String): String = {
+    var contentId = new URL(url).getPath
+    if (contentId.startsWith("/")) {
+      contentId = contentId.substring(1)
+    }
+    contentId
+  }
+
+}

--- a/onward/app/feed/MostReadAgent.scala
+++ b/onward/app/feed/MostReadAgent.scala
@@ -12,7 +12,7 @@ object MostReadAgent extends Logging with ExecutionContexts {
   def update() {
     log.info("Refreshing most read.")
 
-    // limiting to sport/football section for popular/related ABTest
+    // limiting to sport/football section for now as this is only used by popular-in-tag component
     val ophanQuery = OphanApi.getMostReadInSection("sport,football", 2, 1000)
 
     ophanQuery.map{ ophanResults =>

--- a/onward/app/feed/MostReadLifecycle.scala
+++ b/onward/app/feed/MostReadLifecycle.scala
@@ -1,0 +1,29 @@
+package feed
+
+import common.{AkkaAsync, Jobs}
+import play.api.{ Application => PlayApp, GlobalSettings }
+
+trait MostReadLifecycle extends GlobalSettings {
+  override def onStart(app: PlayApp) {
+    super.onStart(app)
+
+    Jobs.deschedule("MostReadAgentRefreshJob")
+
+    // update every 30 min
+    Jobs.schedule("MostReadAgentRefreshJob",  "0 0/30 * * * ?") {
+      MostReadAgent.update()
+    }
+
+    AkkaAsync {
+      MostReadAgent.update()
+    }
+  }
+
+  override def onStop(app: PlayApp) {
+    Jobs.deschedule("MostReadAgentRefreshJob")
+
+    MostReadAgent.stop()
+
+    super.onStop(app)
+  }
+}

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -21,6 +21,7 @@ GET        /top-stories/trails                      controllers.TopStoriesContro
 GET        /top-stories/trails.json                 controllers.TopStoriesController.renderJsonTrails()
 GET        /related/*path.json                      controllers.RelatedController.renderJson(path)
 GET        /related/*path                           controllers.RelatedController.render(path)
+GET        /popular-in-tag/*tag.json                controllers.PopularInTag.renderJson(tag)
 
 GET        /preference/platform/:platform           controllers.ChangeViewController.render(platform, page)
 GET        /preference/edition/:edition             controllers.ChangeEditionController.render(edition)


### PR DESCRIPTION
Implementing popular-in-tag after promising A/B test results. This will replace related content (but not story packages) for all whitelisted tags.

Changed the wording to "Recent in ..." as we have multiple "most popular" components already.

![image](https://cloud.githubusercontent.com/assets/960919/2568142/5085d384-b8de-11e3-9441-2105ec32bf97.png)
