### PR TITLE
Fix nav on smaller sizes

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -230,11 +230,7 @@ object Navigation {
   def localNav(navigation: Seq[NavItem], page: MetaData): Option[Seq[SectionLink]] = topLevelItem(navigation, page)
     .map(_.links).filter(_.nonEmpty)
 
-  def sectionOverride(page: MetaData, localNav: NavItem, currentSublink: Option[SectionLink]): String = page match {
-    case p: Tag => currentSublink.map(_.title).getOrElse(localNav.name.title)
-    case p: Section => currentSublink.map(_.title).getOrElse(localNav.name.title)
-    case _ => localNav.name.title
-  }
+  def sectionOverride(localNav: NavItem, currentSublink: Option[SectionLink]): String = currentSublink.map(_.title).getOrElse(localNav.name.title)
 }
 
 trait Zones extends Navigation {

--- a/common/app/views/fragments/localNav.scala.html
+++ b/common/app/views/fragments/localNav.scala.html
@@ -12,7 +12,7 @@
                         <i class="i i-local-nav-arrow tone-background"></i>
                     </span>
                 </button>
-                <h1 class="localnav__title tone-colour">@Html(Navigation.sectionOverride(metaData, localNav, currentSublink))</h1>
+                <h1 class="localnav__title tone-colour">@Html(Navigation.sectionOverride(localNav, currentSublink))</h1>
             </div>
         </div>
 


### PR DESCRIPTION
The nav title is wrong on smaller sizes:

For example, sizing down `/film` turns the title `"film"` into `"Culture"`.

http://www.theguardian.com/film

This is because for pages which are not a `Tag` or `Section`, we never try to output the `sublink` title, and instead opt for the higher up `title`.
Instead, we always try to output the current sublink.
