### PR TITLE
Compile sprites to utf8 version of SVG instead of Base64

### DIFF
--- a/tools/sprites/spricon-phantom.js
+++ b/tools/sprites/spricon-phantom.js
@@ -8,7 +8,6 @@
 
 /*global phantom:true*/
 /*global window:true*/
-/*global btoa:true*/
 
 /*
 phantom args sent from app.js:
@@ -90,7 +89,7 @@ function processFile() {
 
                 var page = require( "webpage" ).create();
                 var svgdata = fs.read(  inputdir + theFile ) || "";
-                var svgdatauri = "data:image/svg+xml;base64,";
+                var svgdatauri = "data:image/svg+xml;utf8,";
                 var pngdatauri = "data:image/png;base64,";
 
                 // kill the ".svg" at the end of the filename
@@ -103,13 +102,12 @@ function processFile() {
                 var width = svgelem.getAttribute( "width" );
                 var height = svgelem.getAttribute( "height" );
 
-                // get base64 of svg file
-                svgdatauri += btoa(svgdata);
+                svgdatauri += svgdata;
 
                 //If we want to generate base64 svg css
                 if(generatesvg) {
                     // add rules to svg data css file
-                    datacssrules.push( "    %svg-" + cssprefix + filenamenoext +", .svg-" + cssprefix + filenamenoext +" { background-image: url(" + svgdatauri + "); background-position: 0 0; background-repeat: no-repeat; }\n    .svg ." + cssprefix + filenamenoext + " { @extend %svg-" + cssprefix + filenamenoext +" !optional; }\n" );
+                    datacssrules.push( "    %svg-" + cssprefix + filenamenoext +", .svg-" + cssprefix + filenamenoext +" { background-image: url('" + svgdatauri + "'); background-position: 0 0; background-repeat: no-repeat; }\n    .svg ." + cssprefix + filenamenoext + " { @extend %svg-" + cssprefix + filenamenoext +" !optional; }\n" );
                 }
 
                 // set page viewport size to svg dimensions


### PR DESCRIPTION
Because Base64 is bigger and SVGs are better at getting gzipped.

Gains: 8 KB just for the global sprite. So even more overall if you include the commercial sprite.

``` bash
# Normal
105700 _global-icons-svg BASE 64.scss
85398 _global-icons-svg UTF8.scss

# Gzipped
28053  _global-icons-svg BASE64.scss.gz
20714 _global-icons-svg UTF8.scss.gz
```

![ ](http://media.giphy.com/media/qzYBlG969xs6k/giphy.gif)
