### PR TITLE
Onward title goes full width when possible

### DIFF
--- a/common/app/assets/stylesheets/module/onward/_popular.scss
+++ b/common/app/assets/stylesheets/module/onward/_popular.scss
@@ -13,7 +13,7 @@
         }
 
         .tabs__tab:first-child {
-            width: 100%;
+            max-width: 100%;
             border-top: 0;
             padding: $gs-baseline/3 $gs-gutter/4 $gs-baseline/3 0;
 


### PR DESCRIPTION
Found this one when recoding the facia containers / wrapper structure.
### Before

![screen shot 2014-05-02 at 17 45 04](https://cloud.githubusercontent.com/assets/85783/2865349/96eb4b00-d21b-11e3-9bf9-805b75cd6589.PNG)
### After

![screen shot 2014-05-02 at 17 44 58](https://cloud.githubusercontent.com/assets/85783/2865355/9aa119fa-d21b-11e3-9773-a35d88053f74.PNG)

![ ](http://media.giphy.com/media/nlaMVQBGcMLNC/giphy.gif)
