### PR TITLE
Responsive viewer: Chrome settings

### DIFF
--- a/facia-tool/public/html/responsive-viewer.html
+++ b/facia-tool/public/html/responsive-viewer.html
@@ -34,7 +34,7 @@
             #chrome-instructions {
                 text-align: right;
                 font-size: 12px;
-                color: #333;
+                color: #333333;
             }
             #chrome-instructions__toggle {
                 color: #005689;

--- a/facia-tool/public/html/responsive-viewer.html
+++ b/facia-tool/public/html/responsive-viewer.html
@@ -17,23 +17,50 @@
         </script>
         <style>
             body {
+                font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+                margin-top: 4px;
                 background: #CCCCCC;
             }
             iframe {
                 border-radius: 4px;
             }
             h2 {
-                font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
                 font-size: 16px;
-                margin-bottom: 5px;
+                margin: 0 0 5px 0;
             }
             .frames { position: relative; }
             .frames > div { position: absolute; }
+
+            #chrome-instructions {
+                text-align: right;
+                font-size: 12px;
+                color: #333;
+            }
+            #chrome-instructions__toggle {
+                color: #005689;
+                cursor: pointer;
+            }
         </style>
     </head>
     <body>
+        <div id="chrome-instructions" style="display: none;">
+            <div id="chrome-instructions__toggle" onclick="toggle('chrome-instructions__text')">Looks wrong in Chrome?</div>
+            <div id="chrome-instructions__text" style="display: none;">
+                1. go to <em>Settings</em> > <em>Show advanced settings</em> > <em>Content Settings</em> <br />
+                2. under Cookies, uncheck '<em>Block third-party cookies and site data<em>'
+            </div>
+        </div>
+
         <div class="frames"></div>
         <script>
+            function toggle(id) {
+                var el = document.getElementById(id);
+
+                if(el) {
+                    el.style.display = (el.style.display != 'none' ? 'none' : '' );
+                }
+            }
+
             function hashArgs() {
                 var obj = {};
                 window.location.hash.substring(1).split('&').forEach(function(kv) {
@@ -74,6 +101,10 @@
 
             window.onhashchange = init;
             window.onresize = updateScrollables;
+
+            if(window.chrome) {
+                toggle('chrome-instructions');
+            }
         </script>
     </body>
 </html>


### PR DESCRIPTION
Show a link to reveal instructions, in Chrome only:

![fronts-tool](https://cloud.githubusercontent.com/assets/1147913/3122032/63bbfd36-e762-11e3-9539-40a555a9a124.png)
 wrong in Chrome 
