### PR TITLE
Make GZIP permanent

### DIFF
--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -6,7 +6,6 @@ import com.gu.management.play.RequestMetrics
 import contentapi.ElasticSearchContentApiClient
 import play.api.mvc.EssentialFilter
 import play.filters.gzip.GzipFilter
-import conf.Switches.GzipSwitch
 
 object Configuration extends GuardianConfiguration("frontend", webappConfDirectory = "env")
 
@@ -16,7 +15,7 @@ object Static extends Assets(Configuration.assets.path)
 
 object RequestMeasurementMetrics extends RequestMetrics.Standard
 
-object Gzipper extends GzipFilter(shouldGzip = (req, resp) => GzipSwitch.isSwitchedOn)
+object Gzipper extends GzipFilter()
 
 object Filters {
   lazy val common: List[EssentialFilter] = Gzipper :: RequestMeasurementMetrics.asFilters

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -68,11 +68,6 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val GzipSwitch = Switch("Performance Switches", "gzip",
-    "If switched on then http responses will be gzipped",
-    safeState = Off, sellByDate = new DateMidnight(2014, 5, 31)
-  )
-
   val DoubleCacheTimesSwitch = Switch("Performance Switches", "double-cache-times",
     "Doubles the cache time of every endpoint. Turn on to help handle exceptional load.",
     safeState = On, sellByDate = never
@@ -471,7 +466,6 @@ object Switches extends Collections {
     MemcachedSwitch,
     IncludeBuildNumberInMemcachedKey,
     NewSeoSwitch,
-    GzipSwitch,
     GeoMostPopular,
     TagLinkingSwitch,
     FaciaFirstContainerLayoutOverrideSwitch,


### PR DESCRIPTION
In April (before gzip), Data Transfer was 46% of the AWS bill (excluding reserved instances).

In May (after gzip) it has gone down to 37% of the bill which represents a monthly saving of about $900.

Every bit helps

cc @tackley @cantlin 

:dollar: 

![jansen](https://cloud.githubusercontent.com/assets/76709/3090313/ab2f1f60-e58a-11e3-8fe2-790625c9bae9.gif)
