### PR TITLE
New live blog (take 2)

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -98,6 +98,7 @@
                     @if(ABHomeComponent.isSwitchedOn && article.hasMainPicture) {
                         <div class="bottom-marker"></div>
                     }
+                    <div class="after-article js-after-article"></div>
                 </div>
                 <div class="article__secondary-column" aria-hidden="true">
                     <div class="article__secondary-column__inner@if(storyPackage.nonEmpty) { article__secondary-column__inner--fill-vertically}">

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -31,7 +31,7 @@
                         <div class="article-hat-label">Advertisement feature</div>
                     }
 
-                    @fragments.headline(article.headline)
+                    @fragments.headline(article.headline, List("js-score"))
 
                     @fragments.standfirst(article)
 

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -68,19 +68,19 @@
                     }
                 </div>
 
-                @if(article.hasKeyEvents) {
-                    <div class="blog__left-col js-live-blog__key-events js-right-hand-component">
-                        <div class="js-components"></div>
-                        <div class="js-top-marker"></div>
-                        <div class="blog__timeline blog__dropdown">
+                <div class="blog__left-col js-right-hand-component">
+                    <div class="js-top-marker"></div>
+                    @if(article.hasKeyEvents) {
+                        <div class="blog__timeline blog__dropdown js-live-blog__key-events">
                             <div class="blog__timeline-container js-live-blog__timeline-container" data-component="timeline">
                                 @fragments.dropdown("Key events", "live") {
                                     <ul class="timeline js-live-blog__timeline u-unstyled"></ul>
                                 }
                             </div>
                         </div>
-                    </div>
-                }
+                    }
+                    <div class="js-components"></div>
+                </div>
 
                 @fragments.dropdown("Live feed", "live", true) {
                     <div class="js-article__container article__container" data-component="body">

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -37,7 +37,6 @@
         <div class="blog__columning-wrapper">
             <div class="blog__main-column blog__main-background">
                 <div class="blog__standfirst-container">
-                    <div class="js-top-marker"></div>
                     @fragments.standfirst(article)
 
                     @fragments.witnessCallToAction(article)
@@ -70,11 +69,15 @@
                 </div>
 
                 @if(article.hasKeyEvents) {
-                    <div class="blog__timeline blog__dropdown js-live-blog__key-events" data-component="timeline">
-                        <div class="blog__timeline-container js-live-blog__timeline-container">
-                            @fragments.dropdown("Key events", "live") {
-                                <ul class="timeline js-live-blog__timeline u-unstyled"></ul>
-                            }
+                    <div class="blog__left-col js-live-blog__key-events js-right-hand-component">
+                        <div class="js-components"></div>
+                        <div class="js-top-marker"></div>
+                        <div class="blog__timeline blog__dropdown">
+                            <div class="blog__timeline-container js-live-blog__timeline-container" data-component="timeline">
+                                @fragments.dropdown("Key events", "live") {
+                                    <ul class="timeline js-live-blog__timeline u-unstyled"></ul>
+                                }
+                            </div>
                         </div>
                     </div>
                 }
@@ -114,9 +117,8 @@
                     <div class="u-table">
                         <div class="u-table__row">
                             <div class="u-table__cell u-table__cell--top">
-                                <div class="mpu-context js-right-hand-component">
+                                <div class="mpu-context">
                                     <div class="mpu-container js-mpu-ad-slot"></div>
-                                    <div class="js-components"></div>
                                 </div>
                             </div>
                         </div>

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -85,17 +85,7 @@
 
                         <div class="article-body u-cf from-content-api js-blog-blocks @if(article.isLive) {live-blog}"
                         itemprop="@if(article.isReview) {reviewBody} else {articleBody}">
-
-                        @if(article.groupedBlocks.nonEmpty) {
-                            @article.groupedBlocks.map { blockGroup =>
-                                <div class="live-blog__blocks">
-                                    @BodyCleaner(article, blockGroup)
-                                </div>
-                            }
-                        } else {
                             @BodyCleaner(article, article.body)
-                        }
-
                         </div>
 
                         <div class="article__keywords" data-link-name="live blog keywords">

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -16,14 +16,14 @@
         <div class="blog__inner blog__inner--head@if(isDefault){ blog__head-background--default}">
             <header class="article__head">
 
-                <h1 itemprop="headline" class="blog__headline">@Html(article.headline)</h1>
+                <h1 itemprop="headline" class="blog__headline js-score">@Html(article.headline)</h1>
 
                 <div class="blog__head-lower blog__head-background--accent">
                     <div class="blog__last-updated-container">
                         @if(article.isLive) {<span class="blog__live">LIVE</span> }updated <time class="js-timestamp" datetime="@article.webPublicationDate" data-relativeformat="med"></time>
                     </div>
 
-                    <div class="blog__meta-container">
+                    <div class="blog__meta-container js-football-meta">
                         @fragments.meta.byline(article.byline, article)
                         @fragments.meta.dateline(article.webPublicationDate, secondary = true)
                         <div class="js-comment-count blog__comment-count"></div>
@@ -69,7 +69,7 @@
                     }
                 </div>
 
-                @if(article.hasKeyEvents && isDefault) {
+                @if(article.hasKeyEvents) {
                     <div class="blog__timeline blog__dropdown js-live-blog__key-events" data-component="timeline">
                         <div class="blog__timeline-container js-live-blog__timeline-container">
                             @fragments.dropdown("Key events", "live") {

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -32,7 +32,7 @@
 
             </header>
 
-            <div class="after-header"></div>
+            <div class="after-header js-after-head"></div>
         </div>
         <div class="blog__columning-wrapper">
             <div class="blog__main-column blog__main-background">
@@ -111,6 +111,7 @@
                     </div>
                     <div class="js-bottom-marker"></div>
                 }
+                <div class="after-article js-after-article"></div>
             </div>
             <div class="blog__secondary-column" aria-hidden="true">
                 <div class="blog__secondary-column__inner">

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -23,7 +23,7 @@
                         @if(article.isLive) {<span class="blog__live">LIVE</span> }updated <time class="js-timestamp" datetime="@article.webPublicationDate" data-relativeformat="med"></time>
                     </div>
 
-                    <div class="blog__meta-container js-football-meta">
+                    <div class="blog__meta-container">
                         @fragments.meta.byline(article.byline, article)
                         @fragments.meta.dateline(article.webPublicationDate, secondary = true)
                         <div class="js-comment-count blog__comment-count"></div>
@@ -32,7 +32,7 @@
 
             </header>
 
-            <div class="after-header js-after-head"></div>
+            <div class="after-header js-after-head js-football-meta"></div>
         </div>
         <div class="blog__columning-wrapper">
             <div class="blog__main-column blog__main-background">

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -32,12 +32,14 @@
 
             </header>
 
-            <div class="after-header js-after-head js-football-meta"></div>
+            <div class="after-header js-after-head"></div>
         </div>
         <div class="blog__columning-wrapper">
             <div class="blog__main-column blog__main-background">
                 <div class="blog__standfirst-container">
                     @fragments.standfirst(article)
+
+                    <div class="js-football-meta"></div>
 
                     @fragments.witnessCallToAction(article)
 

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -110,7 +110,7 @@ define([
             if (match.pageType === 'stats') {
                 renderNav(match);
             } else {
-                var $h = $('.article__headline', context),
+                var $h = $('.js-score', context),
                     scoreBoard = new ScoreBoard(),
                     scoreContainer = bonzo.create(
                         '<div class="score__container">'+
@@ -217,7 +217,7 @@ define([
             $img.addClass('u-h');
             loading($matchListContainer[0], 'Fetching today\'s matches…', { text: 'Impatient?', href: '/football/live' });
 
-            $('.article__meta-container').before($matchListContainer);
+            $('.js-football-meta').before($matchListContainer);
             ml.fetch($matchListContainer[0]).fail(function() {
                 ml.destroy();
                 $matchListContainer.remove();

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -54,33 +54,36 @@ define([
         }).length === 0;
 
         if (ready) {
-            page.rightHandComponentVisible(function() {
-                extras.forEach(function(extra) {
-                    rhc.addComponent(extra.content, extra.importance);
-                });
-            }, function() {
+            page.belowArticleVisible(function() {
                 var b;
-                $.create('<div class="football-extras"></div>').each(function(extrasContainer) {
-                    extras.forEach(function(extra, i) {
-                        if (dropdownTemplate) {
-                            $.create(dropdownTemplate).each(function (dropdown) {
-                                $('.dropdown__label', dropdown).append(extra.name);
-                                $('.dropdown__content', dropdown).append(extra.content);
-                                $('.dropdown__button', dropdown)
-                                    .attr('data-link-name', 'Show dropdown: '+ extra.name)
-                                    .each(function(el) {
-                                        if (i === 0) { b = el; }
-                                    });
-                            }).appendTo(extrasContainer);
-                        } else {
-                            extrasContainer.appendChild(extra.content);
-                        }
-                    });
-                }).insertAfter($('.article-body', context));
+                $('.js-after-article', context).append(
+                    $.create('<div class="football-extras"></div>').each(function(extrasContainer) {
+                        extras.forEach(function(extra, i) {
+                            if (dropdownTemplate) {
+                                $.create(dropdownTemplate).each(function (dropdown) {
+                                    if(config.page.isLiveBlog) { $(dropdown).addClass('dropdown--live'); }
+                                    $('.dropdown__label', dropdown).append(extra.name);
+                                    $('.dropdown__content', dropdown).append(extra.content);
+                                    $('.dropdown__button', dropdown)
+                                        .attr('data-link-name', 'Show dropdown: '+ extra.name)
+                                        .each(function(el) {
+                                            if (i === 0) { b = el; }
+                                        });
+                                }).appendTo(extrasContainer);
+                            } else {
+                                extrasContainer.appendChild(extra.content);
+                            }
+                        });
+                    })
+                );
 
                 // unfortunately this is here as the buttons event is delegated
                 // so it needs to be in the dom
                 if (b) { bean.fire(b, 'click'); }
+            }, function() {
+                extras.forEach(function(extra) {
+                    rhc.addComponent(extra.content, extra.importance);
+                });
             });
         }
     }

--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -220,7 +220,7 @@ define([
             $img.addClass('u-h');
             loading($matchListContainer[0], 'Fetching today\'s matches…', { text: 'Impatient?', href: '/football/live' });
 
-            $('.js-football-meta').before($matchListContainer);
+            $('.js-football-meta').append($matchListContainer);
             ml.fetch($matchListContainer[0]).fail(function() {
                 ml.destroy();
                 $matchListContainer.remove();

--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -156,10 +156,10 @@ define([
     }
 
     return {
-        init: function (config) {
+        init: function () {
             createAutoRefresh();
             createFilter();
-            if(config.page.keywordIds.indexOf('football/football') < 0 && getKeyEvents().length > 0) {
+            if(getKeyEvents().length > 0) {
                 createTimeline();
             }
         }

--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -116,7 +116,7 @@ define([
             $('.js-live-blog__timeline li:first-child .timeline__title').text('Latest post');
             $('.js-live-blog__timeline li:last-child .timeline__title').text('Opening post');
 
-            if(/desktop|wide/.test(detect.getBreakpoint())) {
+            if(/desktop|wide/.test(detect.getBreakpoint()) && config.page.keywordIds.indexOf('football/football') < 0) {
                 affix = new Affix({
                     element: qwery('.js-live-blog__timeline-container')[0],
                     topMarker: qwery('.js-top-marker')[0],

--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -32,7 +32,7 @@ define([
     var affix = null;
 
     function getKeyEvents() {
-        return qwery('.live-blog__blocks .is-key-event').slice(0, 7);
+        return qwery('.is-key-event').slice(0, 7);
     }
 
     function getBlocks() {

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -48,6 +48,7 @@ define([
 
             bean.on(context, 'click', '.article-elongator', removeTruncation.bind(this));
             mediator.on('module:liveblog:showkeyevents', removeTruncation.bind(this));
+            mediator.on('module:filter:toggle', removeTruncation.bind(this));
 
             $truncatedBlocks.addClass(truncatedClass);
             // Avoid running the twitter widget on truncated tweets.

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -21,13 +21,8 @@ define([
 ) {
     context = context();
     var truncatedClass = 'truncated-block',
-        numBlocks = config.page.section === 'football' ? 1 : 2,
-        $truncatedBlocks = bonzo(qwery('.live-blog__blocks', context).slice(numBlocks));
-
-    function shouldTruncate() {
-        var truncatableLiveBlogs = config.page.section !== 'football' || detect.getBreakpoint() === 'mobile';
-        return config.page.isLiveBlog && $('.live-blog__blocks').length > 1 && truncatableLiveBlogs;
-    }
+        numBlocks = detect.getBreakpoint() === 'mobile' ? 5 : 10,
+        $truncatedBlocks = bonzo(qwery('.block', context).slice(numBlocks));
 
     function removeTruncation() {
         // Reinstate tweets and enhance them.
@@ -40,7 +35,7 @@ define([
 
     function truncate() {
 
-        if (shouldTruncate()) {
+        if (config.page.isLiveBlog && $('.block').length > 1) {
 
             $.create(
                 '<button class="u-fauxlink u-button-reset button button--show-more article-elongator" data-link-name="continue reading">'+

--- a/common/app/assets/javascripts/modules/live/filter.js
+++ b/common/app/assets/javascripts/modules/live/filter.js
@@ -5,10 +5,12 @@
 define([
     'common/$',
     'common/modules/component',
+    'common/utils/mediator',
     'lodash/collections/toArray'
 ], function (
     $,
     component,
+    mediator,
     toArray
 ) {
     'use strict';
@@ -40,7 +42,9 @@ define([
         blocks.reverse();
 
         this.toggleState('order-by-oldest');
-        $(this.context).append(blocks);
+        $(this.context).prepend(blocks);
+
+        mediator.emit('module:filter:toggle');
     };
 
     return Filter;

--- a/common/app/assets/javascripts/utils/page.js
+++ b/common/app/assets/javascripts/utils/page.js
@@ -57,8 +57,8 @@ function(
         }, no);
     }
 
-    function rightHandComponentVisible(yes, no) {
-        var el = $('.js-right-hand-component')[0],
+    function belowArticleVisible(yes, no) {
+        var el = $('.js-after-article')[0],
             vis = el.offsetWidth > 0 && el.offsetHeight > 0;
 
         return isit(vis, yes, no, el);
@@ -69,7 +69,7 @@ function(
         isCompetition: isCompetition,
         isClockwatch: isClockwatch,
         isLiveClockwatch: isLiveClockwatch,
-        rightHandComponentVisible: rightHandComponentVisible
+        belowArticleVisible: belowArticleVisible
     };
 
 }); // define

--- a/common/app/assets/stylesheets/layout/_layout.scss
+++ b/common/app/assets/stylesheets/layout/_layout.scss
@@ -189,7 +189,13 @@ a.edition {
 .component__heading {}
 
 .component--rhc {
-    margin-top: $gs-baseline*3;
+    display: none;
+    @include mq(rightCol) {
+        display: block;
+        @include rem((
+            margin-top:$gs-baseline * 3
+        ));
+    }
 }
 
 .box-indent {

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -774,10 +774,9 @@
     display: block;
     content: ' ';
     @include rem((
-        padding-top: $gs-baseline
+        min-height: 1px
     ));
     @include mq(rightCol) {
         display: none;
     }
-
 }

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -769,3 +769,15 @@
         background-color: $c-brandBlue;
     }
 }
+
+.after-article {
+    display: block;
+    content: ' ';
+    @include rem((
+        padding-top: $gs-baseline
+    ));
+    @include mq(rightCol) {
+        display: none;
+    }
+
+}

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -618,9 +618,11 @@ $block-padding-right: $gs-gutter;
         }
 
         > .element-table {
+            margin: 0;
+
             .table {
-                border: none;
                 background: none;
+                border: 0;
             }
             td {
                 background: none;
@@ -639,6 +641,18 @@ $block-padding-right: $gs-gutter;
             }
             thead {
                 border-top: 1px solid darken($c-neutral8, 4%);
+            }
+            .player-card {
+                background: none;
+                border: 0;
+                border-left: 1px solid darken($c-neutral8, 4%);
+                margin: $gs-baseline/2 $gs-gutter 0;
+                padding: 0 0 0 $gs-gutter;
+            }
+            .player-card__position {
+                @include fs-data(4);
+                color: $c-neutral1;
+                font-weight: 700;
             }
         }
 

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -617,7 +617,32 @@ $block-padding-right: $gs-gutter;
             ));
         }
 
-        > .element-table,
+        > .element-table {
+            .table {
+                border: none;
+                background: none;
+            }
+            td {
+                background: none;
+            }
+            tr {
+                border-bottom: 1px solid darken($c-neutral8, 4%);
+
+                th:first-child,
+                td:first-child {
+                  padding-left: 0;
+                }
+                th:last-child,
+                td:last-child {
+                  padding-right: 0;
+                }
+            }
+            thead {
+                border-top: 1px solid darken($c-neutral8, 4%);
+            }
+        }
+
+        > .element-table .table--football,
         > .element-comment {
             width: auto;
             @include rem((

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -474,7 +474,7 @@ $block-padding-right: $gs-gutter;
     background-color: transparent;
     @include transition(opacity 2s ease-out, background-color 4s ease-out);
 
-    & .truncated-block {
+    &.truncated-block {
         display: none;
     }
 }

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -1070,6 +1070,11 @@ $timeline-width: 14px;
         border-bottom-color: $c-neutral8 !important;
     }
 
+    .match-summary {
+        border-bottom: 0 none;
+        margin-bottom: 0;
+    }
+
     @include mq(rightCol) {
         .tabs__container--multiple {
             background-color: $c-neutral8;
@@ -1083,8 +1088,6 @@ $timeline-width: 14px;
         }
 
         .match-summary {
-            border-bottom: 0 none;
-            margin-bottom: 0;
             padding-bottom: 0;
         }
     }

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -559,7 +559,8 @@ $block-padding-right: $gs-gutter;
 
     .block-title,
     .block-elements > *,
-    .block-elements > .element.element-tweet {
+    .block-elements > .element.element-tweet,
+    .block-elements > .element.element-witness {
         @include rem((
             margin-left: $gs-gutter/2,
             margin-right: $gs-gutter/2

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -92,6 +92,7 @@ $block-padding-right: $gs-gutter;
         top: 0;
         z-index: 200;
         @include rem((
+            padding-top: $gs-baseline*2,
             margin-left:($a-rightCol-width + $gs-gutter) * - 1,
             width:$a-rightCol-width
         ));
@@ -905,15 +906,16 @@ $block-padding-right: $gs-gutter;
 $timeline-width: 14px;
 
 .blog__timeline {
+    @include mq(rightCol) {
+        &:before,
+        &:after,
+        .control {
+            display: none;
+        }
 
-    &:before,
-    &:after,
-    .control {
-        display: none;
-    }
-
-    .dropdown {
-        border-top: none;
+        .dropdown {
+            border-top: none;
+        }
     }
 }
 
@@ -1052,7 +1054,6 @@ $timeline-width: 14px;
 .blog {
     .after-header {
         position: relative;
-        @include full-bleed($c-neutral8);
     }
 
     .tabs__container--multiple {
@@ -1060,7 +1061,6 @@ $timeline-width: 14px;
         @include rem((
             padding-top: $gs-baseline
         ));
-        background-color: $c-neutral8;
     }
 
     .tabs__tab--selected {
@@ -1068,6 +1068,13 @@ $timeline-width: 14px;
     }
 
     @include mq(rightCol) {
+        .tabs__container--multiple {
+            background-color: $c-neutral8;
+        }
+        .after-header {
+            @include full-bleed($c-neutral8);
+        }
+
         .tabs__tab--selected .tab__link {
             background-color: $c-neutral8;
         }

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -86,6 +86,16 @@ $block-padding-right: $gs-gutter;
             padding-left: $a-rightCol-width + $gs-gutter
         ));
     }
+
+    .blog__left-col {
+        position: absolute;
+        top: 0;
+        z-index: 200;
+        @include rem((
+            margin-left:($a-rightCol-width + $gs-gutter) * - 1,
+            width:$a-rightCol-width
+        ));
+    }
 }
 
 @include mq(wide) {
@@ -855,24 +865,14 @@ $timeline-width: 14px;
 
 .blog__timeline {
 
-    @include mq(rightCol) {
-        position: absolute;
-        top: 0;
-        z-index: 200;
-        @include rem((
-            margin-left: ($a-rightCol-width + $gs-gutter)*-1,
-            width: $a-rightCol-width
-        ));
+    &:before,
+    &:after,
+    .control {
+        display: none;
+    }
 
-        &:before,
-        &:after,
-        .control {
-            display: none;
-        }
-
-        .dropdown {
-            border-top: none;
-        }
+    .dropdown {
+        border-top: none;
     }
 }
 
@@ -1029,6 +1029,12 @@ $timeline-width: 14px;
     @include mq(rightCol) {
         .tabs__tab--selected .tab__link {
             background-color: $c-neutral8;
+        }
+
+        .match-summary {
+            border-bottom: 0 none;
+            margin-bottom: 0;
+            padding-bottom: 0;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -862,6 +862,17 @@ $block-padding-right: $gs-gutter;
         }
     }
 
+    & + & {
+        .dropdown__button {
+            border-top: 0 none;
+
+            &:before,
+            &:after {
+                border-top: 0 none;
+            }
+        }
+    }
+
     .dropdown__label {
         @include fs-header(2);
         @include rem((
@@ -953,12 +964,12 @@ $timeline-width: 14px;
     }
 }
 .timeline__link {
+    display: block;
     @include rem((
         padding: $gs-baseline/6 0 $gs-baseline/2
     ));
 
     @include mq(rightCol) {
-        display: block;
         position: relative;
         @include rem((
             padding: 0 0 $gs-baseline*2 $gs-gutter

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -466,18 +466,10 @@ $block-padding-right: $gs-gutter;
     }
 }
 
-/* Blocks container
-   ========================================================================== */
-.live-blog__blocks {
-    opacity: 1;
-    height: auto;
-    background-color: transparent;
-    @include transition(opacity 2s ease-out, background-color 4s ease-out);
-
-    &.truncated-block {
-        display: none;
-    }
+.truncated-block {
+    display: none;
 }
+
 .blog .ad-slot--mpu-banner-ad {
     @include rem((
         padding-top: $gs-baseline

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -558,7 +558,8 @@ $block-padding-right: $gs-gutter;
     }
 
     .block-title,
-    .block-elements > * {
+    .block-elements > *,
+    .block-elements > .element.element-tweet {
         @include rem((
             margin-left: $gs-gutter/2,
             margin-right: $gs-gutter/2

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -308,11 +308,6 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
 
 class LiveBlog(content: ApiContentWithMeta) extends Article(content) {
   private lazy val soupedBody = Jsoup.parseBodyFragment(body).body()
-  lazy val blockCount: Int = soupedBody.select(".block").size()
-  lazy val summary: Option[String] = soupedBody.select(".is-summary").headOption.map(_.toString)
-  lazy val groupedBlocks: List[String]= soupedBody.select(".block").toList.grouped(5).map { group =>
-    group.map(_.toString).mkString
-  }.toList
   lazy val hasKeyEvents: Boolean = soupedBody.select(".is-key-event").nonEmpty
   lazy val isSport: Boolean = tags.exists(_.id == "sport/sport")
   override def cards: List[(String, Any)] = super.cards ++ List(

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -19,7 +19,7 @@
 
 }
 
-<div class="article__meta-container u-cf@if(content.byline.isEmpty){ article__meta-container--no-byline}">
+<div class="article__meta-container js-football-meta u-cf@if(content.byline.isEmpty){ article__meta-container--no-byline}">
     @if(content.isSponsored || content.isAdvertisementFeature) {
         @fragments.commercial.badge(name="badge", adType="paid-for-badge", sizeMapping=Map("mobile" -> Seq("140,80")))
     }


### PR DESCRIPTION
So after much debate, this is take 2. All football components and style have been accounted for.
# 

Apologies for the gigantic 2 week old pull request. Unfortunately it was the only way to manage this large change.

This PR introduces new features and a completely new visual styling for our live blog content across all breakpoints.
- New key events panel to act as a summary and quick navigation
- New red visual tone
- Full bleed banding
- Adjust column breakpoints for live blogs
- Grey background behind content. Creating the blocks to have a card effect.
- Styling for all element and embed types
- New auto update functionality
- New block filtering functionality
- Add agate bold font to desktop

The key events scrolling is only being init'd for desktop view ports, debounced and is being translate-z(0) to force onto the GPU.

![screenshot from 2014-04-30 17 46 04](https://cloud.githubusercontent.com/assets/80089/2844284/e5a1252e-d088-11e3-9d0e-73a475cf06be.png)
![screenshot from 2014-04-30 17 46 20](https://cloud.githubusercontent.com/assets/80089/2844285/e71966c8-d088-11e3-9ee6-f653c8a90fc7.png)
![screenshot from 2014-04-30 17 47 14](https://cloud.githubusercontent.com/assets/80089/2844288/e8d1834c-d088-11e3-8090-97addf17e692.png)
![screenshot from 2014-04-30 17 48 12](https://cloud.githubusercontent.com/assets/80089/2844289/eaf87c70-d088-11e3-8be5-83abf09b9127.png)
