### PR TITLE
Adding aria-label

### DIFF
--- a/commercial/app/views/books/bestsellers.scala.html
+++ b/commercial/app/views/books/bestsellers.scala.html
@@ -23,8 +23,7 @@
             </div>
             <form action="http://www.guardianbookshop.co.uk/BerteShopWeb/search.do" method="POST" class="commercial__search hide-on-mobile" name="QuickSearchForm">
                 <div>
-                    <label for="bookshop" class="u-h">Search bookshop:</label>
-                    <input id="bookshop" name="keyword" class="commercial__search__input" type="text" placeholder="Search books" />
+                    <input id="bookshop" name="keyword" class="commercial__search__input" type="text" placeholder="Search books" aria-label="Search bookshop" />
                     <button type="submit" class="u-button-reset commercial__search__submit">
                         <i class="i i-search"></i>
                     </button>
@@ -71,8 +70,7 @@
         <div class="commercial__foot">
             <form action="http://www.guardianbookshop.co.uk/BerteShopWeb/search.do" method="POST" class="commercial__search" name="QuickSearchForm">
                 <div>
-                    <label for="bookshop" class="u-h">Search bookshop:</label>
-                    <input id="bookshop" name="keyword" class="commercial__search__input" type="text" placeholder="Search bookshop" />
+                    <input id="bookshop" name="keyword" class="commercial__search__input" type="text" placeholder="Search bookshop" aria-label="Search bookshop" />
                     <button type="submit" class="u-button-reset commercial__search__submit">
                         <i class="i i-search"></i>
                     </button>

--- a/commercial/app/views/travelOffers.scala.html
+++ b/commercial/app/views/travelOffers.scala.html
@@ -32,8 +32,7 @@
     <div class="commercial__foot">
         <form action="http://www.guardianholidayoffers.co.uk/Search" class="commercial__search">
             <i class="i i-search-grey"></i>
-            <label for="traveloffer" class="u-h">Find hand picked holidays for hundreds of destinations</label>
-            <input id="traveloffer" name="search" class="text-input" type="text" placeholder="Find your perfect holiday" />
+            <input id="traveloffer" name="search" class="text-input" type="text" placeholder="Find your perfect holiday" aria-label="Find hand picked holidays for hundreds of destinations" />
             <input value="Search" name="go" class="submit-input" type="submit" />
             <input value="%JustOmnitureToken%" name="INTCMP" type="hidden" />
         </form>

--- a/commercial/app/views/travelOffers_large.scala.html
+++ b/commercial/app/views/travelOffers_large.scala.html
@@ -48,8 +48,7 @@
     <div class="commercial__foot">
         <form action="http://www.guardianholidayoffers.co.uk/Search" class="commercial__search">
             <i class="i i-search-grey"></i>
-            <label for="traveloffer" class="u-h">Find hand picked holidays for hundreds of destinations</label>
-            <input id="traveloffer" name="search" class="text-input" type="text" placeholder="Find your perfect holiday" />
+            <input id="traveloffer" name="search" class="text-input" type="text" placeholder="Find your perfect holiday" aria-label="Find hand picked holidays for hundreds of destinations" />
             <input value="Search" name="go" class="submit-input" type="submit" />
             <input value="ILCTOFFTXT5263I" name="INTCMP" type="hidden" />
         </form>


### PR DESCRIPTION
I was thinking about accessibility.

We should be embracing the standards set for it ([ARIA](http://www.w3.org/WAI/intro/aria)).
This is similar to the way we try to minimise hacks in CSS layout as its generally just an amount of time before the agents work around those (`display: none`?).

The reason we have `u-h` is we want things to be read, either by Search Engines or Screen Readers. In the case of labels, it's accessibility, so I say use the right controls for it and let the agents do what they do best. When screen readers decide to not display clipped content, we lose our accessibility.

If anything, this is also just trying to raise the question of accessibility
@gidsg do you have any strong opinions here?

[Source](http://www.w3.org/WAI/GL/wiki/Using_aria-label_to_provide_labels_for_objects)

![Fix it](http://media0.giphy.com/media/149KvVQ3DbPdfO/200_s.gif)
