### PR TITLE
Archive: Ophan tracking update

### DIFF
--- a/archive/app/views/notFound.scala.html
+++ b/archive/app/views/notFound.scala.html
@@ -107,15 +107,16 @@
         <script src="http://pasteup.guim.co.uk/js/lib/requirejs/2.1.5/require.min.js"></script>
 
         <script>
-        require(['http://s.ophan.co.uk/js/ophan.min.js'], function(ophan) {
-        ophan.additionalViewData(function() { return {"httpStatus" : "404"}; });
+        require.config({
+          paths: {
+            'ophan/http-status' : 'http://j.ophan.co.uk/ophan.http-status',
+          }
+        });
+        </script>
 
-        if(document.readyState === 'complete') {
-        ophan.startLog();
-        return;
-        }
-
-        window.addEventListener('load', ophan.startLog, false);
+        <script>
+        require(['ophan/http-status'], function(reporter) {
+          reporter.reportStatus('next-gen', 404);
         });
         </script>
 


### PR DESCRIPTION
Should be pretty straight-forward, this updates the tracking on the Not Found page to allow user-facing 404s to be tracked and reported in Ophan Dashboard.

This based on the code that's in production for the R2 equivalent.
