### PR TITLE
S3 client exceptions

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -116,6 +116,8 @@ object S3Metrics {
     "S3 Client Exceptions",
     "Number of times the AWS S3 client has thrown an Exception"
   )
+
+  val all: Seq[Metric] = Seq(S3ClientExceptionsMetric)
 }
 
 object ContentApiMetrics {
@@ -334,7 +336,7 @@ object FaciaToolMetrics {
     DraftPublishCount, ContentApiPutSuccess, ContentApiPutFailure,
     FrontPressSuccess, FrontPressFailure, FrontPressCronSuccess,
     FrontPressCronFailure, InvalidContentExceptionMetric
-  ) ++ ContentApiMetrics.all
+  ) ++ ContentApiMetrics.all ++ S3Metrics.all
 }
 
 object CommercialMetrics {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -109,6 +109,15 @@ object SystemMetrics extends implicits.Numbers {
   )
 }
 
+object S3Metrics {
+  object S3ClientExceptionsMetric extends SimpleCountMetric(
+    "exception",
+    "s3-client-exception",
+    "S3 Client Exceptions",
+    "Number of times the AWS S3 client has thrown an Exception"
+  )
+}
+
 object ContentApiMetrics {
   object HttpTimingMetric extends FrontendTimingMetric(
     "performance",

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -87,7 +87,13 @@ trait S3 extends Logging {
 
     val request = new PutObjectRequest(bucket, key, new StringInputStream(value), metadata).withCannedAcl(accessControlList)
 
-    client.putObject(request)
+    try {
+      client.putObject(request)
+    } catch {
+      case e: Exception =>
+        S3ClientExceptionsMetric.increment()
+        throw e
+    }
   }
 }
 

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -15,6 +15,7 @@ import javax.crypto.spec.SecretKeySpec
 import sun.misc.BASE64Encoder
 import com.amazonaws.auth.AWSSessionCredentials
 import controllers.Identity
+import common.S3Metrics.S3ClientExceptionsMetric
 
 trait S3 extends Logging {
 
@@ -32,12 +33,21 @@ trait S3 extends Logging {
     val result = client.getObject(request)
 
     // http://stackoverflow.com/questions/17782937/connectionpooltimeoutexception-when-iterating-objects-in-s3
-    try { Some(action(result)) } finally { result.close() }
-
+    try { Some(action(result)) }
+    catch { case _: Exception =>
+      S3ClientExceptionsMetric.increment()
+      None
+    }
+    finally { result.close() }
   } catch {
-    case e: AmazonS3Exception if e.getStatusCode == 404 =>
+    case e: AmazonS3Exception if e.getStatusCode == 404 => {
       log.warn("not found at %s - %s" format(bucket, key))
       None
+    }
+    case e: Exception => {
+      S3ClientExceptionsMetric.increment()
+      None
+    }
   }
 
   def get(key: String): Option[String] = try {

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -34,9 +34,9 @@ trait S3 extends Logging {
 
     // http://stackoverflow.com/questions/17782937/connectionpooltimeoutexception-when-iterating-objects-in-s3
     try { Some(action(result)) }
-    catch { case _: Exception =>
+    catch { case e: Exception =>
       S3ClientExceptionsMetric.increment()
-      None
+      throw e
     }
     finally { result.close() }
   } catch {
@@ -46,7 +46,7 @@ trait S3 extends Logging {
     }
     case e: Exception => {
       S3ClientExceptionsMetric.increment()
-      None
+      throw e
     }
   }
 

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -29,7 +29,8 @@ object Global extends FaciaToolLifecycle with GlobalSettings with CloudWatchAppl
     ("content-api-404", ContentApiMetrics.ContentApi404Metric.getAndReset.toDouble),
     ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
     ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble),
-    ("content-api-invalid-content-exceptions", FaciaToolMetrics.InvalidContentExceptionMetric.getAndReset.toDouble)
+    ("content-api-invalid-content-exceptions", FaciaToolMetrics.InvalidContentExceptionMetric.getAndReset.toDouble),
+    ("s3-client-exceptions", S3Metrics.S3ClientExceptionsMetric.getAndReset.toDouble)
   )
 
   override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration = {


### PR DESCRIPTION
I have added an `S3Metrics` object with `S3ClientExceptionsMetric` for counting any exceptions that happen around the AWS S3 client.

We have no monitoring anywhere in here, and this will give us more visibility.

If you use this client in your application and want to expose these metrics in `CloudWatch` then just add it to your `applicationMetrics`.
