### PR TITLE
Adding fixes to football wallchart

### DIFF
--- a/sport/app/football/implicits/Football.scala
+++ b/sport/app/football/implicits/Football.scala
@@ -137,6 +137,11 @@ trait Football extends Collections {
       "Runner-up Group" -> "Runner-up"
     )
   }
+
+  val roundLinks = Map[String, Round => Option[String]](
+    "700" -> ((round: Round) => round.name.map{ n => s"world-cup-2014-${n.toLowerCase.replace(" ", "-")}" })
+  )
+  def groupTag(competitionId: String, round: Round) = roundLinks.get(competitionId).flatMap(_(round))
 }
 
 object Football extends Football

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -11,7 +11,7 @@
                     competition,
                     date,
                     matchType = matchesList.pageType,
-                    heading = if(dateRow.isFirst) Option(competition.fullName) else None,
+                    heading = if(dateRow.isFirst) Some(("View all "+competition.fullName+" matches", Option(competition.url))) else None,
                     link = if(dateRow.isLast && matchRow.isLast)
                             Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None
                 )

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -4,7 +4,7 @@
     responsiveFont: Boolean = false,
     matchType: String = "",
     linkToCompetition: Boolean = false,
-    heading: Option[String] = None,
+    heading: Option[(String, Option[String])] = None,
     link: Option[(String, String)] = None)(implicit request: RequestHeader)
 @import implicits.Football._
 
@@ -74,7 +74,13 @@
         }
     </tbody>
     <caption class="table__caption table__caption--top">
-        @heading.map{ h => <a href="@competition.url" data-link-name="view @competition.fullName" class="football-matches__heading">@h</a>}
+        @heading.map{ case(text, link) =>
+            @link.map{ href =>
+                <a href="@href" data-link-name="view @text" class="football-matches__heading">@text</a>
+            }.getOrElse{
+                <span class="football-matches__heading">@text</span>
+            }
+        }
         <span class="football-matches__date">@date.toString("E d MMMM")</span>
     </caption>
     @if(linkToCompetition && link == None){<caption class="table__caption table__caption--bottom"><a href="@competition.url@if(matchType!=""){/@matchType}" data-link-name="view @competition.fullName matches" class="full-table-link">Show more <span class="competition-name">@competition.fullName</span> @matchType</a></caption>}

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -40,7 +40,7 @@
                                                 date,
                                                 responsiveFont = true,
                                                 matchType = matchesList.pageType,
-                                                heading = Option(competition.fullName)
+                                                heading = Some((competition.fullName, Option(competition.url)))
                                             )
                                         </div>
                                     </div>

--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -1,5 +1,7 @@
 @(competition: model.Competition, group: Group,
-    heading: Option[String] = None, highlightTeamId: Option[String] = None, striped: Boolean = false,
+    heading: Option[String] = None,
+    headingLink: Option[String] = None,
+    highlightTeamId: Option[String] = None, striped: Boolean = false,
     responsiveFont: Boolean = false, linkToCompetition: Boolean = false,
     withCrests: Boolean = false)(implicit request: RequestHeader)
 <div class="table__container">
@@ -61,7 +63,11 @@
             }
         </tbody>
 
-        @heading.map{ h=> <caption class="table__caption table__caption--top"><a href="@competition.url">@h</a></caption>}
+        @heading.map{ h=>
+            <caption class="table__caption table__caption--top">
+                <a href="@headingLink.getOrElse(competition.url)">@h</a>
+            </caption>
+        }
         @if(linkToCompetition){<caption class="table__caption table__caption--bottom"><a href="@{competition.url + "/table"}" data-link-name="full table" class="full-table-link">View full <span class="competition-name">@competition.fullName</span> table</a></caption>}
     </table>
 </div>

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -37,7 +37,7 @@
                                                 striped = true,
                                                 responsiveFont = true,
                                                 heading = Option(table.competition.fullName),
-                                                linkToCompetition = true
+                                                linkToCompetition = !page.singleCompetition
                                             )
                                         }
                                     }

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -1,7 +1,6 @@
 @(competition: model.Competition, groupStage: _root_.football.model.Groups)(implicit request: RequestHeader)
-@import conf.Switches._
+@import implicits.Football._
 
-@if(WorldCupWallchartEmbedSwitch.isSwitchedOn){@* This is here to remind us to remove the group link (:15) when the world cup is finished *@}
 <ul class="football-groups u-unstyled u-cf">
     @groupStage.groupTables.zipWithRowInfo.map{ case ((round, leagueTableEntries), row) =>
         @defining(groupStage.matchesList(competition, round)) { matches =>
@@ -12,7 +11,7 @@
                             <div class="football-group__table">
                                 @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
                                     heading = round.name,
-                                    headingLink = round.name.map(competition.url+"-"+_.toLowerCase.replace(" ", "-")),
+                                    headingLink = groupTag(competition.id, round),
                                     striped = true,
                                     withCrests = true
                                 )

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -1,5 +1,7 @@
 @(competition: model.Competition, groupStage: _root_.football.model.Groups)(implicit request: RequestHeader)
+@import conf.Switches._
 
+@if(WorldCupWallchartEmbedSwitch.isSwitchedOn){@* This is here to remind us to remove the group link (:15) when the world cup is finished *@}
 <ul class="football-groups u-unstyled u-cf">
     @groupStage.groupTables.zipWithRowInfo.map{ case ((round, leagueTableEntries), row) =>
         @defining(groupStage.matchesList(competition, round)) { matches =>
@@ -10,6 +12,7 @@
                             <div class="football-group__table">
                                 @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
                                     heading = round.name,
+                                    headingLink = round.name.map(competition.url+"-"+_.toLowerCase.replace(" ", "-")),
                                     striped = true,
                                     withCrests = true
                                 )
@@ -20,7 +23,7 @@
                                     @competitionMatches.map { case (competition, matches) =>
                                         @football.views.html.matchList.matchesList(matches, competition, date,
                                             linkToCompetition = false,
-                                            heading = if(info.isFirst) Option("Fixtures and results") else None
+                                            heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
                                         )
                                     }
                                 }

--- a/sport/app/football/views/wallchart/knockoutList.scala.html
+++ b/sport/app/football/views/wallchart/knockoutList.scala.html
@@ -10,7 +10,7 @@
                             @matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
                                 @competitionMatches.map { case (competition, matches) =>
                                     @football.views.html.matchList.matchesList(matches, competition, date,
-                                        heading = if(info.isFirst) Option("Fixtures and results") else None
+                                        heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
                                     )
                                 }
                             }

--- a/sport/app/football/views/wallchart/r2FrontWorldCupEmbed.scala.html
+++ b/sport/app/football/views/wallchart/r2FrontWorldCupEmbed.scala.html
@@ -165,7 +165,11 @@
         @renderGroup(round: Round, leagueTableEntries: Seq[LeagueTableEntry], matchesList: football.model.MatchesList) = {
             <div class="group">
                 @defining(model.Group(round, leagueTableEntries)) { group =>
-                    @round.name.map{ name => <div class="group__name">@name</div>}
+                    @round.name.map{ name =>
+                        <div class="group__name">
+                            <a href="/football/world-cup-2014-@name.toLowerCase.replace(' ', '-')" target="_top">@name</a>
+                        </div>
+                    }
                     <div class="flags">
                         @group.entries.map{ entry =>
                             <div class="flag"><img src="@Configuration.staticSport.path/football/crests/120/@{entry.team.id}.png" width="26" height="15" alt="Flag for @entry.team.name" /></div>


### PR DESCRIPTION
## R2 Embed
- 🐵 Link to group pages.
- 🐵 Link to knockout page - still 404ing as the article isn't published.
## NGW
- 🐵 Link to group pages.
- 🐵 "Fixtures and results" heading don't link.

![world cup 2014 wallchart football the guardian](https://cloud.githubusercontent.com/assets/31692/3056948/8e30bbc0-e1d0-11e3-91ce-9c3b98d57643.png)

P.S. A little mission critical, need to try and launch before lunch tomorrow.
