### PR TITLE
Removed stub pa api, will add back when fb team disbands

### DIFF
--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -14,7 +14,7 @@ front.config=http://s3-eu-west-1.amazonaws.com/aws-frontend-store/CODE/config/fr
 frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 
 # Override football to point to stub data
-football.api.host=http://football-stats-stub.appspot.com/2012-10-20/16-05
+# football.api.host=http://football-stats-stub.appspot.com/2012-10-20/16-05
 
 ajax.url=http://code.api.nextgen.guardianapps.co.uk
 ajax.secureUrl=https://code.api-secure.nextgen.guardianapps.co.uk


### PR DESCRIPTION
We're removing this as an interim measure as we need to test things on code before release.
This is impossible with the current setup.

![](http://media0.giphy.com/media/7q3By1tKdxjJ6/giphy.gif)
