### PR TITLE
WaitHelper added

### DIFF
--- a/integration-tests/webdriver/src/test/java/com/gu/test/Article/ArticleOnwardJourneyTest.java
+++ b/integration-tests/webdriver/src/test/java/com/gu/test/Article/ArticleOnwardJourneyTest.java
@@ -24,6 +24,7 @@ public class ArticleOnwardJourneyTest {
         driver = createWebDriver();
         pageHelper = new PageHelper(driver);
         testArticle = pageHelper.goToArticle("/film/filmblog/2014/may/20/lost-river-reviews-cannes-scorn-ryan-gosling");
+        WaitHelper.waitForArticleLoad(driver);
     }
 
 


### PR DESCRIPTION
Test flaky probably due to not waiting for article to load fully at
start of test.

![neil-degrasse-tyson-science-boop](https://cloud.githubusercontent.com/assets/6571215/3089611/12bcbc3c-e581-11e3-887f-c2d0de5c533c.gif)
