### PR TITLE
Remove x/section types from the tool

### DIFF
--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -8,14 +8,11 @@ define(['knockout'], function(ko) {
             {name: 'news/auto'},
             {name: 'news/most-popular'},
             {name: 'news/people'},
-            {name: 'news/section'},
             {name: 'news/special'},
             {name: 'features'},
             {name: 'features/auto'}, // Behind FeaturesAutoContainerSwitch
             {name: 'features/multimedia'},
-            {name: 'features/section'},
-            {name: 'comment/comment-and-debate'},
-            {name: 'comment/section'}
+            {name: 'comment/comment-and-debate'}
         ],
 
         detectPressFailureMs: 10000,


### PR DESCRIPTION
Editors do not use these container skins anymore. This is just making sure they won't in the next few days (when I'll remove the code for these skins in the templates).

![ ](http://gifs.joelglovier.com/lolwat/boom.gif)
