### PR TITLE
Capi query as data attribute

### DIFF
--- a/common/app/views/fragments/containers/comment.scala.html
+++ b/common/app/views/fragments/containers/comment.scala.html
@@ -13,6 +13,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/commentanddebate.scala.html
+++ b/common/app/views/fragments/containers/commentanddebate.scala.html
@@ -14,6 +14,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -14,6 +14,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -14,6 +14,7 @@
                                 "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
                                 "container--first" -> (containerIndex == 0)))"
                                 data-link-name="all index"
+                                data-capi="@config.contentApiQuery"
                                 data-type="@style.containerType"
                                 data-component="all index">
                 <div class="facia-container__inner">

--- a/common/app/views/fragments/containers/multimedia.scala.html
+++ b/common/app/views/fragments/containers/multimedia.scala.html
@@ -14,6 +14,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="container__border tone-@style.tone tone-accent-border"></div>
 

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -18,6 +18,7 @@
                     data-link-name="block | @config.id"
                     data-id="@config.id"
                     data-type="@style.containerType"
+                    data-capi="@config.contentApiQuery"
                     data-component="@FaciaComponentName(config, collection)">
                     <div class="facia-container__inner">
                         <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/people.scala.html
+++ b/common/app/views/fragments/containers/people.scala.html
@@ -14,6 +14,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/popular.scala.html
+++ b/common/app/views/fragments/containers/popular.scala.html
@@ -11,6 +11,7 @@
             data-link-name="block | @config.id"
             data-id="@config.id"
             data-type="@style.containerType"
+            data-capi="@config.contentApiQuery"
             data-component="@FaciaComponentName(config, collection)">
             <div class="facia-container__inner">
                 <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/section.scala.html
+++ b/common/app/views/fragments/containers/section.scala.html
@@ -13,6 +13,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/series.scala.html
+++ b/common/app/views/fragments/containers/series.scala.html
@@ -14,6 +14,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@style.containerType">
                 <div class="facia-container__inner">
                     <div class="container__border"></div>

--- a/common/app/views/fragments/containers/special.scala.html
+++ b/common/app/views/fragments/containers/special.scala.html
@@ -14,6 +14,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/sport.scala.html
+++ b/common/app/views/fragments/containers/sport.scala.html
@@ -13,6 +13,7 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                data-capi="@config.contentApiQuery"
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -11,6 +11,7 @@
         data-link-name="block | @config.id"
         data-id="@config.id"
         data-type="@style.containerType"
+        data-capi="@config.contentApiQuery"
         data-component="@FaciaComponentName(config, collection)">
         <div class="facia-container__inner">
             <div class="container__border tone-@style.tone tone-accent-border"></div>


### PR DESCRIPTION
@kelvin-chappell - in lieu of Capi queries expressed as structured data/keywords, put the query literal in a data attribute on the container wrapper. eg:

```
data-capi="lifeandstyle/dating"
```

or, less usefully:

```
data-capi="search?tag=lifeandstyle/homes|lifeandstyle/gardens"
```
