### PR TITLE
Complete the magic of the ajax absolute URL

### DIFF
--- a/common/app/assets/javascripts/utils/ajax.js
+++ b/common/app/assets/javascripts/utils/ajax.js
@@ -8,14 +8,10 @@ define([
         throw new Error('AJAX has not been initialised yet');
     };
 
-    var edition = function () {
-        throw new Error('Edition has not been initialised yet');
-    };
-
-
     function ajax(params) {
         if (!params.url.match('^https?://')) {
             params.url = makeAbsolute(params.url);
+            params.crossOrigin = true;
         }
         return ajax.reqwest(params);
     }
@@ -23,9 +19,6 @@ define([
     ajax.reqwest = reqwest; // expose publicly so we can inspect it in unit tests
 
     ajax.init = function (config) {
-
-        edition = config.page.edition;
-
         makeAbsolute = function (url) {
             return config.page.ajaxUrl + url;
         };


### PR DESCRIPTION
The theory for doing this is:
- In development we do not use the `ajaxUrl` property so all URLs aren't `crossOrigin`.
- When releasing to `code` / `prod`, we are now magically put into a `crossOrigin` situation.

This way when we force you into that situation, we make sure we make the necessary accommodations.
We could do a check on `if (location.host !== url.host)` but seems overkill and it works without it.

Now we don't have to have something working locally, that breaks when we release it.

Fixes #3534 due to [this](https://github.com/guardian/frontend/blob/master/common/app/assets/javascripts/bootstraps/football.js#L247).

![Magic hands!](http://cdn.theatlantic.com/static/easel/images/galleries/120051_romney_sparkles_jazz_hands.gif)
