### PR TITLE
Show more matches now works with Ajax

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -2,6 +2,7 @@ define([
     'common/$',
     'bonzo',
     'bean',
+    'common/utils/ajax',
     'common/utils/context',
     'common/utils/config',
     'common/utils/page',
@@ -16,6 +17,7 @@ define([
     $,
     bonzo,
     bean,
+    ajax,
     context,
     config,
     page,
@@ -144,6 +146,25 @@ define([
             if (!e.target.getAttribute('href')) {
                 window.location = this.getAttribute('data-link-to');
             }
+        });
+
+        bean.on(context, 'click', '.js-show-more', function(e) {
+            e.preventDefault();
+            var el = e.currentTarget;
+            ajax({
+                url: el.getAttribute('href') +'.json'
+            }).then(function(resp) {
+                $.create(resp.html).each(function(html) {
+                    $('[data-show-more-contains="'+ el.getAttribute('data-puts-more-into') +'"]', context)
+                        .append($(el.getAttribute('data-shows-more'), html));
+
+                    if (resp[el.getAttribute('data-new-url')]) {
+                        bonzo(el).attr('href', resp[el.getAttribute('data-new-url')]);
+                    } else {
+                        bonzo(el).remove();
+                    }
+                });
+            });
         });
 
         bean.on(context, 'change', $('form.football-leagues')[0], function() {

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -158,8 +158,9 @@ define([
                     $('[data-show-more-contains="'+ el.getAttribute('data-puts-more-into') +'"]', context)
                         .append($(el.getAttribute('data-shows-more'), html));
 
-                    if (resp[el.getAttribute('data-new-url')]) {
-                        bonzo(el).attr('href', resp[el.getAttribute('data-new-url')]);
+                    var nurl = resp[el.getAttribute('data-new-url')];
+                    if (nurl) {
+                        bonzo(el).attr('href', nurl);
                     } else {
                         bonzo(el).remove();
                     }

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -26,27 +26,33 @@
                         </ul>
                     </div>
 
-                    @matchesList.matchesGroupedByDateAndCompetition.map { case (date, competitionMatches) =>
-                        <div class="football-matches__day">
-                            <div class="date-divider">@date.toString("EEEE d MMMM yyyy")</div>
-                            @competitionMatches.map { case (competition, matches) =>
-                                <div class="football-table__container">
-                                    <div class="article__meta-container">
-                                        <h3 class="article__meta-heading"><a href="@LinkTo{@competition.url}" data-link-name="view competition">@competition.fullName</a></h3>
-                                    </div>
+                    <div class="football-matches__container" data-show-more-contains="football-matches">
+                        @matchesList.matchesGroupedByDateAndCompetition.map { case (date, competitionMatches) =>
+                            <div class="football-matches__day">
+                                <div class="date-divider">@date.toString("EEEE d MMMM yyyy")</div>
+                                @competitionMatches.map { case (competition, matches) =>
+                                    <div class="football-table__container">
+                                        <div class="article__meta-container">
+                                            <h3 class="article__meta-heading"><a href="@LinkTo{@competition.url}" data-link-name="view competition">@competition.fullName</a></h3>
+                                        </div>
 
-                                    <div class="article__container u-cf">
-                                        @football.views.html.matchList.matchesList(matches, competition)
+                                        <div class="article__container u-cf">
+                                            @football.views.html.matchList.matchesList(matches, competition)
+                                        </div>
                                     </div>
-                                </div>
-                            }
-                        </div>
-                    }
+                                }
+                            </div>
+                        }
+                    </div>
 
                     @if(matchesList.previousPage.isDefined || matchesList.nextPage.isDefined) {
                         <div class="matches-nav" data-link-name="@matchesList.pageType nav">
                             @matchesList.previousPage.map{url =>
-                                <a href="@url" class="collection__show-more tone-background tone-news" data-link-name="previous" title="Previous page">
+                                <a href="@url" class="collection__show-more tone-background tone-news"
+                                   data-insert-into="football-matches__container"
+                                   data-replace-with="show-more-football-matches--old"
+                                   data-link-name="previous"
+                                   title="Previous page">
                                     <span class="collection__show-more__icon">
                                         <span class="i i-minus-white-mask"></span>
                                         <span class="i i-minus-white"></span>
@@ -55,7 +61,12 @@
                                 </a>
                             }
                             @matchesList.nextPage.map{url =>
-                                <a href="@url" class="collection__show-more tone-background tone-news" data-link-name="next" title="Next page">
+                                <a href="@url" class="collection__show-more tone-background tone-news js-show-more"
+                                   data-shows-more=".football-matches__day"
+                                   data-puts-more-into="football-matches"
+                                   data-new-url="next"
+                                   data-link-name="next"
+                                   title="Next page">
                                     <span class="collection__show-more__icon">
                                         <span class="i i-plus-white-mask"></span>
                                         <span class="i i-plus-white"></span>

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -49,8 +49,9 @@
                         <div class="matches-nav" data-link-name="@matchesList.pageType nav">
                             @matchesList.previousPage.map{url =>
                                 <a href="@url" class="collection__show-more tone-background tone-news"
-                                   data-insert-into="football-matches__container"
-                                   data-replace-with="show-more-football-matches--old"
+                                   data-shows-more=".football-matches__day"
+                                   data-puts-more-into="football-matches"
+                                   data-new-url="previous"
                                    data-link-name="previous"
                                    title="Previous page">
                                     <span class="collection__show-more__icon">


### PR DESCRIPTION
Just a quick fix for the load more matches not working with Ajax, this is particularly important as this button takes you to the lovechild of [R2 and NextGen](http://www.theguardian.com/football/results/2014/Apr/04)

Could have abstracted it out, but we don't seem to use this anywhere else.

If you don't know what I mean:
![badplaces](https://cloud.githubusercontent.com/assets/31692/2679567/20cbc0f0-c175-11e3-8c40-7f2d27814b24.png)

---

![Bounce!](http://www.netanimations.net/this-is-common.gif)
