### PR TITLE
Front SEO data only editable if not already in ContentApi

### DIFF
--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -189,12 +189,12 @@
 
                  <!-- ko if: id -->
                     <div class="instructions">
-                        <!-- ko if: !state.isOpenProps() && !state.hasCapiProps() -->
+                        <!-- ko if: !state.isOpenProps() && !state.hasContentApiProps() -->
                             <span class="linky" data-bind="click: openPropsAttempt">Edit metadata</span>
                         <!-- /ko -->
 
-                        <!-- ko if: state.hasCapiProps -->
-                            <span data-bind="text: state.hasCapiProps"></span>
+                        <!-- ko if: state.hasContentApiProps -->
+                            <span data-bind="text: state.hasContentApiProps"></span>
                             <span class="linky" data-bind="click: openProps">...</span>
                         <!-- /ko -->
                     </div>

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -90,7 +90,7 @@
                     <div class="api-query-results">
                         <div data-bind="
                             attr: {class: 'api-query-status--' + state.apiQueryStatus()},
-                            text: state.apiQueryStatus() === 'check' ? 'Checking...' : state.apiQueryStatus() === 'invalid' ? 'Found no matches' : 'Found matches:'"></div>
+                            text: state.apiQueryStatus() === 'check' ? 'Checking...' : state.apiQueryStatus() === 'invalid' ? 'No matches found' : 'Found matches:'"></div>
                         <div data-bind="foreach: capiResults">
                             <a target="_article" class="api-query-result" data-bind="
                                     attr: {href: 'http://www.theguardian.com/' + id},

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -90,7 +90,7 @@
                     <div class="api-query-results">
                         <div data-bind="
                             attr: {class: 'api-query-status--' + state.apiQueryStatus()},
-                            text: state.apiQueryStatus"></div>
+                            text: state.apiQueryStatus() === 'check' ? 'Checking...' : state.apiQueryStatus() === 'invalid' ? 'Found no matches' : 'Found matches:'"></div>
                         <div data-bind="foreach: capiResults">
                             <a target="_article" class="api-query-result" data-bind="
                                     attr: {href: 'http://www.theguardian.com/' + id},

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -190,11 +190,12 @@
                  <!-- ko if: id -->
                     <div class="instructions">
                         <!-- ko if: !state.isOpenProps() && !state.hasCapiProps() -->
-                            <span class="linky" data-bind="click: openProps">Edit metadata</span>
+                            <span class="linky" data-bind="click: openPropsAttempt">Edit metadata</span>
                         <!-- /ko -->
 
                         <!-- ko if: state.hasCapiProps -->
                             <span data-bind="text: state.hasCapiProps"></span>
+                            <span class="linky" data-bind="click: openProps">...</span>
                         <!-- /ko -->
                     </div>
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -187,13 +187,17 @@
                     </div>
                 <!-- /ko -->
 
-                <!-- ko if: !state.isOpenProps() && id() -->
+                 <!-- ko if: id -->
                     <div class="instructions">
-                        <span class="linky" data-bind="click: openProps">Edit metadata</span>
-                    </div>
-                <!-- /ko -->
+                        <!-- ko if: !state.isOpenProps() && !state.hasCapiProps() -->
+                            <span class="linky" data-bind="click: openProps">Edit metadata</span>
+                        <!-- /ko -->
 
-                <!-- ko if: id -->
+                        <!-- ko if: state.hasCapiProps -->
+                            <span data-bind="text: state.hasCapiProps"></span>
+                        <!-- /ko -->
+                    </div>
+
                     <div data-bind="with: collections">
                         <div class="droppable" data-bind="
                             makeDropabble: true,
@@ -205,7 +209,7 @@
                         <span data-bind="if: !collections.items().length">Empty fronts will be discarded!</span>
                     </div>
                 <!-- /ko -->
-            </div>
+           </div>
 
         </div>
     </script>

--- a/facia-tool/public/javascripts/models/config/collection.js
+++ b/facia-tool/public/javascripts/models/config/collection.js
@@ -80,7 +80,7 @@ define([
             return;
         }
 
-        this.state.apiQueryStatus('checking');
+        this.state.apiQueryStatus('check');
 
         checkCount += 1;
         cc = checkCount;
@@ -89,16 +89,10 @@ define([
         apiQuery += 'show-editors-picks=true&show-fields=headline';
 
         contentApi.fetchContent(apiQuery)
-        .done(function(results) {
+        .always(function(results) {
             if (cc === checkCount) {
                 self.capiResults(results);
                 self.state.apiQueryStatus(results.length ? 'valid' : 'invalid');
-            }
-        })
-        .fail(function() {
-            if (cc === checkCount) {
-                self.capiResults.removeAll();
-                self.state.apiQueryStatus('invalid');
             }
         });
     };

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -120,12 +120,12 @@ define([
             self.state.hasCapiProps('Metadata for this front must be edited with the R2 Tag Manager');
         })
         .fail(function() {
+            self.state.hasCapiProps(false);
             self.openProps();
         });
     };
 
     Front.prototype.openProps = function() {
-        this.state.hasCapiProps(false);
         this.state.isOpenProps(true);
         this.derivePlaceholders();
         this.collections.items().map(function(collection) { collection.close(); });

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -117,7 +117,7 @@ define([
 
         contentApi.fetchMetaForPath(this.id())
         .done(function() {
-            self.state.hasCapiProps('Metadata for this front must be edited with the R2 Tag Manager');
+            self.state.hasCapiProps('Metadata for this front should be edited in the Tag Manager');
         })
         .fail(function() {
             self.openProps();

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -3,6 +3,7 @@ define([
     'knockout',
     'config',
     'modules/vars',
+    'modules/content-api',
     'models/group',
     'models/config/collection',
     'utils/as-observable-props',
@@ -12,6 +13,7 @@ define([
     ko,
     config,
     vars,
+    contentApi,
     Group,
     Collection,
     asObservableProps,
@@ -39,7 +41,8 @@ define([
 
         this.state = asObservableProps([
             'isOpen',
-            'isOpenProps']);
+            'isOpenProps',
+            'hasCapiProps']);
 
         this.collections = new Group({
             parent: self,
@@ -108,9 +111,20 @@ define([
     };
 
     Front.prototype.openProps = function() {
-        this.state.isOpenProps(true);
-        this.derivePlaceholders();
-        this.collections.items().map(function(collection) { collection.close(); });
+        var self = this;
+
+        this.state.hasCapiProps('Checking...');
+
+        contentApi.fetchMetaForPath(this.id())
+        .done(function() {
+            self.state.hasCapiProps('Metadata for this front must be edited with the R2 Tag Manager');
+        })
+        .fail(function() {
+            self.state.hasCapiProps(false);
+            self.state.isOpenProps(true);
+            self.derivePlaceholders();
+            self.collections.items().map(function(collection) { collection.close(); });
+        });
     };
 
     Front.prototype.saveProps = function() {

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -110,21 +110,25 @@ define([
         this.state.isOpen(!this.state.isOpen());
     };
 
-    Front.prototype.openProps = function() {
+    Front.prototype.openPropsAttempt = function() {
         var self = this;
 
-        this.state.hasCapiProps('Checking...');
+        this.state.hasCapiProps('Checking');
 
         contentApi.fetchMetaForPath(this.id())
         .done(function() {
             self.state.hasCapiProps('Metadata for this front must be edited with the R2 Tag Manager');
         })
         .fail(function() {
-            self.state.hasCapiProps(false);
-            self.state.isOpenProps(true);
-            self.derivePlaceholders();
-            self.collections.items().map(function(collection) { collection.close(); });
+            self.openProps();
         });
+    };
+
+    Front.prototype.openProps = function() {
+        this.state.hasCapiProps(false);
+        this.state.isOpenProps(true);
+        this.derivePlaceholders();
+        this.collections.items().map(function(collection) { collection.close(); });
     };
 
     Front.prototype.saveProps = function() {

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -42,7 +42,7 @@ define([
         this.state = asObservableProps([
             'isOpen',
             'isOpenProps',
-            'hasCapiProps']);
+            'hasContentApiProps']);
 
         this.collections = new Group({
             parent: self,
@@ -113,14 +113,14 @@ define([
     Front.prototype.openPropsAttempt = function() {
         var self = this;
 
-        this.state.hasCapiProps('Checking');
+        this.state.hasContentApiProps('Checking');
 
         contentApi.fetchMetaForPath(this.id())
         .done(function() {
-            self.state.hasCapiProps('Metadata for this front must be edited with the R2 Tag Manager');
+            self.state.hasContentApiProps('Metadata for this front must be edited with the R2 Tag Manager');
         })
         .fail(function() {
-            self.state.hasCapiProps(false);
+            self.state.hasContentApiProps(false);
             self.openProps();
         });
     };

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -141,7 +141,7 @@ function (
             url: vars.CONST.apiSearchBase + '/' + path + '?page-size=0'
         }).always(function(resp) {
             var meta = resp.response ?
-               _.chain(['tag', 'section'])
+               _.chain(['section', 'tag'])
                 .map(function(key) { return resp.response[key]; })
                 .filter(function(obj) { return _.isObject(obj) && obj.webTitle && (obj.id || obj.sectionId); })
                 .reduce(function(m, obj) {

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -134,8 +134,33 @@ function (
         return defer.promise();
     }
 
+    function fetchMetaForPath(path) {
+        var defer = $.Deferred();
+
+        authedAjax.request({
+            url: vars.CONST.apiSearchBase + '/' + path + '?page-size=0'
+        }).always(function(resp) {
+            var meta = resp.response ?
+               _.chain(['tag', 'section'])
+                .map(function(key) { return resp.response[key]; })
+                .filter(function(obj) { return _.isObject(obj) && obj.webTitle && (obj.id || obj.sectionId); })
+                .reduce(function(m, obj) {
+                    m = m || {};
+                    m.section  = obj.id || obj.sectionId;
+                    m.webTitle = obj.webTitle;
+                    return m;
+                 }, undefined)
+                .value() : undefined;
+
+            defer[meta ? 'resolve' : 'reject'](meta);
+        });
+
+        return defer.promise();
+    }
+
     return {
         fetchContent: fetchContent,
+        fetchMetaForPath: fetchMetaForPath,
         decorateItems: decorateItems,
         validateItem:  validateItem
     };


### PR DESCRIPTION
Only offer the ability to enter SEO metadata if CAPI has none, i.e. if the front's path does not exist in CAPI/R2.
