### PR TITLE
commercial, soulmates drop down default fix

### DIFF
--- a/commercial/app/views/soulmates.scala.html
+++ b/commercial/app/views/soulmates.scala.html
@@ -60,14 +60,14 @@
                     <label for="age_min" class="search__dropdown">Aged from
                         <select id="age_min" name="age_min" class="search__dropdown__options">
                             @for(ageMin <- 18 to 99) {
-                                <option@if(ageMin == 25){selected="selected"}>@ageMin</option>
+                                <option@if(ageMin == 25){ selected="selected"}>@ageMin</option>
                             }
                         </select>
                     </label>
                     <label for="age_max" class="search__dropdown">To
                         <select id="age_max" name="age_max" class="search__dropdown__options">
                             @for(ageMax <- 18 to 99) {
-                                <option@if(ageMax == 45){selected="selected"}>@ageMax</option>
+                                <option@if(ageMax == 45){ selected="selected"}>@ageMax</option>
                             }
                         </select>
                     </label>


### PR DESCRIPTION
Fix for adding selected="selected" to default selections. It was missing a space before.

![screen shot 2014-04-04 at 11 24 17](https://cloud.githubusercontent.com/assets/1303616/2614222/508fe25e-bbe3-11e3-8c13-a59513bfb0cd.png)
