### PR TITLE
Main media embed

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -1,27 +1,33 @@
 @(article: Article)
 
-@if(!article.hasVideoAtTop) {
-    @if(article.hasMainVideo) {
-        @article.mainVideo.map{ mainVideo =>
-            <div class="gu-video-wrapper">
-                <div class="u-responsive-ratio u-responsive-ratio--hd">
-                    <video data-media-id="@mainVideo.id" class="gu-video" controls="controls">
-                        @for(url <- mainVideo.videoAssets.flatMap(_.url)) {
-                            <source src="@url" />
-                        }
-                        @mainVideo.videoAssets.find(_.mimeType == "video/mp4").map{ encoding =>
-                            <object type="application/x-shockwave-flash" data="@Static("flash/flashmediaelement.swf")" width="620" height="350">
-                                <param name="allowFullScreen" value="true" />
-                                <param name="movie" value="@Static("flash/flashmediaelement.swf")" />
-                                <param name="flashvars" value="file=@encoding.url&amp;controls=true" />
-                                Sorry, your browser is unable to play this video.
-                            </object>
-                        }
-                    </video>
+@if(article.hasMainEmbed) {
+    <div class="media-primary">
+        @Html(article.main)
+    </div>
+} else {
+    @if(!article.hasVideoAtTop) {
+        @if(article.hasMainVideo) {
+            @article.mainVideo.map{ mainVideo =>
+                <div class="gu-video-wrapper">
+                    <div class="u-responsive-ratio u-responsive-ratio--hd">
+                        <video data-media-id="@mainVideo.id" class="gu-video" controls="controls">
+                            @for(url <- mainVideo.videoAssets.flatMap(_.url)) {
+                                <source src="@url" />
+                            }
+                            @mainVideo.videoAssets.find(_.mimeType == "video/mp4").map{ encoding =>
+                                <object type="application/x-shockwave-flash" data="@Static("flash/flashmediaelement.swf")" width="620" height="350">
+                                    <param name="allowFullScreen" value="true" />
+                                    <param name="movie" value="@Static("flash/flashmediaelement.swf")" />
+                                    <param name="flashvars" value="file=@encoding.url&amp;controls=true" />
+                                    Sorry, your browser is unable to play this video.
+                                </object>
+                            }
+                        </video>
+                    </div>
                 </div>
-            </div>
+            }
+        } else {
+            @fragments.img(article.mainPicture, article.hasShowcaseMainPicture, article.isFeature && article.hasShowcaseMainPicture)
         }
-    } else {
-        @fragments.img(article.mainPicture, article.hasShowcaseMainPicture, article.isFeature && article.hasShowcaseMainPicture)
     }
 }

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -55,3 +55,17 @@ case class VideoAsset(private val delegate: Asset, image: Option[ImageContainer]
 
   lazy val source: Option[String] = fields.get("source")
 }
+
+case class EmbedAsset(private val delegate: Asset) {
+
+  private lazy val fields: Map[String,String] = delegate.typeData
+
+  lazy val url: Option[String] = delegate.file
+  lazy val iframeUrl: Option[String] = fields.get("iframeUrl")
+  lazy val scriptName: Option[String] = fields.get("scriptName")
+  lazy val source: Option[String] = fields.get("source")
+  lazy val scriptUrl: Option[String] = fields.get("scriptUrl")
+  lazy val caption: Option[String] = fields.get("caption")
+  lazy val html: Option[String] = fields.get("html")
+  lazy val embedType: Option[String] = fields.get("embedType")
+}

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -11,9 +11,6 @@ trait Element {
   lazy val isBody = delegate.relation == "body"
   lazy val isGallery = delegate.relation == "gallery"
   lazy val isThumbnail = delegate.relation == "thumbnail"
-
-  lazy val isImage = delegate.elementType == "image"
-  lazy val isVideo = delegate.elementType == "video"
 }
 
 object Element {
@@ -21,6 +18,7 @@ object Element {
     theDelegate.elementType match {
       case "image" => new ImageElement(theDelegate, elementIndex)
       case "video" => new VideoElement(theDelegate, elementIndex)
+      case "embed" => new EmbedElement(theDelegate, elementIndex)
       case _ => new Element{
         lazy val delegate = theDelegate
         lazy val index = elementIndex
@@ -62,5 +60,11 @@ trait VideoContainer extends Element {
   lazy val largestVideo: Option[VideoAsset] = videoAssets.headOption
 }
 
+trait EmbedContainer extends Element {
+
+   lazy val embedAssets: Seq[EmbedAsset] = delegate.assets.filter(_.assetType == "embed").map(EmbedAsset(_))
+}
+
 class ImageElement(val delegate: ApiElement, val index: Int) extends Element with ImageContainer
 class VideoElement(val delegate: ApiElement, val index: Int) extends Element with ImageContainer with VideoContainer
+class EmbedElement(val delegate: ApiElement, val index: Int) extends Element with EmbedContainer

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -33,11 +33,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   lazy val hasLargeContributorImage: Boolean = tags.filter(_.hasLargeContributorImage).nonEmpty
   lazy val isFromTheObserver: Boolean = publication == "The Observer"
   lazy val primaryKeyWordTag: Option[Tag] = tags.find(!_.isSectionTag)
-
   lazy val showInRelated: Boolean = delegate.safeFields.get("showInRelatedContent").exists(_ == "true")
-
-  override lazy val description: Option[String] = trailText
-
 
   // read this before modifying
   // https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
@@ -117,6 +113,9 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   override lazy val id: String = delegate.id
   override lazy val webTitle: String = delegate.webTitle
   override lazy val analyticsName = s"GFE:$section:${id.substring(id.lastIndexOf("/") + 1)}"
+  override lazy val description: Option[String] = trailText
+  override lazy val headline: String = apiContent.metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(fields("headline"))
+  override lazy val trailText: Option[String] = apiContent.metaData.get("trailText").flatMap(_.asOpt[String]).orElse(fields.get("trailText"))
   // Meta Data used by plugins on the page
   // people (including 3rd parties) rely on the names of these things, think carefully before changing them
   override def metaData: Map[String, Any] = {
@@ -162,13 +161,11 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
       .map(_.zipWithIndex.map{ case (element, index) =>  Element(element, index)})
       .getOrElse(Nil)
 
-  override lazy val headline: String = apiContent.metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(fields("headline"))
-  override lazy val trailText: Option[String] = apiContent.metaData.get("trailText").flatMap(_.asOpt[String]).orElse(fields.get("trailText"))
+  // Inherited from FaciaFields
   override lazy val group: Option[String] = apiContent.metaData.get("group").flatMap(_.asOpt[String])
-  override lazy val imageAdjust: String = apiContent.metaData.get("imageAdjust").flatMap(_.asOpt[String]).getOrElse("default")
-  override lazy val isBreaking: Boolean = apiContent.metaData.get("isBreaking").flatMap(_.asOpt[Boolean]).getOrElse(false)
   override lazy val supporting: List[Content] = apiContent.supporting
-
+  override lazy val isBreaking: Boolean = apiContent.metaData.get("isBreaking").flatMap(_.asOpt[Boolean]).getOrElse(false)
+  override lazy val imageAdjust: String = apiContent.metaData.get("imageAdjust").flatMap(_.asOpt[String]).getOrElse("default")
   override lazy val imageSrc: Option[String] = apiContent.metaData.get("imageSrc").flatMap(_.asOpt[String])
   override lazy val imageSrcWidth: Option[String] = apiContent.metaData.get("imageSrcWidth").flatMap(_.asOpt[String])
   override lazy val imageSrcHeight: Option[String] = apiContent.metaData.get("imageSrcHeight").flatMap(_.asOpt[String])
@@ -340,6 +337,7 @@ class Snap(snapId: String,
 }
 
 class Article(content: ApiContentWithMeta) extends Content(content) {
+  lazy val main: String = delegate.safeFields.getOrElse("main","")
   lazy val body: String = delegate.safeFields.getOrElse("body","")
   lazy val contentType = "Article"
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -119,6 +119,9 @@ trait Elements {
   def mainVideo: Option[VideoElement] = videos.find(_.isMain).headOption
   lazy val hasMainVideo: Boolean = mainVideo.flatMap(_.videoAssets.headOption).isDefined
 
+  def mainEmbed: Option[EmbedElement] = embeds.find(_.isMain).headOption
+  lazy val hasMainEmbed: Boolean = mainEmbed.flatMap(_.embedAssets.headOption).isDefined
+
   lazy val bodyImages: Seq[ImageElement] = images.filter(_.isBody)
   lazy val bodyVideos: Seq[VideoElement] = videos.filter(_.isBody)
   lazy val videoAssets: Seq[VideoAsset] = videos.flatMap(_.videoAssets)
@@ -126,12 +129,20 @@ trait Elements {
 
   def elements: Seq[Element] = Nil
 
-  protected lazy val images: Seq[ImageElement] = elements.filter(_.isImage)
-    .map(e => new ImageElement(e.delegate, e.index))
+  protected lazy val images: Seq[ImageElement] = elements.flatMap {
+    case image :ImageElement => Some(image)
+    case _ => None
+  }
 
-  protected lazy val videos: Seq[VideoElement] = elements.filter(_.isVideo)
-    .map(e => new VideoElement(e.delegate, e.index))
+  protected lazy val videos: Seq[VideoElement] = elements.flatMap {
+    case video: VideoElement => Some(video)
+    case _ => None
+  }
 
+  protected lazy val embeds: Seq[EmbedElement] = elements.flatMap {
+    case embed: EmbedElement => Some(embed)
+    case _ => None
+  }
 }
 
 trait Tags {


### PR DESCRIPTION
This change recognises embed elements from CAPI, and uses the main html field if a main embed object is present.

![screenshot from 2014-05-21 15 48 05](https://cloud.githubusercontent.com/assets/4549425/3041702/ff30b512-e0f6-11e3-9501-7bd11c5ef521.png)
