### PR TITLE
Enable scroll to top for formstack

### DIFF
--- a/identity/app/views/formstack/formstackComplete.scala.html
+++ b/identity/app/views/formstack/formstackComplete.scala.html
@@ -7,7 +7,11 @@
     <title>@Html(metaData.webTitle)</title>
     @fragments.commonCssSetup(projectName)
 </head>
-<body>
+<body id="top">
+
     <h2 class="formstack-heading formstack-heading--first">Thank you for your submission</h2>
+
+    @fragments.loadCss()
+
 </body>
 </html>


### PR DESCRIPTION
This PR adds functionality to the composer version of the formstack embeds that ensures error messages and complete messages are scrolled in to view.

It works in conjunction with this script: https://s3-eu-west-1.amazonaws.com/aws-frontend-static/CODE/frontend-static/compiled/javascripts/vendor/interactive-boot-script.js
