### PR TITLE
Commercial: fix top banner ad jump

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -45,25 +45,6 @@
     width: auto;
     margin: 0 auto !important;
 }
-.top-banner-ad-container {
-    min-height: 70px;
-
-    @include mq(tablet) {
-        @include rem((
-            padding-top: $gs-baseline/2,
-            padding-bottom: $gs-baseline/2
-        ));
-    }
-    @include mq(faciaLeftCol) {
-        @include rem((
-            width: gs-span(14)
-        ));
-        margin: 0 auto;
-    }
-    @include mq(desktopAd) {
-        min-height: 110px;
-    }
-}
 .ad-slot--container-inline {
     min-height: 50px;
     @include box-sizing(border-box);

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -2,9 +2,11 @@
 .ad-slot__dfp {
     width: 100%;
     overflow-x: hidden;
-    padding: ($gs-baseline/6)*5 0 ($gs-baseline/3) 0;
     text-align: center;
     min-height: 56px;
+    @include rem((
+        padding: ($gs-baseline/6)*5 0 ($gs-baseline/3) 0
+    ));
 
     // For expandables
     position: relative;
@@ -114,17 +116,23 @@
 }
 .ad-slot--top-banner-ad {
     background-color: #f0f0f0;
+    min-height: 50px;
+    @include rem((
+        padding: $gs-baseline 0
+    ));
 
     @include mq(tablet) {
         background-color: transparent;
+        min-height: 90px !important;
     }
-
     @include mq(faciaLeftCol) {
         width: auto;
-        margin-left: gs-span(2) + $gs-gutter;
+        margin-left: gs-span(2) + ($gs-gutter*2);
         text-align: left;
     }
-
+    @include mq(wide) {
+        margin-left: gs-span(3) + ($gs-gutter*2);
+    }
     .ad-slot__label {
         display: none;
     }

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -133,29 +133,6 @@
     @include mq(wide) {
         margin-left: gs-span(3) + ($gs-gutter*2);
     }
-    .ad-slot__label {
-        display: none;
-    }
-}
-.top-banner-ad-container--above-header {
-    &,
-    .ad-slot {
-        display: none;
-
-        @include mq(desktop) {
-            display: block;
-        }
-    }
-}
-.top-banner-ad-container--below-header {
-    &,
-    .ad-slot {
-        display: block;
-
-        @include mq(desktop) {
-            display: none;
-        }
-    }
 }
 .mpu-context {
     // Provides context to sticky positioned blocks

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -114,6 +114,15 @@
         }
     }
 }
+.top-banner-ad-container {
+    margin: 0 auto;
+
+    @include mq(faciaLeftCol) {
+        @include rem((
+            width: gs-span(14)
+        ));
+    }
+}
 .ad-slot--top-banner-ad {
     background-color: #f0f0f0;
     min-height: 50px;
@@ -123,15 +132,12 @@
 
     @include mq(tablet) {
         background-color: transparent;
-        min-height: 90px !important;
+        min-height: 90px;
     }
     @include mq(faciaLeftCol) {
         width: auto;
-        margin-left: gs-span(2) + ($gs-gutter*2);
+        margin-left: gs-span(2) + $gs-gutter;
         text-align: left;
-    }
-    @include mq(wide) {
-        margin-left: gs-span(3) + ($gs-gutter*2);
     }
 }
 .mpu-context {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -100,7 +100,7 @@ object Switches extends Collections {
     "If this switch is on, comments are displayed on articles. Turn this off if the Discussion API is blowing up.",
     safeState = Off, sellByDate = never
   )
-  
+
   val OpenCtaSwitch = Switch("Performance Switches", "open-cta",
     "If this switch is on, will see a CTA to comments on the right hand side. Turn this off if the Open API is blowing up.",
     safeState = Off, sellByDate = never
@@ -276,11 +276,6 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 4, 30)
   )
 
-  val LeadAdTopPageSwitch = Switch("Feature Switches", "lead-ad-top-page",
-    "If this switch is on, the lead ad is placed on top of the page on desktop",
-    safeState = Off, sellByDate = new DateMidnight(2014, 4, 30)
-  )
-  
   val RssLinkSwitch = Switch("Feature Switches", "rss-link",
     "If this switch is on a link to the RSS is rendered in the HTML",
     safeState = Off, sellByDate = new DateMidnight(2014, 4, 7)
@@ -408,7 +403,6 @@ object Switches extends Collections {
     FrontPressJobSwitch,
     LayoutHintsSwitch,
     HelveticaEasterEggSwitch,
-    LeadAdTopPageSwitch,
     RssLinkSwitch,
     PopularInTagSwitch,
     OmnitureVerificationSwitch,

--- a/common/app/views/fragments/adSlot.scala.html
+++ b/common/app/views/fragments/adSlot.scala.html
@@ -1,33 +1,31 @@
 @(id: String, baseSlot: String, medianSlot: String, extendedSlot: String)
 @import conf.Switches._
 
-@if(AdvertSwitch.isSwitchedOn) {
-    @if(OASAdvertSwitch.isSwitchedOn && (!DFPAdvertSwitch.isSwitchedOn || LoadOnlyCommercialComponents.isSwitchedOn)) {
-        @*<!--
-        although we do put a data-link-name attribute on here any ad that iframes itself will be untrackable via this, so
-        take ad clicks with a pinch of salt.
-        -->*@
-        <div class="ad-slot__oas ad-slot--@id"
-             data-link-name="ad slot @id"
-             data-base="@baseSlot"
-             data-median="@medianSlot"
-             data-extended="@extendedSlot">
-             <div class="ad-slot__inner">
-                 <div class="ad-slot__label">Advertisement</div>
-                 <div class="ad-container"></div>
-             </div>
+@if(OASAdvertSwitch.isSwitchedOn && (!DFPAdvertSwitch.isSwitchedOn || LoadOnlyCommercialComponents.isSwitchedOn)) {
+    @*<!--
+    although we do put a data-link-name attribute on here any ad that iframes itself will be untrackable via this, so
+    take ad clicks with a pinch of salt.
+    -->*@
+    <div class="ad-slot__oas ad-slot--@id"
+         data-link-name="ad slot @id"
+         data-base="@baseSlot"
+         data-median="@medianSlot"
+         data-extended="@extendedSlot">
+         <div class="ad-slot__inner">
+             <div class="ad-slot__label">Advertisement</div>
+             <div class="ad-container"></div>
+         </div>
+    </div>
+} else {
+    @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
+        <div
+            class="ad-slot__dfp ad-slot--@id"
+            data-name="top"
+            data-label="false"
+            data-mobile="300,50|320,50"
+            data-tabletportrait="728,90"
+            data-tabletlandscape="728,90|900,250">
+             <div id="dfp-ad-@id" class="ad-container"></div>
         </div>
-    } else {
-        @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
-            <div
-                class="ad-slot__dfp ad-slot--@id"
-                data-name="top"
-                data-label="false"
-                data-mobile="300,50|320,50"
-                data-tabletportrait="728,90"
-                data-tabletlandscape="728,90|900,250">
-                 <div id="dfp-ad-@id" class="ad-container"></div>
-            </div>
-        }
     }
 }

--- a/common/app/views/fragments/adSlot.scala.html
+++ b/common/app/views/fragments/adSlot.scala.html
@@ -19,7 +19,13 @@
         </div>
     } else {
         @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
-            <div class="ad-slot__dfp ad-slot--@id" data-name="top" data-mobile="300,50|320,50" data-tabletportrait="728,90" data-tabletlandscape="900,250|728,90">
+            <div
+                class="ad-slot__dfp ad-slot--@id"
+                data-name="top"
+                data-label="false"
+                data-mobile="300,50|320,50"
+                data-tabletportrait="728,90"
+                data-tabletlandscape="728,90|900,250">
                  <div id="dfp-ad-@id" class="ad-container"></div>
             </div>
         }

--- a/common/app/views/fragments/adSlot.scala.html
+++ b/common/app/views/fragments/adSlot.scala.html
@@ -1,27 +1,27 @@
 @(id: String, baseSlot: String, medianSlot: String, extendedSlot: String)
 @import conf.Switches._
 
-@if(OASAdvertSwitch.isSwitchedOn && (!DFPAdvertSwitch.isSwitchedOn || LoadOnlyCommercialComponents.isSwitchedOn)) {
-    @*<!--
-    although we do put a data-link-name attribute on here any ad that iframes itself will be untrackable via this, so
-    take ad clicks with a pinch of salt.
-    -->*@
-    <div class="ad-slot__oas ad-slot--@id"
-         data-link-name="ad slot @id"
-         data-base="@baseSlot"
-         data-median="@medianSlot"
-         data-extended="@extendedSlot">
-         <div class="ad-slot__inner">
-             <div class="ad-slot__label">Advertisement</div>
-             <div class="ad-container"></div>
-         </div>
-    </div>
-} else {
-    @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
-        <div class="ad-slot__dfp ad-slot--@id" data-name="top" data-mobile="300,50|320,50" data-tabletportrait="728,90" data-tabletlandscape="900,250|728,90">
+@if(AdvertSwitch.isSwitchedOn) {
+    @if(OASAdvertSwitch.isSwitchedOn && (!DFPAdvertSwitch.isSwitchedOn || LoadOnlyCommercialComponents.isSwitchedOn)) {
+        @*<!--
+        although we do put a data-link-name attribute on here any ad that iframes itself will be untrackable via this, so
+        take ad clicks with a pinch of salt.
+        -->*@
+        <div class="ad-slot__oas ad-slot--@id"
+             data-link-name="ad slot @id"
+             data-base="@baseSlot"
+             data-median="@medianSlot"
+             data-extended="@extendedSlot">
              <div class="ad-slot__inner">
-                 <div id="dfp-ad-@id" class="ad-container"></div>
+                 <div class="ad-slot__label">Advertisement</div>
+                 <div class="ad-container"></div>
              </div>
         </div>
+    } else {
+        @if(DFPAdvertSwitch.isSwitchedOn && !LoadOnlyCommercialComponents.isSwitchedOn) {
+            <div class="ad-slot__dfp ad-slot--@id" data-name="top" data-mobile="300,50|320,50" data-tabletportrait="728,90" data-tabletlandscape="900,250|728,90">
+                 <div id="dfp-ad-@id" class="ad-container"></div>
+            </div>
+        }
     }
 }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -15,7 +15,7 @@
     itemscope itemtype="http://schema.org/WebPage">
 
     @fragments.message(metaData)
-    @if(AdvertSwitch.isSwitchedOn && LeadAdTopPageSwitch.isSwitchedOn) {
+    @if(LeadAdTopPageSwitch.isSwitchedOn) {
         <div class="top-banner-ad-container top-banner-ad-container--above-header">
             @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
         </div>
@@ -23,11 +23,7 @@
     @fragments.header(metaData)
 
     <div id="js-context" class="gs-container">
-        @if(AdvertSwitch.isSwitchedOn) {
-            <div class="top-banner-ad-container@if(LeadAdTopPageSwitch.isSwitchedOn){ top-banner-ad-container--below-header}">
-                @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
-            </div>
-        }
+        @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
 
         @fragments.localNav(metaData)
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -15,11 +15,7 @@
     itemscope itemtype="http://schema.org/WebPage">
 
     @fragments.message(metaData)
-    @if(LeadAdTopPageSwitch.isSwitchedOn) {
-        <div class="top-banner-ad-container top-banner-ad-container--above-header">
-            @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
-        </div>
-    }
+
     @fragments.header(metaData)
 
     <div id="js-context" class="gs-container">

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -19,7 +19,11 @@
     @fragments.header(metaData)
 
     <div id="js-context" class="gs-container">
-        @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
+        @if(AdvertSwitch.isSwitchedOn) {
+            <div class="top-banner-ad-container">
+                @fragments.adSlot(id="top-banner-ad", baseSlot="Top2", medianSlot="Top", extendedSlot="Top")
+            </div>
+        }
 
         @fragments.localNav(metaData)
 


### PR DESCRIPTION
Order of DFP's data attribute values important

Also tighten up min-heights of ad

And removed `LeadAdTopPageSwitch`; turning on would break ads, as can't have two ads slots with the same id on a single page
