### PR TITLE
SEO tweaks

### DIFF
--- a/admin/app/views/redirects.scala.html
+++ b/admin/app/views/redirects.scala.html
@@ -3,6 +3,10 @@
 @admin_main("Redirector", "PROD", isAuthed = true) {
     <ul>
         <li>
+            This will <strong>only</strong> add the redirect to Next Gen Web. It will <strong>not</strong> add it to
+            R2 (classic/desktop site) or mobile apps.
+        </li>
+        <li>
             This tool can only insert redirects for URLs that do not already exist. (i.e. the current url must 404).
             Redirects for things that exist will not work (this also means you cannot accidentally redirect the /sport page).
         </li>

--- a/applications/test/ImageContentTemplateTest.scala
+++ b/applications/test/ImageContentTemplateTest.scala
@@ -9,13 +9,13 @@ class ImageContentTemplateTest extends FlatSpec with Matchers {
     browser =>
       import browser._
       $("[itemprop='headline']").first.getText should be("Steve Bell on Iain Duncan Smith and the benefits cap – cartoon")
-      $("#article img").first.getAttribute("src") should endWith ("/Steve-Bell-cartoon-16.07.-001.jpg?width=220&height=-&quality=95")
+      $("#article img").first.getAttribute("src") should endWith ("/Steve-Bell-cartoon-16.07.-001.jpg?width=620&height=-&quality=95")
   }
   
   it should "render a picture" in HtmlUnit("/artanddesign/picture/2013/oct/08/photography") {
     browser =>
       import browser._
       $("[itemprop='headline']").getText should be("Early erotica - a picture from the past")
-      $("#article img").first.getAttribute("src") should endWith ("/French-Nude-in-Body-Stock-010.jpg?width=220&height=-&quality=95")
+      $("#article img").first.getAttribute("src") should endWith ("/French-Nude-in-Body-Stock-015.jpg?width=620&height=-&quality=95")
   }
 }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -37,7 +37,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         Then("I should see the headline of the article")
 
         And("The article is marked up with the correct schema")
-        val article = findFirst("article[itemtype='http://schema.org/Article']")
+        val article = findFirst("article[itemtype='http://schema.org/NewsArticle']")
 
         article.findFirst("[itemprop=headline]").getText should
           be("Liu Xiang pulls up in opening race at second consecutive Olympics")
@@ -121,11 +121,11 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         ImageServerSwitch.switchOn()
 
         Then("I should see the article's image")
-        findFirst("[itemprop='associatedMedia primaryImageOfPage'] img[itemprop=contentURL]").getAttribute("src") should
-          endWith("Pix/pictures/2012/8/6/1344274679326/Gunnerside-village-Swaled-005.jpg?width=220&height=-&quality=95")
+        findFirst("[itemprop='contentURL representativeOfPage']").getAttribute("src") should
+          endWith("Gunnerside-village-Swaled-009.jpg?width=620&height=-&quality=95")
 
         And("I should see the image caption")
-        findFirst("[itemprop='associatedMedia primaryImageOfPage'] [itemprop=description]").getText should
+        findFirst("[itemprop='associatedMedia image'] [itemprop=description]").getText should
           be("Our rivers and natural resources are to be valued and commodified, a move that will benefit only the rich, argues Goegr Monbiot. Photograph: Alamy")
       }
     }
@@ -390,7 +390,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         import browser._
 
         Then("the main picture should be shown")
-        $("[itemprop='associatedMedia primaryImageOfPage']") should have size 1
+        $("[itemprop='contentURL representativeOfPage']") should have size 1
 
         And("the embedded video should not have a poster when there are no images in the video element")
         findFirst("video").getAttribute("poster") should be("")
@@ -421,7 +421,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
       HtmlUnit("/artanddesign/2013/apr/15/buildings-tall-architecture-guardianwitness") { broswer =>
         import broswer._
         Then("The main picture should be show")
-        $("[itemprop='associatedMedia primaryImageOfPage']") should have size 1
+        $("[itemprop='contentURL representativeOfPage']") should have size 1
       }
     }
 

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -1,19 +1,15 @@
 @(image: Option[model.ImageContainer])
-@import views.support.{ImgSrc, Item220, Item620}
+@import views.support.{ImgSrc, Item940, Item620}
 
 @image.map{ picture =>
-    <figure itemprop="associatedMedia primaryImageOfPage" itemscope itemtype="http://schema.org/ImageObject" class="media-primary media-content" data-component="image">
-        <div class="js-image-upgrade" data-src="@ImgSrc.imager(picture, Item620).map(Html(_))">
-            <img src="@Item220.bestFor(picture).map(Html(_))"
-                 class="maxed responsive-img"
-                 itemprop="contentURL"
-                 title="@Item620.altTextFor(picture).getOrElse("")"
-                 alt="@Item620.altTextFor(picture).getOrElse("")" />
-        </div>
-
-        @Item220.captionFor(picture).map{ caption =>
+    <figure itemprop="associatedMedia image" itemscope itemtype="http://schema.org/ImageObject" class="media-primary media-content" data-component="image">
+        <img src="@Item620.bestFor(picture).map(Html(_))"
+             class="maxed responsive-img"
+             itemprop="contentURL representativeOfPage"
+             title="@Item620.altTextFor(picture).getOrElse("")"
+             alt="@Item620.altTextFor(picture).getOrElse("")" />
+        @Item620.captionFor(picture).map{ caption =>
             <figcaption class="main-caption" itemprop="description">@Html(caption)</figcaption>
         }
-
     </figure>
 }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -708,9 +708,9 @@ object TableEmbedComplimentaryToP extends HtmlCleaner {
 
 object VisualTone {
 
-  private val Comment = "comment"
-  private val News = "news"
-  private val Feature = "feature"
+  val Comment = "comment"
+  val News = "news"
+  val Feature = "feature"
 
   private val commentMappings = Seq(
     "tone/comment",


### PR DESCRIPTION
A bit of informed guesswork (based on the first bit of Googlebot crawling)...

Googlebot is seeing the small 220px picture because of the JS upgrades. I now have the 620px picture in directly as the article picture.

We now make better use of the different types of Schema Articles (e.g. NewsArticle, BlogPost).
