### PR TITLE
Facia features on top of the page

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -345,13 +345,6 @@ object Switches extends Collections {
     safeState = On, new DateMidnight().minusDays(1)
   )
 
-  // Facia Switches
-
-  val NewFeaturesContainerSwitch = Switch("Facia", "facia-new-features-container",
-    "If this switch is turned on, the new features container has the right to live.",
-    safeState = Off, sellByDate = new DateMidnight(2014, 6, 15)
-  )
-
   // Facia Tool Switches
 
   val ToolDisable = Switch("Facia Tool", "facia-tool-disable",
@@ -400,14 +393,21 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
+  val FaciaToolContainerTagsSwitch = Switch("Facia Tool", "facia-tool-tags",
+    "If this switch is on the container configuration will allow articles to show their tags or sections",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 7)
+  )
+
+  // Facia Switches
+
   val NewSeoSwitch = Switch("Facia Switches", "new-seo-switch",
     "If this switch is on then the SEO elements for pages will be take from the tool, content api and generated",
     safeState = Off, sellByDate = new DateMidnight(2014, 5, 30)
   )
 
-  val FaciaToolContainerTagsSwitch = Switch("Facia Tool", "facia-tool-tags",
-    "If this switch is on the container configuration will allow articles to show their tags or sections",
-    safeState = Off, sellByDate = new DateMidnight(2014, 6, 7)
+  val FeaturesAutoContainerSwitch = Switch("Facia Switches", "facia-features-auto-container",
+    "If this switch is on, the features auto container has the right to live.",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 15)
   )
 
   // Image Switch
@@ -484,7 +484,7 @@ object Switches extends Collections {
     ABHeaderSearchText,
     ABHighRelevanceCommercialComponent,
     SmartBannerSwitch,
-    NewFeaturesContainerSwitch
+    FeaturesAutoContainerSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -345,6 +345,13 @@ object Switches extends Collections {
     safeState = On, new DateMidnight().minusDays(1)
   )
 
+  // Facia Switches
+
+  val NewFeaturesContainerSwitch = Switch("Facia", "facia-new-features-container",
+    "If this switch is turned on, the new features container has the right to live.",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 15)
+  )
+
   // Facia Tool Switches
 
   val ToolDisable = Switch("Facia Tool", "facia-tool-disable",
@@ -393,21 +400,14 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val FaciaToolContainerTagsSwitch = Switch("Facia Tool", "facia-tool-tags",
-    "If this switch is on the container configuration will allow articles to show their tags or sections",
-    safeState = Off, sellByDate = new DateMidnight(2014, 6, 7)
-  )
-
-  // Facia Switches
-
   val NewSeoSwitch = Switch("Facia Switches", "new-seo-switch",
     "If this switch is on then the SEO elements for pages will be take from the tool, content api and generated",
     safeState = Off, sellByDate = new DateMidnight(2014, 5, 30)
   )
 
-  val FeaturesAutoContainerSwitch = Switch("Facia Switches", "facia-features-auto-container",
-    "If this switch is on, the features auto container has the right to live.",
-    safeState = Off, sellByDate = new DateMidnight(2014, 6, 15)
+  val FaciaToolContainerTagsSwitch = Switch("Facia Tool", "facia-tool-tags",
+    "If this switch is on the container configuration will allow articles to show their tags or sections",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 7)
   )
 
   // Image Switch
@@ -484,7 +484,7 @@ object Switches extends Collections {
     ABHeaderSearchText,
     ABHighRelevanceCommercialComponent,
     SmartBannerSwitch,
-    FeaturesAutoContainerSwitch
+    NewFeaturesContainerSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -290,6 +290,12 @@ object Switches extends Collections {
     safeState = On, sellByDate = new DateMidnight(2014, 6, 30)
   )
 
+  val FaciaFirstContainerLayoutOverrideSwitch = Switch("Feature Switches", "facia-first-container-layout-override",
+    "If this switch is turned on then the first container on every facia front will have a fixed layout " +
+      "containing two slices with one big article in each one of them",
+    safeState = On, sellByDate = new DateMidnight(2014, 6, 10)
+  )
+
   val EnhanceTweetsSwitch = Switch("Feature Switches", "enhance-tweets",
     "If this switch is turned on then embedded tweets will be enhanced using Twitter's widgets.",
     safeState = Off, sellByDate = never
@@ -455,6 +461,7 @@ object Switches extends Collections {
     GzipSwitch,
     GeoMostPopular,
     TagLinkingSwitch,
+    FaciaFirstContainerLayoutOverrideSwitch,
     ABHeaderSearchText,
     ABHighRelevanceCommercialComponent
   )

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -1,32 +1,34 @@
 @(front: MetaData, block: (Config, Collection), collectionsSize: Int = 1, index: Int = 1)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 @import views.support.ForceGroupsCollection
 
-@import Switches.NewFeaturesContainerSwitch
+@import Switches.{ NewFeaturesContainerSwitch, FaciaFirstContainerLayoutOverrideSwitch }
 
-@block._1.collectionType match {
-    case Some("news")                       => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/auto")                  => { @containers.news(ForceGroupsCollection.firstTwoBig(block._2), NewsContainer(), index)(request, templateDeduping, block._1) }
-    case _ if index == 0                    => { @collectionsSize match {
-        case size if size < 3               => { @containers.tag(front, block._2, NewsContainer(showMore = false), index)(request, templateDeduping, block._1) }
-        case _                              => { @containers.tag(front, block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
-    }}
-    case Some("news/sport")                 => { @containers.sport(front, block._2, SportContainer(), index)(request, templateDeduping, block._1) }
-    case Some("comment")                    => { @containers.comment(block._2, CommentContainer(), index)(request, templateDeduping, block._1) }
-    case Some("comment/comment-and-debate") => { @containers.commentanddebate(block._2, CommentAndDebateContainer(), index)(request, templateDeduping, block._1) }
-    case Some("features")                   => { @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/most-popular")          => { @containers.popular(block._2, PopularContainer(), index)(request, block._1) }
-    case Some("news/people")                => { @containers.people(block._2, PeopleContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/special")               => { @containers.special(block._2, SpecialContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/section")               => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
-    case Some("features/section")           => { @containers.section(block._2, SectionContainer(tone = "feature"), index)(request, templateDeduping, block._1) }
-    case Some("comment/section")            => { @containers.section(block._2, SectionContainer(tone = "comment"), index)(request, templateDeduping, block._1) }
-    case Some("features/multimedia")        => { @containers.multimedia(block._2, MultimediaContainer(), index)(request, templateDeduping, block._1) }
-    case Some("newfeatures")                => {
-                                                @if(NewFeaturesContainerSwitch.isSwitchedOn){
-                                                    @containers.newfeatures(block._2, NewFeaturesContainer(), index)(request, templateDeduping, block._1)
-                                                }else{
-                                                    @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1)
+@defining(FaciaFirstContainerLayoutOverrideSwitch.isSwitchedOn) { layoutOverride =>
+    @block._1.collectionType match {
+        case Some("news")                       => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/auto")                  => { @containers.news(ForceGroupsCollection.firstTwoBig(block._2), NewsContainer(), index)(request, templateDeduping, block._1) }
+        case _ if index == 0                    => { @collectionsSize match {
+            case size if size < 3               => { @containers.tag(front, block._2, NewsContainer(showMore = false), index)(request, templateDeduping, block._1) }
+            case _                              => { @containers.tag(front, block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
+        }}
+        case Some("news/sport")                 => { @containers.sport(front, block._2, SportContainer(), index)(request, templateDeduping, block._1) }
+        case Some("comment")                    => { @containers.comment(block._2, CommentContainer(), index)(request, templateDeduping, block._1) }
+        case Some("comment/comment-and-debate") => { @containers.commentanddebate(block._2, CommentAndDebateContainer(), index)(request, templateDeduping, block._1) }
+        case Some("features")                   => { @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/most-popular")          => { @containers.popular(block._2, PopularContainer(), index)(request, block._1) }
+        case Some("news/people")                => { @containers.people(block._2, PeopleContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/special")               => { @containers.special(block._2, SpecialContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/section")               => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
+        case Some("features/section")           => { @containers.section(block._2, SectionContainer(tone = "feature"), index)(request, templateDeduping, block._1) }
+        case Some("comment/section")            => { @containers.section(block._2, SectionContainer(tone = "comment"), index)(request, templateDeduping, block._1) }
+        case Some("features/multimedia")        => { @containers.multimedia(block._2, MultimediaContainer(), index)(request, templateDeduping, block._1) }
+        case Some("newfeatures")                => {
+                                                    @if(NewFeaturesContainerSwitch.isSwitchedOn){
+                                                        @containers.newfeatures(block._2, NewFeaturesContainer(), index)(request, templateDeduping, block._1)
+                                                    }else{
+                                                        @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1)
+                                                    }
                                                 }
-                                            }
-    case _                                  => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
+        case _                                  => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
+    }
 }

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -1,23 +1,26 @@
 @(front: MetaData, block: (Config, Collection), collectionsSize: Int = 1, index: Int = 1)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 @import views.support.ForceGroupsCollection
+@import conf.Switches.{ FaciaFirstContainerLayoutOverrideSwitch }
 
-@block._1.collectionType match {
-    case Some("news")                       => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/auto")                  => { @containers.news(ForceGroupsCollection.firstTwoBig(block._2), NewsContainer(), index)(request, templateDeduping, block._1) }
-    case _ if index == 0                    => { @collectionsSize match {
-        case size if size < 3               => { @containers.tag(front, block._2, NewsContainer(showMore = false), index)(request, templateDeduping, block._1) }
-        case _                              => { @containers.tag(front, block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
-    }}
-    case Some("news/sport")                 => { @containers.sport(front, block._2, SportContainer(), index)(request, templateDeduping, block._1) }
-    case Some("comment")                    => { @containers.comment(block._2, CommentContainer(), index)(request, templateDeduping, block._1) }
-    case Some("comment/comment-and-debate") => { @containers.commentanddebate(block._2, CommentAndDebateContainer(), index)(request, templateDeduping, block._1) }
-    case Some("features")                   => { @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/most-popular")          => { @containers.popular(block._2, PopularContainer(), index)(request, block._1) }
-    case Some("news/people")                => { @containers.people(block._2, PeopleContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/special")               => { @containers.special(block._2, SpecialContainer(), index)(request, templateDeduping, block._1) }
-    case Some("news/section")               => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
-    case Some("features/section")           => { @containers.section(block._2, SectionContainer(tone = "feature"), index)(request, templateDeduping, block._1) }
-    case Some("comment/section")            => { @containers.section(block._2, SectionContainer(tone = "comment"), index)(request, templateDeduping, block._1) }
-    case Some("features/multimedia")        => { @containers.multimedia(block._2, MultimediaContainer(), index)(request, templateDeduping, block._1) }
-    case _                                  => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
+@defining(FaciaFirstContainerLayoutOverrideSwitch.isSwitchedOn) { layoutOverride =>
+    @block._1.collectionType match {
+        case Some("news")                       => { @containers.news(block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/auto")                  => { @containers.news(ForceGroupsCollection.firstTwoBig(block._2), NewsContainer(), index)(request, templateDeduping, block._1) }
+        case _ if layoutOverride && index == 0  => { @collectionsSize match {
+            case size if size < 3               => { @containers.tag(front, block._2, NewsContainer(showMore = false), index)(request, templateDeduping, block._1) }
+            case _                              => { @containers.tag(front, block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
+        }}
+        case Some("news/sport")                 => { @containers.sport(front, block._2, SportContainer(), index)(request, templateDeduping, block._1) }
+        case Some("comment")                    => { @containers.comment(block._2, CommentContainer(), index)(request, templateDeduping, block._1) }
+        case Some("comment/comment-and-debate") => { @containers.commentanddebate(block._2, CommentAndDebateContainer(), index)(request, templateDeduping, block._1) }
+        case Some("features")                   => { @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/most-popular")          => { @containers.popular(block._2, PopularContainer(), index)(request, block._1) }
+        case Some("news/people")                => { @containers.people(block._2, PeopleContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/special")               => { @containers.special(block._2, SpecialContainer(), index)(request, templateDeduping, block._1) }
+        case Some("news/section")               => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
+        case Some("features/section")           => { @containers.section(block._2, SectionContainer(tone = "feature"), index)(request, templateDeduping, block._1) }
+        case Some("comment/section")            => { @containers.section(block._2, SectionContainer(tone = "comment"), index)(request, templateDeduping, block._1) }
+        case Some("features/multimedia")        => { @containers.multimedia(block._2, MultimediaContainer(), index)(request, templateDeduping, block._1) }
+        case _                                  => { @containers.section(block._2, SectionContainer(), index)(request, templateDeduping, block._1) }
+    }
 }


### PR DESCRIPTION
As a first step to allow features to be rendered with a different layout on the front pages, we need to be able to switch off the existing layout override
