### PR TITLE
Commercial: particular order for industries

### DIFF
--- a/commercial/app/model/commercial/jobs/Job.scala
+++ b/commercial/app/model/commercial/jobs/Job.scala
@@ -23,38 +23,39 @@ case class Job(id: Int,
     segment.context.isInSection("business") && someKeywordsMatch
   }
 
-  val industries = sectorIds.flatMap(sectorId => Industries.sectorIdIndustryMap.get(sectorId))
+  val industries: Seq[String] = Industries.sectorIdIndustryMap.filter{ case(id, name) => sectorIds.contains(id) }.values.toSeq
 
-  val mainIndustry: Option[String] = industries.headOption.filterNot(_ == "General")
+  val mainIndustry: Option[String] = industries.headOption
 }
 
 object Industries extends ExecutionContexts {
 
   private lazy val industryKeywords = AkkaAgent(Map.empty[Int, Seq[Keyword]])
 
+  // note, these are ordered by importance
   val sectorIdIndustryMap = Map[Int, String](
-    (101, "Arts & heritage"),
     (111, "Charities"),
-    (124, "Construction"),
+    (286, "Social care"),
     (127, "Education"),
-    (137, "Engineering"),
-    (141, "Environment"),
-    (142, "Design"),
-    (149, "Finance & Accounting"),
-    (158, "General"),
     (166, "Government & Politics"),
-    (184, "Health"),
     (196, "Housing"),
-    (204, "Hospitality"),
-    (211, "Technology"),
-    (218, "Legal"),
-    (219, "Leisure"),
     (223, "Marketing & PR"),
+    (184, "Health"),
     (235, "Media"),
+    (218, "Legal"),
+    (101, "Arts & heritage"),
+    (149, "Finance & Accounting"),
+    (141, "Environment"),
+    (211, "Technology"),
+    (124, "Construction"),
+    (137, "Engineering"),
+    (142, "Design"),
+    (158, "General"),
+    (204, "Hospitality"),
+    (219, "Leisure"),
     (244, "Recruitment"),
     (245, "Retail & FMCG"),
     (259, "Science"),
-    (286, "Social care"),
     (294, "Travel & transport"),
     (343, "Skilled Trade"),
     (350, "Social Enterprise")


### PR DESCRIPTION
Commercial want the industries to be in a particular order when selecting the main industry

This does depend on `Map` filtering and returning values in the written order though...

@kelvin-chappell 
