### PR TITLE
Fix config update

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -14,6 +14,8 @@ trait ConfigAgentTrait extends ExecutionContexts {
 
   def refresh() = S3FrontsApi.getMasterConfig map {s => configAgent.send(Json.parse(s))}
 
+  def refreshWith(json: JsValue): Unit = configAgent.send(json)
+
   def refreshAndReturn(): Future[JsValue] =
     S3FrontsApi.getMasterConfig
       .map(Json.parse)

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -13,10 +13,7 @@ import play.api.libs.ws.Response
 import scala.concurrent.Future
 import conf.Switches.ContentApiPutSwitch
 import model.{NoCache, Cached}
-import play.api.libs.iteratee.Enumerator
-import _root_.util.Enumerators._
 import scala.util.{Failure, Success}
-import play.api.templates.Html
 import play.api.libs.Comet
 
 object FaciaToolController extends Controller with Logging with ExecutionContexts {

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -59,9 +59,12 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     NoCache {
       configJson flatMap(_.asOpt[Config]) map {
         case update: Config => {
+
+          //Only update if it is a valid Config agent
           configJson.foreach { json =>
             ConfigAgent.refreshWith(json)
           }
+
           val identity = Identity(request).get
           UpdateActions.putMasterConfig(update, identity)
           Ok

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -60,7 +60,7 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
       configJson flatMap(_.asOpt[Config]) map {
         case update: Config => {
 
-          //Only update if it is a valid Config agent
+          //Only update if it is a valid Config object
           configJson.foreach { json =>
             ConfigAgent.refreshWith(json)
           }


### PR DESCRIPTION
Update the contents of the `ConfigAgent` when updating the `configuration` from the tool.

After a new collection is created by the tool, the tool pings to say press the paths that contain the collection and also update the collection (PUT) to the Content API.

This ensures that it will `PUT` new collections to the content API as empty.

@stephanfowler @robertberry 
