### PR TITLE
Fix live blog key-events on mobile

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -75,7 +75,7 @@
                 </div>
 
                 <div class="blog__left-col js-right-hand-component">
-                    <div class="js-top-marker @if(isDefault){affix-top-marker}">
+                    <div class="js-top-marker">
                         @if(article.hasKeyEvents) {
                             <div class="blog__timeline blog__dropdown js-live-blog__key-events">
                                 <div class="blog__timeline-container js-live-blog__timeline-container" data-component="timeline">

--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -125,9 +125,11 @@ define([
             $('.js-live-blog__timeline li:last-child .timeline__title').text('Opening post');
 
             if(/desktop|wide/.test(detect.getBreakpoint()) && config.page.keywordIds.indexOf('football/football') < 0) {
+                var topMarker = qwery('.js-top-marker')[0];
+                bonzo(topMarker).addClass('affix-top-marker');
                 affix = new Affix({
                     element: qwery('.js-live-blog__timeline-container')[0],
-                    topMarker: qwery('.js-top-marker')[0],
+                    topMarker: topMarker,
                     bottomMarker: qwery('.js-bottom-marker')[0],
                     containerElement: qwery('.js-live-blog__key-events')[0]
                 });


### PR DESCRIPTION
Fixes a regression that caused the football components to render incorrectly over the weekend, and the key-events to not show correctly on mobile.

This ensures the affix CSS class is only applied on mobile breakpoints and if affix is going to be init'd

/cc @rich-nguyen 
