### PR TITLE
Fix the priority of pressing for displayName

### DIFF
--- a/facia-tool/app/frontpress/FrontPress.scala
+++ b/facia-tool/app/frontpress/FrontPress.scala
@@ -81,7 +81,7 @@ trait FrontPress extends Logging {
     Json.toJson(
       CollectionJson(
         apiQuery       = config.contentApiQuery,
-        displayName    = collection.displayName orElse config.displayName,
+        displayName    = config.displayName.orElse(collection.displayName),
         curated        = collection.curated.map(generateTrailJson),
         editorsPicks   = collection.editorsPicks.map(generateTrailJson),
         mostViewed     = collection.mostViewed.map(generateTrailJson),


### PR DESCRIPTION
Before, the `Collection.displayName` took priority over `Config.displayName`, this has now reversed.

@stephanfowler 
