### PR TITLE
Comment scss-lint out while we sort out the build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "https://rubygems.org"
 
 gem "sass", "~> 3.3.6"
-gem "scss-lint"
+
+# group :development do
+#   gem "scss-lint"
+# end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rainbow (2.0.0)
     sass (3.3.6)
-    scss-lint (0.23.1)
-      rainbow (~> 2.0)
-      sass (~> 3.3.0)
 
 PLATFORMS
   java
@@ -13,4 +9,3 @@ PLATFORMS
 
 DEPENDENCIES
   sass (~> 3.3.6)
-  scss-lint


### PR DESCRIPTION
A gem (rainbow) requires a dependency that works with Ruby >= 1.9.2.
We use 1.8.7.

![ ](http://media.giphy.com/media/qvwCuMCPd5AaY/giphy.gif)
