### PR TITLE
Polyfill function.prototype.bind

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -1,6 +1,7 @@
 /*global guardian:true */
 define([
     'domReady',
+    'common/utils/polyfill',
     'common/utils/mediator',
     'common/utils/ajax',
     'common/utils/detect',
@@ -25,6 +26,7 @@ define([
     'common/bootstraps/identity'
 ], function (
     domReady,
+    polyfill,
     mediator,
     ajax,
     detect,

--- a/common/app/assets/javascripts/utils/polyfill.js
+++ b/common/app/assets/javascripts/utils/polyfill.js
@@ -1,0 +1,37 @@
+define(function() {
+
+    /**
+     * ARE YOU SURE YOU WANT TO ADD SOMETHING TO THIS FILE?!
+     * You must have an extremely good reason to add a polyfill,
+     * we prefer progressive enhancement over graceful degradation
+     *
+     * This is not to stop you adding polyfills, it is here to make you think before doing so.
+     */
+
+    if (!Function.prototype.bind) {
+        Function.prototype.bind = function (oThis) {
+            if (typeof this !== 'function') {
+                // closest thing possible to the ECMAScript 5
+                // internal IsCallable function
+                throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+            }
+
+            var aArgs = Array.prototype.slice.call(arguments, 1),
+                fToBind = this,
+                Noop = function () {},
+                fBound = function () {
+                    return fToBind.apply(this instanceof Noop && oThis
+                            ? this
+                            : oThis,
+                        aArgs.concat(Array.prototype.slice.call(arguments)));
+                };
+
+            Noop.prototype = this.prototype;
+            fBound.prototype = new Noop();
+
+            return fBound;
+        };
+    }
+
+    return true;
+});

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -15,7 +15,6 @@
             && 'addEventListener' in window
             && 'localStorage' in window
             && 'sessionStorage' in window
-            && 'bind' in Function
             && (
                 ('XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest())
                 || 'XDomainRequest' in window


### PR DESCRIPTION
So... Although this PR goes against our core beliefs and especially against mine, there is a valid, data driven, reason to this madness.

We recently added `Function.prototype.bind` to our cut-the-mustard test, which inadvertently kicked out ~4% of users from receiving our core JavaScript application. This took that demographic from 6 to 10%, and broke our line in the sand to serve JS to ~95% of users.

This PR introduces a `polyfill.js` which includes one for `bind()`, and a strongly worded comment.

This is a temporary change going forward, as we are discussing the ability to separate analytics & advert code from our core JS file. More to follow in the coming weeks.

/cc @ironsidevsquincy @gklopper @tackley 
