### PR TITLE
Guard against Bad Commercial Component Feed

### DIFF
--- a/commercial/app/model/commercial/AdAgent.scala
+++ b/commercial/app/model/commercial/AdAgent.scala
@@ -1,16 +1,23 @@
 package model.commercial
 
-import common.AkkaAgent
-import scala.util.Random
+import common.{Logging, AkkaAgent}
 import scala.concurrent.duration._
+import scala.util.Random
 
-trait AdAgent[T <: Ad] extends BaseAdAgent[T] {
+trait AdAgent[T <: Ad] extends BaseAdAgent[T] with Logging {
 
   private lazy val agent = AkkaAgent[Seq[T]](Nil)
 
   def currentAds: Seq[T] = agent()
 
-  protected def updateCurrentAds(ads: Seq[T]) = agent.alter(_ => ads)(1.seconds)
+  protected def updateCurrentAds(freshAds: Seq[T]) = agent.alter { oldAds =>
+    if (freshAds.nonEmpty) {
+      freshAds
+    } else {
+      log.warn("Cannot update current ads because feed is empty")
+      oldAds
+    }
+  }(1.seconds)
 
   def stop() {
     agent.close()

--- a/commercial/app/model/commercial/AdAgent.scala
+++ b/commercial/app/model/commercial/AdAgent.scala
@@ -10,14 +10,14 @@ trait AdAgent[T <: Ad] extends BaseAdAgent[T] with Logging {
 
   def currentAds: Seq[T] = agent()
 
-  protected def updateCurrentAds(freshAds: Seq[T]) = agent.alter { oldAds =>
+  protected def updateCurrentAds(freshAds: Seq[T]) = agent.send { oldAds =>
     if (freshAds.nonEmpty) {
       freshAds
     } else {
       log.warn("Cannot update current ads because feed is empty")
       oldAds
     }
-  }(1.seconds)
+  }
 
   def stop() {
     agent.close()


### PR DESCRIPTION
If there's no new data, keep the old data instead.
This is to protect us when feeds are down.
