### PR TITLE
Snaps: parameter rejig

### DIFF
--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -14,7 +14,8 @@ import concurrent.FutureOpt
 
 
 object FrontsController extends Controller with ExecutionContexts with GetPaClient {
-  val SNAP_TYPE = "football"
+  val SNAP_TYPE = "json.html"
+  val SNAP_CSS = "football"
 
   def index = Action.async { implicit request =>
     for {
@@ -25,7 +26,7 @@ object FrontsController extends Controller with ExecutionContexts with GetPaClie
   }
 
   def matchDay = Action.async { implicit request =>
-    val snapFields = SnapFields(SNAP_TYPE, s"$host/football/live.json", s"${Configuration.site.host}/football/live", "Live matches", "Today's matches")
+    val snapFields = SnapFields(SNAP_TYPE, SNAP_CSS, s"$host/football/live.json", s"${Configuration.site.host}/football/live", "Live matches", "Today's matches")
     previewFrontsComponent(snapFields)
   }
 
@@ -38,13 +39,13 @@ object FrontsController extends Controller with ExecutionContexts with GetPaClie
   def results(competitionId: String) = Action.async { implicit request =>
     val foResult =
       if ("all" == competitionId) {
-        val snapFields = SnapFields(SNAP_TYPE, s"$host/football/results.json", s"${Configuration.site.host}/football/results", "Results", "View the full results from today's matches")
+        val snapFields = SnapFields(SNAP_TYPE, SNAP_CSS, s"$host/football/results.json", s"${Configuration.site.host}/football/results", "Results", "View the full results from today's matches")
         FutureOpt.fromFuture(previewFrontsComponent(snapFields))
       } else {
         for {
           season <- getCompetition(competitionId)
           competitionName = PA.competitionName(season)
-          snapFields = SnapFields(SNAP_TYPE, s"$host/football/$competitionId/results.json", s"${Configuration.site.host}/football/results", s"$competitionName results", s"View the full results from today's $competitionName matches")
+          snapFields = SnapFields(SNAP_TYPE, SNAP_CSS, s"$host/football/$competitionId/results.json", s"${Configuration.site.host}/football/results", s"$competitionName results", s"View the full results from today's $competitionName matches")
           previewContent <- FutureOpt.fromFuture(previewFrontsComponent(snapFields))
         } yield previewContent
       }
@@ -60,13 +61,13 @@ object FrontsController extends Controller with ExecutionContexts with GetPaClie
   def fixtures(competitionId: String) = Action.async { implicit request =>
     val foResult =
       if ("all" == competitionId) {
-        val snapFields = SnapFields(SNAP_TYPE, s"$host/football/fixtures.json", s"${Configuration.site.host}/football/fixtures", "Upcoming fixtures", "See which teams are up against each other")
+        val snapFields = SnapFields(SNAP_TYPE, SNAP_CSS, s"$host/football/fixtures.json", s"${Configuration.site.host}/football/fixtures", "Upcoming fixtures", "See which teams are up against each other")
         FutureOpt.fromFuture(previewFrontsComponent(snapFields))
       } else {
         for {
           season <- getCompetition(competitionId)
           competitionName = PA.competitionName(season)
-          snapFields = SnapFields(SNAP_TYPE, s"$host/football/$competitionId/fixtures.json", s"${Configuration.site.host}/football/fixtures", s"$competitionName upcoming fixtures", s"See which $competitionName teams are up against each other")
+          snapFields = SnapFields(SNAP_TYPE, SNAP_CSS, s"$host/football/$competitionId/fixtures.json", s"${Configuration.site.host}/football/fixtures", s"$competitionName upcoming fixtures", s"See which $competitionName teams are up against each other")
           previewContent <- FutureOpt.fromFuture(previewFrontsComponent(snapFields))
         } yield previewContent
       }
@@ -84,7 +85,7 @@ object FrontsController extends Controller with ExecutionContexts with GetPaClie
       for {
         season <- getCompetition(competitionId)
         competitionName = PA.competitionName(season)
-        snapFields = SnapFields(SNAP_TYPE, s"$host/football/$competitionId/table.json", s"${Configuration.site.host}/football/tables", s"$competitionName table", s"View the full standing for the $competitionName")
+        snapFields = SnapFields(SNAP_TYPE, SNAP_CSS, s"$host/football/$competitionId/table.json", s"${Configuration.site.host}/football/tables", s"$competitionName table", s"View the full standing for the $competitionName")
         previewContent <- FutureOpt.fromFuture(previewFrontsComponent(snapFields))
       } yield previewContent
     foResult.getOrElse(throw new RuntimeException(s"Competition $competitionId not found"))

--- a/admin/app/football/model/SnapFields.scala
+++ b/admin/app/football/model/SnapFields.scala
@@ -3,10 +3,10 @@ package football.model
 import java.net.URLEncoder
 
 
-case class SnapFields(`type`: String, uri: String, fallbackUrl: String, fallbackHeadline: String, fallbackTrailtext: String) {
+case class SnapFields(`type`: String, `css`: String, uri: String, fallbackUrl: String, fallbackHeadline: String, fallbackTrailtext: String) {
   private implicit class RichString(string: String) {
     def encode = URLEncoder.encode(string, "UTF-8")
   }
 
-  val snapUrl = s"$fallbackUrl?gu-snapType=${`type`.encode}&gu-snapUri=${uri.encode}&gu-headline=${fallbackHeadline.encode}&gu-trailText=${fallbackTrailtext.encode}"
+  val snapUrl = s"$fallbackUrl?snap-type=${`type`.encode}&snap-css=${`css`.encode}&snap-uri=${uri.encode}&snap-headline=${fallbackHeadline.encode}&snap-trailText=${fallbackTrailtext.encode}"
 }

--- a/admin/app/football/model/SnapFields.scala
+++ b/admin/app/football/model/SnapFields.scala
@@ -8,5 +8,5 @@ case class SnapFields(`type`: String, `css`: String, uri: String, fallbackUrl: S
     def encode = URLEncoder.encode(string, "UTF-8")
   }
 
-  val snapUrl = s"$fallbackUrl?snap-type=${`type`.encode}&snap-css=${`css`.encode}&snap-uri=${uri.encode}&snap-headline=${fallbackHeadline.encode}&snap-trailText=${fallbackTrailtext.encode}"
+  val snapUrl = s"$fallbackUrl?gu-snapType=${`type`.encode}&gu-snapCss=${`css`.encode}&gu-snapUri=${uri.encode}&gu-headline=${fallbackHeadline.encode}&gu-trailText=${fallbackTrailtext.encode}"
 }

--- a/admin/app/football/model/SnapFields.scala
+++ b/admin/app/football/model/SnapFields.scala
@@ -3,10 +3,10 @@ package football.model
 import java.net.URLEncoder
 
 
-case class SnapFields(`type`: String, `css`: String, uri: String, fallbackUrl: String, fallbackHeadline: String, fallbackTrailtext: String) {
+case class SnapFields(`type`: String, css: String, uri: String, fallbackUrl: String, fallbackHeadline: String, fallbackTrailtext: String) {
   private implicit class RichString(string: String) {
     def encode = URLEncoder.encode(string, "UTF-8")
   }
 
-  val snapUrl = s"$fallbackUrl?gu-snapType=${`type`.encode}&gu-snapCss=${`css`.encode}&gu-snapUri=${uri.encode}&gu-headline=${fallbackHeadline.encode}&gu-trailText=${fallbackTrailtext.encode}"
+  val snapUrl = s"$fallbackUrl?gu-snapType=${`type`.encode}&gu-snapCss=${css.encode}&gu-snapUri=${uri.encode}&gu-headline=${fallbackHeadline.encode}&gu-trailText=${fallbackTrailtext.encode}"
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -306,6 +306,7 @@ class Snap(snapId: String,
 ) extends Content(new ApiContentWithMeta(SnapApiContent, supporting = snapSupporting, metaData = snapMeta)) {
 
   val snapType: Option[String] = snapMeta.get("snapType").flatMap(_.asOpt[String])
+  val snapCss: Option[String] = snapMeta.get("snapCss").flatMap(_.asOpt[String])
   val snapUri: Option[String] = snapMeta.get("snapUri").flatMap(_.asOpt[String])
 
   lazy val snapUrl: Option[String] = snapMeta.get("href").flatMap(_.asOpt[String])

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -828,7 +828,7 @@ object GetClasses {
   }
 
   def makeSnapClasses(trail: Trail): Seq[String] = trail match {
-    case snap: Snap => "facia-snap" +: snap.snapType.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
+    case snap: Snap => "facia-snap" +: snap.snapCss.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
     case _  => Nil
   }
 

--- a/facia-tool/app/frontpress/FrontPress.scala
+++ b/facia-tool/app/frontpress/FrontPress.scala
@@ -40,6 +40,7 @@ trait FrontPress extends Logging {
     supporting:   Option[Seq[JsValue]],
     href:         Option[JsValue],
     snapType:     Option[JsValue],
+    snapCss:      Option[JsValue],
     snapUri:      Option[JsValue]
   )
 
@@ -168,6 +169,7 @@ trait FrontPress extends Logging {
         supporting =  Option(content.supporting.map(generateInnerTrailJson)).filter(_.nonEmpty),
         href =        content.apiContent.metaData.get("href"),
         snapType = content.apiContent.metaData.get("snapType"),
+        snapCss = content.apiContent.metaData.get("snapCss"),
         snapUri = content.apiContent.metaData.get("snapUri")
       )
     )

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -59,7 +59,7 @@ case class CollectionMetaUpdate(
 trait UpdateActions extends Logging {
 
   val collectionCap: Int = Configuration.facia.collectionCap
-  val itemMetaWhitelistFields: Seq[String] = Seq("headline", "href", "snapType", "snapUri", "trailText", "group", "supporting", "imageAdjust", "isBreaking", "updatedAt")
+  val itemMetaWhitelistFields: Seq[String] = Seq("headline", "href", "snapType", "snapCss", "snapUri", "trailText", "group", "supporting", "imageAdjust", "isBreaking", "updatedAt")
   
   implicit val collectionMetaWrites = Json.writes[CollectionMetaUpdate]
   implicit val updateListWrite = Json.writes[UpdateList]

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -349,9 +349,9 @@
                     <div class="secondary">
                         <span data-bind="
                             visible: isSnap,
-                            attr: {class: 'is' + (meta.snapType() ? ' is--' + meta.snapType() : '')},
+                            attr: {class: 'is' + (meta.snapCss() ? ' is--' + meta.snapCss() : '')},
                             click: open,
-                            text: meta.snapType() || 'snap'"></span>
+                            text: meta.snapCss() || 'snap'"></span>
 
                         <span class="is is--breaking" data-bind="
                             visible: meta.isBreaking,

--- a/facia-tool/public/javascripts/models/collections/article.js
+++ b/facia-tool/public/javascripts/models/collections/article.js
@@ -52,6 +52,7 @@ define([
                 'isBreaking',
                 'group',
                 'snapType',
+                'snapCss',
                 'snapUri']);
 
             this.state = asObservableProps([

--- a/facia/app/assets/javascripts/modules/ui/snaps.js
+++ b/facia/app/assets/javascripts/modules/ui/snaps.js
@@ -53,7 +53,7 @@ define([
 
         iframe.style.width = '100%';
         iframe.style.border = 'none';
-        iframe.height = '200';
+        iframe.style.height = '200px';
         iframe.src = el.getAttribute('data-snap-uri');
         bonzo(el).html(iframe);
     }
@@ -74,15 +74,18 @@ define([
         bonzo(el).addClass('facia-snap-embed');
         setSnapPoint(el);
 
-        if(el.getAttribute('data-snap-type') === 'iframe') {
-            injectIframe(el);
+        switch (el.getAttribute('data-snap-type')) {
+            case 'document':
+                injectIframe(el);
+                break;
 
-        } else if(el.getAttribute('data-snap-type') === 'fragment') {
-            fetchFragment(el);
+            case 'fragment':
+                fetchFragment(el);
+                break;
 
-        } else {
-            // assumes a {"html": "<p>Stuff</p>"} response
-            fetchFragment(el, true);
+            case 'json.html':
+                fetchFragment(el, true);
+                break;
         }
     }
 

--- a/facia/app/assets/javascripts/modules/ui/snaps.js
+++ b/facia/app/assets/javascripts/modules/ui/snaps.js
@@ -13,7 +13,9 @@ define([
 ) {
 
     function init() {
-        var snaps = toArray($('.facia-snap[data-snap-uri^="http"]'));
+        var snaps = toArray($('.facia-snap'))
+                .filter(function(el) { return el.getAttribute('data-snap-uri'); })
+                .filter(function(el) { return el.getAttribute('data-snap-type'); });
 
         snaps.forEach(fetchSnap);
 


### PR DESCRIPTION
New query params for draggable snap urls:
- `gu-snapUri` is as before
- `gu-snapType` now describes the endpoint; valid values are `document`, `fragment`, `json.html`
- `gu-snapCss` now sets the `gu-snap--...` class. Optional.

NB. `json.html` means a html property within json - like the current football embeds.

cc/ @adamnfish @jamesgorrie
