### PR TITLE
Add the rawQueryParam to the X-Accel-Redirect from facia to applications

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -32,7 +32,9 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
   }
 
   def applicationsRedirect(path: String) = Action { implicit request =>
-    Ok.withHeaders("X-Accel-Redirect" -> (s"/applications/$path" + (if (request.isRss) "/rss" else "")))
+    Ok.withHeaders("X-Accel-Redirect" -> (s"/applications/$path" +
+      (if (request.isRss) "/rss" else "") +
+      (if (request.queryString.nonEmpty) s"?${request.rawQueryString}" else "")))
   }
 
   //Only used by dev-build for rending special urls such as lifeandstyle/home-and-garden


### PR DESCRIPTION
The redirect from `facia` to `applications` is swallowing query parameters. This makes sure query parameters don't get lost in the transition.

E.g. http://www.theguardian.com/football/tottenham-hotspur?page=2

@gklopper 
