### PR TITLE
Match day -> Today's matches with date

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -173,7 +173,7 @@ define([
                         $.create('<div class="js-football-match-day" data-link-name="football-match-day-embed"></div>').each(function (container) {
                             football.matchDayFor(competition, resp.matchDate).fetch(container).then(function() {
                                 extras[1] = {
-                                    name: 'Match day',
+                                    name: 'Today\'s matches',
                                     importance: 2,
                                     content: container,
                                     ready: true

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -39,6 +39,12 @@
     }
 }
 
+.football-matches__date {
+    color: $c-neutral2-contrasted;
+    float: right;
+    font-weight: normal;
+}
+
 .football-match__report {
     position: absolute;
     right: 0;

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -6,7 +6,7 @@
     @matchesList.matchesGroupedByDateAndCompetition.map { case (date, competitionMatches) =>
         <div class="football-matches__day table--small">
             @competitionMatches.map { case (competition, matches) =>
-                @football.views.html.matchList.matchesList(matches, competition, showCaption=true)
+                @football.views.html.matchList.matchesList(matches, competition, Option(date), showCaption=true)
             }
         </div>
     }

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -1,9 +1,9 @@
-@(matchesList: List[FootballMatch], competition: model.Competition, showCaption: Boolean = false)(implicit request: RequestHeader)
+@(matchesList: List[FootballMatch], competition: model.Competition, date: Option[org.joda.time.DateMidnight] = null, showCaption: Boolean = false)(implicit request: RequestHeader)
 @import implicits.Football._
 
 <table class="table football-matches">
     @if(showCaption){
-        <caption><a href="@competition.url">@competition.fullName</a></caption>
+        <caption><a href="@competition.url">@competition.fullName</a>@date.map{ date => <span class="football-matches__date">@date.toString("d MMMM yyyy")</span>}</caption>
     }
     <thead hidden>
         <tr>


### PR DESCRIPTION
After chatting to @mr-mr and Nick Hayley, we've decided to go with "Today's matches" on the matches table.

Match day seemed to vague as to what might be lurking beneath the label.

Today's matches might be semantically wrong in context of the viewer, but in context of the match, it is correct. Given that most match articles are read on the day, or there abouts, we thought this was fine. We have added the date to the table to make sure there is no mix ups.

We also agreed we would put this in front of users to see that they are getting what they expect.
# Too much talking, show me

![today smatches](https://cloud.githubusercontent.com/assets/31692/2718616/6e3e00ac-c551-11e3-9303-26b30c227985.png)

---

![Matches](http://img0.joyreactor.com/pics/post/match-fire-gif-208286.gif)
