### PR TITLE
Remove overflow-x from ad slots

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -1,6 +1,5 @@
 .ad-slot--dfp {
     width: 100%;
-    overflow-x: hidden;
     text-align: center;
     min-height: 56px;
     // For expandables
@@ -217,7 +216,7 @@
         @include clearfix;
         position: relative;
         min-height: 90px;
-        border-top: none;
+        border-top: 0;
         z-index: 99;
         border-bottom-width: 0;
 

--- a/common/app/assets/stylesheets/module/_article.scss
+++ b/common/app/assets/stylesheets/module/_article.scss
@@ -504,8 +504,8 @@
 }
 
 .article__keywords--more-tags {
-  vertical-align: bottom;
-  display: inline-block;
+    vertical-align: bottom;
+    display: inline-block;
 }
 
 
@@ -812,26 +812,26 @@
 }
 
 .drop-cap {
-  @include mq($to: tablet) {
+    @include mq($to: tablet) {
 
-    float: left;
-    display: inline-block;
-    text-transform: uppercase;
-    @include f-headline;
-    font-weight: 200;
-    @include box-sizing(border-box);
-    @include rem((
-        height: 2*get-line-height($fs-bodyCopy, 3),
-        padding-top: 1px,
-        margin-right: 4px
-    ));
-
-    .drop-cap__inner {
+        float: left;
         display: inline-block;
-        vertical-align: text-top;
-        @include font-size(52px, 40px);
+        text-transform: uppercase;
+        @include f-headline;
+        font-weight: 200;
+        @include box-sizing(border-box);
+        @include rem((
+            height: 2*get-line-height($fs-bodyCopy, 3),
+            padding-top: 1px,
+            margin-right: 4px
+        ));
+
+        .drop-cap__inner {
+            display: inline-block;
+            vertical-align: text-top;
+            @include font-size(52px, 40px);
+        }
     }
-  }
 }
 
 .drop-cap--wide {

--- a/common/app/assets/stylesheets/module/commercial/_soulmates.scss
+++ b/common/app/assets/stylesheets/module/commercial/_soulmates.scss
@@ -280,7 +280,7 @@ $c-soulmates-red: #d70851;
             ));
         }
         .lineitems {
-            width: 75%
+            width: 75%;
         }
     }
     @include mq(leftCol) {

--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -190,8 +190,8 @@ $football-crest--large: 60px;
 }
 
 @mixin match-summary--responsive {
-   &.match-summary,
-   .match-summary {
+    &.match-summary,
+    .match-summary {
         @include rem((
             margin-bottom: $gs-baseline*4
         ));


### PR DESCRIPTION
Was causing scrollbars to appear on certain browser; not sure why it was there in the first place

Also, annoyingly includes sass-lint issues I had to fix

![image001](https://cloud.githubusercontent.com/assets/74132/3013101/0d3e28de-df43-11e3-86c3-73a05bf111e5.jpg)
