### PR TITLE
Add minimal-ui attribute to the viewport meta tag

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -42,7 +42,7 @@
     <meta name="msapplication-TileColor" content="#004983" />
     <meta name="msapplication-TileImage" content="@Static("images/favicons/windows_tile_144_b.png")" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="HandheldFriendly" content="True" />
 


### PR DESCRIPTION
With iOS 7.1 beta 2 Apple added a new viewport meta tag that allows us to minimize the top and bottom bars in Safari on the iPhone. It’ll be basically the same behaviour as if the user starts to scroll. In the past we had to do this with a little trick and trigger the behaviour with a 1px scroll when the page was loaded.

/cc @kaelig 
