### PR TITLE
Remove unnecessary load path for components

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,10 +33,7 @@ module.exports = function (grunt) {
                     style: 'compressed',
                     sourcemap: true,
                     noCache: true,
-                    quiet: (isDev) ? false : true,
-                    loadPath: [
-                        'common/app/assets/stylesheets/components/sass-mq'
-                    ]
+                    quiet: (isDev) ? false : true
                 }
             }
         },


### PR DESCRIPTION
Due to the gussification (#3966) of components, we no longer need to specify the sass-mq path in the configuration for grunt compilation.

![ ](http://media.giphy.com/media/AonwbCZCgeD5u/giphy.gif)
