### PR TITLE
Commercial: move Article's right MPU into javascript

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -105,9 +105,7 @@
                             <div class="u-table__row">
                                 <div class="u-table__cell u-table__cell--top">
                                     <div class="mpu-context js-right-hand-component">
-                                        <div class="mpu-container js-mpu-ad-slot">
-                                            @fragments.commercial.standardAd(name="right", adType="mpu-banner-ad", sizeMapping=Map("tabletlandscape" -> Seq("300,250")))
-                                        </div>
+                                        <div class="mpu-container js-mpu-ad-slot"></div>
                                         <div class="js-components"></div>
                                     </div>
                                 </div>

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -74,9 +74,7 @@
                             <div class="u-table__row">
                                 <div class="u-table__cell u-table__cell--top">
                                     <div class="mpu-context js-right-hand-component">
-                                        <div class="mpu-container js-mpu-ad-slot">
-                                            @fragments.commercial.standardAd(name="right", adType="mpu-banner-ad", sizeMapping=Map("tabletlandscape" -> Seq("300,250")))
-                                        </div>
+                                        <div class="mpu-container js-mpu-ad-slot"></div>
                                         <div class="js-components"></div>
                                     </div>
                                 </div>

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -286,7 +286,7 @@ define([
 
                 // if it's an article, excluding live blogs, create our inline adverts
                 if (config.switches.standardAdverts && config.page.contentType === 'Article') {
-                    new ArticleAsideAdverts().init();
+                    new ArticleAsideAdverts(config).init();
                     // no inline adverts on live
                     if (!config.page.isLiveBlog) {
                         new ArticleBodyAdverts().init();

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -43,6 +43,7 @@ define([
     'common/modules/ui/message',
     'common/modules/identity/autosignin',
     'common/modules/adverts/article-body-adverts',
+    'common/modules/adverts/article-aside-adverts',
     'common/modules/adverts/collection-adverts',
     'common/modules/adverts/dfp',
     'common/modules/analytics/commercial/tags/container',
@@ -94,6 +95,7 @@ define([
     Message,
     AutoSignin,
     ArticleBodyAdverts,
+    ArticleAsideAdverts,
     CollectionAdverts,
     DFP,
     TagContainer,
@@ -283,8 +285,12 @@ define([
                     options = {};
 
                 // if it's an article, excluding live blogs, create our inline adverts
-                if (config.switches.standardAdverts && config.page.contentType === 'Article' && !config.page.isLiveBlog) {
-                    new ArticleBodyAdverts().init();
+                if (config.switches.standardAdverts && config.page.contentType === 'Article') {
+                    new ArticleAsideAdverts().init();
+                    // no inline adverts on live
+                    if (!config.page.isLiveBlog) {
+                        new ArticleBodyAdverts().init();
+                    }
                 }
 
                 new CollectionAdverts(config).init();

--- a/common/app/assets/javascripts/modules/adverts/article-aside-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-aside-adverts.js
@@ -1,0 +1,37 @@
+define([
+    'common/$',
+    'common/utils/detect',
+    'lodash/objects/assign'
+], function (
+    $,
+    detect,
+    _assign
+) {
+
+    var adSlotTemplate =
+        '<div class="ad-slot ad-slot--dfp ad-slot--mpu-banner-ad" data-link-name="ad slot right" data-name="right" data-mobile="300,50" data-tabletlandscape="300,250">' +
+            '<div id="dfp-ad--right" class="ad-slot__container">' +
+        '</div>';
+
+    function ArticleAsideAdverts(config) {
+        this.config = _assign(this.defaultConfig, config);
+    }
+
+    ArticleAsideAdverts.prototype.defaultConfig = {
+        columnSelector: '.article__secondary-column',
+        adSlotContainerSelector: '.js-mpu-ad-slot'
+    };
+
+    ArticleAsideAdverts.prototype.init = function() {
+        // is the switch off, or is the secondary column hidden
+        if (!this.config.switches.standardAdverts || $(this.config.columnSelector).css('display') === 'none') {
+            return false;
+        }
+
+        return $(this.config.adSlotContainerSelector)
+            .append(adSlotTemplate);
+    };
+
+    return ArticleAsideAdverts;
+
+});

--- a/common/app/assets/javascripts/modules/adverts/article-aside-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-aside-adverts.js
@@ -9,7 +9,7 @@ define([
 ) {
 
     var adSlotTemplate =
-        '<div class="ad-slot ad-slot--dfp ad-slot--mpu-banner-ad" data-link-name="ad slot right" data-name="right" data-mobile="300,50" data-tabletlandscape="300,250">' +
+        '<div class="ad-slot ad-slot--dfp ad-slot--mpu-banner-ad" data-link-name="ad slot right" data-name="right" data-tabletlandscape="300,250">' +
             '<div id="dfp-ad--right" class="ad-slot__container">' +
         '</div>';
 
@@ -19,7 +19,8 @@ define([
 
     ArticleAsideAdverts.prototype.defaultConfig = {
         columnSelector: '.article__secondary-column',
-        adSlotContainerSelector: '.js-mpu-ad-slot'
+        adSlotContainerSelector: '.js-mpu-ad-slot',
+        switches: {}
     };
 
     ArticleAsideAdverts.prototype.init = function() {

--- a/common/app/assets/javascripts/modules/adverts/article-aside-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/article-aside-adverts.js
@@ -1,10 +1,12 @@
 define([
     'common/$',
     'common/utils/detect',
+    'common/utils/page',
     'lodash/objects/assign'
 ], function (
     $,
     detect,
+    page,
     _assign
 ) {
 
@@ -25,12 +27,16 @@ define([
 
     ArticleAsideAdverts.prototype.init = function() {
         // is the switch off, or is the secondary column hidden
-        if (!this.config.switches.standardAdverts || $(this.config.columnSelector).css('display') === 'none') {
+        if (!this.config.switches.standardAdverts) {
             return false;
         }
 
-        return $(this.config.adSlotContainerSelector)
-            .append(adSlotTemplate);
+        return page.rightHandComponentVisible(
+            (function(rightHandComponent) {
+                return $(this.config.adSlotContainerSelector, rightHandComponent)
+                    .append(adSlotTemplate);
+            }).bind(this)
+        );
     };
 
     return ArticleAsideAdverts;

--- a/common/test/assets/javascripts/spec/adverts/article-aside-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/article-aside-adverts.spec.js
@@ -15,7 +15,7 @@ define([
         var fixturesConfig = {
                 id: 'article-aside-adverts',
                 fixtures: [
-                    '<div class="article__secondary-column">' +
+                    '<div class="js-right-hand-component" style="height: 1px">' +
                         '<div class="js-mpu-ad-slot"></div>' +
                     '</div>'
                 ]

--- a/common/test/assets/javascripts/spec/adverts/article-aside-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/article-aside-adverts.spec.js
@@ -1,0 +1,74 @@
+define([
+    'common/$',
+    'bonzo',
+    'helpers/fixtures',
+    'common/modules/adverts/article-aside-adverts'
+], function(
+    $,
+    bonzo,
+    fixtures,
+    ArticleAsideAdverts
+){
+
+    describe('Article Aside Adverts', function() {
+
+        var fixturesConfig = {
+                id: 'article-aside-adverts',
+                fixtures: [
+                    '<div class="article__secondary-column">' +
+                        '<div class="js-mpu-ad-slot"></div>' +
+                    '</div>'
+                ]
+            },
+            createSwitch = function(value){
+                return {
+                    switches: {
+                        standardAdverts: value
+                    }
+                };
+            };
+
+        beforeEach(function() {
+            fixtures.render(fixturesConfig);
+        });
+
+        afterEach(function() {
+            fixtures.clean(fixturesConfig.id);
+        });
+
+        it('should be able to instantiate', function() {
+            var articleAsideAdverts = new ArticleAsideAdverts();
+            expect(articleAsideAdverts).toBeDefined();
+        });
+
+        it('should not initiated if standard-adverts switch is off', function() {
+            var articleAsideAdverts = new ArticleAsideAdverts(createSwitch(false));
+            expect(articleAsideAdverts.init()).toBeFalsy();
+        });
+
+        it('should return the ad slot container on init', function() {
+            var articleAsideAdverts = new ArticleAsideAdverts(createSwitch(true));
+            expect(articleAsideAdverts.init()[0]).toBe($('#' + fixturesConfig.id + ' .js-mpu-ad-slot')[0]);
+        });
+
+        it('should have the correct ad name', function() {
+            var articleAsideAdverts = new ArticleAsideAdverts(createSwitch(true));
+            articleAsideAdverts.init();
+            expect($('#' + fixturesConfig.id + ' .ad-slot').data('name')).toBe('right');
+        });
+
+        it('should have the correct size mappings', function() {
+            var articleAsideAdverts = new ArticleAsideAdverts(createSwitch(true));
+            articleAsideAdverts.init();
+            expect($('#' + fixturesConfig.id + ' .ad-slot').data('tabletlandscape')).toBe('300,250');
+        });
+
+        it('should not add ad slot to hidden column', function() {
+            $('#' + fixturesConfig.id + ' .article__secondary-column').css('display', 'none');
+            var articleAsideAdverts = new ArticleAsideAdverts(createSwitch(true));
+            expect($('#' + fixturesConfig.id + ' .ad-slot').length).toBe(0);
+        });
+
+    });
+
+});


### PR DESCRIPTION
We should not be (css) hiding adverts at certain breakpoints, as it give a false ad impression

In this case, we were only showing the right MPU on articles at breakpoints > tablet landscape.

I've removed the hard-coded slot, and we now create the slot with JS only if the column is visible

Downside is if the page is initially loaded at tablet portrait, and then rotated to tablet landscape, the advert will not be there. We can look into this in the future

![1327602286_cute_bichon_frise_puppy](https://cloud.githubusercontent.com/assets/74132/2789787/df5907d4-cbb2-11e3-992c-2be38e6f90f6.gif)
