### PR TITLE
Use isSSL instead of page.contentType

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -242,7 +242,7 @@ define([
         loadAdverts: function (config) {
             // Having to check 3 switches for ads so that DFP and OAS can run in parallel
             // with each other and still have a master switch to turn off all adverts
-            if(!userPrefs.isOff('adverts') && config.switches.adverts && !config.page.shouldHideAdverts && !isSSL) {
+            if(!userPrefs.isOff('adverts') && config.switches.adverts && !config.page.shouldHideAdverts && !config.page.isSSL) {
 
                 var hasAdsToLoad = config.switches.oasAdverts || config.switches.dfpAdverts,
                     onResize = {
@@ -467,7 +467,7 @@ define([
         },
 
         startRegister: function(config) {
-            if (!isSSL) {
+            if (!config.page.isSSL) {
                 register.initialise(config);
             }
         },

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -224,7 +224,7 @@ define([
                 });
             });
 
-            if (config.switches.ophan && config.page.contentType !== 'Identity' && config.page.section !== 'identity') {
+            if (config.switches.ophan && !config.page.isSSL) {
                 require('ophan/ng', function (ophan) {
                     ophan.record({'ab': ab.getParticipations()});
 
@@ -242,7 +242,7 @@ define([
         loadAdverts: function (config) {
             // Having to check 3 switches for ads so that DFP and OAS can run in parallel
             // with each other and still have a master switch to turn off all adverts
-            if(!userPrefs.isOff('adverts') && config.switches.adverts && !config.page.shouldHideAdverts && config.page.contentType !== 'Identity' && config.page.section !== 'identity') {
+            if(!userPrefs.isOff('adverts') && config.switches.adverts && !config.page.shouldHideAdverts && !isSSL) {
 
                 var hasAdsToLoad = config.switches.oasAdverts || config.switches.dfpAdverts,
                     onResize = {
@@ -467,7 +467,7 @@ define([
         },
 
         startRegister: function(config) {
-            if (config.page.contentType !== 'Identity' && config.page.section !== 'identity') {
+            if (!isSSL) {
                 register.initialise(config);
             }
         },


### PR DESCRIPTION
@chrisfinch I prefer this solution to your 076278d - does that work for you? In general we want to avoid lots of _if section = foo { ... }_ scattered across the code.
