### PR TITLE
Remove switch wrap from site message template

### DIFF
--- a/common/app/views/fragments/message.scala.html
+++ b/common/app/views/fragments/message.scala.html
@@ -3,15 +3,13 @@
 @import java.net.URLEncoder.encode
 @import common.ClassicLink
 
-@if(ReleaseMessageSwitch.isSwitchedOn) {
-    <div class="site-message js-site-message is-hidden" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
-        <div class="site-message__inner js-site-message-inner gs-container">
-            <div class="js-site-message-copy u-cf">
-            </div>
-            <button class="site-message__close js-site-message-close" data-link-name="hide release message">
-                <i class="i i-message-close"></i>
-                <span class="u-h">Hide this message</span>
-            </button>
+<div class="site-message js-site-message is-hidden" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
+    <div class="site-message__inner js-site-message-inner gs-container">
+        <div class="js-site-message-copy u-cf">
         </div>
-    </div> 
-}
+        <button class="site-message__close js-site-message-close" data-link-name="hide release message">
+            <i class="i i-message-close"></i>
+            <span class="u-h">Hide this message</span>
+        </button>
+    </div>
+</div>


### PR DESCRIPTION
The site message template was wrapped around the release message switch. This was preventing us from using the `ui/message.js` module whilst having the release message swicth state set to `off`. 

The JS module itself has no dependencies on the switch being on, therefore the template should still be available for other instances of the module to use.

/cc @mattosborn @rich-nguyen 
