### PR TITLE
making sure images don't go more than width of container

### DIFF
--- a/common/app/assets/stylesheets/module/commercial/_jobs.scss
+++ b/common/app/assets/stylesheets/module/commercial/_jobs.scss
@@ -159,6 +159,7 @@
     }
     .commercial--jobs__job__logo {
         border: 1px solid $c-neutral1;
+        max-width: 100%;
     }
     .commercial--jobs__job__logo,
     .commercial--jobs__job__description,


### PR DESCRIPTION
Fix for images breaking out of container.

Before;
![screen shot 2014-05-06 at 09 55 17](https://cloud.githubusercontent.com/assets/1303616/2887525/68a36014-d4fc-11e3-8c59-735c50fd6df0.png)

After;
![screen shot 2014-05-06 at 09 57 25](https://cloud.githubusercontent.com/assets/1303616/2887532/7b3d5e0a-d4fc-11e3-9fae-802b5ed64d23.png)
