### PR TITLE
Batch the putting of cloudwatch metrics

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -534,9 +534,8 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
     val systemMetrics  = this.systemMetrics
     val applicationMetrics  = this.applicationMetrics
     CloudWatch.put("ApplicationSystemMetrics", systemMetrics)
-    if (applicationMetrics.nonEmpty) {
-      CloudWatch.putWithDimensions(applicationMetricsNamespace, applicationMetrics, Seq(applicationDimension))
-    }
+    for (metrics <- applicationMetrics.grouped(20))
+      CloudWatch.putWithDimensions(applicationMetricsNamespace, metrics, Seq(applicationDimension))
   }
 
   override def onStart(app: PlayApp) {


### PR DESCRIPTION
The metrics for `facia-tool` now have more than 20, which cloudwatch can't accept because of it's 20 limit. This batches the putting of the cloudwatch metrics. (For all apps)
