### PR TITLE
Degrade gracefully on football overview flexbox

### DIFF
--- a/common/app/assets/stylesheets/module/football/_overview.scss
+++ b/common/app/assets/stylesheets/module/football/_overview.scss
@@ -15,6 +15,9 @@
             ));
             display: inline-block;
             display: flex;
+            @supports not (flex-wrap: wrap) {
+                display: inline-block;
+            }
             width: 49.5%;
         }
 
@@ -37,6 +40,10 @@
     @include mq(tablet) {
         display: flex;
         flex-wrap: wrap;
+
+        @supports not (flex-wrap: wrap) {
+            display: block;
+        }
 
         .dropdown {
             border-top: 0 none;


### PR DESCRIPTION
Degrading gracefully for browsers supporting the old flexbox (Firefox >= 24).
![flexbox](https://cloud.githubusercontent.com/assets/31692/2968644/2497b58a-db43-11e3-81a7-bb84fd0ad176.png)

---

![What?](http://3.bp.blogspot.com/-0xQ7pt8ocw0/UnwSwVPDuAI/AAAAAAAAOyg/EnBLQ_TAmMM/s1600/no-idea-what-i-am-doing.gif)
