### PR TITLE
Search text label

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -2,15 +2,17 @@ define([
     'common/common',
     'common/utils/storage',
     'common/utils/mediator',
-    'common/modules/analytics/mvt-cookie'
+    'common/modules/analytics/mvt-cookie',
+    'modules/experiments/tests/searchText'
 ], function (
     common,
     store,
     mediator,
-    mvtCookie
+    mvtCookie,
+    HeaderSearchText
     ) {
 
-    var TESTS = [],
+    var TESTS = [HeaderSearchText],
        participationsKey = 'gu.ab.participations';
 
     function getParticipations() {

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -3,7 +3,7 @@ define([
     'common/utils/storage',
     'common/utils/mediator',
     'common/modules/analytics/mvt-cookie',
-    'modules/experiments/tests/searchText'
+    'common/modules/experiments/searchText'
 ], function (
     common,
     store,

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -9,11 +9,11 @@ define([
     store,
     mediator,
     mvtCookie,
-    HeaderSearchText
+    ABHeaderSearchText
     ) {
 
-    var TESTS = [HeaderSearchText],
-       participationsKey = 'gu.ab.participations';
+    var TESTS = [new ABHeaderSearchText()];
+    var participationsKey = 'gu.ab.participations';
 
     function getParticipations() {
         return store.local.get(participationsKey) || {};

--- a/common/app/assets/javascripts/modules/experiments/searchText.js
+++ b/common/app/assets/javascripts/modules/experiments/searchText.js
@@ -7,15 +7,15 @@ define(['bonzo'], function (bonzo) {
         this.expiry = '2014-06-09';
         this.author = 'Raul Tudor';
         this.description = 'The header search box will display a label for tablet and desktop.';
-        this.audience = 0.1;
-        this.audienceOffset = 0.4;
+        this.audience = 0.5;
+        this.audienceOffset = 0;
         this.successMeasure = 'Clicks/taps on the search box.';
         this.audienceCriteria = 'Users who are not on mobile.';
-        this.dataLinkNames = 'header search box label';
+        this.dataLinkNames = 'Search icon';
         this.idealOutcome = 'Increased number of clicks/taps on the search box.';
 
-        this.canRun = function(config) {
-            detect.getBreakpoint() !== 'mobile';
+        this.canRun = function (config) {
+            return detect.getBreakpoint() !== 'mobile';
         };
 
         this.variants = [
@@ -27,7 +27,12 @@ define(['bonzo'], function (bonzo) {
             {
                 id: 'hide',
                 test: function (context, config) {
-//                    bonzo(context.querySelector('.control--search .control__info')).hide();
+                    // hide text
+                    bonzo(context.querySelector('.top-nav__item--search .control__info')).hide();
+                    // make it narrower
+                    bonzo(context.querySelector('.top-nav__item--search'))
+                        .removeClass('top-nav__item--search')
+                        .addClass('top-nav__item--search__hidden');
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/searchText.js
+++ b/common/app/assets/javascripts/modules/experiments/searchText.js
@@ -27,7 +27,7 @@ define(['bonzo'], function (bonzo) {
             {
                 id: 'hide',
                 test: function (context, config) {
-                    bonzo(context.querySelector('.control--search .control__info')).hide();
+//                    bonzo(context.querySelector('.control--search .control__info')).hide();
                 }
             }
         ];

--- a/common/app/assets/javascripts/modules/experiments/searchText.js
+++ b/common/app/assets/javascripts/modules/experiments/searchText.js
@@ -1,4 +1,4 @@
-define(['bonzo'], function (bonzo) {
+define(['bonzo', 'common/utils/detect'], function (bonzo, detect) {
 
     var HeaderSearchText = function () {
 

--- a/common/app/assets/javascripts/modules/experiments/searchText.js
+++ b/common/app/assets/javascripts/modules/experiments/searchText.js
@@ -4,7 +4,7 @@ define(['bonzo'], function (bonzo) {
 
         this.id = 'HeaderSearchText';
         this.start = '2014-05-12';
-        this.expiry = '2014-06-9';
+        this.expiry = '2014-06-09';
         this.author = 'Raul Tudor';
         this.description = 'The header search box will display a label for tablet and desktop.';
         this.audience = 0.1;

--- a/common/app/assets/javascripts/modules/experiments/searchText.js
+++ b/common/app/assets/javascripts/modules/experiments/searchText.js
@@ -33,6 +33,6 @@ define(['bonzo'], function (bonzo) {
         ];
     };
 
-    return GeoMostPopular;
+    return HeaderSearchText;
 
 });

--- a/common/app/assets/javascripts/modules/experiments/searchText.js
+++ b/common/app/assets/javascripts/modules/experiments/searchText.js
@@ -1,0 +1,38 @@
+define(['bonzo'], function (bonzo) {
+
+    var HeaderSearchText = function () {
+
+        this.id = 'HeaderSearchText';
+        this.start = '2014-05-12';
+        this.expiry = '2014-06-9';
+        this.author = 'Raul Tudor';
+        this.description = 'The header search box will display a label for tablet and desktop.';
+        this.audience = 0.1;
+        this.audienceOffset = 0.4;
+        this.successMeasure = 'Clicks/taps on the search box.';
+        this.audienceCriteria = 'Users who are not on mobile.';
+        this.dataLinkNames = 'header search box label';
+        this.idealOutcome = 'Increased number of clicks/taps on the search box.';
+
+        this.canRun = function(config) {
+            detect.getBreakpoint() !== 'mobile';
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function (context, config) {
+                }
+            },
+            {
+                id: 'hide',
+                test: function (context, config) {
+                    bonzo(context.querySelector('.control--search .control__info')).hide();
+                }
+            }
+        ];
+    };
+
+    return GeoMostPopular;
+
+});

--- a/common/app/assets/stylesheets/module/nav/_control.scss
+++ b/common/app/assets/stylesheets/module/nav/_control.scss
@@ -43,6 +43,13 @@
 }
 
 
+/* Search control & control info (text label next to it)
+   ========================================================================== */
+
+.control--search {
+    overflow: visible; // Makes control__info visible
+}
+
 /* Profile control & control info (text label next to it)
    ========================================================================== */
 

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -398,3 +398,11 @@
         }
     }
 }
+
+.top-nav__item--search {
+    @include mq(tablet) {
+        @include rem((
+            width: 92px
+        ));
+    }
+}

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -406,3 +406,6 @@
         ));
     }
 }
+
+.top-nav__item--search__hidden {
+}

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -303,6 +303,11 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
+  val HeaderSearchText = Switch("Feature Switches", "header-search-text",
+    "If this switch is turned on then the header search box will display a label for tablet and desktop.",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 9)
+  )
+
   // Dummy Switches
 
   val IntegrationTestSwitch = Switch("Unwired Test Switch", "integration-test-switch",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -303,7 +303,7 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val HeaderSearchText = Switch("Feature Switches", "header-search-text",
+  val ABHeaderSearchText = Switch("A/B Tests", "ab-header-search-text",
     "If this switch is turned on then the header search box will display a label for tablet and desktop.",
     safeState = Off, sellByDate = new DateMidnight(2014, 6, 9)
   )
@@ -439,7 +439,8 @@ object Switches extends Collections {
     MemcachedSwitch,
     IncludeBuildNumberInMemcachedKey,
     GzipSwitch,
-    GeoMostPopular
+    GeoMostPopular,
+    ABHeaderSearchText
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -22,14 +22,14 @@ to apply any necessary changes to non-shared code there too.
                     </a>
                 </div>
                 @if(SearchSwitch.isSwitchedOn) {
-                    <div class="top-nav__item" data-component="search">
-                        <a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax data-link-name="Search icon" 
-                           class="control control--search js-search-toggle" data-toggle="nav-popup--search">
-                           <span class="u-h">Search</span>
-                           <span class="control__icon">
-                               <i class="i i-search"></i>
-                               <i class="i i-search-active"></i>
-                           </span>
+                    <div class="top-nav__item top-nav__item--search" data-component="search">
+                        <a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax data-link-name="Search icon"
+                        class="control control--search js-search-toggle" data-toggle="nav-popup--search">
+                            <span class="control__icon">
+                                <i class="i i-search"></i>
+                                <i class="i i-search-active"></i>
+                            </span>
+                            <span class="control__info hide-on-mobile">Search</span>
                         </a>
                     </div>
                 }

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -121,9 +121,9 @@ define([
 
     GeoMostPopular) {
     
-    var TESTS = {
-            Related: new GeoMostPopular()    //  and here.
-        };
+    var TESTS = [
+            new GeoMostPopular()    //  and here.
+        ];
     
     ...
 


### PR DESCRIPTION
The search text label should be displayed on tablets on desktop clients, but not on mobile.
In order to test whether or not this has the intended outcome, I've added an A/B test for it.

![screen shot 2014-05-12 at 16 48 15](https://cloud.githubusercontent.com/assets/1492162/2946925/9600f820-d9f0-11e3-99c8-6149dc940dcf.png)
![screen shot 2014-05-12 at 16 48 32](https://cloud.githubusercontent.com/assets/1492162/2946926/96199470-d9f0-11e3-8084-cee3fef91e0d.png)
