### PR TITLE
Commercial: correctly remove ad label if event is empty

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -287,9 +287,9 @@ define([
     };
 
     DFP.prototype.removeLabel = function($slot) {
-        $slot.parent()
-            .removeClass('ad-label--showing')
-            .previous().remove();
+        var $slotParent = $slot.parent()
+            .removeClass('ad-label--showing');
+        $('.ad-slot__label', $slotParent[0]).remove();
     };
 
     DFP.prototype.fireAdRequest = function() {

--- a/common/test/assets/javascripts/spec/adverts/DFP.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/DFP.spec.js
@@ -94,6 +94,7 @@ define([
 
             it('should not be rendered twice', function() {
                 var $slot = $('#dfp-already-labelled');
+                dfp.addLabel($slot);
                 expect($slot.previous().hasClass('ad-slot__label')).toBe(false);
             });
 
@@ -101,6 +102,25 @@ define([
                 var $slot = $('#dfp-dont-label');
                 dfp.addLabel($slot);
                 expect($slot.previous().hasClass('ad-slot__label')).toBe(false);
+            });
+
+            it('should remove advert is ad event is empty', function() {
+                var id = 'dfp-html-slot',
+                    $slot = $('#' + id);
+                dfp.addLabel($slot);
+                dfp.parseAd({
+                    isEmpty: true,
+                    slot: {
+                        getSlotId: function() {
+                            return {
+                                getDomId: function() {
+                                    return id;
+                                }
+                            };
+                        }
+                    }
+                });
+                expect($('.ad-slot__label', $slot.parent()[0]).length).toBe(0);
             });
 
         });


### PR DESCRIPTION
Previously, was removing whatever element was _before_ the advert

![1376947737_cheerleader_with_burning_baton_fail](https://cloud.githubusercontent.com/assets/74132/2707770/1c9dee58-c4a5-11e3-95c6-f83fa4d7efcf.gif)
