### PR TITLE
Add group tables to the football admin

### DIFF
--- a/admin/app/views/football/fragments/chooseGroup.scala.html
+++ b/admin/app/views/football/fragments/chooseGroup.scala.html
@@ -1,0 +1,13 @@
+@(name: String)
+
+<select name="@name" id="id-@name" class="form-control" data-placeholder="Choose group">
+    <option value="">(choose group)</option>
+    <option value="group-a">Group A</option>
+    <option value="group-b">Group B</option>
+    <option value="group-c">Group C</option>
+    <option value="group-d">Group D</option>
+    <option value="group-e">Group E</option>
+    <option value="group-f">Group F</option>
+    <option value="group-g">Group G</option>
+    <option value="group-h">Group H</option>
+</select>

--- a/admin/app/views/football/fronts/index.scala.html
+++ b/admin/app/views/football/fronts/index.scala.html
@@ -62,6 +62,7 @@
         <div class="col-sm-6">
             <form class="form-inline" role="form" action="/admin/football/fronts/tables/redirect" method="post">
                 @views.html.football.fragments.chooseLeague("competition", competitions)
+                @views.html.football.fragments.chooseGroup("group")
                 <button type="submit" class="btn btn-success">League table</button>
             </form>
         </div>

--- a/admin/app/views/football/leagueTables/tablesIndex.scala.html
+++ b/admin/app/views/football/leagueTables/tablesIndex.scala.html
@@ -12,17 +12,7 @@
                 @views.html.football.fragments.chooseLeague("competitionId", leagues)
 
                 <div class="form-group">
-                    <select name="group" id="id-group" class="form-control" data-placeholder="Choose group">
-                        <option value="">choose group (only supported with full league)</option>
-                        <option value="group-a">Group A</option>
-                        <option value="group-b">Group B</option>
-                        <option value="group-c">Group C</option>
-                        <option value="group-d">Group D</option>
-                        <option value="group-e">Group E</option>
-                        <option value="group-f">Group F</option>
-                        <option value="group-g">Group G</option>
-                        <option value="group-h">Group H</option>
-                    </select>
+                    @views.html.football.fragments.chooseGroup("group")
                 </div>
             </div>
 

--- a/admin/app/views/football/leagueTables/tablesIndex.scala.html
+++ b/admin/app/views/football/leagueTables/tablesIndex.scala.html
@@ -10,6 +10,20 @@
             <div class="col-xs-6">
                 <label for="id-competitionId">League</label>
                 @views.html.football.fragments.chooseLeague("competitionId", leagues)
+
+                <div class="form-group">
+                    <select name="group" id="id-group" class="form-control" data-placeholder="Choose group">
+                        <option value="">choose group (only supported with full league)</option>
+                        <option value="group-a">Group A</option>
+                        <option value="group-b">Group B</option>
+                        <option value="group-c">Group C</option>
+                        <option value="group-d">Group D</option>
+                        <option value="group-e">Group E</option>
+                        <option value="group-f">Group F</option>
+                        <option value="group-g">Group G</option>
+                        <option value="group-h">Group H</option>
+                    </select>
+                </div>
             </div>
 
             <div class="col-xs-6">

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -88,6 +88,7 @@ POST        /admin/football/fronts/fixtures/redirect                            
 GET         /admin/football/fronts/fixtures/:competition                                       controllers.admin.FrontsController.fixtures(competition: String)
 POST        /admin/football/fronts/tables/redirect                                             controllers.admin.FrontsController.tablesRedirect
 GET         /admin/football/fronts/tables/:competition                                         controllers.admin.FrontsController.tables(competition: String)
+GET         /admin/football/fronts/tables/:competition/:group                                  controllers.admin.FrontsController.groupTables(competition, group)
 POST        /admin/football/fronts/matches/redirect                                            controllers.admin.FrontsController.matchesRedirect
 GET         /admin/football/fronts/matches/:competitionId                                      controllers.admin.FrontsController.chooseMatchForComp(competitionId)
 GET         /admin/football/fronts/matches/:competitionId/:teamId                              controllers.admin.FrontsController.chooseMatchForCompAndTeam(competitionId, teamId)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -178,6 +178,7 @@ POST        /admin/football/fronts/fixtures/redirect                            
 GET         /admin/football/fronts/fixtures/:competition                                                             controllers.admin.FrontsController.fixtures(competition: String)
 POST        /admin/football/fronts/tables/redirect                                                                   controllers.admin.FrontsController.tablesRedirect
 GET         /admin/football/fronts/tables/:competition                                                               controllers.admin.FrontsController.tables(competition: String)
+GET         /admin/football/fronts/tables/:competition/:group                                                        controllers.admin.FrontsController.groupTables(competition, group)
 POST        /admin/football/fronts/matches/redirect                                                                  controllers.admin.FrontsController.matchesRedirect
 GET         /admin/football/fronts/matches/:competitionId                                                            controllers.admin.FrontsController.chooseMatchForComp(competitionId)
 GET         /admin/football/fronts/matches/:competitionId/:teamId                                                    controllers.admin.FrontsController.chooseMatchForCompAndTeam(competitionId, teamId)


### PR DESCRIPTION
Table embeds can be be selected for specific groups. It is also possible to create a snap for a group table from the Fronts section of the football admin.
