### PR TITLE
Football preview. Now with BigFatScore

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -30,8 +30,7 @@ define([
     context = context();
 
     function renderNav(match, callback) {
-        var matchInfo = new MatchInfo(match, config.page.pageId);
-        return matchInfo.fetch().then(function(resp) {
+        return (new MatchInfo(match, config.page.pageId)).fetch().then(function(resp) {
             var $nav = $.create(resp.nav).first().each(function(nav) {
                 if (match.id || $('.tabs__tab', nav).length > 2) {
                     $('.after-header', context).append(nav);

--- a/common/app/assets/javascripts/utils/page.js
+++ b/common/app/assets/javascripts/utils/page.js
@@ -1,19 +1,38 @@
 define([
     'common/$',
-    'common/utils/config'
+    'common/utils/config',
+    'lodash/objects/assign'
 ],
-function($, config) {
+function(
+    $,
+    config,
+    assign
+) {
 
     function isMatch(yes) {
         var teams = config.referencesOfType('paFootballTeam'),
-            footballMatch = config.page.footballMatch;
+            match = config.page.footballMatch || {};
 
-        if (footballMatch ||
-            ((config.hasTone('Match reports') || config.hasSeries('Match previews') || config.page.isLiveBlog) && teams.length === 2)) {
-            return yes(footballMatch || {
-                date: config.webPublicationDateAsUrlPart(),
-                teams: teams
-            });
+        // the order of this is important as, on occasion,
+        // "minbymin" is tagged with "match reports" but should be considered "minbymin".
+        assign(match, {
+            date: config.webPublicationDateAsUrlPart(),
+            teams: teams,
+            pageType: (function() {
+                if (config.page.isLiveBlog) {
+                    return 'minbymin';
+                } else if (config.hasTone('Match reports')) {
+                    return 'report';
+                } else if (config.hasSeries('Match previews')) {
+                    return 'preview';
+                } else if (match.id) {
+                    return 'stats';
+                }
+            }())
+        });
+
+        if (match.id || (match.pageType && match.teams.length === 2)) {
+            return yes(match);
         }
     }
 

--- a/common/app/assets/javascripts/utils/page.js
+++ b/common/app/assets/javascripts/utils/page.js
@@ -1,12 +1,14 @@
 define([
     'common/$',
     'common/utils/config',
-    'lodash/objects/assign'
+    'lodash/objects/assign',
+    'lodash/collections/find'
 ],
 function(
     $,
     config,
-    assign
+    assign,
+    find
 ) {
 
     function isMatch(yes) {
@@ -18,17 +20,15 @@ function(
         assign(match, {
             date: config.webPublicationDateAsUrlPart(),
             teams: teams,
-            pageType: (function() {
-                if (config.page.isLiveBlog) {
-                    return 'minbymin';
-                } else if (config.hasTone('Match reports')) {
-                    return 'report';
-                } else if (config.hasSeries('Match previews')) {
-                    return 'preview';
-                } else if (match.id) {
-                    return 'stats';
-                }
-            }())
+            pageType: find([
+                ['minbymin', config.page.isLiveBlog],
+                ['report', config.hasTone('Match reports')],
+                ['preview', config.hasSeries('Match previews')],
+                ['stats', match.id],
+                [null, true] // We need a default
+            ], function(type) {
+                return type[1] === true;
+            })[0]
         });
 
         if (match.id || (match.pageType && match.teams.length === 2)) {

--- a/common/test/assets/javascripts/spec/utils/page.spec.js
+++ b/common/test/assets/javascripts/spec/utils/page.spec.js
@@ -1,0 +1,106 @@
+define([
+    'common/utils/config',
+    'common/utils/page'
+], function(
+    config,
+    page
+) {
+
+    describe('Page', function() {
+        var cb;
+        function reset() {
+            cb = sinon.spy();
+            config.page.tones = '';
+            config.page.series = '';
+            config.isLiveBlog = false;
+        }
+        beforeEach(reset);
+
+        describe ('isMatch', function() {
+            beforeEach(reset);
+
+            it('should callback on match reports', function() {
+                // Report
+                config.referencesOfType = function() { return [34, 3] };
+                config.page.tones = 'Match reports';
+                page.isMatch(cb);
+                expect(cb.calledWith({
+                    date: '2013/03/20',
+                    teams: [34, 3],
+                    pageType: 'report'
+                })).toBe(true);
+            });
+
+            it('should callback on minute by minute live blogs', function() {
+                // Report
+                config.referencesOfType = function() { return [33, 1] };
+                config.page.isLiveBlog = true;
+                page.isMatch(cb);
+                expect(cb.calledWith({
+                    date: '2013/03/20',
+                    teams: [33, 1],
+                    pageType: 'minbymin'
+                })).toBe(true);
+                config.page.isLiveBlog = false;
+            });
+
+            it('should callback on match previews', function() {
+                // Report
+                config.referencesOfType = function() { return [1, 2] };
+                config.page.series = 'Match previews';
+                page.isMatch(cb);
+                expect(cb.calledWith({
+                    date: '2013/03/20',
+                    teams: [1, 2],
+                    pageType: 'preview'
+                })).toBe(true);
+            });
+
+            it('should not callback without two teams', function() {
+                // Report
+                config.referencesOfType = function() { return [1] };
+                config.page.isLiveBlog = true;
+                page.isMatch(cb);
+                expect(cb.called).toBe(false);
+            });
+        });
+
+
+        describe('isClockwatch', function() {
+            beforeEach(reset);
+
+            it ('should not callback on non-clockwatch series', function() {
+                config.page.series = 'Blogger of the week (Cities)';
+                page.isClockwatch(cb);
+                expect(cb.called).toBe(false);
+            });
+
+            it ('should callback on clockwacth pages', function() {
+                config.page.series = 'Clockwatch';
+                page.isClockwatch(cb);
+                expect(cb.called).toBe(true);
+            });
+        });
+
+        describe('isLiveClockwatch', function() {
+            beforeEach(reset);
+
+            it ('should not callback on non-live clockwatches', function() {
+                config.page.series = 'Clockwatch';
+                config.page.isLive = false;
+                page.isLiveClockwatch(cb);
+                expect(cb.called).toBe(false);
+            });
+
+            it ('should callback on live clockwatches', function() {
+                config.page.series = 'Clockwatch';
+                config.page.isLive = true;
+                page.isLiveClockwatch(cb);
+                expect(cb.called).toBe(true);
+            });
+        });
+
+        xdescribe('isCompetition'); // this isn't implemented properly, so left out for now
+    });
+
+});

--- a/common/test/assets/javascripts/spec/utils/page.spec.js
+++ b/common/test/assets/javascripts/spec/utils/page.spec.js
@@ -14,7 +14,6 @@ define([
             config.page.series = '';
             config.isLiveBlog = false;
         }
-        beforeEach(reset);
 
         describe ('isMatch', function() {
             beforeEach(reset);
@@ -100,7 +99,6 @@ define([
             });
         });
 
-        xdescribe('isCompetition'); // this isn't implemented properly, so left out for now
     });
 
 });

--- a/common/test/assets/javascripts/spec/utils/page.spec.js
+++ b/common/test/assets/javascripts/spec/utils/page.spec.js
@@ -14,9 +14,9 @@ define([
             config.page.series = '';
             config.isLiveBlog = false;
         }
+        beforeEach(reset);
 
         describe ('isMatch', function() {
-            beforeEach(reset);
 
             it('should callback on match reports', function() {
                 // Report
@@ -66,8 +66,6 @@ define([
 
 
         describe('isClockwatch', function() {
-            beforeEach(reset);
-
             it ('should not callback on non-clockwatch series', function() {
                 config.page.series = 'Blogger of the week (Cities)';
                 page.isClockwatch(cb);
@@ -82,8 +80,6 @@ define([
         });
 
         describe('isLiveClockwatch', function() {
-            beforeEach(reset);
-
             it ('should not callback on non-live clockwatches', function() {
                 config.page.series = 'Clockwatch';
                 config.page.isLive = false;


### PR DESCRIPTION
Previously we were including the <abbr title="Big Fat Score">`BFS`</abbr> on the liveblog only, and then the `scoreSummary` on other page types.

It is now `BFS` on all pages (preview, liveblog) and the `scoreSummary` solely on the report.

There was a little refactor in this as we were using a few factors to decide what type of page we were on (tags, `config.vars` etc). We now use `match.pageType`.

In the refactor there was some legwork removed for when you're on a stats page.
## Looky

![previewbfs](https://cloud.githubusercontent.com/assets/31692/2643527/ac6a4f10-bf1c-11e3-87b7-92d04571a1b7.png)

---

![Clean the mess](http://24.media.tumblr.com/b3f2405ae2fdc67d410ff805b369a110/tumblr_mrn6xr69QH1r3gb3zo1_400.gif)
