### PR TITLE
Commercial: fix empty badge spacing on fronts

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -306,6 +306,8 @@ define([
                 if (config.page.pageType !== 'Article' && window.location.hash !== '#show-badge') {
                     var selector = options.dfpSelector || '.ad-slot--dfp';
                     options.dfpSelector = selector + ':not(.ad-slot--paid-for-badge)';
+                } else {
+                    $('.dfp-badge-container').css('display', 'block');
                 }
 
                 dfpAds = new DFP(extend(config, options));

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -256,6 +256,10 @@
         }
     }
 }
+// can be removed once we dynamically add the sponsored badge ad slot to fronts
+.dfp-badge-container {
+    display: none;
+}
 .ad-slot__label {
     height: $mpu-ad-label-height;
     background-color: $c-neutral8;

--- a/common/app/views/fragments/containers/special.scala.html
+++ b/common/app/views/fragments/containers/special.scala.html
@@ -29,7 +29,9 @@
                         </h2>
                     }
                 </div>
-                @fragments.commercial.badge(name="badge", adType="paid-for-badge", sizeMapping=Map("mobile" -> Seq("140,80")))
+                <div class="dfp-badge-container">
+                    @fragments.commercial.badge(name="badge", adType="paid-for-badge", sizeMapping=Map("mobile" -> Seq("140,80")))
+                </div>
                 <div class="container__body container--rolled-up-hide">
                     @fragments.collections.special(items, style, containerIndex)
                 </div>

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -26,7 +26,9 @@
                 </h2>
             }
         </div>
-        @fragments.commercial.badge(name="badge", adType="paid-for-badge", sizeMapping=Map("mobile" -> Seq("140,80")))
+        <div class="dfp-badge-container">
+            @fragments.commercial.badge(name="badge", adType="paid-for-badge", sizeMapping=Map("mobile" -> Seq("140,80")))
+        </div>
         <div class="container__body">
             @fragments.contributor(page)
             @fragments.collections.tag(collection.items, style, containerIndex)


### PR DESCRIPTION
Getting messy, but this is while we aren't dynamically adding the sponsored/advertisement feature ad slot into fronts
### Before

![screen shot 2014-05-02 at 17 36 55](https://cloud.githubusercontent.com/assets/74132/2865046/1dd81250-d218-11e3-8ab6-626c07d701ff.png)
### After

![screen shot 2014-05-02 at 17 36 59](https://cloud.githubusercontent.com/assets/74132/2865050/292aa74e-d218-11e3-8229-8bf807203816.png)
