### PR TITLE
Adding truncation to football liveblogs

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -5,6 +5,7 @@ define([
     'common/$',
     'fence',
     'common/modules/ui/rhc',
+    'common/modules/article/truncate',
     'common/modules/ui/autoupdate',
     'common/modules/live/filter',
     'common/modules/discussion/loader',
@@ -18,6 +19,7 @@ define([
     $,
     fence,
     rhc,
+    truncate,
     AutoUpdate,
     LiveFilter,
     DiscussionLoader,
@@ -56,7 +58,6 @@ define([
         },
 
         initDiscussion: function() {
-
             common.mediator.on('page:article:ready', function(config, context) {
                 if (config.page.commentable && config.switches.discussion) {
                     var discussionLoader = new DiscussionLoader(context, common.mediator, { 'switches': config.switches });
@@ -103,6 +104,12 @@ define([
                 articleHeadline.style.fontWeight = 'bold';
                 articleHeadline.style.letterSpacing = '-1px';
             }
+        },
+
+        initTruncate: function() {
+            mediator.on('page:article:ready', function() {
+                truncate();
+            });
         }
     };
 
@@ -115,6 +122,7 @@ define([
             modules.initFence();
             modules.initLayoutHints(config);
             modules.initHelvetica(config);
+            modules.initTruncate();
         }
         common.mediator.emit('page:article:ready', config, context);
     };

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -29,7 +29,7 @@ define([
 
         if (shouldTruncate()) {
             $.create(
-                '<button class="u-fauxlink u-button-reset button--show-more '+ articleElongateClass +'">'+
+                '<button class="u-fauxlink u-button-reset button button--show-more '+ articleElongateClass +'">'+
                     '<i class="i i-plus-white-med tone-background"></i>'+
                     'View all updates'+
                 '</button>'

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -29,8 +29,8 @@ define([
 
         if (shouldTruncate()) {
             $.create(
-                '<button class="u-fauxlink u-button-reset button button--show-more '+ articleElongateClass +'">'+
-                    '<i class="i i-plus-white-med tone-background"></i>'+
+                '<button class="u-fauxlink u-button-reset button button--show-more '+ articleElongateClass +'" data-link-name="continue reading">'+
+                    '<span class="tone-background i-center"><i class="i i-plus-white-med"></i></span>'+
                     'View all updates'+
                 '</button>'
             ).each(function(el) {

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -1,0 +1,49 @@
+define([
+    'common/$',
+    'bean',
+    'bonzo',
+    'common/utils/config',
+    'common/utils/context',
+    'common/utils/detect'
+], function(
+    $,
+    bean,
+    bonzo,
+    config,
+    context,
+    detect
+) {
+
+context = context();
+function shouldTruncate() {
+    return config.page.isLiveBlog &&
+        detect.getBreakpoint() === 'mobile' &&
+        config.page.section === 'football' &&
+        $('.live-blog__blocks').length > 1;
+}
+
+function truncate() {
+    var articleElongateClass = 'article-elongator',
+        truncatedClass = 'article--truncated',
+        $article = $('#article', context).addClass(truncatedClass);
+
+    if (shouldTruncate()) {
+        $.create(
+            '<button class="u-fauxlink u-button-reset '+ articleElongateClass +'">'+
+                'View all updates'+
+            '</button>'
+        ).each(function(el) {
+            $('.article-body', context).append(el);
+        });
+
+        bean.on(context, 'click', '.'+articleElongateClass, function(e) {
+            e.preventDefault();
+            $article.removeClass(truncatedClass);
+            bonzo(e.currentTarget).addClass('u-h');
+        });
+    }
+}
+
+return truncate;
+
+}); // define

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -14,36 +14,37 @@ define([
     detect
 ) {
 
-context = context();
-function shouldTruncate() {
-    return config.page.isLiveBlog &&
-        detect.getBreakpoint() === 'mobile' &&
-        config.page.section === 'football' &&
-        $('.live-blog__blocks').length > 1;
-}
-
-function truncate() {
-    var articleElongateClass = 'article-elongator',
-        truncatedClass = 'article--truncated',
-        $article = $('#article', context).addClass(truncatedClass);
-
-    if (shouldTruncate()) {
-        $.create(
-            '<button class="u-fauxlink u-button-reset '+ articleElongateClass +'">'+
-                'View all updates'+
-            '</button>'
-        ).each(function(el) {
-            $('.article-body', context).append(el);
-        });
-
-        bean.on(context, 'click', '.'+articleElongateClass, function(e) {
-            e.preventDefault();
-            $article.removeClass(truncatedClass);
-            bonzo(e.currentTarget).addClass('u-h');
-        });
+    context = context();
+    function shouldTruncate() {
+        return config.page.isLiveBlog &&
+            detect.getBreakpoint() === 'mobile' &&
+            config.page.section === 'football' &&
+            $('.live-blog__blocks').length > 1;
     }
-}
 
-return truncate;
+    function truncate() {
+        var articleElongateClass = 'article-elongator',
+            truncatedClass = 'article--truncated',
+            $article = $('#article', context).addClass(truncatedClass);
+
+        if (shouldTruncate()) {
+            $.create(
+                '<button class="u-fauxlink u-button-reset button--show-more '+ articleElongateClass +'">'+
+                    '<i class="i i-plus-white-med tone-background"></i>'+
+                    'View all updates'+
+                '</button>'
+            ).each(function(el) {
+                $('.article-body', context).append(el);
+            });
+
+            bean.on(context, 'click', '.'+articleElongateClass, function(e) {
+                e.preventDefault();
+                $article.removeClass(truncatedClass);
+                bonzo(e.currentTarget).addClass('u-h');
+            });
+        }
+    }
+
+    return truncate;
 
 }); // define

--- a/common/app/assets/stylesheets/base/_buttons.scss
+++ b/common/app/assets/stylesheets/base/_buttons.scss
@@ -1,3 +1,4 @@
+.button {}
 .button--show-more {
     @include fs-textsans(3);
     @include rem((
@@ -7,7 +8,7 @@
     border-top: 1px dotted $c-neutral3;
     text-align: center;
 
-    .i.i-plus-white-med {
+    .svg .i-plus-white-med {
         @include rounded-corners(50%);
         @include rem((
             height: $gs-baseline*2,

--- a/common/app/assets/stylesheets/base/_buttons.scss
+++ b/common/app/assets/stylesheets/base/_buttons.scss
@@ -8,14 +8,20 @@
     border-top: 1px dotted $c-neutral3;
     text-align: center;
 
-    .svg .i-plus-white-med {
-        @include rounded-corners(50%);
+    .i-center {
+        @include rounded-corners($gs-baseline*3);
         @include rem((
             height: $gs-baseline*2,
             margin-right: $gs-gutter/2,
             width: $gs-baseline*2
         ));
-        background-position: center;
+        display: inline-block;
         vertical-align: middle;
+
+        .i {
+            @include rem((
+                margin-top: $gs-baseline/4
+            ));
+        }
     }
 }

--- a/common/app/assets/stylesheets/base/_buttons.scss
+++ b/common/app/assets/stylesheets/base/_buttons.scss
@@ -1,0 +1,20 @@
+.button--show-more {
+    @include fs-textsans(3);
+    @include rem((
+        margin-bottom: $gs-baseline,
+        padding: ($gs-baseline/3)*2 0
+    ));
+    border-top: 1px dotted $c-neutral3;
+    text-align: center;
+
+    .i.i-plus-white-med {
+        @include rounded-corners(50%);
+        @include rem((
+            height: $gs-baseline*2,
+            margin-right: $gs-gutter/2,
+            width: $gs-baseline*2
+        ));
+        background-position: center;
+        vertical-align: middle;
+    }
+}

--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -18,6 +18,7 @@
 
 @import "base/_tables";
 @import "base/_forms";
+@import "base/_buttons";
 
 
 /* ==========================================================================

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -6,6 +6,16 @@
     @include fs-bodyCopy(3);
 }
 
+.article--truncated {
+    // Remember to update this number in module/article/truncate.js
+    .live-blog__blocks {
+        display: none;
+    }
+    .live-blog__blocks:first-child {
+        display: block;
+    }
+}
+
 .article__zone {
     @include fs-header(3);
     @include box-sizing(border-box);
@@ -758,4 +768,18 @@
             margin-bottom: $gs-baseline/2
         ));
     }
+}
+
+.article-elongator {
+    @include fs-bodyCopy(3, true);
+    @include rem((
+        margin-bottom: $gs-baseline,
+        padding: $gs-baseline,
+        top: -$gs-baseline*2
+    ));
+    background: $c-neutral6;
+    border-bottom: 1px dotted $c-neutral3;
+    border-top: 1px dotted $c-neutral3;
+    position: relative;
+    text-align: center;
 }

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -7,7 +7,6 @@
 }
 
 .article--truncated {
-    // Remember to update this number in module/article/truncate.js
     .live-blog__blocks {
         display: none;
     }

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -771,15 +771,8 @@
 }
 
 .article-elongator {
-    @include fs-bodyCopy(3, true);
     @include rem((
-        margin-bottom: $gs-baseline,
-        padding: $gs-baseline,
         top: -$gs-baseline*2
     ));
-    background: $c-neutral6;
-    border-bottom: 1px dotted $c-neutral3;
-    border-top: 1px dotted $c-neutral3;
     position: relative;
-    text-align: center;
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -308,7 +308,7 @@ class LiveBlog(content: ApiContentWithMeta) extends Article(content) {
   private lazy val soupedBody = Jsoup.parseBodyFragment(body).body()
   lazy val blockCount: Int = soupedBody.select(".block").size()
   lazy val summary: Option[String] = soupedBody.select(".is-summary").headOption.map(_.toString)
-  lazy val groupedBlocks: List[String]= soupedBody.select(".block").toList.grouped(10).map { group =>
+  lazy val groupedBlocks: List[String]= soupedBody.select(".block").toList.grouped(5).map { group =>
     group.map(_.toString).mkString
   }.toList
   override def cards: List[(String, Any)] = super.cards ++ List(


### PR DESCRIPTION
- Very rudimentary truncation

This is two fold - Football's requirements are pretty simple, and live blogs are being rehashed.

We can look at extending [`shouldTruncate`](https://github.com/guardian/frontend/compare/football-liveblog-truncation?expand=1#diff-78360b6b49c840a5052f32afe5da688cR18) to return a set of arguments for [`truncate`](https://github.com/guardian/frontend/pull/3912/files#diff-78360b6b49c840a5052f32afe5da688cR25) dependant on factors. This seemed like over engineering for now.
# Show me the simple truncation

![truncate](https://cloud.githubusercontent.com/assets/31692/2704805/48ebcd26-c474-11e3-9fa3-7d5528060df8.png)

---

![TRUNK](http://www.ohmagif.com/gif/0811/elephant-trunk-stunt.gif)
