### PR TITLE
Add facia tool to root project

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -151,6 +151,7 @@ object Frontend extends Build with Prototypes {
   val main = root().aggregate(
     common,
     facia,
+    faciaTool,
     article,
     applications,
     sport,


### PR DESCRIPTION
World's smallest pull request

This not being here is why Facia tool does not properly work with an IntelliJ 13 import. I'm raising it as a pull request as the same issue will exist for 
- `dev-build`
- `fronts-endtoend-tests`

and I'm not sure whether or not I should add those, too. Who owns them?
