### PR TITLE
Commercial: styling for article advertisement feature

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -9,7 +9,7 @@
         </span>
     </h2>
     <div class="article-wrapper monocolumn-wrapper tone-@VisualTone(article)">
-        <article id="article" class="article @if(article.isLive){is-live}"
+        <article id="article" class="article @if(article.isLive){is-live} @if(article.isAdvertisementFeature){article--advertisement-feature}"
                  itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
 
             @if(ABHomeComponent.isSwitchedOn && article.hasMainPicture) {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -129,6 +129,7 @@
     }
 }
 .ad-slot--mpu-banner-ad {
+    padding-top: 0;
     padding-bottom: 37px;
     width: 300px;
     height: 250px;

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -7,7 +7,6 @@
 }
 .article--advertisement-feature {
     @include f-textsans;
-    @include font-size(16, 24);
 }
 
 .article__zone {

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -5,6 +5,10 @@
     ));
     @include fs-bodyCopy(3);
 }
+.article--advertisement-feature {
+    @include f-textsans;
+    @include font-size(16, 24);
+}
 
 .article__zone {
     @include fs-header(3);


### PR DESCRIPTION
Currently just changing body text to `textSans` - debate to be had around whether we want to include another font (`displaySans`) for the headlines

![screen shot 2014-04-28 at 17 15 20](https://cloud.githubusercontent.com/assets/74132/2819612/6e7a6eb8-cef0-11e3-9c72-51b8b94def16.png)
