### PR TITLE
Fix Snap image overriding

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -212,7 +212,8 @@ object Content {
           snapSupporting = (json \ "meta" \ "supporting").asOpt[List[JsValue]].getOrElse(Nil)
             .flatMap(Content.fromPressedJson),
           (json \ "webPublicationDate").asOpt[DateTime].getOrElse(DateTime.now),
-          snapMeta = snapMeta
+          snapMeta = snapMeta,
+          snapElements = parseElements(json)
         )
       )
     }
@@ -295,28 +296,34 @@ private object ArticleSchemas {
   }
 }
 
-object SnapApiContent extends ApiContent(
- id                           = "",
-  sectionId                   = None,
-  sectionName                 = None,
-  webPublicationDateOption    = Some(DateTime.now),
-  webTitle                    = "",
-  webUrl                      = "http://www.theguardian.com/",
-  apiUrl                      = "",
-  fields                      = None,
-  tags                        = Nil,
-  factboxes                   = Nil,
-  mediaAssets                 = Nil,
-  elements                    = None,
-  references                  = Nil,
-  isExpired                   = None
-)
+object SnapApiContent {
+
+  def apply(): ApiContent = ApiContent(
+    id                           = "",
+    sectionId                   = None,
+    sectionName                 = None,
+    webPublicationDateOption    = Some(DateTime.now),
+    webTitle                    = "",
+    webUrl                      = "http://www.theguardian.com/",
+    apiUrl                      = "",
+    fields                      = None,
+    tags                        = Nil,
+    factboxes                   = Nil,
+    mediaAssets                 = Nil,
+    elements                    = Option(Nil),
+    references                  = Nil,
+    isExpired                   = None
+  )
+
+  def apply(snapElements: List[ApiElement]): ApiContent = apply().copy(elements = Some(snapElements))
+}
 
 class Snap(snapId: String,
            snapSupporting: List[Content],
            snapWebPublicationDate: DateTime,
-           snapMeta: Map[String, JsValue]
-            ) extends Content(new ApiContentWithMeta(SnapApiContent, supporting = snapSupporting, metaData = snapMeta)) {
+           snapMeta: Map[String, JsValue],
+           snapElements: List[ApiElement] = Nil
+            ) extends Content(new ApiContentWithMeta(SnapApiContent(snapElements), supporting = snapSupporting, metaData = snapMeta)) {
 
   val snapType: Option[String] = snapMeta.get("snapType").flatMap(_.asOpt[String])
   val snapCss: Option[String] = snapMeta.get("snapCss").flatMap(_.asOpt[String])


### PR DESCRIPTION
Adding an image to a `Snap` doesn't work.

This fixes that.
#### Technical:
- First ensure that the new `Element` which is the override always gets added to the head of `elements` for a `Snap`. This wasn't working before because a `Snap` always had a `None` for its `elements` which is an `Option[List[Element]]]`; we map over this to add the `Element` to the head. (This then ends up in the `pressed` `elements` key in `pressed.json`)
- Parse elements for a `Snap` from `pressed.json` and be able to mix it into the newly created `Snap` object.
