### PR TITLE
Fix Empty-Target Bug In Ad Requests

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -144,6 +144,12 @@ define([
             return value ? queryString.formatKeyword(value).replace(/&/g, 'and').replace(/'/g, '') : '';
         }
 
+        function addTarget(targets, target) {
+            if (target.length > 0) {
+                extend(targets, target);
+            }
+        }
+
         var conf        = this.config.page,
             section     = encodeTargetValue(conf.section),
             series      = encodeTargetValue(conf.series),
@@ -171,8 +177,8 @@ define([
             'a'       : AudienceScience.getSegments(),
             'at'      : Cookies.get('adtest') || ''
         };
-        extend(targets, AudienceScienceGateway.getSegments());
-        extend(targets, criteo.getSegments());
+        addTarget(targets, AudienceScienceGateway.getSegments());
+        addTarget(targets, criteo.getSegments());
 
         return targets;
     };


### PR DESCRIPTION
There shouldn't be ad targets that have no name or value.

This should fix the warning shown in the 'page request' here for example:
http://www.theguardian.com/uk?googfc
And it fixes the bug that was guarded in #4204 which was stopping video ads.
