### PR TITLE
Adding scoreboard to football previews

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -132,7 +132,7 @@ define([
                     scoreBoard.template = match.pageType === 'report' ? resp.scoreSummary : resp.matchSummary;
 
                     // only show scores on liveblogs or started matches
-                    if(!/^\s+$/.test(scoreBoard.template) && (config.page.isLiveBlog || resp.hasStarted)) {
+                    if(!/^\s+$/.test(scoreBoard.template)) {
                         scoreBoard.render(scoreContainer);
 
                         if (match.pageType === 'report') {
@@ -143,6 +143,8 @@ define([
                                 });
                             });
                         }
+                    } else {
+                        $h.removeClass('u-h');
                     }
 
                     // match stats


### PR DESCRIPTION
Fixes #3954 & #4002.
Bugfix: If there is no template it replaces the header.

![scoreonpreview](https://cloud.githubusercontent.com/assets/31692/2802047/ef3193ce-cc89-11e3-8636-c741d455135e.png)

---

![Score!](http://usedwigs.com/wp-content/uploads/2010/06/soccergif08.gif)
