### PR TITLE
Facia tool: show article id until headline loads

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -328,7 +328,7 @@
                         click: open">Breaking News</span>
 
                     <a class="headline" target="article" data-bind="
-                        text: meta.headline() || fields.headline(),
+                        text: meta.headline() || fields.headline() || id,
                         attr: {href: id},
                         click: open"></a>
 


### PR DESCRIPTION
Make it easier to carry on editing when ContentApi requests are slow/failing

![fronts-tool](https://cloud.githubusercontent.com/assets/1147913/2776027/9b730f28-cacd-11e3-8803-832854a6978d.png)
