### PR TITLE
Reinstate DFP Cache Read

### DIFF
--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -7,6 +7,7 @@ import play.api.mvc.WithFilters
 object Global
   extends WithFilters(Filters.common: _*)
   with DevParametersLifecycle
+  with DfpAgentLifecycle
   with CloudWatchApplicationMetrics {
   override lazy val applicationName = Management.applicationName
 }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -544,6 +544,17 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
       }
     }
 
+    scenario("Signify to the user an article is sponsored"){
+      Given("I visit a sponsored article entitled 'Feeling hungry? Try the fine flavours of floral gastronomy'")
+      StandardAdvertsSwitch.switchOn()
+      HtmlUnit("/lifeandstyle/2014/may/02/feeling-hungry-try-the-fine-favours-of-floral-gastronomy") { browser =>
+        import browser._
+        Then("I should see a message")
+        val adSlot = $(".ad-slot--paid-for-badge")
+        adSlot.getAttribute("data-name") should be ("spbadge")
+        adSlot.findFirst(".ad-slot__container").getId should be ("dfp-ad--spbadge")
+      }
+    }
 
     scenario("Health check"){
       HtmlUnit("/world/2013/sep/15/obama-rouhani-united-nations-meeting") { browser =>

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -21,7 +21,10 @@ object DfpAgent extends ExecutionContexts with Logging {
     }
   }
 
-  def isSponsored(content: Content) = false
+  def isSponsored(content: Content) = {
+    val contentKeywords = content.keywords.map(_.name.toLowerCase.replace(" ", "-"))
+    (contentKeywords intersect targetedKeywords).nonEmpty
+  }
 
   def refresh() {
     def fetchTargetedKeywords() = {


### PR DESCRIPTION
This reads DFP data from an S3 doc to decide whether an article is sponsored or not.

It was taken out while we fixed the large-jar deployment problem, but this part is not affected by the problem.

/cc @kenlim @ironsidevsquincy 
