### PR TITLE
Resolve Merge Conflicts in Admin Assembly

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -74,8 +74,7 @@ object Frontend extends Build with Prototypes {
       "com.typesafe.slick" %% "slick" % "1.0.0",
       "postgresql" % "postgresql" % "8.4-703.jdbc4" from "http://jdbc.postgresql.org/download/postgresql-8.4-703.jdbc4.jar",
       "com.gu" %% "pa-client" % paVersion,
-      "com.google.api-ads" % "ads-lib" % "1.26.0",
-      "com.google.api-ads" % "dfp-axis" % "1.26.0"
+      "com.google.api-ads" % "dfp-axis" % "1.27.0"
     )
   )
   val faciaTool = application("facia-tool").dependsOn(commonWithTests)

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -97,6 +97,11 @@ trait Prototypes {
         case s: String if s.startsWith("scala/concurrent/stm") => MergeStrategy.first
         case s: String if s.endsWith("ServerWithStop.class") => MergeStrategy.first  // There is a scala trait and a Java interface
 
+        // transitive dependencies of DFP API
+        case "com/google/common/annotations/Beta.class" => MergeStrategy.first
+        case s: String if s.startsWith("com/google/common/") => MergeStrategy.first
+        case s: String if s.startsWith("org/apache/commons/collections/") => MergeStrategy.first
+
         // Take ours, i.e. MergeStrategy.last...
         case "logger.xml" => MergeStrategy.last
         case "version.txt" => MergeStrategy.last


### PR DESCRIPTION
DFP API transitive dependencies introduce different versions of classes to the classpath.
So using MergeStrategy.first to choose the first version that appears on the classpath.
