### PR TITLE
Responsive images for showcase elements in the body

### DIFF
--- a/common/app/views/support/images.scala
+++ b/common/app/views/support/images.scala
@@ -43,6 +43,7 @@ object Item460 extends Profile(Some(460), None)
 object Item620 extends Profile(Some(620), None)
 object Item640 extends Profile(Some(640), None)
 object Item700 extends Profile(Some(700), None)
+object Item860 extends Profile(Some(860), None)
 object Item940 extends Profile(Some(940), None)
 
 // Just degrade the image quality without adjusting the width/height
@@ -62,6 +63,7 @@ object Profile {
     Item620,
     Item640,
     Item700,
+    Item860,
     Item940
   )
 }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -251,7 +251,7 @@ case class VideoEmbedCleaner(contentVideos: Seq[VideoElement]) extends HtmlClean
 
 case class PictureCleaner(contentImages: Seq[ImageElement]) extends HtmlCleaner with implicits.Numbers {
 
-  def clean(body: Document): Document = {
+  def cleanStandardPictures(body: Document): Document = {
     body.getElementsByTag("figure").foreach { fig =>
       if(!fig.hasClass("element-comment") && !fig.hasClass("element-witness")) {
         fig.attr("itemprop", "associatedMedia")
@@ -263,11 +263,11 @@ case class PictureCleaner(contentImages: Seq[ImageElement]) extends HtmlCleaner 
           fig.addClass("img")
           img.attr("itemprop", "contentURL")
 
-          asset.foreach { image =>
+          asset.map { image =>
             image.url.map(url => img.attr("src", ImgSrc(url, Item620).toString))
             img.attr("width", s"${image.width}")
 
-            //otherwsie we mess with aspect ratio
+            //otherwise we mess with aspect ratio
             img.removeAttr("height")
 
             fig.addClass(image.width match {
@@ -296,8 +296,30 @@ case class PictureCleaner(contentImages: Seq[ImageElement]) extends HtmlCleaner 
     body
   }
 
+  def cleanShowcasePictures(body: Document): Document = {
+    for {
+      element <- body.getElementsByClass("element--showcase")
+      asset <- findContainerFromId(element.attr("data-media-id"))
+      imagerSrc <- ImgSrc.imager(asset, Item860)
+      imgElement <- element.getElementsByTag("img")
+    } {
+      imgElement.wrap(s"""<div class="js-image-upgrade" data-src="$imagerSrc"></div>""")
+      imgElement.addClass("responsive-img")
+    }
+
+    body
+  }
+
+  def clean(body: Document): Document = {
+    cleanShowcasePictures(cleanStandardPictures(body))
+  }
+
   def findImageFromId(id:String): Option[ImageAsset] = {
-    contentImages.find(_.id == id).flatMap(Item620.elementFor)
+    findContainerFromId(id).flatMap(Item620.elementFor)
+  }
+
+  def findContainerFromId(id:String): Option[ImageContainer] = {
+    contentImages.find(_.id == id)
   }
 }
 


### PR DESCRIPTION
We should upgrade our images in the body, since the 620 standard width would be scaled. Quality is improved a bit.

Before:
![before](https://cloud.githubusercontent.com/assets/4549425/3055354/93ef87a4-e1c0-11e3-869c-eb7367c995f3.png)

After:
![after](https://cloud.githubusercontent.com/assets/4549425/3055355/960d8130-e1c0-11e3-88ce-f3bb6cf219ae.png)
