### PR TITLE
Hide interactive section header on mobile

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -1,7 +1,7 @@
 @(interactive: Interactive, storyPackage: List[Trail], index: Int, trail: Boolean)(implicit request: RequestHeader)
 @import conf.Switches.DiscussionSwitch
 <div class="gs-container">
-    <h2 class="article__zone tone-@VisualTone(interactive) tone-accent-border">
+    <h2 class="article__zone tone-@VisualTone(interactive) tone-accent-border hide-on-mobile">
         <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@interactive.section}">@Html(interactive.sectionName.toLowerCase)</a>
     </h2>
 


### PR DESCRIPTION
### Before

![screen shot 2014-05-12 at 16 40 45](https://cloud.githubusercontent.com/assets/85783/2946468/184b0640-d9ec-11e3-96b8-5cd13f3fa32d.PNG)
### After

![screen shot 2014-05-12 at 16 40 34](https://cloud.githubusercontent.com/assets/85783/2946469/1ba5b8e4-d9ec-11e3-95b0-5bf1b7bccd4e.PNG)

![the-internet](https://cloud.githubusercontent.com/assets/85783/2946476/2d8fe534-d9ec-11e3-8af7-d63bdd1134d1.gif)
