### PR TITLE
Specify a separate ivy cache for sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ common/app/assets/stylesheets/theme/_commercial-icons-sprite.scss
 common/app/assets/stylesheets/theme/_commercial-icons-svg.scss
 common/app/assets/stylesheets/theme/_global-icons-sprite.scss
 common/app/assets/stylesheets/theme/_global-icons-svg.scss
+
+ivy-sbt

--- a/sbt
+++ b/sbt
@@ -60,4 +60,5 @@ fake_secret="myKV8HQkjcaxygbDuyneHBeyFgsyyM8yCFFOxyDoT0QGuyrY7IyammSyP1VivCxS"
 java $FRONTEND_JVM_ARGS  \
   $DEBUG_PARAMS \
   -DAPP_SECRET=$fake_secret \
+  -Dsbt.ivy.home=`dirname $0`/ivy-sbt \
   -jar `dirname $0`/dev/sbt-launch.jar "$@"


### PR DESCRIPTION
This avoids ivy lock contention between sbt and intellij
