### PR TITLE
Give overlay higher z-index than advert

### DIFF
--- a/common/app/assets/stylesheets/module/_overlay.scss
+++ b/common/app/assets/stylesheets/module/_overlay.scss
@@ -6,6 +6,7 @@
     left: 0;
     width: 100%;
     height: 100%;
+    z-index: 100;
 
     .is-updating {
         margin-top: ($gs-baseline/3)*20;


### PR DESCRIPTION
fixes https://github.com/guardian/frontend/issues/4472
### Before

![screen shot 2014-05-29 at 14 17 31](https://cloud.githubusercontent.com/assets/74132/3117784/a1b2421e-e733-11e3-8e77-c9b414ff67af.png)
### After

![screen shot 2014-05-29 at 14 19 22](https://cloud.githubusercontent.com/assets/74132/3117805/de038ed0-e733-11e3-8dff-3eba9d6e3c88.png)
