### PR TITLE
Fix navigation

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -17,6 +17,13 @@ case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
   def currentFor(page: MetaData): Boolean = name.currentFor(page) ||
     links.exists(_.currentFor(page)) || exactFor(page)
 
+  def currentForIncludingAllTags(page: MetaData): Boolean = name.currentForIncludingAllTags(page) ||
+    links.exists(_.currentForIncludingAllTags(page))
+
+  def searchForCurrentSublink(page: MetaData): Option[SectionLink] =
+    links.find(_.currentFor(page))
+    .orElse(links.find(_.currentForIncludingAllTags(page)))
+
   def exactFor(page: MetaData): Boolean = page.section == name.href.dropWhile(_ == '/') || page.url == name.href
 }
 

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -12,7 +12,7 @@ case class SectionLink(zone: String, title: String, breadcumbTitle: String, href
 
 case class Zone(name: SectionLink, sections: Seq[SectionLink])
 
-case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil, current: Boolean = false) {
+case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
   def currentFor(page: MetaData): Boolean = name.currentFor(page) ||
     links.exists(_.currentFor(page)) || exactFor(page)
 

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -194,7 +194,8 @@ object Breadcrumbs {
   object Navigation {
 
     def topLevelItem(navigation: Seq[NavItem], page: MetaData): Option[NavItem] = navigation.find(_.exactFor(page))
-    .orElse(navigation.find(_.currentFor(page)))
+    .orElse(navigation.find(_.currentFor(page))) //This includes a search on the HEAD of Tags for (page: MetaData)
+    .orElse(navigation.find(_.currentForIncludingAllTags(page))) //This is the search for ALL tags
 
   def subNav(navigation: Seq[NavItem], page: MetaData): Option[SectionLink] = topLevelItem(navigation, page).flatMap(_.links.find(_.currentFor(page)))
 

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -199,8 +199,8 @@ object Breadcrumbs {
 
   def subNav(navigation: Seq[NavItem], page: MetaData): Option[SectionLink] = topLevelItem(navigation, page).flatMap(_.links.find(_.currentFor(page)))
 
-  def localNav(navigation: Seq[NavItem], page: MetaData): Option[Seq[SectionLink]] = topLevelItem(navigation, page)
-    .map(_.links).filter(_.nonEmpty)
+  def localNav(navigation: Seq[NavItem], page: MetaData): Option[NavItem] = topLevelItem(navigation, page)
+    .filter(_.links.nonEmpty)
 
   def sectionOverride(localNav: NavItem, currentSublink: Option[SectionLink]): String = currentSublink.map(_.title).getOrElse(localNav.name.title)
 }

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -6,8 +6,9 @@ case class SectionLink(zone: String, title: String, breadcumbTitle: String, href
   def currentFor(page: MetaData): Boolean = page.url == href ||
     s"/${page.section}" == href ||
     page.url == href ||
-    page.tags.exists(t => s"/${t.id}" == href) ||
     (Edition.all.exists(_.id.toLowerCase == page.id.toLowerCase) && href == "/")
+
+  def currentForIncludingAllTags(page: MetaData): Boolean = page.tags.exists(t => s"/${t.id}" == href)
 }
 
 case class Zone(name: SectionLink, sections: Seq[SectionLink])

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -126,12 +126,12 @@ to apply any necessary changes to non-shared code there too.
             </div>
             @* Secondary nav *@
             @Navigation.localNav(navigation, page).map { localNav =>
-                @defining(localNav.find(_.currentFor(page))){ currentSublink =>
+                @defining(localNav.searchForCurrentSublink(page)){ currentSublink =>
                     <div class="localnav-container u-cf" data-component="navigation"
                          @currentSublink.map{ s => itemprop="child" itemscope itemtype="http://data-vocabulary.org/Breadcrumb" }>
                         <div class="gs-container">
                             <ul class="nav nav--local" data-link-name="Local Navigation">
-                                @localNav.map { nav =>
+                                @localNav.links.map { nav =>
                                     <li class="nav__item @currentSublink.filter(_.href == nav.href).map{ current => is-active }">
                                         <a href="@LinkTo{@nav.href}" class="nav__link" data-link-name="@nav.href">
                                                 @Html(nav.title)


### PR DESCRIPTION
The navigation in articles is broken and no one seems to have noticed.
I am unsure if this has recently happened because of code churn, or has always been broken since around Feb.

For example, on [this page](http://www.theguardian.com/film/2014/may/21/batman-vs-superman-costume-batsuit-kevin-smith), the article is clearly a `film` article. But it shows up in the main Nav as `World` -> `Us`.

This happens for a lot of different articles. And sometimes, doesn't happen for other articles.

This PR fixes that.
#### Why (Technical)

The searching through `NavItem`s in `Edition` is wrong.

What was happening was we were iterating through the `Edition` `NavItems` and checking if a `MetaData` (`Article`) object belonged to any of the items. One of the comparisons (In the middle of all the ORs) uses the code `page.tags.exists(t => s"/${t.id}" == href)`.

This meant that for EACH `Edition` `NavItem`, we checked if the `SectionLink.href` matched ANY tag.

What happens if an article has the tag `film/film` but also the tag `world/usa`?
Since we are iterating over the `NavItem`s from an `Edition`, this means that the order there wins. In the  [example](http://www.theguardian.com/film/2014/may/21/batman-vs-superman-costume-batsuit-kevin-smith) in this PR, `world/usa` comes first in the list of `NavItems` for `Uk`. So unfortunately in the navigation it will show up as `World` -> `Us`.

I have removed the searching of all tags, and moved this search into an explicit method `currentForIncludingAllTags(page)`.

It is slightly weird. We now have `currentFor` AND `currentForIncludingAllTags`. Then we also have `searchForCurrentSublink` that uses both together.
We do this because when searching through a `List` of `NavItem`, we never want to do a search on tags unless the search fails.
If we have only one `NavItem` and a `MetaData` (`Article`), then we want to just do one after the other for this `NavItem`.

This also fixes the `breadcrumbs`.
