### PR TITLE
Updated extras rendering when football table fails

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -181,6 +181,9 @@ define([
                     ready: true
                 } : undefined;
                 renderExtras(extras, dropdownTemplate);
+            }, function() {
+                delete extras[1];
+                renderExtras(extras, dropdownTemplate);
             });
         });
 


### PR DESCRIPTION
Needed to remember to reset the `extras` array.
We will be writing some rendering tests before the football team disbands.

![Code king](http://media.giphy.com/media/TqRkEhK7Dnv6U/giphy.gif)
