### PR TITLE
Fix football components at mobile breakpoint

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -63,7 +63,7 @@ define([
                         extras.forEach(function(extra, i) {
                             if (dropdownTemplate) {
                                 $.create(dropdownTemplate).each(function (dropdown) {
-                                    if(config.page.isLiveBlog) { $(dropdown).addClass('dropdown--live'); }
+                                    if(config.page.isLiveBlog) { $(dropdown).addClass('dropdown--key-events'); }
                                     $('.dropdown__label', dropdown).append(extra.name);
                                     $('.dropdown__content', dropdown).append(extra.content);
                                     $('.dropdown__button', dropdown)

--- a/common/app/assets/javascripts/utils/page.js
+++ b/common/app/assets/javascripts/utils/page.js
@@ -63,7 +63,7 @@ function(
 
     function belowArticleVisible(yes, no) {
         var el = $('.js-after-article')[0],
-            vis = el.offsetWidth > 0 && el.offsetHeight > 0;
+            vis =  window.getComputedStyle(el).getPropertyValue('display') !== 'none';
 
         return isit(vis, yes, no, el);
     }

--- a/common/app/assets/javascripts/utils/page.js
+++ b/common/app/assets/javascripts/utils/page.js
@@ -63,7 +63,7 @@ function(
 
     function belowArticleVisible(yes, no) {
         var el = $('.js-after-article')[0],
-            vis =  window.getComputedStyle(el).getPropertyValue('display') !== 'none';
+            vis = window.getComputedStyle(el).getPropertyValue('display') !== 'none';
 
         return isit(vis, yes, no, el);
     }

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -801,12 +801,17 @@
 }
 
 .after-article {
+    position: relative;
     display: block;
     content: " ";
     @include rem((
         top: -$gs-baseline*2
     ));
-    position: relative;
+
+    //This is required for football components, please do not remove
+    @include mq(rightCol) {
+        display: none;
+    }
 }
 
 .drop-cap {

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -804,9 +804,6 @@
     position: relative;
     display: block;
     content: " ";
-    @include rem((
-        top: -$gs-baseline*2
-    ));
 
     //This is required for football components, please do not remove
     @include mq(rightCol) {


### PR DESCRIPTION
This fixes a regression which was preventing the football components from loading on mobile breakpoints.

/cc @jamesgorrie 
### Before

![screenshot from 2014-05-16 16 08 59](https://cloud.githubusercontent.com/assets/80089/2998575/360d189e-dd0c-11e3-9287-cfa4921b1005.png)
### After

![screenshot from 2014-05-16 16 10 08](https://cloud.githubusercontent.com/assets/80089/2998580/3e16fe88-dd0c-11e3-9ca5-0692d1db7469.png)
