### PR TITLE
Show ads to signed-in users

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -119,7 +119,8 @@ define([
                           .setTargeting('bp', detect.getBreakpoint())
                           .setTargeting('cat', section)
                           .setTargeting('ct', contentType)
-                          .setTargeting('gdncrm', UserAdTargeting.getUserSegments() || [])
+                          // leave out CRM data until needed
+                          //.setTargeting('gdncrm', UserAdTargeting.getUserSegments() || [])
                           .setTargeting('k', keywords)
                           .setTargeting('p', 'ng')
                           .setTargeting('pt', contentType)


### PR DESCRIPTION
Bad value in CRM data is stopping ad call, but ads aren't using CRM data yet so can be ignored for targeting purposes.
