### PR TITLE
.unstyled -> .u-unstyled

### DIFF
--- a/archive/app/views/notFound.scala.html
+++ b/archive/app/views/notFound.scala.html
@@ -20,9 +20,9 @@
     <link rel="stylesheet" type="text/css" href="/css/layout.pasteup.min.css" />
     <![endif]-->
         <style>
-        .unstyled { list-style: none;}
+        .u-unstyled { list-style: none;}
 
-        .unstyled  li {
+        .u-unstyled  li {
         display: block;
         float:left;
         width: 40%;
@@ -57,7 +57,7 @@
                     <p>You may have followed a broken or outdated link, or there may be an error on our site.</p>
                     <p>Please follow one of the links below to continue exploring.</p>
                     <nav>
-                        <ul role="navigation" class="unstyled">
+                        <ul role="navigation" class="u-unstyled">
                             <li><a href="/">Home</a></li>
                             <li class="zone-news"><a href="/uk" class="zone-color zone-background-hover">UK news</a></li>
                             <li class="zone-news"><a href="/world" class="zone-color zone-background-hover">World news</a></li>

--- a/common/app/views/fragments/collections/multimedia.scala.html
+++ b/common/app/views/fragments/collections/multimedia.scala.html
@@ -1,7 +1,7 @@
 @(items: Seq[Trail], style: Container, containerIndex: Int)(implicit request: RequestHeader)
 
 <div class="collection-wrapper collection-wrapper--position-1">
-    <ul class="unstyled l-row l-row--items-3 l-row--layout-m collection">
+    <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m collection">
         @items.slice(0, 1).zipWithIndex.map{ case (trail, index) =>
             @fragments.collections.items.standard(trail, index, containerIndex, "l-row__item--break-m")
         }
@@ -13,7 +13,7 @@
 @defining(items.slice(3, 7)) { items =>
     @if(items.nonEmpty) {
         <div class="collection-wrapper collection-wrapper--position-2">
-            <ul class="unstyled l-row l-row--items-4 l-row--layout-m collection">
+            <ul class="u-unstyled l-row l-row--items-4 l-row--layout-m collection">
                 @items.zipWithIndex.map{ case (trail, index) =>
                     @fragments.collections.items.standard(trail, index + 3, containerIndex)
                 }

--- a/identity/app/views/public_profile_page.scala.html
+++ b/identity/app/views/public_profile_page.scala.html
@@ -16,7 +16,7 @@
             }
         </div>
         <div class="fieldset__fields">
-            <ul class="unstyled">
+            <ul class="u-unstyled">
                 <li class="form-field">
                     <h4>Location:</h4>
                     <p class="identity-section__text">@user.publicFields.location</p>

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -31,7 +31,7 @@
                 <div class="form__note">All fields required.</div>
             </div>
             <div class="fieldset__fields">
-                <ul class="unstyled">
+                <ul class="u-unstyled">
 
                     @inputField(Email(registrationForm("user.primaryEmailAddress"), '_label -> "Email address", 'tabindex -> 1))
 

--- a/identity/app/views/signin.scala.html
+++ b/identity/app/views/signin.scala.html
@@ -33,7 +33,7 @@
             </div>
 
             <div class="fieldset__fields">
-                <ul class="unstyled">
+                <ul class="u-unstyled">
 
                     @inputField(Email(signinForm("email"), '_label -> "Email address", 'class -> "js-signin-email",  ('tabindex, 1)))
 

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -31,7 +31,7 @@
                     }
                 </td>
                 <td class="football-match__teams table-column--main">
-                    <a href="@LinkTo{@theMatch.smartUrl}" class="unstyled football-teams u-cf" data-link-name="match-redirect">
+                    <a href="@LinkTo{@theMatch.smartUrl}" class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
                         <div class="football-match__team football-match__team--home football-team">
                             <div class="football-team__name">@theMatch.homeTeam.name</div>
                             <div class="football-team__score">@theMatch.homeTeam.score</div>


### PR DESCRIPTION
Some of the templates were still using the non-prefixed version of the `unstyled` helper. This PR renames them into `u-unstyled`.
## Before

![screen shot 2014-04-14 at 11 08 55](https://cloud.githubusercontent.com/assets/85783/2693973/e3f5ffde-c3bc-11e3-8168-626177060797.PNG)
## After

![screen shot 2014-04-14 at 11 09 09](https://cloud.githubusercontent.com/assets/85783/2693975/e739c144-c3bc-11e3-9192-18e8f370b8e0.PNG)

![ ](http://media.giphy.com/media/rW5uNVaLIg0zC/giphy.gif)
