### PR TITLE
Scss-lint grunt & config update

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -27,8 +27,11 @@ linters:
         - common/app/assets/stylesheets/base/_type.scss # We need to declare font-size twice
         - common/app/assets/stylesheets/_mixins.scss
 
+  MergeableSelector:
+    enabled: false
+
   DuplicateRoot:
-    enabled: true
+    enabled: false
 
   EmptyLineBetweenBlocks:
     enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "sass", "~> 3.3.6"
+gem "sass", "~> 3.3.7"
 
 group :development do
   gem "scss-lint"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source "https://rubygems.org"
 
 gem "sass", "~> 3.3.6"
 
-# group :development do
-#   gem "scss-lint"
-# end
+group :development do
+  gem "scss-lint"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     rainbow (2.0.0)
-    sass (3.3.6)
+    sass (3.3.7)
     scss-lint (0.23.1)
       rainbow (~> 2.0)
       sass (~> 3.3.0)
@@ -12,5 +12,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  sass (~> 3.3.6)
+  sass (~> 3.3.7)
   scss-lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    rainbow (2.0.0)
     sass (3.3.6)
+    scss-lint (0.23.1)
+      rainbow (~> 2.0)
+      sass (~> 3.3.0)
 
 PLATFORMS
   java
@@ -9,3 +13,4 @@ PLATFORMS
 
 DEPENDENCIES
   sass (~> 3.3.6)
+  scss-lint

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -719,6 +719,7 @@ module.exports = function (grunt) {
     grunt.registerTask('validate', function(app) {
         grunt.task.run([
             'validate:css',
+            'validate:sass',
             'validate:js:' + (app || '')
         ]);
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -498,7 +498,7 @@ module.exports = function (grunt) {
                 'common/app/assets/stylesheets'
             ],
             options: {
-                bundleExec: true,
+                // bundleExec: true, // uncomment once CI excludes the :development bundler group
                 config: '.scss-lint.yml',
                 reporterOutput: null
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -498,7 +498,7 @@ module.exports = function (grunt) {
                 'common/app/assets/stylesheets'
             ],
             options: {
-                // bundleExec: true, // uncomment once CI excludes the :development bundler group
+                bundleExec: true,
                 config: '.scss-lint.yml',
                 reporterOutput: null
             }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "moment": "~2.5.1",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-env": "~0.4.1",
-    "grunt-scss-lint": "^0.1.6"
+    "grunt-scss-lint": "^0.1.7"
   },
   "scripts": {
     "postinstall": "grunt hookmeup"


### PR DESCRIPTION
- [new] Update grunt-scss-lint to latest version, bringing colouring to the terminal output
- [new] Disable enforcement of a single rule declaration per Sass file (gets rid of alerts like _"Merge root rule `.blog__head-background--default` with identical rule on line 207"_) /cc @phamann
- ~~[temporary fix] `grunt validate:sass` works with the locally installed scss-lint gem (instead of relying on bundler which prevented it from running)~~
- [new] `grunt validate` lints Sass as well as JS and CSS
- **Update Thursday 8th** [new] Update Sass to latest version

PS: I am currently writing a post about this: ["Improving Your Sass Code Quality With scss-lint"](https://gist.github.com/kaelig/7da58c0a03c2b4df248e).

![ ](http://media.giphy.com/media/LCfmgllXiNfAk/giphy.gif)
