### PR TITLE
Use responsive main media images

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -27,7 +27,7 @@
                 </div>
             }
         } else {
-            @fragments.img(article.mainPicture, article.hasShowcaseMainPicture, article.isFeature && article.hasShowcaseMainPicture)
+            @fragments.img(article.mainPicture, article.hasShowcaseMainPicture, article.isFeature)
         }
     }
 }

--- a/common/app/assets/javascripts/modules/ui/images.js
+++ b/common/app/assets/javascripts/modules/ui/images.js
@@ -16,7 +16,7 @@ function (
         upgrade: function(context) {
             context = context || document;
             var options = {
-                    availableWidths: [ 140, 220, 300, 460, 620, 700, 940, 1430, 1920 ],
+                    availableWidths: [ 140, 220, 300, 460, 620, 700, 860, 940, 1430, 1920 ],
                     strategy: 'container',
                     replacementDelay: 0
                 },

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -1,42 +1,52 @@
-@(img: Option[model.ImageContainer], isShowcase: Boolean = false, isFullWidth: Boolean = false)
-@import views.support.{Item620, Naked}
+@(img: Option[model.ImageContainer], isShowcase: Boolean = false, isFeature: Boolean = false)
+@import views.support.{Item300, Item620, Showcase, Naked, Profile}
 
 @img.map{ picture =>
 
-    @if(isFullWidth) {
-        @ImgSrc.imager(picture, Naked).map { imgSrc =>
-            <figure itemprop="associatedMedia image" itemscope itemtype="http://schema.org/ImageObject" data-component="image"
-                class="media-primary media-content@if(isShowcase){ media-primary--showcase}">
+    <figure itemprop="associatedMedia image" itemscope itemtype="http://schema.org/ImageObject" data-component="image"
+        class="media-primary media-content@if(isShowcase){ media-primary--showcase}">
+
+        @if(isFeature && isShowcase) {
+            @ImgSrc.imager(picture, Naked).map { imgSrc =>
+
                 <div class="js-image-upgrade u-responsive-ratio u-responsive-ratio--letterbox" data-src="@imgSrc">
-                    @image(picture, Item620)
+                    @image(picture)
                 </div>
                 <div class="gs-container">
                     <div class="content__main-column">
-                        @caption(picture, Item620)
+                        @caption(picture)
                     </div>
                 </div>
-            </figure>
+            }
+        } else {
+            @if(isShowcase) {
+                @upgrade(picture, Showcase)
+            } else {
+                @upgrade(picture, Item620)
+            }
+            @caption(picture)
         }
-    } else {
-        <figure itemprop="associatedMedia image" itemscope itemtype="http://schema.org/ImageObject" data-component="image"
-            class="media-primary media-content@if(isShowcase){ media-primary--showcase}" >
-            @image(picture, Item620)
-            @caption(picture, Item620)
-        </figure>
+    </figure>
+}
+
+@upgrade(picture: model.ImageContainer, upgradeProfile: Profile) = {
+    @ImgSrc.imager(picture, upgradeProfile).map { imgSrc =>
+        <div class="js-image-upgrade" data-src="@imgSrc">
+            @image(picture)
+        </div>
     }
 }
 
-@image(image: model.ImageContainer, imageProfile: views.support.Profile) = {
-
-    <img src="@imageProfile.bestFor(image).map(Html(_))"
+@image(picture: model.ImageContainer) = {
+    <img src="@Item300.bestFor(picture).map(Html(_))"
          class="maxed responsive-img"
          itemprop="contentURL representativeOfPage"
-         title="@imageProfile.altTextFor(image).getOrElse("")"
-         alt="@imageProfile.altTextFor(image).getOrElse("")" />
+         title="@Item300.altTextFor(picture).getOrElse("")"
+         alt="@Item300.altTextFor(picture).getOrElse("")" />
 }
 
-@caption(image: model.ImageContainer, imageProfile: views.support.Profile) = {
-  @imageProfile.captionFor(image).map { caption =>
-      <figcaption class="main-caption" itemprop="description">@Html(caption)</figcaption>
-  }
+@caption(picture: model.ImageContainer) = {
+    @Item300.captionFor(picture).map { caption =>
+        <figcaption class="main-caption" itemprop="description">@Html(caption)</figcaption>
+    }
 }

--- a/common/app/views/support/images.scala
+++ b/common/app/views/support/images.scala
@@ -35,6 +35,7 @@ object Contributor extends Profile(Some(140), Some(140))
 object GalleryLargeImage extends Profile(Some(1024), None)
 object GalleryLargeTrail extends Profile(Some(480), Some(288))
 object GallerySmallTrail extends Profile(Some(280), Some(168))
+object Showcase extends Profile(Some(860), None)
 object Item120 extends Profile(Some(120), None)
 object Item140 extends Profile(Some(140), None)
 object Item220 extends Profile(Some(220), None)
@@ -43,7 +44,6 @@ object Item460 extends Profile(Some(460), None)
 object Item620 extends Profile(Some(620), None)
 object Item640 extends Profile(Some(640), None)
 object Item700 extends Profile(Some(700), None)
-object Item860 extends Profile(Some(860), None)
 object Item940 extends Profile(Some(940), None)
 
 // Just degrade the image quality without adjusting the width/height
@@ -56,6 +56,7 @@ object Profile {
     GalleryLargeTrail,
     GallerySmallTrail,
     Naked,
+    Showcase,
     Item140,
     Item220,
     Item300,
@@ -63,7 +64,6 @@ object Profile {
     Item620,
     Item640,
     Item700,
-    Item860,
     Item940
   )
 }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -304,7 +304,7 @@ case class PictureCleaner(contentImages: Seq[ImageElement]) extends HtmlCleaner 
     for {
       element <- body.getElementsByClass("element--showcase")
       asset <- findContainerFromId(element.attr("data-media-id"))
-      imagerSrc <- ImgSrc.imager(asset, Item860)
+      imagerSrc <- ImgSrc.imager(asset, Showcase)
       imgElement <- element.getElementsByTag("img")
     } {
       imgElement.wrap(s"""<div class="js-image-upgrade" data-src="$imagerSrc"></div>""")


### PR DESCRIPTION
This will mean that the page source will contain a 300px main media image, which will be upgraded to a maximum of 620/860 width image (standard article or showcase, respectively).
