### PR TITLE
Facia snap supporting

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -195,6 +195,8 @@ object Content {
       Option(
         new Snap(
           snapId = itemId,
+          snapSupporting = (json \ "meta" \ "supporting").asOpt[List[JsValue]].getOrElse(Nil)
+            .flatMap(Content.fromPressedJson),
           (json \ "webPublicationDate").asOpt[DateTime].getOrElse(DateTime.now),
           snapMeta = snapMeta
         )
@@ -297,9 +299,10 @@ object SnapApiContent extends ApiContent(
     )
 
 class Snap(snapId: String,
+           snapSupporting: List[Content],
            snapWebPublicationDate: DateTime,
            snapMeta: Map[String, JsValue]
-) extends Content(new ApiContentWithMeta(SnapApiContent, metaData = snapMeta)) {
+) extends Content(new ApiContentWithMeta(SnapApiContent, supporting = snapSupporting, metaData = snapMeta)) {
 
   val snapType: Option[String] = snapMeta.get("snapType").flatMap(_.asOpt[String])
   val snapUri: Option[String] = snapMeta.get("snapUri").flatMap(_.asOpt[String])

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -149,14 +149,17 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
     else {
       val results = collectionItems.foldLeft(Future[List[Content]](Nil)) {
         (foldListFuture, collectionItem) =>
+          lazy val supportingAsContent: Future[List[Content]] = {
+            lazy val supportingLinks: List[CollectionItem] = retrieveSupportingLinks(collectionItem)
+            if (!hasParent) getArticles(supportingLinks, edition, hasParent = true) else Future.successful(Nil)
+          }
           if (collectionItem.isSnap) {
-            foldListFuture.map(_ :+ new Snap(collectionItem.id, collectionItem.webPublicationDate.getOrElse(DateTime.now), collectionItem.metaData.getOrElse(Map.empty)))
+            for {
+              contentList <- foldListFuture
+              supporting  <- supportingAsContent
+            } yield contentList :+ new Snap(collectionItem.id, supporting, collectionItem.webPublicationDate.getOrElse(DateTime.now), collectionItem.metaData.getOrElse(Map.empty))
           }
           else {
-            lazy val supportingAsContent: Future[List[Content]] = {
-              lazy val supportingLinks: List[CollectionItem] = retrieveSupportingLinks(collectionItem)
-              if (!hasParent) getArticles(supportingLinks, edition, hasParent = true) else Future.successful(Nil)
-            }
             val response = ContentApi().item(collectionItem.id, edition).showFields(showFieldsWithBodyQuery).response
 
             val content = response.map(_.content).recover {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -801,7 +801,7 @@ object GetClasses {
   }
 
   def makeSnapClasses(trail: Trail): Seq[String] = trail match {
-    case snap: Snap => snap.snapType.map(t => Seq(s"facia-snap facia-snap--$t")).getOrElse(Seq("facia-snap facia-snap--default"))
+    case snap: Snap => "facia-snap" +: snap.snapType.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
     case _  => Nil
   }
 


### PR DESCRIPTION
This introduces supporting content for `Snaps`, which includes `Snaps`.

@stephanfowler 
