### PR TITLE
Container MPU max-height

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_misc.scss
+++ b/common/app/assets/stylesheets/module/containers/_misc.scss
@@ -52,9 +52,11 @@
     position: relative;
 
     @include mq(tablet) {
+        max-height: gs-height(6);
         min-height: $mpu-ad-label-height + $mpu-resulting-height + $mpu-align-offset;
     }
     @include mq(desktop) {
+        max-height: gs-height(7);
         min-height: $mpu-ad-label-height + $mpu-original-height + $mpu-align-offset;
     }
 


### PR DESCRIPTION
Stops it increasing to an insane height if the neighbouring `linkslist` gets too high
### Desktop

![screen shot 2014-05-09 at 14 13 33](https://cloud.githubusercontent.com/assets/74132/2928369/f3764b94-d77b-11e3-8601-8ed2e39ab4c3.png)
### Tablet

![screen shot 2014-05-09 at 14 13 41](https://cloud.githubusercontent.com/assets/74132/2928371/f672b1b6-d77b-11e3-991c-3dd3a660548e.png)
