### PR TITLE
Profile nav popup is properly aligned

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_pop-up.scss
+++ b/common/app/assets/stylesheets/module/nav/_pop-up.scss
@@ -103,7 +103,7 @@
         right: auto;
         top: -1px;
         @include rem((
-            left: 303px,
+            left: 319px,
             width: gs-span(3)
         ));
     }
@@ -161,7 +161,7 @@
 .nav-popup--profile-docked-left {
     @include mq(tablet) {
         @include rem((
-            left: $gs-gutter/2
+            left: $gs-gutter
         ));
     }
 }


### PR DESCRIPTION
Fixes a regression that occurred when we introduced the search label.
## Biphaure

![screen shot 2014-05-29 at 16 17 56](https://cloud.githubusercontent.com/assets/85783/3119288/f4a24f76-e744-11e3-8d5a-38c837b07cbd.PNG)
## Hafteure

![screen shot 2014-05-29 at 16 17 46](https://cloud.githubusercontent.com/assets/85783/3119290/f7eead1e-e744-11e3-8ef9-55c9831e9584.PNG)

![fail-ant-spider](https://cloud.githubusercontent.com/assets/85783/3119304/1481bdb8-e745-11e3-9b39-8360959fde2b.gif)
