### PR TITLE
additional variants styling

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
+++ b/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
@@ -29,7 +29,7 @@
         display: block;
     }
     .linkslist__item {
-        border-top: 0px solid #000000;
+      border-top-width: 0;
     }
     .across__title {
         border-top: 1px solid $c-neutral5;
@@ -55,7 +55,7 @@
     }
     .linkslist__image-container {
         display: none;
-        @include mq($from: desktop){
+        @include mq(desktop) {
             display: block;
         }
     }

--- a/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
+++ b/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
@@ -28,6 +28,12 @@
     .across__title__action {
         display: block;
     }
+    .linkslist__item {
+        border-top: 0px solid #000000;
+    }
+    .across__title {
+        border-top: 1px solid $c-neutral5;
+    }
 }
 
 .container--acrossthegrauniad-variant-3col1storythumb {
@@ -36,14 +42,22 @@
         display: block;
     }
     .across__action {
-        @include rem((
-            padding-left: 98px
-        ));
+        @include mq(desktop) {
+            @include rem((
+                padding-left: 98px
+            ));
+        }
     }
     .across__item {
         @include rem((
             margin-bottom: $gs-baseline/2
         ));
+    }
+    .linkslist__image-container {
+        display: none;
+        @include mq($from: desktop){
+            display: block;
+        }
     }
 }
 .container--acrossthegrauniad-variant-3col2stories {
@@ -52,9 +66,10 @@
     }
 }
 
-@include guss-columns($base-class: '.across--columns', $column-min-width: gs-span(4) + $gs-gutter, $column-rule: 1px solid $c-neutral5);
+@include guss-columns($base-class: '.across--columns', $column-min-width: gs-span(4) + $gs-gutter, $column-rule: 0px solid $c-neutral5);
 
 .across--columns__item {
+    border-top: 1px solid $c-neutral5;
     @include rem((
         margin-top: $gs-baseline/4,
         margin-bottom: get-line-height($fs-headlines, 1)
@@ -83,8 +98,6 @@
     }
     .across__action {
         color: $c-neutral1;
-    }
-    .across__action {
         &:visited {
             color: $c-neutral2;
         }


### PR DESCRIPTION
- borders on top of sections instead of stories
  ![screen shot 2014-06-03 at 16 22 56](https://cloud.githubusercontent.com/assets/1492162/3162227/21e4811a-eb33-11e3-8100-5f8906d47f61.png)
- hide images for 3col1storiesThumb for tablet width and less
  ![screen shot 2014-06-03 at 16 27 07](https://cloud.githubusercontent.com/assets/1492162/3162266/8d343d5c-eb33-11e3-9416-ccbec4da0e5f.png)
  ![screen shot 2014-06-03 at 16 26 59](https://cloud.githubusercontent.com/assets/1492162/3162267/8d4754be-eb33-11e3-8ee8-6064c0bbeb18.png)
  ![screen shot 2014-06-03 at 16 26 38](https://cloud.githubusercontent.com/assets/1492162/3162268/8d49a14c-eb33-11e3-9a29-5f805d119528.png)
