### PR TITLE
Fronts components in admin

### DIFF
--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -99,7 +99,6 @@ object FrontsController extends Controller with ExecutionContexts with GetPaClie
   }
 
   private def previewFrontsComponent(snapFields: SnapFields): Future[SimpleResult] = {
-    print(snapFields)
     val result = (for {
       previewResponse <- WS.url(snapFields.uri).get()
     } yield {

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -1,0 +1,74 @@
+package controllers.admin
+
+import play.api.mvc.{Action, Controller}
+import play.api.libs.ws.WS
+import play.api.templates.Html
+import common.ExecutionContexts
+import football.services.GetPaClient
+import football.model.PA
+import model.Cached
+import conf.Configuration
+
+object FrontsController extends Controller with ExecutionContexts with GetPaClient {
+  def index = Action.async { implicit request =>
+    for {
+      competitions <- client.competitions.map(PA.filterCompetitions)
+    } yield {
+      Cached(3600)(Ok(views.html.football.fronts.index(competitions)))
+    }
+  }
+
+  def matchDay = Action.async { implicit request =>
+    val url = s"${Configuration.sport.apiUrl}/football/live.json"
+    WS.url(url).get().map { response =>
+      val embedContent = (response.json \ "html").as[String]
+      Cached(60)(Ok(views.html.football.fronts.viewEmbed(url, "Live matches", Html(embedContent))))
+    }
+  }
+
+  def resultsRedirect = Action { implicit request =>
+    val submission = request.body.asFormUrlEncoded.get
+    val competitionId = submission.get("competition").get.head
+    Cached(60)(SeeOther(s"/admin/football/fronts/results/$competitionId"))
+  }
+
+  def results(competition: String) = Action.async { implicit request =>
+    val url =
+      if ("all" == competition) s"${Configuration.sport.apiUrl}/football/results.json"
+      else s"${Configuration.sport.apiUrl}/football/$competition/results.json"
+    WS.url(url).get().map { response =>
+      val embedContent = (response.json \ "html").as[String]
+      Cached(60)(Ok(views.html.football.fronts.viewEmbed(url, "Results", Html(embedContent))))
+    }
+  }
+
+  def fixturesRedirect = Action { implicit request =>
+    val submission = request.body.asFormUrlEncoded.get
+    val competitionId = submission.get("competition").get.head
+    Cached(60)(SeeOther(s"/admin/football/fronts/fixtures/$competitionId"))
+  }
+
+  def fixtures(competition: String) = Action.async { implicit request =>
+    val url =
+      if ("all" == competition) s"${Configuration.sport.apiUrl}/football/fixtures.json"
+      else s"${Configuration.sport.apiUrl}/football/$competition/fixtures.json"
+    WS.url(url).get().map { response =>
+      val embedContent = (response.json \ "html").as[String]
+      Cached(60)(Ok(views.html.football.fronts.viewEmbed(url, "Fixtures", Html(embedContent))))
+    }
+  }
+
+  def tablesRedirect = Action { implicit request =>
+    val submission = request.body.asFormUrlEncoded.get
+    val competitionId = submission.get("competition").get.head
+    Cached(60)(SeeOther(s"/admin/football/fronts/tables/$competitionId"))
+  }
+
+  def tables(competition: String) = Action.async { implicit request =>
+    val url = s"${Configuration.sport.apiUrl}/football/$competition/table.json"
+    WS.url(url).get().map { response =>
+      val embedContent = (response.json \ "html").as[String]
+      Cached(60)(Ok(views.html.football.fronts.viewEmbed(url, "Table", Html(embedContent))))
+    }
+  }
+}

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -65,6 +65,9 @@ object FrontsController extends Controller with ExecutionContexts with GetPaClie
   }
 
   def tables(competition: String) = Action.async { implicit request =>
+    for {
+      competition <- None
+    } yield 1
     val url = s"${Configuration.sport.apiUrl}/football/$competition/table.json"
     WS.url(url).get().map { response =>
       val embedContent = (response.json \ "html").as[String]

--- a/admin/app/football/controllers/TeamController.scala
+++ b/admin/app/football/controllers/TeamController.scala
@@ -21,21 +21,6 @@ object TeamController extends Controller with ExecutionContexts with GetPaClient
     Cached(60)(Ok(views.html.football.team.teamIndex(teams)))
   }
 
-  def redirectToSquadPictures = Authenticated { request =>
-    val submission = request.body.asFormUrlEncoded.get
-    val teamId = submission.get("team").get.head
-    NoCache(SeeOther(s"/admin/football/team/images/$teamId"))
-  }
-
-  def squadPictures(teamId: String) = Authenticated.async { request =>
-    client.squad(teamId).map { squad =>
-      val players = squad.map { squadMember =>
-        Player(squadMember.playerId, teamId, squadMember.name)
-      }
-      Cached(60)(Ok(views.html.football.team.squadImages(teamId, players, PA.teams.all)))
-    }
-  }
-
   def redirectToTeamHead2Head = Authenticated { implicit request =>
     val submission = request.body.asFormUrlEncoded.get
     val team1Id = submission.get("team1").get.head

--- a/admin/app/football/model/PA.scala
+++ b/admin/app/football/model/PA.scala
@@ -1,45 +1,41 @@
 package football.model
 
 import pa.{Team, Season}
-import org.joda.time.DateMidnight
 import implicits.Collections
 
 
 object PA extends Collections {
-
-  val competitions: List[Season] = List(
-    Season("100", "785", "Barclays Premier League 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("101", "786", "Sky Bet Championship 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("102", "787", "Sky Bet League 1 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("103", "788", "Sky Bet League 2 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("104", "789", "The Skrill Premier 13/14", new DateMidnight(2013, 6, 30), new DateMidnight(2014, 6, 29)),
-    Season("120", "790", "Scottish Premiership 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("121", "791", "Scottish Championship 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("122", "792", "Scottish League One 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("123", "793", "Scottish League Two 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 5, 31)),
-    Season("300", "904", "The FA Cup with Budweiser 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("301", "905", "Capital One Cup 13/14", new DateMidnight(2013, 6, 1), new DateMidnight(2014, 6, 30)),
-    Season("400", "955", "FA Community Shield 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("500", "974", "UEFA Champions League 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("501", "975", "UEFA Champions League Qualifying 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("510", "976", "UEFA Europa League 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("511", "977", "UEFA Europa League Qualifying 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("530", "979", "UEFA Super Cup 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("620", "992", "French Ligue 1 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("625", "994", "German Bundesliga 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("635", "1003", "Italy Serie A 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("650", "1015", "Spanish Liga BBVA 13/14", new DateMidnight(2013, 7, 1), new DateMidnight(2014, 6, 30)),
-    Season("650", "216", "Spanish Primera Liga BBVA", new DateMidnight(2012, 8, 1), new DateMidnight(2013, 6, 30)),
-    Season("700", "524", "2014 FIFA World Cup", new DateMidnight(2014, 6, 1), new DateMidnight(2014, 7, 31)),
-    Season("701", "220", "2014 FIFA World Cup qualification (UEFA)", new DateMidnight(2012, 9, 1), new DateMidnight(2014, 1, 1)),
-    Season("721", "783", "International Friendly 2013/2014", new DateMidnight(2013, 5, 25), new DateMidnight(2014, 5, 25)),
-    Season("762", "1191", "American MLS League 13", new DateMidnight(2013, 3, 1), new DateMidnight(2013, 11, 30))
+  
+  val competitionNames = Map[String, String](
+    ("100", "Premier League"),
+    ("101", "Championship"),
+    ("102", "League One"),
+    ("103", "League Two"),
+    ("120", "Scottish Premier League"),
+    ("121", "Scottish Championship"),
+    ("122", "Scottish League One"),
+    ("123", "Scottish League Two"),
+    ("300", "FA Cup"),
+    ("320", "Scottish Cup"),
+    ("301", "Capital One Cup"),
+    ("400", "Community Shield"),
+    ("500", "Champions League"),
+    ("510", "Europa League"),
+    ("620", "Ligue 1"),
+    ("625", "Bundesliga"),
+    ("635", "Serie A"),
+    ("650", "La Liga"),
+    ("700", "World Cup 2014"),
+    ("721", "International friendlies")
   )
+  def competitionName(season: Season): String = {
+    competitionNames.get(season.id).getOrElse(season.name)
+  }
 
   val approvedCompetitions = List(
     "100", "500", "510", "300", "301", "101", "102",
     "103", "400", "120", "121", "122", "123", "320",
-    "321", "701", "721", "650", "620", "625", "635"
+    "321", "700", "721", "650", "620", "625", "635"
   )
 
   def filterCompetitions(competitions: List[Season]): List[Season] = {

--- a/admin/app/football/model/SnapFields.scala
+++ b/admin/app/football/model/SnapFields.scala
@@ -1,0 +1,12 @@
+package football.model
+
+import java.net.URLEncoder
+
+
+case class SnapFields(`type`: String, uri: String, fallbackUrl: String, fallbackHeadline: String, fallbackTrailtext: String) {
+  private implicit class RichString(string: String) {
+    def encode = URLEncoder.encode(string, "UTF-8")
+  }
+
+  val snapUrl = s"$fallbackUrl?gu-snapType=${`type`.encode}&gu-snapUri=${uri.encode}&gu-headline=${fallbackHeadline.encode}&gu-trailText=${fallbackTrailtext.encode}"
+}

--- a/admin/app/views/football/fragments/chooseLeague.scala.html
+++ b/admin/app/views/football/fragments/chooseLeague.scala.html
@@ -1,8 +1,10 @@
 @(fieldName: String, leagues: List[pa.Season])
+@import _root_.football.model.PA.competitionName
+
 <div class="form-group">
     <select name="@fieldName" id="id-@fieldName" class="form-control" data-placeholder="Choose league">
         @for(league <- leagues) {
-        <option value="@league.competitionId">@league.name</option>
+        <option value="@league.competitionId">@competitionName(league)</option>
         }
     </select>
 </div>

--- a/admin/app/views/football/fronts/failedEmbed.scala.html
+++ b/admin/app/views/football/fronts/failedEmbed.scala.html
@@ -4,7 +4,7 @@
     <div class="row">
         <div class="col-sm-12">
             <hgroup class="page-header">
-                <button class="btn btn-success disabled pull-right">Drag me to Facia</button>
+                <button class="btn btn-success disabled pull-right">Drag to the Fronts Editor</button>
                 <h1>@snapFields.fallbackHeadline</h1>
             </hgroup>
         </div>

--- a/admin/app/views/football/fronts/failedEmbed.scala.html
+++ b/admin/app/views/football/fronts/failedEmbed.scala.html
@@ -1,0 +1,26 @@
+@(message: Html, snapFields: _root_.football.model.SnapFields)
+
+@views.html.football.main(snapFields.fallbackHeadline) {
+    <div class="row">
+        <div class="col-sm-12">
+            <hgroup class="page-header">
+                <button class="btn btn-success disabled pull-right">Drag me to Facia</button>
+                <h1>@snapFields.fallbackHeadline</h1>
+            </hgroup>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-danger">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Error loading Front content</h3>
+                </div>
+                <div class="panel-body">
+                    <p>Technical details were</p>
+                    <pre>@message</pre>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/admin/app/views/football/fronts/index.scala.html
+++ b/admin/app/views/football/fronts/index.scala.html
@@ -1,0 +1,71 @@
+@(competitions: List[pa.Season])
+
+@views.html.football.main("Fronts components") {
+    <hgroup class="page-header">
+        <h1>Fronts components</h1>
+    </hgroup>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <h2>Matchday</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-12">
+            <p>
+                <a href="/admin/football/fronts/live" class="btn btn-success">Today's matches</a>
+            </p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-12">
+            <h2>Fixtures</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-4">
+            <p>
+                <a href="/admin/football/fronts/fixtures/all" class="btn btn-success">All fixtures</a>
+            </p>
+        </div>
+        <div class="col-sm-8">
+            <form class="form-inline" role="form" action="/admin/football/fronts/fixtures/redirect" method="post">
+                @views.html.football.fragments.chooseLeague("competition", competitions)
+                <button type="submit" class="btn btn-success">Competition fixtures</button>
+            </form>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-12">
+            <h2>Results</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-4">
+            <p>
+                <a href="/admin/football/fronts/results/all" class="btn btn-success">All results</a>
+            </p>
+        </div>
+        <div class="col-sm-8">
+            <form class="form-inline" role="form" action="/admin/football/fronts/results/redirect" method="post">
+                @views.html.football.fragments.chooseLeague("competition", competitions)
+                <button type="submit" class="btn btn-success">Competition results</button>
+            </form>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-12">
+            <h2>Tables</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <form class="form-inline" role="form" action="/admin/football/fronts/tables/redirect" method="post">
+                @views.html.football.fragments.chooseLeague("competition", competitions)
+                <button type="submit" class="btn btn-success">League table</button>
+            </form>
+        </div>
+        <div class="col-sm-6">
+        </div>
+    </div>
+}

--- a/admin/app/views/football/fronts/viewEmbed.scala.html
+++ b/admin/app/views/football/fronts/viewEmbed.scala.html
@@ -7,30 +7,12 @@
                 <a href="@snapFields.snapUrl" class="btn btn-success pull-right">Drag me to Facia</a>
                 <h1>@snapFields.fallbackHeadline</h1>
             </hgroup>
-            <p>
-                Preview at multiple sizes:
-            </p>
         </div>
     </div>
 
     <div class="row">
         <div class="col-md-12">
-            <div class="front-embed-preview half">
-                @content
-            </div>
             <div class="front-embed-preview half-sm">
-                @content
-            </div>
-            <div class="front-embed-preview third">
-                @content
-            </div>
-            <div class="front-embed-preview third-sm">
-                @content
-            </div>
-            <div class="front-embed-preview quarter">
-                @content
-            </div>
-            <div class="front-embed-preview quarter-sm">
                 @content
             </div>
         </div>

--- a/admin/app/views/football/fronts/viewEmbed.scala.html
+++ b/admin/app/views/football/fronts/viewEmbed.scala.html
@@ -1,14 +1,48 @@
 @(identifier: String, title: String, content: Html)
 
 @views.html.football.main(title) {
-    <hgroup class="page-header">
-        <a href="@identifier" class="btn btn-success pull-right">Drag me to Facia</a>
-        <h1>@title</h1>
-    </hgroup>
+    <div class="row">
+        <div class="col-sm-12">
+            <hgroup class="page-header">
+                <a href="@identifier" class="btn btn-success pull-right">Drag me to Facia</a>
+                <h1>@title</h1>
+            </hgroup>
+            <p>
+                Preview at multiple sizes:
+            </p>
+        </div>
+    </div>
 
-    <div class="front-embed-container">
-        <div data-embed-type="table" class="match-list match-list--football">
-            @content
+    <div class="row">
+        <div class="col-md-6">
+            <div class="front-embed-preview half">
+                @content
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="front-embed-preview half-sm">
+                @content
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="front-embed-preview third">
+                @content
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="front-embed-preview third-sm">
+                @content
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="front-embed-preview quarter">
+                @content
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="front-embed-preview quarter-sm">
+                @content
+            </div>
         </div>
     </div>
 }

--- a/admin/app/views/football/fronts/viewEmbed.scala.html
+++ b/admin/app/views/football/fronts/viewEmbed.scala.html
@@ -14,32 +14,22 @@
     </div>
 
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-12">
             <div class="front-embed-preview half">
                 @content
             </div>
-        </div>
-        <div class="col-md-6">
             <div class="front-embed-preview half-sm">
                 @content
             </div>
-        </div>
-        <div class="col-md-4">
             <div class="front-embed-preview third">
                 @content
             </div>
-        </div>
-        <div class="col-md-4">
             <div class="front-embed-preview third-sm">
                 @content
             </div>
-        </div>
-        <div class="col-md-4">
             <div class="front-embed-preview quarter">
                 @content
             </div>
-        </div>
-        <div class="col-md-4">
             <div class="front-embed-preview quarter-sm">
                 @content
             </div>

--- a/admin/app/views/football/fronts/viewEmbed.scala.html
+++ b/admin/app/views/football/fronts/viewEmbed.scala.html
@@ -1,0 +1,14 @@
+@(identifier: String, title: String, content: Html)
+
+@views.html.football.main(title) {
+    <hgroup class="page-header">
+        <a href="@identifier" class="btn btn-success pull-right">Drag me to Facia</a>
+        <h1>@title</h1>
+    </hgroup>
+
+    <div class="front-embed-container">
+        <div data-embed-type="table" class="match-list match-list--football">
+            @content
+        </div>
+    </div>
+}

--- a/admin/app/views/football/fronts/viewEmbed.scala.html
+++ b/admin/app/views/football/fronts/viewEmbed.scala.html
@@ -1,11 +1,11 @@
-@(identifier: String, title: String, content: Html)
+@(content: Html, snapFields: _root_.football.model.SnapFields)
 
-@views.html.football.main(title) {
+@views.html.football.main(snapFields.fallbackHeadline) {
     <div class="row">
         <div class="col-sm-12">
             <hgroup class="page-header">
-                <a href="@identifier" class="btn btn-success pull-right">Drag me to Facia</a>
-                <h1>@title</h1>
+                <a href="@snapFields.snapUrl" class="btn btn-success pull-right">Drag me to Facia</a>
+                <h1>@snapFields.fallbackHeadline</h1>
             </hgroup>
             <p>
                 Preview at multiple sizes:

--- a/admin/app/views/football/fronts/viewEmbed.scala.html
+++ b/admin/app/views/football/fronts/viewEmbed.scala.html
@@ -4,7 +4,7 @@
     <div class="row">
         <div class="col-sm-12">
             <hgroup class="page-header">
-                <a href="@snapFields.snapUrl" class="btn btn-success pull-right">Drag me to Facia</a>
+                <a href="@snapFields.snapUrl" class="btn btn-success pull-right">Drag to the Fronts Editor</a>
                 <h1>@snapFields.fallbackHeadline</h1>
             </hgroup>
         </div>

--- a/admin/app/views/football/main.scala.html
+++ b/admin/app/views/football/main.scala.html
@@ -46,6 +46,7 @@
                   <li><a href="/admin/football/player">Players</a></li>
                   <li><a href="/admin/football/team">Teams</a></li>
                   <li><a href="/admin/football/tables">Tables</a></li>
+                  <li><a href="/admin/football/fronts">Fronts</a></li>
                   <li><a href="/admin/football/browse">API browser</a></li>
               </ul>
             </div>

--- a/admin/app/views/football/main.scala.html
+++ b/admin/app/views/football/main.scala.html
@@ -10,6 +10,19 @@
         <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css" />
         <link rel="stylesheet" media="screen" href='@routes.Assets.at("football/css/football-main.css")' />
         <link rel="stylesheet" href='@routes.Assets.at("football/css/jquery-ui-1.10.4.custom.css")' />
+
+            <!--[if (gt IE 9)|(IEMobile)]><!-->
+        @if(play.Play.isDev()) {
+            <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head.default.css")" />
+        } else {
+            <style>
+            @Html(Static.css.head(None))
+            </style>
+        }
+            <!--<![endif]-->
+
+        <link rel="stylesheet" type="text/css" href="@Static("stylesheets/global.css")" />
+
         <script src='@routes.Assets.at("football/javascripts/jquery-1.10.2.js")'></script>
         <script src='@routes.Assets.at("football/javascripts/jquery-ui-1.10.4.custom.min.js")'></script>
         <script src='@routes.Assets.at("football/javascripts/bootstrap/bootstrap.min.js")'></script>

--- a/admin/app/views/football/team/teamIndex.scala.html
+++ b/admin/app/views/football/team/teamIndex.scala.html
@@ -14,12 +14,4 @@
 
         <button type="submit" class="btn btn-success">Fight!</button>
     </form>
-
-    <form class="form-inline" role="form" action="/admin/football/team/images" method="post">
-        <h2>Squad images</h2>
-
-        @views.html.football.fragments.chooseTeam("team", teams)
-
-        <button type="submit" class="btn btn-success">View</button>
-    </form>
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -86,5 +86,13 @@ POST        /admin/football/tables/league                                     co
 GET         /admin/football/tables/league/:competitionId                      controllers.admin.TablesController.leagueTable(competitionId: String)
 GET         /admin/football/tables/league/:competitionId/:focus               controllers.admin.TablesController.leagueTableFragment(competitionId: String, focus: String)
 GET         /admin/football/tables/league/:competitionId/:team1Id/:team2Id    controllers.admin.TablesController.leagueTable2Teams(competitionId: String, team1Id: String, team2Id: String)
+GET         /admin/football/fronts                                            controllers.admin.FrontsController.index
+GET         /admin/football/fronts/live                                       controllers.admin.FrontsController.matchDay
+POST        /admin/football/fronts/results/redirect                           controllers.admin.FrontsController.resultsRedirect
+GET         /admin/football/fronts/results/:competition                       controllers.admin.FrontsController.results(competition: String)
+POST        /admin/football/fronts/fixtures/redirect                          controllers.admin.FrontsController.fixturesRedirect
+GET         /admin/football/fronts/fixtures/:competition                      controllers.admin.FrontsController.fixtures(competition: String)
+POST        /admin/football/fronts/tables/redirect                            controllers.admin.FrontsController.tablesRedirect
+GET         /admin/football/fronts/tables/:competition                        controllers.admin.FrontsController.tables(competition: String)
 
 GET         /admin/football/api/squad/:teamId                                 controllers.admin.PlayerController.squad(teamId: String)

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -74,8 +74,6 @@ GET         /admin/football/browser/*query                                    co
 GET         /admin/football/team                                              controllers.admin.TeamController.teamIndex
 POST        /admin/football/team/head2head                                    controllers.admin.TeamController.redirectToTeamHead2Head
 GET         /admin/football/team/head2head/:team1Id/:team2Id                  controllers.admin.TeamController.teamHead2Head(team1Id: String, team2Id: String)
-POST        /admin/football/team/images                                       controllers.admin.TeamController.redirectToSquadPictures
-GET         /admin/football/team/images/:teamId                               controllers.admin.TeamController.squadPictures(teamId: String)
 GET         /admin/football/player                                            controllers.admin.PlayerController.playerIndex
 POST        /admin/football/player/head2head                                  controllers.admin.PlayerController.redirectToHead2Head
 GET         /admin/football/player/head2head/:player1Id/:player2Id            controllers.admin.PlayerController.head2Head(player1Id: String, player2Id: String)

--- a/admin/public/football/css/football-main.css
+++ b/admin/public/football/css/football-main.css
@@ -131,3 +131,8 @@ label[for] {
 .loading {
     background: url("/assets/internal/images/ajax-loader.gif") right center no-repeat;
 }
+
+.front-embed-container {
+    margin: 20px auto 0 auto;
+    width: 313px;
+}

--- a/admin/public/football/css/football-main.css
+++ b/admin/public/football/css/football-main.css
@@ -133,8 +133,9 @@ label[for] {
 }
 
 .front-embed-preview {
-    margin: 20px auto 0 auto;
+    margin: 10px;
     border: solid 1px #ccc;
+    float: left;
 }
 .half {
     width: 460px;

--- a/admin/public/football/css/football-main.css
+++ b/admin/public/football/css/football-main.css
@@ -132,7 +132,25 @@ label[for] {
     background: url("/assets/internal/images/ajax-loader.gif") right center no-repeat;
 }
 
-.front-embed-container {
+.front-embed-preview {
     margin: 20px auto 0 auto;
+    border: solid 1px #ccc;
+}
+.half {
+    width: 460px;
+}
+.half-sm {
+    width: 360px;
+}
+.third {
     width: 313px;
+}
+.third-sm {
+    width: 233px;
+}
+.quarter {
+    width: 220px;
+}
+.quarter-sm {
+    width: 160px;
 }

--- a/admin/public/football/css/football-main.css
+++ b/admin/public/football/css/football-main.css
@@ -134,7 +134,6 @@ label[for] {
 
 .front-embed-preview {
     margin: 10px;
-    border: solid 1px #ccc;
     float: left;
 }
 .half {

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -19,7 +19,10 @@ class TablesControllerTest extends FreeSpec with GetPaClient with ExecutionConte
     val Some(result) = route(FakeRequest(GET, "/admin/football/tables"))
     status(result) should equal(OK)
     val content = contentAsString(result)
-    PA.competitions.foreach(season => content should include(season.name))
+    PA.competitionNames
+      .filter { case (seasonId, _) => PA.approvedCompetitions.contains(seasonId) }
+      .values
+      .foreach(seasonName => content should include(seasonName))
   }
 
   "submitting a choice of league redirects to the correct table page" in Fake {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -161,7 +161,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   }
 
   object sport {
-    lazy val apiUrl = configuration.getStringProperty("sport.apiUrl").getOrElse("http://api.nextgen.guardianapps.co.uk")
+    lazy val apiUrl = configuration.getStringProperty("sport.apiUrl").getOrElse(ajax.url)
   }
 
   object oas {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -160,6 +160,10 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val path = configuration.getMandatoryStringProperty("staticSport.path")
   }
 
+  object sport {
+    lazy val apiUrl = configuration.getStringProperty("sport.apiUrl").getOrElse("http://api.nextgen.guardianapps.co.uk")
+  }
+
   object oas {
     lazy val siteIdHost = configuration.getStringProperty("oas.siteId.host").getOrElse(".guardian.co.uk")
     lazy val url = configuration.getStringProperty("oas.url").getOrElse("http://oas.theguardian.com/RealMedia/ads/")

--- a/common/app/concurrent/FutureOpt.scala
+++ b/common/app/concurrent/FutureOpt.scala
@@ -22,5 +22,5 @@ case class FutureOpt[A](self: Future[Option[A]]) {
 object FutureOpt {
   def fromFuture[A](a: Future[A])(implicit ex: ExecutionContext): FutureOpt[A] = FutureOpt(a.map(Option(_)))
   def fromOpt[A](a: Option[A]): FutureOpt[A] = FutureOpt(Future.successful(a))
-  def fromValue[A](a: A): FutureOpt[A] = FutureOpt(Future.successful(Some(a)))
+  def fromValue[A](a: A): FutureOpt[A] = FutureOpt(Future.successful(Option(a)))
 }

--- a/common/app/concurrent/FutureOpt.scala
+++ b/common/app/concurrent/FutureOpt.scala
@@ -1,0 +1,26 @@
+package concurrent
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+case class FutureOpt[A](self: Future[Option[A]]) {
+
+  def map[B](f: A => B)(implicit ex: ExecutionContext): FutureOpt[B] = FutureOpt(self.map(_ map f))
+
+  def flatMap[B](f: A => FutureOpt[B])(implicit ex: ExecutionContext) = FutureOpt {
+    for {
+      optA <- self
+      optB <- Future.traverse(optA.toList)(f andThen (_.self))
+    } yield optB.headOption.flatten
+  }
+
+  def getOrElse(a: => A)(implicit ex: ExecutionContext): Future[A] = self.map(_.getOrElse(a))
+
+  def orElse(a: => Option[A])(implicit ex: ExecutionContext): FutureOpt[A] = FutureOpt(self.map(_ orElse a))
+}
+
+object FutureOpt {
+  def fromFuture[A](a: Future[A])(implicit ex: ExecutionContext): FutureOpt[A] = FutureOpt(a.map(Option(_)))
+  def fromOpt[A](a: Option[A]): FutureOpt[A] = FutureOpt(Future.successful(a))
+  def fromValue[A](a: A): FutureOpt[A] = FutureOpt(Future.successful(Some(a)))
+}

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -22,7 +22,7 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // the properties needed to run this project. Make sure you update it if there
     // are any required changes, update the hash below, and off you go.
 
-    hash should be ("4cbf0f0a7a0f85d6f4db15fd040bd2ce")
+    hash should be ("0b582ca53634faf0aea27d5231f93686")
 
   }
 }

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -11,7 +11,7 @@ import com.gu.openplatform.contentapi.connection.Http
 import recorder.ContentApiHttpRecorder
 import com.gu.management.play.InternalManagementPlugin
 import play.api.GlobalSettings
-import concurrent.Future
+import scala.concurrent.Future
 import org.apache.commons.codec.digest.DigestUtils
 import com.gargoylesoftware.htmlunit.BrowserVersion
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -164,6 +164,14 @@ GET         /admin/football/tables/league/:competitionId                        
 GET         /admin/football/tables/league/:competitionId/:focus                                                      controllers.admin.TablesController.leagueTableFragment(competitionId: String, focus: String)
 GET         /admin/football/tables/league/:competitionId/:team1Id/:team2Id                                           controllers.admin.TablesController.leagueTable2Teams(competitionId: String, team1Id: String, team2Id: String)
 GET         /admin/football/api/squad/:teamId                                                                        controllers.admin.PlayerController.squad(teamId: String)
+GET         /admin/football/fronts                                                                                   controllers.admin.FrontsController.index
+GET         /admin/football/fronts/live                                                                              controllers.admin.FrontsController.matchDay
+POST        /admin/football/fronts/results/redirect                                                                  controllers.admin.FrontsController.resultsRedirect
+GET         /admin/football/fronts/results/:competition                                                              controllers.admin.FrontsController.results(competition: String)
+POST        /admin/football/fronts/fixtures/redirect                                                                 controllers.admin.FrontsController.fixturesRedirect
+GET         /admin/football/fronts/fixtures/:competition                                                             controllers.admin.FrontsController.fixtures(competition: String)
+POST        /admin/football/fronts/tables/redirect                                                                   controllers.admin.FrontsController.tablesRedirect
+GET         /admin/football/fronts/tables/:competition                                                               controllers.admin.FrontsController.tables(competition: String)
 
 # Commercial
 GET         /commercial/travel/offers.json                                                                           controllers.commercial.TravelOffers.listOffers

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -151,8 +151,6 @@ GET         /admin/football/browser/*query                                      
 GET         /admin/football/team                                                                                     controllers.admin.TeamController.teamIndex
 POST        /admin/football/team/head2head                                                                           controllers.admin.TeamController.redirectToTeamHead2Head
 GET         /admin/football/team/head2head/:team1Id/:team2Id                                                         controllers.admin.TeamController.teamHead2Head(team1Id: String, team2Id: String)
-POST        /admin/football/team/images                                                                              controllers.admin.TeamController.redirectToSquadPictures
-GET         /admin/football/team/images/:teamId                                                                      controllers.admin.TeamController.squadPictures(teamId: String)
 GET         /admin/football/player                                                                                   controllers.admin.PlayerController.playerIndex
 POST        /admin/football/player/head2head                                                                         controllers.admin.PlayerController.redirectToHead2Head
 GET         /admin/football/player/head2head/:player1Id/:player2Id                                                   controllers.admin.PlayerController.head2Head(player1Id: String, player2Id: String)

--- a/discussion/test/CommentBoxControllerTest.scala
+++ b/discussion/test/CommentBoxControllerTest.scala
@@ -1,6 +1,6 @@
 package test
 
-import concurrent.Future
+import scala.concurrent.Future
 
 import discussion.model.{PrivateProfileFields, Profile}
 import discussion.DiscussionApi

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -70,7 +70,9 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
 
   def renderCompetitionJson(competition: String) = renderCompetition(competition)
   def renderCompetition(competition: String) = Action { implicit request =>
-    loadTables.find(_.competition.url.endsWith(s"/$competition")).map { table =>
+    val table = loadTables.find(_.competition.url.endsWith(s"/$competition")).orElse(loadTables.find(_.competition.id == competition))
+    table.map { table =>
+
       val page = new Page(
         "football/tables",
         "football",
@@ -96,7 +98,7 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
   def renderCompetitionGroupJson(competition: String, groupReference: String) = renderCompetitionGroup(competition, groupReference)
   def renderCompetitionGroup(competition: String, groupReference: String) = Action { implicit request =>
     val response = for {
-      table <- loadTables.find(_.competition.url.endsWith(s"/$competition"))
+      table <- loadTables.find(_.competition.url.endsWith(s"/$competition")).orElse(loadTables.find(_.competition.id == competition))
       group <- table.groups.find { group =>
         group.round.name.exists(name => name.toLowerCase == groupReference.toLowerCase.replace("-", " "))
       }

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -30,7 +30,7 @@ trait MatchListController extends Controller with Requests {
   }
 
   protected def lookupCompetition(tag: String): Option[Competition] = {
-    Competitions().withTag(tag)
+    Competitions().withTag(tag).orElse(Competitions().withId(tag))
   }
   protected def lookupTeam(tag: String): Option[FootballTeam] = {
     for {


### PR DESCRIPTION
Adds a new Front section to the Football Admin. This allows editors to select components for inclusion in the Facia Tool.

Also tidies the football admin by removing some of the hard-coded information, in particular the all-important hard-coded season dates.

Minor changes to sport were required to for this change, specifically allowing the competition's id in place of its tag for the JSON calls that power fronts. The changes are otherwise confined to the football admin. Integration with Facia is ongoing, this PR supports that process.

![football-fronts-admin](https://cloud.githubusercontent.com/assets/29761/2831355/324fe3e6-cfb8-11e3-8c75-9950d19cd40c.png)
