### PR TITLE
adding grunt plugin for quick live css reload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -705,6 +705,28 @@ module.exports = function (grunt) {
                     to: ''
                 }]
             }
+        },
+
+        reloadlet: {
+            options: {
+                port: 8005
+            },
+            main: {
+                sass: {
+                    src: 'common/app/assets/stylesheets/',
+                    dest: 'static/target/stylesheets'
+                },
+                assets: [
+                    {
+                        local: 'static/target/stylesheets/head.default.css',
+                        remote: '/assets/stylesheets/head.default.css'
+                    },
+                    {
+                        local: 'static/target/stylesheets/global.css',
+                        remote: '/assets/stylesheets/global.css'
+                    }
+                ]
+            }
         }
     });
 
@@ -729,6 +751,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-asset-monitor');
     grunt.loadNpmTasks('grunt-text-replace');
+    grunt.loadNpmTasks('grunt-reloadlet');
 
     grunt.registerTask('default', ['compile', 'test', 'analyse']);
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "moment": "~2.5.1",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-env": "~0.4.1",
-    "grunt-scss-lint": "^0.1.7"
+    "grunt-scss-lint": "^0.1.7",
+    "grunt-reloadlet": "~0.1.1"
   },
   "scripts": {
     "postinstall": "grunt hookmeup"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-env": "~0.4.1",
     "grunt-scss-lint": "^0.1.7",
-    "grunt-reloadlet": "~0.1.2"
+    "grunt-reloadlet": "~0.1.3"
   },
   "scripts": {
     "postinstall": "grunt hookmeup"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-env": "~0.4.1",
     "grunt-scss-lint": "^0.1.7",
-    "grunt-reloadlet": "~0.1.1"
+    "grunt-reloadlet": "~0.1.2"
   },
   "scripts": {
     "postinstall": "grunt hookmeup"


### PR DESCRIPTION
to use:
0. `npm install` 
1. `grunt reloadlet` to launch sass watch and the live reload server
2. copy `node_modules/grunt-reloadlet/bookmarklet.js` file contents into a bookmark and run it (on a local gu page)
3. save css and the appropriate css assets should be reloaded

plugin source is here:
https://github.com/mattosborn/grunt-reloadlet
