### PR TITLE
Give key events nice underlines

### DIFF
--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -81,7 +81,7 @@ define([
     function createKeyEventHTML(el) {
         var keyEventTemplate = '<li class="timeline__item" data-event-id="{{id}}">' +
             '<a class="timeline__link" href="#{{id}}" data-event-id="{{id}}">' +
-            '<span class="timeline__date">{{time}}</span><span class="timeline__title">{{title}}</span></a></li>';
+            '<span class="timeline__date">{{time}}</span><span class="timeline__title u-underline">{{title}}</span></a></li>';
 
         var data = {
             id: el.getAttribute('id'),

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -193,6 +193,9 @@ $block-padding-right: $gs-gutter;
 
 /* Design
    ========================================================================== */
+.blog {
+    background-color: $c-neutral8;
+}
 .blog__zone--default {
     @include mq(tablet, rightCol) {
         @include full-bleed($c-liveDefault);

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -193,7 +193,7 @@ $block-padding-right: $gs-gutter;
 
 /* Design
    ========================================================================== */
-.blog {
+.blog__secondary-column {
     background-color: $c-neutral8;
 }
 .blog__zone--default {
@@ -983,7 +983,8 @@ $timeline-width: 14px;
         ));
         border-left: 1px solid $c-neutral5;
 
-        &:hover {
+        &:hover,
+        &:active {
             text-decoration: none;
         }
 
@@ -1001,7 +1002,9 @@ $timeline-width: 14px;
             background-color: $c-neutral5;
         }
 
-        &:hover:before,
+        &:hover:before {
+            background-color: $c-neutral2;
+        }
         &.live-blog__key-event--selected:before {
             background-color: $c-neutral1;
         }
@@ -1050,9 +1053,13 @@ $timeline-width: 14px;
     color: $c-neutral1;
 
     @include mq(rightCol) {
-        display: block;
+        display: inline;
+        border-color: $c-neutral8;
 
-        .timeline__link:hover &,
+        .timeline__link:hover & {
+            border-color:  $c-neutral2;
+        }
+
         .live-blog__key-event--selected & {
             font-weight: bold;
         }


### PR DESCRIPTION
- Uses @kaelig `u-underline` helper to give live-blog key events nice underlines on hover.
- Gives the circle on timeline lighter shade of grey on hover.
