### PR TITLE
Truncation of scorers on Big match spesh

### DIFF
--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -97,6 +97,20 @@
         ));
     }
 
+    .team__scorers {
+        @include fs-data(2, true);
+
+        dd:nth-child(3) {
+            &:after {
+                content: "…";
+                display: block;
+            }
+        }
+        dd:nth-of-type(n+3) {
+            display: none;
+        }
+    }
+
     // Different snap sizes
     // See javascripts/modules/ui/snaps.js
     &.facia-snap-point--large {


### PR DESCRIPTION
Show only the first two scorers and ellipsisise.

![scorers-bad](https://cloud.githubusercontent.com/assets/31692/2997134/f5990832-dcfb-11e3-8fdd-4076997f2540.png)
![scorers](https://cloud.githubusercontent.com/assets/31692/2997133/f589d222-dcfb-11e3-9918-c5a7b44e3bbe.png)
