### PR TITLE
Facia tool: link to "broken" content

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -302,10 +302,10 @@
                 </a>
 
                 <div class="article_content is-empty" data-bind="if: state.isEmpty">
-                    This content is unavailable, deleted, or has a new URL
                     <a target="article" class="is-empty__url" data-bind="
-                        attr: {href: id},
+                        attr: {href: 'http://www.theguardian.com/' + id},
                         text: id"></a>
+                    This content is unavailable, deleted, or has a new URL
                 </div>
 
                 <div class="article_content" data-bind="if: !state.isEmpty()">


### PR DESCRIPTION
Adds a usable link to "broken" content, because it might only appear broken due to a momentary Capi error.

![fronts-tool](https://cloud.githubusercontent.com/assets/1147913/2581496/1241efc8-b9b9-11e3-9383-fd6d392a9821.png)
