### PR TITLE
Commercial: change class on collection with/without ads

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/collection-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/collection-adverts.js
@@ -47,7 +47,7 @@ define([
 
         adCollections.forEach(function($collection, index) {
             $collection
-                .removeClass('linklist-container')
+                .removeClass('linkslist-container')
                 .addClass('collection-wrapper collection-wrapper--position-2')
                 .html(
                     collectionTemplate

--- a/common/app/assets/javascripts/modules/adverts/collection-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/collection-adverts.js
@@ -35,7 +35,7 @@ define([
             return false;
         }
         // filter out hidden containers
-        $(this.config.containerSelector)
+        var adCollections = $(this.config.containerSelector)
             .map(function(container) { return $(container); })
             .filter(function($container) {
                 return qwery(this.config.selector, $container[0]).length && $container.css('display') !== 'none';
@@ -43,14 +43,20 @@ define([
             .map(function($container) {
                 return $(this.config.selector, $container[0]).first();
             }, this)
-            .slice(0, adNames.length)
-            .forEach(function($slot, index) {
-                $slot.html(
+            .slice(0, adNames.length);
+
+        adCollections.forEach(function($collection, index) {
+            $collection
+                .removeClass('linklist-container')
+                .addClass('collection-wrapper collection-wrapper--position-2')
+                .html(
                     collectionTemplate
-                        .replace('{{collection}}', $slot.html())
+                        .replace('{{collection}}', $collection.html())
                         .replace('{{adSlot}}', adSlotTemplate.replace(/{{name}}/g, adNames[index]))
                 );
-            });
+        });
+
+        return adCollections;
     };
 
     return CollectionAdverts;

--- a/common/app/views/fragments/collections/features.scala.html
+++ b/common/app/views/fragments/collections/features.scala.html
@@ -12,7 +12,7 @@
 </div>
 @defining(items.slice(3, 11)) { items =>
     @if(items.nonEmpty) {
-        <div class="collection-wrapper collection-wrapper--position-2 collection-wrapper--ad">
+        <div class="linkslist-container tone-@{style.tone} collection-wrapper--ad">
                 <ul class="l-columns linkslist features__columns">
                     @items.zipWithIndex.map{ case (trail, index) =>
                         @trail match {

--- a/common/app/views/fragments/collections/people.scala.html
+++ b/common/app/views/fragments/collections/people.scala.html
@@ -10,7 +10,7 @@
 
 @defining(items.slice(3, 11)) { items =>
     @if(items.nonEmpty) {
-        <div class="collection-wrapper collection-wrapper--position-2 collection-wrapper--ad">
+        <div class="linkslist-container tone-@{style.tone} collection-wrapper--ad">
             <ul class="l-columns linkslist features__columns">
                 @items.zipWithIndex.map{ case (trail, index) =>
                     @trail match {

--- a/common/app/views/fragments/collections/tag.scala.html
+++ b/common/app/views/fragments/collections/tag.scala.html
@@ -43,7 +43,7 @@
             }
             @defining(items.slice(baguetteCount + 6, baguetteCount + 14)) { items =>
                 @if(items.nonEmpty) {
-                    <div class="collection-wrapper collection-wrapper--position-2 collection-wrapper--ad">
+                    <div class="linkslist-container tone-@{style.tone} collection-wrapper--ad">
                         <ul class="l-columns linkslist linkslist--with-images">
                             @items.zipWithIndex.map{ case (trail, index) =>
                                 @trail match {

--- a/common/test/assets/javascripts/spec/adverts/collection-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/collection-adverts.spec.js
@@ -19,7 +19,7 @@ define([
         var fixturesConfig = {
                 id: 'collection-adverts',
                 fixtures: [
-                    '<div class="container"><div class="collection-wrapper--ad"><div class="collection-one"></div></div></div>',
+                    '<div class="container"><div class="linklist-container collection-wrapper--ad"><div class="collection-one"></div></div></div>',
                     '<div class="container"></div>',
                     '<div class="container"><div class="collection-wrapper--ad"><div class="collection-two"></div></div></div>',
                     '<div class="container"><div class="collection-wrapper--ad"><div class="collection-three"></div></div></div>',
@@ -94,6 +94,14 @@ define([
             var $collectionItem = $('.collection-wrapper--ad .collection__item').map(function(slot) { return $(slot); });
             expect($collectionItem[0].html()).toEqual('<div class="collection-two"></div>');
             expect($collectionItem[1].html()).toEqual('<div class="collection-three"></div>');
+        });
+
+        it('should change collection classes', function() {
+            var collectionAdverts = new CollectionAdverts(createSwitch(true));
+            collectionAdverts.init().forEach(function($adCollection) {
+                expect($adCollection.hasClass('linklist-container')).toEqual(false);
+                expect($adCollection.hasClass('collection-wrapper collection-wrapper--position-2')).toEqual(true);
+            });
         });
 
     });

--- a/common/test/assets/javascripts/spec/adverts/collection-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/collection-adverts.spec.js
@@ -19,7 +19,7 @@ define([
         var fixturesConfig = {
                 id: 'collection-adverts',
                 fixtures: [
-                    '<div class="container"><div class="linklist-container collection-wrapper--ad"><div class="collection-one"></div></div></div>',
+                    '<div class="container"><div class="linkslist-container collection-wrapper--ad"><div class="collection-one"></div></div></div>',
                     '<div class="container"></div>',
                     '<div class="container"><div class="collection-wrapper--ad"><div class="collection-two"></div></div></div>',
                     '<div class="container"><div class="collection-wrapper--ad"><div class="collection-three"></div></div></div>',
@@ -99,7 +99,7 @@ define([
         it('should change collection classes', function() {
             var collectionAdverts = new CollectionAdverts(createSwitch(true));
             collectionAdverts.init().forEach(function($adCollection) {
-                expect($adCollection.hasClass('linklist-container')).toEqual(false);
+                expect($adCollection.hasClass('linkslist-container')).toEqual(false);
                 expect($adCollection.hasClass('collection-wrapper collection-wrapper--position-2')).toEqual(true);
             });
         });


### PR DESCRIPTION
Fixes

![screen shot 2014-04-15 at 11 35 13](https://cloud.githubusercontent.com/assets/74132/2706106/ae826a9a-c489-11e3-8596-f1c510d2035a.jpeg)

If a collection has an ad, it needs a different set of classes than without

TODO: simplify HTML when adding adverts to a collection 
