### PR TITLE
Remove duplicates of league names on Matches component

### DIFF
--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -58,8 +58,7 @@
         }
     }
 
-    .football-team__form,
-    .football-matches__date {
+    .football-team__form {
         display: none;
     }
 

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -35,9 +35,11 @@
 }
 
 .football-matches__date {
-    color: $c-neutral2-contrasted;
-    float: right;
-    font-weight: normal;
+    color: $c-neutral1;
+    display: block;
+    @include rem((
+        margin-top: $gs-baseline/2
+    ));
 }
 
 .football-match__report {

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -35,9 +35,11 @@
 }
 
 .football-matches__date {
-    color: $c-neutral2-contrasted;
-    float: right;
-    font-weight: normal;
+    color: $c-neutral1;
+    display: block;
+    @include rem((
+        margin-top: $gs-baseline/2
+    ));
 }
 
 .football-match__report {
@@ -137,6 +139,10 @@
             content: "v";
         }
     }
+}
+
+.football-matches__heading + .football-matches__date {
+    border-top: 0 none;
 }
 
 .js-on .football-matches tr {

--- a/common/app/assets/stylesheets/module/football/_matches.scss
+++ b/common/app/assets/stylesheets/module/football/_matches.scss
@@ -141,10 +141,6 @@
     }
 }
 
-.football-matches__heading + .football-matches__date {
-    border-top: 0 none;
-}
-
 .js-on .football-matches tr {
     cursor: pointer;
 }

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -11,7 +11,7 @@
                     competition,
                     date,
                     matchType = matchesList.pageType,
-                    heading = Option(competition.fullName),
+                    heading = if(dateRow.isFirst) Option(competition.fullName) else None,
                     link = if(dateRow.isLast && matchRow.isLast)
                             Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None
                 )

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -4,7 +4,7 @@
 
 <div class="c-football-matches">
     @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), dateRow) =>
-        <div class="football-matches__day" data-is-first="@dateRow.isFirst">
+        <div class="football-matches__day">
             @competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
                 @football.views.html.matchList.matchesList(
                     matches,

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -4,14 +4,14 @@
 
 <div class="c-football-matches">
     @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), dateRow) =>
-        <div class="football-matches__day">
+        <div class="football-matches__day" data-is-first="@dateRow.isFirst">
             @competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
                 @football.views.html.matchList.matchesList(
                     matches,
                     competition,
                     date,
                     matchType = matchesList.pageType,
-                    heading = Option(competition.fullName),
+                    heading = if(dateRow.isFirst) Option(competition.fullName) else None,
                     link = if(dateRow.isLast && matchRow.isLast)
                             Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None
                 )

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -73,7 +73,10 @@
             </tr>
         }
     </tbody>
-    <caption class="table__caption table__caption--top">@heading.map{ h => <a href="@competition.url" data-link-name="view @competition.fullName">@h</a>}<span class="football-matches__date">@date.toString("E d MMMM")</span></caption>
+    <caption class="table__caption table__caption--top">
+        @heading.map{ h => <a href="@competition.url" data-link-name="view @competition.fullName" class="football-matches__heading">@h</a>}
+        <span class="football-matches__date">@date.toString("E d MMMM")</span>
+    </caption>
     @if(linkToCompetition && link == None){<caption class="table__caption table__caption--bottom"><a href="@competition.url@if(matchType!=""){/@matchType}" data-link-name="view @competition.fullName matches" class="full-table-link">Show more <span class="competition-name">@competition.fullName</span> @matchType</a></caption>}
     @link.map{ case (text, href) => <caption class="table__caption table__caption--bottom"><a href="@href" data-link-name="view matches" class="full-table-link">@text</a></caption>}
 </table>


### PR DESCRIPTION
Removal of duplicate league names in component.
Fixes #4102 

![toomanyleaguenames](https://cloud.githubusercontent.com/assets/31692/2996843/827e21ec-dcf7-11e3-82b4-373513b3e02b.png)
![toomanyleaguenames](https://cloud.githubusercontent.com/assets/31692/2996844/828d7d0e-dcf7-11e3-9abd-4be3a221f799.png)
