### PR TITLE
Commercial: don't show 320 width inline ads at mobile

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-body-adverts.js
@@ -28,7 +28,7 @@ define([
     ArticleBodyAdverts.prototype.inlineSlots = [];
 
     ArticleBodyAdverts.prototype.config = {
-        inlineAdTemplate: '<div class="ad-slot--dfp ad-slot--inline" data-name="%dfp_slot%" data-mobile="300,50|320,50" data-tabletportrait="300,250"><div id="dfp-ad--%dfp_slot%" class="ad-slot__container"></div></div>'
+        inlineAdTemplate: '<div class="ad-slot--dfp ad-slot--inline" data-name="%dfp_slot%" data-mobile="300,50" data-mobilelandscape="300,50|320,50" data-tabletportrait="300,250"><div id="dfp-ad--%dfp_slot%" class="ad-slot__container"></div></div>'
     };
 
     ArticleBodyAdverts.prototype.generateInlineAdSlot = function(dfpName) {

--- a/common/app/assets/javascripts/modules/adverts/collection-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/collection-adverts.js
@@ -12,7 +12,7 @@ define([
 
     var adNames = ['inline1', 'inline2'],
         adSlotTemplate =
-            '<div class="ad-slot ad-slot--dfp ad-slot--container-inline" data-link-name="ad slot {{name}}" data-name="{{name}}" data-mobile="300,50" data-tabletportrait="300,250">' +
+            '<div class="ad-slot ad-slot--dfp ad-slot--container-inline" data-link-name="ad slot {{name}}" data-name="{{name}}" data-mobile="300,50" data-mobilelandscape="300,50|320,50" data-tabletportrait="300,250">' +
                 '<div id="dfp-ad--{{name}}" class="ad-slot__container">' +
             '</div>',
         collectionTemplate =

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -97,6 +97,7 @@ define([
         // These should match the widths inside _vars.scss
         breakpoints: {
             mobile: 0,
+            mobilelandscape: 480,
             tabletportrait: 740,
             tabletlandscape: 900,
             desktop: 980,


### PR DESCRIPTION
A mobile at 320 width leaves a 300px space for an inline ad, so we can't show 320 width ads

Added a `mobilelandscape` DFP breakpoint, at which we can start to show these wider ads
