### PR TITLE
Only init non-modern Ophan in non-secure environments

### DIFF
--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -46,13 +46,14 @@
                             *@
                             var img = new Image();
                             img.src = "@{Configuration.debug.beaconUrl}/count/pva.gif";
-                        }
 
-                        var s = document.createElement('script' ),
-                                sc = document.getElementsByTagName('script')[0];
-                        s.src = '@Static("javascripts/bootstraps/ophan.js")';
-                        s.aysnc = true;
-                        sc.parentNode.insertBefore(s, sc);
+                            var s = document.createElement('script'),
+                                    sc = document.getElementsByTagName('script')[0];
+
+                            s.src = '@Static("javascripts/bootstraps/ophan.js")';
+                            s.aysnc = true;
+                            sc.parentNode.insertBefore(s, sc);
+                        }
                     }
                 </script>
         }


### PR DESCRIPTION
/cc @gklopper 

Don't think this is related to Omniture confidence, but its a start.
