### PR TITLE
Make Ad Targeting Consistent

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -119,7 +119,7 @@ define([
             keywords = '';
         }
 
-        return {
+        var targets = {
             'url'     : window.location.pathname,
             'edition' : edition,
             'cat'     : section,
@@ -131,6 +131,17 @@ define([
             'a'       : AudienceScience.getSegments().slice(0, 40) || [],
             'at'      : Cookies.get('adtest') || ''
         };
+
+        var criteoSegmentString = Cookies.get("cto2_guardian");
+        if (criteoSegmentString !== null) {
+            var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
+            for (var i = 0; i < criteoSegments.length; i++) {
+                var segmentKv = criteoSegments[i].split('=');
+                targets[segmentKv[0]] = segmentKv[1];
+            }
+        }
+
+        return targets;
     };
 
     DFP.prototype.setPageTargetting = function() {

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -132,7 +132,7 @@ define([
             'pt'      : contentType,
             'p'       : 'ng',
             'bp'      : detect.getBreakpoint(),
-            'a'       : AudienceScience.getSegments(),
+            'a'       : AudienceScience.getSegments(this.config),
             'at'      : Cookies.get('adtest') || ''
         };
         AudienceScienceGateway.addSegments(this.config, targets);

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -135,8 +135,8 @@ define([
             'a'       : AudienceScience.getSegments(),
             'at'      : Cookies.get('adtest') || ''
         };
-        AudienceScienceGateway.addSegments(targets);
-        Criteo.addSegments(targets);
+        extend(targets, AudienceScienceGateway.getSegments());
+        extend(targets, Criteo.getSegments());
 
         return targets;
     };

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -9,6 +9,7 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/modules/analytics/commercial/tags/common/audience-science',
+    'common/modules/analytics/commercial/tags/common/criteo',
     'common/modules/adverts/userAdTargeting',
     'common/modules/adverts/query-string',
     'lodash/arrays/flatten',
@@ -23,6 +24,7 @@ define([
     detect,
     mediator,
     AudienceScience,
+    Criteo,
     UserAdTargeting,
     queryString,
     _flatten,
@@ -131,15 +133,7 @@ define([
             'a'       : AudienceScience.getSegments().slice(0, 40) || [],
             'at'      : Cookies.get('adtest') || ''
         };
-
-        var criteoSegmentString = Cookies.get("cto2_guardian");
-        if (criteoSegmentString !== null) {
-            var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
-            for (var i = 0; i < criteoSegments.length; i++) {
-                var segmentKv = criteoSegments[i].split('=');
-                targets[segmentKv[0]] = segmentKv[1];
-            }
-        }
+        Criteo.addSegments(targets);
 
         return targets;
     };

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -136,7 +136,7 @@ define([
             'at'      : Cookies.get('adtest') || ''
         };
         AudienceScienceGateway.addSegments(this.config, targets);
-        Criteo.addSegments(targets);
+        Criteo.addSegments(this.config, targets);
 
         return targets;
     };

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -9,6 +9,7 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/modules/analytics/commercial/tags/common/audience-science',
+    'common/modules/analytics/commercial/tags/common/audience-science-gateway',
     'common/modules/analytics/commercial/tags/common/criteo',
     'common/modules/adverts/userAdTargeting',
     'common/modules/adverts/query-string',
@@ -24,6 +25,7 @@ define([
     detect,
     mediator,
     AudienceScience,
+    AudienceScienceGateway,
     Criteo,
     UserAdTargeting,
     queryString,
@@ -130,9 +132,10 @@ define([
             'pt'      : contentType,
             'p'       : 'ng',
             'bp'      : detect.getBreakpoint(),
-            'a'       : AudienceScience.getSegments().slice(0, 40) || [],
+            'a'       : AudienceScience.getSegments(),
             'at'      : Cookies.get('adtest') || ''
         };
+        AudienceScienceGateway.addSegments(this.config, targets);
         Criteo.addSegments(targets);
 
         return targets;

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -106,9 +106,10 @@ define([
      * url    = path
      */
     DFP.prototype.buildPageTargetting = function () {
-        var conf = this.config.page,
-            section = conf.section ? conf.section.toLowerCase() : '',
+        var conf        = this.config.page,
+            section     = conf.section ? conf.section.toLowerCase() : '',
             contentType = conf.contentType ? conf.contentType.toLowerCase() : '',
+            edition     = conf.edition ? conf.edition.toLowerCase() : '',
             keywords;
         if (conf.keywords) {
             keywords = conf.keywords.split(',').map(function (keyword) {
@@ -119,15 +120,16 @@ define([
         }
 
         return {
-            'a': AudienceScience.getSegments() || [],
-            'at': Cookies.get('adtest') || '',
-            'bp': detect.getBreakpoint(),
-            'cat': section,
-            'ct': contentType,
-            'k': keywords,
-            'p': 'ng',
-            'pt': contentType,
-            'url': window.location.pathname
+            'url'     : window.location.pathname,
+            'edition' : edition,
+            'cat'     : section,
+            'k'       : keywords,
+            'ct'      : contentType,
+            'pt'      : contentType,
+            'p'       : 'ng',
+            'bp'      : detect.getBreakpoint(),
+            'a'       : AudienceScience.getSegments().slice(0, 40) || [],
+            'at'      : Cookies.get('adtest') || ''
         };
     };
 

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -132,11 +132,11 @@ define([
             'pt'      : contentType,
             'p'       : 'ng',
             'bp'      : detect.getBreakpoint(),
-            'a'       : AudienceScience.getSegments(this.config),
+            'a'       : AudienceScience.getSegments(),
             'at'      : Cookies.get('adtest') || ''
         };
-        AudienceScienceGateway.addSegments(this.config, targets);
-        Criteo.addSegments(this.config, targets);
+        AudienceScienceGateway.addSegments(targets);
+        Criteo.addSegments(targets);
 
         return targets;
     };

--- a/common/app/assets/javascripts/modules/adverts/query-string.js
+++ b/common/app/assets/javascripts/modules/adverts/query-string.js
@@ -1,50 +1,23 @@
-define([
-    'common/modules/analytics/commercial/tags/common/audience-science'
-], function (
-    audienceScience
-) {
+define([], function () {
 
-    function generateQueryString(config, userSegments) {
+    function generateQueryString(queryParams) {
         var query = '';
 
-        if (config.keywords) {
-            query += getKeywords(config);
-        }
-
-        if (config.contentType) {
-            query += '&pt=' + getPageType(config);
-            query += '&ct=' + getPageType(config);
-        }
-        if (config.section) {
-            query += '&cat=' + encodeURIComponent(config.section.toLowerCase());
-        }
-
-        var segments = audienceScience.getSegments().slice(0, 70);
-        if (segments) {
-            query += getSegments(segments);
-        }
-
-        if (userSegments) {
-            query += getUserSegments(userSegments);
+        for (var param in queryParams) {
+            if (queryParams.hasOwnProperty(param)) {
+                if (query !== '') {
+                    query += '&';
+                }
+                var targetValue = queryParams[param];
+                if (typeof targetValue === 'string') {
+                    query += param + '=' + targetValue;
+                } else {
+                    query += param + '=' + targetValue.join('&' + param + '=');
+                }
+            }
         }
 
         return query;
-    }
-
-    function getUserSegments(userSegments) {
-        return userSegments.map(function(segment) {
-            return '&gdncrm=' + encodeURIComponent(segment);
-        }).join('');
-    }
-
-    function getSegments(segments) {
-        return segments.map(function(segment) {
-            return '&a=' + segment;
-        }).join('');
-    }
-
-    function getPageType(config) {
-        return encodeURIComponent(config.contentType.toLowerCase());
     }
 
     function formatKeyword(keyword) {

--- a/common/app/assets/javascripts/modules/adverts/video.js
+++ b/common/app/assets/javascripts/modules/adverts/video.js
@@ -212,21 +212,7 @@ define([
 
         var adUnit = dfpAds.buildAdUnit.bind(this)();
 
-        var custParams = '';
-        var targets = dfpAds.buildPageTargetting.bind(this)();
-        for (var target in targets) {
-            if (targets.hasOwnProperty(target)) {
-                if (custParams !== '') {
-                    custParams += '&';
-                }
-                var targetValue = targets[target];
-                if (typeof targetValue === 'string') {
-                    custParams += target + '=' + targetValue;
-                } else {
-                    custParams += target + '=' + targetValue.join('&' + target + '=');
-                }
-            }
-        }
+        var custParams = queryString.generateQueryString(dfpAds.buildPageTargetting.bind(this)());
         var encodedCustParams = encodeURIComponent(custParams);
 
         var timestamp = new Date().getTime();

--- a/common/app/assets/javascripts/modules/adverts/video.js
+++ b/common/app/assets/javascripts/modules/adverts/video.js
@@ -4,21 +4,17 @@ define([
     'common/utils/to-array',
     'bean',
     'common/utils/ajax',
-    'common/utils/detect',
-    'common/utils/cookies',
-    'common/modules/adverts/userAdTargeting',
-    'common/modules/adverts/query-string'
+    'common/modules/adverts/query-string',
+    'common/modules/adverts/dfp'
 ], function(
     $,
     mediator,
     toArray,
     bean,
     ajax,
-    detect,
-    cookies,
-    userAdTargeting,
-    queryString
-) {
+    queryString,
+    DFP
+    ) {
 
     function Video(config) {
         this.config = config.config;
@@ -206,26 +202,36 @@ define([
 
     Video.prototype.init = function(config) {
 
-        var url;
-
         this.xmlSelectors = {
             'adUrl': 'VASTAdTagURI',
             'impressionUrl': 'Impression',
             'clickTrackUrl': 'ClickTracking'
         };
 
-        var section = this.config.page.section + (this.config.page.isFront ? '/front' : ''),
-            adUnit = '/' + config.dfpAccountId + '/' + config.dfpAdUnitRoot + '/' + section;
+        var dfpAds = new DFP(config);
 
-        var rawCustParams = queryString.generateQueryString(config, userAdTargeting.getUserSegments());
-        rawCustParams += '&at=' + (cookies.get('adtest') || '');
-        rawCustParams += '&bp=' + detect.getBreakpoint();
-        rawCustParams += '&p=ng';
-        var custParams = encodeURIComponent(rawCustParams);
+        var adUnit = dfpAds.buildAdUnit.bind(this)();
+
+        var custParams = '';
+        var targets = dfpAds.buildPageTargetting.bind(this)();
+        for (var target in targets) {
+            if (targets.hasOwnProperty(target)) {
+                if (custParams !== '') {
+                    custParams += '&';
+                }
+                var targetValue = targets[target];
+                if (typeof targetValue === 'string') {
+                    custParams += target + '=' + targetValue;
+                } else {
+                    custParams += target + '=' + targetValue.join('&' + target + '=');
+                }
+            }
+        }
+        var encodedCustParams = encodeURIComponent(custParams);
 
         var timestamp = new Date().getTime();
 
-        url = 'http://' + config.dfpHost + '/gampad/ads?correlator=' + timestamp + '&gdfp_req=1&env=vp&impl=s&output=xml_vast2&unviewed_position_start=1&iu=' + adUnit + '&sz=400x300&scp=slot%3Dvideo&cust_params=' + custParams;
+        var url = 'http://' + config.dfpHost + '/gampad/ads?correlator=' + timestamp + '&gdfp_req=1&env=vp&impl=s&output=xml_vast2&unviewed_position_start=1&iu=' + adUnit + '&sz=400x300&scp=slot%3Dvideo&cust_params=' + encodedCustParams;
 
         this.getVastData(url);
 

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
@@ -1,37 +1,39 @@
 define([], function () {
 
-// TODO switch
     function addSegments(config, targeting) {
-        var segments;
+        if (config.switches.audienceScienceGateway) {
 
-        switch (config.page.section) {
-            case 'sport':
-                segments = ['FKSWod', '2xivTZ'];
-                break;
-            case 'football':
-                segments = ['FKSWod', '2xivTZ'];
-                break;
-            case 'lifeandstyle':
-                segments = ['TQV1_5', 'J0tykU'];
-                break;
-            case 'technology':
-                segments = ['9a9VRE', 'TL3gqK'];
-                break;
-            case 'fashion':
-                segments = ['TQV1_5', 'J0tykU'];
-                break;
-            case 'childrens-books-site':
-                segments = [];
-                break;
-            case 'news':
-                segments = ['eMdl6Y', 'mMYVrM'];
-                break;
-            default:
-                segments = ['c7Zrhu', 'Y1C40a'];
-        }
+            var segments;
 
-        for (var i = 0; i < segments.length; i++) {
-            targeting['pq_' + segments[i]] = '';
+            switch (config.page.section) {
+                case 'sport':
+                    segments = ['FKSWod', '2xivTZ'];
+                    break;
+                case 'football':
+                    segments = ['FKSWod', '2xivTZ'];
+                    break;
+                case 'lifeandstyle':
+                    segments = ['TQV1_5', 'J0tykU'];
+                    break;
+                case 'technology':
+                    segments = ['9a9VRE', 'TL3gqK'];
+                    break;
+                case 'fashion':
+                    segments = ['TQV1_5', 'J0tykU'];
+                    break;
+                case 'childrens-books-site':
+                    segments = [];
+                    break;
+                case 'news':
+                    segments = ['eMdl6Y', 'mMYVrM'];
+                    break;
+                default:
+                    segments = ['c7Zrhu', 'Y1C40a'];
+            }
+
+            for (var i = 0; i < segments.length; i++) {
+                targeting['pq_' + segments[i]] = '';
+            }
         }
     }
 

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
@@ -10,7 +10,7 @@ define([
 
     function getSegments() {
         var segments = storage.local.get('gu.ads.audsci');
-        return (segments) ? segments.slice(0, 40) : [];
+        return (segments) ? segments.slice(0,70) : [];
     }
 
     function load(config) {

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
@@ -1,6 +1,8 @@
-define([], function () {
+define([
+    'common/utils/config'
+], function (config) {
 
-    function addSegments(config, targeting) {
+    function addSegments(targeting) {
         if (config.switches.audienceScienceGateway) {
 
             var segments;

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
@@ -1,64 +1,42 @@
-define([
-    'common/utils/cookies',
-    'common/utils/storage'
-], function(
-    Cookies,
-    storage
-) {
+define([], function () {
 
-    var revenueScienceUrl = 'js!http://js.revsci.net/gateway/gw.js?csid=E05516';
+// TODO switch
+    function addSegments(config, targeting) {
+        var segments;
 
-    function getSegments() {
-        var segments = storage.local.get('gu.ads.audsci');
-        return (segments) ? segments.slice(0,70) : [];
-    }
-
-    function load(config) {
-        // Audience Science calls these functions on window.
-        window.DM_prepClient = function(csid, client) {
-            client.DM_addEncToLoc('siteName', '');
-            client.DM_addEncToLoc('comFolder', '');
-            client.DM_addEncToLoc('mobile', true);
-
-            if(config.audienceScienceData) {
-                for(var i = 0, j = config.audienceScienceData.length; i<j; ++i) {
-                    var item = config.audienceScienceData[i];
-                    client.DM_addEncToLoc(item.name, item.value);
-                }
-            }
-        };
-        window.DM_onSegsAvailable = function(segments) {
-            storage.local.set('gu.ads.audsci', processSegments(segments));
-            // Kill any legacy cookies
-            Cookies.cleanUp(['rsi_segs']);
-        };
-        // Then load audsci to get latests segments.
-        require([revenueScienceUrl], function() {
-            window.E05516.DM_tag();
-        });
-    }
-
-    // This is replicating what Audience Science do when they set a cookie.
-    // For some reason they don't do it to segments passed in the onSegsAvailable callback.
-    function processSegments(segments) {
-        var pSegs = [];
-        var pat = /.*_5.*/;
-        var pat2 = /([^_]{2})[^_]*_(.*)/;
-        for (var i = 0, x = segments.length; i < x && i < 100; ++i) {
-            if (!pat.test(segments[i])) {
-                var f = pat2.exec(segments[i]);
-                if (f!==null) {
-                    pSegs.push(f[1] + f[2]);
-                    ++i;
-                }
-            }
+        switch (config.page.section) {
+            case 'sport':
+                segments = ['FKSWod', '2xivTZ'];
+                break;
+            case 'football':
+                segments = ['FKSWod', '2xivTZ'];
+                break;
+            case 'lifeandstyle':
+                segments = ['TQV1_5', 'J0tykU'];
+                break;
+            case 'technology':
+                segments = ['9a9VRE', 'TL3gqK'];
+                break;
+            case 'fashion':
+                segments = ['TQV1_5', 'J0tykU'];
+                break;
+            case 'childrens-books-site':
+                segments = [];
+                break;
+            case 'news':
+                segments = ['eMdl6Y', 'mMYVrM'];
+                break;
+            default:
+                segments = ['c7Zrhu', 'Y1C40a'];
         }
-        return pSegs;
+
+        for (var i = 0; i < segments.length; i++) {
+            targeting['pq_' + segments[i]] = '';
+        }
     }
 
     return {
-        getSegments: getSegments,
-        load: load
+        addSegments: addSegments
     };
 
 });

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
@@ -2,40 +2,28 @@ define([
     'common/utils/config'
 ], function (config) {
 
+    var segments = {
+        'sport': ['FKSWod', '2xivTZ'],
+        'football': ['FKSWod', '2xivTZ'],
+        'lifeandstyle': ['TQV1_5', 'J0tykU'],
+        'technology': ['9a9VRE', 'TL3gqK'],
+        'fashion': ['TQV1_5', 'J0tykU'],
+        'childrens-books-site': [],
+        'news': ['eMdl6Y', 'mMYVrM'],
+        'default': ['c7Zrhu', 'Y1C40a']
+    };
+
     function addSegments(targeting) {
         if (config.switches.audienceScienceGateway) {
 
-            var segments;
-
-            switch (config.page.section) {
-                case 'sport':
-                    segments = ['FKSWod', '2xivTZ'];
-                    break;
-                case 'football':
-                    segments = ['FKSWod', '2xivTZ'];
-                    break;
-                case 'lifeandstyle':
-                    segments = ['TQV1_5', 'J0tykU'];
-                    break;
-                case 'technology':
-                    segments = ['9a9VRE', 'TL3gqK'];
-                    break;
-                case 'fashion':
-                    segments = ['TQV1_5', 'J0tykU'];
-                    break;
-                case 'childrens-books-site':
-                    segments = [];
-                    break;
-                case 'news':
-                    segments = ['eMdl6Y', 'mMYVrM'];
-                    break;
-                default:
-                    segments = ['c7Zrhu', 'Y1C40a'];
+            var targetedSegments = segments[config.page.section];
+            if (targetedSegments === null) {
+                targetedSegments = segments['default'];
             }
 
-            for (var i = 0; i < segments.length; i++) {
-                targeting['pq_' + segments[i]] = '';
-            }
+            targetedSegments.foreach(function (segment) {
+                targeting['pq_' + segment] = '';
+            });
         }
     }
 

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science-gateway.js
@@ -13,22 +13,26 @@ define([
         'default': ['c7Zrhu', 'Y1C40a']
     };
 
-    function addSegments(targeting) {
+    function getSegments() {
+        var result = {};
+
         if (config.switches.audienceScienceGateway) {
 
             var targetedSegments = segments[config.page.section];
-            if (targetedSegments === null) {
+            if (typeof targetedSegments === 'undefined') {
                 targetedSegments = segments['default'];
             }
 
-            targetedSegments.foreach(function (segment) {
-                targeting['pq_' + segment] = '';
+            targetedSegments.forEach(function (segment) {
+                result['pq_' + segment] = '';
             });
         }
+
+        return result;
     }
 
     return {
-        addSegments: addSegments
+        getSegments: getSegments
     };
 
 });

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science.js
@@ -1,14 +1,16 @@
 define([
     'common/utils/cookies',
-    'common/utils/storage'
+    'common/utils/storage',
+    'common/utils/config'
 ], function(
     Cookies,
-    storage
+    storage,
+    config
 ) {
 
     var revenueScienceUrl = 'js!http://js.revsci.net/gateway/gw.js?csid=E05516';
 
-    function getSegments(config) {
+    function getSegments() {
         if (config.switches.audienceScience) {
             var segments = storage.local.get('gu.ads.audsci');
             return (segments) ? segments.slice(0, 40) : [];

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/audience-science.js
@@ -8,9 +8,13 @@ define([
 
     var revenueScienceUrl = 'js!http://js.revsci.net/gateway/gw.js?csid=E05516';
 
-    function getSegments() {
-        var segments = storage.local.get('gu.ads.audsci');
-        return (segments) ? segments.slice(0, 40) : [];
+    function getSegments(config) {
+        if (config.switches.audienceScience) {
+            var segments = storage.local.get('gu.ads.audsci');
+            return (segments) ? segments.slice(0, 40) : [];
+        } else {
+            return [];
+        }
     }
 
     function load(config) {

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
@@ -3,21 +3,25 @@ define([
     'common/utils/config'
 ], function (Cookies, config) {
 
-    function addSegments(targeting) {
+    function getSegments() {
+        var result = {};
+
         if (config.switches.criteo) {
             var criteoSegmentString = Cookies.get('cto2_guardian');
             if (criteoSegmentString !== null) {
                 var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
-                criteoSegments.foreach(function (segment) {
+                criteoSegments.forEach(function (segment) {
                     var segmentKv = segment.split('=');
-                    targeting[segmentKv[0]] = segmentKv[1];
+                    result[segmentKv[0]] = segmentKv[1];
                 });
             }
         }
+
+        return result;
     }
 
     return {
-        addSegments: addSegments
+        getSegments: getSegments
     };
 
 });

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
@@ -1,8 +1,9 @@
 define([
-    'common/utils/cookies'
-], function (Cookies) {
+    'common/utils/cookies',
+    'common/utils/config'
+], function (Cookies, config) {
 
-    function addSegments(config, targeting) {
+    function addSegments(targeting) {
         if (config.switches.criteo) {
             var criteoSegmentString = Cookies.get('cto2_guardian');
             if (criteoSegmentString !== null) {

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
@@ -1,0 +1,21 @@
+define([
+    'common/utils/cookies'
+], function (Cookies) {
+
+    // TODO switch
+    function addSegments(targeting) {
+        var criteoSegmentString = Cookies.get("cto2_guardian");
+        if (criteoSegmentString !== null) {
+            var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
+            for (var i = 0; i < criteoSegments.length; i++) {
+                var segmentKv = criteoSegments[i].split('=');
+                targeting[segmentKv[0]] = segmentKv[1];
+            }
+        }
+    }
+
+    return {
+        addSegments: addSegments
+    };
+
+});

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
@@ -7,10 +7,10 @@ define([
             var criteoSegmentString = Cookies.get('cto2_guardian');
             if (criteoSegmentString !== null) {
                 var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
-                for (var i = 0; i < criteoSegments.length; i++) {
-                    var segmentKv = criteoSegments[i].split('=');
+                criteoSegments.foreach(function (segment) {
+                    var segmentKv = segment.split('=');
                     targeting[segmentKv[0]] = segmentKv[1];
-                }
+                });
             }
         }
     }

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
@@ -2,14 +2,15 @@ define([
     'common/utils/cookies'
 ], function (Cookies) {
 
-    // TODO switch
-    function addSegments(targeting) {
-        var criteoSegmentString = Cookies.get('cto2_guardian');
-        if (criteoSegmentString !== null) {
-            var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
-            for (var i = 0; i < criteoSegments.length; i++) {
-                var segmentKv = criteoSegments[i].split('=');
-                targeting[segmentKv[0]] = segmentKv[1];
+    function addSegments(config, targeting) {
+        if (config.switches.criteo) {
+            var criteoSegmentString = Cookies.get('cto2_guardian');
+            if (criteoSegmentString !== null) {
+                var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
+                for (var i = 0; i < criteoSegments.length; i++) {
+                    var segmentKv = criteoSegments[i].split('=');
+                    targeting[segmentKv[0]] = segmentKv[1];
+                }
             }
         }
     }

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/criteo.js
@@ -4,7 +4,7 @@ define([
 
     // TODO switch
     function addSegments(targeting) {
-        var criteoSegmentString = Cookies.get("cto2_guardian");
+        var criteoSegmentString = Cookies.get('cto2_guardian');
         if (criteoSegmentString !== null) {
             var criteoSegments = decodeURIComponent(criteoSegmentString).split('&');
             for (var i = 0; i < criteoSegments.length; i++) {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -123,18 +123,22 @@ object Switches extends Collections {
   )
 
   // Ad Targeting
+  /*
+    These switches are to control length of request to DFP
+    while there's a problem with the maximum length constraint
+  */
 
   val AudienceScienceSwitch = Switch("Ad Targeting", "audience-science",
     "If this switch is on, Audience Science segments will be used to target ads.",
-    safeState = Off, sellByDate = never)
+    safeState = Off, sellByDate = new DateMidnight(2014, 11, 1))
 
   val AudienceScienceGatewaySwitch = Switch("Ad Targeting", "audience-science-gateway",
     "If this switch is on, Audience Science Gateway segments will be used to target ads.",
-    safeState = Off, sellByDate = never)
+    safeState = Off, sellByDate = new DateMidnight(2014, 11, 1))
 
   val CriteoSwitch = Switch("Ad Targeting", "criteo",
     "If this switch is on, Criteo segments will be used to target ads.",
-    safeState = Off, sellByDate = never)
+    safeState = Off, sellByDate = new DateMidnight(2014, 11, 1))
 
   // Commercial Tags
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -43,7 +43,6 @@ object Switches extends Collections {
   // Switch names can be letters numbers and hyphens only
 
   private lazy val never = new DateMidnight(2100, 1, 1)
-  private lazy val endOfQ4 = new DateMidnight(2014, 4, 1)
 
   // this is 3 months - at the end of this a decision is expected
   // and one (or both) of the 2 needs to go.
@@ -125,19 +124,23 @@ object Switches extends Collections {
 
   // Commercial Tags
 
-  val AudienceScienceSwitch = Switch("Commercial Tags", "audience-science",
+  val AudienceScienceSwitch = Switch("Commercial Targeting", "audience-science",
     "If this switch is on Audience Science segments will be used to target ads.",
     safeState = Off, sellByDate = never)
 
-  val ImrWorldwideSwitch = Switch("Commercial Tags", "imr-worldwide",
+  val AudienceScienceGatewaySwitch = Switch("Commercial Targeting", "audience-science-gateway",
+    "If this switch is on Audience Science Gateway segments will be used to target ads.",
+    safeState = Off, sellByDate = never)
+
+  val ImrWorldwideSwitch = Switch("Commercial Targeting", "imr-worldwide",
     "Enable the IMR Worldwide audience segment tracking.",
     safeState = Off, sellByDate = profilingEvalDeadline)
 
-  val EffectiveMeasureSwitch = Switch("Commercial Tags", "effective-measure",
+  val EffectiveMeasureSwitch = Switch("Commercial Targeting", "effective-measure",
     "Enable the Effective Measure audience segment tracking.",
     safeState = Off, sellByDate = profilingEvalDeadline)
 
-  val ForeseeSwitch = Switch("Commercial Tags", "foresee",
+  val ForeseeSwitch = Switch("Commercial Targeting", "foresee",
     "Enable Forsee surveys for a sample of our audience",
     safeState = Off, sellByDate = new DateMidnight(2014,5,1)) // 3 month trial
 
@@ -362,6 +365,7 @@ object Switches extends Collections {
     CommercialComponentsSwitch,
     VideoAdvertsSwitch,
     AudienceScienceSwitch,
+    AudienceScienceGatewaySwitch,
     DiscussionSwitch,
     OpenCtaSwitch,
     FontSwitch,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -122,25 +122,31 @@ object Switches extends Collections {
     safeState = On, sellByDate = never
   )
 
+  // Ad Targeting
+
+  val AudienceScienceSwitch = Switch("Ad Targeting", "audience-science",
+    "If this switch is on, Audience Science segments will be used to target ads.",
+    safeState = Off, sellByDate = never)
+
+  val AudienceScienceGatewaySwitch = Switch("Ad Targeting", "audience-science-gateway",
+    "If this switch is on, Audience Science Gateway segments will be used to target ads.",
+    safeState = Off, sellByDate = never)
+
+  val CriteoSwitch = Switch("Ad Targeting", "criteo",
+    "If this switch is on, Criteo segments will be used to target ads.",
+    safeState = Off, sellByDate = never)
+
   // Commercial Tags
 
-  val AudienceScienceSwitch = Switch("Commercial Targeting", "audience-science",
-    "If this switch is on Audience Science segments will be used to target ads.",
-    safeState = Off, sellByDate = never)
-
-  val AudienceScienceGatewaySwitch = Switch("Commercial Targeting", "audience-science-gateway",
-    "If this switch is on Audience Science Gateway segments will be used to target ads.",
-    safeState = Off, sellByDate = never)
-
-  val ImrWorldwideSwitch = Switch("Commercial Targeting", "imr-worldwide",
+  val ImrWorldwideSwitch = Switch("Commercial Tags", "imr-worldwide",
     "Enable the IMR Worldwide audience segment tracking.",
     safeState = Off, sellByDate = profilingEvalDeadline)
 
-  val EffectiveMeasureSwitch = Switch("Commercial Targeting", "effective-measure",
+  val EffectiveMeasureSwitch = Switch("Commercial Tags", "effective-measure",
     "Enable the Effective Measure audience segment tracking.",
     safeState = Off, sellByDate = profilingEvalDeadline)
 
-  val ForeseeSwitch = Switch("Commercial Targeting", "foresee",
+  val ForeseeSwitch = Switch("Commercial Tags", "foresee",
     "Enable Forsee surveys for a sample of our audience",
     safeState = Off, sellByDate = new DateMidnight(2014,5,1)) // 3 month trial
 
@@ -366,6 +372,7 @@ object Switches extends Collections {
     VideoAdvertsSwitch,
     AudienceScienceSwitch,
     AudienceScienceGatewaySwitch,
+    CriteoSwitch,
     DiscussionSwitch,
     OpenCtaSwitch,
     FontSwitch,


### PR DESCRIPTION
This change:
- sets video ads to use the same targeting as standard ads
- Adds Audience Science Gateway segment targeting
- Adds Criteo segment targeting
