### PR TITLE
Stop loading unsecure content from ophan and revsci in Identity

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -222,7 +222,7 @@ define([
                 });
             });
 
-            if (config.switches.ophan) {
+            if (config.switches.ophan && config.page.contentType !== 'Identity' && config.page.section !== 'identity') {
                 require('ophan/ng', function (ophan) {
                     ophan.record({'ab': ab.getParticipations()});
 
@@ -240,7 +240,7 @@ define([
         loadAdverts: function (config) {
             // Having to check 3 switches for ads so that DFP and OAS can run in parallel
             // with each other and still have a master switch to turn off all adverts
-            if(!userPrefs.isOff('adverts') && config.switches.adverts && !config.page.shouldHideAdverts) {
+            if(!userPrefs.isOff('adverts') && config.switches.adverts && !config.page.shouldHideAdverts && config.page.contentType !== 'Identity' && config.page.section !== 'identity') {
 
                 var hasAdsToLoad = config.switches.oasAdverts || config.switches.dfpAdverts,
                     onResize = {
@@ -465,7 +465,9 @@ define([
         },
 
         startRegister: function(config) {
-            register.initialise(config);
+            if (config.page.contentType !== 'Identity' && config.page.section !== 'identity') {
+                register.initialise(config);
+            }
         },
 
         loadCommercialComponent: function(config) {


### PR DESCRIPTION
This is a hacky change to stop unsecured content (ie http vs https) loading on identity pages. The reason for this is that @rtyley and myself think that it is the cause or at least a contributing factor to a lot of the IE related errors we have been getting recently.

If we find that this makes a difference to our issues we will investigate a more permanent/sane solution.

![cb4c82ed-0730-4493-a296-d806edfa771b](https://cloud.githubusercontent.com/assets/1170410/2601986/2d584f9e-bb19-11e3-9838-77862a0a29fd.gif)
