### PR TITLE
Add profile for 640px 16:9 video poster frames

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -140,7 +140,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
     scenario("Poster image on embedded video", ArticleComponents) {
       HtmlUnit("/world/2013/sep/25/kenya-mall-attack-bodies") { browser =>
         import browser._
-        findFirst("video").getAttribute("poster") should endWith ("Westgate-shopping-centre--015.jpg?width=620&height=-&quality=95")
+        findFirst("video").getAttribute("poster") should endWith ("Westgate-shopping-centre--016.jpg?width=640&height=-&quality=95")
       }
     }
 
@@ -389,7 +389,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         Then("the main picture should be hidden")
         $("[itemprop='associatedMedia primaryImageOfPage']") should have size 0
 
-        findFirst("video").getAttribute("poster") should endWith("/2013/3/26/1364309868130/Jeremy-Hunt-announcing-ch-015.jpg?width=620&height=-&quality=95")
+        findFirst("video").getAttribute("poster") should endWith("/2013/3/26/1364309869688/Jeremy-Hunt-announcing-ch-016.jpg?width=640&height=-&quality=95")
       }
     }
 

--- a/common/app/views/support/images.scala
+++ b/common/app/views/support/images.scala
@@ -41,6 +41,7 @@ object Item220 extends Profile(Some(220), None)
 object Item300 extends Profile(Some(300), None)
 object Item460 extends Profile(Some(460), None)
 object Item620 extends Profile(Some(620), None)
+object Item640 extends Profile(Some(640), None)
 object Item700 extends Profile(Some(700), None)
 object Item940 extends Profile(Some(940), None)
 
@@ -59,6 +60,7 @@ object Profile {
     Item300,
     Item460,
     Item620,
+    Item640,
     Item700,
     Item940
   )

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -225,7 +225,7 @@ case class VideoEmbedCleaner(contentVideos: Seq[VideoElement]) extends HtmlClean
       val asset = findVideoFromId(mediaId)
 
       // add the poster url
-      asset.flatMap(_.image).flatMap(Item620.bestFor).map(_.toString()).foreach{ url =>
+      asset.flatMap(_.image).flatMap(Item640.bestFor).map(_.toString()).foreach{ url =>
         element.attr("poster", url)
       }
 


### PR DESCRIPTION
This prevents our Guardian videos having letter boxed poster images.

/cc @rich-nguyen 
