### PR TITLE
Make Ophan request for non-modern browsers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -375,6 +375,14 @@ module.exports = function (grunt) {
                     dest: staticTargetDir + 'javascripts/vendor'
                 }]
             },
+            'curl': {
+                files: [{
+                    expand: true,
+                    cwd: 'common/app/assets/javascripts/components/curl/dist/curl',
+                    src: ['curl.js'],
+                    dest: staticTargetDir + 'javascripts'
+                }]
+            },
             'javascript-common': {
                 files: [{
                     expand: true,
@@ -789,6 +797,7 @@ module.exports = function (grunt) {
             'clean:assets',
             'copy:headCss',
             'copy:vendor',
+            'copy:curl',
             'hash'
         ]);
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,16 @@ module.exports = function (grunt) {
                     }
                 }
             },
+            ophan: {
+                options: {
+                    baseUrl: 'common/app/assets/javascripts',
+                    name: 'common/bootstraps/ophan',
+                    out: staticTargetDir + 'javascripts/bootstraps/ophan.js',
+                    wrap: {
+                        startFile: 'common/app/assets/javascripts/components/curl/dist/curl/curl.js'
+                    }
+                }
+            },
             admin: {
                 options: {
                     baseUrl: 'admin/app/assets/javascripts',
@@ -373,14 +383,6 @@ module.exports = function (grunt) {
                     cwd: 'common/app/public/javascripts/vendor',
                     src: ['**/foresee/**'],
                     dest: staticTargetDir + 'javascripts/vendor'
-                }]
-            },
-            'curl': {
-                files: [{
-                    expand: true,
-                    cwd: 'common/app/assets/javascripts/components/curl/dist/curl',
-                    src: ['curl.js'],
-                    dest: staticTargetDir + 'javascripts'
                 }]
             },
             'javascript-common': {
@@ -797,7 +799,6 @@ module.exports = function (grunt) {
             'clean:assets',
             'copy:headCss',
             'copy:vendor',
-            'copy:curl',
             'hash'
         ]);
     });

--- a/common/app/assets/javascripts/bootstraps/ophan.js
+++ b/common/app/assets/javascripts/bootstraps/ophan.js
@@ -1,0 +1,1 @@
+require('ophan/ng', function() {});

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -47,6 +47,12 @@
                             var img = new Image();
                             img.src = "@{Configuration.debug.beaconUrl}/count/pva.gif";
                         }
+
+                        var s = document.createElement('script' ),
+                                sc = document.getElementsByTagName('script')[0];
+                        s.src = '@Static("javascripts/bootstraps/ophan.js")';
+                        s.aysnc = true;
+                        sc.parentNode.insertBefore(s, sc);
                     }
                 </script>
         }

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -49,7 +49,14 @@
         // must always be set before the Omniture file is parsed
         window.s_account = guardian.config.page.omnitureAccount;
 
-        if (!isModern) { return false; }
+        if (!isModern) {
+            var s = document.createElement('script' ),
+                sc = document.getElementsByTagName('script')[0];
+            s.src = '@Static("javascripts/bootstraps/ophan.js")';
+            s.aysnc = true;
+            sc.parentNode.insertBefore(s, sc);
+            return false;
+        }
 
         @if(CssFromStorageSwitch.isSwitchedOn && !play.Play.isDev()) {
             function loadCssFromStorage() {

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -49,14 +49,7 @@
         // must always be set before the Omniture file is parsed
         window.s_account = guardian.config.page.omnitureAccount;
 
-        if (!isModern) {
-            var s = document.createElement('script' ),
-                sc = document.getElementsByTagName('script')[0];
-            s.src = '@Static("javascripts/bootstraps/ophan.js")';
-            s.aysnc = true;
-            sc.parentNode.insertBefore(s, sc);
-            return false;
-        }
+        if (!isModern) { return false; }
 
         @if(CssFromStorageSwitch.isSwitchedOn && !play.Play.isDev()) {
             function loadCssFromStorage() {


### PR DESCRIPTION
Ophan is currently init'd inside our core app.js file. This is for various reasons such as the ability to pump in extra data such as A/B tests and component tracking.

A major side-effect of this means user agents which do no "cut-the-mustard" are exempt from Ophan tracking. This obviously is not acceptable.

Therefore, this PR introduces a new decoupled ophan.js bootstrap which is loaded for non-modern browsers.

/cc @tackley @philwills @ironsidevsquincy @gklopper 
