### PR TITLE
Revert emergency fix

### DIFF
--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -25,7 +25,7 @@ object Seg {
 
 trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging {
 
-  case class InvalidContent(id: String) extends Throwable(s"Invalid Content: $id")
+  case class InvalidContent(id: String) extends Exception(s"Invalid Content: $id")
   val showFieldsQuery: String = FaciaDefaults.showFields
   val showFieldsWithBodyQuery: String = FaciaDefaults.showFieldsWithBody
 

--- a/facia-tool/conf/application-logger.xml
+++ b/facia-tool/conf/application-logger.xml
@@ -3,7 +3,7 @@
     <contextName>frontend-facia-tool</contextName>
 
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/frontend-facia-tool.log</file>
+        <file>logs/frontend-admin.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-facia-tool.log.%d{yyyy-MM-dd}.gz</fileNamePattern>

--- a/facia-tool/conf/application-logger.xml
+++ b/facia-tool/conf/application-logger.xml
@@ -3,7 +3,7 @@
     <contextName>frontend-facia-tool</contextName>
 
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/frontend-admin.log</file>
+        <file>logs/frontend-facia-tool.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-facia-tool.log.%d{yyyy-MM-dd}.gz</fileNamePattern>


### PR DESCRIPTION
This reverts the emergency fix put in by #3699.

We do not want disappearing content under any circumstances.
After investigating (and trying to recreate) the issues that happened last week around the Content API, I have come to the conclusion that the Content API was giving back empty `results` and `editorsPicks`.

We are currently deciding what to do when this does happen, and under what conditions to fail.

@gklopper @stephanfowler 
