### PR TITLE
Make Masterclass Commercial Components Keyword-specific

### DIFF
--- a/commercial/app/controllers/commercial/MasterClasses.scala
+++ b/commercial/app/controllers/commercial/MasterClasses.scala
@@ -1,48 +1,43 @@
 package controllers.commercial
 
-import play.api.mvc._
 import common.{JsonNotFound, JsonComponent}
-import model.commercial.masterclasses.MasterClassAgent
 import model.Cached
+import model.commercial.masterclasses.{MasterClass, MasterClassAgent}
+import play.api.mvc._
 
 object MasterClasses extends Controller {
 
   implicit val codec = Codec.utf_8
 
-  def renderMasterclass = Action {
+  private def renderMasterclassAction(nilResult: RequestHeader => Result)
+                                     (result: Seq[MasterClass] => RequestHeader => SimpleResult) = Action {
     implicit request =>
       MasterClassAgent.adsTargetedAt(segment) match {
-        case Nil => NotFound
-        case upcoming =>
-          Cached(60)(Ok(views.html.masterclasses(upcoming take 4)))
+        case Nil => nilResult(request)
+        case masterClasses =>
+          Cached(60) {
+            result(masterClasses take 4)(request)
+          }
       }
   }
 
-  def list = Action {
-    implicit request =>
-      MasterClassAgent.adsTargetedAt(segment) match {
-        case Nil => JsonNotFound.apply()
-        case upcoming =>
-          Cached(60)(JsonComponent(views.html.masterclasses(upcoming take 4)))
-      }
+  def renderMasterclass = renderMasterclassAction(implicit request => NotFound) {
+    masterClasses => implicit request =>
+      Ok(views.html.masterclasses(masterClasses))
   }
 
-  def renderMasterclassHigh = Action {
-    implicit request =>
-      MasterClassAgent.adsTargetedAt(segment) match {
-        case Nil => NotFound
-        case upcoming =>
-          Cached(60)(Ok(views.html.masterclassesHigh(upcoming take 4)))
-      }
+  def list = renderMasterclassAction(implicit request => JsonNotFound.apply()(request)) {
+    masterClasses => implicit request =>
+      JsonComponent(views.html.masterclasses(masterClasses))
   }
 
-  def listHigh = Action {
-    implicit request =>
-      MasterClassAgent.adsTargetedAt(segment) match {
-        case Nil => JsonNotFound.apply()
-        case upcoming =>
-          Cached(60)(JsonComponent(views.html.masterclassesHigh(upcoming take 4)))
-      }
+  def renderMasterclassHigh = renderMasterclassAction(implicit request => NotFound) {
+    masterClasses => implicit request =>
+      Ok(views.html.masterclassesHigh(masterClasses))
   }
 
+  def listHigh = renderMasterclassAction(implicit request => JsonNotFound.apply()(request)) {
+    masterClasses => implicit request =>
+      JsonComponent(views.html.masterclassesHigh(masterClasses))
+  }
 }

--- a/commercial/app/controllers/commercial/MasterClasses.scala
+++ b/commercial/app/controllers/commercial/MasterClasses.scala
@@ -11,41 +11,37 @@ object MasterClasses extends Controller {
 
   def renderMasterclass = Action {
     implicit request =>
-      MasterClassAgent.getUpcoming match {
+      MasterClassAgent.adsTargetedAt(segment) match {
         case Nil => NotFound
-        case upcoming => {
+        case upcoming =>
           Cached(60)(Ok(views.html.masterclasses(upcoming take 4)))
-        }
       }
   }
 
   def list = Action {
     implicit request =>
-      MasterClassAgent.getUpcoming match {
+      MasterClassAgent.adsTargetedAt(segment) match {
         case Nil => JsonNotFound.apply()
-        case upcoming => {
+        case upcoming =>
           Cached(60)(JsonComponent(views.html.masterclasses(upcoming take 4)))
-        }
       }
   }
 
   def renderMasterclassHigh = Action {
     implicit request =>
-      MasterClassAgent.getUpcoming match {
+      MasterClassAgent.adsTargetedAt(segment) match {
         case Nil => NotFound
-        case upcoming => {
+        case upcoming =>
           Cached(60)(Ok(views.html.masterclassesHigh(upcoming take 4)))
-        }
       }
   }
 
   def listHigh = Action {
     implicit request =>
-      MasterClassAgent.getUpcoming match {
+      MasterClassAgent.adsTargetedAt(segment) match {
         case Nil => JsonNotFound.apply()
-        case upcoming => {
+        case upcoming =>
           Cached(60)(JsonComponent(views.html.masterclassesHigh(upcoming take 4)))
-        }
       }
   }
 

--- a/commercial/app/model/commercial/Lookup.scala
+++ b/commercial/app/model/commercial/Lookup.scala
@@ -4,11 +4,8 @@ import com.gu.openplatform.contentapi
 import com.gu.openplatform.contentapi.model.Tag
 import common.{Edition, Logging, ExecutionContexts}
 import conf.ContentApi
-import model.commercial.masterclasses.EventbriteMasterClass
 import model.{ImageElement, Content}
 import scala.concurrent.Future
-
-case class MasterClass(eventBriteEvent: EventbriteMasterClass, imageElement: Option[model.ImageElement])
 
 object Lookup extends ExecutionContexts with Logging {
   def thumbnail(contentId: String): Future[Option[ImageElement]] = {

--- a/commercial/app/model/commercial/masterclasses/MasterClass.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClass.scala
@@ -33,7 +33,7 @@ object EventbriteMasterClass {
     val tags = {
       for {
         rawTag <- (block \ "tags").as[String].split(",")
-        tag = rawTag.toLowerCase.replace("course", "").replace("courses", "").trim()
+        tag = rawTag.toLowerCase.replaceAll("courses?", "").trim()
         if tag.nonEmpty && !ignoredTags.exists(tag.contains)
       } yield tag
     }.toSeq

--- a/commercial/app/model/commercial/masterclasses/MasterClass.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClass.scala
@@ -9,9 +9,16 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Element, Document}
 import play.api.libs.json.JsValue
 
+case class MasterClass(eventBriteEvent: EventbriteMasterClass, imageElement: Option[model.ImageElement]) extends Ad {
+
+  def isTargetedAt(segment: Segment) = eventBriteEvent.isTargetedAt(segment)
+}
+
 object EventbriteMasterClass {
   private val datePattern: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")
   private val guardianUrlLinkText = "Full course and returns information on the Masterclasses website"
+
+  private val ignoredTags = Seq("masterclass", "short")
 
   def apply(block: JsValue): Option[EventbriteMasterClass] = {
     val id = (block \ "id").as[Long]
@@ -26,8 +33,8 @@ object EventbriteMasterClass {
     val tags = {
       for {
         rawTag <- (block \ "tags").as[String].split(",")
-        tag = rawTag.toLowerCase.trim()
-        if tag.nonEmpty && !tag.contains("masterclass")
+        tag = rawTag.toLowerCase.replace("course", "").replace("courses", "").trim()
+        if tag.nonEmpty && !ignoredTags.exists(tag.contains)
       } yield tag
     }.toSeq
 

--- a/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
@@ -1,40 +1,35 @@
 package model.commercial.masterclasses
 
 import common.{AkkaAgent, ExecutionContexts, Logging}
+import model.ImageElement
+import model.commercial.{Segment, AdAgent, Lookup}
 import org.joda.time.DateTime
 import scala.concurrent.Future
-import model.commercial.{MasterClass, Lookup}
-import model.ImageElement
-import play.api.Play
-import play.api.Play.current
+import scala.concurrent.duration._
 
+object MasterClassAgent extends AdAgent[MasterClass] with ExecutionContexts {
 
-object MasterClassAgent extends Logging with ExecutionContexts {
-
-  private val placeholder = {
+  val placeholder = {
     val masterClass1 = MasterClass(EventbriteMasterClass("1", "MasterClass A", new DateTime(),
       "http://www.theguardian.com", "Description of MasterClass A", "Live", Venue(), Ticket(1.0) :: Nil, 1,
       "http://www.theguardian.com", tags = Nil), None)
-    val masterClass2 = MasterClass(masterClass1.eventBriteEvent.copy(name = "MasterClass B", description = "MasterClass with multiple tickets", tickets = List(Ticket(1.0), Ticket(5.0))), None)
-    val masterClass3 = MasterClass(masterClass1.eventBriteEvent.copy(name = "Guardian MasterClass C", description = "Description of MasterClass C"), None)
+    val masterClass2 = MasterClass(masterClass1.eventBriteEvent.copy(name = "MasterClass B",
+      description = "MasterClass with multiple tickets", tickets = List(Ticket(1.0), Ticket(5.0))), None)
+    val masterClass3 = MasterClass(masterClass1.eventBriteEvent.copy(name = "Guardian MasterClass C",
+      description = "Description of MasterClass C"), None)
     Seq(masterClass1, masterClass2, masterClass3)
   }
 
-  private lazy val agent = AkkaAgent[Seq[MasterClass]](Nil)
+  updateCurrentAds(placeholder)
 
-  agent send placeholder
+  override def defaultAds = currentAds take 4
 
-  def getUpcoming: Seq[MasterClass] = {
-    agent.get()
+  override def adsTargetedAt(segment: Segment) = {
+    super.adsTargetedAt(segment).sortBy(_.eventBriteEvent.startDate.getMillis)
   }
 
   def wrapEventbriteWithContentApi(eventbriteEvents: Seq[EventbriteMasterClass]): Future[Seq[MasterClass]] = {
-    var results = eventbriteEvents
-    if (Play.isDev) {
-      results = eventbriteEvents.takeRight(10)
-    }
-
-    val seqThumbs: Seq[Future[MasterClass]] = results.map {
+    val seqThumbs: Seq[Future[MasterClass]] = eventbriteEvents.map {
       event =>
         val contentId: String = event.guardianUrl.replace("http://www.theguardian.com/", "")
         val thumbnail: Future[Option[ImageElement]] = Lookup.thumbnail(contentId)
@@ -50,23 +45,66 @@ object MasterClassAgent extends Logging with ExecutionContexts {
   }
 
   def refresh() {
+
+    def populateKeywordIds(events: Seq[EventbriteMasterClass]):Seq[EventbriteMasterClass] = {
+      val populated = events map { event =>
+        val eventKeywordIds = event.tags.flatMap(MasterClassTagsAgent.forTag).distinct
+        event.copy(keywordIds = eventKeywordIds)
+      }
+
+      val unpopulated = populated.filter(_.keywordIds.isEmpty)
+      if (unpopulated.nonEmpty) {
+        val unpopulatedString = unpopulated.map { event =>
+          event.name + ": tags(" + event.tags.mkString(", ") + ")"
+        }.mkString("; ")
+        log.info(s"No keywords for these master classes: $unpopulatedString")
+      }
+
+      populated
+    }
+
     for {
       eventBrite <- EventbriteApi.loadAds()
-      masterclasses <- wrapEventbriteWithContentApi(eventBrite.filter(_.isOpen))
+      masterclasses <- wrapEventbriteWithContentApi(populateKeywordIds(eventBrite.filter(_.isOpen)))
     } {
-      log.info("Updating Masterclass agent")
-      agent send { oldMasterclasses =>
-        if(masterclasses.nonEmpty) {
-          masterclasses
-        } else {
-          oldMasterclasses
+      updateCurrentAds(masterclasses)
+    }
+  }
+}
+
+
+object MasterClassTagsAgent extends ExecutionContexts with Logging {
+
+  private lazy val tagKeywordIds = AkkaAgent(Map.empty[String, Seq[String]])
+
+  private val defaultTags = Seq(
+    "creative writing",
+    "journalism",
+    "photography",
+    "travel"
+  )
+
+  def refresh(): Future[Seq[Future[Map[String, Seq[String]]]]] = {
+    val tags = {
+      val currentAds = MasterClassAgent.currentAds
+      if (currentAds == MasterClassAgent.placeholder) {
+        defaultTags
+      } else {
+        currentAds.flatMap(_.eventBriteEvent.tags).distinct
+      }
+    }
+    Future.sequence {
+      tags map { tag =>
+        Lookup.keyword("\"" + tag + "\"") map { keywords =>
+          tagKeywordIds.alter(_.updated(tag, keywords.map(_.id)))(2.seconds)
         }
       }
     }
   }
 
   def stop() {
-    agent.close()
+    tagKeywordIds.close()
   }
 
+  def forTag(name: String) = tagKeywordIds().get(name).getOrElse(Nil)
 }

--- a/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
@@ -14,7 +14,7 @@ object MasterClassAgent extends Logging with ExecutionContexts {
   private val placeholder = {
     val masterClass1 = MasterClass(EventbriteMasterClass("1", "MasterClass A", new DateTime(),
       "http://www.theguardian.com", "Description of MasterClass A", "Live", Venue(), Ticket(1.0) :: Nil, 1,
-      "http://www.theguardian.com"), None)
+      "http://www.theguardian.com", tags = Nil), None)
     val masterClass2 = MasterClass(masterClass1.eventBriteEvent.copy(name = "MasterClass B", description = "MasterClass with multiple tickets", tickets = List(Ticket(1.0), Ticket(5.0))), None)
     val masterClass3 = MasterClass(masterClass1.eventBriteEvent.copy(name = "Guardian MasterClass C", description = "Description of MasterClass C"), None)
     Seq(masterClass1, masterClass2, masterClass3)

--- a/commercial/app/views/masterclasses.scala.html
+++ b/commercial/app/views/masterclasses.scala.html
@@ -1,4 +1,4 @@
-@(events: Seq[model.commercial.MasterClass])(implicit request: RequestHeader)
+@(events: Seq[model.commercial.masterclasses.MasterClass])(implicit request: RequestHeader)
 
 @import conf.Configuration
 

--- a/commercial/app/views/masterclassesHigh.scala.html
+++ b/commercial/app/views/masterclassesHigh.scala.html
@@ -1,4 +1,4 @@
-@(events: Seq[model.commercial.MasterClass])(implicit request: RequestHeader)
+@(events: Seq[model.commercial.masterclasses.MasterClass])(implicit request: RequestHeader)
 
 @import conf.Configuration
 

--- a/commercial/test/model/commercial/masterclasses/SingleEventbriteMasterClassParsingTest.scala
+++ b/commercial/test/model/commercial/masterclasses/SingleEventbriteMasterClassParsingTest.scala
@@ -52,6 +52,13 @@ class SingleEventbriteMasterClassParsingTest extends FlatSpec with Matchers {
     result.displayPrice should be ("£400.00 to £2,600.00")
   }
 
+  "MasterClass companion object" should "handle tags" in {
+    val event = Json.parse(json)
+    val tags = EventbriteMasterClass(event).get.tags
+
+    tags should be(Seq("travel", "travel writing", "short course"))
+  }
+
   "Generated masterclass object" should "have a desription text that is truncated to 250 chars" in {
     val event: JsValue = Json.parse(json)
 

--- a/commercial/test/model/commercial/masterclasses/SingleEventbriteMasterClassParsingTest.scala
+++ b/commercial/test/model/commercial/masterclasses/SingleEventbriteMasterClassParsingTest.scala
@@ -56,7 +56,7 @@ class SingleEventbriteMasterClassParsingTest extends FlatSpec with Matchers {
     val event = Json.parse(json)
     val tags = EventbriteMasterClass(event).get.tags
 
-    tags should be(Seq("travel", "travel writing", "short course"))
+    tags should be(Seq("travel", "travel writing"))
   }
 
   "Generated masterclass object" should "have a desription text that is truncated to 250 chars" in {

--- a/commercial/test/services/CommercialHealthcheckTest.scala
+++ b/commercial/test/services/CommercialHealthcheckTest.scala
@@ -1,10 +1,3 @@
 package services
 
-import model.commercial.masterclasses.MasterClassAgent
-
-class CommercialHealthcheckTest extends HealthcheckTest("/commercial/masterclasses?s=music") {
-
-  override def prepareForTest() {
-    MasterClassAgent.getUpcoming
-  }
-}
+class CommercialHealthcheckTest extends HealthcheckTest("/commercial/masterclasses.json")


### PR DESCRIPTION
This change should make masterclass ads more specific to the current page.

Four classes will be shown; if there aren't enough classes matching current keywords the list will be filled by drawing from upcoming classes of any type.
