### PR TITLE
Add proper 3-letter team codes to football stats

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -33,6 +33,7 @@ object Frontend extends Build with Prototypes {
       "org.rometools" % "rome-modules" % "1.0"
     )
   )
+  val paVersion = "4.6"
 
   def withTests(project: Project) = project % "test->test;compile->compile"
 
@@ -43,7 +44,7 @@ object Frontend extends Build with Prototypes {
   val applications = application("applications").dependsOn(commonWithTests).aggregate(common)
   val archive = application("archive").dependsOn(commonWithTests).aggregate(common)
   val sport = application("sport").dependsOn(commonWithTests).aggregate(common).settings(
-    libraryDependencies += "com.gu" %% "pa-client" % "4.5",
+    libraryDependencies += "com.gu" %% "pa-client" % paVersion,
     templatesImport ++= Seq(
       "pa._",
       "feed._",
@@ -70,7 +71,7 @@ object Frontend extends Build with Prototypes {
     libraryDependencies ++= Seq(
       "com.typesafe.slick" %% "slick" % "1.0.0",
       "postgresql" % "postgresql" % "8.4-703.jdbc4" from "http://jdbc.postgresql.org/download/postgresql-8.4-703.jdbc4.jar",
-      "com.gu" %% "pa-client" % "4.5"
+      "com.gu" %% "pa-client" % paVersion
     )
   )
   val faciaTool = application("facia-tool").dependsOn(commonWithTests)

--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -21,8 +21,8 @@
                data-chart-show-values="true">
             <thead hidden>
                 <tr>
-                    <th>@away.name.toUpperCase.substring(0,3)</th>
-                    <th>@home.name.toUpperCase.substring(0,3)</th>
+                    <th>@pa.TeamCodes.codeFor(away)</th>
+                    <th>@pa.TeamCodes.codeFor(home)</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Updates to latest PA Client, which includes the curated 3-letter team codes.

Before:
![3-letter-team-code-before](https://cloud.githubusercontent.com/assets/29761/2654954/01e7d34c-bfde-11e3-8c2f-10d37805d703.png)

After:
![3-letter-team-code-after](https://cloud.githubusercontent.com/assets/29761/2654956/0f0f860a-bfde-11e3-8ad0-a3985f2fe902.png)

See also https://github.com/guardian/pa-football-client/pull/29
