### PR TITLE
Mobile share buttons

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -129,7 +129,7 @@
     }
 }
 .ad-slot--mpu-banner-ad {
-    padding-top: 29px; // Align with bottom of image
+    padding-top: 0px; //Changed when share buttons were moved to the left
     padding-bottom: 37px;
     width: 300px;
     height: 250px;

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -129,7 +129,6 @@
     }
 }
 .ad-slot--mpu-banner-ad {
-    padding-top: 0px; //Changed when share buttons were moved to the left
     padding-bottom: 37px;
     width: 300px;
     height: 250px;

--- a/common/app/assets/stylesheets/module/_social.scss
+++ b/common/app/assets/stylesheets/module/_social.scss
@@ -6,11 +6,16 @@
     overflow: hidden;
 }
 .social-wrapper--aside {
+    display: none;
     padding-top: 0;
     border-top: 1px dotted $c-neutral4;
     @include rem((
         margin-bottom: ($gs-baseline/3)*4
-  ));
+    ));
+
+    @include mq(leftCol) {
+        display: block;
+    }
 }
 
 .social {
@@ -32,7 +37,10 @@
 .social__item {
     float: left;
     width: 30px;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+    @include mq($to: desktop) {
+        margin-right: 10px;
+    }
 }
 .social__action {
     display: block;
@@ -47,7 +55,7 @@
  *     </span>
  * </element>
  */
-@include mq( desktop ){
+@include mq(desktop) {
     .social-icon-wrapper {
         opacity: .6;
 

--- a/common/app/assets/stylesheets/module/_social.scss
+++ b/common/app/assets/stylesheets/module/_social.scss
@@ -39,7 +39,7 @@
     width: 30px;
 
     @include mq($to: desktop) {
-        margin-right: 10px;
+        margin-right: $gs-gutter/2;
     }
 }
 .social__action {


### PR DESCRIPTION
This prevents the share buttons from being shown incorrectly on mobile, ( as shown below ). It also corrects the alignment the mpu banner add on the right hand side
![mobile-share](https://cloud.githubusercontent.com/assets/986155/2732387/ec6b4988-c639-11e3-8607-7d65ed57bf94.png)
