### PR TITLE
Change default article headline size at wider breakpoints

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -227,10 +227,7 @@
     color: $c-neutral2;
 
     @include mq(tablet) {
-        @include rem((
-            font-size: 18px,
-            line-height: 22px
-        ));
+        @include font-size(18px, 22px);
         -webkit-font-smoothing: antialiased;
         @include rem((
             margin-bottom: ($gs-baseline/3)*4

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -142,7 +142,7 @@
     }
     @include mq(tablet) {
         -webkit-font-smoothing: antialiased;
-        @include fs-headline(8, true);
+        @include fs-headline(7, true);
         @include rem((
             margin-bottom: $gs-row-height
         ));
@@ -227,7 +227,10 @@
     color: $c-neutral2;
 
     @include mq(tablet) {
-        @include fs-headline(2, true);
+        @include rem((
+            font-size: 18px,
+            line-height: 22px
+        ));
         -webkit-font-smoothing: antialiased;
         @include rem((
             margin-bottom: ($gs-baseline/3)*4

--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -210,7 +210,7 @@ $football-crest-large: 60px;
 }
 
 .team__battle-line {
-    @include fs-headline(8);
+    @include fs-headline(7);
     display: none;
     height: 50px;
     position: absolute;


### PR DESCRIPTION
As per request form designers, we have bumped down the stand-first and headline size on articles above tablet breakpoints

**Yes** the new standfirst size is _not_ on the type-scale, there will be a discussion as to how to introduce it into the scale at a later date.

Also change football score battle-line to match new article headline size.
#### Before

![screenshot from 2014-05-07 13 13 43](https://cloud.githubusercontent.com/assets/80089/2902182/77877b70-d5e1-11e3-9f13-7ba96bcfe625.png)
#### After

![screenshot from 2014-05-07 13 13 26](https://cloud.githubusercontent.com/assets/80089/2902185/7b7fd844-d5e1-11e3-91b4-b59728364b9e.png)
