### PR TITLE
Remove unused formatTags fragment

### DIFF
--- a/common/app/views/fragments/formatTags.scala.html
+++ b/common/app/views/fragments/formatTags.scala.html
@@ -1,3 +1,0 @@
-@(tag: Tag)(implicit request: RequestHeader)
-
-<li class="b1"><a href="@LinkTo{@tag.url}">@Html(tag.name)</a></li>


### PR DESCRIPTION
Could not find anywhere where this template is used.

![outta-here](https://cloud.githubusercontent.com/assets/85783/2958488/fec7107e-daa9-11e3-960c-31ff7672ead2.gif)
