### PR TITLE
SVG sprite optimisation: urlencoded

### DIFF
--- a/tools/sprites/spricon-phantom.js
+++ b/tools/sprites/spricon-phantom.js
@@ -102,7 +102,7 @@ function processFile() {
                 var width = svgelem.getAttribute( "width" );
                 var height = svgelem.getAttribute( "height" );
 
-                svgdatauri += svgdata;
+                svgdatauri += encodeURIComponent(svgdata);
 
                 //If we want to generate base64 svg css
                 if(generatesvg) {

--- a/tools/sprites/spricon-phantom.js
+++ b/tools/sprites/spricon-phantom.js
@@ -8,7 +8,6 @@
 
 /*global phantom:true*/
 /*global window:true*/
-/*global btoa:true*/
 
 /*
 phantom args sent from app.js:
@@ -90,7 +89,7 @@ function processFile() {
 
                 var page = require( "webpage" ).create();
                 var svgdata = fs.read(  inputdir + theFile ) || "";
-                var svgdatauri = "data:image/svg+xml;base64,";
+                var svgdatauri = "data:image/svg+xml;utf8,";
                 var pngdatauri = "data:image/png;base64,";
 
                 // kill the ".svg" at the end of the filename
@@ -103,13 +102,12 @@ function processFile() {
                 var width = svgelem.getAttribute( "width" );
                 var height = svgelem.getAttribute( "height" );
 
-                // get base64 of svg file
-                svgdatauri += btoa(svgdata);
+                svgdatauri += svgdata;
 
                 //If we want to generate base64 svg css
                 if(generatesvg) {
                     // add rules to svg data css file
-                    datacssrules.push( "    %svg-" + cssprefix + filenamenoext +", .svg-" + cssprefix + filenamenoext +" { background-image: url(" + svgdatauri + "); background-position: 0 0; background-repeat: no-repeat; }\n    .svg ." + cssprefix + filenamenoext + " { @extend %svg-" + cssprefix + filenamenoext +" !optional; }\n" );
+                    datacssrules.push( "    %svg-" + cssprefix + filenamenoext +", .svg-" + cssprefix + filenamenoext +" { background-image: url('" + svgdatauri + "'); background-position: 0 0; background-repeat: no-repeat; }\n    .svg ." + cssprefix + filenamenoext + " { @extend %svg-" + cssprefix + filenamenoext +" !optional; }\n" );
                 }
 
                 // set page viewport size to svg dimensions


### PR DESCRIPTION
Take 2 on the #4381 PR
- Sprites are URLEncoded (should work in all browsers)
- Compiles well on Ruby 1.8.7
### Gains

**Before:**_global-icons-svg-base64.scss 107KB
**After:** _global-icons-svg-utf8.scss 100KB

**Before:**_global-icons-svg-base64.scss.gz 28KB
**After:** _global-icons-svg-utf8.scss.gz 22KB

**Before:** _commercial-icons-svg-base64.scss 31KB
**After:** _commercial-icons-svg-utf8.scss 26KB

**Before:**_commercial-icons-svg-base64.scss.gz 10KB
**After:** _commercial-icons-svg-utf8.scss.gz 6KB

It would be great to have a cross browser testing session on this branch @mstorijo 

![ ](http://gifs.joelglovier.com/oh-shit/refreshing.gif)
