### PR TITLE
Typography refactor & pagination tweaks

### DIFF
--- a/common/app/assets/stylesheets/_extends-only.scss
+++ b/common/app/assets/stylesheets/_extends-only.scss
@@ -50,6 +50,6 @@
     &:focus,
     &:hover {
         text-decoration: none;
-        color: $c-body;
+        color: $c-neutral1;
     }
 }

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -77,8 +77,6 @@ $c-brandBlue: #214583;
 $c-brandLightBlue: #94b1ca;
 $c-error: #d61d00;
 
-$c-body: #545454;
-
 $c-neutral1: #333333;
 $c-neutral2: #767676;
 // Enhance contrast of grey text on light grey background

--- a/common/app/assets/stylesheets/base/_forms.scss
+++ b/common/app/assets/stylesheets/base/_forms.scss
@@ -175,12 +175,9 @@
 }
 
 .label {
-    color: $c-neutral1;
     cursor: pointer;
     display: block;
     @include rem((
-        font-size: 16px,
-        line-height: 24px,
         margin-bottom: 6px
     ));
 }
@@ -190,7 +187,7 @@
     border: 1px solid $c-neutral4;
     @include box-shadow(none);
     @include box-sizing(border-box);
-    color: $c-body;
+    color: $c-neutral1;
     display: inline-block;
     font-family: $sans-serif;
     @include rem((

--- a/common/app/assets/stylesheets/base/_tables.scss
+++ b/common/app/assets/stylesheets/base/_tables.scss
@@ -45,7 +45,6 @@ td {
 .table {
     background: $c-neutral8;
     border-top: 2px solid $c-newsAccent;
-    color: $c-neutral1;
 
     th,
     td,
@@ -59,7 +58,6 @@ td {
 
     th,
     thead td {
-        color: $c-neutral1;
         font-weight: 800;
     }
 

--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -7,6 +7,8 @@
 
 html {
     font-family: $serif;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
 
     // Set baseline font size to 10px
     // This is used as a baseline for rem (root ems) values
@@ -17,9 +19,9 @@ html {
     font-size: calc(1em * .625);
 }
 body {
-    color: $c-body;
+    color: $c-neutral1;
     font-size: 1.6em; // Bump font-size back up to 16px
-    line-height: 1.4;
+    line-height: 1.5;
 }
 
 
@@ -32,7 +34,6 @@ h3,
 h4,
 h5,
 h6 {
-    color: $c-neutral1;
     margin: 0;
 }
 

--- a/common/app/assets/stylesheets/module/_content.scss
+++ b/common/app/assets/stylesheets/module/_content.scss
@@ -3,7 +3,6 @@
         padding-top: $gs-row-height*.5,
         padding-bottom: $gs-baseline*3.5
     ));
-    @include fs-bodyCopy(3);
 
     &:after { // clearfix
         content: '';
@@ -34,24 +33,24 @@
 .content__main-column {
     position: relative;
 
-    @include mq($from: tablet) {
+    @include mq(tablet) {
         @include rem((
             max-width: 620px
         ));
         margin: auto;
     }
-    @include mq($from: rightCol) {
+    @include mq(rightCol) {
         @include rem((
             margin-left: 0,
             margin-right: gs-span(4) + $gs-gutter
         ));
     }
-    @include mq($from: leftCol) {
+    @include mq(leftCol) {
         @include rem((
             margin-left: gs-span(2) + $gs-gutter
         ));
     }
-    @include mq($from: wide) {
+    @include mq(wide) {
         @include rem((
             margin-left: gs-span(3) + $gs-gutter
         ));
@@ -111,6 +110,7 @@
     @include mq($to: tablet) {
         border-top-style: solid;
         border-top-width: 2px;
+
         .has-localnav & {
             border-top: 0;
         }
@@ -153,31 +153,32 @@
     ));
     @include mq($to: tablet) {
         border-bottom: 1px solid $c-neutral7;
+
         .has-localnav & {
             display: none;
         }
     }
 
-    @include mq($from: tablet) {
+    @include mq(tablet) {
         @include rem((
             padding-bottom: ($gs-baseline/2) * 3
         ));
     }
 
-    @include mq($from: leftCol) {
+    @include mq(leftCol) {
         float: left;
         @include rem((
             margin-left: -(gs-span(2) + $gs-gutter),
             width: gs-span(2)
         ));
     }
-    @include mq($from: wide) {
+    @include mq(wide) {
         @include rem((
             margin-left: -(gs-span(3) + $gs-gutter),
             width: gs-span(3)
         ));
     }
-    @include mq($from: leftCol, $to: wide) {
+    @include mq(leftCol, wide) {
         @include rem((
             width: gs-span(2)
         ));
@@ -222,15 +223,14 @@
 .content__standfirst {
     @include fs-headline(1);
     @include rem((
-            margin-bottom: $gs-baseline
+        margin-bottom: $gs-baseline
     ));
     color: $c-neutral2;
 
     @include mq(tablet) {
         @include font-size(18px, 22px);
-        -webkit-font-smoothing: antialiased;
         @include rem((
-                margin-bottom: ($gs-baseline/3)*4
+            margin-bottom: ($gs-baseline/3)*4
         ));
     }
 
@@ -320,8 +320,6 @@
             padding-top: $gs-baseline/6,
             padding-bottom: $gs-baseline
         ));
-    }
-    @include mq($from: leftCol) {
         border-top: 1px dotted $c-neutral5;
     }
 
@@ -349,7 +347,7 @@
         height: gs-span(2); //This is intentionally square
         margin-right: 0;
         @include rem((
-            margin-bottom: $gs-baseline,
+            margin-bottom: $gs-baseline
         ));
     }
 }
@@ -373,14 +371,14 @@
     @include rem((
         margin-bottom: $gs-baseline
     ));
-    @include mq($to: leftCol) {
-        border-top: 1px dotted $c-neutral5;
-        border-bottom: 1px dotted $c-neutral5;
-    }
+    border-top: 1px dotted $c-neutral5;
+    border-bottom: 1px dotted $c-neutral5;
 
     @include mq(leftCol) {
         position: absolute;
         top: 0;
+        border-top: 0;
+        border-bottom: 0;
         @include rem((
             margin-left: ($a-leftCol-width + $gs-gutter)*-1,
             margin-bottom: ($gs-baseline/3)*4,
@@ -410,17 +408,6 @@
     }
 }
 
-.content__breadcrumb {
-    @include rem((
-        padding: $gs-gutter
-    ));
-    @include mq($from: mobileLandscape) {
-        @include rem((
-            padding: $gs-gutter
-        ));
-    }
-}
-
 .content-meta {
     @include fs-textsans(3);
     font-weight: bold;
@@ -438,7 +425,6 @@
         @include mq($from: tablet, $to: leftCol) {
             border-top: 1px dotted $c-neutral5;
         }
-
     }
 }
 
@@ -453,6 +439,9 @@
 
 .content-meta--inline {
     margin: 0;
+    @include rem((
+        padding-top: $gs-baseline/2
+    ));
 
     .content-meta__label,
     .content-meta__item {
@@ -462,37 +451,34 @@
         ));
     }
 
-    @include mq(tablet) {
-        @include rem((
-            margin: 0 0 $gs-baseline/2
-        ));
-    }
-
-    @include mq($to: leftCol) {
-        @include rem((
-            padding-top: $gs-baseline/2
-        ));
-    }
-
     @include mq($to: tablet) {
         .has-localnav & {
             padding-top: 0;
         }
     }
+
+    @include mq(tablet) {
+        padding-top: 0;
+        @include rem((
+            margin: 0 0 $gs-baseline/2
+        ));
+    }
 }
 
 .content__mobile-full-width {
-    @include mq($to: mobileLandscape) {
-        @include rem((
-            margin-left: -($gs-gutter/2),
-            margin-right: -($gs-gutter/2)
-        ));
-    }
-    @include mq($from: mobileLandscape, $to: tablet) {
+    @include rem((
+        margin-left: -($gs-gutter/2),
+        margin-right: -($gs-gutter/2)
+    ));
+    @include mq(mobileLandscape, tablet) {
         @include rem((
             margin-left: -$gs-gutter,
             margin-right: -$gs-gutter
         ));
+    }
+    @include mq(tablet) {
+        margin-left: 0;
+        margin-right: 0;
     }
 }
 
@@ -546,7 +532,7 @@
 }
 
 .drop-cap--wide {
-    @include mq($from: tablet) {
+    @include mq(tablet) {
         float: left;
         display: inline-block;
         text-transform: uppercase;

--- a/common/app/assets/stylesheets/module/_disc.scss
+++ b/common/app/assets/stylesheets/module/_disc.scss
@@ -11,7 +11,6 @@ $disc-respond-when: rightCol;
         padding-top: $gs-baseline/2
     ));
     border-top: 1px solid $c-neutral4;
-    color: $c-neutral1;
 
     @include mq($disc-respond-when) {
         &:first-of-type {

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -1,6 +1,5 @@
 $comment-meta-breakpoint: leftCol;
 $avatarSize: 44px;
-$c-replyText: $c-body;
 
 /* ==========================================================================
    Discussion
@@ -117,7 +116,6 @@ $c-replyText: $c-body;
     &.show-more__container--older,
     &.show-more__container--hidden,
     &.show-more__container--featured {
-        color: $c-neutral1;
         border-top: 1px dotted $c-neutral3;
     }
 }
@@ -268,7 +266,6 @@ $c-replyText: $c-body;
 .d-comment__author,
 .d-comment-box__author {
     @include fs-textsans(4);
-    color: $c-neutral1;
     font-weight: bold;
     display: block;
     overflow: hidden;
@@ -281,7 +278,6 @@ $c-replyText: $c-body;
     @include fs-textsans(1);
     text-transform: uppercase;
     display: block;
-    color: $c-neutral1;
 }
 .d-comment__author-label--staff { display: none; }
 .d-comment--staff .d-comment__author-label--staff { display: block; }
@@ -293,7 +289,6 @@ $c-replyText: $c-body;
 }
 .d-comment__reply-to-author,
 .d-comment-box__reply-to-author {
-    color: $c-neutral1;
     @include fs-textsans(4);
     display: none;
 }
@@ -330,7 +325,6 @@ $c-replyText: $c-body;
 .d-comment__pick {
     white-space: nowrap;
     @include fs-textsans(4);
-    color: $c-neutral1;
     font-weight: bold;
     @include rem((
         margin-bottom: $gs-baseline/6
@@ -357,7 +351,6 @@ $c-replyText: $c-body;
 }
 .d-comment__body {
     @include fs-textsans(4);
-    color: $c-neutral1;
     min-height: 2.5em;
     position: relative;
     z-index: 2;
@@ -628,7 +621,6 @@ $c-replyText: $c-body;
         ));
     }
     .d-comment__body {
-        color: $c-replyText;
         @include rem((
             margin-top: $gs-baseline/3
         ));
@@ -749,7 +741,6 @@ $c-replyText: $c-body;
    ========================================================================== */
 
 .discussion__heading {
-    color: $c-neutral1;
     border-top: 1px solid $c-neutral4;
     margin-bottom: 0;
     @include rem((
@@ -1203,7 +1194,6 @@ $c-replyText: $c-body;
     @include rem((
         margin-bottom: $gs-baseline/2
     ));
-    color: $c-neutral1;
     display: inline-block;
 }
 .d-comment-box__parent-comment-body {

--- a/common/app/assets/stylesheets/module/_gallerythumbs.scss
+++ b/common/app/assets/stylesheets/module/_gallerythumbs.scss
@@ -85,7 +85,7 @@
     @extend %type-7;
     line-height: 16px;
     background-color: #ffffff;
-    color: $c-body !important;
+    color: $c-neutral1 !important;
     position: absolute;
     top: 0;
     left: 0;

--- a/common/app/assets/stylesheets/module/_headline-list.scss
+++ b/common/app/assets/stylesheets/module/_headline-list.scss
@@ -119,7 +119,6 @@
             padding-bottom: ($gs-baseline/3)*7
         ));
         border-top-color: $c-neutral4;
-        color: $c-neutral1;
         @include fs-headline(1);
 
         @include mq(rightCol) {
@@ -193,7 +192,6 @@
 
     .headline-list__body {
         padding-left: 0;
-        color: $c-neutral1;
         @include fs-headline(1);
     }
 

--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -285,7 +285,7 @@
 
 .formstack-count {
     position: absolute;
-    color: $c-body;
+    color: $c-neutral1;
     font-family: $sans-serif;
     @include rem((
         font-size: 13px,

--- a/common/app/assets/stylesheets/module/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/_live-blog.scss
@@ -235,9 +235,6 @@ $block-padding-right: $gs-gutter;
 
 .block.is-key-event {
     border-top: 2px solid $c-neutral1;
-    .block-title {
-        color: $c-neutral1;
-    }
 }
 
 .truncated-block {
@@ -714,8 +711,11 @@ $timeline-width: 14px;
         padding: $gs-baseline/6 0 $gs-baseline/2
     ));
 
+    &,
     &:hover,
+    &:visited,
     &:active {
+        color: $c-neutral1;
         text-decoration: none;
     }
 
@@ -766,7 +766,6 @@ $timeline-width: 14px;
     @include rem((
         width: gs-span(1)
     ));
-    color: $c-neutral1;
     @include fs-data(4);
     font-weight: bold;
 
@@ -788,7 +787,6 @@ $timeline-width: 14px;
 .timeline__title {
     display: table-cell;
     @include fs-textsans(3);
-    color: $c-neutral1;
     border-color: $c-neutral8;
 
     .timeline__link:hover & {

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -27,7 +27,6 @@ $comercial-comp-baseline: 10px;
     width: 100%;
     position: relative;
     background-color: $c-commercial-comp-neutral;
-    color: $c-neutral1;
     text-align: left;
     .container__border {
         border-top: 0;
@@ -146,8 +145,6 @@ $comercial-comp-baseline: 10px;
     @include box-sizing(border-box);
     position: relative;
     padding: 0;
-
-    color: $c-neutral1;
     @include fs-headline(1);
 
     &:nth-child(n + 4) {
@@ -161,7 +158,6 @@ $comercial-comp-baseline: 10px;
     }
 }
 .lineitem__title {
-    color: $c-neutral1;
     @include fs-headline(1);
     font-weight: normal;
     text-overflow: ellipsis;
@@ -170,7 +166,6 @@ $comercial-comp-baseline: 10px;
 }
 .lineitem__description,
 .lineitem__link {
-    color: $c-neutral1;
     @include fs-data(4);
 
     strong {
@@ -179,6 +174,7 @@ $comercial-comp-baseline: 10px;
     }
 }
 .lineitem__link {
+    color: $c-neutral1;
     display: block;
     float: left;
     overflow: hidden;

--- a/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
+++ b/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
@@ -81,7 +81,6 @@
     .across {
         @include f-headline;
     }
-    .across,
     .across__action {
         color: $c-neutral1;
     }

--- a/common/app/assets/stylesheets/module/external/_d2-comments.scss
+++ b/common/app/assets/stylesheets/module/external/_d2-comments.scss
@@ -3,7 +3,6 @@
 
 .d2-comment-embedded {
     background-color: #ffffff;
-    color: $c-neutral1;
     font-family: sans-serif;
     overflow: hidden;
     position: relative;

--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -11,13 +11,9 @@
 
 .from-content-api {
     word-wrap: break-word;
-    @include fs-bodyCopy(3);
 }
 .from-content-api,
 .from-content-api .block-elements {
-
-    color: $c-neutral1;
-
     > p,
     ul,
     ol,
@@ -279,7 +275,6 @@ p + video {
     }
     th {
         font-weight: 600;
-        color: $c-neutral1;
     }
     tbody tr:nth-child(odd) td {
         background-color: darken($c-neutral8, 4%);

--- a/common/app/assets/stylesheets/module/facia/_pagination.scss
+++ b/common/app/assets/stylesheets/module/facia/_pagination.scss
@@ -4,20 +4,20 @@
         margin: $gs-baseline 0
     ));
     text-align: center;
-    @include fs-data(4);
+    @include fs-textsans(4);
     border-top: 1px solid $c-neutral5;
 
     @include mq(leftCol) {
         float: right;
         @include rem((
             width: gs-span(12)
-        ))
+        ));
     }
 
     @include mq(wide) {
         @include rem((
             width: gs-span(13)
-        ))
+        ));
     }
 }
 
@@ -28,11 +28,12 @@
         float: right;
         @include rem((
             width: gs-span(4)
-        ))
+        ));
     }
 }
 
 .pagination__item {
+    color: $c-neutral3;
     display: inline-block;
 }
 
@@ -40,7 +41,7 @@
     float: right;
     text-align: right;
     @include rem((
-        width: 60px
+        width: gs-span(1)
     ));
 }
 
@@ -48,7 +49,7 @@
     float: left;
     text-align: left;
     @include rem((
-        width: 60px
+        width: gs-span(1)
     ));
 }
 
@@ -58,7 +59,11 @@
     ));
 }
 
+.pagination__action--current {
+    font-weight: bold;
+    color: $c-neutral1;
+}
+
 .pagination_legend {
     float: left;
 }
-

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -27,7 +27,7 @@
             @pagination.pages.map{ pageNum =>
                 <li class="pagination__item">
                     @if(pageNum == pagination.currentPage) {
-                        <span class="pagination__action">@pageNum</span>
+                        <span class="pagination__action pagination__action--current">@pageNum</span>
                     } else {
                         <a class="pagination__action @actionClass" data-page="@pageNum" href="@paginated(page.url, pageNum)">@pageNum</a>
                     }


### PR DESCRIPTION
This PR bundles a few changes at once.

**The gist of it:** we won't have to specify the colour c-neutral1 and a default font-size on all of our components anymore. Yey: they now are the default.

There should be no visual changes, aside from pagination tweaks.
### All changes:
- remove `c-body`, set default body colour as `$c-neutral-1`.
- Remove instances where `color: $c-neutral1` is redundant
- typography is now always 16px/24px across all screen sizes. So this is not set at a global level (on body) instead of setting it on `.content` and `.from-content-api`
- same antialias on all the typography (as seen with Chris P) — guss will be updated soon to reflect this change
- pagination UX: states (clickable/not-clickable, current page) are more obvious (design approved by @vilderness) — it's relying on the new default body colour so I bundled this change directly in that PR
- made content css mobile first
## Pagination: before

![before](https://cloud.githubusercontent.com/assets/85783/3133642/7e5a057e-e81c-11e3-8106-a7ebfea5188d.PNG)
## Pagination: after

![after](https://cloud.githubusercontent.com/assets/85783/3133644/81df5e74-e81c-11e3-98d1-2724faea68df.PNG)

![ ](http://gifs.joelglovier.com/silly-animals/gear-up.gif)
