### PR TITLE
Short names on wallchart

### DIFF
--- a/common/app/assets/stylesheets/module/football/_overview.scss
+++ b/common/app/assets/stylesheets/module/football/_overview.scss
@@ -96,6 +96,15 @@
     }
 }
 
+.football-group__matches {
+    .team-name:after {
+        content: attr(data-abbr);
+    }
+    .team-name__long {
+        @include u-h;
+    }
+}
+
 .football-knockouts--has-spider {
     @include mq(rightCol) {
         display: none;
@@ -301,11 +310,12 @@
 }
 
 .football-round--playoff {
+    background: $c-neutral8;
     bottom: 0;
     height: 25%;
     left: 42.857142857%; // 50 - (100/7/2) Half off the width of a seventh to get it exactly center
     position: absolute;
-    z-index: 1;
+    z-index: 2;
 
     .football-round__name {
         display: none;


### PR DESCRIPTION
[For the wallchart](http://www.theguardian.com/football/world-cup-2014/overview)
- Abbreviate football teams on fixture
- Ellipsis long team names else where
- Fix playoff / final `:hover` overlapping issue

![names-abbr](https://cloud.githubusercontent.com/assets/31692/2970215/70c4dc84-db58-11e3-8fd3-905ddbbdae20.png)
![names-overlap](https://cloud.githubusercontent.com/assets/31692/2970216/70c51334-db58-11e3-8b07-0c2574bdcade.png)

---

![Amazing](http://fc09.deviantart.net/fs70/f/2010/271/8/e/lollipop_animation__by_lonewolf_faraway-d2znbp9.gif)
