### PR TITLE
Commercial: Change Default Job Type to Media

### DIFF
--- a/commercial/app/model/commercial/jobs/JobsAgent.scala
+++ b/commercial/app/model/commercial/jobs/JobsAgent.scala
@@ -5,7 +5,7 @@ import model.commercial.AdAgent
 
 object JobsAgent extends AdAgent[Job] with ExecutionContexts with Logging {
 
-  override def defaultAds = currentAds filter (_.industries.contains("General"))
+  override def defaultAds = currentAds filter (_.industries.contains("Media"))
 
   def refresh() {
     for {jobs <- JobsApi.loadAds()} {


### PR DESCRIPTION
If showing the jobs commercial component and no jobs match the current page, fall back to showing media jobs instead of general jobs.
