### PR TITLE
Fix avatar-upload redirect url on Edit Public Profile  page

### DIFF
--- a/identity/app/views/fragments/profile/public_profile_form.scala.html
+++ b/identity/app/views/fragments/profile/public_profile_form.scala.html
@@ -47,7 +47,7 @@
                     <li class="form-field">
                         <input type="file" name="file" accept="image/gif, image/jpeg, image/png" />
                         <input type="hidden" name="signed_data" value="@avatarUploadData.signedData" />
-                        <input type="hidden" name="redirect_url" value="@idUrlBuilder.buildUrl("/public/edit", idRequest)">
+                        <input type="hidden" name="redirect_url" value="@idUrlBuilder.buildUrl("/public/edit")">
                     </li>
                     <li>
                         <button type="submit" class="submit-input js-avatar-upload-button" data-link-name="Upload Avatar">Upload</button>


### PR DESCRIPTION
The avatar-upload-service accepts a 'redirect_id' where- once your image is posted - it will return you. Unfortunately, we were defining the field like this in our form:

```
<input type="hidden" name="redirect_url" value="https://profile.theguardian.com/public/edit?returnUrl=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile">
```

The '?returnUrl=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile' part of that url is superfluous, and unfortunately the gu-image-upload service has a bug in /it's/ url construction (where it adds the 'signed_data' parameter) so it attempts to send the user to a subtly invalid url like this:

https://profile.theguardian.com/public/edit?returnUrl=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile?signed_data=eyJ1c2VybmFtZSI6IlJvYmVydG8gVHlsZXkiLCJpbWFnZV91cGxvYWRfc3VjY2VzcyI6dHJ1ZSwidXNlcl9pZCI6IjEyNTk3Mjk3IiwicmVxdWlyZWRfaW1hZ2VfaG9zdCI6Imh0dHA6XC9cL3N0YXRpYy5ndWltLmNvLnVrIiwiaXNfc29jaWFsIjpmYWxzZX0.Xpp86s1Kz1cDLEI_q5UaEeT5kEs

Note that the 'signed_data' is prefixed with a '?' rather than an '&', so the url is now corrupt. The easiest way to avoid this bug is just to remove the superfluous part of our requested redirect_url, which is what this commit does.

The 'idRequest' parameter was responsible for adding this unwanted extra segment:

https://github.com/guardian/frontend/blob/8b51e6d0/identity/app/services/IdentityUrlBuilder.scala#L9-L25

https://jira.gutools.co.uk/browse/IDN-1774
