### PR TITLE
SEO: Remove itemprop='datePublished' from all content trails

### DIFF
--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -47,7 +47,6 @@
                                         Last updated:
                                         <time
                                             class="js-timestamp"
-                                            itemprop="datePublished"
                                             datetime="@latestUpdate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
                                             data-relativeformat="long"
                                             data-timestamp="@latestUpdate.getMillis"><span class="timestamp__text">@Format(latestUpdate, "E, h:ma")</span></time>

--- a/common/app/views/fragments/items/elements/meta.scala.html
+++ b/common/app/views/fragments/items/elements/meta.scala.html
@@ -3,7 +3,6 @@
 <div class="item__meta">
     <time
         class="item__timestamp js-item__timestamp"
-        itemprop="datePublished"
         datetime="@trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
         data-timestamp="@trail.webPublicationDate.getMillis"
         data-relativeformat="short">


### PR DESCRIPTION
This removes the datePublished schema attribute from all facia/container trails, as per adivce from the SEO team. 

From Joost:

"There are itemprop=datePublished attributes on related articles, this might cause havoc as it now seems Google is unable to correctly parse the date published:

http://www.google.com/webmasters/tools/richsnippets?url=http://www.theguardian.com/film/2014/may/14/grace-of-monaco-cannes-review-nicole-kidman?view=mobile

For now my suggestion be to remove the itemprop, as it seems there is no proper way to define that something is a related article with schema.org yet."

/cc @gklopper 
