### PR TITLE
Editable SEO fields

### DIFF
--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -15,7 +15,11 @@ case class Config(
 
 case class Front(
                   collections: List[String],
-                  webTitle: Option[String]
+                  section: Option[String],
+                  webTitle: Option[String],
+                  title: Option[String],
+                  description: Option[String],
+                  priority: Option[String]
                   )
 
 case class Collection(

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -11,47 +11,55 @@
     <div class="updating">Updating</div>
 
     <div class="left-col">
-        <div class="title">Clipboard</div>
-        <div class="clipboard__wrapper" data-bind="with: clipboard">
-            <div class="clipboard droppable" data-bind="
-                makeDropabble: true,
-                css: {underDrag: underDrag},
-                template: {name: 'template_collection', foreach: items}"></div>
-        </div>
-
-        <div class="title">Orphaned containers</div>
+        <div class="title">Containers</div>
         <div class="scrollable cnf-collections" data-bind="
-            template: {name: 'template_collection', foreach: orphans}"></div>
+            template: {name: 'template_minimal_collection', foreach: collections}"></div>
     </div>
 
     <div class="right-col">
-        <div class="title">Fronts</div>
-        <div class="instructions">
-            Create a <span data-bind="click: createFront" class="linky">front</span>
+        <div class="title">
+            Fronts
+            <!--span data-bind="click: createFront" class="linky">+</span-->
         </div>
         <div class="scrollable cnf-fronts" data-bind="
             template: {name: 'template_front', foreach: fronts}"></div>
     </div>
 
+    <script type="text/html" id="template_minimal_collection">
+        <div class="cnf-collection">
+            <a class="cnf-collection__name" data-bind="
+                click: toggleOpen,
+                attr: {href: id, title: id},
+                text: meta.displayName() || '(no title)'"></a>
+
+            <span class="placements">
+                on
+                <span data-bind="foreach: parents">
+                    <a class="cnf-collection__also-on" data-bind="
+                        click: $root.openFront,
+                        text: id"></a>
+                </span>
+            </span>
+        </div>
+    </script>
+
     <script type="text/html" id="template_collection">
         <div class="cnf-collection" data-bind="
             css: {
                 underDrag: state.underDrag,
-                open: state.open}">
+                open: state.isOpen}">
 
             <span class="cnf-collection__index" data-bind="text: $index() + 1"></span>
 
             <a class="cnf-collection__name" data-bind="
                 click: toggleOpen,
-                attr: {href: id},
+                attr: {href: id, title: id},
                 text: meta.displayName() || '(no title)'"></a>
-
-            <span class="cnf-collection__id" data-bind="text: id"></span>
 
             <span class="placements" data-bind="
                 if: parents().length,
                 css: {'is-single': parents().length === 1}">
-                <span class="also">also</span> on
+                also on
                 <span data-bind="foreach: parents">
                     <!-- ko if: $parents[2] ? id !== $parents[2].id : true -->
                         <a class="cnf-collection__also-on" data-bind="
@@ -61,7 +69,7 @@
                 </span>
             </span>
 
-            <!-- ko if: state.open -->
+            <!-- ko if: state.isOpen -->
             <div class="cnf-form">
                 <label>Title</label>
                 <input type="text" data-bind="
@@ -107,7 +115,7 @@
 
                 <div class="tools">
                     <button class="tool" data-bind="
-                        click: save">Save</button>
+                        click: save">Save container</button>
 
                     <!-- ko if: $parents[1] -->
                         <button class="tool" data-bind="
@@ -127,45 +135,72 @@
 
     <script type="text/html" id="template_front">
         <div class="cnf-front" data-bind="
-                css: {isProvisional: !id()}">
+            css: {open: state.isOpen}">
 
             <div class="title" data-bind="
-                click: toggleOpen,
-                text: id"></div>
+                text: id,
+                visible: id,
+                click: toggleOpen"></div>
 
             <!-- ko if: !id() -->
-            <div class="cnf-form">
-                <div class="title">New Front</div>
-                <label>Path</label>
-                <input type="text" data-bind="
-                    value: id"/>
+                <div class="cnf-front__inner cnf-form">
+                    <label>Type</label>
+                    <input type="radio" name="group01" data-bind="checkedValue: undefined, checked: props.priority" />
+                    <span class="radio-label">editorial</span>
+                    <input type="radio" name="group01" value="commercial" data-bind="checked: props.priority" />
+                    <span class="radio-label">commercial</span>
 
-                <div class="tools">
-                    <button class="tool">OK</button>
+                    <label>URL path</label>
+                    <input type="text" placeholder="eg. world/middleeast" data-bind="value: id"/>
+
+                    <div class="tools">
+                        <span class="tool">Create front</span>
+                    </div>
                 </div>
-            </div>
             <!-- /ko -->
 
-            <div data-bind="if: id() && state.open()">
-                <div class="cnf-front__inner">
-                    <div data-bind="visible: state.openProps">
-                        <div class="cnf-form" data-bind="">
-                                <label>Title</label>
-                                <input type="text" data-bind="
-                                    value: props.webTitle"/>
-                            <div class="tools"><span class="tool" data-bind="click: save">Save</span></div>
+            <div class="cnf-front__inner" data-bind="if: state.isOpen">
+                <!-- ko if: state.isOpenProps() -->
+                    <div class="cnf-form">
+                        <label>Section</label>
+                        <input type="text" data-bind="
+                            attr: {placeholder: placeholders.section},
+                            value: props.section"/>
+
+                        <label>Name</label>
+                        <input type="text" data-bind="
+                            attr: {placeholder: placeholders.webTitle},
+                            value: props.webTitle"/>
+
+                        <label>SEO Title</label>
+                        <textarea data-bind="
+                            attr: {placeholder: placeholders.title},
+                            value: props.title"></textarea>
+
+                        <label>Description</label>
+                        <textarea data-bind="
+                            attr: {placeholder: placeholders.description},
+                            value: props.description"></textarea>
+
+                        <label>Type</label>
+                        <input type="radio" name="group02" data-bind="checkedValue: undefined, checked: props.priority" />
+                        <span class="radio-label">editorial</span>
+                        <input type="radio" name="group02" value="commercial" data-bind="checked: props.priority" />
+                        <span class="radio-label">commercial</span>
+
+                        <div class="tools">
+                            <span class="tool" data-bind="click: saveProps">Save metadata</span>
                         </div>
                     </div>
-                    <div data-bind="visible: !state.openProps(), click: openProps">
-                        <div class="cnf-form" data-bind="">
-                            <div>
-                                <label>Title</label>
-                                <span data-bind="text: props.webTitle() || 'None!'"></span>
-                            </div>
-                        </div>
+                <!-- /ko -->
+
+                <!-- ko if: !state.isOpenProps() && id() -->
+                    <div class="instructions">
+                        <span class="linky" data-bind="click: openProps">Edit metadata</span>
                     </div>
+                <!-- /ko -->
 
-
+                <!-- ko if: id -->
                     <div data-bind="with: collections">
                         <div class="droppable" data-bind="
                             makeDropabble: true,
@@ -173,10 +208,10 @@
                             template: {name: 'template_collection', foreach: items}"></div>
                     </div>
                     <div class="instructions">
-                        Drop a container above, or <span data-bind="click: createCollection" class="linky">create</span> one.
-                        <div data-bind="if: !collections.items().length">Note: empty fronts will be discarded</div>
+                        <span data-bind="click: createCollection" class="linky">Create a container</span> or drop one above.
+                        <span data-bind="if: !collections.items().length">Empty fronts will be discarded!</span>
                     </div>
-                </div>
+                <!-- /ko -->
             </div>
 
         </div>

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -117,15 +117,8 @@
                     <button class="tool" data-bind="
                         click: save">Save container</button>
 
-                    <!-- ko if: $parents[1] -->
-                        <button class="tool" data-bind="
-                            click: $parents[1].depopulateCollection">Remove</button>
-                    <!-- /ko -->
-
-                    <!-- ko if: parents().length === 0 -->
-                        <button class="tool" data-bind="
-                            click: discard">Remove completely</button>
-                    <!-- /ko -->
+                    <button class="tool tool--rhs" data-bind="
+                        click: $parents[1].depopulateCollection">Remove</button>
                 </div>
             </div>
             <!-- /ko -->

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -665,6 +665,11 @@ button {
     cursor: pointer;
 }
 
+.tool--rhs {
+    float: right;
+    margin: 0 10px 0 0;
+}
+
 .tool:hover {
     text-decoration: none;
     color: #ffffff;

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -166,7 +166,7 @@ a:hover {
 
 .updating {
     display: none;
-    color: #009900;
+    color: #46c430;
     position: absolute;
     top: 13px;
     right: 15px;
@@ -484,6 +484,13 @@ input[type="text"] {
     border-radius: 2px;
 }
 
+.radio-label {
+    color: #666666;
+    float: left;
+    font-size: 12px;
+    padding: 0 10px 0 2px;
+}
+
 textarea.trailtext {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -768,7 +775,6 @@ button {
 .instructions {
     font-size: 12px;
     color: #999999;
-    padding: 0 0 10px 4px;
 }
 
 /*****************************************/
@@ -776,20 +782,28 @@ button {
 /*****************************************/
 
 .cnf-fronts {
-    border-top: 1px solid #dbd8c9;
+    margin-top: 10px;
+    padding: 0 15px 0 0;
 }
 
 .cnf-front {
-    padding: 4px 0 4px 4px;
-    border-bottom: 1px solid #dbd8c9;
+    padding-top: 2px;
+}
+
+.cnf-front.open {
+    background: #f4f3e8;
+    padding-bottom: 5px;
+    margin: 0 0 10px 0;
 }
 
 .cnf-front .title {
     cursor: pointer;
+    height: 24px;
+    font-weight: normal;
 }
 
-.cnf-front.isProvisional {
-    background: #dbd8c9;
+.cnf-front.open .title {
+    font-weight: bold;
 }
 
 .cnf-front__inner {
@@ -802,17 +816,22 @@ button {
 
 .cnf-collection {
     position: relative;
-    background: #ffffff;
-    padding: 4px 0 4px 5px;
-    border-top: 3px solid #ffffff;
+    padding: 1px 0 1px 5px;
 }
 
-.cnf-collection:nth-child(odd) {
+.cnf-front .cnf-collection {
+    border-top: 3px solid #f4f3e8;
+}
+
+.cnf-front .cnf-collection:nth-child(odd) {
+    background: #ffffff;
+}
+
+.cnf-front .cnf-collection:nth-child(even) {
     background: #f4f3e8;
 }
 
 .cnf-collection.open {
-    background: #f4f3e8;
     padding-bottom: 5px;
 }
 
@@ -828,19 +847,6 @@ button {
 
 .cnf-collection__name {
     color: #000000;
-}
-
-.cnf-collection__id {
-    display: none;
-    color: #999999;
-    font-size: 10px;
-    float: right;
-    margin: 0 5px 0 0;
-}
-
-.cnf-collection.open .cnf-collection__id,
-.cnf-collection:hover .cnf-collection__id {
-    display: block;
 }
 
 .cnf-collection__also-on {
@@ -874,14 +880,13 @@ button {
     display: none;
 }
 
-.cnf-form {
-    overflow: auto;
-    margin: 0 0 10px 0;
+.cnf-collection .cnf-form {
+    margin-left: 20px;
 }
 
 .cnf-form label {
     font-size: 12px;
-    color: #999999;
+    color: #666666;
     width: 65px;
     float: left;
     clear: left;
@@ -889,26 +894,27 @@ button {
 }
 
 .cnf-form input,
+.cnf-form textarea,
 .cnf-form select{
     float: left;
     clear: right;
+    color: #000000;
 }
 
-.cnf-form .advanced-options {
-    clear: both;
-    font-size: 10px;
+.cnf-form input[type="text"],
+.cnf-form textarea,
+.cnf-form select{
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    font-size: 12px;
+    line-height: 14px;
+    width: 300px;
+    margin: 0 0 2px 0;
 }
 
 .cnf-form .tools {
+    padding: 10px 0;
     clear: left;
-}
-
-.cnf-form .tools-advanced {
-    position: absolute;
-    bottom: 5px;
-    right: 5px;
-    font-size: 12px;
-    color: #CCCCCC;
 }
 
 .cnf-form .api-query-status {

--- a/facia-tool/public/javascripts/models/config/collection.js
+++ b/facia-tool/public/javascripts/models/config/collection.js
@@ -39,12 +39,12 @@ define([
         }
 
         this.state = asObservableProps([
-            'open',
+            'isOpen',
             'underDrag',
             'apiQueryStatus']);
 
         this.meta.apiQuery.subscribe(function(val) {
-            if (this.state.open()) {
+            if (this.state.isOpen()) {
                 this.meta.apiQuery(val.replace(/\s+/g, ''));
                 this.checkApiQueryStatus();
             }
@@ -52,14 +52,18 @@ define([
     }
 
     Collection.prototype.toggleOpen = function() {
-        this.state.open(!this.state.open());
+        this.state.isOpen(!this.state.isOpen());
+    };
+
+    Collection.prototype.close = function() {
+        this.state.isOpen(false);
     };
 
     Collection.prototype.save = function() {
         if (vars.model.collections.indexOf(this) < 0) {
             vars.model.collections.unshift(this);
         }
-        this.state.open(false);
+        this.state.isOpen(false);
         this.state.apiQueryStatus(undefined);
         vars.model.save(this);
     };

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -19,31 +19,27 @@ define([
     findFirstById
 ) {
     function Front(opts) {
-        var self = this;
+        var self = this,
+            props = [
+                'section',
+                'webTitle',
+                'title',
+                'description',
+                'priority'];
 
         opts = opts || {};
 
         this.id = ko.observable(opts.id);
 
-        this.id.subscribe(function(id) {
-            id = id || '';
-            id = id.toLowerCase();
-            id = id.replace(/^\/|\/$/g, '');
-            id = id.replace(/[^a-z0-9\/\-]*/g, '');
-            self.id(id);
-            if(_.filter(vars.model.fronts(), function(front) { return front.id() === id; }).length > 1) {
-                self.id(undefined);
-            }
-        });
+        this.props  = asObservableProps(props);
 
-        this.props  = asObservableProps([
-            'webTitle']);
+        this.placeholders  = asObservableProps(props);
 
         populateObservables(this.props,  opts);
 
         this.state = asObservableProps([
-            'open',
-            'openProps']);
+            'isOpen',
+            'isOpenProps']);
 
         this.collections = new Group({
             parent: self,
@@ -59,19 +55,67 @@ define([
                 .value()
         });
 
+        this.id.subscribe(function() {
+            this.validate(true);
+            if (this.id()) {
+                this.setOpen(true);
+            }
+        }, this);
+
+        this.props.webTitle.subscribe(function() {
+            this.derivePlaceholders();
+        }, this);
+
         this.depopulateCollection = this._depopulateCollection.bind(this);
     }
 
-    Front.prototype.setOpen = function(isOpen) {
-        this.state.open(isOpen);
+    Front.prototype.validate = function(checkUniqueness) {
+        var self = this;
+
+        this.id((this.id() || '')
+            .toLowerCase()
+            .replace(/^\/|\/$/g, '')
+            .replace(/[^a-z0-9\/\-]*/g, '')
+        );
+
+        if (!this.id()) { return; }
+
+        if(checkUniqueness && _.filter(vars.model.fronts(), function(front) { return front.id() === self.id(); }).length > 1) {
+            this.id(undefined);
+            return;
+        }
+    };
+
+    Front.prototype.derivePlaceholders = function() {
+        var path = (this.id() || '').split('/'),
+            isEditionalised = _.some(['uk', 'us', 'au'], function(edition) { return edition === path[0]; });
+
+        if (!path.length) { return; }
+
+        this.placeholders.section(this.props.section() || (isEditionalised ? path.length === 1 ? undefined : path[1] : path[0]));
+        this.placeholders.webTitle(this.props.webTitle() || toTitleCase(path.slice(path.length > 1 ? 1 : 0).join(' ').replace(/\-/g, ' ')) || this.id());
+        this.placeholders.title(this.placeholders.webTitle() + ' news, comment and analysis from the Guardian' + (this.placeholders.section() ? ' | ' + toTitleCase(this.placeholders.section()) : ''));
+        this.placeholders.description('Latest ' + this.placeholders.webTitle() + ' news, comment and analysis from the Guardian, the world\'s leading liberal voice');
+    };
+
+    Front.prototype.setOpen = function(isOpen, withOpenProps) {
+        this.state.isOpen(isOpen);
+        this.state.isOpenProps(withOpenProps);
     };
 
     Front.prototype.toggleOpen = function() {
-        this.state.open(!this.state.open());
+        this.state.isOpen(!this.state.isOpen());
     };
 
     Front.prototype.openProps = function() {
-        this.state.openProps(true);
+        this.state.isOpenProps(true);
+        this.derivePlaceholders();
+        this.collections.items().map(function(collection) { collection.close(); });
+    };
+
+    Front.prototype.saveProps = function() {
+        vars.model.save();
+        this.state.isOpenProps(false);
     };
 
     Front.prototype.createCollection = function() {
@@ -84,16 +128,15 @@ define([
     };
 
     Front.prototype._depopulateCollection = function(collection) {
-        collection.state.open(false);
+        collection.state.isOpen(false);
         collection.parents.remove(this);
         this.collections.items.remove(collection);
         vars.model.save(collection);
     };
 
-    Front.prototype.save = function() {
-        vars.model.save();
-        this.state.openProps(false);
-    };
+    function toTitleCase(str) {
+        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    }
 
     return Front;
 });

--- a/facia-tool/public/javascripts/models/config/main.js
+++ b/facia-tool/public/javascripts/models/config/main.js
@@ -73,9 +73,9 @@ define([
             }
         };
 
-        model.openFront = function(front, withOpenProps) {
+        model.openFront = function(front) {
             _.each(model.fronts(), function(f){
-                f.setOpen(f === front, withOpenProps);
+                f.setOpen(f === front, false);
             });
         };
 


### PR DESCRIPTION
![fronst-tool](https://cloud.githubusercontent.com/assets/1147913/2888712/6e0aa0c6-d510-11e3-9ef4-049b5723cf20.png)

Adds these fields per front, into the config:

```
section
webTitle
title
description
priority
```

Changes the LHS column to an alphabetical list of all containers. The concept of "orphaned containers" is removed; they are no longer persisted (they were just accumulating and being ignored).

![fronst-tool](https://cloud.githubusercontent.com/assets/1147913/2888683/9ed5ef90-d50f-11e3-900e-6b7c5798f74b.png)
