### PR TITLE
RSS pubDates

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -6,6 +6,7 @@ import org.joda.time.DateTime
 import java.io.StringWriter
 import org.jsoup.Jsoup
 import com.sun.syndication.feed.synd._
+import com.sun.syndication.feed.module.{DCModuleImpl}
 import com.sun.syndication.feed.module.mediarss._
 import com.sun.syndication.feed.module.mediarss.types.{Credit, Metadata, UrlReference, MediaContent}
 import com.sun.syndication.io.SyndFeedOutput
@@ -95,15 +96,17 @@ object TrailsToRss extends implicits.Collections {
         module
       }
 
+      // Entry: DublinCore 
+      val dc = new DCModuleImpl
+      dc.setDate(trail.webPublicationDate.toDate);
+
       // Entry
       val entry = new SyndEntryImpl
-      entry.setTitle(cleanInvalidXmlChars(trail.headline))
+      entry.setTitle(cleanInvalidXmlChars(trail.linkText))
       entry.setLink(trail.webUrl)
       entry.setDescription(description)
-      entry.setAuthor(trail.byline.getOrElse(""))
-      entry.setPublishedDate(trail.webPublicationDate.toDate)
       entry.setCategories(categories)
-      entry.setModules(new java.util.ArrayList(modules))
+      entry.setModules(new java.util.ArrayList(modules ++ Seq(dc)))
       entry
 
     }.asJava

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -99,7 +99,8 @@ object TrailsToRss extends implicits.Collections {
       // Entry: DublinCore 
       val dc = new DCModuleImpl
       dc.setDate(trail.webPublicationDate.toDate);
-
+      dc.setContributor(trail.byline.getOrElse("Guardian Staff"));
+  
       // Entry
       val entry = new SyndEntryImpl
       entry.setTitle(cleanInvalidXmlChars(trail.linkText))

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -96,7 +96,7 @@ object TrailsToRss extends implicits.Collections {
         module
       }
 
-      // Entry: DublinCore - setPublishedDate won't work without this
+      // Entry: DublinCore 
       val dc = new DCModuleImpl
       dc.setDate(trail.webPublicationDate.toDate);
 
@@ -106,7 +106,6 @@ object TrailsToRss extends implicits.Collections {
       entry.setLink(trail.webUrl)
       entry.setDescription(description)
       entry.setCategories(categories)
-      entry.setPublishedDate(dc.getDate())
       entry.setModules(new java.util.ArrayList(modules ++ Seq(dc)))
       entry
 

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -96,7 +96,7 @@ object TrailsToRss extends implicits.Collections {
         module
       }
 
-      // Entry: DublinCore 
+      // Entry: DublinCore - setPublishedDate won't work without this
       val dc = new DCModuleImpl
       dc.setDate(trail.webPublicationDate.toDate);
 
@@ -106,6 +106,7 @@ object TrailsToRss extends implicits.Collections {
       entry.setLink(trail.webUrl)
       entry.setDescription(description)
       entry.setCategories(categories)
+      entry.setPublishedDate(dc.getDate())
       entry.setModules(new java.util.ArrayList(modules ++ Seq(dc)))
       entry
 

--- a/common/test/common/TrailsToRss.scala
+++ b/common/test/common/TrailsToRss.scala
@@ -31,8 +31,8 @@ class TrailsToRssTest extends FlatSpec with Matchers {
 case class TestTrail(url: String) extends Trail {
   def webPublicationDate: DateTime = DateTime.now
   def shortUrl: String = ""
-  def linkText: String = ""
-  def headline: String = "hello …"
+  def linkText: String = "hello …"
+  def headline: String = ""
   def webUrl: String = ""
   def trailText: Option[String] = None
   def section: String = ""

--- a/common/test/common/TrailsToRss.scala
+++ b/common/test/common/TrailsToRss.scala
@@ -26,6 +26,12 @@ class TrailsToRssTest extends FlatSpec with Matchers {
     val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
     ((rss \\ "item" \\ "title" )(1).text) should be("hello")
   }
+  
+  "TrailsToRss" should "should include published date and byline" in {
+    val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
+    ((rss \\ "item" \\ "contributor" ).filter(_.prefix == "dc").head.text) should be("Chadders")
+    ((rss \\ "item" \\ "pubDate" ).size) should be(2)
+  }
 
 
 case class TestTrail(url: String) extends Trail {
@@ -38,6 +44,7 @@ case class TestTrail(url: String) extends Trail {
   def section: String = ""
   def sectionName: String = ""
   def isLive: Boolean = true
+  override def byline: Option[String] = Some("Chadders") // this is how I'd like to be remembered
 }
 
 }

--- a/facia/app/services/repositories.scala
+++ b/facia/app/services/repositories.scala
@@ -20,7 +20,7 @@ case class IndexPage(page: MetaData, trails: Seq[Content])
 
 trait Index extends ConciergeRepository with QueryDefaults {
 
-  private val rssFields = s"$trailFields,body,standfirst"
+  private val rssFields = s"$trailFields,byline,body,standfirst"
 
   def normaliseTag(tag: String): String = {
     val conversions: Map[String, String] =


### PR DESCRIPTION
- Published dates in feeds
- The SEO team also want us to use `linkText` for external facing feeds
- I've added contributor because the SEO team want that displayed on the Google editors picks

/cc @ironsidevsquincy - so looking at the source code of SyndEntryImpl the [setPublishedDate method](http://grepcode.com/file/repo1.maven.org/maven2/rome/rome/0.9/com/sun/syndication/feed/synd/SyndEntryImpl.java#318) used the DublinCore module to do it's setting and getting. For some reason setting it directly like we tried didn't work, instead you have to set it in the DublinCore module, which generates a pubDate element. Stupid and undocumented.
