### PR TITLE
Change X-Accel-Redirects

### DIFF
--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -34,7 +34,7 @@ class GalleryControllerTest extends FlatSpec with Matchers {
   it should "internal redirect when content type is not gallery" in Fake {
     val result = controllers.GalleryController.render("world/video/2012/feb/10/inside-tibet-heart-protest-video")(TestRequest("/world/video/2012/feb/10/inside-tibet-heart-protest-video"))
     status(result) should be(200)
-    header("X-Accel-Redirect", result).get should be("/type/video/world/video/2012/feb/10/inside-tibet-heart-protest-video")
+    header("X-Accel-Redirect", result).get should be("/applications/world/video/2012/feb/10/inside-tibet-heart-protest-video")
   }
 
   it should "display an expired message for expired content" in Fake {

--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -39,7 +39,7 @@ class IndexControllerTest extends FlatSpec with Matchers {
   it should "internal redirect when content type is not front" in Fake {
     val result = controllers.IndexController.render("world/video/2012/feb/10/inside-tibet-heart-protest-video")(TestRequest("/world/video/2012/feb/10/inside-tibet-heart-protest-video"))
     status(result) should be(200)
-    header("X-Accel-Redirect", result).get should be("/type/video/world/video/2012/feb/10/inside-tibet-heart-protest-video")
+    header("X-Accel-Redirect", result).get should be("/applications/world/video/2012/feb/10/inside-tibet-heart-protest-video")
   }
 
   it should "200 when content type is front trails" in Fake {

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -81,7 +81,7 @@ class ArticleControllerTest extends FlatSpec with Matchers {
   it should "internal redirect unsupported content to classic" in Fake {
     val result = controllers.ArticleController.renderArticle("world/video/2012/feb/10/inside-tibet-heart-protest-video")(TestRequest("world/video/2012/feb/10/inside-tibet-heart-protest-video"))
     status(result) should be(200)
-    header("X-Accel-Redirect", result).get should be("/type/video/world/video/2012/feb/10/inside-tibet-heart-protest-video")
+    header("X-Accel-Redirect", result).get should be("/applications/world/video/2012/feb/10/inside-tibet-heart-protest-video")
   }
 
   val expiredArticle = "football/2012/sep/14/zlatan-ibrahimovic-paris-st-germain-toulouse"

--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -53,8 +53,8 @@ private object InternalRedirect{
   def contentTypes(response: ItemResponse)(implicit request: RequestHeader): Option[Right[Nothing, SimpleResult]] = {
     response.content.map {
       case a if a.isArticle || a.isLiveBlog => internalRedirect("type/article", a.id)
-      case v if v.isVideo => internalRedirect("type/video", v.id)
-      case g if g.isGallery => internalRedirect("type/gallery", g.id)
+      case v if v.isVideo => internalRedirect("applications", v.id)
+      case g if g.isGallery => internalRedirect("applications", g.id)
       case unsupportedContent => Right(Redirect(unsupportedContent.webUrl, Map("view" -> Seq("classic"))))
     }
   }

--- a/common/test/common/ModelOrResultTest.scala
+++ b/common/test/common/ModelOrResultTest.scala
@@ -59,7 +59,7 @@ class ModelOrResultTest extends FlatSpec with Matchers with ExecutionContexts {
     }
 
     status(notFound) should be(200)
-    headers(notFound).apply("X-Accel-Redirect") should be("/type/video/the/id")
+    headers(notFound).apply("X-Accel-Redirect") should be("/applications/the/id")
   }
 
   it should "internal redirect to a gallery if it has shown up at the wrong server" in {

--- a/facia/test/IndexControllerTest.scala
+++ b/facia/test/IndexControllerTest.scala
@@ -39,7 +39,7 @@ class IndexControllerTest extends FlatSpec with Matchers {
   it should "internal redirect when content type is not front" in Fake {
     val result = controllers.IndexController.render("world/video/2012/feb/10/inside-tibet-heart-protest-video")(TestRequest("/world/video/2012/feb/10/inside-tibet-heart-protest-video"))
     status(result) should be(200)
-    header("X-Accel-Redirect", result).get should be("/type/video/world/video/2012/feb/10/inside-tibet-heart-protest-video")
+    header("X-Accel-Redirect", result).get should be("/applications/world/video/2012/feb/10/inside-tibet-heart-protest-video")
   }
 
   it should "200 when content type is front trails" in Fake {


### PR DESCRIPTION
We will only have one `X-Accel-Redirect` in `nginx`for `applications`, which will be `/appliations/$path`.

This depends on 
https://github.com/guardian/platform/pull/482

And
https://github.com/guardian/platform/pull/483
depends on this
