### PR TITLE
Add more information to diffs

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -81,7 +81,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     FaciaToolMetrics.DraftPublishCount.increment()
     val block = FaciaApi.publishBlock(id, identity)
     block.foreach{ b =>
-      UpdateActions.archiveBlock(id, b, JsString("publish"), identity)
+      UpdateActions.archiveBlock(id, b, "publish", identity)
       pressCollectionId(id)
     }
     notifyContentApi(id)
@@ -92,7 +92,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     val identity = Identity(request).get
     val block = FaciaApi.discardBlock(id, identity)
     block.foreach { b =>
-      UpdateActions.archiveBlock(id, b, JsString("discard"), identity)
+      UpdateActions.archiveBlock(id, b, "discard", identity)
     }
     NoCache(Ok)
   }

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -81,7 +81,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     FaciaToolMetrics.DraftPublishCount.increment()
     val block = FaciaApi.publishBlock(id, identity)
     block.foreach{ b =>
-      UpdateActions.archiveBlock(id, b, "publish", identity)
+      UpdateActions.archivePublishBlock(id, b, identity)
       pressCollectionId(id)
     }
     notifyContentApi(id)
@@ -92,7 +92,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     val identity = Identity(request).get
     val block = FaciaApi.discardBlock(id, identity)
     block.foreach { b =>
-      UpdateActions.archiveBlock(id, b, "discard", identity)
+      UpdateActions.archiveDiscardBlock(id, b, identity)
     }
     NoCache(Ok)
   }

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -81,7 +81,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     FaciaToolMetrics.DraftPublishCount.increment()
     val block = FaciaApi.publishBlock(id, identity)
     block.foreach{ b =>
-      FaciaApi.archive(id, b, JsString("publish"), identity)
+      UpdateActions.archiveBlock(id, b, JsString("publish"), identity)
       pressCollectionId(id)
     }
     notifyContentApi(id)
@@ -92,7 +92,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     val identity = Identity(request).get
     val block = FaciaApi.discardBlock(id, identity)
     block.foreach { b =>
-      FaciaApi.archive(id, b, JsString("discard"), identity)
+      UpdateActions.archiveBlock(id, b, JsString("discard"), identity)
     }
     NoCache(Ok)
   }

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -95,7 +95,7 @@ trait UpdateActions extends Logging {
   def updateCollectionMeta(block: Block, update: CollectionMetaUpdate, identity: Identity): Block =
     block.copy(displayName=update.displayName, href=update.href)
 
-  def putBlock(id: String, block: Block, identity: Identity, updateJson: JsValue): Block =
+  def putBlock(id: String, block: Block, identity: Identity): Block =
     FaciaApi.putBlock(id, block, identity)
 
   def archiveBlock(id: String, block: Block, update: JsValue, identity: Identity): Block =
@@ -118,7 +118,7 @@ trait UpdateActions extends Logging {
     .map(insertIntoLive(update, _))
     .map(insertIntoDraft(update, _))
     .map(capCollection)
-    .map(putBlock(id, _, identity, updateJson))
+    .map(putBlock(id, _, identity))
     .map(archiveBlock(id, _, updateJson, identity))
     .orElse(createBlock(id, identity, update))
   }
@@ -128,14 +128,14 @@ trait UpdateActions extends Logging {
     getBlock(id)
       .map(deleteFromLive(update, _))
       .map(deleteFromDraft(update, _))
-      .map(putBlock(id, _, identity, updateJson))
       .map(archiveBlock(id, _, updateJson, identity))
+      .map(putBlock(id, _, identity))
   }
 
   def updateCollectionMeta(id: String, update: CollectionMetaUpdate, identity: Identity): Option[Block] =
     getBlock(id)
       .map(updateCollectionMeta(_, update, identity))
-      .map(putBlock(id, _, identity, Json.toJson(update)))
+      .map(putBlock(id, _, identity))
 
   private def updateList(update: UpdateList, blocks: List[Trail]): List[Trail] = {
     val listWithoutItem = blocks.filterNot(_.id == update.item)

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -98,6 +98,8 @@ trait UpdateActions extends Logging {
   def putBlock(id: String, block: Block, identity: Identity): Block =
     FaciaApi.putBlock(id, block, identity)
 
+  def archiveBlock(id: String, block: Block, update: JsValue, action: String, identity: Identity): Block =
+    archiveBlock(id, block, Json.obj("action" -> action, "update" -> update), identity)
   def archiveBlock(id: String, block: Block, update: JsValue, identity: Identity): Block =
     Try(FaciaApi.archive(id, block, update, identity)) match {
       case Failure(t: Throwable) => {
@@ -119,7 +121,7 @@ trait UpdateActions extends Logging {
     .map(insertIntoDraft(update, _))
     .map(capCollection)
     .map(putBlock(id, _, identity))
-    .map(archiveBlock(id, _, updateJson, identity))
+    .map(archiveBlock(id, _, updateJson, "update", identity))
     .orElse(createBlock(id, identity, update))
   }
 
@@ -128,7 +130,7 @@ trait UpdateActions extends Logging {
     getBlock(id)
       .map(deleteFromLive(update, _))
       .map(deleteFromDraft(update, _))
-      .map(archiveBlock(id, _, updateJson, identity))
+      .map(archiveBlock(id, _, updateJson, "delete", identity))
       .map(putBlock(id, _, identity))
   }
 

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -100,6 +100,8 @@ trait UpdateActions extends Logging {
 
   def archiveBlock(id: String, block: Block, update: JsValue, action: String, identity: Identity): Block =
     archiveBlock(id, block, Json.obj("action" -> action, "update" -> update), identity)
+
+  //Publish and discard do not need action string above as there is no diff
   def archiveBlock(id: String, block: Block, update: JsValue, identity: Identity): Block =
     Try(FaciaApi.archive(id, block, update, identity)) match {
       case Failure(t: Throwable) => {

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -107,8 +107,10 @@ trait UpdateActions extends Logging {
   private def archiveBlock(id: String, block: Block, action: String, identity: Identity): Block =
     archiveBlock(id, block, Json.obj("action" -> action), identity)
 
-  def archiveBlock(id: String, block: Block, updateJson: JsValue, action: String, identity: Identity): Block =
-    archiveBlock(id, block, Json.obj("action" -> action, "update" -> updateJson), identity)
+  def archiveUpdateBlock(id: String, block: Block, updateJson: JsValue, identity: Identity): Block =
+    archiveBlock(id, block, Json.obj("action" -> "update", "update" -> updateJson), identity)
+  def archiveDeleteBlock(id: String, block: Block, updateJson: JsValue, identity: Identity): Block =
+    archiveBlock(id, block, Json.obj("action" -> "delete", "update" -> updateJson), identity)
 
   private def archiveBlock(id: String, block: Block, updateJson: JsValue, identity: Identity): Block =
     Try(FaciaApi.archive(id, block, updateJson, identity)) match {
@@ -131,7 +133,7 @@ trait UpdateActions extends Logging {
     .map(insertIntoDraft(update, _))
     .map(capCollection)
     .map(putBlock(id, _, identity))
-    .map(archiveBlock(id, _, updateJson, "update", identity))
+    .map(archiveUpdateBlock(id, _, updateJson, identity))
     .orElse(createBlock(id, identity, update))
   }
 
@@ -140,7 +142,7 @@ trait UpdateActions extends Logging {
     getBlock(id)
       .map(deleteFromLive(update, _))
       .map(deleteFromDraft(update, _))
-      .map(archiveBlock(id, _, updateJson, "delete", identity))
+      .map(archiveDeleteBlock(id, _, updateJson, identity))
       .map(putBlock(id, _, identity))
   }
 

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -115,7 +115,7 @@ trait UpdateActions extends Logging {
 
   def putMasterConfig(config: Config, identity: Identity): Option[Config] = {
     FaciaApi.archiveMasterConfig(config, identity)
-    FaciaApi.putMasterConfig(config, identity)
+    FaciaApi.putMasterConfig(config)
   }
 
   def updateCollectionList(id: String, update: UpdateList, identity: Identity): Option[Block] = {

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -98,7 +98,13 @@ trait UpdateActions extends Logging {
   def putBlock(id: String, block: Block, identity: Identity): Block =
     FaciaApi.putBlock(id, block, identity)
 
-  def archiveBlock(id: String, block: Block, action: String, identity: Identity): Block =
+  //Archiving
+  def archivePublishBlock(id: String, block: Block, identity: Identity): Block =
+    archiveBlock(id, block, "publish", identity)
+  def archiveDiscardBlock(id: String, block: Block, identity: Identity): Block =
+    archiveBlock(id, block, "discard", identity)
+
+  private def archiveBlock(id: String, block: Block, action: String, identity: Identity): Block =
     archiveBlock(id, block, Json.obj("action" -> action), identity)
 
   def archiveBlock(id: String, block: Block, updateJson: JsValue, action: String, identity: Identity): Block =

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -98,12 +98,15 @@ trait UpdateActions extends Logging {
   def putBlock(id: String, block: Block, identity: Identity): Block =
     FaciaApi.putBlock(id, block, identity)
 
-  def archiveBlock(id: String, block: Block, update: JsValue, action: String, identity: Identity): Block =
-    archiveBlock(id, block, Json.obj("action" -> action, "update" -> update), identity)
+  def archiveBlock(id: String, block: Block, action: String, identity: Identity): Block =
+    archiveBlock(id, block, Json.obj("action" -> action), identity)
+
+  def archiveBlock(id: String, block: Block, updateJson: JsValue, action: String, identity: Identity): Block =
+    archiveBlock(id, block, Json.obj("action" -> action, "update" -> updateJson), identity)
 
   //Publish and discard do not need action string above as there is no diff
-  def archiveBlock(id: String, block: Block, update: JsValue, identity: Identity): Block =
-    Try(FaciaApi.archive(id, block, update, identity)) match {
+  private def archiveBlock(id: String, block: Block, updateJson: JsValue, identity: Identity): Block =
+    Try(FaciaApi.archive(id, block, updateJson, identity)) match {
       case Failure(t: Throwable) => {
         log.warn(t.toString)
         block

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -104,7 +104,6 @@ trait UpdateActions extends Logging {
   def archiveBlock(id: String, block: Block, updateJson: JsValue, action: String, identity: Identity): Block =
     archiveBlock(id, block, Json.obj("action" -> action, "update" -> updateJson), identity)
 
-  //Publish and discard do not need action string above as there is no diff
   private def archiveBlock(id: String, block: Block, updateJson: JsValue, identity: Identity): Block =
     Try(FaciaApi.archive(id, block, updateJson, identity)) match {
       case Failure(t: Throwable) => {

--- a/facia-tool/app/tools/FaciaApi.scala
+++ b/facia-tool/app/tools/FaciaApi.scala
@@ -64,7 +64,7 @@ object FaciaApi extends FaciaApiRead with FaciaApiWrite {
     S3FrontsApi.archive(id, Json.prettyPrint(Json.toJson(newBlock)), identity)
   }
 
-  def putMasterConfig(config: Config, identity: Identity): Option[Config] = {
+  def putMasterConfig(config: Config): Option[Config] = {
     Try(S3FrontsApi.putMasterConfig(Json.prettyPrint(Json.toJson(config)))).map(_ => config).toOption
   }
   def archiveMasterConfig(config: Config, identity: Identity): Unit = S3FrontsApi.archiveMasterConfig(Json.prettyPrint(Json.toJson(config)), identity)


### PR DESCRIPTION
This PR adds information for when an update in history is a `delete`.
It also does a bit of refactoring on the methods so that we are more explicit about it and not passing in strings from random places.

@stephanfowler 

Diff updates in history now look like this:

```
{
  ...
  "diff" : {
    "action" : "update",
    "update" : {
      "id" : "au/culture/regular-stories",
      "item" : "world/2014/mar/11/syria-war-international-effort-southern-front-assad",
      "position" : "world/2014/mar/11/syria-war-international-effort-southern-front-assad",
      "itemMeta" : {
        "updatedAt" : "1394539029:f90,1396447876,1396449584:0C0,1396451572,1396452701:0C0",
        "headline" : "New Stuff"
      },
      "live" : false,
      "draft" : true
    }
  }
```

```
{
 ...
  "diff" : {
    "action" : "delete",
    "update" : {
      "id" : "au/culture/regular-stories",
      "item" : "business/2014/apr/02/centrica-chief-executive-share-bonus-scheme-2m",
      "live" : false,
      "draft" : true
    }
  }
}
```
