### PR TITLE
Put RHC back into flow

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -578,6 +578,7 @@
     .article__secondary-column {
         position: relative;
         display: table-cell;
+        z-index: 1;
         @include rem((
             width: $a-rightCol-width
         ));


### PR DESCRIPTION
As the DOM flow is Article, RHC, Other bits (discussion, story packages) if we apply the `.article__secondary-column__inner--fill-vertically` the interactivity of the RHC is lost as it's overlapped by the next elements in the DOM.

This fixes that.

![flowbug](https://cloud.githubusercontent.com/assets/31692/2799365/af5c29b0-cc5e-11e3-8238-21836c0f5bc4.png)

---

![Go with the flow](http://stream1.gifsoup.com/view/17030/waterfall-o.gif)
