### PR TITLE
Prevent horizontal overflow on root elements

### DIFF
--- a/common/app/assets/stylesheets/base/_base.scss
+++ b/common/app/assets/stylesheets/base/_base.scss
@@ -14,6 +14,13 @@ body {
     background-color: #ffffff;
 }
 
+@if $old-ie == false {
+    html,
+    body {
+        overflow-x: hidden;
+    }
+}
+
 body:after {
     content: "mobile";
     @include u-h;


### PR DESCRIPTION
This is to prevent any malicious or intentional code from causing scroll overflow on the root elements.

(am doing this in a separate PR to allow the fronts team to ship the multimedia container)

/cc @kaelig 
