### PR TITLE
Enable Badge on Sponsored Containers

### DIFF
--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -2,9 +2,8 @@ package dfp
 
 import common._
 import conf.Configuration.commercial.dfpDataKey
-import model.Content
-import model.Section
-import model.Tag
+import java.net.URLDecoder
+import model.{Config, Content, Section, Tag}
 import play.api.Play.current
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Json._
@@ -33,9 +32,19 @@ object DfpAgent extends ExecutionContexts with Logging {
     }
   }
 
+  private def isSponsoredContainer(config: Config, p: String => Boolean): Boolean = {
+    config.contentApiQuery.fold(false) { encodedQuery =>
+      val query = URLDecoder.decode(encodedQuery, "utf-8")
+      val tokens = query.split( """\?|&|=|\(|\)|\||\,""").map(_.replaceFirst(".*/", ""))
+      tokens exists p
+    }
+  }
+
   def isSponsored(content: Content): Boolean = isSponsored(content.keywords)
 
   def isSponsored(section: Section): Boolean = isSponsored(section.id)
+
+  def isSponsored(config: Config): Boolean = isSponsoredContainer(config, isSponsored)
 
   def isSponsored(keywords: Seq[Tag]): Boolean = keywords.exists(keyword => isSponsored(keyword.id))
 
@@ -44,6 +53,8 @@ object DfpAgent extends ExecutionContexts with Logging {
   def isAdvertisementFeature(content: Content): Boolean = isAdvertisementFeature(content.keywords)
 
   def isAdvertisementFeature(section: Section): Boolean = isAdvertisementFeature(section.id)
+
+  def isAdvertisementFeature(config: Config): Boolean = isSponsoredContainer(config, isAdvertisementFeature)
 
   def isAdvertisementFeature(keywords: Seq[Tag]): Boolean =
     keywords.exists(keyword => isAdvertisementFeature(keyword.id))
@@ -92,9 +103,16 @@ object DfpAgent extends ExecutionContexts with Logging {
     dfpDataAgent close()
   }
 
-  private val testDfpData = DfpData(Seq(
-    LineItem(0, Seq(TargetSet("AND", Seq(Target("slot","IS",Seq("spbadge")),Target("k","IS",Seq("media"))))))
-  ))
+  private val testDfpData = {
+    val sponsoredTargetSet =
+      TargetSet("AND", Seq(Target("slot", "IS", Seq("spbadge")), Target("k", "IS", Seq("media"))))
+    val adFeatureTargetSet =
+      TargetSet("AND", Seq(Target("slot", "IS", Seq("adbadge")), Target("k", "IS", Seq("film"))))
+    DfpData(Seq(
+      LineItem(0, Seq(sponsoredTargetSet)),
+      LineItem(1, Seq(adFeatureTargetSet))
+    ))
+  }
 }
 
 

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -7,6 +7,7 @@ import com.gu.openplatform.contentapi.model.ItemResponse
 import conf.ContentApi
 import services.ConfigAgent
 import common.FaciaToolMetrics.{ContentApiSeoRequestFailure, ContentApiSeoRequestSuccess}
+import dfp.DfpAgent
 
 case class Config(
                    id: String,
@@ -17,7 +18,10 @@ case class Config(
                    collectionType: Option[String],
                    showTags: Boolean = false,
                    showSections: Boolean = false
-                   )
+                   ) {
+  def isSponsored = DfpAgent.isSponsored(this)
+  def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(this)
+}
 
 object Config {
   def apply(id: String): Config = Config(id, None, None, None, Nil, None)

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -1,0 +1,146 @@
+package dfp
+
+import model.Config
+import org.scalatest.Inspectors._
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.test.FakeApplication
+import play.api.test.Helpers._
+
+class DfpAgentTest extends FlatSpec with Matchers {
+
+  def apiQuery(apiQuery: String) = {
+    Config("id", Some(apiQuery), None, None)
+  }
+
+  "isSponsored" should "be true for a sponsored container" in running(FakeApplication()) {
+
+    val apiQueries = Seq(
+      "search?tag=books%2Fmedia&section=money",
+      "search?tag=environment%2Fblog%7Cmedia%2Fmedia%2Fguardian-environment-blogs%7Cenvironment" +
+      "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7books%2Fmedia",
+      "search?tag=media%2Fmedia&section=sport&page-size=50",
+      "search?tag=books%2Fmedia&section=culture%7Cmusic%7Cmedia%7Cbooks%7Cartanddesign%7Cstage%7Ctv-and-radio",
+      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cmedia%2Fmedia))%7C(tone%2Fcomment%2C" +
+      "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
+      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods-sector|business" +
+      "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking|business/construction" +
+      "|mediao/media|business/healthcare|business/insurance|business/mining|business/musicindustry|business" +
+      "/pharmaceuticals-industry|business/realestate|business/retail|business/technology|media/media|business" +
+      "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
+      "media?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "search?tag=world/mongolia|world/afghanistan|books/media|world/bangladesh|world/bhutan|world/burma|world" +
+      "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world/srilanka|world" +
+      "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china|world/indonesia|world" +
+      "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines|world/singapore|world" +
+      "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
+      "books/media",
+      "books/media?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "media?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "books/media?edition=au",
+      "media"
+    )
+
+    forEvery(apiQueries) { q =>
+      DfpAgent.isSponsored(apiQuery(q)) should be(true)
+    }
+  }
+
+  "isSponsored" should "be false for a non sponsored container" in running(FakeApplication()) {
+
+    val apiQueries = Seq(
+      "search?tag=type%2Fvideo&section=money",
+      "search?tag=environment%2Fblog%7Cenvironment%2Fseries%2Fguardian-environment-blogs%7Cenvironment" +
+      "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7Cenvironment%2Fbike-blog",
+      "search?tag=type%2Fgallery&section=sport&page-size=50",
+      "search?tag=tone%2Freviews&section=culture%7Cmusic%7Cculture%7Cbooks%7Cartanddesign%7Cstage%7Ctv-and-radio",
+      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cbusiness%2Fus-personal-finance))%7C(tone%2Fcomment%2C" +
+      "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
+      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods-sector|business" +
+      "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking|business/construction" +
+      "|film/film-industry|business/healthcare|business/insurance|business/mining|business/musicindustry|business" +
+      "/pharmaceuticals-industry|business/realestate|business/retail|business/technology|business/telecoms|business" +
+      "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
+      "technology?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "search?tag=world/mongolia|world/afghanistan|world/azerbaijan|world/bangladesh|world/bhutan|world/burma|world" +
+      "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world/srilanka|world" +
+      "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china|world/indonesia|world" +
+      "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines|world/singapore|world" +
+      "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
+      "news/special",
+      "uk/money?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "au?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "sport/motorsports?edition=au",
+      "environment"
+    )
+
+    forEvery(apiQueries) { q =>
+      DfpAgent.isSponsored(apiQuery(q)) should be(false)
+    }
+  }
+
+  "isAdvertisementFeature" should "be true for an advertisement feature container" in running(FakeApplication()) {
+
+    val apiQueries = Seq(
+      "search?tag=books%2Ffilm&section=money",
+      "search?tag=environment%2Fblog%7Cfilm%2Ffilm%2Fguardian-environment-blogs%7Cenvironment" +
+      "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7books%2Ffilm",
+      "search?tag=film%2Ffilm&section=sport&page-size=50",
+      "search?tag=books%2Ffilm&section=culture%7Cmusic%7Cfilm%7Cbooks%7Cartanddesign%7Cstage%7Ctv-and-radio",
+      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cfilm%2Ffilm))%7C(tone%2Fcomment%2C" +
+      "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
+      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods-sector|business" +
+      "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking|business/construction" +
+      "|filmo/film|business/healthcare|business/insurance|business/mining|business/musicindustry|business" +
+      "/pharmaceuticals-industry|business/realestate|business/retail|business/technology|film/film|business" +
+      "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
+      "film?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "search?tag=world/mongolia|world/afghanistan|books/film|world/bangladesh|world/bhutan|world/burma|world" +
+      "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world/srilanka|world" +
+      "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china|world/indonesia|world" +
+      "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines|world/singapore|world" +
+      "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
+      "books/film",
+      "books/film?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "film?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "books/film?edition=au",
+      "film"
+    )
+
+    forEvery(apiQueries) { q =>
+      DfpAgent.isAdvertisementFeature(apiQuery(q)) should be(true)
+    }
+  }
+
+  "isAdvertisementFeature" should "be false for a non advertisement feature container" in running(FakeApplication()) {
+
+    val apiQueries = Seq(
+      "search?tag=type%2Fvideo&section=money",
+      "search?tag=environment%2Fblog%7Cenvironment%2Fseries%2Fguardian-environment-blogs%7Cenvironment" +
+      "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7Cenvironment%2Fbike-blog",
+      "search?tag=type%2Fgallery&section=sport&page-size=50",
+      "search?tag=tone%2Freviews&section=culture%7Cmusic%7Cculture%7Cbooks%7Cartanddesign%7Cstage%7Ctv-and-radio",
+      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cbusiness%2Fus-personal-finance))%7C(tone%2Fcomment%2C" +
+      "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
+      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods-sector|business" +
+      "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking|business/construction" +
+      "|film/film-industry|business/healthcare|business/insurance|business/mining|business/musicindustry|business" +
+      "/pharmaceuticals-industry|business/realestate|business/retail|business/technology|business/telecoms|business" +
+      "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
+      "technology?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "search?tag=world/mongolia|world/afghanistan|world/azerbaijan|world/bangladesh|world/bhutan|world/burma|world" +
+      "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world/srilanka|world" +
+      "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china|world/indonesia|world" +
+      "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines|world/singapore|world" +
+      "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
+      "news/special",
+      "uk/money?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "au?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
+      "sport/motorsports?edition=au",
+      "environment"
+    )
+
+    forEvery(apiQueries) { q =>
+      DfpAgent.isAdvertisementFeature(apiQuery(q)) should be(false)
+    }
+  }
+}


### PR DESCRIPTION
This allows containers to know whether they are sponsored or advertisement features, and should thus show some kind of badge.
