### PR TITLE
shift comments below onwards unless the user is signed in

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -51,7 +51,8 @@ define([
     'common/modules/onward/right-most-popular',
     'common/modules/analytics/register',
     'common/modules/commercial/loader',
-    'common/modules/onward/tonal'
+    'common/modules/onward/tonal',
+    'common/modules/identity/api'
 ], function (
     $,
     mediator,
@@ -103,7 +104,8 @@ define([
     RightMostPopular,
     register,
     CommercialLoader,
-    TonalComponent
+    TonalComponent,
+    Id
 ) {
 
     var hasBreakpointChanged = detect.hasCrossedBreakpoint();
@@ -510,6 +512,14 @@ define([
                         .init(commercialComponent[1], slot);
                 }
             });
+        },
+
+        repositionComments: function() {
+            mediator.on('page:common:ready', function() {
+                if(!Id.isUserLoggedIn()) {
+                    $('.js-comments').insertAfter(qwery('.js-popular'));
+                }
+            });
         }
     };
 
@@ -558,6 +568,7 @@ define([
             modules.augmentInteractive();
             modules.runForseeSurvey(config);
             modules.startRegister(config);
+            modules.repositionComments();
         }
         mediator.emit('page:common:ready', config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -105,7 +105,7 @@ define([
     register,
     CommercialLoader,
     TonalComponent,
-    Id
+    id
 ) {
 
     var hasBreakpointChanged = detect.hasCrossedBreakpoint();
@@ -516,7 +516,7 @@ define([
 
         repositionComments: function() {
             mediator.on('page:common:ready', function() {
-                if(!Id.isUserLoggedIn()) {
+                if(!id.isUserLoggedIn()) {
                     $('.js-comments').insertAfter(qwery('.js-popular'));
                 }
             });


### PR DESCRIPTION
Does what it says. 
When there is no signed in user - move comments to below the onwards components

Signed In:

![signedcomments](https://cloud.githubusercontent.com/assets/986155/2917842/37db42b0-d6ca-11e3-9e41-90d737ed12b1.png)

Not Signed In:

![signedoutcomments](https://cloud.githubusercontent.com/assets/986155/2917857/55f36bce-d6ca-11e3-908a-251e4bebd028.png)
