### PR TITLE
Show football match comments

### DIFF
--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -125,6 +125,7 @@
 }
 
 .football-match__comments {
+    @include fs-data(4, true);
     color: $c-neutral2-contrasted;
     text-align: center;
 }

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -98,6 +98,7 @@
 }
 
 .football-team__score {
+    color: $c-neutral2-contrasted;
     position: absolute;
     top: 0;
 }
@@ -121,6 +122,11 @@
     &:after {
         content: "\2013";
     }
+}
+
+.football-match__comments {
+    color: $c-neutral2-contrasted;
+    text-align: center;
 }
 
 .football-match--fixture {

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -53,6 +53,10 @@
                         </div>
 
                         <div class="football-teams__battleline"></div>
+
+                        @theMatch.comments.map { comments =>
+                            <div class="football-match__comments">@comments</div>
+                        }
                     </a>
                 </td>
             </tr>

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -55,7 +55,7 @@
                         <div class="football-teams__battleline"></div>
 
                         @theMatch.comments.map { comments =>
-                            <div class="football-match__comments">@comments</div>
+                            <div class="football-match__comments">@comments.reverse.dropWhile(_ == '.').reverse</div>
                         }
                     </a>
                 </td>

--- a/sport/test/FootballTestData.scala
+++ b/sport/test/FootballTestData.scala
@@ -58,7 +58,7 @@ trait FootballTestData {
     Competition("500", "/football/championsleague", "Champions League", "Champions League", "European",
       startDate = Some((today - 2.months).toDateMidnight),
       matches = Seq(
-        result("Bolton", "Derby", 1, 1, today - 1.day),
+        result("Bolton", "Derby", 1, 1, today - 1.day, Some("Bolton win 4-2 on penalties.")),
         liveMatch("Cardiff", "Brighton", 2, 0, today.withTime(15, 0, 0, 0)),
         fixture("Wolves", "Burnley", today + 2.days)
       ),
@@ -85,11 +85,12 @@ trait FootballTestData {
     awayTeam = team.copy(id = awayName, name = awayName, score = None)
   )
 
-  private def result(homeName: String, awayName: String, homeScore: Int, awayScore: Int, date: DateTime) = _result.copy(
+  private def result(homeName: String, awayName: String, homeScore: Int, awayScore: Int, date: DateTime, comments: Option[String] = None) = _result.copy(
     id = s"result $homeName $awayName $date",
     date = date,
     homeTeam = team.copy(id = homeName, name = homeName, score = Some(homeScore)),
-    awayTeam = team.copy(id = awayName, name = awayName, score = Some(awayScore))
+    awayTeam = team.copy(id = awayName, name = awayName, score = Some(awayScore)),
+    comments = comments
   )
 
   private def leagueEntry(team: String, rank: Int) = LeagueTableEntry("1", None,

--- a/sport/test/ResultsFeatureTest.scala
+++ b/sport/test/ResultsFeatureTest.scala
@@ -34,6 +34,9 @@ class ResultsFeatureTest extends FeatureSpec with GivenWhenThen with Matchers wi
 
         And("Matches should not contain form")
         $(".football-team__form").size() should be(0)
+
+        Then("I should see match comments")
+        $(".football-match__comments").getTexts.exists(_.contains("Bolton win 4-2 on penalties")) should equal(true)
       }
     }
 


### PR DESCRIPTION
- Comments are now added to match results.

See here for and example [Local](http://m.thegulocal.com/football/results/2014/apr/12) | [Live](http://www.gu.com/football/results/2014/apr/12)
## Look at me now

![matchcomments](https://cloud.githubusercontent.com/assets/31692/2708622/189dc52c-c4ae-11e3-9267-f346f40ba79a.png)

---

![Bloblob](http://gifrific.com/wp-content/uploads/2012/07/Artosis-Starcraft-2-Commentator-Excited.gif)
