### PR TITLE
Adding base table sass to football head

### DIFF
--- a/common/app/assets/stylesheets/head.football.scss
+++ b/common/app/assets/stylesheets/head.football.scss
@@ -16,10 +16,7 @@
 @import "module/football/_global";
 @import "module/football/_league-list";
 
-
-/* ==========================================================================
-   Duplication
-   ========================================================================== */
-
+// These are duplicated from global to stop FOUC
+@import "base/_tables";
 @import "module/football/_tables";
 @import "module/football/_matches";


### PR DESCRIPTION
The tables are completely useless if the CSS fails to load.
Given these pages audience is almost predominantly mobile, this can happen quite easily, and has happened personally and for other members of the team.

![buggered tables](https://cloud.githubusercontent.com/assets/31692/2577104/5480b9b2-b97a-11e3-94ef-2142f7a16d19.png)

---

![They are the same](http://www.moillusions.com/wp-content/uploads/photos1.blogger.com/blogger/5639/2020/400/tabletops.gif)
