### PR TITLE
change news container title to display the date only for edition fronts ...

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -15,7 +15,7 @@
     }
     .container__title {
         display: none;
-        color: $c-neutral1;
+        color: $c-newsDefault;
         margin-bottom: 0;
     }
     @include mq(tablet) {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -236,6 +236,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   object facia {
     lazy val stage = configuration.getStringProperty("facia.stage").getOrElse(Configuration.environment.stage)
     lazy val collectionCap: Int = configuration.getIntegerProperty("facia.collection.cap").getOrElse(25)
+    lazy val editionFronts = Edition.all.map {e => "/" + e.id.toLowerCase}
   }
 
   object faciatool {

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -1,4 +1,5 @@
 @(collection: Collection, style: NewsContainer, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
+@import common.Edition
 
 @import org.joda.time.DateTime
 
@@ -19,28 +20,39 @@
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>
                     <div class="container__header">
-                        <h2 class="container__title">
-                            <span class="container__title__label today">
-                                <b class="today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</b>
-                                <span class="u-nobr today__sub">
-                                    <span class="today__dayofmonth js-dayofmonth">@Format(DateTime.now(), "d")</span>
-                                    <span class="today__month">@Format(DateTime.now(), "MMMM")</span>
-                                    <span class="today__year">@Format(DateTime.now(), "yyyy")</span>
-                                </span>
-                            </span>
-                            @LatestUpdate(collection, items).map { latestUpdate =>
-                                <span class="container__updated">
-                                    <span class="i--circle i--clock">
-                                        <span class="i i-clock-hands-white"></span>
+                        <h2 class="container__title tone-news tone-background">
+                            @if(! Configuration.facia.editionFronts.contains(request.uri.toLowerCase) ){
+                                @*if we are not on edition fronts we don't display dated title, *@
+                                @*but rather the container's title with an optional link specified in facia-tool *@
+                                @if(config.href){
+                                    <a class="container__title__label u-text-hyphenate" data-link-name="section heading"
+                                        href="@config.href">@config.displayName</a>
+                                } else {
+                                    <span class="container__title__label u-text-hyphenate">@title</span>
+                                }
+                            } else {
+                                <span class="container__title__label today">
+                                    <b class="today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</b>
+                                    <span class="u-nobr today__sub">
+                                        <span class="today__dayofmonth js-dayofmonth">@Format(DateTime.now(), "d")</span>
+                                        <span class="today__month">@Format(DateTime.now(), "MMMM")</span>
+                                        <span class="today__year">@Format(DateTime.now(), "yyyy")</span>
                                     </span>
-                                    Last updated:
-                                    <time
-                                        class="js-timestamp"
-                                        itemprop="datePublished"
-                                        datetime="@latestUpdate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-                                        data-relativeformat="long"
-                                        data-timestamp="@latestUpdate.getMillis"><span class="timestamp__text">@Format(latestUpdate, "E, h:ma")</span></time>
                                 </span>
+                                @LatestUpdate(collection, items).map { latestUpdate =>
+                                    <span class="container__updated">
+                                        <span class="i--circle i--clock">
+                                            <span class="i i-clock-hands-white"></span>
+                                        </span>
+                                        Last updated:
+                                        <time
+                                            class="js-timestamp"
+                                            itemprop="datePublished"
+                                            datetime="@latestUpdate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                                            data-relativeformat="long"
+                                            data-timestamp="@latestUpdate.getMillis"><span class="timestamp__text">@Format(latestUpdate, "E, h:ma")</span></time>
+                                    </span>
+                                }
                             }
                         </h2>
                     </div>


### PR DESCRIPTION
change news container title to display the date only for edition fronts (/uk, /us, /au), on all other fronts, display the container title with an optional link specified in facia-tool

![screen shot 2014-05-15 at 10 23 58](https://cloud.githubusercontent.com/assets/1492162/2982297/4d02dab0-dc13-11e3-8ba1-fe354d10dcad.png)
![screen shot 2014-05-15 at 10 23 04](https://cloud.githubusercontent.com/assets/1492162/2982298/4d032f56-dc13-11e3-8c02-4327f27bb8f0.png)
