### PR TITLE
Facia tool: alert if press fails

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -86,6 +86,9 @@ object S3FrontsApi extends S3 {
   val namespace = "frontsapi"
   lazy val location = s"$stage/$namespace"
 
+  def getPressedKeyForPath(path: String): String =
+    s"$location/pressed/$path/pressed.json"
+
   def getSchema = get(s"$location/schema.json")
   def getConfig(id: String) = get(s"$location/config/$id/config.json")
   def getMasterConfig: Option[String] = get(s"$location/config/config.json")
@@ -122,11 +125,11 @@ object S3FrontsApi extends S3 {
   def getConfigIds(prefix: String): List[String] = getListing(prefix, "/config.json")
   def getCollectionIds(prefix: String): List[String] = getListing(prefix, "/collection.json")
 
-  def putPressedJson(id: String, json: String) =
-    putPrivate(s"$location/pressed/$id/pressed.json", json, "application/json")
+  def putPressedJson(path: String, json: String) =
+    putPrivate(getPressedKeyForPath(path), json, "application/json")
 
   def getPressedLastModified(path: String): Option[String] =
-    getLastModified(s"$location/pressed/$path/pressed.json").map(_.toString)
+    getLastModified(getPressedKeyForPath(path)).map(_.toString)
 }
 
 trait SecureS3Request extends implicits.Dates with Logging {

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -124,6 +124,9 @@ object S3FrontsApi extends S3 {
 
   def putPressedJson(id: String, json: String) =
     putPrivate(s"$location/pressed/$id/pressed.json", json, "application/json")
+
+  def getPressedLastModified(path: String): Option[String] =
+    getLastModified(s"$location/pressed/$path/pressed.json").map(_.toString)
 }
 
 trait SecureS3Request extends implicits.Dates with Logging {

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -154,4 +154,9 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     if (Switches.FaciaToolPressSwitch.isSwitchedOn) {
       FrontPressJob.pressByCollectionIds(ids)
     }
+
+  def getLastUpdated(path: String) = AjaxExpiringAuthentication { request =>
+    val now: Option[String] = S3FrontsApi.getPressedLastModified(path)
+    now.map(Ok(_)).getOrElse(NotFound)
+  }
 }

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -155,7 +155,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
       FrontPressJob.pressByCollectionIds(ids)
     }
 
-  def getLastUpdated(path: String) = AjaxExpiringAuthentication { request =>
+  def getLastModified(path: String) = AjaxExpiringAuthentication { request =>
     val now: Option[String] = S3FrontsApi.getPressedLastModified(path)
     now.map(Ok(_)).getOrElse(NotFound)
   }

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -4,10 +4,14 @@
 
 <div style="display: none;" data-bind="visible: true">
 
-    <div class="status status-danger" data-bind="text: alertError, visible: alertError"></div>
-    <div class="status status-warning" data-bind="visible: hasPressFaliure">
-        Failed to go live.
+    <div class="status status-danger" data-bind="visible: statusCapiErrors">
+        Sorry, ContentApi is unhealthy. Fronts may fail to update. If this persists for longer than 10 minutes, <a href="https://sites.google.com/a/guardian.co.uk/digital-incident-management/">contact support</a>.
+        <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>
+    </div>
+    <div class="status status-warning" data-bind="visible: statusPressFaliure">
+        Sorry, a network delay meant your change couldn't go live.
         <a data-bind="click: pressFront">Retry?</a>
+        <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>
     </div>
 
     <div class="toolbar" data-bind="visible: true" style="display: none">

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -5,12 +5,15 @@
 <div style="display: none;" data-bind="visible: true">
 
     <div class="status status-danger" data-bind="visible: statusCapiErrors">
-        Sorry, ContentApi is unhealthy. Fronts may fail to update. If this persists for longer than 10 minutes, <a href="https://sites.google.com/a/guardian.co.uk/digital-incident-management/">contact support</a>.
+        Sorry, ContentApi is unhealthy. Fronts may fail to update.
+        <a data-bind="click: pressFront">Retry it?</a>
+        If this persists beyond ten minutes, <a href="https://sites.google.com/a/guardian.co.uk/digital-incident-management/">contact support</a>.
         <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>
     </div>
     <div class="status status-warning" data-bind="visible: statusPressFailure">
         Sorry, a network delay meant your change couldn't go live.
-        <a data-bind="click: pressFront">Retry?</a>
+        <a data-bind="click: pressFront">Retry it?</a>
+        If this persists beyond ten minutes, <a href="https://sites.google.com/a/guardian.co.uk/digital-incident-management/">contact support</a>.
         <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>
     </div>
 

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -8,7 +8,7 @@
         Sorry, ContentApi is unhealthy. Fronts may fail to update. If this persists for longer than 10 minutes, <a href="https://sites.google.com/a/guardian.co.uk/digital-incident-management/">contact support</a>.
         <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>
     </div>
-    <div class="status status-warning" data-bind="visible: statusPressFaliure">
+    <div class="status status-warning" data-bind="visible: statusPressFailure">
         Sorry, a network delay meant your change couldn't go live.
         <a data-bind="click: pressFront">Retry?</a>
         <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -3,6 +3,13 @@
 @admin_main("Fronts editor", env, isAuthed = true, identity) {
 
 <div style="display: none;" data-bind="visible: true">
+
+    <div class="status status-danger" data-bind="text: alertError, visible: alertError"></div>
+    <div class="status status-warning" data-bind="visible: hasPressFaliure">
+        Failed to go live.
+        <a data-bind="click: pressFront">Retry?</a>
+    </div>
+
     <div class="toolbar" data-bind="visible: true" style="display: none">
 
         <span data-bind="if: fronts().length > 1">
@@ -81,7 +88,6 @@
     </div>
 
     <div class="right-col" data-bind="css: {'live-mode': $root.liveMode}">
-        <div class="status status-danger" data-bind="text: alertError, visible: alertError"></div>
         <div class="collections__inner scrollable" data-bind="template: {name: 'template_collection', foreach: collections}"></div>
     </div>
 

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -22,6 +22,7 @@ GET           /configuration             controllers.FaciaToolController.configE
 POST          /collection/publish/*id    controllers.FaciaToolController.publishCollection(id)
 POST          /collection/discard/*id    controllers.FaciaToolController.discardCollection(id)
 POST          /collection/update/*id     controllers.FaciaToolController.updateCollection(id)
+GET           /collection/lastupdated/*id controllers.FaciaToolController.getLastUpdated(id)
 
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
 POST          /edits                     controllers.FaciaToolController.collectionEdits

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -22,7 +22,7 @@ GET           /configuration             controllers.FaciaToolController.configE
 POST          /collection/publish/*id    controllers.FaciaToolController.publishCollection(id)
 POST          /collection/discard/*id    controllers.FaciaToolController.discardCollection(id)
 POST          /collection/update/*id     controllers.FaciaToolController.updateCollection(id)
-GET           /collection/lastupdated/*id controllers.FaciaToolController.getLastUpdated(id)
+GET           /collection/lastmodified/*path controllers.FaciaToolController.getLastModified(path)
 
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
 POST          /edits                     controllers.FaciaToolController.collectionEdits

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -22,7 +22,8 @@ GET           /configuration             controllers.FaciaToolController.configE
 POST          /collection/publish/*id    controllers.FaciaToolController.publishCollection(id)
 POST          /collection/discard/*id    controllers.FaciaToolController.discardCollection(id)
 POST          /collection/update/*id     controllers.FaciaToolController.updateCollection(id)
-GET           /collection/lastmodified/*path controllers.FaciaToolController.getLastModified(path)
+
+GET           /front/lastmodified/*path  controllers.FaciaToolController.getLastModified(path)
 
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
 POST          /edits                     controllers.FaciaToolController.collectionEdits

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -19,11 +19,13 @@ a, a:hover {
 }
 
 .status {
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
     position: fixed;
     width: 100%;
     background: #999999;
     color: #FFFFFF;
-    padding: 15px 5px;
+    padding: 15px 40px 15px 40px;
     z-index: 2;
     text-align: center;
 }
@@ -34,6 +36,12 @@ a, a:hover {
 
 .status-danger {
     background: #d61d00;
+}
+
+.status .icon-remove {
+    position: absolute;
+    right: 10px;
+    top: 15px;
 }
 
 .scrollable {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -21,7 +21,6 @@ a, a:hover {
 .status {
     position: fixed;
     width: 100%;
-    top: 0px;
     background: #999999;
     color: #FFFFFF;
     padding: 15px 5px;
@@ -50,7 +49,7 @@ a, a:hover {
     position: fixed;
     top: 8px;
     left: 15px;
-    z-index: 2;
+    z-index: 3;
 }
 
 .tool-title {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -18,11 +18,23 @@ a, a:hover {
     cursor: pointer;
 }
 
+.status {
+    position: fixed;
+    width: 100%;
+    top: 0px;
+    background: #999999;
+    color: #FFFFFF;
+    padding: 15px 5px;
+    z-index: 2;
+    text-align: center;
+}
+
+.status-warning {
+    background: #FF9900;
+}
+
 .status-danger {
     background: #d61d00;
-    color: #FFFFFF;
-    padding: 2px 10px;
-    margin: 0 0 10px 0;
 }
 
 .scrollable {

--- a/facia-tool/public/javascripts/models/collections/article.js
+++ b/facia-tool/public/javascripts/models/collections/article.js
@@ -126,7 +126,7 @@ define([
                  ].filter(function(prop) {return !deepGet(opts, prop);});
 
                 if (missingProps.length) {
-                    vars.model.alertError('ContentApi is misbehaving. This front may fail to update.');
+                    vars.model.statusCapiErrors(true);
                     window.console.error('ContentApi missing: "' + missingProps.join('", "') + '" for ' + this.id);
                 } else {
                     this.state.isLoaded(true);

--- a/facia-tool/public/javascripts/models/collections/collection.js
+++ b/facia-tool/public/javascripts/models/collections/collection.js
@@ -118,7 +118,7 @@ define([
             self.load()
             .then(function(){
                 if (goLive) {
-                    vars.model.deferredDetectPressFaliure();
+                    vars.model.deferredDetectPressFailure();
                 }
             });
         });
@@ -137,7 +137,7 @@ define([
         })
         .then(function() {
             if(vars.state.liveMode()) {
-                vars.model.deferredDetectPressFaliure();
+                vars.model.deferredDetectPressFailure();
             }
         });
     };

--- a/facia-tool/public/javascripts/models/collections/collection.js
+++ b/facia-tool/public/javascripts/models/collections/collection.js
@@ -115,7 +115,12 @@ define([
             url: vars.CONST.apiBase + '/collection/'+ (goLive ? 'publish' : 'discard') + '/' + this.id
         })
         .then(function() {
-            self.load();
+            self.load()
+            .then(function(){
+                if (goLive) {
+                    vars.model.deferredDetectPressFaliure();
+                }
+            });
         });
     };
 
@@ -128,6 +133,11 @@ define([
                 item:       item.id,
                 live:       vars.state.liveMode(),
                 draft:     !vars.state.liveMode()
+            }
+        })
+        .then(function() {
+            if(vars.state.liveMode()) {
+                vars.model.deferredDetectPressFaliure();
             }
         });
     };

--- a/facia-tool/public/javascripts/models/collections/droppable.js
+++ b/facia-tool/public/javascripts/models/collections/droppable.js
@@ -93,6 +93,11 @@ define([
                             itemMeta: _.isEmpty(itemMeta) ? undefined : itemMeta
                         },
                         remove: remove
+                    })
+                    .then(function() {
+                        if(vars.state.liveMode()) {
+                            vars.model.deferredDetectPressFaliure();
+                        }
                     });
                     
                     if (sourceList && !sourceList.keepCopy && sourceList !== targetList) {

--- a/facia-tool/public/javascripts/models/collections/droppable.js
+++ b/facia-tool/public/javascripts/models/collections/droppable.js
@@ -96,7 +96,7 @@ define([
                     })
                     .then(function() {
                         if(vars.state.liveMode()) {
-                            vars.model.deferredDetectPressFaliure();
+                            vars.model.deferredDetectPressFailure();
                         }
                     });
                     

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -38,10 +38,10 @@ define([
         var model = vars.model = {};
 
         model.statusCapiErrors = ko.observable(false);
-        model.statusPressFaliure = ko.observable(false);
+        model.statusPressFailure = ko.observable(false);
         model.clearStatuses = function() {
             model.statusCapiErrors(false);
-            model.statusPressFaliure(false);
+            model.statusPressFailure(false);
         };
 
         model.collections = ko.observableArray();
@@ -80,8 +80,8 @@ define([
             return vars.CONST.viewer + '#env=' + config.env + '&url=' + model.front() + encodeURIComponent('?view=mobile');
         });
 
-        function detectPressFaliure() {
-            model.statusPressFaliure(false);
+        function detectPressFailure() {
+            model.statusPressFailure(false);
 
             if (model.front()) {
                 authedAjax.request({
@@ -93,7 +93,7 @@ define([
                     if (resp.status !== 200) { return; }
                     lastPressed = new Date(resp.responseText);
                     if (isValidDate(lastPressed)) {
-                        model.statusPressFaliure(
+                        model.statusPressFailure(
                             _.some(model.collections(), function(collection) {
                                 var l = new Date(collection.state.lastUpdated());
                                 return isValidDate(l) ? l > lastPressed : false;
@@ -104,10 +104,10 @@ define([
             }
         }
 
-        var deferredDetectPressFaliure = _.debounce(detectPressFaliure, 5000);
+        var deferredDetectPressFailure = _.debounce(detectPressFailure, vars.CONST.detectPressFailureMs || 10000);
         
         function pressFront() {
-            model.statusPressFaliure(false);
+            model.statusPressFailure(false);
 
             if (model.front()) {
                 authedAjax.request({
@@ -115,12 +115,12 @@ define([
                     method: 'post'
                 })
                 .always(function() {
-                    deferredDetectPressFaliure();
+                    deferredDetectPressFailure();
                 });
             }
         }
 
-        model.deferredDetectPressFaliure = deferredDetectPressFaliure;
+        model.deferredDetectPressFailure = deferredDetectPressFailure;
         model.pressFront = pressFront;
         
         function getFront() {

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -37,9 +37,12 @@ define([
 
         var model = vars.model = {};
 
-        model.alertError = ko.observable();
-        
-        model.hasPressFaliure = ko.observable(false);
+        model.statusCapiErrors = ko.observable(false);
+        model.statusPressFaliure = ko.observable(false);
+        model.clearStatuses = function() {
+            model.statusCapiErrors(false);
+            model.statusPressFaliure(false);
+        };
 
         model.collections = ko.observableArray();
 
@@ -78,7 +81,8 @@ define([
         });
 
         function detectPressFaliure() {
-            model.hasPressFaliure(false);
+            model.statusPressFaliure(false);
+
             if (model.front()) {
                 authedAjax.request({
                     url: '/front/lastmodified/' + model.front()
@@ -89,10 +93,10 @@ define([
                     if (resp.status !== 200) { return; }
                     lastPressed = new Date(resp.responseText);
                     if (isValidDate(lastPressed)) {
-                        model.hasPressFaliure(
+                        model.statusPressFaliure(
                             _.some(model.collections(), function(collection) {
-                               var l = new Date(collection.state.lastUpdated());
-                               return isValidDate(l) ? l > lastPressed : false;
+                                var l = new Date(collection.state.lastUpdated());
+                                return isValidDate(l) ? l > lastPressed : false;
                             })
                         );
                     }
@@ -100,10 +104,11 @@ define([
             }
         }
 
-        var deferredDetectPressFaliure = _.debounce(detectPressFaliure, 10000);
+        var deferredDetectPressFaliure = _.debounce(detectPressFaliure, 5000);
         
         function pressFront() {
-            model.hasPressFaliure(false);
+            model.statusPressFaliure(false);
+
             if (model.front()) {
                 authedAjax.request({
                     url: '/collection/update/' + model.collections()[0].id,
@@ -115,7 +120,6 @@ define([
             }
         }
 
-        model.detectPressFaliure = detectPressFaliure;
         model.deferredDetectPressFaliure = deferredDetectPressFaliure;
         model.pressFront = pressFront;
         

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -100,7 +100,7 @@ define([
             }
         }
 
-        var deferredDetectPressFaliure = _.debounce(detectPressFaliure, 2000);
+        var deferredDetectPressFaliure = _.debounce(detectPressFaliure, 10000);
         
         function pressFront() {
             model.hasPressFaliure(false);
@@ -115,7 +115,6 @@ define([
             }
         }
 
-        // TODO: use pub/sub, not calls to vars.model.deferredDetectPressFaliure() etc.
         model.detectPressFaliure = detectPressFaliure;
         model.deferredDetectPressFaliure = deferredDetectPressFaliure;
         model.pressFront = pressFront;

--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -16,6 +16,8 @@ define(['knockout'], function(ko) {
             'comment/section'
         ],
 
+        detectPressFailureMs: 10000,
+
         maxFronts: 100,
 
         groups: ['standard,big,very big,huge'],

--- a/facia-tool/public/javascripts/utils/is-valid-date.js
+++ b/facia-tool/public/javascripts/utils/is-valid-date.js
@@ -1,0 +1,5 @@
+define([], function() {
+  return function(date) {
+    return Object.prototype.toString.call(date) === '[object Date]' ? !isNaN(date.getTime()) : false;
+  };
+});


### PR DESCRIPTION
Validates the modified date of the current front's pressed file, ten seconds after a publish event or after any edit when in live mode. A valid pressed date is one which is later than all that fronts' collections' modified dates.  

![error-connection](https://cloud.githubusercontent.com/assets/1147913/2631742/bcb372ea-be5c-11e3-8e76-091a801b2fc9.png)

![error-content-api](https://cloud.githubusercontent.com/assets/1147913/2631745/c04cdf54-be5c-11e3-88f4-ae294919fffc.png)
