### PR TITLE
Remove unused CTA classes

### DIFF
--- a/common/app/assets/stylesheets/module/_cta.scss
+++ b/common/app/assets/stylesheets/module/_cta.scss
@@ -1,52 +1,3 @@
-.cta {
-    @include fs-data(3);
-    -webkit-font-smoothing: subpixel-antialiased; // Text look fatter, better for a CTA
-    line-height: 1;
-    color: $c-body;
-    text-align: center;
-    display: block;
-    @include rem((
-        padding: $gs-baseline 0,
-        margin: $gs-baseline 0
-    ));
-    border: 0;
-    background-color: $c-neutral7;
-    text-shadow: none;
-    cursor: pointer;
-
-    &:hover,
-    &:focus {
-        background-color: $c-neutral5;
-    }
-
-    &,
-    &:hover,
-    &:focus,
-    &:active {
-        @include box-shadow(none);
-    }
-}
-button.cta {
-    width: 100%;
-}
-
-.cta--read-more {
-    @include box-sizing(border-box);
-    @include font($serif, normal, 16, 16);
-    text-align: left;
-    @include rem((
-        padding: ($gs-baseline/3)*4 $gutter/2
-    ));
-}
-
-.cta--read-more__icon {
-    @include rotate(90deg);
-    float: right;
-    @include rem((
-        margin-right: ($gs-gutter / 5) * 2
-    ));
-}
-
 .top {
     @include fs-data(3);
     display: block;
@@ -70,17 +21,6 @@ button.cta {
             padding-right: $gs-gutter
         ));
     }
-}
-
-.cta-small {
-    @include fs-data(4);
-    display: block;
-    @include rem((
-        padding: ($gs-baseline - 3) 0 $gs-baseline
-    ));
-}
-.cta-small--border {
-    border-bottom: 1px solid $c-neutral6;
 }
 
 .most-viewed-no-js {

--- a/discussion/app/views/fragments/commentBox.scala.html
+++ b/discussion/app/views/fragments/commentBox.scala.html
@@ -1,6 +1,6 @@
 @()(implicit request: RequestHeader)
 <form class="component js-comment-box d-comment-box">
-    <label for="body" class="d-comment-box__add-comment cta">Add your comment</label>
+    <label class="d-comment-box__add-comment">Add your comment</label>
 
     <div class="d-comment-box__meta">
             <span class="d-comment-box__avatar-wrapper">


### PR DESCRIPTION
Looks like the only place where the `.cta` class was still used is the comment box. Which is a class that hides the label anyway.

Also removed the `for="body"` attribute on said label because it wasn't pointing to anything.

![ ](http://gifs.joelglovier.com/upset/tableflip.gif)
