### PR TITLE
Commercial: add Media Math tags

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/media-math.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/media-math.js
@@ -24,28 +24,27 @@ define([
         };
 
     return {
-        load: function(config, opts) {
+        load: function(config) {
             config = _defaults(
                 config || {},
                 defaultConfig,
                 {
+                    referrer: document.referrer,
                     switches: {},
                     page: {}
                 }
             );
-            opts = opts || {};
 
             if (!config.switches.mediaMath) {
                 return false;
             }
 
             var page = config.page,
-                referrer = opts.documentReferrer || document.referrer,
                 tags = _pairs({
                     v1: (page.host ? page.host : '') + '/' + page.pageId,
                     v2: page.section,
-                    v3: extractSearchTerm(referrer),
-                    v4: referrer,
+                    v3: extractSearchTerm(config.referrer),
+                    v4: config.referrer,
                     v5: page.keywords ? page.keywords.replace(/,/g, '|') : '',
                     v6: page.contentType ? page.contentType.toLowerCase() : ''
                 })

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/media-math.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/media-math.js
@@ -1,0 +1,63 @@
+define([
+    'common/utils/config',
+    'lodash/objects/defaults',
+    'lodash/objects/pairs'
+], function(
+    defaultConfig,
+    _defaults,
+    _pairs
+) {
+
+    var mediaMathBaseUrl = '//pixel.mathtag.com/event/img?mt_id=328671&mt_adid=114751',
+        extractSearchTerm = function (referrer) {
+            return referrer
+                .split('?')
+                .pop()
+                .split('&')
+                .filter(function(query) {
+                    return ['q','p','as_q','as_epq','as_oq','query','search','wd','ix'].indexOf(query.split('=').shift()) > -1;
+                })
+                .map(function(searchQuery) {
+                    return decodeURIComponent(searchQuery.split('=').pop().replace(/\\+/g, ' '));
+                })
+                .shift();
+        };
+
+    return {
+        load: function(config, opts) {
+
+            _defaults(
+                config,
+                defaultConfig,
+                {
+                    switches: {},
+                    page: {}
+                }
+            );
+            opts = opts || {};
+
+            if (!config.switches.mediaMath) {
+                return false;
+            }
+
+            var page = config.page,
+                referrer = opts.documentReferrer || document.referrer,
+                tags = _pairs({
+                    v1: page.host + '/' + page.pageId,
+                    v2: page.section,
+                    v3: extractSearchTerm(referrer),
+                    v4: referrer,
+                    v5: page.keywords ? page.keywords.replace(/,/g, '|') : '',
+                    v6: page.contentType ? page.contentType.toLowerCase() : ''
+                })
+                    // turn into a query string
+                    .map(function (pair) { return pair.join('='); })
+                    .join('&');
+
+            var img = new Image();
+            img.src = mediaMathBaseUrl + '&' + tags;
+            return img;
+        }
+    };
+
+});

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/common/media-math.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/common/media-math.js
@@ -25,9 +25,8 @@ define([
 
     return {
         load: function(config, opts) {
-
-            _defaults(
-                config,
+            config = _defaults(
+                config || {},
                 defaultConfig,
                 {
                     switches: {},
@@ -43,7 +42,7 @@ define([
             var page = config.page,
                 referrer = opts.documentReferrer || document.referrer,
                 tags = _pairs({
-                    v1: page.host + '/' + page.pageId,
+                    v1: (page.host ? page.host : '') + '/' + page.pageId,
                     v2: page.section,
                     v3: extractSearchTerm(referrer),
                     v4: referrer,

--- a/common/app/assets/javascripts/modules/analytics/commercial/tags/container.js
+++ b/common/app/assets/javascripts/modules/analytics/commercial/tags/container.js
@@ -4,17 +4,19 @@
 define([
     'common/modules/analytics/commercial/tags/common/audience-science',
     'common/modules/analytics/commercial/tags/common/imrworldwide',
+    'common/modules/analytics/commercial/tags/common/media-math',
     'common/modules/analytics/commercial/tags/au/amaa',
     'common/modules/analytics/commercial/tags/au/effective-measure'
 ], function(
     AudienceScience,
     IMRWorldwide,
+    mediaMath,
     Amaa,
     EffectiveMeasure
 ) {
 
     function init(config) {
-        
+
         switch (config.page.edition.toLowerCase()) {
 
             case 'au':
@@ -22,7 +24,7 @@ define([
                 if (config.switches.amaa) {
                     Amaa.load();
                 }
-                
+
                 if (config.switches.effectiveMeasure) {
                     EffectiveMeasure.load();
                 }
@@ -34,19 +36,21 @@ define([
                 break;
 
             default:
-                
+
                 if (config.switches.audienceScience) {
                     AudienceScience.load(config.page);
                 }
-                
+
                 if (config.switches.imrWorldwide) {
                     IMRWorldwide.load();
                 }
-                
+
                 break;
         }
+
+        mediaMath.load();
     }
-    
+
     return {
         init: init
     };

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -159,6 +159,10 @@ object Switches extends Collections {
     "Enable Forsee surveys for a sample of our audience",
     safeState = Off, sellByDate = new DateMidnight(2014,5,1)) // 3 month trial
 
+  val MediaMathSwitch = Switch("Commercial Tags", "media-math",
+    "Enable Media Math audience segment tracking",
+    safeState = Off, sellByDate = never)
+
   // Commercial Feeds
 
   val TravelOffersFeedSwitch = Switch("Performance Switches", "gu-travel-offers",
@@ -414,6 +418,7 @@ object Switches extends Collections {
     EffectiveMeasureSwitch,
     ImrWorldwideSwitch,
     ForeseeSwitch,
+    MediaMathSwitch,
     DiagnosticsLogging,
     TravelOffersFeedSwitch,
     JobFeedSwitch,

--- a/common/test/assets/javascripts/spec/analytics/commercial/tags/common/media-math.spec.js
+++ b/common/test/assets/javascripts/spec/analytics/commercial/tags/common/media-math.spec.js
@@ -4,12 +4,13 @@ define([
     mediaMath
 ){
 
-    function createConfig(switchValue, page) {
+    function createConfig(switchValue, page, referrer) {
         return {
             switches: {
                 mediaMath: switchValue
             },
-            page: page
+            page: page,
+            referrer: referrer
         };
     };
     function extractParam(img, paramName) {
@@ -47,13 +48,13 @@ define([
         });
 
         it('should send the correct "v3" param', function() {
-            var img = mediaMath.load(createConfig(true), { documentReferrer: "http://www.google.com?foo=bar&q=a search\\\\another one" });
+            var img = mediaMath.load(createConfig(true, {}, "http://www.google.com?foo=bar&q=a search\\\\another one"));
             expect(extractParam(img, 'v3')).toBe('a%20search%20another%20one');
         });
 
         it('should send the correct "v4" param', function() {
             var referrer = 'http://www.google.com',
-                img = mediaMath.load(createConfig(true), { documentReferrer: referrer });
+                img = mediaMath.load(createConfig(true, {}, referrer));
             expect(extractParam(img, 'v4')).toBe(referrer);
         });
 

--- a/common/test/assets/javascripts/spec/analytics/commercial/tags/common/media-math.spec.js
+++ b/common/test/assets/javascripts/spec/analytics/commercial/tags/common/media-math.spec.js
@@ -1,0 +1,72 @@
+define([
+    'common/modules/analytics/commercial/tags/common/media-math'
+], function(
+    mediaMath
+){
+
+    function createConfig(switchValue, page) {
+        return {
+            switches: {
+                mediaMath: switchValue
+            },
+            page: page
+        };
+    };
+    function extractParam(img, paramName) {
+        var paramValue = new RegExp(paramName + '=([^&]*)').exec(img.src);
+        return paramValue && paramValue[1];
+    }
+
+    describe('Media Math', function() {
+
+        it('should not load if "mediaMath" switch is off', function() {
+            expect(mediaMath.load(createConfig(false))).toBeFalsy();
+        });
+
+        it('should return the image element', function() {
+            var img = mediaMath.load(createConfig(true));
+            expect(img.nodeName.toLowerCase()).toBe('img');
+        });
+
+        it('should have the correct base for the img url', function() {
+            var img = mediaMath.load(createConfig(true));
+            expect(img.src.indexOf('http://pixel.mathtag.com/event/img?mt_id=328671&mt_adid=114751')).toBe(0);
+        });
+
+        it('should send the correct "v1" param', function() {
+            var host = 'http://www.theguardian.com',
+                pageId = 'uk-news/2014/apr/24/crime-rate-england-wales-falls-lowest-level-33-years',
+                img = mediaMath.load(createConfig(true, { host: 'http://www.theguardian.com', pageId: pageId }));
+            expect(extractParam(img, 'v1')).toBe(host + '/' + pageId);
+        });
+
+        it('should send the correct "v2" param', function() {
+            var section = 'uk-news',
+                img = mediaMath.load(createConfig(true, { section: section }));
+            expect(extractParam(img, 'v2')).toBe(section);
+        });
+
+        it('should send the correct "v3" param', function() {
+            var img = mediaMath.load(createConfig(true), { documentReferrer: "http://www.google.com?foo=bar&q=a search\\\\another one" });
+            expect(extractParam(img, 'v3')).toBe('a%20search%20another%20one');
+        });
+
+        it('should send the correct "v4" param', function() {
+            var referrer = 'http://www.google.com',
+                img = mediaMath.load(createConfig(true), { documentReferrer: referrer });
+            expect(extractParam(img, 'v4')).toBe(referrer);
+        });
+
+        it('should send the correct "v5" param', function() {
+            var img = mediaMath.load(createConfig(true, { keywords: 'Crime,UK news,Police'}));
+            expect(extractParam(img, 'v5')).toBe('Crime|UK%20news|Police');
+        });
+
+        it('should send the correct "v6" param', function() {
+            var img = mediaMath.load(createConfig(true, { contentType: 'Article'}));
+            expect(extractParam(img, 'v6')).toBe('article');
+        });
+
+    });
+
+});


### PR DESCRIPTION
Basically a port of https://github.com/guardian/r2-frontend/blob/master/r2frontend-static/src/main/resources/common/scripts/mediamath-tag.js 

![1285842896_sidewalk-car-crash](https://cloud.githubusercontent.com/assets/74132/2792537/322111e8-cbd4-11e3-9223-8ac607f0e836.gif)
