### PR TITLE
reducing depth of css selectors

### DIFF
--- a/commercial/app/views/travelOffersHigh.scala.html
+++ b/commercial/app/views/travelOffersHigh.scala.html
@@ -40,7 +40,7 @@
                                     <img class="lineitem__image" src="@offer.imageUrl" alt="" />
                                 </a>
                                 <div class="lineitem__offer">
-                                    <a class="lineitem__link" href="@AdLink{@offer.offerUrl}" data-link-name="merchandising-travel-v@{version}_@{date}-high-@{offer.title}">
+                                    <a class="lineitem__link lineitem__offer__link" href="@AdLink{@offer.offerUrl}" data-link-name="merchandising-travel-v@{version}_@{date}-high-@{offer.title}">
                                         <h4 class="lineitem__title">@offer.title</h4>
                                         <p class="lineitem__meta">@offer.durationInWords from <span class="lineitem__price">£@offer.fromPrice</span></p>
                                     </a>

--- a/common/app/assets/stylesheets/module/commercial/_travel.scss
+++ b/common/app/assets/stylesheets/module/commercial/_travel.scss
@@ -501,7 +501,7 @@ $c-commercial-travel-dark: #002b6c;
                     ));
                 }
                 
-                .lineitem__offer .lineitem__link {
+                .lineitem__offer__link {
                     width: auto;
                 }
                 


### PR DESCRIPTION
This fixes the issue of excessive depth in the css, (was 5 levels, we should be at a maximum of 4).

As the commercial components across both articles & fronts and have high & low relevance while trying to keep the same html it's tricky to keep the depth down!
