### PR TITLE
Do not be explicit about pressing Asset typeData

### DIFF
--- a/facia-tool/app/frontpress/FrontPress.scala
+++ b/facia-tool/app/frontpress/FrontPress.scala
@@ -150,17 +150,13 @@ trait FrontPress extends Logging {
     "assets" -> element.delegate.assets.map(generateAsset)
   )
 
+  //Asset typeData: width, height, credit, caption
   private def generateAsset(asset: Asset): JsValue =
     Json.obj(
       "type" -> asset.`type`,
       "mimeType" -> asset.mimeType,
       "file" -> asset.file,
-      "typeData" -> Json.obj(
-        ("height", asset.typeData.get("height")),
-        ("credit", asset.typeData.get("credit")),
-        ("caption", asset.typeData.get("caption")),
-        ("width", asset.typeData.get("width"))
-      )
+      "typeData" -> asset.typeData
     )
 
   private def generateItemMeta(content: Content): JsValue =


### PR DESCRIPTION
Being explicit about `Asset.typeData` upon page pressing was causing `nulls` to appear in the `pressed.json` `typeData`. This was causing a problem during parsing as we are expecting a `Map[String, String]` on parsing.

This lines up the types in pressing and parsing by outputting the `Map[String, String]` from the `Asset` directly.

@gklopper 
In this instance of the cartoon, there was no `caption`, and it was appearing as `null` in the `typeData` `Map`.
