### PR TITLE
Facia: single inline ad slot

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -292,12 +292,6 @@ define([
 
     DFP.prototype.init = function() {
 
-        if (detect.getBreakpoint() === 'mobile') {
-            $('.ad-slot--mpu-in-row-pattern').removeClass('ad-slot__dfp');
-        } else {
-            $('.ad-slot--inline').removeClass('ad-slot__dfp');
-        }
-
         this.$dfpAdSlots = $(this.config.dfpSelector);
 
         // If there's no ads on the page, then don't load anything

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -77,10 +77,13 @@
         @include mq(mobileLandscape, tablet) {
             position: absolute;
             width: 50%;
-            height: 50px;
+            height: 100%;
             text-align: left;
             z-index: -1;
-            margin: 0 auto;
+            @include rem((
+                padding-left: 2px,
+                font-size: 10px
+            ));
         }
     }
     @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -62,30 +62,51 @@
         min-height: 110px;
     }
 }
-.ad-slot--mpu-in-row-pattern {
-    position: absolute;
-    left: 0;
-    right: 0;
-    @if $browser-supports-flexbox {
-        @include rem((
-            bottom: $mpu-align-offset
-        ));
-    } @else {
-        bottom: 0;
-    }
-    top: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    width: auto;
+.ad-slot--container-inline {
+    min-height: 50px;
+    @include box-sizing(border-box);
     @include rem((
-        margin: 0 $gs-gutter/2
+        margin: $gs-baseline 0 $gs-baseline/2,
+        padding: 0 $gs-gutter/2 0
     ));
-    background-color: $c-neutral8;
 
-    .ad-container {
+    .ad-slot__label {
+        max-width: 300px;
+        margin: 0 auto;
+
+        @include mq(mobileLandscape, tablet) {
+            position: absolute;
+            width: 50%;
+            height: 50px;
+            text-align: left;
+            z-index: -1;
+            margin: 0 auto;
+        }
+    }
+    @include mq(tablet) {
         position: absolute;
-        bottom: 0;
+        left: 0;
         right: 0;
+        @if $browser-supports-flexbox {
+            @include rem((
+                bottom: $mpu-align-offset
+            ));
+        } @else {
+            bottom: 0;
+        }
+        top: 0;
+        padding: 0;
+        width: auto;
+        @include rem((
+            margin: 0 $gs-gutter / 2
+        ));
+        background-color: $c-neutral8;
+
+        .ad-container {
+            position: absolute;
+            bottom: 0;
+            right: 0;
+        }
     }
 }
 .ad-slot--top-banner-ad {

--- a/common/app/assets/stylesheets/module/containers/_misc.scss
+++ b/common/app/assets/stylesheets/module/containers/_misc.scss
@@ -50,8 +50,10 @@
 
 .l-row__item--mpu {
     position: relative;
-    min-height: $mpu-ad-label-height + $mpu-resulting-height + $mpu-align-offset;
 
+    @include mq(tablet) {
+        min-height: $mpu-ad-label-height + $mpu-resulting-height + $mpu-align-offset;
+    }
     @include mq(desktop) {
         min-height: $mpu-ad-label-height + $mpu-original-height + $mpu-align-offset;
     }

--- a/common/app/views/fragments/collections/features.scala.html
+++ b/common/app/views/fragments/collections/features.scala.html
@@ -31,8 +31,8 @@
                         </ul>
             @style.adSlot.map { adSlot =>
                     </li>
-                    <li class="l-row__item l-row__item--mpu hide-on-mobile">
-                        @fragments.inlineAdSlot(id="mpu-in-row-pattern", adSlot=adSlot, mobileOnly=false)
+                    <li class="l-row__item l-row__item--mpu">
+                        @fragments.containerInlineAdSlot(adSlot=adSlot)
                     </li>
                 </ul>
             }
@@ -55,7 +55,4 @@
             </ul>
         </div>
     }
-}
-@style.adSlot.map { adSlot =>
-    @fragments.inlineAdSlot(id="inline", adSlot=adSlot, mobileOnly=true)
 }

--- a/common/app/views/fragments/collections/people.scala.html
+++ b/common/app/views/fragments/collections/people.scala.html
@@ -28,8 +28,8 @@
                         </ul>
             @style.adSlot.map { adSlot =>
                     </li>
-                    <li class="l-row__item l-row__item--mpu hide-on-mobile">
-                        @fragments.inlineAdSlot(id="mpu-in-row-pattern", adSlot=adSlot, mobileOnly=false)
+                    <li class="l-row__item l-row__item--mpu">
+                        @fragments.containerInlineAdSlot(adSlot=adSlot)
                     </li>
                 </ul>
             }
@@ -52,7 +52,4 @@
             </ul>
         </div>
     }
-}
-@style.adSlot.map { adSlot =>
-    @fragments.inlineAdSlot(id="inline", adSlot=adSlot, mobileOnly=true)
 }

--- a/common/app/views/fragments/containerInlineAdSlot.scala.html
+++ b/common/app/views/fragments/containerInlineAdSlot.scala.html
@@ -1,4 +1,4 @@
-@(id: String, adSlot: AdSlot, mobileOnly: Boolean)
+@(adSlot: AdSlot)
 @import views.support.AdSlot
 @import conf.Switches._
 
@@ -8,15 +8,15 @@
         although we do put a data-link-name attribute on here any ad that iframes itself will be untrackable via this, so
         take ad clicks with a pinch of salt.
         -->*@
-        <div class="ad-slot__oas ad-slot--@id @if(mobileOnly){mobile-only}else{hide-on-mobile}" data-link-name="ad slot @id" data-base="@adSlot.baseName" data-median="@adSlot.medianName">
+        <div class="ad-slot__oas ad-slot--container-inline" data-link-name="ad slot container inline" data-base="@adSlot.baseName" data-median="@adSlot.medianName">
             <div class="ad-slot__label">Advertisement</div>
             <div class="ad-container"></div>
         </div>
     } else {
         @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
 
-            <div class="ad-slot__dfp ad-slot--@id @if(mobileOnly){mobile-only}else{hide-on-mobile}" data-link-name="ad slot @id" data-name="@adSlot.dfpDataName" data-mobile="300,50|320,50" data-tabletportrait="300,250">
-                 <div id="inline-ad-slot__@{adSlot.dfpDataName}@if(mobileOnly){--mobile}" class="ad-container"></div>
+            <div class="ad-slot__dfp ad-slot--container-inline" data-link-name="ad slot container inline" data-name="@adSlot.dfpDataName" data-mobile="300,50|320,50" data-tabletportrait="300,250">
+                 <div id="inline-ad-slot__@{adSlot.dfpDataName}" class="ad-container"></div>
             </div>
         }
     }

--- a/common/app/views/fragments/containerInlineAdSlot.scala.html
+++ b/common/app/views/fragments/containerInlineAdSlot.scala.html
@@ -15,7 +15,7 @@
     } else {
         @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
 
-            <div class="ad-slot__dfp ad-slot--container-inline" data-link-name="ad slot container inline" data-name="@adSlot.dfpDataName" data-mobile="300,50|320,50" data-tabletportrait="300,250">
+            <div class="ad-slot__dfp ad-slot--container-inline" data-link-name="ad slot container inline" data-name="@adSlot.dfpDataName" data-mobile="300,50" data-tabletportrait="300,250">
                  <div id="inline-ad-slot__@{adSlot.dfpDataName}" class="ad-container"></div>
             </div>
         }


### PR DESCRIPTION
No longer have two slots (one mobile, one desktop), as screws up DFP in a number of ways (e.g. makes two calls). DFP is, after all, responsive, so lets use it

Side effect is ad moves above the show more '+' button. Lets see how bad that it (moving it below the button was never a strong requirement, just something the editors mentioned)

![screen shot 2014-04-01 at 12 49 26](https://cloud.githubusercontent.com/assets/74132/2578606/bd2de340-b993-11e3-8ea8-164280e3e81d.jpeg)
