### PR TITLE
Display "post" instead of "posts" in "Show 1 new post"

### DIFF
--- a/common/app/assets/javascripts/modules/live/notification-bar.js
+++ b/common/app/assets/javascripts/modules/live/notification-bar.js
@@ -16,13 +16,12 @@ define([
     NotificationBar.prototype.manipulationType = 'prepend';
     NotificationBar.prototype.classes = {
         'count' : 'js-notify-count',
-        'button' : 'js-notify-btn',
-        'count-plural' : 'js-notify-count__plural'
+        'button' : 'js-notify-btn'
     };
 
     NotificationBar.prototype.template = '<div class="block block--notification js-block-notification notify">' +
         '<div class="block-elements"><button class="notify__btn u-button-reset js-notify-btn"> ' +
-        'Show <span class="notify__count js-notify-count"></span> new post<span class="js-notify-count__plural">s</button></div></div>';
+        'Show <span class="notify__count js-notify-count"></span> new post<span class="notify__count-plural">s</button></div></div>';
 
     NotificationBar.prototype.ready = function() {
         this.on('click', this.getClass('button'), function() {

--- a/common/app/assets/javascripts/modules/live/notification-bar.js
+++ b/common/app/assets/javascripts/modules/live/notification-bar.js
@@ -16,12 +16,13 @@ define([
     NotificationBar.prototype.manipulationType = 'prepend';
     NotificationBar.prototype.classes = {
         'count' : 'js-notify-count',
-        'button' : 'js-notify-btn'
+        'button' : 'js-notify-btn',
+        'count-plural' : 'js-notify-count__plural'
     };
 
     NotificationBar.prototype.template = '<div class="block block--notification js-block-notification notify">' +
         '<div class="block-elements"><button class="notify__btn u-button-reset js-notify-btn"> ' +
-        'Show <span class="notify__count js-notify-count"></span> new posts</button></div></div>';
+        'Show <span class="notify__count js-notify-count"></span> new post<span class="js-notify-count__plural">s</button></div></div>';
 
     NotificationBar.prototype.ready = function() {
         this.on('click', this.getClass('button'), function() {
@@ -38,6 +39,7 @@ define([
 
     NotificationBar.prototype.setCount = function(count) {
         this.getElem('count').innerHTML = count;
+        this.getElem('count-plural').style.display = (count === 1) ? 'none' : 'inline';
     };
 
     return NotificationBar;


### PR DESCRIPTION
### Before

![screen shot 2014-05-12 at 14 51 01](https://cloud.githubusercontent.com/assets/85783/2945038/84782862-d9dc-11e3-8620-7fe37e327fbf.PNG)
### After

![screen shot 2014-05-12 at 14 51 13](https://cloud.githubusercontent.com/assets/85783/2945039/875c2268-d9dc-11e3-8adc-6522783f1205.PNG)

@rich-nguyen @phamann @mattosborn I couldn't find the JS tests for this. Would love to know how to test it if you don't have time to test it yourselves.

![night-is-a-dark-time](https://cloud.githubusercontent.com/assets/85783/2946459/0cd62506-d9ec-11e3-93b4-3d36125d93ba.gif)
