### PR TITLE
Facia tool title default

### DIFF
--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -17,6 +17,8 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
 
   //Intentionally blank
   val defaultTitle: String = ""
+  val defaultCollectionType: String = "news"
+  val defaultEmail: String = "guardian.frontend.fronts@theguardian.com"
 
   case class Item(
                    id: String,
@@ -74,13 +76,13 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
     val maybeBlock = FaciaApi.getBlock(config.id)
 
     ContentApiPut(
-      config.collectionType.getOrElse("news"),
+      config.collectionType.getOrElse(defaultCollectionType),
       config.displayName.getOrElse(defaultTitle),
       config.groups,
       maybeBlock map { block => generateItems(block.live) } getOrElse Nil,
       config.contentApiQuery,
       maybeBlock map { _.lastUpdated } getOrElse { DateTime.now.toString },
-      maybeBlock map { _.updatedEmail } getOrElse { "guardian.frontend.fronts@theguardian.com" }
+      maybeBlock map { _.updatedEmail } getOrElse { defaultEmail }
     )
   }
 

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -22,7 +22,7 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
 
   case class ContentApiPut(
                             `type`: String,
-                            title: Option[String],
+                            title: String,
                             groups: Seq[String],
                             curatedContent: Seq[Item],
                             backfill: Option[String],

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -15,6 +15,9 @@ import org.joda.time.DateTime
 
 trait ContentApiWrite extends ExecutionContexts with Logging {
 
+  //Intentionally blank
+  val defaultTitle: String = ""
+
   case class Item(
                    id: String,
                    metadata: Option[Map[String, JsValue]]
@@ -72,7 +75,7 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
 
     ContentApiPut(
       config.collectionType.getOrElse("news"),
-      config.displayName,
+      config.displayName.getOrElse(defaultTitle),
       config.groups,
       maybeBlock map { block => generateItems(block.live) } getOrElse Nil,
       config.contentApiQuery,


### PR DESCRIPTION
MAPI requires the title of a collection to exist. If there is no title, instead of it not existing in the JSON, this ensures that the key exists, even as a blank string.

@stephanfowler @robertberry 
