### PR TITLE
Populate eVar11 with section name for video tracking

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
+++ b/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
@@ -87,7 +87,7 @@ define([
                         break;
                 }
                 s.prop41 = type;
-                s.linkTrackVars = 'prop43,prop44,prop45,eVar43,eVar44,eVar45,prop41,events';
+                s.linkTrackVars = 'prop11,prop43,prop44,prop45,eVar11,eVar43,eVar44,eVar45,prop41,events';
                 s.linkTrackEvents = event;
                 s.events = event;
 
@@ -127,10 +127,12 @@ define([
 
             s.loadMediaModule(provider, restricted);
 
+            s.prop11 = config.page.section || '';
             s.prop43 = 'Video';
             s.prop44 = config.page.analyticsName;
             s.prop45 = s.channel;
 
+            s.eVar11 = s.prop11;
             s.eVar43 = s.prop43;
             s.eVar44 = s.prop44;
             s.eVar45 = s.prop45;

--- a/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
+++ b/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
@@ -127,7 +127,7 @@ define([
 
             s.loadMediaModule(provider, restricted);
 
-            s.prop11 = config.page.section || '';
+            s.prop11 = config.page.sectionName || '';
             s.prop43 = 'Video';
             s.prop44 = config.page.analyticsName;
             s.prop45 = s.channel;

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -135,7 +135,8 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     ("wordCount", wordCount),
     ("shortUrl", shortUrl),
     ("thumbnail", thumbnailPath.getOrElse(false)),
-    ("references", delegate.references.map(r => Reference(r.id)))
+    ("references", delegate.references.map(r => Reference(r.id))),
+    ("sectionName", sectionName)
     ) ++ Map(seriesMeta : _*)
   }
 


### PR DESCRIPTION
As requested by Matt Kopka this ensures we populate the eVar11 variable with the section name. This allows parity with the R2 video reporting.

We don't seem to have any unit tests around video tracking. Which I will look into this week.

/cc @gklopper 
