### PR TITLE
Remove the '+' for creating blank snaps

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -45,9 +45,6 @@
     <div class="left-col">
         <div class="title">
             Clipboard
-            <span class="linky" data-bind="
-                visible: switches()['facia-tool-snaps'],
-                click: createSnap">+</span>
         </div>
         <div class="clipboard__wrapper" data-bind="with: clipboard">
             <div class="clipboard droppable" data-bind="


### PR DESCRIPTION
Snaps now only get created by dragging them in
