### PR TITLE
Fixes #3738 by only showing on live blogs or started matches

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -54,31 +54,33 @@ define([
                     }
                 });
 
-                if (!match.id && (config.page.isLiveBlog || resp.hasStarted)) {
+                if (!match.id) {
                     scoreContainer.innerHTML = '';
                     scoreBoard.template = config.page.isLiveBlog ? resp.matchSummary : resp.scoreSummary;
 
-                    if(!/^\s+$/.test(scoreBoard.template)) {
+                    if(!/^\s+$/.test(scoreBoard.template) && (config.page.isLiveBlog || resp.hasStarted)) {
                         scoreBoard.render(scoreContainer);
+
+                        $('.tab--min-by-min a', $nav).first().each(function(el) {
+                            bonzo(scoreBoard.elem).addClass('u-fauxlink');
+                            bean.on(scoreBoard.elem, 'click', function() {
+                                window.location = el.getAttribute('href');
+                            });
+                        });
                     }
 
-                    $('.tab--min-by-min a', $nav).first().each(function(el) {
-                        bonzo(scoreBoard.elem).addClass('u-fauxlink');
-                        bean.on(scoreBoard.elem, 'click', function() {
-                            window.location = el.getAttribute('href');
+                    if (resp.hasStarted) {
+                        var statsUrl = $('.tab--stats a', $nav).attr('href').replace(/^.*\/\/[^\/]+/, ''),
+                            statsContainer = bonzo.create('<div class="match-stats__container"></div>'),
+                            matchStats = new MatchStats(statsUrl);
+
+                        page.rightHandComponentVisible(function() {
+                            rhc.addComponent(statsContainer, 3);
+                        }, function() {
+                            $article.append(statsContainer);
                         });
-                    });
-
-                    var statsUrl = $('.tab--stats a', $nav).attr('href').replace(/^.*\/\/[^\/]+/, ''),
-                        statsContainer = bonzo.create('<div class="match-stats__container"></div>'),
-                        matchStats = new MatchStats(statsUrl);
-
-                    page.rightHandComponentVisible(function() {
-                        rhc.addComponent(statsContainer, 3);
-                    }, function() {
-                        $article.append(statsContainer);
-                    });
-                    matchStats.fetch(statsContainer);
+                        matchStats.fetch(statsContainer);
+                    }
                 }
             });
         });

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -54,7 +54,7 @@ define([
                     }
                 });
 
-                if (!match.id) {
+                if (!match.id && (config.page.isLiveBlog || resp.hasStarted)) {
                     scoreContainer.innerHTML = '';
                     scoreBoard.template = config.page.isLiveBlog ? resp.matchSummary : resp.scoreSummary;
 

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -54,10 +54,11 @@ define([
                     }
                 });
 
-                if (!match.id) {
+                if (!match.id) { // match.id only exists on match stat pages
                     scoreContainer.innerHTML = '';
                     scoreBoard.template = config.page.isLiveBlog ? resp.matchSummary : resp.scoreSummary;
 
+                    // only show scores on liveblogs or started matches
                     if(!/^\s+$/.test(scoreBoard.template) && (config.page.isLiveBlog || resp.hasStarted)) {
                         scoreBoard.render(scoreContainer);
 

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -46,7 +46,8 @@ object MoreOnMatchController extends Controller with Football with Requests with
           JsonComponent(
             "nav" -> football.views.html.fragments.matchNav(populateNavModel(theMatch, filtered)),
             "matchSummary" -> football.views.html.fragments.matchSummary(theMatch),
-            "scoreSummary" -> football.views.html.fragments.scoreSummary(theMatch)
+            "scoreSummary" -> football.views.html.fragments.scoreSummary(theMatch),
+            "hasStarted" -> theMatch.hasStarted
           )
         }
       }


### PR DESCRIPTION
Logic is:
- If we're not on a match page
- If we are a liveblog or the match has started, show score
- If the match has started show stats

Then show stats and score summary.

![Simple logic](http://courses.umass.edu/phil512-klement/penrose.gif)
