### PR TITLE
Saucisson and New Features Container

### DIFF
--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -86,6 +86,7 @@
 @import 'module/facia/_extends';
 @import 'module/containers/_sport';
 @import 'module/containers/_features';
+@import 'module/containers/_newfeatures';
 @import 'module/containers/_comment';
 @import 'module/containers/_special';
 @import 'module/containers/_section';

--- a/common/app/assets/stylesheets/head.facia.scss
+++ b/common/app/assets/stylesheets/head.facia.scss
@@ -10,6 +10,7 @@
 @import 'module/facia/_supporting';
 @import 'module/facia/_fromage';
 @import 'module/facia/_baguette';
+@import 'module/facia/_saucisson';
 
 @import 'module/containers/_news';
 @import 'module/containers/_tag';

--- a/common/app/assets/stylesheets/module/containers/_newfeatures.scss
+++ b/common/app/assets/stylesheets/module/containers/_newfeatures.scss
@@ -1,0 +1,35 @@
+.container--newfeatures {
+    .container__body {
+        @include rem((
+            padding-top: $gs-baseline/3
+        ));
+        @include mq(tablet, desktop) {
+            padding-top: 0;
+        }
+    }
+    .linkslist-container {
+        @include mq($to: desktop) {
+            margin-top: 0;
+        }
+    }
+    .ad-slot--inline {
+        margin-top: $gs-baseline;
+        margin-bottom: $gs-baseline/2;
+    }
+    .container__banding:first-child .saucisson {
+        border-top-width: 0;
+    }
+}
+
+.facia-slice__item--floated-m {
+    @include mq($to: tablet) {
+        .item__media-wrapper {
+            float: left;
+            @include box-sizing(border-box);
+            width: 50%;
+            @include rem((
+                padding-right: $gs-gutter/2
+            ));
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia/_saucisson.scss
+++ b/common/app/assets/stylesheets/module/facia/_saucisson.scss
@@ -1,0 +1,115 @@
+/**
+ * Saucisson object
+ *
+ * Single full width story
+ */
+
+
+/* Wrapper
+   ========================================================================== */
+
+.saucisson {
+    @include rem((
+        margin: 0 $gs-gutter/2 $gs-baseline
+    ));
+    border-top-width: 2px;
+    border-top-style: solid;
+
+    @include mq(tablet) {
+        @include rem((
+            margin-bottom: $gs-baseline*1.75
+        ));
+    }
+
+    .item__title {
+        @include fs-headline(2, $size-only: true);
+        padding-top: 0;
+        @include rem((
+            margin-bottom: $gs-baseline
+        ));
+
+        @include mq(tablet) {
+            @include fs-headline(4, true);
+            @include rem((
+                margin-bottom: $gs-baseline*1.25
+            ));
+        }
+    }
+}
+.saucisson,
+.saucisson__container {
+    @include clearfix;
+}
+.saucisson__container {
+    // used for spacing, width set if needed
+    border-top: 0 solid transparent;
+    position: relative;
+    @include rem((
+        padding-bottom: $gs-row-height - $gs-baseline/3
+    ));
+
+    @include mq(tablet) {
+        padding-bottom: 0;
+        padding-left: 66.6666666%;
+    }
+}
+
+
+/* Main elements
+   ========================================================================== */
+
+.saucisson__link {
+    color: $c-neutral1;
+    display: block;
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+
+        .item__title {
+            text-decoration: underline;
+        }
+    }
+    &:active {
+        .item__title {
+            text-decoration: none;
+        }
+    }
+    &:visited,
+    &:visited .item__title {
+        color: $c-neutral2;
+    }
+}
+.saucisson__media-wrapper {
+    @include box-sizing(border-box);
+
+    @include mq(tablet) {
+        @include rem((
+            margin-right: $gs-gutter/2,
+            padding-right: $gs-gutter/2
+        ));
+        float: left;
+        width: 200%; // Twice as big as the text bit
+        margin-left: -200%;
+    }
+}
+.saucisson__image-container {}
+
+.saucisson__standfirst {
+    @include f-headline;
+    @include rem((
+        font-size: 14px,
+        line-height: 18px
+    ));
+    color: $c-neutral2;
+
+    p {
+        margin-bottom: 0; // Some trail texts are wrapped in a paragraph
+    }
+
+    @include mq(tablet) {
+        @include rem((
+            margin-bottom: $gs-baseline + 2
+        ));
+    }
+}

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -334,7 +334,15 @@ object Switches extends Collections {
     safeState = On, new DateMidnight().minusDays(1)
   )
 
+  // Facia Switches
+
+  val NewFeaturesContainerSwitch = Switch("Facia", "facia-new-features-container",
+    "If this switch is turned on, the new features container has the right to live.",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 15)
+  )
+
   // Facia Tool Switches
+
   val ToolDisable = Switch("Facia Tool", "facia-tool-disable",
     "If this is switched on then the fronts tool is disabled",
     safeState = Off, sellByDate = never
@@ -462,7 +470,8 @@ object Switches extends Collections {
     GeoMostPopular,
     TagLinkingSwitch,
     ABHeaderSearchText,
-    ABHighRelevanceCommercialComponent
+    ABHighRelevanceCommercialComponent,
+    NewFeaturesContainerSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/views/fragments/collections/commentanddebate.scala.html
+++ b/common/app/views/fragments/collections/commentanddebate.scala.html
@@ -1,7 +1,7 @@
 @(items: Seq[Trail], style: Container, containerIndex: Int)(implicit request: RequestHeader, config: Config)
 
 <div class="facia-slice-wrapper facia-slice-wrapper--position-1">
-    <ul class="u-unstyled l-row l-row--items-3 collection">
+    <ul class="u-unstyled l-row l-row--items-3 facia-slice">
         @items.slice(0, 3).zipWithIndex.map{ case (trail, index) =>
             @fragments.collections.items.simplecomment(trail, index, containerIndex)
         }
@@ -10,7 +10,7 @@
 @defining(items.slice(3, 7)) { items =>
     @if(items.nonEmpty) {
         <div class="facia-slice-wrapper facia-slice-wrapper--position-2">
-            <ul class="u-unstyled l-row l-row--items-4 collection">
+            <ul class="u-unstyled l-row l-row--items-4 facia-slice">
                 @items.zipWithIndex.map{ case (trail, index) =>
                     @fragments.collections.items.standard(trail, index + 3, containerIndex)
                 }

--- a/common/app/views/fragments/collections/people.scala.html
+++ b/common/app/views/fragments/collections/people.scala.html
@@ -1,7 +1,7 @@
 @(items: Seq[Trail], style: PeopleContainer, containerIndex: Int)(implicit request: RequestHeader, config: Config)
 
 <div class="facia-slice-wrapper facia-slice-wrapper--position-1">
-    <ul class="u-unstyled l-row l-row--items-3 collection">
+    <ul class="u-unstyled l-row l-row--items-3 facia-slice">
         @items.slice(0, 3).zipWithIndex.map{ case (trail, index) =>
             @fragments.collections.items.standard(trail, index, containerIndex)
         }

--- a/common/app/views/fragments/collections/series.scala.html
+++ b/common/app/views/fragments/collections/series.scala.html
@@ -1,7 +1,7 @@
 @(items: Seq[Trail], style: Container, containerIndex: Int)(implicit request: RequestHeader, config: Config)
 
 <div class="facia-slice-wrapper facia-slice-wrapper--position-1">
-    <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m collection">
+    <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m facia-slice">
         @items.slice(0, 1).zipWithIndex.map{ case (trail, index) =>
             @fragments.collections.items.standard(trail, index, containerIndex, "l-row__item--break-m")
         }
@@ -13,7 +13,7 @@
 @defining(items.slice(3, 7)) { items =>
     @if(items.nonEmpty) {
         <div class="facia-slice-wrapper facia-slice-wrapper--position-2">
-            <ul class="u-unstyled l-row l-row--items-4 l-row--layout-m collection">
+            <ul class="u-unstyled l-row l-row--items-4 l-row--layout-m facia-slice">
                 @items.zipWithIndex.map{ case (trail, index) =>
                     @fragments.collections.items.standard(trail, index + 3, containerIndex)
                 }

--- a/common/app/views/fragments/collections/special.scala.html
+++ b/common/app/views/fragments/collections/special.scala.html
@@ -1,7 +1,7 @@
 @(items: Seq[Trail], style: Container, containerIndex: Int)(implicit request: RequestHeader, config: Config)
 
 <div class="facia-slice-wrapper">
-    <ul class="u-unstyled l-row l-row--items-4 l-row--layout-m collection">
+    <ul class="u-unstyled l-row l-row--items-4 l-row--layout-m facia-slice">
         @items.slice(0, 4).zipWithIndex.map{ case (trail, index) =>
             @fragments.collections.items.standard(trail, index + 3, containerIndex)
         }

--- a/common/app/views/fragments/collections/tag.scala.html
+++ b/common/app/views/fragments/collections/tag.scala.html
@@ -33,7 +33,7 @@
             @defining(items.slice(baguetteCount + 2, baguetteCount + 6)) { items =>
                 @if(items.nonEmpty) {
                     <div class="facia-slice-wrapper">
-                        <ul class="u-unstyled l-row l-row--layout-m l-row--items-4 collection">
+                        <ul class="u-unstyled l-row l-row--layout-m l-row--items-4 facia-slice">
                             @items.zipWithIndex.map{ case (trail, index) =>
                                 @fragments.collections.items.standard(trail, baguetteCount + index + 2, containerIndex)
                             }

--- a/common/app/views/fragments/containers/multimedia.scala.html
+++ b/common/app/views/fragments/containers/multimedia.scala.html
@@ -30,7 +30,7 @@
                         }
                         <div class="container__body container--rolled-up-hide">
                             <div class="facia-slice-wrapper facia-slice-wrapper--position-1">
-                                <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m collection">
+                                <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m facia-slice">
                                     @items.take(1).zipWithIndex.map{ case (trail, index) =>
                                         @fragments.collections.items.standard(trail, index, containerIndex, "l-row__item--break-m")
                                     }
@@ -48,7 +48,7 @@
                             @defining(items.slice(3, 7)) { items =>
                                 @if(items.nonEmpty) {
                                     <div class="facia-slice-wrapper facia-slice-wrapper--position-2">
-                                        <ul class="u-unstyled l-row l-row--items-4 collection">
+                                        <ul class="u-unstyled l-row l-row--items-4 facia-slice">
                                             @items.zipWithIndex.map{ case (trail, index) =>
                                                 @fragments.collections.items.standard(trail, index + 3, containerIndex)
                                             }

--- a/common/app/views/fragments/containers/newfeatures.scala.html
+++ b/common/app/views/fragments/containers/newfeatures.scala.html
@@ -1,0 +1,110 @@
+@(collection: Collection, style: NewFeaturesContainer, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
+
+@defining((config.displayName.orElse(collection.displayName), config.href.orElse(collection.href))) { case (title, href) =>
+
+    @defining(templateDeduping(11, collection.items)) { items =>
+        @if(items.nonEmpty) {
+            <section
+                class="@RenderClasses(Map(
+                    "container" -> true,
+                    "container--row-pattern" -> true,
+                    s"container--${style.containerType}" -> true,
+                    "js-container--toggle" -> (containerIndex > 0 && title.nonEmpty),
+                    "container--first" -> (containerIndex == 0)))"
+                data-link-name="block | @config.id"
+                data-id="@config.id"
+                data-type="@style.containerType"
+                data-component="@FaciaComponentName(config, collection)">
+                <div class="container__banding">
+                    <div class="facia-container__inner">
+                        <div class="container__border tone-@style.tone tone-accent-border"></div>
+                        <div class="container__header">
+                            @title.map { title =>
+                                <h2 class="container__title tone-@style.tone tone-background">
+                                    @href.map { href =>
+                                        <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                                    }.getOrElse{
+                                        <span class="container__title__label u-text-hyphenate">@Html(title)</span>
+                                    }
+                                </h2>
+                            }
+                        </div>
+                        <div class="container__body">
+                            <div class="facia-slice-wrapper facia-slice-wrapper--position-1 container--rolled-up-hide">
+                                @items.take(1).zipWithIndex.map{ case (trail, index) =>
+                                    @fragments.items.saucisson(trail, index)
+                                }
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="container__banding container--rolled-up-hide">
+                    <div class="facia-container__inner">
+                        <div class="container__body">
+                            @defining(items.slice(1, 4)) { items =>
+                                @if(items.nonEmpty) {
+                                    <div class="facia-slice-wrapper facia-slice-wrapper--position-2">
+                                        <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m facia-slice">
+                                            @items.take(1).zipWithIndex.map{ case (trail, index) =>
+                                                @fragments.collections.items.standard(trail, index + 1, containerIndex, "l-row__item--break-m facia-slice__item--floated-m")
+                                            }
+                                            @items.drop(1).zipWithIndex.map{ case (trail, index) =>
+                                                @fragments.collections.items.standard(trail, index + 1, containerIndex)
+                                            }
+                                        </ul>
+                                    </div>
+                                }
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="container__banding container--rolled-up-hide">
+                    <div class="facia-container__inner">
+                        <div class="container__body">
+                            @defining(items.slice(4, 10)) { items =>
+                                @if(items.nonEmpty) {
+                                    <div class="linkslist-container tone-@{style.tone} facia-slice-wrapper--ad" data-tone="@style.tone">
+                                        <ul class="l-columns linkslist">
+                                            @items.zipWithIndex.map{ case (trail, index) =>
+                                                @trail match {
+                                                    case l: LiveBlog if l.isLive         => { @fragments.items.linksList.live(l, index + 4, Some("boost")) }
+                                                    case g: Gallery                      => { @fragments.items.linksList.gallery(g, index + 4, Some("boost")) }
+                                                    case v: Video                        => { @fragments.items.linksList.video(v, index + 4, Some("boost")) }
+                                                    case c if c.visualTone == "comment"  => { @fragments.items.linksList.comment(c, index + 4, Some("boost")) }
+                                                    case t                               => { @fragments.items.linksList.standard(t, index + 4, Some("boost")) }
+                                                }
+                                            }
+                                        </ul>
+                                    </div>
+                                }
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="container__banding container--rolled-up-hide">
+                    <div class="facia-container__inner">
+                        <div class="container__body">
+                            @defining(items.drop(10)) { case (items) =>
+                                @if(items.nonEmpty) {
+                                    <div class="linkslist-container @if(style.showMore){js-container--show-more} tone-@{style.tone}" data-tone="@style.tone">
+                                        <ul class="l-columns linkslist">
+                                            @items.zipWithIndex.map{ case (trail, index) =>
+                                                @trail match {
+                                                    case l: LiveBlog if l.isLive           => { @fragments.items.linksList.live(l, index + 10) }
+                                                    case g: Gallery                        => { @fragments.items.linksList.gallery(g, index + 10) }
+                                                    case v: Video                          => { @fragments.items.linksList.video(v, index + 10) }
+                                                    case c if c.visualTone == "comment"    => { @fragments.items.linksList.comment(c, index + 10) }
+                                                    case t                                 => { @fragments.items.linksList.standard(t, index + 10) }
+                                                }
+                                            }
+                                        </ul>
+                                    </div>
+                                }
+                            }
+                        </div>
+                    </div>
+                </div>
+            </section>
+        }
+    }
+}

--- a/common/app/views/fragments/items/saucisson.scala.html
+++ b/common/app/views/fragments/items/saucisson.scala.html
@@ -1,0 +1,57 @@
+@(trail: Trail, index: Int, imageAdjustOverride: Option[String] = None)(implicit request: RequestHeader, config: Config)
+
+@defining((trail.visualTone, imageAdjustOverride.getOrElse(trail.imageAdjust))) { case (tone, imageAdjust) =>
+    <div
+        class="@GetClasses.forSaucisson(trail, imageAdjust)"
+        @if(trail.isCommentable) {
+            @trail.discussionId.map{ id =>
+                data-discussion-id="@id"
+            }
+            data-discussion-closed="@trail.isClosedForComments"
+        }
+        data-link-name="trail | @{index + 1}"
+        @SnapData(trail)>
+
+        <div class="saucisson__container">
+            <a @LinkTo(trail).map{url=>href=@url} class="saucisson__link" data-link-name="article">
+                @if(imageAdjust != Some("hide")) {
+                    @trail.trailPicture(5,3).map{ imageContainer =>
+                        @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
+                            <div class="saucisson__media-wrapper">
+                                <div class="saucisson__image-container u-responsive-ratio@if(imageAdjust == "boost"){ js-image-upgrade inlined-image" data-src="@imgSrc}">
+                                    @if(imageAdjust == "boost") {
+                                        @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                    } else {
+                                        @Item220.bestFor(imageContainer).map{ url => <img src="@url" alt="" /> }
+                                    }
+                                </div>
+                            </div>
+                        }
+                    }
+                }
+                @fragments.items.elements.title(trail, index, 0)
+            </a>
+            @if(tone == "comment") {
+                @trail.byline.map { byLine =>
+                    <p class="saucisson__byline tone-colour">@Html(byLine)</p>
+                }
+            }
+
+            @trail match { case content:model.Content => @fragments.items.elements.tagOrSection(content) }
+
+            @trail.trailText.map { text =>
+                <div class="saucisson__standfirst">@Html(text)
+                    @trail match { case content:model.Content => @fragments.items.elements.starRating(content) }
+                </div>
+            }
+
+            @fragments.items.elements.supporting(trail.supporting, style = "fit")
+
+            @* Display meta only if there is a discussion *@
+            @if(trail.isCommentable) {
+                @fragments.items.elements.meta(trail)
+            }
+        </div>
+
+    </div>
+}

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -843,6 +843,30 @@ object GetClasses {
     RenderClasses(classes:_*)
   }
 
+  def forSaucisson(trail: Trail, imageAdjust: String): String = {
+    val baseClasses: Seq[String] = Seq(
+      "saucisson",
+      s"tone-${trail.visualTone}",
+      "tone-accent-border"
+    )
+    val f: Seq[(Trail, String) => String] = Seq(
+      (trail: Trail, imageAdjust: String) =>
+        if (trail.isLive) "item--live" else "",
+      (trail: Trail, imageAdjust: String) =>
+        if (trail.trailPicture(5,3).isEmpty || imageAdjust == "hide"){
+          "saucisson--has-no-image"
+        }else{
+          "saucisson--has-image"
+        },
+      (trail: Trail, imageAdjust: String) =>
+        if (!trail.trailPicture(5,3).isEmpty) s"saucisson--imageadjust-$imageAdjust" else "",
+      (trail: Trail, imageAdjust: String) =>
+        if (trail.isCommentable) "saucisson--has-discussion" else "saucisson--has-no-discussion"
+    )
+    val classes = f.foldLeft(baseClasses){case (cl, fun) => cl :+ fun(trail, imageAdjust)} ++ makeSnapClasses(trail)
+    RenderClasses(classes:_*)
+  }
+
   def makeSnapClasses(trail: Trail): Seq[String] = trail match {
     case snap: Snap => "facia-snap" +: snap.snapCss.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
     case _  => Nil

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import common._
-import conf.Switches.{ ShowAllArticleEmbedsSwitch, ArticleSlotsSwitch, TagLinkingSwitch }
+import conf.Switches.{ ShowAllArticleEmbedsSwitch, ArticleSlotsSwitch, TagLinkingSwitch, NewFeaturesContainerSwitch }
 import model._
 
 import java.net.URLEncoder._
@@ -82,6 +82,10 @@ case class CommentAndDebateContainer(showMore: Boolean = true) extends Container
 }
 case class FeaturesContainer(showMore: Boolean = true) extends Container {
   val containerType = "features"
+  val tone = "feature"
+}
+case class NewFeaturesContainer(showMore: Boolean = true) extends Container {
+  val containerType = "newfeatures"
   val tone = "feature"
 }
 case class PopularContainer(showMore: Boolean = true) extends Container {

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -1,5 +1,7 @@
 @(front: MetaData, block: (Config, Collection), collectionsSize: Int = 1, index: Int = 1)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
+@import Switches.NewFeaturesContainerSwitch
+
 @block._1.collectionType match {
     case Some("news")                       => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
     case Some("news/auto")                  => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
@@ -18,5 +20,12 @@
     case Some("features/section")           => { @containers.section(block._2, SectionContainer(tone = "feature"), index)(request, templateDeduping, block._1) }
     case Some("comment/section")            => { @containers.section(block._2, SectionContainer(tone = "comment"), index)(request, templateDeduping, block._1) }
     case Some("features/multimedia")        => { @containers.multimedia(block._2, MultimediaContainer(), index)(request, templateDeduping, block._1) }
+    case Some("newfeatures")                => {
+                                                @if(NewFeaturesContainerSwitch.isSwitchedOn){
+                                                    @containers.newfeatures(block._2, NewFeaturesContainer(), index)(request, templateDeduping, block._1)
+                                                }else{
+                                                    @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1)
+                                                }
+                                            }
     case _                                  => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
 }


### PR DESCRIPTION
- [new] Saucisson pattern: a single full-width item, with an image that takes 2 thirds of the horizontal space on tablet and up (Used as a skin for the first item in Features containers)
- [new] New Features Container (see screenshots)
- [new] Trying 

From now on, new containers/skins have a sell-by date. At which point we can assess whether we keep the container/skin for another X weeks or KILL THEM (duration TBD).

Note: if an editor uses the new features container but the switch is off, it defaults to the old features container
## Mobile

![screen shot 2014-05-21 at 17 12 05](https://cloud.githubusercontent.com/assets/85783/3043336/38ba97a4-e105-11e3-8918-d4dd21de9bb1.PNG)
## Tablet

![screen shot 2014-05-21 at 17 11 56](https://cloud.githubusercontent.com/assets/85783/3043337/3bb682ce-e105-11e3-9f3e-c48edea1dc80.PNG)
## Desktop

![screen shot 2014-05-21 at 17 11 49](https://cloud.githubusercontent.com/assets/85783/3043338/40754a2a-e105-11e3-83a1-0612d6c1a7ae.PNG)

![ ](http://media.giphy.com/media/899rXpPrpJ4c0/giphy.gif)
