### PR TITLE
Facia json lite

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -43,7 +43,7 @@ trait QueryDefaults extends implicits.Collections with ExecutionContexts {
     val tag = "tag=type/gallery|type/article|type/video|type/sudoku"
     val editorsPicks = "show-editors-picks=true"
     val showInlineFields = s"show-fields=$trailFields"
-    val showFields = "trailText,headline,shortUrl,liveBloggingNow,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent"
+    val showFields = "trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent"
     val showFieldsWithBody = showFields + ",body"
 
     val all = Seq(tag, editorsPicks, showInlineFields, showFields)

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -80,8 +80,8 @@ object SeoData extends ExecutionContexts with Logging {
       val webTitle: String = webTitleFromTail(name :: tail)
       SeoData(path, section, webTitle, None, descriptionFromWebTitle(webTitle))
     case oneWord :: tail =>
-      val capitalOneWorld: String = webTitleFromTail(oneWord :: tail)
-      SeoData(path, oneWord, capitalOneWorld, None, descriptionFromWebTitle(capitalOneWorld))
+      val webTitleOnePart: String = webTitleFromTail(oneWord :: tail)
+      SeoData(path, oneWord, webTitleOnePart, None, descriptionFromWebTitle(webTitleOnePart))
   }
 
   def webTitleFromTail(tail: List[String]): String = tail.flatMap(_.split('-')).flatMap(_.split('/')).map(_.capitalize).mkString(" ")

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -80,7 +80,7 @@ object SeoData extends ExecutionContexts with Logging {
       val webTitle: String = webTitleFromTail(name :: tail)
       SeoData(path, section, webTitle, None, descriptionFromWebTitle(webTitle))
     case oneWord :: tail =>
-      val capitalOneWorld: String = oneWord.capitalize
+      val capitalOneWorld: String = webTitleFromTail(oneWord :: tail)
       SeoData(path, oneWord, capitalOneWorld, None, descriptionFromWebTitle(capitalOneWorld))
   }
 

--- a/common/test/model/SeoDataTest.scala
+++ b/common/test/model/SeoDataTest.scala
@@ -43,13 +43,13 @@ class SeoDataTest extends FlatSpec with Matchers {
   }
 
   it should "handle one word" in {
-    val seoData: SeoData = SeoData.fromPath("somethinghere")
+    val seoData: SeoData = SeoData.fromPath("something-here")
 
-    seoData.id should be("somethinghere")
-    seoData.section should be ("somethinghere")
-    seoData.webTitle should be ("Somethinghere")
-    seoData.title.map(_  should include ("Somethinghere"))
-    seoData.description.get should include ("Somethinghere")
+    seoData.id should be("something-here")
+    seoData.section should be ("something-here")
+    seoData.webTitle should be ("Something Here")
+    seoData.title.map(_  should include ("Something Here"))
+    seoData.description.get should include ("Something Here")
   }
 
   it should "turn dashes into spaces" in {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -57,10 +57,7 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
 
   def renderFrontJsonLite(path: String) = MemcachedAction{ implicit request =>
     FrontJson.getAsJsValue(path).map{ json =>
-      Cached(60)(Ok(Json.obj(
-        "webTitle" -> (json \ "seoData" \ "webTitle"),
-        "collections" -> JsonLite(json)
-      )))
+      Cached(60)(Ok(JsonLite(json)))
     }
   }
 
@@ -128,7 +125,14 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
   }
 
   private object JsonLite{
-    def apply(json: JsValue): Seq[JsValue] = {
+    def apply(json: JsValue): JsValue = {
+      Json.obj(
+        "webTitle" -> (json \ "seoData" \ "webTitle"),
+        "collections" -> getCollections(json)
+      )
+    }
+
+    def getCollections(json: JsValue): Seq[JsValue] = {
       (json \ "collections").asOpt[Seq[Map[String, JsObject]]].getOrElse(Nil).flatMap{ c => c.values.map(getCollection) }
     }
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -55,41 +55,11 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
       renderFrontPress(path)
   }
 
-  def getCollections(json: JsValue): Seq[JsValue] = {
-    (json \ "collections").asOpt[Seq[Map[String, JsObject]]].getOrElse(Nil).flatMap{ c => c.values.map(getCollection) }
-  }
-
-  def getCollection(json: JsValue): JsValue = {
-    Json.obj(
-        "displayName" -> (json \ "displayName"),
-        "href" -> (json \ "href"),
-        "content" -> getContent(json)
-    )
-  }
-
-  def getContent(json: JsValue): Seq[JsValue] = {
-    val curated = (json \ "curated").asOpt[Seq[JsObject]].getOrElse(Nil)
-    val editorsPicks = (json \ "editorsPicks").asOpt[Seq[JsObject]].getOrElse(Nil)
-    val results = (json \ "results").asOpt[Seq[JsObject]].getOrElse(Nil)
-
-    (curated ++ editorsPicks ++ results)
-    .filterNot{ j =>
-      (j \ "id").asOpt[String].exists(_.startsWith("snap/"))
-     }
-    .take(3).map{ j =>
-      Json.obj(
-        "headline" -> (j \ "safeFields" \ "headline"),
-        "thumbnail" -> (j \ "safeFields" \ "thumbnail"),
-        "id" -> (j \ "id")
-      )
-    }
-  }
-
   def renderFrontJsonLite(path: String) = MemcachedAction{ implicit request =>
     FrontJson.getAsJsValue(path).map{ json =>
       Cached(60)(Ok(Json.obj(
         "webTitle" -> (json \ "seoData" \ "webTitle"),
-        "collections" -> getCollections(json)
+        "collections" -> JsonLite(json)
       )))
     }
   }
@@ -155,6 +125,38 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
       "html" -> views.html.fragments.frontBody(faciaPage),
       "config" -> Json.parse(views.html.fragments.javaScriptConfig(faciaPage).body)
     )
+  }
+
+  private object JsonLite{
+    def apply(json: JsValue): Seq[JsValue] = {
+      (json \ "collections").asOpt[Seq[Map[String, JsObject]]].getOrElse(Nil).flatMap{ c => c.values.map(getCollection) }
+    }
+
+    def getCollection(json: JsValue): JsValue = {
+      Json.obj(
+          "displayName" -> (json \ "displayName"),
+          "href" -> (json \ "href"),
+          "content" -> getContent(json)
+      )
+    }
+
+    def getContent(json: JsValue): Seq[JsValue] = {
+      val curated = (json \ "curated").asOpt[Seq[JsObject]].getOrElse(Nil)
+      val editorsPicks = (json \ "editorsPicks").asOpt[Seq[JsObject]].getOrElse(Nil)
+      val results = (json \ "results").asOpt[Seq[JsObject]].getOrElse(Nil)
+
+      (curated ++ editorsPicks ++ results)
+      .filterNot{ j =>
+        (j \ "id").asOpt[String].exists(_.startsWith("snap/"))
+       }
+      .take(3).map{ j =>
+        Json.obj(
+          "headline" -> (j \ "safeFields" \ "headline"),
+          "thumbnail" -> (j \ "safeFields" \ "thumbnail"),
+          "id" -> (j \ "id")
+        )
+      }
+    }
   }
 
   private def getPressedCollection(collectionId: String): Future[Option[Collection]] =

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -79,6 +79,7 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
     .take(3).map{ j =>
       Json.obj(
         "headline" -> (j \ "safeFields" \ "headline"),
+        "thumbnail" -> (j \ "safeFields" \ "thumbnail"),
         "id" -> (j \ "id")
       )
     }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -76,7 +76,7 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
     .filterNot{ j =>
       (j \ "id").asOpt[String].exists(_.startsWith("snap/"))
      }
-    .take(8).map{ j =>
+    .take(3).map{ j =>
       Json.obj(
         "headline" -> (j \ "safeFields" \ "headline"),
         "id" -> (j \ "id")

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -57,7 +57,7 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
 
   def renderFrontJsonLite(path: String) = MemcachedAction{ implicit request =>
     FrontJson.getAsJsValue(path).map{ json =>
-      Cached(60)(Ok(JsonLite(json)))
+      Cached(60)(Ok(FrontJsonLite.get(json)))
     }
   }
 
@@ -122,45 +122,6 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
       "html" -> views.html.fragments.frontBody(faciaPage),
       "config" -> Json.parse(views.html.fragments.javaScriptConfig(faciaPage).body)
     )
-  }
-
-  private object JsonLite{
-    def apply(json: JsValue): JsValue = {
-      Json.obj(
-        "webTitle" -> (json \ "seoData" \ "webTitle"),
-        "collections" -> getCollections(json)
-      )
-    }
-
-    def getCollections(json: JsValue): Seq[JsValue] = {
-      (json \ "collections").asOpt[Seq[Map[String, JsObject]]].getOrElse(Nil).flatMap{ c => c.values.map(getCollection) }
-    }
-
-    def getCollection(json: JsValue): JsValue = {
-      Json.obj(
-          "displayName" -> (json \ "displayName"),
-          "href" -> (json \ "href"),
-          "content" -> getContent(json)
-      )
-    }
-
-    def getContent(json: JsValue): Seq[JsValue] = {
-      val curated = (json \ "curated").asOpt[Seq[JsObject]].getOrElse(Nil)
-      val editorsPicks = (json \ "editorsPicks").asOpt[Seq[JsObject]].getOrElse(Nil)
-      val results = (json \ "results").asOpt[Seq[JsObject]].getOrElse(Nil)
-
-      (curated ++ editorsPicks ++ results)
-      .filterNot{ j =>
-        (j \ "id").asOpt[String].exists(_.startsWith("snap/"))
-       }
-      .take(3).map{ j =>
-        Json.obj(
-          "headline" -> (j \ "safeFields" \ "headline"),
-          "thumbnail" -> (j \ "safeFields" \ "thumbnail"),
-          "id" -> (j \ "id")
-        )
-      }
-    }
   }
 
   private def getPressedCollection(collectionId: String): Future[Option[Collection]] =

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -3,7 +3,7 @@ package controllers.front
 import model._
 import scala.concurrent.Future
 import play.api.libs.ws.{Response, WS}
-import play.api.libs.json.{JsNull, JsValue, Json}
+import play.api.libs.json.{JsObject, JsNull, JsValue, Json}
 import common.ExecutionContexts
 import model.FaciaPage
 import services.SecureS3Request
@@ -19,6 +19,17 @@ trait FrontJson extends ExecutionContexts {
   def get(path: String): Future[Option[FaciaPage]] = {
     val response = SecureS3Request.urlGet(getAddressForPath(path)).get()
     parseResponse(response)
+  }
+
+  def getAsJsValue(path: String): Future[JsValue] = {
+    val response = SecureS3Request.urlGet(getAddressForPath(path)).get()
+
+    response.map { r =>
+      r.status match {
+        case 200 => Json.parse(r.body)
+        case _   => JsObject(Nil)
+      }
+    }
   }
 
   private def parseCollection(json: JsValue): Collection = {

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -23,5 +23,6 @@ GET        /container/*id.json                                         controlle
 
 # Editionalised pages
 GET        /*path/rss                                                  controllers.FaciaController.renderFrontRss(path)
+GET        /*path/lite.json                                            controllers.FaciaController.renderFrontJsonLite(path)
 GET        /*path.json                                                 controllers.FaciaController.renderFrontJson(path)
 GET        /*path                                                      controllers.FaciaController.renderFront(path)


### PR DESCRIPTION
Adds `/*path/lite.json` for a very minimal view of a front, consisting of headline, url & thumb for three items from each of its containers. Intended as an ajax endpoint for the "Across the Guardian" module. 

```
{
  "webTitle": "Across-the-guardian"
  "collections": [
    {
      "displayName": "Culture",
      "href": "tone/features",
      "content": [
        {
          "headline": "Independent Scotland '£5bn better off by 2030' - live campaign coverage",
          "id": "uk-news/scotland-blog/2014/may/28/danny-alexander-alex-salmond-clash-economy-scotland-live",
          "thumbnail": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/5/27/1401223484541/dbdad47e-469d-4ff5-a292-e84f2f8ad67b-140x84.jpeg"
        },
        {
          "headline": "Quiz: How many of these metal album covers do you recognise?",
          "id": "music/musicblog/quiz/2014/may/28/metal-best-albums-how-many-do-you-recognise-heavy-motley-crue-all-time-covers-sleeve",
          "thumbnail": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/5/28/1401276866196/mechanical.jpeg"
        },
        {
          "headline": "Shardenfreude: London's copycat craze is crystal clear",
          "id": "artanddesign/architecture-design-blog/2014/may/28/shardenfreude-londons-copycat-craze-is-crystal-clear",
          "thumbnail": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/5/28/1401271582236/178f4732-8140-45a9-b1b4-4658de38e6ab-140x84.jpeg"
        }
      ]
    }
    {
      "displayName": "Business",
      "href": "business",
      "content": [
        {
          "headline": "Business live: German unemployment rises, as Merkel confirmed as world's most powerful woman again",
          "id": "business/2014/may/28/markets-rally-china-property-german-unemployment-live",
          "thumbnail": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/5/28/1401265039553/54a38860-692d-4786-83da-9d94d16ac8b1-140x84.jpeg"
        },

        ... etc ...
```
