### PR TITLE
Basic styling of commercial components on page skin fronts

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -190,6 +190,16 @@
     @include rem((
         margin-top: $gs-baseline
     ));
+
+    @include mq(wide) {
+        .has-page-skin & {
+            margin-left: auto;
+            margin-right: auto;
+            @include rem((
+                width: gs-span(12) + ($gs-gutter*2)
+            ));
+        }
+    }
 }
 .ad-slot--commercial-component-high {
     display: none;

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -2,7 +2,7 @@ $c-commercial-comp-neutral: #edede7;
 $comercial-comp-baseline: 10px;
 
 .l-footer {
-    margin-top: 0;
+    margin-top: 0 !important;
 }
 .facia-container--layout-front .commercial {
     padding: 0;

--- a/common/app/assets/stylesheets/module/commercial/_jobs.scss
+++ b/common/app/assets/stylesheets/module/commercial/_jobs.scss
@@ -262,6 +262,10 @@
                 margin-right: $gs-gutter/2
             ));
         }
+
+        .has-page-skin & .commercial--jobs__job:nth-child(n+2) {
+            display: none;
+        }
     }
 }
 /* article */

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -93,7 +93,7 @@
                 margin-left: auto;
                 margin-right: auto;
                 @include rem((
-                    width: gs-span(12) + $gs-gutter
+                    width: gs-span(12) + ($gs-gutter*2)
                 ));
             }
             .facia-container__inner {


### PR DESCRIPTION
This will need further work, mainly to see if it's viable to maintain page skin versions of the commercial components

![screen shot 2014-06-03 at 15 57 55](https://cloud.githubusercontent.com/assets/74132/3161852/ec2559f8-eb2f-11e3-80a0-07d832a76d55.png)
