### PR TITLE
Fix case in FaciaToolController where you would need scala.language.post...

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -120,9 +120,9 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
           val identity: Identity = Identity(request).get
           val updatedCollections: Map[String, Block] = update.collect {
             case ("update", updateList) =>
-              UpdateActions.updateCollectionList(updateList.id, updateList, identity).map(updateList.id ->)
+              UpdateActions.updateCollectionList(updateList.id, updateList, identity).map(updateList.id -> _)
             case ("remove", updateList) =>
-              UpdateActions.updateCollectionFilter(updateList.id, updateList, identity).map(updateList.id ->)
+              UpdateActions.updateCollectionFilter(updateList.id, updateList, identity).map(updateList.id -> _)
           }.flatten.toMap
 
           pressCollectionIds(updatedCollections.keySet)


### PR DESCRIPTION
I thought I could have this by default, but it turns out I need `scala.language.postfixOps`
