### PR TITLE
Show more replies work again

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -320,7 +320,7 @@ Comments.prototype.fetchComments = function(options) {
  */
 Comments.prototype.renderComments = function(resp) {
     var html = bonzo.create(resp.html),
-        comments = qwery(this.getClass('jsContent'), html);
+        content = qwery(this.getClass('jsContent'), html);
 
     // Stop duplication in new comments section
     qwery(this.getClass('comment'), this.getElem('newComments')).forEach(function(comment) {
@@ -330,8 +330,10 @@ Comments.prototype.renderComments = function(resp) {
         }
     });
 
-    $(this.getClass('jsContent'), this.elem).replaceWith(comments);
-    this.addMoreRepliesButtons(comments);
+    $(this.getClass('jsContent'), this.elem).replaceWith(content);
+    this.addMoreRepliesButtons(qwery(
+        this.getClass('comment'), content
+    ));
 
     if (!this.isReadOnly()) {
         RecommendComments.init(this.context);
@@ -362,21 +364,20 @@ Comments.prototype.addMoreRepliesButtons = function (comments) {
             renderedReplies = qwery(self.getClass('reply'), elem);
 
         if (renderedReplies.length < replies) {
+            var numHiddenReplies = replies - renderedReplies.length,
+                showButtonHtml = '<li>'+
+                    '<span><i class="i i-plus-white-small"></i></span>'+
+                    'Show '+ numHiddenReplies +' more '+ (numHiddenReplies === 1 ? 'reply' : 'replies')+
+                '</li>';
 
-            var numHiddenReplies = replies - renderedReplies.length;
-
-            var showButton = '';
-            showButton += '<li class="' + self.getClass('showReplies', true) + '" ';
-            showButton += 'data-link-name="Show more replies" ';
-            showButton += 'data-is-ajax data-comment-id="' + elem.getAttribute('data-comment-id') + '">';
-            showButton += '<span><i class="i i-plus-white-small"></i></span>';
-            showButton += 'Show ' + numHiddenReplies + ' more ' + (numHiddenReplies === 1 ? 'reply' : 'replies');
-            showButton += '</li>';
-
-            showButton = bonzo.create(showButton);
-            bonzo(showButton).data('source-comment', elem);
-
-            bonzo(qwery('.d-thread--responses', elem)).append(showButton);
+            $.create(showButtonHtml)
+                .addClass(self.getClass('showReplies', true))
+                .data('source-comment', elem)
+                .attr({
+                    'data-link-name': 'Show more replies',
+                    'data-is-ajax': '',
+                    'data-comment-id': elem.getAttribute('data-comment-id')
+                }).appendTo($('.d-thread--responses', elem));
         }
     });
 };


### PR DESCRIPTION
When re-rendering comments (e.g. changing page/order) - the show more replies link disappears.
It now no longer does.

![showmorereplies](https://cloud.githubusercontent.com/assets/31692/3172234/3f328b14-ebd2-11e3-8ceb-d7e0229676fb.png)
