### PR TITLE
Only show two comments on page load

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -346,6 +346,7 @@ Comments.prototype.renderComments = function(resp) {
 Comments.prototype.showHiddenComments = function(e) {
     if (e) { e.preventDefault(); }
     this.removeState('shut');
+    this.removeState('partial');
     this.emit('first-load');
 };
 

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -178,10 +178,8 @@ Loader.prototype.loadComments = function(args) {
 
             if (showComments) {
                 // Comments are being loaded in the no-top-comments-available context
-                bonzo(self.getElem('joinDiscussion')).addClass('u-h');
                 bonzo(self.comments.getElem('header')).removeClass('u-h');
                 self.comments.removeState('shut');
-                self.comments.removeState('partial');
             }
 
             self.on('click', self.getElem('joinDiscussion'), function (e) {

--- a/common/app/assets/javascripts/modules/discussion/top-comments.js
+++ b/common/app/assets/javascripts/modules/discussion/top-comments.js
@@ -106,9 +106,7 @@ TopComments.prototype.fetch = function(parent) {
         function render(resp) {
             // Success: Render Top or Regular comments
             if (resp.currentCommentCount > 0) {
-
                 // Render Top Comments
-
                 self.topCommentsAmount = resp.currentCommentCount;
                 self.parent = parent;
                 self.elem = bonzo.create(resp.html);
@@ -117,13 +115,10 @@ TopComments.prototype.fetch = function(parent) {
                 self.elems = {};
                 self.prerender();
                 self.ready();
-
                 self.mediator.emit('module:topcomments:loadcomments');
             } else {
-
-                $('.discussion__comments--top-comments').remove();
-
                 // Render Regular Comments
+                $('.discussion__comments--top-comments').remove();
                 self.mediator.emit('module:topcomments:loadcomments', { showLoader: true });
             }
         },


### PR DESCRIPTION
Removal of removal of functionality.
Currently, without top comments, all 10 comments show.

Discussions should (and will with this) work as follows:
- [x] If there are top comments hide comments behind "show-more"
- [x] If not, show 2 and the rest behind "show-more"

![Hide the comments](http://goinglikesixty.com/wp-content/uploads/2012/09/dogblanket.gif)
