### PR TITLE
Add missing cache header and tweak cache times

### DIFF
--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -64,6 +64,6 @@ object MatchController extends Controller with Football with Requests with Loggi
     }
 
     // we do not keep historical data, so just redirect old stuff to the results page (see also MatchController)
-    response.getOrElse(Future.successful(Found("/football/results")))
+    response.getOrElse(Future.successful(Cached(30){Found("/football/results")}))
   }
 }

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -56,7 +56,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
       }
     }
 
-    maybeResponse.getOrElse(Future.successful(Cached(300){ JsonNotFound() }))
+    maybeResponse.getOrElse(Future.successful(Cached(30){ JsonNotFound() }))
   }
 
   def moreOnJson(matchId: String) = moreOn(matchId)
@@ -76,7 +76,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
     }
 
     val response: Future[SimpleResult] = maybeResponse.getOrElse(Future { JsonNotFound() })
-    response map { Cached(300) }
+    response map { Cached(60) }
   }
 
   def loadMoreOn(request: RequestHeader, theMatch: FootballMatch): Future[Seq[Content]] = {


### PR DESCRIPTION
This will help mitigate the problems on football articles caused by unfilled agents post-deploy.
