### PR TITLE
Use DFP Data to Determine Sponsorship Status

### DIFF
--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -29,13 +29,24 @@ object DfpAgent extends ExecutionContexts with Logging {
 
   private def normalise(name: String) = name.toLowerCase.replaceAll("[+\\s]+", "-")
 
+  private def isSponsoredType(keyword: String, p: DfpData => String => Boolean): Boolean = {
+    dfpData.fold(false) { data =>
+      p(data)(normalise(keyword))
+    }
+  }
+
   def isSponsored(content: Content): Boolean = isSponsored(content.keywords)
 
   def isSponsored(section: Section): Boolean = isSponsored(section.webTitle)
 
   def isSponsored(keywords: Seq[Tag]): Boolean = keywords.exists(keyword => isSponsored(keyword.name))
 
-  def isSponsored(keyword: String): Boolean = dfpData.fold(false)(_.isSponsored(normalise(keyword)))
+  def isSponsored(keyword: String): Boolean = isSponsoredType(keyword, _.isSponsored)
+
+  def isAdvertisementFeature(keywords: Seq[Tag]): Boolean =
+    keywords.exists(keyword => isAdvertisementFeature(keyword.name))
+
+  def isAdvertisementFeature(keyword: String): Boolean = isSponsoredType(keyword, _.isAdvertisementFeature)
 
   def refresh() {
 

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -10,7 +10,6 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.Json._
 import play.api.libs.json.{JsSuccess, JsResult, JsValue, JsPath, Reads}
 import play.api.{Play, Application, GlobalSettings}
-import scala.Some
 import scala.io.Codec.UTF8
 import services.S3
 

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -2,54 +2,100 @@ package dfp
 
 import common._
 import conf.Configuration.commercial.dfpDataKey
+import model.Content
+import model.Section
+import model.Tag
 import play.api.Play.current
-import model.{Section, Tag, Content}
+import play.api.libs.functional.syntax._
 import play.api.libs.json.Json._
+import play.api.libs.json.{JsSuccess, JsResult, JsValue, JsPath, Reads}
 import play.api.{Play, Application, GlobalSettings}
+import scala.Some
 import scala.io.Codec.UTF8
 import services.S3
 
+
 object DfpAgent extends ExecutionContexts with Logging {
 
-  private lazy val targetedKeywordsAgent = AkkaAgent[Seq[String]](Nil)
+  private lazy val dfpDataAgent = AkkaAgent[Option[DfpData]](None)
 
-  def targetedKeywords: Seq[String] = {
+  private def dfpData: Option[DfpData] = {
     if (Play.isTest) {
-      Seq("live-better")
+      Some(DfpData(Seq(LineItem(0, Nil))))
     } else {
-      targetedKeywordsAgent get()
+      dfpDataAgent get()
     }
   }
 
-  def normalise(name: String) = name.toLowerCase.replaceAll("[+\\s]+", "-")
+  private def normalise(name: String) = name.toLowerCase.replaceAll("[+\\s]+", "-")
 
   def isSponsored(content: Content): Boolean = isSponsored(content.keywords)
 
-  def isSponsored(section: Section): Boolean = targetedKeywords contains normalise(section.webTitle)
+  def isSponsored(section: Section): Boolean = isSponsored(section.webTitle)
 
-  def isSponsored(tags: Seq[Tag]): Boolean = {
-    val normalisedTags = tags.map(tag => normalise(tag.name))
-    (normalisedTags intersect targetedKeywords).nonEmpty
-  }
+  def isSponsored(keywords: Seq[Tag]): Boolean = keywords.exists(keyword => isSponsored(keyword.name))
+
+  def isSponsored(keyword: String): Boolean = dfpData.fold(false)(_.isSponsored(normalise(keyword)))
 
   def refresh() {
-    def fetchTargetedKeywords() = {
-      val json = S3.get(dfpDataKey)(UTF8) map parse
-      val currKeywords = json map (_.as[Seq[String]]) getOrElse Nil
 
-      val removedKeywords = targetedKeywords filterNot (currKeywords.contains(_))
-      if (removedKeywords.nonEmpty) log.info(s"Removed DFP keywords: $removedKeywords")
-      val newKeywords = currKeywords filterNot (targetedKeywords.contains(_))
-      if (newKeywords.nonEmpty) log.info(s"New DFP keywords loaded: $newKeywords")
+    implicit val targetReads: Reads[Target] = (
+      (JsPath \ "name").read[String] and
+        (JsPath \ "op").read[String] and
+        (JsPath \ "values").read[Seq[String]]
+      )(Target.apply _)
 
-      currKeywords
+    implicit val targetSetReads: Reads[TargetSet] = (
+      (JsPath \ "op").read[String] and
+        (JsPath \ "targets").read[Seq[Target]]
+      )(TargetSet.apply _)
+
+    implicit val lineItemReads: Reads[LineItem] = (
+      (JsPath \ "id").read[Long] and
+        (JsPath \ "targetSets").read[Seq[TargetSet]]
+      )(LineItem.apply _)
+
+    // See http://stackoverflow.com/questions/18625185/parsing-a-list-of-models-in-play-2-1-x
+    implicit val reader = new Reads[DfpData] {
+      def reads(js: JsValue): JsResult[DfpData] = {
+        JsSuccess(DfpData((js \ "lineItems").as[Seq[LineItem]]))
+      }
     }
 
-    targetedKeywordsAgent sendOff (current => fetchTargetedKeywords())
+    def fetchDfpData(): Option[DfpData] = {
+
+      def logDataChanges(freshData: Option[DfpData]) {
+        def minus(optData: Option[DfpData], optSubData: Option[DfpData]): Seq[LineItem] = {
+          for {
+            data <- optData
+            subData <- optSubData
+          } yield
+            data.lineItems filterNot (subData.lineItems contains _)
+        }.getOrElse(Nil)
+        val removedLineItems = minus(dfpData, freshData)
+        if (removedLineItems.nonEmpty) log.info(s"Removed DFP line items: $removedLineItems")
+        val newLineItems = minus(freshData, dfpData)
+        if (newLineItems.nonEmpty) log.info(s"New DFP line items loaded: $newLineItems")
+      }
+
+      val json = S3.get(dfpDataKey)(UTF8) map parse
+      val freshData = json map (_.as[DfpData])
+
+      logDataChanges(freshData)
+
+      freshData
+    }
+
+    dfpDataAgent sendOff { oldData =>
+      val freshData = fetchDfpData()
+      if (freshData.exists(_.lineItems.nonEmpty)) {
+        freshData
+      } else oldData
+    }
   }
 
   def stop() {
-    targetedKeywordsAgent close()
+    dfpDataAgent close()
   }
 }
 

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -1,0 +1,46 @@
+package dfp
+
+case class Target(name: String, op: String, values: Seq[String]) {
+
+  def isPositive(targetName: String) = name == targetName && op == "IS"
+
+  def isSlot(value: String) = isPositive("slot") && values.contains(value)
+
+  val isSponsoredSlot = isSlot("spbadge")
+
+  val isAdvertisementFeatureSlot = isSlot("adbadge")
+
+  val isKeyword = isPositive("k")
+}
+
+case class TargetSet(op: String, targets: Seq[Target]) {
+
+  def keywords(p: Target => Boolean): Seq[String] = {
+    if (targets exists p) {
+      targets.filter(_.isKeyword).flatMap(_.values).distinct
+    }
+    else Nil
+  }
+
+  val sponsoredKeywords = keywords(_.isSponsoredSlot)
+
+  val advertisementFeatureKeywords = keywords(_.isAdvertisementFeatureSlot)
+}
+
+case class LineItem(id: Long, targetSets: Seq[TargetSet]) {
+
+  val sponsoredKeywords = targetSets.flatMap(_.sponsoredKeywords).distinct
+
+  val advertisementFeatureKeywords = targetSets.flatMap(_.advertisementFeatureKeywords).distinct
+}
+
+case class DfpData(lineItems: Seq[LineItem]) {
+
+  val sponsoredKeywords = lineItems.flatMap(_.sponsoredKeywords).distinct
+
+  val advertisementFeatureKeywords = lineItems.flatMap(_.sponsoredKeywords).distinct
+
+  def isSponsored(keyword: String) = sponsoredKeywords contains keyword
+
+  def isAdvertisementFeature(keyword: String) = advertisementFeatureKeywords contains keyword
+}

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -140,5 +140,5 @@ trait Tags {
   lazy val types: Seq[Tag] = tagsOfType("type")
 
   def isSponsored = DfpAgent.isSponsored(keywords)
-  def isAdvertisementFeature = false
+  def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(keywords)
 }


### PR DESCRIPTION
This uses cached DFP data to decide whether to request a badge from the ad server.

DFP line items have target sets consisting of targets related by an operator.
If a target set holds a badge slot target and a keyword target we consider the keyword to be sponsored.

/cc @kenlim @ironsidevsquincy 
