### PR TITLE
Fix Sponsorship Logic in Front Containers

### DIFF
--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -1,4 +1,4 @@
-@(page: MetaData, collection: Collection, style: NewsContainer, containerIndex: Int, pagination: Option[Pagination] = None)(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
+@(page: MetaData, collection: Collection, style: NewsContainer, containerIndex: Int, pagination: Option[Pagination] = None, isSponsored: Boolean = false)(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
 
 @if(collection.items.nonEmpty) {
     <section
@@ -26,7 +26,7 @@
                 </h2>
             }
         </div>
-        @if(page.isSponsored) {
+        @if(isSponsored) {
             @fragments.commercial.badge(name="spbadge", adType="paid-for-badge", sizeMapping=Map("mobile" -> Seq("140,90")))
         }
         <div class="container__body">

--- a/facia/app/services/repositories.scala
+++ b/facia/app/services/repositories.scala
@@ -11,13 +11,20 @@ import contentapi.QueryDefaults
 import scala.concurrent.Future
 import play.api.mvc.{RequestHeader, SimpleResult}
 import com.gu.openplatform.contentapi.ApiError
+import dfp.DfpAgent
 
 object IndexPagePagination {
   def pageSize: Int = 20 //have a good think before changing this
 }
 
 case class IndexPage(page: MetaData, trails: Seq[Content],
-                     date: DateTime = DateTime.now)
+                     date: DateTime = DateTime.now) {
+
+  def isSponsored = {
+    val tags = (page.keywords ++ trails.flatMap(_.keywords)).distinct
+    DfpAgent.isSponsored(tags)
+  }
+}
 
 trait Index extends ConciergeRepository with QueryDefaults {
 

--- a/facia/app/views/fragments/indexBody.scala.html
+++ b/facia/app/views/fragments/indexBody.scala.html
@@ -2,7 +2,7 @@
 
 <div class="facia-container facia-container--layout-front monocolumn-wrapper monocolumn-wrapper--no-limit" data-link-name="Front" role="main">
 
-    @fragments.containers.tag(index.page, Collection(index.trails), NewsContainer(showMore = false), containerIndex = 0, pagination = index.page.pagination)(request, templateDeduping, Config(s"${index.page.id}/news/regular-stories", displayName = Some(index.page.webTitle)))
+    @fragments.containers.tag(index.page, Collection(index.trails), NewsContainer(showMore = false), containerIndex = 0, pagination = index.page.pagination, index.isSponsored)(request, templateDeduping, Config(s"${index.page.id}/news/regular-stories", displayName = Some(index.page.webTitle)))
 
     <section class="no-indent-article__zone">
         @fragments.footballNav(index.page)


### PR DESCRIPTION
Considering trail keywords as well as page keywords to determine if front is sponsored.

/cc @ironsidevsquincy @kenlim 
