### PR TITLE
Fix Sponsorship Logic in Front Containers

### DIFF
--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -3,7 +3,7 @@ package dfp
 import common._
 import conf.Configuration.commercial.dfpDataKey
 import play.api.Play.current
-import model.{Tag, Content}
+import model.{Section, Tag, Content}
 import play.api.libs.json.Json._
 import play.api.{Play, Application, GlobalSettings}
 import scala.io.Codec.UTF8
@@ -25,8 +25,10 @@ object DfpAgent extends ExecutionContexts with Logging {
 
   def isSponsored(content: Content): Boolean = isSponsored(content.keywords)
 
+  def isSponsored(section: Section): Boolean = targetedKeywords contains normalise(section.webTitle)
+
   def isSponsored(tags: Seq[Tag]): Boolean = {
-    val normalisedTags = tags.map(_.name.toLowerCase.replace(" ", "-"))
+    val normalisedTags = tags.map(tag => normalise(tag.name))
     (normalisedTags intersect targetedKeywords).nonEmpty
   }
 

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -2,6 +2,7 @@ package model
 
 import com.gu.openplatform.contentapi.model.{ Section => ApiSection }
 import common.Pagination
+import dfp.DfpAgent
 
 case class Section(private val delegate: ApiSection, override val pagination: Option[Pagination] = None) extends MetaData {
 
@@ -22,4 +23,6 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
     "keywords" -> webTitle,
     "content-type" -> "Section"
   )
+
+  override def isSponsored = DfpAgent.isSponsored(this)
 }


### PR DESCRIPTION
This makes section logic consistent with logic for other content types.

/cc @ironsidevsquincy @kenlim 
