### PR TITLE
do not show the mobile dropcaps on desktop when the dropcaps--wide class...

### DIFF
--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -810,6 +810,8 @@
 }
 
 .drop-cap {
+  @include mq($to: tablet) {
+
     float: left;
     display: inline-block;
     text-transform: uppercase;
@@ -827,17 +829,23 @@
         vertical-align: text-top;
         @include font-size(52px, 40px);
     }
+  }
+}
 
+.drop-cap--wide {
     @include mq($from: tablet) {
-        &.drop-cap--wide {
-            @include rem((
-                margin-right: 5px,
-                height: 3*get-line-height($fs-bodyCopy, 3)
-            ));
+        float: left;
+        display: inline-block;
+        text-transform: uppercase;
+        @include f-headline;
+        font-weight: 200;
+        @include rem((
+            margin-right: 5px,
+            height: 3*get-line-height($fs-bodyCopy, 3)
+        ));
 
-            .drop-cap__inner {
-                @include font-size(84px, 68px);
-            }
+        .drop-cap__inner {
+            @include font-size(84px, 68px);
         }
     }
 }

--- a/common/app/assets/stylesheets/theme/_tones.scss
+++ b/common/app/assets/stylesheets/theme/_tones.scss
@@ -205,8 +205,17 @@
 
             }
         }
+
         .drop-cap {
-            color: $colour;
+            @include mq($to: tablet) {
+                color: $colour;
+            }
+        }
+
+        .drop-cap--wide {
+            @include mq($from: tablet) {
+                color: $colour;
+            }
         }
 
     }

--- a/common/app/assets/stylesheets/theme/_tones.scss
+++ b/common/app/assets/stylesheets/theme/_tones.scss
@@ -217,6 +217,5 @@
                 color: $colour;
             }
         }
-
     }
 }


### PR DESCRIPTION
This fixes an issue raised by Chris - when a piece of content has not been marked up with with dropcap--wide class ( for breakpoints of desktop and wider ), don't show the mobile drop cap. Which results in the example below: 

![dropcap-desktop-error](https://cloud.githubusercontent.com/assets/986155/2983606/be1395c4-dc26-11e3-9560-5c39627b6212.png)

Fix: 

![dropcap-desktop-fix](https://cloud.githubusercontent.com/assets/986155/2983608/c8ddda82-dc26-11e3-8e25-267dea7e5313.png)
