### PR TITLE
Facia tags

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -308,7 +308,7 @@
     }
 }
 .item__tag {
-    @include fs-textsans(1);
+    @include fs-headline(1);
 }
 .item__meta {
     position: absolute;

--- a/common/app/views/fragments/items/elements/tagOrSection.scala.html
+++ b/common/app/views/fragments/items/elements/tagOrSection.scala.html
@@ -8,7 +8,7 @@
             }
         }
         @if(config.showSections) {
-            <a href="@LinkTo {/@content.section}">@content.section</a>
+            <a href="@LinkTo {/@content.section}">@content.section.capitalize</a>
         }
     </div>
 }

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -32,13 +32,13 @@
                 </div>
             </a>
             <a href="@LinkTo{@trail.url}" class="item__link item__link--no-border" data-link-name="article">
-                @trail match { case content:model.Content => @fragments.items.elements.tagOrSection(content) }
-
                 <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--has-icon-mobile">
                     <span class="i i-gallery-yellow-small"></span>
                     @RemoveOuterParaHtml(trail.headline)
                 </h@if(isFirstContainer && index == 0){1}else{2}>
             </a>
+
+            @trail match { case content:model.Content => @fragments.items.elements.tagOrSection(content) }
 
             @trail.trailText.map { text =>
                 <div class="item__standfirst">@Html(text)</div>

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -28,12 +28,13 @@
                         </div>
                     }
                 </div>
-                @trail match { case content:model.Content => @fragments.items.elements.tagOrSection(content) }
                 <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--has-icon-mobile">
                     <span class="i i-video-yellow-small"></span>
                     @RemoveOuterParaHtml(trail.headline)
                 </h@if(isFirstContainer && index == 0){1}else{2}>
             </a>
+
+            @trail match { case content:model.Content => @fragments.items.elements.tagOrSection(content) }
 
             @trail.trailText.map { text =>
                 <div class="item__standfirst">@Html(text)</div>


### PR DESCRIPTION
A few adjustments to way tags are being displayed in facia
- capitalise section name
- move tags below trail title
- match tag size to commentator name on comment trails
