### PR TITLE
Read more links inside the RSS item description

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -70,7 +70,7 @@ object TrailsToRss extends implicits.Collections {
           case a: Article => Jsoup.parseBodyFragment(a.body).select("p:lt(2)").toArray.map(_.toString).mkString("")
           case _ => ""
         }
-      val readMore = s""" <a href="${trail.webUrl}">Read more...</a>"""
+      val readMore = s""" <a href="${trail.webUrl}">Continue reading...</a>"""
       description.setValue(cleanInvalidXmlChars(standfirst + intro + readMore))
 
       val images: Seq[ImageAsset] = (trail.bodyImages ++ trail.mainPicture ++ trail.thumbnail).map{ i =>

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -70,7 +70,8 @@ object TrailsToRss extends implicits.Collections {
           case a: Article => Jsoup.parseBodyFragment(a.body).select("p:lt(2)").toArray.map(_.toString).mkString("")
           case _ => ""
         }
-      description.setValue(cleanInvalidXmlChars(standfirst + intro))
+      val readMore = s""" <a href="${trail.webUrl}">Read more...</a>"""
+      description.setValue(cleanInvalidXmlChars(standfirst + intro + readMore))
 
       val images: Seq[ImageAsset] = (trail.bodyImages ++ trail.mainPicture ++ trail.thumbnail).map{ i =>
         i.imageCrops.filter(c => (c.width == 140 && c.height == 84) || (c.width == 460 && c.height == 276))


### PR DESCRIPTION
This improves the obviousness of the article continuing on the website.

A few users have asked for this, which seems like a good idea. 

![denmark](https://cloud.githubusercontent.com/assets/84996/2617536/aafecfae-bc13-11e3-955c-98561317ab71.png)
