### PR TITLE
Commercial: Add high relevance commercial component to curated fronts

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -45,6 +45,7 @@ define([
     'common/modules/adverts/article-body-adverts',
     'common/modules/adverts/article-aside-adverts',
     'common/modules/adverts/slice-adverts',
+    'common/modules/adverts/front-commercial-components',
     'common/modules/adverts/dfp',
     'common/modules/analytics/commercial/tags/container',
     'common/modules/analytics/foresee-survey',
@@ -99,6 +100,7 @@ define([
     ArticleBodyAdverts,
     ArticleAsideAdverts,
     SliceAdverts,
+    frontCommercialComponents,
     dfp,
     TagContainer,
     Foresee,
@@ -285,6 +287,8 @@ define([
                 }
 
                 new SliceAdverts(config).init();
+
+                frontCommercialComponents.init(config);
 
                 var options = {};
 

--- a/common/app/assets/javascripts/modules/adverts/front-commercial-components.js
+++ b/common/app/assets/javascripts/modules/adverts/front-commercial-components.js
@@ -1,0 +1,25 @@
+define([
+    'common/$',
+    'lodash/functions/once'
+], function (
+    $,
+    once
+) {
+
+    var adSlot =
+        '<div class="ad-slot ad-slot--dfp ad-slot--commercial-component-high" data-link-name="ad slot merchandising-high" data-name="merchandising-high" data-label="false" data-refresh="false" data-desktop="888,87">' +
+            '<div id="dfp-ad--merchandising-high" class="ad-slot__container"></div>' +
+        '</div>';
+
+    return {
+
+        init: once(function() {
+            var $containers = $('.facia-container section.container');
+            if($containers.length < 4) {
+                return $containers.first().after(adSlot);
+            }
+        })
+
+    };
+
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/high-relevance-commercial-component.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/high-relevance-commercial-component.js
@@ -1,6 +1,8 @@
 define([
+    'qwery',
     'common/$'
 ], function (
+    qwery,
     $
     ) {
 
@@ -25,7 +27,8 @@ define([
         this.idealOutcome = 'Click through/revenue produced by component increases, without detrimentally impacting click through on containers/';
 
         this.canRun = function (config) {
-            return config.page.contentType === 'Tag' || config.page.isFront;
+            // only apply on fronts with at least 4 containers
+            return (config.page.contentType === 'Tag' || config.page.isFront) && qwery('.facia-container section.container').length >= 4;
         };
 
         this.variants = [


### PR DESCRIPTION
As in, fronts with less than 4 containers. Other fronts are currently being [a/b tested](https://github.com/guardian/frontend/blob/master/common/app/assets/javascripts/modules/experiments/tests/high-relevance-commercial-component.js)
