### PR TITLE
Config tool: max path length three

### DIFF
--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -97,6 +97,9 @@ define([
             .toLowerCase()
             .replace(/^\/|\/$/g, '')
             .replace(/[^a-z0-9\/\-]*/g, '')
+            .split('/')
+            .slice(0,3)
+            .join('/')
         );
 
         if (!this.id()) { return; }

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -95,6 +95,7 @@ define([
 
         this.id((this.id() || '')
             .toLowerCase()
+            .replace(/\/+/g, '/')
             .replace(/^\/|\/$/g, '')
             .replace(/[^a-z0-9\/\-]*/g, '')
             .split('/')


### PR DESCRIPTION
New paths contain a maximum of three path components. 
Eg. `/world/series/foo` but not `/world/series/foo/bar`
