### PR TITLE
Commercial: Page skin advert

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -2,6 +2,12 @@
 
 <div data-link-name="Front" role="main" class="facia-container facia-container--layout-front @if(index.page.isAdvertisementFeature && !index.page.isSponsored){facia-container--advertisement-feature}">
 
+    @if(index.page.hasPageskin) {
+        <div class="pageskin-container">
+            @fragments.commercial.adSlot(name="pageskin", adType="pageskin", sizeMapping=Map("mobile" -> Seq("1300,1200")), showLabel=false, refresh=false)
+        </div>
+    }
+
     @fragments.containers.tag(index.page, Collection(index.trails), NewsContainer(showMore = false), containerIndex = 0, pagination = index.page.pagination)(request, templateDeduping, Config(s"${index.page.id}/news/regular-stories", displayName = Some(index.page.webTitle)))
 
     <section class="no-indent-article__zone facia-container__inner">

--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -1,16 +1,16 @@
 @(index: services.IndexPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
-<div class="@RenderClasses((
+<div class="@RenderClasses(Map(
         "facia-container" -> true,
         "facia-container--layout-front" -> true,
         "facia-container--advertisement-feature}" -> (index.page.isAdvertisementFeature && !index.page.isSponsored),
-        "facia-container--pageskin" -> index.page.hasPageskin))"
+        "facia-container--page-skin" -> index.page.hasPageSkin))"
     data-link-name="Front"
     role="main">
 
-    @if(index.page.hasPageskin) {
-        <div class="pageskin-container">
-            @fragments.commercial.adSlot(name="pageskin", adType="pageskin", sizeMapping=Map("wide" -> Seq("1300,1200")), showLabel=false, refresh=false)
+    @if(index.page.hasPageSkin) {
+        <div class="page-skin-container">
+            @fragments.commercial.adSlot(name="pageskin", adType="page-skin", sizeMapping=Map("wide" -> Seq("1300,1200")), showLabel=false, refresh=false)
         </div>
     }
 

--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -1,10 +1,16 @@
 @(index: services.IndexPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
-<div data-link-name="Front" role="main" class="facia-container facia-container--layout-front @if(index.page.isAdvertisementFeature && !index.page.isSponsored){facia-container--advertisement-feature}">
+<div class="@RenderClasses((
+        "facia-container" -> true,
+        "facia-container--layout-front" -> true,
+        "facia-container--advertisement-feature}" -> (index.page.isAdvertisementFeature && !index.page.isSponsored),
+        "facia-container--pageskin" -> index.page.hasPageskin))"
+    data-link-name="Front"
+    role="main">
 
     @if(index.page.hasPageskin) {
         <div class="pageskin-container">
-            @fragments.commercial.adSlot(name="pageskin", adType="pageskin", sizeMapping=Map("mobile" -> Seq("1300,1200")), showLabel=false, refresh=false)
+            @fragments.commercial.adSlot(name="pageskin", adType="pageskin", sizeMapping=Map("wide" -> Seq("1300,1200")), showLabel=false, refresh=false)
         </div>
     }
 

--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -3,8 +3,7 @@
 <div class="@RenderClasses(Map(
         "facia-container" -> true,
         "facia-container--layout-front" -> true,
-        "facia-container--advertisement-feature}" -> (index.page.isAdvertisementFeature && !index.page.isSponsored),
-        "facia-container--page-skin" -> index.page.hasPageSkin))"
+        "facia-container--advertisement-feature}" -> (index.page.isAdvertisementFeature && !index.page.isSponsored)))"
     data-link-name="Front"
     role="main">
 

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -55,7 +55,8 @@ define([
     'common/modules/onward/tonal',
     'common/modules/identity/api',
     'common/modules/onward/more-tags',
-    'common/modules/ui/smartAppBanner'
+    'common/modules/ui/smartAppBanner',
+    'common/modules/adverts/pageskin'
 ], function (
     $,
     mediator,
@@ -111,7 +112,8 @@ define([
     TonalComponent,
     id,
     MoreTags,
-    smartAppBanner
+    smartAppBanner,
+    pageskin
 ) {
 
     var modules = {
@@ -515,13 +517,8 @@ define([
             }
         },
 
-        stickyPageskin: function() {
-            var $pageskin = $('.ad-slot--pageskin').first(),
-                $window = $(window),
-                contextPos = $('#js-context').offset().top;
-            mediator.on('window:scroll', function() {
-                $pageskin.css('top', Math.max(0, $window.scrollTop() - contextPos));
-            });
+        pageskin: function() {
+            pageskin.init();
         }
     };
 
@@ -573,7 +570,7 @@ define([
             modules.repositionComments();
             modules.showMoreTagsLink();
             modules.showSmartBanner(config);
-            modules.stickyPageskin(config);
+            modules.pageskin();
         }
         mediator.emit('page:common:ready', config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -517,8 +517,8 @@ define([
             }
         },
 
-        pageSkin: function() {
-            pageSkin.init();
+        pageSkin: function(config) {
+            pageSkin.init(config);
         }
     };
 
@@ -570,7 +570,7 @@ define([
             modules.repositionComments();
             modules.showMoreTagsLink();
             modules.showSmartBanner(config);
-            modules.pageSkin();
+            modules.pageSkin(config);
         }
         mediator.emit('page:common:ready', config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -56,7 +56,7 @@ define([
     'common/modules/identity/api',
     'common/modules/onward/more-tags',
     'common/modules/ui/smartAppBanner',
-    'common/modules/adverts/pageskin'
+    'common/modules/adverts/page-skin'
 ], function (
     $,
     mediator,
@@ -113,7 +113,7 @@ define([
     id,
     MoreTags,
     smartAppBanner,
-    pageskin
+    pageSkin
 ) {
 
     var modules = {
@@ -517,8 +517,8 @@ define([
             }
         },
 
-        pageskin: function() {
-            pageskin.init();
+        pageSkin: function() {
+            pageSkin.init();
         }
     };
 
@@ -570,7 +570,7 @@ define([
             modules.repositionComments();
             modules.showMoreTagsLink();
             modules.showSmartBanner(config);
-            modules.pageskin();
+            modules.pageSkin();
         }
         mediator.emit('page:common:ready', config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -513,6 +513,15 @@ define([
             if(config.switches.smartBanner) {
                 smartAppBanner.init();
             }
+        },
+
+        stickyPageskin: function() {
+            var $pageskin = $('.ad-slot--pageskin').first(),
+                $window = $(window),
+                contextPos = $('#js-context').offset().top;
+            mediator.on('window:scroll', function() {
+                $pageskin.css('top', Math.max(0, $window.scrollTop() - contextPos));
+            });
         }
     };
 
@@ -564,6 +573,7 @@ define([
             modules.repositionComments();
             modules.showMoreTagsLink();
             modules.showSmartBanner(config);
+            modules.stickyPageskin(config);
         }
         mediator.emit('page:common:ready', config, context);
     };

--- a/common/app/assets/javascripts/modules/adverts/page-skin.js
+++ b/common/app/assets/javascripts/modules/adverts/page-skin.js
@@ -8,18 +8,18 @@ define([
     once
 ) {
 
-    var pageskinHeight = 1200,
-        $pageskin = $('.ad-slot--pageskin').first(),
+    var pageSkinHeight = 1200,
+        $pageSkin = $('.ad-slot--page-skin').first(),
         $window = $(window);
 
     return {
 
-        // creates a sticky pageskin
+        // creates a sticky page skin
         init: once(function() {
             mediator.on('window:scroll', function() {
                 var contextPos = $('#js-context').offset().top,
-                    maximumTop = $('.l-footer').offset().top - contextPos - pageskinHeight;
-                $pageskin.css('top', Math.min(Math.max(0, $window.scrollTop() - contextPos), maximumTop));
+                    maximumTop = $('.l-footer').offset().top - contextPos - pageSkinHeight;
+                $pageSkin.css('top', Math.min(Math.max(0, $window.scrollTop() - contextPos), maximumTop));
             });
         })
 

--- a/common/app/assets/javascripts/modules/adverts/page-skin.js
+++ b/common/app/assets/javascripts/modules/adverts/page-skin.js
@@ -15,12 +15,14 @@ define([
     return {
 
         // creates a sticky page skin
-        init: once(function() {
-            mediator.on('window:scroll', function() {
-                var contextPos = $('#js-context').offset().top,
-                    maximumTop = $('.l-footer').offset().top - contextPos - pageSkinHeight;
-                $pageSkin.css('top', Math.min(Math.max(0, $window.scrollTop() - contextPos), maximumTop));
-            });
+        init: once(function(config) {
+            if (config.page.hasPageSkin) {
+                mediator.on('window:scroll', function() {
+                    var contextPos = $('#js-context').offset().top,
+                        maximumTop = $('.l-footer').offset().top - contextPos - pageSkinHeight;
+                    $pageSkin.css('top', Math.min(Math.max(0, $window.scrollTop() - contextPos), maximumTop));
+                });
+            }
         })
 
     };

--- a/common/app/assets/javascripts/modules/adverts/pageskin.js
+++ b/common/app/assets/javascripts/modules/adverts/pageskin.js
@@ -1,0 +1,28 @@
+define([
+    'common/$',
+    'common/utils/mediator',
+    'lodash/functions/once'
+], function (
+    $,
+    mediator,
+    once
+) {
+
+    var pageskinHeight = 1200,
+        $pageskin = $('.ad-slot--pageskin').first(),
+        $window = $(window);
+
+    return {
+
+        // creates a sticky pageskin
+        init: once(function() {
+            mediator.on('window:scroll', function() {
+                var contextPos = $('#js-context').offset().top,
+                    maximumTop = $('.l-footer').offset().top - contextPos - pageskinHeight;
+                $pageskin.css('top', Math.min(Math.max(0, $window.scrollTop() - contextPos), maximumTop));
+            });
+        })
+
+    };
+
+});

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -10,7 +10,7 @@
         border-bottom: 2px solid $c-brandBlue;
     }
     @include mq(wide) {
-        > * {
+        .has-page-skin & > * {
             margin: 0 auto;
             @include rem((
                 width: gs-span(12)

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -7,6 +7,15 @@
 
     @include mq(tablet) {
         background: $c-neutral8;
+        border-bottom: 2px solid $c-brandBlue;
+    }
+    @include mq(wide) {
+        > * {
+            margin: 0 auto;
+            @include rem((
+                width: gs-span(12)
+            ));
+        }
     }
 }
 

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -13,7 +13,7 @@
         .has-page-skin & > * {
             margin: 0 auto;
             @include rem((
-                width: gs-span(12)
+                width: gs-span(12) + ($gs-gutter*2)
             ));
         }
     }

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -323,7 +323,6 @@
 .ad-slot--page-skin {
     z-index: 0;
     position: absolute;
-    background: linear-gradient($c-neutral8, #ffffff);
     @include transition(top .5s)
 }
 .ad-slot__label {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -310,6 +310,24 @@
         }
     }
 }
+.pageskin-container {
+    display: none;
+
+    @include mq(wide) {
+        display: block;
+        position: relative;
+        width: 1300px;
+        margin: 0 auto;
+    }
+}
+.ad-slot--pageskin {
+    position: absolute;
+    height: 1200px;
+    width: 100%;
+    top: 0;
+    left: 0;
+    background: linear-gradient($c-neutral8, #ffffff);
+}
 .ad-slot__label {
     height: $mpu-ad-label-height;
     background-color: $c-neutral8;

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -323,6 +323,7 @@
 .ad-slot--page-skin {
     z-index: 0;
     position: absolute;
+    top: 0;
     @include transition(top .5s)
 }
 .ad-slot__label {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -327,6 +327,7 @@
     top: 0;
     left: 0;
     background: linear-gradient($c-neutral8, #ffffff);
+    @include transition(top .5s)
 }
 .ad-slot__label {
     height: $mpu-ad-label-height;

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -321,11 +321,8 @@
     }
 }
 .ad-slot--pageskin {
+    z-index: 0;
     position: absolute;
-    height: 1200px;
-    width: 100%;
-    top: 0;
-    left: 0;
     background: linear-gradient($c-neutral8, #ffffff);
     @include transition(top .5s)
 }

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -310,7 +310,7 @@
         }
     }
 }
-.pageskin-container {
+.page-skin-container {
     display: none;
 
     @include mq(wide) {
@@ -320,7 +320,7 @@
         margin: 0 auto;
     }
 }
-.ad-slot--pageskin {
+.ad-slot--page-skin {
     z-index: 0;
     position: absolute;
     background: linear-gradient($c-neutral8, #ffffff);

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -98,7 +98,7 @@
             }
             .facia-container__inner {
                 @include rem((
-                        width: gs-span(12)
+                    width: gs-span(12)
                 ));
             }
             .container__body {

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -177,6 +177,13 @@
 
 @include mq(wide) {
     .facia-container--pageskin.facia-container--layout-front {
+        .container {
+            margin-left: auto;
+            margin-right: auto;
+            @include rem((
+                width: gs-span(12) + $gs-gutter
+            ));
+        }
         .facia-container__inner {
             @include rem((
                 width: gs-span(12)

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -174,3 +174,30 @@
         }
     }
 }
+
+.facia-container--pageskin.facia-container--layout-front {
+    .facia-container__inner {
+        @include mq(wide) {
+            @include rem((
+                width: gs-span(12)
+            ));
+        }
+    }
+    .container__body {
+        margin-left: 0;
+    }
+    .container__title {
+        width: auto !important;
+        margin-right: 0;
+        float: none;
+        @include rem((
+            margin-bottom: $gs-baseline
+        ));
+    }
+    .container--news .container__title {
+        display: none;
+    }
+    .container__toggle {
+        left: auto;
+    }
+}

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -93,7 +93,7 @@
                 margin-left: auto;
                 margin-right: auto;
                 @include rem((
-                        width: gs-span(12) + $gs-gutter
+                    width: gs-span(12) + $gs-gutter
                 ));
             }
             .facia-container__inner {
@@ -109,7 +109,7 @@
                 margin-right: 0;
                 float: none;
                 @include rem((
-                        margin-bottom: $gs-baseline
+                    margin-bottom: $gs-baseline
                 ));
             }
             .container--news .container__title {

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -177,6 +177,8 @@
 
 @include mq(wide) {
     .facia-container--pageskin.facia-container--layout-front {
+        overflow: hidden;
+
         .container {
             margin-left: auto;
             margin-right: auto;

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -86,6 +86,39 @@
                 width: gs-span(12)
             ));
         }
+        .has-page-skin & {
+            overflow: hidden;
+
+            .container {
+                margin-left: auto;
+                margin-right: auto;
+                @include rem((
+                        width: gs-span(12) + $gs-gutter
+                ));
+            }
+            .facia-container__inner {
+                @include rem((
+                        width: gs-span(12)
+                ));
+            }
+            .container__body {
+                margin-left: 0;
+            }
+            .container__title {
+                width: auto !important;
+                margin-right: 0;
+                float: none;
+                @include rem((
+                        margin-bottom: $gs-baseline
+                ));
+            }
+            .container--news .container__title {
+                display: none;
+            }
+            .container__toggle {
+                left: auto;
+            }
+        }
     }
 }
 .facia-container--layout-article {
@@ -171,42 +204,6 @@
         @include mq($to: tablet) {
             @include fs-header(3, true);
             padding-left: 0;
-        }
-    }
-}
-
-@include mq(wide) {
-    .facia-container--page-skin.facia-container--layout-front {
-        overflow: hidden;
-
-        .container {
-            margin-left: auto;
-            margin-right: auto;
-            @include rem((
-                width: gs-span(12) + $gs-gutter
-            ));
-        }
-        .facia-container__inner {
-            @include rem((
-                width: gs-span(12)
-            ));
-        }
-        .container__body {
-            margin-left: 0;
-        }
-        .container__title {
-            width: auto !important;
-            margin-right: 0;
-            float: none;
-            @include rem((
-                margin-bottom: $gs-baseline
-            ));
-        }
-        .container--news .container__title {
-            display: none;
-        }
-        .container__toggle {
-            left: auto;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -176,7 +176,7 @@
 }
 
 @include mq(wide) {
-    .facia-container--pageskin.facia-container--layout-front {
+    .facia-container--page-skin.facia-container--layout-front {
         overflow: hidden;
 
         .container {

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -175,29 +175,29 @@
     }
 }
 
-.facia-container--pageskin.facia-container--layout-front {
-    .facia-container__inner {
-        @include mq(wide) {
+@include mq(wide) {
+    .facia-container--pageskin.facia-container--layout-front {
+        .facia-container__inner {
             @include rem((
                 width: gs-span(12)
             ));
         }
-    }
-    .container__body {
-        margin-left: 0;
-    }
-    .container__title {
-        width: auto !important;
-        margin-right: 0;
-        float: none;
-        @include rem((
-            margin-bottom: $gs-baseline
-        ));
-    }
-    .container--news .container__title {
-        display: none;
-    }
-    .container__toggle {
-        left: auto;
+        .container__body {
+            margin-left: 0;
+        }
+        .container__title {
+            width: auto !important;
+            margin-right: 0;
+            float: none;
+            @include rem((
+                margin-bottom: $gs-baseline
+            ));
+        }
+        .container--news .container__title {
+            display: none;
+        }
+        .container__toggle {
+            left: auto;
+        }
     }
 }

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -113,7 +113,6 @@
 .nav-container {
     display: none;
     clear: both;
-    border-bottom: 2px solid $c-brandBlue;
 
     @include mq(tablet) {
         display: block;

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -125,6 +125,11 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 6, 30)
   )
 
+  val ForcePageSkinSwitch = Switch("Advertising", "force-page-skin",
+    "Temp switch, allows us to force the page into 'page skin' mode",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 7)
+  )
+
   // Ad Targeting
   /*
     These switches are to control length of request to DFP
@@ -472,7 +477,8 @@ object Switches extends Collections {
     ABHighRelevanceCommercialComponent,
     ABHideSupportingLinks,
     SmartBannerSwitch,
-    FeaturesAutoContainerSwitch
+    FeaturesAutoContainerSwitch,
+    ForcePageSkinSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -160,6 +160,7 @@ trait Tags {
 
   def isSponsored = DfpAgent.isSponsored(keywords)
   def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(keywords)
+  def hasPageskin: Boolean = true
 
   // Tones are all considered to be 'News' it is the default so we do not list news tones explicitly
   lazy val visualTone: String =

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -160,7 +160,7 @@ trait Tags {
 
   def isSponsored = DfpAgent.isSponsored(keywords)
   def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(keywords)
-  def hasPageskin: Boolean = true
+  def hasPageSkin: Boolean = true
 
   // Tones are all considered to be 'News' it is the default so we do not list news tones explicitly
   lazy val visualTone: String =

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -3,6 +3,7 @@ package model
 import common.{Pagination, ManifestData}
 import conf.Configuration
 import dfp.DfpAgent
+import conf.Switches._
 
 trait MetaData extends Tags {
   def id: String
@@ -160,8 +161,8 @@ trait Tags {
 
   def isSponsored = DfpAgent.isSponsored(keywords)
   def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(keywords)
-  // TODO: hook up to dfp
-  def hasPageSkin: Boolean = false
+  // TODO: hook up to dfp and remove switch
+  def hasPageSkin: Boolean = ForcePageSkinSwitch.isSwitchedOn
 
   // Tones are all considered to be 'News' it is the default so we do not list news tones explicitly
   lazy val visualTone: String =

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -160,7 +160,8 @@ trait Tags {
 
   def isSponsored = DfpAgent.isSponsored(keywords)
   def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(keywords)
-  def hasPageSkin: Boolean = true
+  // TODO: hook up to dfp
+  def hasPageSkin: Boolean = false
 
   // Tones are all considered to be 'News' it is the default so we do not list news tones explicitly
   lazy val visualTone: String =

--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -22,7 +22,8 @@
         "beaconUrl": "@Configuration.debug.beaconUrl",
         "renderTime": "@{(new DateTime).toISODateTimeNoMillisString}",
         "isSSL": @Configuration.environment.secure,
-        "assetsPath": "@Configuration.assets.path"
+        "assetsPath": "@Configuration.assets.path",
+        "hasPageSkin": @item.hasPageSkin
     },
     "switches" : { @{Html(conf.Switches.all.map{ switch =>
             s""""${JavaScriptVariableName(switch.name)}":${switch.isSwitchedOn}"""

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -12,8 +12,8 @@
 <body
     id="top"
     class="@RenderClasses(Map(
-        "has-page-skin" -> metaData.hasPageSkin,
-        "has-localnav" -> Navigation.topLevelItem(Edition(request).navigation, metaData).filter(_.links.nonEmpty).nonEmpty))"
+        ("has-page-skin", metaData.hasPageSkin),
+        ("has-localnav", Navigation.topLevelItem(Edition(request).navigation, metaData).filter(_.links.nonEmpty).nonEmpty)))"
     itemscope itemtype="http://schema.org/WebPage">
 
     <div class="top-banner-ad-container top-banner-ad-container--desktop top-banner-ad-container--@metaData match {

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -10,8 +10,10 @@
     @fragments.head(metaData, projectName, head, curlPaths)
 </head>
 <body
-    @Navigation.topLevelItem(Edition(request).navigation, metaData).filter(_.links.nonEmpty).map{ localNav => class="has-localnav" }
     id="top"
+    class="@RenderClasses(Map(
+        "has-page-skin" -> metaData.hasPageSkin,
+        "has-localnav" -> Navigation.topLevelItem(Edition(request).navigation, metaData).filter(_.links.nonEmpty).nonEmpty))"
     itemscope itemtype="http://schema.org/WebPage">
 
     <div class="top-banner-ad-container top-banner-ad-container--desktop top-banner-ad-container--@metaData match {

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -2,6 +2,11 @@
 
 @if(faciaPage.collections.nonEmpty) {
     <div class="facia-container facia-container--layout-front @if(faciaPage.isAdvertisementFeature && !faciaPage.isSponsored){facia-container--advertisement-feature} facia-container--pageskin" data-link-name="Front" role="main">
+
+        <div class="pageskin-container">
+            <div class="ad-slot--pageskin"></div>
+        </div>
+
         @defining(faciaPage.collections.filter(_._2.items.nonEmpty)) { collections =>
             @collections.zipWithIndex.map{ case(block, index) =>
                 @fragments.frontCollection(faciaPage, block, collections.size, index)

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -5,13 +5,13 @@
             "facia-container" -> true,
             "facia-container--layout-front" -> true,
             "facia-container--advertisement-feature" -> (faciaPage.isAdvertisementFeature && !faciaPage.isSponsored),
-            "facia-container--pageskin" -> faciaPage.hasPageskin))"
+            "facia-container--page-skin" -> faciaPage.hasPageSkin))"
         data-link-name="Front"
         role="main">
 
-        @if(faciaPage.hasPageskin) {
-            <div class="pageskin-container">
-                @fragments.commercial.adSlot(name="pageskin", adType="pageskin", sizeMapping=Map("wide" -> Seq("1300,1200")), showLabel=false, refresh=false)
+        @if(faciaPage.hasPageSkin) {
+            <div class="page-skin-container">
+                @fragments.commercial.adSlot(name="pageskin", adType="page-skin", sizeMapping=Map("wide" -> Seq("1300,1200")), showLabel=false, refresh=false)
             </div>
         }
 

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -4,8 +4,7 @@
     <div class="@RenderClasses(Map(
             "facia-container" -> true,
             "facia-container--layout-front" -> true,
-            "facia-container--advertisement-feature" -> (faciaPage.isAdvertisementFeature && !faciaPage.isSponsored),
-            "facia-container--page-skin" -> faciaPage.hasPageSkin))"
+            "facia-container--advertisement-feature" -> (faciaPage.isAdvertisementFeature && !faciaPage.isSponsored)))"
         data-link-name="Front"
         role="main">
 

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,7 +1,7 @@
 @(faciaPage: FaciaPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @if(faciaPage.collections.nonEmpty) {
-    <div class="facia-container facia-container--layout-front @if(faciaPage.isAdvertisementFeature && !faciaPage.isSponsored){facia-container--advertisement-feature}" data-link-name="Front" role="main">
+    <div class="facia-container facia-container--layout-front @if(faciaPage.isAdvertisementFeature && !faciaPage.isSponsored){facia-container--advertisement-feature} facia-container--pageskin" data-link-name="Front" role="main">
         @defining(faciaPage.collections.filter(_._2.items.nonEmpty)) { collections =>
             @collections.zipWithIndex.map{ case(block, index) =>
                 @fragments.frontCollection(faciaPage, block, collections.size, index)

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,11 +1,19 @@
 @(faciaPage: FaciaPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
 
 @if(faciaPage.collections.nonEmpty) {
-    <div class="facia-container facia-container--layout-front @if(faciaPage.isAdvertisementFeature && !faciaPage.isSponsored){facia-container--advertisement-feature} facia-container--pageskin" data-link-name="Front" role="main">
+    <div class="@RenderClasses(Map(
+            "facia-container" -> true,
+            "facia-container--layout-front" -> true,
+            "facia-container--advertisement-feature" -> (faciaPage.isAdvertisementFeature && !faciaPage.isSponsored),
+            "facia-container--pageskin" -> faciaPage.hasPageskin))"
+        data-link-name="Front"
+        role="main">
 
-        <div class="pageskin-container">
-            <div class="ad-slot--pageskin"></div>
-        </div>
+        @if(faciaPage.hasPageskin) {
+            <div class="pageskin-container">
+                @fragments.commercial.adSlot(name="pageskin", adType="pageskin", sizeMapping=Map("wide" -> Seq("1300,1200")), showLabel=false, refresh=false)
+            </div>
+        }
 
         @defining(faciaPage.collections.filter(_._2.items.nonEmpty)) { collections =>
             @collections.zipWithIndex.map{ case(block, index) =>

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -10,7 +10,7 @@
 
         @if(faciaPage.hasPageSkin) {
             <div class="page-skin-container">
-                @fragments.commercial.adSlot(name="pageskin", adType="page-skin", sizeMapping=Map("wide" -> Seq("1300,1200")), showLabel=false, refresh=false)
+                @fragments.commercial.adSlot(name="pageskin-inread", adType="page-skin", sizeMapping=Map("wide" -> Seq("1,1")), showLabel=false, refresh=false)
             </div>
         }
 


### PR DESCRIPTION
If the front has an advert page skin, at `wide` breakpoint layout reverts back to `desktop`

![screen shot 2014-05-29 at 16 34 18](https://cloud.githubusercontent.com/assets/74132/3119486/b6ef60ea-e746-11e3-9f95-d7e9309b4b69.png)
