### PR TITLE
fixng components margin on article pages in wide screens

### DIFF
--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -1,6 +1,7 @@
 .facia-container--commercial {
     &.facia-container--layout-article {
         padding: 0;
+        margin: 0;
         @include rem((
             max-width: gs-span(15.5)
         ));


### PR DESCRIPTION
Removing margin: auto for wide screens on article pages.

Before;
![screen shot 2014-04-10 at 12 28 30](https://cloud.githubusercontent.com/assets/1303616/2666767/542db886-c0a3-11e3-834f-b2a9e5de4bff.png)

After;
![screen shot 2014-04-10 at 12 28 39](https://cloud.githubusercontent.com/assets/1303616/2666771/5c743e02-c0a3-11e3-8a7a-5d42e942ba2c.png)
