### PR TITLE
Identity: guide users to sign in to resend their verification email

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -3,7 +3,7 @@ package controllers
 import play.api.mvc.{Controller, Action}
 import com.google.inject.{Inject, Singleton}
 import idapiclient.IdApiClient
-import services.{IdentityUrlBuilder, IdRequestParser}
+import services.{AuthenticationService, IdentityUrlBuilder, IdRequestParser}
 import common.ExecutionContexts
 import utils.SafeLogging
 import model.IdentityPage
@@ -12,6 +12,7 @@ import actions.AuthActionWithUser
 @Singleton
 class EmailVerificationController @Inject()( api: IdApiClient,
                                              authActionWithUser: AuthActionWithUser,
+                                             authenticationService: AuthenticationService,
                                              idRequestParser: IdRequestParser,
                                              idUrlBuilder: IdentityUrlBuilder)
   extends Controller with ExecutionContexts with SafeLogging {
@@ -35,7 +36,8 @@ class EmailVerificationController @Inject()( api: IdApiClient,
 
             case Right(ok) => validated
           }
-          Ok(views.html.email_verified(validationState, page, idRequest, idUrlBuilder))
+          val userIsLoggedIn = authenticationService.requestPresentsAuthenticationCredentials(request)
+          Ok(views.html.email_verified(validationState, page, idRequest, idUrlBuilder, userIsLoggedIn))
       }
   }
 

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -16,15 +16,7 @@ class AuthenticationService @Inject()(cookieDecoder: FrontendIdentityCookieDecod
                                       idRequestParser: IdRequestParser,
                                       identityUrlBuilder: IdentityUrlBuilder) extends Logging {
   def handleAuthenticatedRequest[A](request: Request[A]): Either[SimpleResult, AuthRequest[A]] = {
-    val authRequestOpt = for {
-      scGuU <- request.cookies.get("SC_GU_U")
-      guU <- request.cookies.get("GU_U")
-      minimalSecureUser <- cookieDecoder.getUserDataForScGuU(scGuU.value)
-      guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
-      fullUser = guUCookieData.getUser if (fullUser.getId == minimalSecureUser.getId)
-    } yield AuthRequest(request, fullUser, new ScGuU(scGuU.value))
-
-    authRequestOpt match {
+    authenticatedRequestFor(request) match {
       case Some(authRequest) => {
         logger.trace("user is logged in")
         Right(authRequest)
@@ -36,4 +28,15 @@ class AuthenticationService @Inject()(cookieDecoder: FrontendIdentityCookieDecod
       }
     }
   }
+
+  def authenticatedRequestFor[A](request: Request[A]): Option[AuthRequest[A]] = for {
+    scGuU <- request.cookies.get("SC_GU_U")
+    guU <- request.cookies.get("GU_U")
+    minimalSecureUser <- cookieDecoder.getUserDataForScGuU(scGuU.value)
+    guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
+    fullUser = guUCookieData.getUser if (fullUser.getId == minimalSecureUser.getId)
+  } yield AuthRequest(request, fullUser, new ScGuU(scGuU.value))
+
+  def requestPresentsAuthenticationCredentials(request: Request[_]) = authenticatedRequestFor(request).isDefined
+
 }

--- a/identity/app/views/email_verified.scala.html
+++ b/identity/app/views/email_verified.scala.html
@@ -1,4 +1,4 @@
-@(state: controllers.ValidationState, page: MetaData, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader)
+@(state: controllers.ValidationState, page: MetaData, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, userIsLoggedIn: Boolean)(implicit request: RequestHeader)
 
 @import controllers.ValidationState._
 @import views.html.fragments.registrationFooter
@@ -17,7 +17,11 @@
             } else{
                 <h1 class="identity-title">Sorry, this email confirmation link is not recognised.</h1>
             }
-            <button type="button" class="submit-input js-id-send-validation-email" data-link-name="Resend verification email">Resend my verification email</button>
+            @if(userIsLoggedIn) {
+                <button type="button" class="submit-input js-id-send-validation-email" data-link-name="Resend verification email">Resend my verification email</button>
+            } else {
+                <a class="submit-input" href="@idUrlBuilder.buildUrl("/verify-email", idRequest)" data-link-name="Sign in and resend verification email">Sign in to resend your verification email</a>
+            }
         }
         @registrationFooter(page, idRequest, idUrlBuilder)
     </div>

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -1,16 +1,15 @@
 package controllers
 
 import org.scalatest.{ShouldMatchers, path}
-import services.{IdRequestParser, IdentityUrlBuilder}
+import services.{AuthenticationService, IdRequestParser, IdentityUrlBuilder, IdentityRequest}
 import idapiclient.IdApiClient
 import org.scalatest.mock.MockitoSugar
 import test.{TestRequest, Fake}
-import play.api.mvc.RequestHeader
+import play.api.mvc.{Request, RequestHeader}
 import scala.concurrent.Future
 import org.mockito.Mockito._
 import org.mockito.Matchers
 import play.api.test.Helpers._
-import services.IdentityRequest
 import idapiclient.TrackingData
 import client.Error
 import actions.AuthActionWithUser
@@ -19,6 +18,7 @@ class EmailVerificationControllerTest extends path.FreeSpec with ShouldMatchers 
   val api = mock[IdApiClient]
   val idRequestParser = mock[IdRequestParser]
   val authActionWithUser = mock[AuthActionWithUser]
+  val authenticationService = mock[AuthenticationService]
   val idUrlBuilder = mock[IdentityUrlBuilder]
   val idRequest = mock[IdentityRequest]
   val trackingData = mock[TrackingData]
@@ -27,8 +27,9 @@ class EmailVerificationControllerTest extends path.FreeSpec with ShouldMatchers 
 
   when(idRequestParser.apply(Matchers.any[RequestHeader])) thenReturn idRequest
   when(idRequest.trackingData) thenReturn trackingData
+  when(authenticationService.requestPresentsAuthenticationCredentials(Matchers.any[Request[_]])) thenReturn true
 
-  val controller = new EmailVerificationController(api, authActionWithUser, idRequestParser, idUrlBuilder)
+  val controller = new EmailVerificationController(api, authActionWithUser, authenticationService, idRequestParser, idUrlBuilder)
 
   "Given the verify method is called" - Fake {
     val testRequest = TestRequest()


### PR DESCRIPTION
The 'Resend my verification email' button did nothing if you were NOT signed in, see the button on this page:

https://profile.theguardian.com/verify-email/useThisBrokenToken

Now the user is guided to sign-in instead, and this action automatically resends their validation email.

https://jira.gutools.co.uk/browse/IDN-1736
