### PR TITLE
Polyfill Function.prototype.bind take 2.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function (grunt) {
             common: {
                 options: {
                     baseUrl: 'common/app/assets/javascripts',
-                    name: 'common/bootstraps/app',
+                    name: 'common/bootstraps/go',
                     out: staticTargetDir + 'javascripts/bootstraps/app.js',
                     shim: {
                         imager: {
@@ -75,8 +75,7 @@ module.exports = function (grunt) {
                         }
                     },
                     wrap: {
-                        startFile: 'common/app/assets/javascripts/components/curl/dist/curl-with-js-and-domReady/curl.js',
-                        endFile:   'common/app/assets/javascripts/bootstraps/go.js'
+                        startFile: 'common/app/assets/javascripts/components/curl/dist/curl-with-js-and-domReady/curl.js'
                     }
                 }
             },

--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -81,6 +81,7 @@ define([
 
         userTiming.mark('App Begin');
 
+        errors.init({ isDev: config.page.isDev, buildNumber: config.page.buildNumber });
         mediator.on('module:error', errors.log);
 
         domReady(function() {

--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -8,7 +8,6 @@ define([
     'common/utils/context',
     'common/utils/userTiming',
 
-    'common/modules/analytics/errors',
     'common/modules/ui/fonts',
     'common/modules/adverts/userAdTargeting',
     'common/modules/discussion/api',
@@ -32,7 +31,6 @@ define([
     Context,
     userTiming,
 
-    Errors,
     Fonts,
     UserAdTargeting,
     DiscussionApi,
@@ -57,18 +55,6 @@ define([
 
         initialiseDiscussionApi: function(config) {
             DiscussionApi.init(config);
-        },
-
-        attachGlobalErrorHandler: function (config) {
-            if (!config.switches.clientSideErrors) {
-                return false;
-            }
-            var e = new Errors({
-                isDev: config.page.isDev,
-                buildNumber: config.page.buildNumber
-            });
-            e.init();
-            mediator.on('module:error', e.log);
         },
 
         loadFonts: function(config, ua) {
@@ -100,7 +86,7 @@ define([
 
             modules.initialiseAjax(config);
             modules.initialiseDiscussionApi(config);
-            modules.attachGlobalErrorHandler(config);
+//            modules.attachGlobalErrorHandler(config);
             modules.loadFonts(config, navigator.userAgent);
             modules.initId(config, context);
             modules.initUserAdTargeting();

--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -86,7 +86,6 @@ define([
 
             modules.initialiseAjax(config);
             modules.initialiseDiscussionApi(config);
-//            modules.attachGlobalErrorHandler(config);
             modules.loadFonts(config, navigator.userAgent);
             modules.initId(config, context);
             modules.initUserAdTargeting();

--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -7,6 +7,7 @@ define([
     'common/utils/config',
     'common/utils/context',
     'common/utils/userTiming',
+    'common/modules/analytics/errors',
 
     'common/modules/ui/fonts',
     'common/modules/adverts/userAdTargeting',
@@ -30,6 +31,7 @@ define([
     config,
     Context,
     userTiming,
+    errors,
 
     Fonts,
     UserAdTargeting,
@@ -78,6 +80,8 @@ define([
     var routes = function() {
 
         userTiming.mark('App Begin');
+
+        mediator.on('module:error', errors.log);
 
         domReady(function() {
             var context = document.getElementById('js-context');

--- a/common/app/assets/javascripts/bootstraps/go.js
+++ b/common/app/assets/javascripts/bootstraps/go.js
@@ -1,10 +1,34 @@
 /*global guardian:true */
 require([
+    'common/utils/config',
+    'common/utils/mediator',
+    'common/modules/analytics/errors',
+    'common/utils/polyfill',
     'common/bootstraps/app'
 ], function(
+    config,
+    mediator,
+    Errors,
+    polyfills,
     bootstrap
 ) {
+
+    var attachGlobalErrorHandler = function (config) {
+        if (!config.switches.clientSideErrors) {
+            return false;
+        }
+        var e = new Errors({
+            isDev: config.page.isDev,
+            buildNumber: config.page.buildNumber
+        });
+        e.init();
+        mediator.on('module:error', e.log);
+    };
+
+
     if (guardian.isModernBrowser) {
+        attachGlobalErrorHandler(config);
+        polyfills.load();
         bootstrap.go();
     }
 });

--- a/common/app/assets/javascripts/bootstraps/go.js
+++ b/common/app/assets/javascripts/bootstraps/go.js
@@ -1,14 +1,12 @@
 /*global guardian:true */
 require([
     'common/utils/config',
-    'common/utils/mediator',
     'common/modules/analytics/errors',
     'common/utils/polyfill',
     'common/bootstraps/app'
 ], function(
     config,
-    mediator,
-    Errors,
+    errors,
     polyfills,
     bootstrap
 ) {
@@ -17,12 +15,10 @@ require([
         if (!config.switches.clientSideErrors) {
             return false;
         }
-        var e = new Errors({
+        errors.init({
             isDev: config.page.isDev,
             buildNumber: config.page.buildNumber
         });
-        e.init();
-        mediator.on('module:error', e.log);
     };
 
 

--- a/common/app/assets/javascripts/bootstraps/go.js
+++ b/common/app/assets/javascripts/bootstraps/go.js
@@ -21,7 +21,6 @@ require([
         });
     };
 
-
     if (guardian.isModernBrowser) {
         attachGlobalErrorHandler(config);
         polyfills.load();

--- a/common/app/assets/javascripts/modules/analytics/errors.js
+++ b/common/app/assets/javascripts/modules/analytics/errors.js
@@ -1,69 +1,65 @@
 define([
-    'common/modules/userPrefs',
     'common/modules/analytics/beacon'
 ], function (
-    userPrefs,
     beacon
 ) {
 
-    var Errors = function (config) {
+    var isDev,
+        cons,
+        win,
+        buildNumber;
 
-        var c = config || {},
-            isDev = (c.isDev !== undefined) ? c.isDev : false,
-            cons = c.console || window.console,
-            win = c.window || window,
-            prefs = c.userPrefs || userPrefs,
-            buildNumber = c.buildNumber || 'unknown',
+    function makeUrl(properties) {
+        var query = [];
 
-            makeUrl = function(properties) {
-                var query = [];
+        for (var name in properties) {
+            query.push(name + '=' + encodeURIComponent(properties[name]));
+        }
+        return '/js.gif?' + query.join('&');
+    }
 
-                for (var name in properties) {
-                    query.push(name + '=' + encodeURIComponent(properties[name]));
-                }
-                return '/js.gif?' + query.join('&');
-            },
+    function log(message, filename, lineno, isUncaught) {
+        // error events are thrown by script elements
+        if (message.toString() === '[object Event]' && message.target instanceof HTMLScriptElement) {
+            message = 'Syntax or http error: ' + message.target.src;
+        }
+        var errorType = 'js';
+        if (filename === 'common/modules/adverts/documentwriteslot.js' || message === 'Script error.') {
+            errorType = 'ads';
+        }
 
-            log = function(message, filename, lineno, isUncaught) {
-                // error events are thrown by script elements
-                if (message.toString() === '[object Event]' && message.target instanceof HTMLScriptElement) {
-                    message = 'Syntax or http error: ' + message.target.src;
-                }
-                var errorType = 'js';
-                if (filename === 'common/modules/adverts/documentwriteslot.js' || message === 'Script error.') {
-                    errorType = 'ads';
-                }
-
-                var error = {
-                    message: message,
-                    filename: filename,
-                    lineno: lineno,
-                    build: buildNumber,
-                    type: errorType
-                };
-                if (isDev) {
-                    if (isUncaught !== true) {
-                        cons.error(error);
-                    }
-                    return false;
-                } else {
-                    beacon.fire(makeUrl(error));
-                    return (prefs.isOn('showErrors')) ? false : true;
-                }
-            },
-
-            init = function() {
-                win.onerror = function(message, filename, lineno) {
-                    return log(message, filename, lineno, true);
-                };
-            };
-
-        return {
-            log: log,
-            init: init
+        var error = {
+            message: message,
+            filename: filename,
+            lineno: lineno,
+            build: buildNumber,
+            type: errorType
         };
+        if (isDev) {
+            if (isUncaught !== true) {
+                cons.error(error);
+            }
+            return false;
+        } else {
+            beacon.fire(makeUrl(error));
+            return (!/#showErrors/.test(win.location.hash));
+        }
+    }
 
+    function init(config) {
+        isDev = config.isDev || false;
+        cons = config.console || window.console;
+        win = config.window || window;
+        buildNumber = config.buildNumber || 'unknown';
+
+        win.onerror = function(message, filename, lineno) {
+            return log(message, filename, lineno, true);
+        };
+    }
+
+    return {
+        log: log,
+        init: init
     };
 
-    return Errors;
 });

--- a/common/app/assets/javascripts/utils/polyfill.js
+++ b/common/app/assets/javascripts/utils/polyfill.js
@@ -1,4 +1,4 @@
-define('common/utils/polyfill', [], function() {
+define(function() {
 
     /**
      * ARE YOU SURE YOU WANT TO ADD SOMETHING TO THIS FILE?!

--- a/common/app/assets/javascripts/utils/polyfill.js
+++ b/common/app/assets/javascripts/utils/polyfill.js
@@ -1,0 +1,48 @@
+define('common/utils/polyfill', [], function() {
+
+    /**
+     * ARE YOU SURE YOU WANT TO ADD SOMETHING TO THIS FILE?!
+     * You must have an extremely good reason to add a polyfill,
+     * we prefer progressive enhancement over graceful degradation
+     *
+     * This is not to stop you adding polyfills, it is here to make you think before doing so.
+     */
+
+    var polyfills = {
+        bind: function() {
+            if (!Function.prototype.bind) {
+                Function.prototype.bind = function (oThis) {
+                    if (typeof this !== 'function') {
+                        // closest thing possible to the ECMAScript 5
+                        // internal IsCallable function
+                        throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+                    }
+
+                    var aArgs = Array.prototype.slice.call(arguments, 1),
+                        fToBind = this,
+                        NOOP = function () {},
+                        fBound = function () {
+                            return fToBind.apply(this instanceof NOOP && oThis
+                                    ? this
+                                    : oThis,
+                                aArgs.concat(Array.prototype.slice.call(arguments)));
+                        };
+
+                    NOOP.prototype = this.prototype;
+                    fBound.prototype = new NOOP();
+
+                    return fBound;
+                };
+            }
+        }
+    };
+
+    return {
+        load: function() {
+            for(var fill in polyfills) {
+                polyfills[fill]();
+            }
+        }
+    };
+
+});

--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -15,7 +15,6 @@
             && 'addEventListener' in window
             && 'localStorage' in window
             && 'sessionStorage' in window
-            && 'bind' in Function
             && (
                 ('XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest())
                 || 'XDomainRequest' in window

--- a/common/test/assets/javascripts/spec/Errors.spec.js
+++ b/common/test/assets/javascripts/spec/Errors.spec.js
@@ -1,17 +1,21 @@
-define(['common/common', 'bean', 'common/modules/analytics/errors'], function(common, bean, Errors) {
+define(['common/common', 'bean', 'common/modules/analytics/errors'], function(common, bean, errors) {
 
     describe("Errors", function() {
-       
-        var e,
-            p = '/uk/2012/oct/15/mod-military-arms-firms',
-            w = {},
+
+        var w = {
+                location: {
+                    hash: ''
+                }
+            },
             fakeError = { 'message': 'foo', lineno: 1, filename: 'foo.js' };
-        
+
         beforeEach(function() {
-            e = new Errors({window: w, buildNumber: 643});
-            e.init();
+            errors.init({
+                window: w,
+                buildNumber: 643
+            });
         });
-        
+
         afterEach(function() {
             common.$g('#js-err').remove();
         });
@@ -21,32 +25,35 @@ define(['common/common', 'bean', 'common/modules/analytics/errors'], function(co
         });
 
         it("should log javascript errors with the error message, line number, build number, and file", function(){
-            expect(e.log(fakeError.message, fakeError.filename, fakeError.lineno)).toBeTruthy();
+            expect(errors.log(fakeError.message, fakeError.filename, fakeError.lineno)).toBeTruthy();
         });
 
-        it("after logging, should let browser handle error if user pref switch 'showErrors is on", function(){
-            var userPrefs = {
-                    isOn: jasmine.createSpy('isOn').andReturn(true)
-                },
-                e = new Errors({ userPrefs: userPrefs });
-            expect(e.log(fakeError.message, fakeError.filename, fakeError.lineno)).toBeFalsy();
+        it("after logging, should let browser handle error if window hash is set", function(){
+            var win = {
+                location: {
+                    hash: '#showErrors'
+                }
+            };
+            errors.init({window: win, buildNumber: 643});
+            expect(errors.log(fakeError.message, fakeError.filename, fakeError.lineno)).toBeFalsy();
         });
 
         it("if DEV, and an uncaught error, should do nothing", function(){
             var cons = {
-                    error: jasmine.createSpy('error')
-                },
-                e = new Errors({ isDev: true, console: cons });
-            expect(e.log(fakeError.message, fakeError.filename, fakeError.lineno, true)).toBeFalsy();
+                error: jasmine.createSpy('error')
+            };
+            errors.init({ isDev: true, console: cons });
+            expect(errors.log(fakeError.message, fakeError.filename, fakeError.lineno, true)).toBeFalsy();
             expect(cons.error).not.toHaveBeenCalled();
         });
 
         it("if DEV, and a caught error, should log to console", function(){
             var cons = {
-                    error: jasmine.createSpy('error')
-                },
-                e = new Errors({ isDev: true, console: cons, buildNumber: 643 });
-            expect(e.log(fakeError.message, fakeError.filename, fakeError.lineno)).toBeFalsy(false);
+                error: jasmine.createSpy('error')
+            };
+
+            errors.init({ isDev: true, console: cons, buildNumber: 643 });
+            expect(errors.log(fakeError.message, fakeError.filename, fakeError.lineno)).toBeFalsy(false);
             expect(cons.error.mostRecentCall.args[0]).toEqual({
                 message: fakeError.message, filename: fakeError.filename, lineno: fakeError.lineno,
                 build: 643, type: 'js'
@@ -59,7 +66,7 @@ define(['common/common', 'bean', 'common/modules/analytics/errors'], function(co
             script.src = 'http://foo.com/bar.js';
             // fake event
             bean.on(script, 'error', function(event) {
-                expect(e.log(event.originalEvent, fakeError.filename, fakeError.lineno)).toBeTruthy();
+                expect(errors.log(event.originalEvent, fakeError.filename, fakeError.lineno)).toBeTruthy();
             })
             bean.fire(script, 'error');
         });


### PR DESCRIPTION
Take 2 for polyfilling .bind();
- Introduce new polyfill module
- Move error handling attachment higher up the execution chain
- Remove go.js wrap file

We recently added Function.prototype.bind to our cut-the-mustard test, which inadvertently kicked out ~4% of users from receiving our core JavaScript application. This took that demographic from 6 to 10%, and broke our line in the sand to serve JS to ~95% of users.

This is a temporary change going forward, as we are discussing the ability to separate analytics & advert code from our core JS file. More to follow in the coming weeks.

/cc @rich-nguyen @ironsidevsquincy 
