### PR TITLE
Add support for uploading Avatars [#IDN-1774]

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -269,6 +269,11 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val url = configuration.getMandatoryStringProperty("formstack.url")
     lazy val oAuthToken = configuration.getMandatoryStringProperty("formstack.oauthToken")
   }
+
+  object avatars {
+    lazy val imageHost = configuration.getMandatoryStringProperty("avatars.image.host")
+    lazy val signingKey = configuration.getMandatoryStringProperty("avatars.signing.key")
+  }
 }
 
 object ManifestData {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -234,6 +234,11 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
+  val IdentityAvatarUploadSwitch = Switch("Feature Switches", "id-avatar-upload",
+    "If this switch is on, users can upload avatars on their profile page",
+    safeState = Off, sellByDate = never
+  )
+
   val IdentityEthicalAwardsSwitch = Switch("Feature Switches", "id-ethical-awards",
     "If this switch is on, Ethical awards forms will be available",
     safeState = Off, sellByDate = new DateMidnight(2014, 5, 15))

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -395,6 +395,7 @@ object Switches extends Collections {
     FacebookAutoSigninSwitch,
     IdentityFormstackSwitch,
     IdentityEthicalAwardsSwitch,
+    IdentityAvatarUploadSwitch,
     ABBlendedContainersUk,
     ABBlendedContainersUs,
     ABBlendedContainersAu,

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -21,7 +21,7 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // There is a document (that would have been shared with you) that contains all
     // the properties needed to run this project. Make sure you update it if there 
     // are any required changes, update the hash below, and off you go.
-    hash should be ("c3e4c10d47769bff20fd0ae9df69ac1d")
+    hash should be ("682f23189da30bc2d105629476bc8d9f")
 
   }
 }

--- a/identity/app/model/AvatarData.scala
+++ b/identity/app/model/AvatarData.scala
@@ -1,0 +1,14 @@
+package model
+
+import conf.Configuration
+
+object AvatarData {
+  def apply(user: com.gu.identity.model.User): AvatarData =
+    AvatarData(user.getPublicFields.getDisplayName, user.getId(), Configuration.avatars.imageHost)
+}
+
+case class AvatarData(userName: String, userId: String, imageHost: String) {
+  val jsonFormat = "{\"username\":\"%s\",\"user_id\":\"%s\",\"required_image_host\":\"%s\",\"is_social\":false}"
+
+  def toJson = jsonFormat.format(userName, userId, imageHost)
+}

--- a/identity/app/model/AvatarUploadData.scala
+++ b/identity/app/model/AvatarUploadData.scala
@@ -1,0 +1,3 @@
+package model
+
+case class AvatarUploadData(uploadUrl: String, signedData: String)

--- a/identity/app/services/AvatarSigningService.scala
+++ b/identity/app/services/AvatarSigningService.scala
@@ -1,0 +1,28 @@
+package services
+
+import javax.crypto.spec.SecretKeySpec
+import javax.crypto.Mac
+import org.apache.commons.codec.digest.DigestUtils.md5Hex
+import org.apache.commons.codec.binary.Base64.{encodeBase64URLSafeString => toBase64}
+import model.AvatarData
+import scala.language.implicitConversions
+
+class AvatarSigningService(keyString: String) {
+
+  private val key = new SecretKeySpec(md5Hex(keyString), "HmacSHA1")
+
+  private def _sign(message: String) = {
+    val mac = Mac getInstance "HmacSHA1"
+    mac.init(key)
+    toBase64(mac.doFinal(message))
+  }
+
+  def sign(data: AvatarData) = {
+    val base64Json = toBase64(data.toJson)
+    s"$base64Json.${_sign(base64Json)}"
+  }
+
+  private implicit def stringToBytes(str: String): Array[Byte] = str getBytes "UTF-8"
+}
+
+

--- a/identity/app/services/AvatarSigningService.scala
+++ b/identity/app/services/AvatarSigningService.scala
@@ -3,15 +3,16 @@ package services
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.Mac
 import org.apache.commons.codec.digest.DigestUtils.md5Hex
-import org.apache.commons.codec.binary.Base64.{encodeBase64URLSafeString => toBase64}
+import org.apache.commons.codec.binary.Base64.{encodeBase64URLSafeString => toBase64, decodeBase64}
 import model.AvatarData
 import scala.language.implicitConversions
+import play.libs.Json.{parse => parseJson}
 
 class AvatarSigningService(keyString: String) {
 
   private val key = new SecretKeySpec(md5Hex(keyString), "HmacSHA1")
 
-  private def _sign(message: String) = {
+  private[services] def _sign(message: String) = {
     val mac = Mac getInstance "HmacSHA1"
     mac.init(key)
     toBase64(mac.doFinal(message))
@@ -22,7 +23,44 @@ class AvatarSigningService(keyString: String) {
     s"$base64Json.${_sign(base64Json)}"
   }
 
+  def wasUploadSuccessful(signedString: String): Either[String, Boolean] = {
+
+    val msgAndSig = signedString split "\\." match {
+      case Array(message, signature) => Right(message, signature)
+      case _ => Left("Bad response from upload:\n" + signedString)
+    }
+
+    val validMsg = msgAndSig.right flatMap {
+      case (msg, sig) => checkSig(msg, sig)
+    }
+
+    validMsg.right flatMap getUploadStatus
+  }
+
+  private def getUploadStatus(base64Response: String): Either[String, Boolean] = {
+
+    val jsonString: String = decodeBase64(base64Response)
+    val parsedJson = parseJson(jsonString)
+    val status = (parsedJson get "image_upload_success").booleanValue
+
+    if (status)
+      Right(true)
+    else {
+      val errorMsg = (parsedJson get "image_upload_failure_message").asText
+      Left(errorMsg)
+    }
+
+
+  }
+
+  private def checkSig(message: String, signature: String): Either[String, String] = {
+    if (_sign(message) == signature) Right(message)
+    else Left("Invalid signature")
+  }
+
+
   private implicit def stringToBytes(str: String): Array[Byte] = str getBytes "UTF-8"
+  private implicit def bytesToString(bytes: Array[Byte]): String = new String(bytes, "UTF-8")
 }
 
 

--- a/identity/app/views/fragments/profile/public_profile_form.scala.html
+++ b/identity/app/views/fragments/profile/public_profile_form.scala.html
@@ -5,20 +5,34 @@
 @import form.Input
 @import helper._
 
+<fieldset class="fieldset">
+    <div class="fieldset__heading">
+        <div class="user-avatar" data-userid="@user.id"></div>
+        <h2 class="form__heading">
+            @user.publicFields.displayName
+        </h2>
+        @user.dates.accountCreatedDate.map { joinDate =>
+            <p class="form-field__note">Joined: @joinDate.toString("d MMM yyyy")</p>
+        }
+    </div>
+</fieldset>
+
 @for(avatarUploadData <- avatarUploadDataOpt) {
 <form class="form js-avatar-upload-form" novalidate action="@avatarUploadData.uploadUrl" role="main" method="post" enctype="multipart/form-data">
     <fieldset class="fieldset">
 
         <div class="fieldset__heading">
             <h2 class="form__heading">Profile image</h2>
-            <div class="form__note">This image will appear next to your comments.</div>
+            <div class="form__note">This image will appear next to your comments. Only .jpg, .png or .gif files are accepted.</div>
         </div>
 
         <div class="fieldset__fields">
             <ul class="u-unstyled">
-                <input type="file" name="file"  />
-                <input type="hidden" name="signed_data" value="@avatarUploadData.signedData" />
-                <input type="hidden" name="redirect_url" value="@idUrlBuilder.buildUrl("/public/edit", idRequest)">
+                <li class="form-field">
+                    <input type="file" name="file" accept="image/gif, image/jpeg, image/png" />
+                    <input type="hidden" name="signed_data" value="@avatarUploadData.signedData" />
+                    <input type="hidden" name="redirect_url" value="@idUrlBuilder.buildUrl("/public/edit", idRequest)">
+                </li>
                 <li>
                     <button type="submit" class="submit-input js-avatar-upload-button" data-link-name="Upload Avatar">Upload</button>
                 </li>
@@ -31,18 +45,6 @@
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/public/edit", idRequest)" role="main" method="post">
     @views.html.helper.CSRF.formField
-
-    <fieldset class="fieldset">
-        <div class="fieldset__heading">
-            <div class="user-avatar" data-userid="@user.id"></div>
-            <h2 class="form__heading">
-                @user.publicFields.displayName
-            </h2>
-            @user.dates.accountCreatedDate.map { joinDate =>
-                <p class="form-field__note">Joined: @joinDate.toString("d MMM yyyy")</p>
-            }
-        </div>
-    </fieldset>
 
     @if(publicProfileForm.globalError.isDefined) {
         <div class="form__error">@publicProfileForm.globalErrors.map(_.message).mkString(", ")</div>

--- a/identity/app/views/fragments/profile/public_profile_form.scala.html
+++ b/identity/app/views/fragments/profile/public_profile_form.scala.html
@@ -27,6 +27,26 @@
     <fieldset class="fieldset">
 
         <div class="fieldset__heading">
+            <h2 class="form__heading">Profile image</h2>
+            <div class="form__note">This image will appear next to your comments.</div>
+        </div>
+
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+
+                @inputField(Upload(publicProfileForm("avatar"), ('_label, "Profile image"))) // Generated input should NOT have text-input class but not sure how to do this...
+
+                <li>
+                    <button type="submit" class="submit-input" data-link-name="Create account">Save changes</button>
+                </li>
+            </ul>
+        </div>
+
+    </fieldset>
+
+    <fieldset class="fieldset">
+
+        <div class="fieldset__heading">
             <h2 class="form__heading">Public profile</h2>
             <div class="form__note">These details will be visible to everyone who sees your profile.</div>
         </div>

--- a/identity/app/views/fragments/profile/public_profile_form.scala.html
+++ b/identity/app/views/fragments/profile/public_profile_form.scala.html
@@ -1,4 +1,7 @@
-@(idUrlBuilder: services.IdentityUrlBuilder, idRequest: services.IdentityRequest, user: com.gu.identity.model.User, publicProfileForm: Form[form.ProfileFormData], avatarUploadDataOpt: Option[model.AvatarUploadData])(implicit request: RequestHeader)
+@(idUrlBuilder: services.IdentityUrlBuilder, idRequest: services.IdentityRequest, user: com.gu.identity.model.User,
+    publicProfileForm: Form[form.ProfileFormData], avatarUploadDataOpt: Option[model.AvatarUploadData],
+    avatarUploadStatus: Option[Either[String, Boolean]])
+    (implicit request: RequestHeader)
 
 @import views.html.fragments.form.{inputField, textareaField}
 @import form.IdFormHelpers._
@@ -12,7 +15,7 @@
             @user.publicFields.displayName
         </h2>
         @user.dates.accountCreatedDate.map { joinDate =>
-            <p class="form-field__note">Joined: @joinDate.toString("d MMM yyyy")</p>
+        <p class="form-field__note">Joined: @joinDate.toString("d MMM yyyy")</p>
         }
     </div>
 </fieldset>
@@ -44,32 +47,32 @@
 }
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/public/edit", idRequest)" role="main" method="post">
-    @views.html.helper.CSRF.formField
+@views.html.helper.CSRF.formField
 
-    @if(publicProfileForm.globalError.isDefined) {
-        <div class="form__error">@publicProfileForm.globalErrors.map(_.message).mkString(", ")</div>
-    }
+@if(publicProfileForm.globalError.isDefined) {
+<div class="form__error">@publicProfileForm.globalErrors.map(_.message).mkString(", ")</div>
+}
 
-    <fieldset class="fieldset">
+<fieldset class="fieldset">
 
-        <div class="fieldset__heading">
-            <h2 class="form__heading">Public profile</h2>
-            <div class="form__note">These details will be visible to everyone who sees your profile.</div>
-        </div>
+    <div class="fieldset__heading">
+        <h2 class="form__heading">Public profile</h2>
+        <div class="form__note">These details will be visible to everyone who sees your profile.</div>
+    </div>
 
-        <div class="fieldset__fields">
-            <ul class="u-unstyled">
+    <div class="fieldset__fields">
+        <ul class="u-unstyled">
 
-                @inputField(Input(publicProfileForm("location"), ('_label, "Location")))
-                @textareaField(Input(publicProfileForm("aboutMe"), ('_label, "About me"), ('class, "textarea--long")))
-                @textareaField(Input(publicProfileForm("interests"), ('_label, "Interests"), ('class, "textarea--mid"), ('maxlength, "255")))
-                @inputField(Input(publicProfileForm("webPage"), ('_label, "Website (enter full address)")))
+            @inputField(Input(publicProfileForm("location"), ('_label, "Location")))
+            @textareaField(Input(publicProfileForm("aboutMe"), ('_label, "About me"), ('class, "textarea--long")))
+            @textareaField(Input(publicProfileForm("interests"), ('_label, "Interests"), ('class, "textarea--mid"), ('maxlength, "255")))
+            @inputField(Input(publicProfileForm("webPage"), ('_label, "Website (enter full address)")))
 
-                <li>
-                    <button type="submit" class="submit-input" data-link-name="Create account">Save changes</button>
-                </li>
-            </ul>
-        </div>
+            <li>
+                <button type="submit" class="submit-input" data-link-name="Create account">Save changes</button>
+            </li>
+        </ul>
+    </div>
 
-    </fieldset>
+</fieldset>
 </form>

--- a/identity/app/views/fragments/profile/public_profile_form.scala.html
+++ b/identity/app/views/fragments/profile/public_profile_form.scala.html
@@ -1,9 +1,33 @@
-@(idUrlBuilder: services.IdentityUrlBuilder, idRequest: services.IdentityRequest, user: com.gu.identity.model.User, publicProfileForm: Form[form.ProfileFormData])(implicit request: RequestHeader)
+@(idUrlBuilder: services.IdentityUrlBuilder, idRequest: services.IdentityRequest, user: com.gu.identity.model.User, publicProfileForm: Form[form.ProfileFormData], avatarUploadDataOpt: Option[model.AvatarUploadData])(implicit request: RequestHeader)
 
 @import views.html.fragments.form.{inputField, textareaField}
 @import form.IdFormHelpers._
 @import form.Input
 @import helper._
+
+@for(avatarUploadData <- avatarUploadDataOpt) {
+<form class="form js-avatar-upload-form" novalidate action="@avatarUploadData.uploadUrl" role="main" method="post" enctype="multipart/form-data">
+    <fieldset class="fieldset">
+
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Profile image</h2>
+            <div class="form__note">This image will appear next to your comments.</div>
+        </div>
+
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+                <input type="file" name="file"  />
+                <input type="hidden" name="signed_data" value="@avatarUploadData.signedData" />
+                <input type="hidden" name="redirect_url" value="@idUrlBuilder.buildUrl("/public/edit", idRequest)">
+                <li>
+                    <button type="submit" class="submit-input js-avatar-upload-button" data-link-name="Upload Avatar">Upload</button>
+                </li>
+            </ul>
+        </div>
+
+    </fieldset>
+</form>
+}
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/public/edit", idRequest)" role="main" method="post">
     @views.html.helper.CSRF.formField
@@ -23,26 +47,6 @@
     @if(publicProfileForm.globalError.isDefined) {
         <div class="form__error">@publicProfileForm.globalErrors.map(_.message).mkString(", ")</div>
     }
-
-    <fieldset class="fieldset">
-
-        <div class="fieldset__heading">
-            <h2 class="form__heading">Profile image</h2>
-            <div class="form__note">This image will appear next to your comments.</div>
-        </div>
-
-        <div class="fieldset__fields">
-            <ul class="u-unstyled">
-
-                @inputField(Upload(publicProfileForm("avatar"), ('_label, "Profile image"))) // Generated input should NOT have text-input class but not sure how to do this...
-
-                <li>
-                    <button type="submit" class="submit-input" data-link-name="Create account">Save changes</button>
-                </li>
-            </ul>
-        </div>
-
-    </fieldset>
 
     <fieldset class="fieldset">
 

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -1,11 +1,12 @@
 @(
-        page: model.MetaData with tracking.TrackingParams,
-        user: com.gu.identity.model.User,
-        forms: controllers.ProfileForms,
-        idRequest: services.IdentityRequest,
-        idUrlBuilder: services.IdentityUrlBuilder,
-        avatarUploadData: Option[model.AvatarUploadData]
-)(implicit request: RequestHeader)
+    page: model.MetaData with tracking.TrackingParams,
+    user: com.gu.identity.model.User,
+    forms: controllers.ProfileForms,
+    idRequest: services.IdentityRequest,
+    idUrlBuilder: services.IdentityUrlBuilder,
+    avatarUploadData: Option[model.AvatarUploadData],
+    avatarUploadResponse: Option[Either[String, Boolean]]
+    )(implicit request: RequestHeader)
 
 @import tracking.TrackingParams
 @import views.html.fragments.form.{inputField, textareaField}
@@ -32,18 +33,18 @@
         <div class="tabs__content">
             <div id="tabs-account-profile-1" class="tabs__pane u-cf" role="tabpanel" aria-labelledby="tabs-account-profile-1-tab" data-link-name="Public Profile" data-link-context="Identity/profile"@if(!forms.isPublicFormActive){ style="display: none;"}>
 
-                @public_profile_form(idUrlBuilder, idRequest, user, forms.publicForm, avatarUploadData)
+            @public_profile_form(idUrlBuilder, idRequest, user, forms.publicForm, avatarUploadData, avatarUploadResponse)
 
-            </div>
-
-            <div id="tabs-account-profile-2" class="tabs__pane u-cf" role="tabpanel" aria-labelledby="tabs-account-profile-2-tab" data-link-name="Account" data-link-context="Identity/profile"@if(forms.isPublicFormActive){ style="display: none;"}>
-
-                @account_details_form(idUrlBuilder, idRequest, user, forms.accountForm)
-
-            </div>
         </div>
-    </div>
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+        <div id="tabs-account-profile-2" class="tabs__pane u-cf" role="tabpanel" aria-labelledby="tabs-account-profile-2-tab" data-link-name="Account" data-link-context="Identity/profile"@if(forms.isPublicFormActive){ style="display: none;"}>
+
+        @account_details_form(idUrlBuilder, idRequest, user, forms.accountForm)
+
+    </div>
+</div>
+</div>
+
+@registrationFooter(page, idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -3,7 +3,8 @@
         user: com.gu.identity.model.User,
         forms: controllers.ProfileForms,
         idRequest: services.IdentityRequest,
-        idUrlBuilder: services.IdentityUrlBuilder
+        idUrlBuilder: services.IdentityUrlBuilder,
+        avatarUploadData: Option[model.AvatarUploadData]
 )(implicit request: RequestHeader)
 
 @import tracking.TrackingParams
@@ -31,7 +32,7 @@
         <div class="tabs__content">
             <div id="tabs-account-profile-1" class="tabs__pane u-cf" role="tabpanel" aria-labelledby="tabs-account-profile-1-tab" data-link-name="Public Profile" data-link-context="Identity/profile"@if(!forms.isPublicFormActive){ style="display: none;"}>
 
-                @public_profile_form(idUrlBuilder, idRequest, user, forms.publicForm)
+                @public_profile_form(idUrlBuilder, idRequest, user, forms.publicForm, avatarUploadData)
 
             </div>
 

--- a/identity/test/services/AvatarSigningServiceTest.scala
+++ b/identity/test/services/AvatarSigningServiceTest.scala
@@ -7,11 +7,41 @@ import org.scalatest.Matchers
 
 class AvatarSigningServiceTest extends FunSuite with Matchers {
 
+
+  val base64Payload = "eyJ1c2VybmFtZSI6ImRhdmlkc291cCIsImltYWdlX3VwbG9hZF9zdWNjZXNzIjp0cnVlLCJ1c2VyX2lkIjoiMjE4MDE0MTkiLCJyZXF1aXJlZF9pbWFnZV9ob3N0IjoiaHR0cDpcL1wvc3RhdGljLmd1aW1jb2RlLmNvLnVrIiwiaXNfc29jaWFsIjpmYWxzZX0"
+
+
   test("Should correctly sign avatar data") {
     val signingService = new AvatarSigningService("Gary Balls")
     val signature = signingService sign AvatarData("talkboy", "3040245", "http://static.guimcode.co.uk")
 
     signature should be("eyJ1c2VybmFtZSI6InRhbGtib3kiLCJ1c2VyX2lkIjoiMzA0MDI0NSIsInJlcXVpcmVkX2ltYWdlX2hvc3QiOiJodHRwOi8vc3RhdGljLmd1aW1jb2RlLmNvLnVrIiwiaXNfc29jaWFsIjpmYWxzZX0.K-v6OXoltSP_iFqVPhwpMU_1YuU")
+  }
+
+  test("Should validate signature when reading response data") {
+
+    val signingService = new AvatarSigningService("Gary Balls")
+    val signature = signingService _sign base64Payload
+    val signedString = base64Payload + "." + signature
+
+    signingService.wasUploadSuccessful(signedString) should be(Right(true))
+
+    val wrongSigningService = new AvatarSigningService("Sir Gareth Balls")
+    wrongSigningService.wasUploadSuccessful(signedString) should be(Left("Invalid signature"))
+  }
+
+  test("Should handle responses without a signature") {
+    val signingService = new AvatarSigningService("Gary Balls")
+    signingService.wasUploadSuccessful(base64Payload) should be(Left("Bad response from upload:\n" + base64Payload))
+  }
+
+  test("Should extract error message if upload fails") {
+    val failureResponse = "eyJpbWFnZV91cGxvYWRfc3VjY2VzcyI6ZmFsc2UsImltYWdlX3VwbG9hZF9mYWlsdXJlX21lc3NhZ2UiOiJXZSBjb3VsZG4ndCBsb2FkIHRoYXQgaW1hZ2UgLSB3ZSBvbmx5IGRvIFBORywgSlBFRyBhbmQgR0lGLiJ9"
+    val signingService = new AvatarSigningService("Gary Balls")
+    val signature = signingService._sign(failureResponse)
+    val signedResponse = failureResponse + "." + signature
+
+    signingService.wasUploadSuccessful(signedResponse) should be(Left("We couldn't load that image - we only do PNG, JPEG and GIF."))
   }
 
 

--- a/identity/test/services/AvatarSigningServiceTest.scala
+++ b/identity/test/services/AvatarSigningServiceTest.scala
@@ -1,0 +1,18 @@
+package services
+
+import org.scalatest.FunSuite
+import model.AvatarData
+
+import org.scalatest.Matchers
+
+class AvatarSigningServiceTest extends FunSuite with Matchers {
+
+  test("Should correctly sign avatar data") {
+    val signingService = new AvatarSigningService("Gary Balls")
+    val signature = signingService sign AvatarData("talkboy", "3040245", "http://static.guimcode.co.uk")
+
+    signature should be("eyJ1c2VybmFtZSI6InRhbGtib3kiLCJ1c2VyX2lkIjoiMzA0MDI0NSIsInJlcXVpcmVkX2ltYWdlX2hvc3QiOiJodHRwOi8vc3RhdGljLmd1aW1jb2RlLmNvLnVrIiwiaXNfc29jaWFsIjpmYWxzZX0.K-v6OXoltSP_iFqVPhwpMU_1YuU")
+  }
+
+
+}


### PR DESCRIPTION
Allows users to upload new Avatars for their profile:

https://profile.thegulocal.com/public/edit

The avatars are sent for moderation in the Discussion tool, so they're not available immediately.

The Avatar upload system we're hooking into /could/ be described as legacy. The fact that it uses GAE is not the problem, the dependency on the Guardian DocRoot (rather than S3) is closer to the mark.

https://jira.gutools.co.uk/browse/IDN-1774
https://sites.google.com/a/guardian.co.uk/discussion-project/
https://sites.google.com/a/guardian.co.uk/discussion-project/avatars/avatar-upload

The Avatar upload is behind a switch, which is off for now.
