### PR TITLE
Facia news auto

### DIFF
--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -30,6 +30,10 @@ object Config {
   val emptyConfig = Config("")
 }
 
+trait CollectionItems {
+  def items: Seq[Content] = List()
+}
+
 case class Collection(curated: Seq[Content],
                       editorsPicks: Seq[Content],
                       mostViewed: Seq[Content],
@@ -38,9 +42,8 @@ case class Collection(curated: Seq[Content],
                       href: Option[String],
                       lastUpdated: Option[String],
                       updatedBy: Option[String],
-                      updatedEmail: Option[String]) extends implicits.Collections {
-
-  lazy val items: Seq[Content] = (curated ++ editorsPicks ++ mostViewed ++ results).distinctBy(_.url)
+                      updatedEmail: Option[String]) extends implicits.Collections with CollectionItems {
+  override lazy val items: Seq[Content] = (curated ++ editorsPicks ++ mostViewed ++ results).distinctBy(_.url)
 }
 
 object Collection {

--- a/common/app/views/support/ForceGroupsCollection.scala
+++ b/common/app/views/support/ForceGroupsCollection.scala
@@ -15,7 +15,7 @@ trait FirstTwoBigItems extends CollectionItems {
       case x :: y :: tail =>
         setMetaFields(x, Map("group" -> "1", "imageAdjust" -> "boost")) ::
           setMetaFields(y, Map("group" -> "1")) :: tail
-      case x :: Nil => List(setMetaFields(x, Map("group" -> "1", "imageAdjust" -> "boost")))
+      case x => x.map(setMetaFields(_, Map("group" -> "1", "imageAdjust" -> "boost")))
     }
   }
 }

--- a/common/app/views/support/ForceGroupsCollection.scala
+++ b/common/app/views/support/ForceGroupsCollection.scala
@@ -1,0 +1,28 @@
+package views.support
+
+import model.{CollectionItems, Collection, Content}
+import play.api.libs.json.JsString
+
+trait FirstTwoBigItems extends CollectionItems {
+  override lazy val items: Seq[Content] = {
+    def setMetaFields(c: Content, fields: Map[String, String]): Content = {
+      Content(apiContent = c.apiContent.copy(metaData = c.apiContent.metaData ++ fields.map {
+        case (k, v) => k -> JsString(v)
+      }))
+    }
+
+    super.items match {
+      case x :: y :: tail =>
+        setMetaFields(x, Map("group" -> "1", "imageAdjust" -> "boost")) ::
+          setMetaFields(y, Map("group" -> "1")) :: tail
+      case x :: Nil => List(setMetaFields(x, Map("group" -> "1", "imageAdjust" -> "boost")))
+    }
+  }
+}
+
+object ForceGroupsCollection {
+  def firstTwoBig(c: Collection): Collection = {
+    new Collection(c.curated, c.editorsPicks, c.mostViewed, c.results, c.displayName, c.href,
+      c.lastUpdated, c.updatedBy, c.updatedEmail) with FirstTwoBigItems
+  }
+}

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -1,8 +1,9 @@
 @(front: MetaData, block: (Config, Collection), collectionsSize: Int = 1, index: Int = 1)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
+@import views.support.ForceGroupsCollection
 
 @block._1.collectionType match {
     case Some("news")                       => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/auto")                  => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
+    case Some("news/auto")                  => { @containers.news(ForceGroupsCollection.firstTwoBig(block._2), NewsContainer(), index)(request, templateDeduping, block._1) }
     case _ if index == 0                    => { @collectionsSize match {
         case size if size < 3               => { @containers.tag(front, block._2, NewsContainer(showMore = false), index)(request, templateDeduping, block._1) }
         case _                              => { @containers.tag(front, block._2, NewsContainer(), index)(request, templateDeduping, block._1) }


### PR DESCRIPTION
make the first two items big, boost the first trail
- happens upon selecting news/auto in facia/tool

![screen shot 2014-05-21 at 15 43 58](https://cloud.githubusercontent.com/assets/1492162/3041640/6234fb06-e0f6-11e3-8a5f-ce2409ce0b58.png)
