### PR TITLE
Adding configuration for new facia pages

### DIFF
--- a/facia/app/controllers/FrontPage.scala
+++ b/facia/app/controllers/FrontPage.scala
@@ -261,6 +261,19 @@ object FrontPage {
         "is-front" -> true
       )
     },
+    new FrontPage(isNetworkFront = false) {
+      override val id = "environment"
+      override val section = "environment"
+      override val webTitle = " Environment news, comment and analysis from the Guardian"
+      override lazy val analyticsName = "GFE:Environment"
+      override lazy val description = Some("Environment news, comment and discussion on key green, environmental and climate change issues from the Guardian")
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Environment",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
 
     //TODO important this one is last for matching purposes
     new FrontPage(isNetworkFront = true) {

--- a/facia/app/controllers/FrontPage.scala
+++ b/facia/app/controllers/FrontPage.scala
@@ -111,7 +111,7 @@ object FrontPage {
 
     new FrontPage(isNetworkFront = false) {
       override val id = "lifeandstyle/love-and-sex"
-      override val section = "lifeandstyle"
+      override val section = "Life and style"
       override val webTitle = "Love and sex"
       override lazy val analyticsName = "GFE:Love and sex"
       override lazy val description = Some("Sex and relationship advice from the Guardian. Sexual health matters, sexuality, information and sex tips all discussed")
@@ -125,7 +125,7 @@ object FrontPage {
 
     new FrontPage(isNetworkFront = false) {
       override val id = "lifeandstyle/home-and-garden"
-      override val section = "lifeandstyle"
+      override val section = "Life and style"
       override val webTitle = "Home and garden"
       override lazy val analyticsName = "GFE:Home and garden"
       override lazy val description = Some("Latest home and garden news, comment and analysis from the Guardian, the world’s leading liberal voice")
@@ -270,6 +270,19 @@ object FrontPage {
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Environment",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+    new FrontPage(isNetworkFront = false) {
+      override val id = "technology"
+      override val section = "technology"
+      override val webTitle = " Technology news, comment and analysis"
+      override lazy val analyticsName = "GFE:Technology"
+      override lazy val description = Some("Latest technology news, comment and analysis from the Guardian, the world's leading liberal voice")
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Technology",
         "content-type" -> "Section",
         "is-front" -> true
       )

--- a/facia/app/controllers/FrontPage.scala
+++ b/facia/app/controllers/FrontPage.scala
@@ -16,7 +16,7 @@ object FrontPage {
       override val section = "sport"
       override val webTitle = "Sport news, comment and results"
       override lazy val analyticsName = "GFE:sport"
-      override lazy val description = Some("Latest sport news, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val description = Some("Sport news, results, fixtures, blogs and comments on UK and world sport from the Guardian, the world's leading liberal voice")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Sport",
@@ -30,7 +30,7 @@ object FrontPage {
       override val section = "money"
       override val webTitle = "Personal finance and money news, analysis and comment"
       override lazy val analyticsName = "GFE:money"
-      override lazy val description = Some("Latest money news, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val description = Some("Latest personal finance and money news, comment and information on your property, mortgages, insurance, savings and investments from the Guardian, the world's leading liberal voice")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Money",
@@ -44,7 +44,7 @@ object FrontPage {
       override val section = "commentisfree"
       override val webTitle = "Comment is free"
       override lazy val analyticsName = "GFE:commentisfree"
-      override lazy val description = Some("Latest comment is free news, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val description = Some("Latest comment, analysis and discussion from the Guardian. CP Scott: &quot;Comment is free, but facts are sacred&quot;")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Comment is free",
@@ -58,7 +58,7 @@ object FrontPage {
       override val section = "business"
       override val webTitle = "Latest financial, market &amp; economic news and analysis"
       override lazy val analyticsName = "GFE:business"
-      override lazy val description = Some("Latest business news, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val description = Some("Latest financial, market &amp; economic news and analysis")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Business",
@@ -72,7 +72,7 @@ object FrontPage {
       override val section = "culture"
       override val webTitle = "Culture"
       override lazy val analyticsName = "GFE:culture"
-      override lazy val description = Some("Latest culture news, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val description = Some("Culture news, comment, video and pictures from The Guardian")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Culture",
@@ -81,57 +81,15 @@ object FrontPage {
       )
     },
 
-    new FrontPage(isNetworkFront = true) {
-      override val id = "uk-alpha"
-      override val section = ""
-      override val webTitle = "Latest news, sport and comment from the Guardian"
-      override lazy val analyticsName = "GFE:Network Front Alpha"
-      override lazy val description = Some("Latest news, comment and analysis from the Guardian, the world’s leading liberal voice")
-      override lazy val rssPath = Some(s"/rss")
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = true) {
-      override val id = "au-alpha"
-      override val section = ""
-      override val webTitle = "Latest news, sport and comment from the Guardian"
-      override lazy val analyticsName = "GFE:Network Front Alpha"
-      override lazy val description = Some("Latest news, comment and analysis from the Guardian, the world’s leading liberal voice")
-      override lazy val rssPath = Some(s"/rss")
-
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    },
-
-    new FrontPage(isNetworkFront = true) {
-      override val id = "us-alpha"
-      override val section = ""
-      override val webTitle = "Latest news, sport and comment from the Guardian"
-      override lazy val analyticsName = "GFE:Network Front Alpha"
-      override lazy val description = Some("Latest news, comment and analysis from the Guardian, the world’s leading liberal voice")
-      override lazy val rssPath = Some(s"/rss")
-      
-      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "content-type" -> "Network Front",
-        "is-front" -> true
-      )
-    },
-
     new FrontPage(isNetworkFront = false) {
       override val id = "business/companies"
       override val section = "business"
       override val webTitle = "Companies"
-      override lazy val analyticsName = "GFE:Business"
-      override lazy val description = Some("Latest busines news, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val analyticsName = "GFE:Companies"
+      override lazy val description = Some("Latest company news, comment and analysis from the Guardian, the world’s leading liberal voice")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Business",
+        "keywords" -> "Companies",
         "content-type" -> "Section",
         "is-front" -> true
       )
@@ -141,11 +99,11 @@ object FrontPage {
       override val id = "world/asia"
       override val section = "world"
       override val webTitle = "Asia"
-      override lazy val analyticsName = "GFE:World"
+      override lazy val analyticsName = "GFE:Asia"
       override lazy val description = Some("Latest Asian news, comment and analysis from the Guardian, the world’s leading liberal voice")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "World",
+        "keywords" -> "Asia",
         "content-type" -> "Section",
         "is-front" -> true
       )
@@ -155,8 +113,8 @@ object FrontPage {
       override val id = "lifeandstyle/love-and-sex"
       override val section = "lifeandstyle"
       override val webTitle = "Love and sex"
-      override lazy val analyticsName = "GFE:Life and style"
-      override lazy val description = Some("Latest love and sex news, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val analyticsName = "GFE:Love and sex"
+      override lazy val description = Some("Sex and relationship advice from the Guardian. Sexual health matters, sexuality, information and sex tips all discussed")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Life and style",
@@ -169,11 +127,11 @@ object FrontPage {
       override val id = "lifeandstyle/home-and-garden"
       override val section = "lifeandstyle"
       override val webTitle = "Home and garden"
-      override lazy val analyticsName = "GFE:Life and style"
+      override lazy val analyticsName = "GFE:Home and garden"
       override lazy val description = Some("Latest home and garden news, comment and analysis from the Guardian, the world’s leading liberal voice")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-        "keywords" -> "Life and style",
+        "keywords" -> "Home and garden",
         "content-type" -> "Section",
         "is-front" -> true
       )
@@ -223,12 +181,82 @@ object FrontPage {
     new FrontPage(isNetworkFront = false) {
       override val id = "lifeandstyle"
       override val section = "Life and style"
-      override val webTitle = "The Guardian"
+      override val webTitle = "Life"
       override lazy val analyticsName = "GFE:Life and style"
-      override lazy val description = Some("Latest life and style, comment and analysis from the Guardian, the world’s leading liberal voice")
+      override lazy val description = Some("Latest news and comment on life and style from the Guardian")
 
       override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
         "keywords" -> "Life and style",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+      
+    new FrontPage(isNetworkFront = false) {
+      override val id = "education"
+      override val section = "Education"
+      override val webTitle = "Education news, comment and analysis"
+      override lazy val analyticsName = "GFE:Education"
+      override lazy val description = Some("Latest education news, comment and analysis on schools, colleges, universities, further and higher education and teaching from the Guardian, the world's leading liberal voice")
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Education",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+    
+    new FrontPage(isNetworkFront = false) {
+      override val id = "fashion"
+      override val section = "fashion"
+      override val webTitle = "Fashion news, advice and pictures"
+      override lazy val analyticsName = "GFE:Fashion"
+      override lazy val description = Some("The latest fashion news, advice and comment  from the Guardian")
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Fashion",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+    
+    new FrontPage(isNetworkFront = false) {
+      override val id = "science"
+      override val section = "science"
+      override val webTitle = "Science"
+      override lazy val analyticsName = "GFE:Science"
+      override lazy val description = Some("Latest news and comment on Science from the Guardian")
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Science",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+
+    new FrontPage(isNetworkFront = false) {
+      override val id = "travel"
+      override val section = "travel"
+      override val webTitle = "Travel news, travel guides and reviews"
+      override lazy val analyticsName = "GFE:Travel"
+      override lazy val description = Some("Latest travel news and reviews on UK and world holidays, travel guides to global destinations, city breaks, hotels and restaurant information from the Guardian, the world's leading liberal voice")
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "Travel",
+        "content-type" -> "Section",
+        "is-front" -> true
+      )
+    },
+    
+    new FrontPage(isNetworkFront = false) {
+      override val id = "world/usa"
+      override val section = "world"
+      override val webTitle = "United States"
+      override lazy val analyticsName = "GFE:US News"
+      override lazy val description = Some("Latest news and comment on United States from the Guardian")
+
+      override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
+        "keywords" -> "US News",
         "content-type" -> "Section",
         "is-front" -> true
       )


### PR DESCRIPTION
This configuration file should contain all fronts created within Facia.

I've updated those that were in there already ensuring WebTitles, Descriptions and Analytics names updated are correct.

Added new fronts so that titles and meta descriptions are correct and added Sections so that the correct navigation is displayed when on that page.
