### PR TITLE
Remove unused placeholder mixin

### DIFF
--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -257,14 +257,6 @@
     position: sticky;
 }
 
-// Set the properties of placeholder text
-@mixin placeholder {
-    ::-webkit-input-placeholder { @content; }
-    :-moz-placeholder           { @content; }
-    ::-moz-placeholder          { @content; }
-    :-ms-input-placeholder      { @content; }
-}
-
 // Vertical linear gradient with a plain fallback for older browsers
 @mixin simple-gradient($from, $to) {
     // Fix for browsers not understanding transparent


### PR DESCRIPTION
We used to style placeholders but we don't anymore (which is good!).

![ ](https://31.media.tumblr.com/8c2ec92b066a75f874bb523a193afbc9/tumblr_inline_n2x13cFMjZ1raprkq.gif)
