### PR TITLE
Add correct relegation lines

### DIFF
--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -108,7 +108,7 @@ td {
 }
 
 .table-row--divider td {
-    border-bottom: 1px dashed $c-neutral1;
+    border-top: 1px dashed $c-neutral1;
 }
 
 .table-row--break td {

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -93,27 +93,27 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
   )
 
   val competitionDefinitions = Seq(
-    Competition("100", "/football/premierleague", "Premier League", "Premier League", "English", showInTeamsList = true, tableDividers = List(4, 5, 17)),
-    Competition("500", "/football/championsleague", "Champions League", "Champions League", "European", tableDividers = List(2, 6, 21)),
-    Competition("510", "/football/uefa-europa-league", "Europa League", "Europa League", "European", tableDividers = List(2)),
+    Competition("100", "/football/premierleague", "Premier League", "Premier League", "English", showInTeamsList = true, tableDividers = List(5, 6, 18)),
+    Competition("500", "/football/championsleague", "Champions League", "Champions League", "European", tableDividers = List(3, 7, 22)),
+    Competition("510", "/football/uefa-europa-league", "Europa League", "Europa League", "European", tableDividers = List(3)),
     Competition("300", "/football/fa-cup", "FA Cup", "FA Cup", "English"),
     Competition("301", "/football/capital-one-cup", "Capital One Cup", "Capital One Cup", "English"),
-    Competition("101", "/football/championship", "Championship", "Championship", "English", showInTeamsList = true, tableDividers = List(2, 6, 21)),
-    Competition("102", "/football/leagueonefootball", "League One", "League One", "English", showInTeamsList = true, tableDividers = List(2, 6, 20)),
-    Competition("103", "/football/leaguetwofootball", "League Two", "League Two", "English", showInTeamsList = true, tableDividers = List(3, 7, 22)),
+    Competition("101", "/football/championship", "Championship", "Championship", "English", showInTeamsList = true, tableDividers = List(3, 7, 22)),
+    Competition("102", "/football/leagueonefootball", "League One", "League One", "English", showInTeamsList = true, tableDividers = List(3, 7, 21)),
+    Competition("103", "/football/leaguetwofootball", "League Two", "League Two", "English", showInTeamsList = true, tableDividers = List(4, 8, 23)),
     Competition("400", "/football/community-shield", "Community Shield", "Community Shield", "English", showInTeamsList = true),
-    Competition("120", "/football/scottish-premiership", "Scottish Premier League", "Scottish Premier League", "Scottish", showInTeamsList = true, tableDividers = List(1, 3, 6, 11)),
-    Competition("121", "/football/scottish-championship", "Scottish Championship", "Scottish Championship", "Scottish", showInTeamsList = true, tableDividers = List(1, 8, 9)),
-    Competition("122", "/football/scottish-league-one", "Scottish League One", "Scottish League One", "Scottish", showInTeamsList = true, tableDividers = List(1, 4, 8, 9)),
-    Competition("123", "/football/scottish-league-two", "Scottish League Two", "Scottish League Two", "Scottish", showInTeamsList = true, tableDividers = List(1, 4)),
+    Competition("120", "/football/scottish-premiership", "Scottish Premier League", "Scottish Premier League", "Scottish", showInTeamsList = true, tableDividers = List(2, 4, 7, 12)),
+    Competition("121", "/football/scottish-championship", "Scottish Championship", "Scottish Championship", "Scottish", showInTeamsList = true, tableDividers = List(2, 9, 10)),
+    Competition("122", "/football/scottish-league-one", "Scottish League One", "Scottish League One", "Scottish", showInTeamsList = true, tableDividers = List(2, 5, 9, 10)),
+    Competition("123", "/football/scottish-league-two", "Scottish League Two", "Scottish League Two", "Scottish", showInTeamsList = true, tableDividers = List(2, 5)),
     Competition("320", "/football/scottishcup", "Scottish Cup", "Scottish Cup", "Scottish"),
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),
     Competition("701", "/football/world-cup-2014-qualifiers", "World Cup 2014 qualifiers", "World Cup 2014 qualifiers", "Internationals"),
     Competition("721", "/football/friendlies", "International friendlies", "Friendlies", "Internationals"),
-    Competition("650", "/football/laligafootball", "La Liga", "La Liga", "European", showInTeamsList = true, tableDividers = List(4, 6, 17)),
-    Competition("620", "/football/ligue1football", "Ligue 1", "Ligue 1", "European", showInTeamsList = true, tableDividers = List(3, 4, 17)),
-    Competition("625", "/football/bundesligafootball", "Bundesliga", "Bundesliga", "European", showInTeamsList = true, tableDividers = List(3, 4, 6, 15, 16)),
-    Competition("635", "/football/serieafootball", "Serie A", "Serie A", "European", showInTeamsList = true, tableDividers = List(3, 5, 17))
+    Competition("650", "/football/laligafootball", "La Liga", "La Liga", "European", showInTeamsList = true, tableDividers = List(5, 7, 18)),
+    Competition("620", "/football/ligue1football", "Ligue 1", "Ligue 1", "European", showInTeamsList = true, tableDividers = List(4, 5, 18)),
+    Competition("625", "/football/bundesligafootball", "Bundesliga", "Bundesliga", "European", showInTeamsList = true, tableDividers = List(4, 5, 7, 16, 17)),
+    Competition("635", "/football/serieafootball", "Serie A", "Serie A", "European", showInTeamsList = true, tableDividers = List(4, 6, 18))
   )
 
   val competitionAgents = competitionDefinitions map { CompetitionAgent(_) }


### PR DESCRIPTION
This solves the semantics of where a relegation line should be .

It also solves the problem of keeping `border-collapse: collapse;` but also showing the relegation line (they weren't showing on embedded tables).

It is now also consistent with the embed tool.
## Prove it

![relegation-lines](https://cloud.githubusercontent.com/assets/31692/2718055/5148985c-c549-11e3-9c4b-f2edde537553.png)

---

![Magic innit](http://greyscalegorilla.com/blog/wp-content/uploads/2011/12/Stripes3.gif)
