### PR TITLE
Fix group order

### DIFF
--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -43,7 +43,17 @@ case class Block(
                   displayName: Option[String],
                   href: Option[String],
                   diff: Option[JsValue]
-                  )
+                  ) {
+
+  def sortByGroup: Block = this.copy(
+    live = sortTrailsByGroup(this.live),
+    draft = this.draft.map(sortTrailsByGroup)
+  )
+
+  private def sortTrailsByGroup(trails: List[Trail]): List[Trail] =
+    trails.sortBy(_.meta.get("group").asOpt[String].map(-_.toInt).getOrElse(0))
+
+}
 
 case class Trail(
                   id: String,

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -50,8 +50,10 @@ case class Block(
     draft = this.draft.map(sortTrailsByGroup)
   )
 
-  private def sortTrailsByGroup(trails: List[Trail]): List[Trail] =
-    trails.sortBy(_.meta.get("group").asOpt[String].map(-_.toInt).getOrElse(0))
+  private def sortTrailsByGroup(trails: List[Trail]): List[Trail] = {
+    val trailGroups = trails.groupBy(_.meta.get("group").asOpt[String].map(_.toInt).getOrElse(0))
+    trailGroups.keys.toList.sorted(Ordering.Int.reverse).flatMap(trailGroups.getOrElse(_, Nil))
+  }
 
 }
 

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -161,6 +161,7 @@ trait UpdateActions extends Logging {
     getBlock(id)
     .map(insertIntoLive(update, _))
     .map(insertIntoDraft(update, _))
+    .map(_.sortByGroup)
     .map(capCollection)
     .map(putBlock(id, _, identity))
     .map(archiveUpdateBlock(id, _, updateJson, identity))
@@ -172,6 +173,7 @@ trait UpdateActions extends Logging {
     getBlock(id)
       .map(deleteFromLive(update, _))
       .map(deleteFromDraft(update, _))
+      .map(_.sortByGroup)
       .map(archiveDeleteBlock(id, _, updateJson, identity))
       .map(putBlock(id, _, identity))
   }
@@ -179,6 +181,7 @@ trait UpdateActions extends Logging {
   def updateCollectionMeta(id: String, update: CollectionMetaUpdate, identity: Identity): Option[Block] =
     getBlock(id)
       .map(updateCollectionMeta(_, update, identity))
+      .map(_.sortByGroup)
       .map(putBlock(id, _, identity))
 
   private def updateList(update: UpdateList, blocks: List[Trail]): List[Trail] = {


### PR DESCRIPTION
We need to force sorting by `group` for `collection` `trails`.

When a collection is switched between a grouped collection type and a non grouped collection type, we get into an inconsistent state.

For example, after changing over a `Collection` to a grouped type, we start sending diffs to insert an item to the middle of the list with a higher group. There is no forcing on the order, and this means a group with for example 3, ends up in the middle of the list of items with a group 0, or even no group.

At the time of writing:
- Facia-tool UI sorts by group
- Facia-tool API does no sorting (With this PR forcing a sort)
- Facia templates sort by group
- Content API receives the grouping out of order
- MAPI expects the list to be in order of group

This will make everything align.

@robertberry @stephanfowler 
