### PR TITLE
Commercial: Fix Keyword Encoding

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/query-string.js
+++ b/common/app/assets/javascripts/modules/adverts/query-string.js
@@ -21,7 +21,7 @@ define([], function () {
     }
 
     function formatKeyword(keyword) {
-        return keyword.replace(/\s/g, '-').toLowerCase();
+        return keyword.replace(/\+/g, '').replace(/\s+/g, '-').toLowerCase();
     }
 
     function getKeywords(config) {

--- a/common/app/assets/javascripts/modules/adverts/query-string.js
+++ b/common/app/assets/javascripts/modules/adverts/query-string.js
@@ -21,7 +21,7 @@ define([], function () {
     }
 
     function formatKeyword(keyword) {
-        return keyword.replace(/\+/g, '').replace(/\s+/g, '-').toLowerCase();
+        return keyword.replace(/[+\s]+/g, '-').toLowerCase();
     }
 
     function getKeywords(config) {


### PR DESCRIPTION
This fixes encoding of keywords.
eg. 'Secure + protect' -> 'secure-protect'

/cc @ironsidevsquincy @kenlim 
