### PR TITLE
Commercial: ad high-profile merchandising slot

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -117,6 +117,10 @@
             </div>
         </article>
 
+        <div class="facia-container facia-container--layout-article monocolumn-wrapper monocolumn-wrapper--no-limit facia-container--commercial">
+            @fragments.commercial.commercialComponent(name="merchandising-high", adType="commercial-component", sizeMapping=Map("mobile" -> Seq("888,87")))
+        </div>
+
         @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {
             <div class="article__inner js-comments" data-component="discussion">
                 @fragments.discussion(article.isClosedForComments, article.shortUrlId)

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -118,7 +118,7 @@
         </article>
 
         <div class="facia-container facia-container--layout-article monocolumn-wrapper monocolumn-wrapper--no-limit facia-container--commercial">
-            @fragments.commercial.commercialComponent(name="merchandising-high", adType="commercial-component", sizeMapping=Map("desktop" -> Seq("888,87")))
+            @fragments.commercial.commercialComponent(name="merchandising-high", adType="commercial-component-high", sizeMapping=Map("desktop" -> Seq("888,87")))
         </div>
 
         @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -118,7 +118,7 @@
         </article>
 
         <div class="facia-container facia-container--layout-article monocolumn-wrapper monocolumn-wrapper--no-limit facia-container--commercial">
-            @fragments.commercial.commercialComponent(name="merchandising-high", adType="commercial-component", sizeMapping=Map("mobile" -> Seq("888,87")))
+            @fragments.commercial.commercialComponent(name="merchandising-high", adType="commercial-component", sizeMapping=Map("desktop" -> Seq("888,87")))
         </div>
 
         @if(DiscussionSwitch.isSwitchedOn && article.isCommentable) {

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -317,7 +317,13 @@ define([
 
     DFP.prototype.init = function() {
 
-        this.$dfpAdSlots = $(this.config.dfpSelector);
+        var dfpAdSlots = qwery(this.config.dfpSelector)
+            // filter out hidden ads
+            .filter(function(adSlot) {
+                return bonzo(adSlot).css('display') !== 'none';
+            });
+
+        this.$dfpAdSlots = bonzo(dfpAdSlots);
 
         // If there's no ads on the page, then don't load anything
         if (this.$dfpAdSlots.length === 0) {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -135,7 +135,8 @@
     height: 250px;
     overflow: hidden;
 }
-.ad-slot--commercial-component {
+.ad-slot--commercial-component,
+.ad-slot--commercial-component-high {
     width: 100%;
     min-height: 0;
     padding-top: 0;
@@ -143,6 +144,13 @@
     @include rem((
         margin-top: $gs-baseline
     ));
+}
+.ad-slot--commercial-component-high {
+    display: none;
+
+    @include mq(desktop) {
+        display: block;
+    }
 }
 .ad-slot--paid-for-badge {
     min-height: 0;

--- a/common/test/assets/javascripts/spec/adverts/DFP.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/DFP.spec.js
@@ -189,5 +189,13 @@ define([
             expect(setTargetingSpy).toHaveBeenCalledWith('slot', 'inline1');
         });
 
+        it('should not create ad if slot is not displayed', function() {
+            $('.ad-slot--dfp').first().css('display', 'none');
+            dfp.init();
+            expect(dfp.$dfpAdSlots.length).toBe(3);
+            var adSlots = dfp.$dfpAdSlots.map(function(adSlot) { return adSlot; });
+            expect(adSlots.some(function(adSlot) { return adSlot === $('.ad-slot--dfp').first()[0]; })).toBe(false);
+        });
+
     });
 });


### PR DESCRIPTION
Currently only on > desktop breakpoints. 

Using size `888x87` and name `merchandising-high`
