### PR TITLE
SEO: Change social tracking behaviour and fb share link

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -435,15 +435,15 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         import browser._
 
         val mailShareUrl = "mailto:?subject=Mark%20Kermode%27s%20DVD%20round-up&body=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review"
-        val fbShareUrl = "https://www.facebook.com/dialog/feed?app_id=232588266837342&redirect_uri=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&link=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&ref=responsive"
+        val fbShareUrl = "https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&ref=responsive"
         val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark+Kermode%27s+DVD+round-up&url=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review"
         val gplusShareUrl = "https://plus.google.com/share?url=http%3A%2F%2Flocalhost%3A9000%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review&hl=en-GB&wwc=1"
 
         Then("I should see buttons for my favourite social network")
-        findFirst(".social__action[data-link-name=social-mail]").getAttribute("href") should be(mailShareUrl)
-        findFirst(".social__action[data-link-name=social-fb]").getAttribute("href") should be(fbShareUrl)
-        findFirst(".social__action[data-link-name=social-twitter]").getAttribute("href") should be(twitterShareUrl)
-        findFirst(".social__action[data-link-name=social-gplus]").getAttribute("href") should be(gplusShareUrl)
+        findFirst(".social__item[data-link-name=email] .social__action").getAttribute("href") should be(mailShareUrl)
+        findFirst(".social__item[data-link-name=facebook] .social__action").getAttribute("href") should be(fbShareUrl)
+        findFirst(".social__item[data-link-name=twitter] .social__action").getAttribute("href") should be(twitterShareUrl)
+        findFirst(".social__item[data-link-name=gplus] .social__action").getAttribute("href") should be(gplusShareUrl)
       }
 
       Given("I want to track the responsive share buttons using Facebook Insights")
@@ -454,7 +454,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         val fbShareTrackingToken = "ref=responsive"
 
         Then("I should pass Facebook a tracking token")
-        findFirst(".social__action[data-link-name=social-fb]").getAttribute("href") should include(fbShareTrackingToken)
+        findFirst(".social__item[data-link-name=facebook] .social__action").getAttribute("href") should include(fbShareTrackingToken)
       }
 
 

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -81,6 +81,13 @@ define([
             // this allows 'live' Omniture tracking of Navigation Interactions
             s.eVar7 = 'D=pageName';
             s.prop37 = 'D=v37';
+
+            if(/social/.test(tag)) {
+                s.linkTrackVars += ',eVar12';
+                s.linkTrackEvents += ',event16';
+                s.eVar12 = tag;
+                s.events = s.apl(s.events, 'event16', ',');
+            }
         };
 
         // used where we don't have an element to pass as a tag

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -14,7 +14,7 @@
     <div class="js-comment-count"></div>
     <div class="social-wrapper social-wrapper--aside" data-component="share">
         <h2 class="social__head">Share this article</h2>
-        @fragments.social(content, "next to content")
+        @fragments.social(content, "top")
     </div>
 
 }

--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -1,10 +1,10 @@
-@(page: MetaData, position: String = "after content")(implicit request: RequestHeader)
+@(page: MetaData, position: String = "bottom")(implicit request: RequestHeader)
 
 @defining(s"http://${request.host}${request.path}"){ url =>
-    <ul class="social u-unstyled u-cf" data-link-name="@position">
-        <li class="social__item">
+    <ul class="social u-unstyled u-cf" data-component="social" data-link-name="social">
+        <li class="social__item" data-link-name="email">
             <a  class="social__action social-icon-wrapper"
-                data-link-name="social-mail"
+                data-link-name="@position"
                 href="mailto:?subject=@helper.urlEncode(page.webTitle).replaceAll("\\+", "%20")&amp;body=@helper.urlEncode(url)">
                 <span class="u-h">Share via Email</span>
                 <span class="social-icon">
@@ -12,9 +12,9 @@
                 </span>
             </a>
         </li>
-        <li class="social__item">
+        <li class="social__item" data-link-name="facebook">
             <a  class="social__action social-icon-wrapper"
-                data-link-name="social-fb"
+                data-link-name="@position"
                 href="https://www.facebook.com/sharer/sharer.php?u=@helper.urlEncode(url)">
                 <span class="u-h">Share on Facebook</span>
                 <span class="social-icon">
@@ -22,9 +22,9 @@
                 </span>
             </a>
         </li>
-        <li class="social__item">
+        <li class="social__item" data-link-name="twitter">
             <a  class="social__action social-icon-wrapper"
-                data-link-name="social-twitter"
+                data-link-name="@position"
                 href="https://twitter.com/intent/tweet?text=@helper.urlEncode(page.webTitle)&amp;url=@helper.urlEncode(url)">
                 <span class="u-h">Share on Twitter</span>
                 <span class="social-icon">
@@ -32,9 +32,9 @@
                 </span>
             </a>
         </li>
-        <li class="social__item">
+        <li class="social__item" data-link-name="google plus">
             <a  class="social__action social-icon-wrapper"
-                data-link-name="social-gplus"
+                data-link-name="@position"
                 href="https://plus.google.com/share?url=@helper.urlEncode(url)&amp;hl=en-GB&amp;wwc=1">
                 <span class="u-h">Share on Google+</span>
                 <span class="social-icon">

--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -15,14 +15,14 @@
         <li class="social__item">
             <a  class="social__action social-icon-wrapper"
                 data-link-name="social-fb"
-                href="https://www.facebook.com/dialog/feed?app_id=@Configuration.javascript.pageData("guardian.page.fbAppId")&amp;redirect_uri=@helper.urlEncode(url)&amp;link=@helper.urlEncode(url)&amp;ref=responsive">
+                href="https://www.facebook.com/sharer/sharer.php?u=@helper.urlEncode(url)">
                 <span class="u-h">Share on Facebook</span>
                 <span class="social-icon">
                     <i class="i-share-facebook i"></i>
                 </span>
             </a>
-       </li>
-       <li class="social__item">
+        </li>
+        <li class="social__item">
             <a  class="social__action social-icon-wrapper"
                 data-link-name="social-twitter"
                 href="https://twitter.com/intent/tweet?text=@helper.urlEncode(page.webTitle)&amp;url=@helper.urlEncode(url)">

--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -15,7 +15,7 @@
         <li class="social__item" data-link-name="facebook">
             <a  class="social__action social-icon-wrapper"
                 data-link-name="@position"
-                href="https://www.facebook.com/sharer/sharer.php?u=@helper.urlEncode(url)">
+                href="https://www.facebook.com/sharer/sharer.php?u=@helper.urlEncode(url)&ref=responsive">
                 <span class="u-h">Share on Facebook</span>
                 <span class="social-icon">
                     <i class="i-share-facebook i"></i>
@@ -32,7 +32,7 @@
                 </span>
             </a>
         </li>
-        <li class="social__item" data-link-name="google plus">
+        <li class="social__item" data-link-name="gplus">
             <a  class="social__action social-icon-wrapper"
                 data-link-name="@position"
                 href="https://plus.google.com/share?url=@helper.urlEncode(url)&amp;hl=en-GB&amp;wwc=1">

--- a/common/test/assets/javascripts/spec/Omniture.spec.js
+++ b/common/test/assets/javascripts/spec/Omniture.spec.js
@@ -145,6 +145,24 @@ define(['fixtures/config', 'analytics/omniture', 'common/common'], function(test
             });
         });
 
+        it("should send event16 when social button has been clicked", function(){
+            var o = new Omniture(s),
+                clickSpec = {
+                    target: document.documentElement,
+                    samePage: false,
+                    sameHost: false,
+                    tag: 'social | facebook | top'
+                }
+                ;
+            o.go(config);
+            waits(100);
+            runs(function() {
+                common.mediator.emit('module:clickstream:click', clickSpec);
+                expect(s.apl).toHaveBeenCalled();
+                expect(s.apl.args[0][1]).toBe('event16');
+            });
+        });
+
         it("should make a non-delayed s.tl call for same-page links", function(){
 
             var o = new Omniture(s),


### PR DESCRIPTION
From the SEO hit list:
- Update the facebook share link to sharer.php
- Change the data link names for all social buttons
- Use new omniture eVar and event to track social actions

/cc @rrees 
