### PR TITLE
Max width on football goal stats

### DIFF
--- a/common/app/assets/stylesheets/module/football/_stats.scss
+++ b/common/app/assets/stylesheets/module/football/_stats.scss
@@ -19,6 +19,8 @@
 .goal-attempts {
     @include fs-data(5);
     color: #ffffff;
+    margin: 0 auto;
+    max-width: $gs-column-width*5;
     overflow: hidden;
     position: relative;
 }


### PR DESCRIPTION
Weight loss on goal posts like you've never seen before.
Don't believe me, just look at the results.
# Before

![goal-biiig](https://cloud.githubusercontent.com/assets/31692/2717655/fae55d10-c543-11e3-94b0-094dd7e16b4b.png)
# After

![small-goals](https://cloud.githubusercontent.com/assets/31692/2717656/fae64f54-c543-11e3-8e97-dc96bff6cd3b.png)

---

![Deflating](http://stream1.gifsoup.com/view4/1899025/balloon-deflate-o.gif)
