### PR TITLE
Don't pseudo link matches in World Cup

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -247,12 +247,6 @@ define([
         });
 
         // Binding
-        bean.on(context, 'click', '.table tr[data-link-to]', function(e) {
-            if (!e.target.getAttribute('href')) {
-                window.location = this.getAttribute('data-link-to');
-            }
-        });
-
         bean.on(context, 'click', '.js-show-more', function(e) {
             e.preventDefault();
             var el = e.currentTarget;
@@ -277,11 +271,20 @@ define([
             window.location = this.value;
         });
 
+        if(!config.page.isFootballWorldCup2014) {
+            bean.on(context, 'click', '.table tr[data-link-to]', function (e) {
+                if (!e.target.getAttribute('href')) {
+                    window.location = this.getAttribute('data-link-to');
+                }
+            });
+        }
+
         // World Cup content
         // config.switches.worldCupWallchartEmbed
         // Remove this content below when you remove the switch as it's specific to World Cup 2014
         if (config.page.isFootballWorldCup2014) {
             $('a').attr('target', '_top');
+
             (function() {
                 var t, h, i, resize;
 


### PR DESCRIPTION
We cannot use the pseudo linking in the world cup embed as it is embedded in an iframe.
We are now demoted to normal links.
![Dangit](http://3.bp.blogspot.com/-Qs56Z2dGXx4/UeW1AS6ornI/AAAAAAAAAFE/EOEsJiN3C5M/s320/Neil-deGrasse-Tyson-gif.gif)
