### PR TITLE
fixing line breaking for a bullet format

### DIFF
--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -142,7 +142,12 @@
 .bullet,
 .from-content-api ul > li,
 .article__standfirst ul > li {
-    @include faux-bullet-point($offset-y: 3px)
+    @include faux-bullet-point($offset-y: 3px);
+
+    > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
+        display: inline;
+    }
+
 }
 
 .bullet {


### PR DESCRIPTION
this stops line breaking for the following bullet point format: 

`<ul><li><p>text</p></li></ul>`
