### PR TITLE
Update incorrect team name

### DIFF
--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -44,7 +44,7 @@ object TeamMap extends ExecutionContexts with Logging {
     ("45938", "Airdrie"),
     ("125", "QOS FC"),
     ("17635", "Annan"),
-    ("128", "East Stirling"),
+    ("128", "Stirling Albion"),
     ("13732", "Harrogate"),
     ("79", "Halifax"),
     ("136", "Boston"),


### PR DESCRIPTION
East Stirling -> Stirling Albion

e.g. http://www.theguardian.com/football/match/2014/may/14/stirling-v-eastfife

![the-littlest-pr](https://cloud.githubusercontent.com/assets/29761/2997362/7a10876e-dcfe-11e3-838e-4ce0b625a934.png)
