### PR TITLE
Config tool: sanitize capi queries

### DIFF
--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -72,12 +72,12 @@ define([
                     var targetList = ko.dataFor(element),
                         targetItem = ko.dataFor(event.target),
                         id = event.dataTransfer.getData('Text'),
-                        ourQueryParams   = parseQueryParams(id, {
+                        knownQueryParams = parseQueryParams(id, {
                             namespace: 'gu-',
                             excludeNamespace: false,
                             stripNamespace: true
                         }),
-                        theirQueryParams = parseQueryParams(id, {
+                        unknownQueryParams = parseQueryParams(id, {
                             namespace: 'gu-',
                             excludeNamespace: true
                         }),
@@ -129,15 +129,15 @@ define([
                     storage.removeItem(storageKey);
 
                     if (!sourceItem || sourceItem.id !== urlAbsPath(id)) {
-                        sourceItem = {meta: ourQueryParams};
+                        sourceItem = {meta: knownQueryParams};
                         sourceList = undefined;
-                        id = id.split('?')[0] + (_.isEmpty(theirQueryParams) ? '' : '?' + _.map(theirQueryParams, function(val, key) {
+                        id = id.split('?')[0] + (_.isEmpty(unknownQueryParams) ? '' : '?' + _.map(unknownQueryParams, function(val, key) {
                             return key + (val ? '=' + val : '');
                         }).join('&'));
                     }
 
                     // Parse url from links such as http://www.google.co.uk/?param-name=http://www.theguardian.com/foobar
-                    _.each(theirQueryParams, function(val, key) {
+                    _.each(unknownQueryParams, function(val, key) {
                         // Grab the last query param val that looks like a Guardian url
                         if (key === 'url' && (val + '').match(/^http:\/\/www.theguardian.com/)) {
                             id = val;

--- a/facia-tool/public/javascripts/bindings/droppable.js
+++ b/facia-tool/public/javascripts/bindings/droppable.js
@@ -72,8 +72,15 @@ define([
                     var targetList = ko.dataFor(element),
                         targetItem = ko.dataFor(event.target),
                         id = event.dataTransfer.getData('Text'),
-                        ourQueryParams   = parseQueryParams(id, 'gu-', false, true),
-                        theirQueryParams = parseQueryParams(id, 'gu-', true),
+                        ourQueryParams   = parseQueryParams(id, {
+                            namespace: 'gu-',
+                            excludeNamespace: false,
+                            stripNamespace: true
+                        }),
+                        theirQueryParams = parseQueryParams(id, {
+                            namespace: 'gu-',
+                            excludeNamespace: true
+                        }),
                         sourceItem,
                         position,
                         newItems,

--- a/facia-tool/public/javascripts/models/config/collection.js
+++ b/facia-tool/public/javascripts/models/config/collection.js
@@ -3,6 +3,7 @@ define([
     'knockout',
     'modules/vars',
     'modules/content-api',
+    'utils/strip-empty-query-params',
     'utils/as-observable-props',
     'utils/populate-observables',
     'utils/collection-guid'
@@ -10,6 +11,7 @@ define([
     ko,
     vars,
     contentApi,
+    stripEmptyQueryParams,
     asObservableProps,
     populateObservables,
     collectionGuid
@@ -70,6 +72,8 @@ define([
             vars.model.collections.unshift(this);
         }
         this.state.isOpen(false);
+
+        this.meta.apiQuery(stripEmptyQueryParams(this.meta.apiQuery()));
         this.state.apiQueryStatus(undefined);
         vars.model.save(this);
     };

--- a/facia-tool/public/javascripts/utils/parse-query-params.js
+++ b/facia-tool/public/javascripts/utils/parse-query-params.js
@@ -3,6 +3,14 @@ define(['utils/url-query'], function(urlQuery) {
     return function(url, opts) {
         opts = opts || {};
 
+        /**
+         * Returns query params as an object.
+         * @param {function} predicate        Function to determine which vals get included
+         * @param {string}   namespace        Optional prefix for param keys
+         * @param {boolean}  excludeNamespace Optional whether to exclude or include namespaced params
+         * @param {boolean}  stripNamespace   Optional whether to strip namsepace from param names
+         */
+
         return _.chain(urlQuery(url).split('&'))
             .filter(function(kv) {
                 return kv; })

--- a/facia-tool/public/javascripts/utils/parse-query-params.js
+++ b/facia-tool/public/javascripts/utils/parse-query-params.js
@@ -6,9 +6,9 @@ define(['utils/url-query'], function(urlQuery) {
         /**
          * Returns query params as an object.
          * @param {function} predicate        optional fn to determine which vals get included
-         * @param {string}   namespace        Optional prefix for param keys
-         * @param {boolean}  excludeNamespace Optional whether to exclude or include prefixed keys
-         * @param {boolean}  stripNamespace   Optional whether to strip prefix from returned object's keys
+         * @param {string}   namespace        optional prefix for param keys
+         * @param {boolean}  excludeNamespace optional whether to exclude or include prefixed keys
+         * @param {boolean}  stripNamespace   optional whether to strip prefix from returned object's keys
          */
 
         return _.chain(urlQuery(url).split('&'))

--- a/facia-tool/public/javascripts/utils/parse-query-params.js
+++ b/facia-tool/public/javascripts/utils/parse-query-params.js
@@ -1,15 +1,28 @@
 /* global _: true */
 define(['utils/url-query'], function(urlQuery) {
-    return function(url, namespace, excludeNamespace, stripNamespace) {
-      return _.chain(urlQuery(url).split('&'))
-          .filter(function(kv) { return kv; })
-          .map(function(kv) { return kv.split('='); })
-          .filter(function(kv) { return !namespace || kv[0].indexOf(namespace) === (excludeNamespace ? -1 : 0); })
-          .map(function(kv) { return [
-              namespace && stripNamespace && !excludeNamespace ? kv[0].slice(namespace.length) : kv[0],
-              kv[1] === undefined ? undefined : decodeURIComponent(kv[1].replace(/\+/g, ' '))
-          ]; })
-          .object()
-          .value();
+    return function(url, opts) {
+        opts = opts || {};
+
+        return _.chain(urlQuery(url).split('&'))
+            .filter(function(kv) {
+                return kv; })
+
+            .map(function(kv) {
+                return kv.split('='); })
+
+            .filter(function(kv) {
+                return _.isFunction(opts.predicate) ? opts.predicate(kv[1]) : true; })
+
+            .filter(function(kv) {
+                return !opts.namespace || kv[0].indexOf(opts.namespace) === (opts.excludeNamespace ? -1 : 0); })
+
+            .map(function(kv) {
+                return [
+                    opts.namespace && opts.stripNamespace && !opts.excludeNamespace ? kv[0].slice(opts.namespace.length) : kv[0],
+                    kv[1] === undefined ? undefined : decodeURIComponent(kv[1].replace(/\+/g, ' '))
+                ]; })
+
+            .object()
+            .value();
     };
 });

--- a/facia-tool/public/javascripts/utils/parse-query-params.js
+++ b/facia-tool/public/javascripts/utils/parse-query-params.js
@@ -5,10 +5,11 @@ define(['utils/url-query'], function(urlQuery) {
 
         /**
          * Returns query params as an object.
-         * @param {function} predicate        optional fn to determine which vals get included
-         * @param {string}   namespace        optional prefix for param keys
-         * @param {boolean}  excludeNamespace optional whether to exclude or include prefixed keys
-         * @param {boolean}  stripNamespace   optional whether to strip prefix from returned object's keys
+         * @param {function} opts                  optional options
+         * @param {function} opts.predicate        fn to determine which vals get included
+         * @param {string}   opts.namespace        prefix for param keys
+         * @param {boolean}  opts.excludeNamespace whether to exclude or include prefixed keys
+         * @param {boolean}  opts.stripNamespace   whether to strip prefix from returned object's keys
          */
 
         return _.chain(urlQuery(url).split('&'))

--- a/facia-tool/public/javascripts/utils/parse-query-params.js
+++ b/facia-tool/public/javascripts/utils/parse-query-params.js
@@ -1,16 +1,20 @@
 /* global _: true */
 define(['utils/url-query'], function(urlQuery) {
+    /**
+     * Returns query params as an object.
+     * @param {function} opts                  optional options
+     * @param {function} opts.predicate        fn to determine which vals get included
+     * @param {string}   opts.namespace        prefix for param keys
+     * @param {boolean}  opts.excludeNamespace whether to exclude or include prefixed keys
+     * @param {boolean}  opts.stripNamespace   whether to strip prefix from returned object's keys
+     */
+
     return function(url, opts) {
         opts = opts || {};
 
-        /**
-         * Returns query params as an object.
-         * @param {function} opts                  optional options
-         * @param {function} opts.predicate        fn to determine which vals get included
-         * @param {string}   opts.namespace        prefix for param keys
-         * @param {boolean}  opts.excludeNamespace whether to exclude or include prefixed keys
-         * @param {boolean}  opts.stripNamespace   whether to strip prefix from returned object's keys
-         */
+        var nsIndex = opts.excludeNamespace ? -1 : 0,
+            nsStrip = opts.namespace && opts.stripNamespace && !opts.excludeNamespace,
+            nsLength = opts.namespace ? ('' + opts.namespace).length : 0;
 
         return _.chain(urlQuery(url).split('&'))
             .filter(function(kv) {
@@ -23,11 +27,11 @@ define(['utils/url-query'], function(urlQuery) {
                 return _.isFunction(opts.predicate) ? opts.predicate(kv[1]) : true; })
 
             .filter(function(kv) {
-                return !opts.namespace || kv[0].indexOf(opts.namespace) === (opts.excludeNamespace ? -1 : 0); })
+                return !opts.namespace || kv[0].indexOf(opts.namespace) === nsIndex; })
 
             .map(function(kv) {
                 return [
-                    opts.namespace && opts.stripNamespace && !opts.excludeNamespace ? kv[0].slice(opts.namespace.length) : kv[0],
+                    nsStrip ? kv[0].slice(nsLength) : kv[0],
                     kv[1] === undefined ? undefined : decodeURIComponent(kv[1].replace(/\+/g, ' '))
                 ]; })
 

--- a/facia-tool/public/javascripts/utils/parse-query-params.js
+++ b/facia-tool/public/javascripts/utils/parse-query-params.js
@@ -5,10 +5,10 @@ define(['utils/url-query'], function(urlQuery) {
 
         /**
          * Returns query params as an object.
-         * @param {function} predicate        Function to determine which vals get included
+         * @param {function} predicate        optional fn to determine which vals get included
          * @param {string}   namespace        Optional prefix for param keys
-         * @param {boolean}  excludeNamespace Optional whether to exclude or include namespaced params
-         * @param {boolean}  stripNamespace   Optional whether to strip namsepace from param names
+         * @param {boolean}  excludeNamespace Optional whether to exclude or include prefixed keys
+         * @param {boolean}  stripNamespace   Optional whether to strip prefix from returned object's keys
          */
 
         return _.chain(urlQuery(url).split('&'))

--- a/facia-tool/public/javascripts/utils/strip-empty-query-params.js
+++ b/facia-tool/public/javascripts/utils/strip-empty-query-params.js
@@ -1,0 +1,18 @@
+/* global _: true */
+define(['utils/parse-query-params'], function(parseQueryParams) {
+    return function (url) {
+        var bits = (url + '').split('?');
+
+        if (bits.length <= 1) {
+            return url;
+
+        } else {
+            return _.initial(bits).concat(
+                _.map(
+                    parseQueryParams(url, {predicate: function(str) { return str;}}),
+                    function(val, key) { return key + '=' + val; }
+                ).join('&')
+            ).join('?');
+        }
+    };
+});


### PR DESCRIPTION
Because empty query params in capi queries break the pressing job.
