### PR TITLE
Make BMS responsive when called over JSON

### DIFF
--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -12,7 +12,7 @@ $football-crest-large: 60px;
     display: block;
     position: relative;
 
-    &:hover {
+    &a:hover {
         background: $c-neutral7;
         text-decoration: none;
     }
@@ -194,6 +194,12 @@ $football-crest-large: 60px;
 }
 
 @mixin match-summary--responsive {
+    .match-summary {
+        @include rem((
+            margin-bottom: $gs-baseline*3
+        ));
+    }
+
     .match-summary__teams {
         border-top: 0 none;
     }

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -52,7 +52,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
         case filtered => Cached(if(theMatch.isLive) 10 else 300) {
           JsonComponent(
             "nav" -> football.views.html.fragments.matchNav(populateNavModel(theMatch, filtered)),
-            "matchSummary" -> football.views.html.fragments.matchSummary(theMatch, Competitions().competitionForMatch(theMatch.id)),
+            "matchSummary" -> football.views.html.fragments.matchSummary(theMatch, Competitions().competitionForMatch(theMatch.id), responsive = true),
             "scoreSummary" -> football.views.html.fragments.scoreSummary(theMatch),
             "hasStarted" -> theMatch.hasStarted,
             "group" -> group,


### PR DESCRIPTION
- Add responsive class to BMS for [article scoreboard](http://www.theguardian.com/football/2014/apr/05/manchester-city-southampton-live-mbm)
- Allow space for stadium name below BMS on widescreens
- Only hover when the BMS is a link

![What](http://img.izifunny.com/pics/2013/20130606/640/15-hilarious-no-nose-animated-gifs_1.gif)
