### PR TITLE
Handle 'Out of page' adverts

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -327,8 +327,8 @@ define([
                             return size[0] + '-' + size[1];
                         }
                     ),
-                    slot = googletag
-                        .defineSlot(adUnit, size, id)
+                    slot = ($adSlot.data('out-of-page')
+                            ? googletag.defineOutOfPageSlot(adUnit, id) : googletag.defineSlot(adUnit, size, id))
                         .addService(googletag.pubads())
                         .defineSizeMapping(sizeMapping)
                         .setTargeting('slot', $adSlot.data('name'));

--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -1,4 +1,4 @@
-@(name: String, adType: String, sizeMapping: Map[String, Seq[String]], showLabel: Boolean = true, refresh: Boolean = true)
+@(name: String, adType: String, sizeMapping: Map[String, Seq[String]], showLabel: Boolean = true, refresh: Boolean = true, outOfPage: Boolean = false)
 
 <div
     id="dfp-ad--@name"
@@ -7,6 +7,7 @@
     data-name="@name"
     @if(!showLabel){ data-label="false" }
     @if(!refresh){ data-refresh="false" }
+    @if(outOfPage){ data-out-of-page="true" }
     @sizeMapping.map{ case(breakpoint, sizes) =>
         data-@breakpoint="@sizes.mkString("|")"
     }></div>

--- a/common/test/assets/javascripts/spec/adverts/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/dfp.spec.js
@@ -35,7 +35,7 @@ define([
                         getSlotId: function() {
                             return {
                                 getDomId: function() {
-                                    return id
+                                    return id;
                                 }
                             }
                         }

--- a/common/test/assets/javascripts/spec/adverts/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/dfp.spec.js
@@ -76,6 +76,7 @@ define([
                     return sizeMapping;
                 },
                 defineSlot: sinon.spy(function() { return window.googletag; }),
+                defineOutOfPageSlot: sinon.spy(function() { return window.googletag; }),
                 addService: sinon.spy(function() { return window.googletag; }),
                 defineSizeMapping: sinon.spy(function() { return window.googletag; }),
                 setTargeting: sinon.spy(function(type, id) { return id; }),
@@ -193,8 +194,22 @@ define([
         });
 
         it('should create ad slot', function() {
-            var adSlot = dfp.createAdSlot('right', 'right-type')
+            var adSlot = dfp.createAdSlot('right', 'right-type');
             expect(adSlot).toBe('<div id="dfp-ad--right" class="ad-slot ad-slot--dfp ad-slot--right-type" data-link-name="ad slot right" data-name="right" data-refresh="true" data-label="true" data-tabletlandscape="300,250|300,600"></div>')
+        });
+
+        it('should be able to create "out of page" ad slot', function() {
+            $('.ad-slot--dfp').first().data('out-of-page', true);
+            dfp.init({
+                page: {
+                    dfpAccountId: 123456,
+                    dfpAdUnitRoot: 'theguardian.com',
+                    isFront: true,
+                    section: ''
+                }
+            });
+            window.googletag.cmd.forEach(function(func) { func(); });
+            expect(window.googletag.defineOutOfPageSlot).toHaveBeenCalledWith('/123456/theguardian.com/front', 'dfp-ad-html-slot');
         });
 
         describe('labelling', function() {

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -10,7 +10,7 @@
 
         @if(faciaPage.hasPageSkin) {
             <div class="page-skin-container">
-                @fragments.commercial.adSlot(name="pageskin-inread", adType="page-skin", sizeMapping=Map("wide" -> Seq("1,1")), showLabel=false, refresh=false)
+                @fragments.commercial.adSlot(name="pageskin-inread", adType="page-skin", sizeMapping=Map("wide" -> Seq("1,1")), showLabel=false, refresh=false, outOfPage=true)
             </div>
         }
 


### PR DESCRIPTION
Page skin adverts are created as 'out of page' adverts in DFP. For these to work we need to call a different GPT method

![1401389934_cute_kid_in_predator_costume](https://cloud.githubusercontent.com/assets/74132/3145964/30d3b046-ea3f-11e3-9886-c6809f7f63e3.gif)
