### PR TITLE
Include mostViewed when parsing capi results

### DIFF
--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -97,7 +97,7 @@ function (
             url: vars.CONST.apiSearchBase + '/' + apiUrl
         }).always(function(resp) {
             var items = resp.response ?
-                        _.chain(['editorsPicks', 'results'])
+                        _.chain(['editorsPicks', 'results', 'mostViewed'])
                          .filter(function(key) { return _.isArray(resp.response[key]); })
                          .map(function(key) { return resp.response[key]; })
                          .flatten()


### PR DESCRIPTION
Include `mostViewed` when parsing capi results, so that queries in Most Popular collections validate:

![fronst-tool](https://cloud.githubusercontent.com/assets/1147913/2815335/a4cd14f8-ceb8-11e3-856a-2b7f3d347262.png)
