### PR TITLE
Facia tool: batch ids for CAPI requests

### DIFF
--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -35,6 +35,14 @@ function (
     }
 
     function decorateItems (articles) {
+        var num = vars.CONST.capiBatchSize || 10;
+
+        _.each(_.range(0, articles.length, num), function(index) {
+            decorateBatch(articles.slice(index, index + num));
+        });
+    }
+
+    function decorateBatch (articles) {
         var ids = [];
 
         articles.forEach(function(article){

--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -23,11 +23,15 @@ define(['knockout'], function(ko) {
         groups: ['standard,big,very big,huge'],
 
         viewer: 'http://s3-eu-west-1.amazonaws.com/facia/responsive-viewer.html',
+
         filterTypes: {
             section: { display: 'in section:', param: 'section', path: 'sections', placeholder: 'e.g. news' },
             tag:     { display: 'with tag:',   param: 'tag',     path: 'tags',     placeholder: 'e.g. sport/triathlon' }
         },
+
         searchPageSize:        50,
+
+        capiBatchSize:         10,
 
         collectionsPollMs:     10000,
         latestArticlesPollMs:  20000,


### PR DESCRIPTION
We're hitting CAPI's current 2048 byte limit on URL length when querying for a large number of content ids. Mitigate this by making multiple requests for batches of 10. 
