### PR TITLE
Replies to user's comments on profile page

### DIFF
--- a/common/app/assets/javascripts/modules/component.js
+++ b/common/app/assets/javascripts/modules/component.js
@@ -2,12 +2,16 @@ define([
     'bean',
     'qwery',
     'bonzo',
-    'common/utils/ajax'
+    'common/utils/ajax',
+    'lodash/objects/assign',
+    'lodash/objects/clone'
 ], function(
     bean,
     qwery,
     bonzo,
-    ajax
+    ajax,
+    assign,
+    clone
     ) {
 
     /**
@@ -321,11 +325,7 @@ define([
      * @param {Object} options
      */
     Component.prototype.setOptions = function(options) {
-        options = options || {};
-        this.options = {};
-        for (var prop in this.defaultOptions) {
-            this.options[prop] = options.hasOwnProperty(prop) ? options[prop] : this.defaultOptions[prop];
-        }
+        this.options = assign(clone(this.defaultOptions), this.options||{}, options);
     };
 
     /**

--- a/common/app/assets/stylesheets/module/_disc.scss
+++ b/common/app/assets/stylesheets/module/_disc.scss
@@ -1,16 +1,21 @@
+/* ==========================================================================
+   Discussion
+   ========================================================================== */
 $disc-respond-when: rightCol;
+$disc-avatar-size: 44px;
 .disc-discussions {
     margin: 0;
 }
 .disc-discussion {}
 
+/* ==========================================================================
+   Comment
+   ========================================================================== */
 .disc-comment {
     @include fs-textsans(4);
     @include rem((
-        padding-bottom: $gs-baseline/2,
-        padding-top: $gs-baseline/2
+        padding-bottom: $gs-baseline/2
     ));
-    border-top: 1px solid $c-neutral4;
 
     @include mq($disc-respond-when) {
         &:first-of-type {
@@ -30,31 +35,31 @@ $disc-respond-when: rightCol;
     }
 }
 .disc-comment__date-published {
-    @include mq($disc-respond-when) {
-        display: block;
-    }
+    @include fs-textsans(1);
+    display: block;
 }
 .disc-comment__permalink {
     color: $c-neutral2;
 }
 .disc-comment__recommend {
-    display: inline-block;
-    cursor: default;
-    float: right;
-    width: auto;
+    @include rem((
+        top: $gs-baseline/2
+    ));
 
-    @include mq($disc-respond-when) {
-        @include rem((
-            margin-top: $gs-baseline/2
-        ));
-        display: block;
-    }
+    cursor: default;
+    position: absolute;
+    right: 0;
+    width: auto;
 }
 .disc-comment__recommend-count {
     @include rem((
         margin-right: $gs-gutter/4
     ));
     display: inline-block;
+
+    .disc-comment__recommend--active & {
+        color: $c-commentDefault;
+    }
 }
 .disc-comment__recommend-button {
     @include border-radius(18px);
@@ -69,17 +74,12 @@ $disc-respond-when: rightCol;
     .i {
         vertical-align: middle;
     }
-}
-.disc-comment__recommend--open {
-    .disc-comment__recommend-button {
+
+    .disc-comment__recommend--open & {
         background-color: $c-newsDefault;
     }
-}
-.disc-comment__recommend--active {
-    .disc-comment__recommend-count {
-        color: $c-commentDefault;
-    }
-    .disc-comment__recommend-button {
+
+    .disc-comment__recommend--active & {
         background-color: $c-commentDefault;
     }
 }
@@ -89,17 +89,144 @@ $disc-respond-when: rightCol;
         margin-bottom: $gs-baseline
     ));
 
-    @include mq($disc-respond-when) {
-        @include rem((
-            width: gs-span(8)
-        ));
-    }
-
     blockquote {
         @include rem((
             margin: $gs-baseline $gs-gutter,
             padding-left: $gs-gutter/2
         ));
         border-left: 3px solid transparentize($c-neutral1, .75);
+    }
+}
+
+
+/* ==========================================================================
+   Profile
+   ========================================================================== */
+.disc-profile {
+    @include fs-textsans(4);
+}
+.disc-profile__avatar {
+    @include border-radius($gs-gutter*4);
+    @include rem((
+        height: $disc-avatar-size,
+        width: $disc-avatar-size
+    ));
+    float: left;
+    overflow: hidden;
+}
+.disc-profile__avatar-image {
+    height: 100%;
+    width: 100%;
+}
+.disc-profile__user-info {
+    @include rem((
+        padding-left: $disc-avatar-size+($gs-gutter/2)
+    ));
+}
+.disc-profile__badges {
+    @include fs-textsans(1);
+    text-transform: uppercase;
+}
+.disc-profile__date {
+    @include fs-textsans(1);
+    color: $c-neutral2-contrasted;
+}
+
+
+/* ==========================================================================
+   Activity stream
+   ========================================================================== */
+.activity-stream {
+    @include rem((
+        margin-left: $gs-gutter,
+        margin-right: $gs-gutter
+    ));
+}
+.activity-stream--loading:after {
+    @include fs-textsans(4);
+    @include rem((
+        min-height: $gs-baseline*20,
+        padding-top: $gs-baseline*2
+    ));
+    content: 'Loading comments…';
+    display: block;
+    text-align: center;
+}
+.activity-stream__item {
+    @include rem((
+        padding-bottom: $gs-baseline/2,
+        padding-top: $gs-baseline/2
+    ));
+    border-top: 1px solid $c-neutral4;
+}
+.activity-item__title {
+    @include fs-header(2);
+    @include rem((
+        margin-bottom: $gs-baseline
+    ));
+    font-weight: normal;
+
+    @include mq(leftCol) {
+        @include fs-header(1, true);
+        @include rem((
+            margin-right: $gs-gutter,
+            width: $a-leftCol-width
+        ));
+        float: left;
+        position: relative;
+        z-index: 1;
+    }
+
+    @include mq(wide) {
+        @include rem((
+            width: $a-leftColWide-width
+        ));
+    }
+}
+.activity-item__content {
+    position: relative;
+
+    @include mq(leftCol) {
+        @include rem((
+            margin-left: $a-leftCol-width+$gs-gutter
+        ));
+    }
+
+    @include mq(wide) {
+        @include rem((
+            margin-left: $a-leftColWide-width+$gs-gutter
+        ));
+    }
+}
+.activity-item__content-meta {
+    @include fs-textsans(4);
+
+    @include mq($disc-respond-when) {
+        @include rem((
+            width: gs-span(2.5)
+        ));
+        float: left;
+    }
+}
+.activity-item__content-body {
+    @include mq($disc-respond-when) {
+        @include rem((
+            margin-left: gs-span(2.5)+$gs-gutter,
+            margin-right: $gs-gutter*3
+        ));
+    }
+}
+
+.activity-stream--discussions {
+    .activity-item__content {
+        @include rem((
+            padding-top: $gs-baseline/2
+        ));
+        border-top: 1px solid $c-neutral4;
+    }
+
+    .activity-item__content--no-border {
+        border-top: 0 none;
+        padding-top: 0;
     }
 }

--- a/common/app/assets/stylesheets/module/_identity.scss
+++ b/common/app/assets/stylesheets/module/_identity.scss
@@ -35,6 +35,13 @@
     max-width: none;
 }
 
+.identity-header {
+    @include rem((
+        margin-left: $gs-gutter,
+        margin-right: $gs-gutter
+    ));
+}
+
 .identity-section {
     border-top: 1px solid $c-neutral7;
     @include box-sizing(border-box);
@@ -321,11 +328,6 @@
 
 /* Public Profile Page
    ========================================================================== */
-.activity-stream {
-    @include rem((
-        margin-top: -$gs-baseline*2
-    ));
-}
 .identity-public-profile {
     .identity-section__text {
         white-space: pre-line;
@@ -335,5 +337,11 @@
 .facia-container--layout-identity {
     .facia-container__inner {
         margin-bottom: 0;
+    }
+}
+
+.tabs--identity {
+    .tabs__tab--selected {
+        border-top-color: $c-newsAccent;
     }
 }

--- a/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
+++ b/common/app/assets/stylesheets/module/containers/_acrossthegrauniad.scss
@@ -29,7 +29,7 @@
         display: block;
     }
     .linkslist__item {
-      border-top-width: 0;
+        border-top-width: 0;
     }
     .across__title {
         border-top: 1px solid $c-neutral5;

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -32,7 +32,8 @@ GET         /discussion/$order<(oldest|newest)>/$discussionKey</?p/\w+>.json    
 GET         /discussion/$discussionKey</?p/\w+>                                                                      controllers.DiscussionApp.comments(discussionKey: discussion.model.DiscussionKey, order: String = "newest")
 GET         /discussion/$order<(oldest|newest)>/$discussionKey</?p/\w+>                                              controllers.DiscussionApp.comments(discussionKey: discussion.model.DiscussionKey, order: String)
 
-GET         /discussion/profile/:id/discussions.json                                                                    controllers.DiscussionApp.profileDiscussions(id: String)
+GET         /discussion/profile/:id/discussions.json                                                                 controllers.DiscussionApp.profileDiscussions(id: String)
+GET         /discussion/profile/:id/replies.json                                                                 controllers.DiscussionApp.profileReplies(id: String)
 
 GET         /open/cta/article/*discussionKey.json                                                                    controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
 

--- a/discussion/app/controllers/ProfileActivityController.scala
+++ b/discussion/app/controllers/ProfileActivityController.scala
@@ -8,10 +8,18 @@ trait ProfileActivityController extends DiscussionController {
 
   def profileDiscussions(userId: String) = Action.async { implicit request =>
     val page = request.getQueryString("page") getOrElse "1"
-    val order = request.getQueryString("orderBy") getOrElse "newest"
-    discussionApi.profileDiscussions(userId, page, order) map { profileDiscussions =>
+    discussionApi.profileDiscussions(userId, page) map { profileDiscussions =>
       Cached(60) {
         JsonComponent("html" -> views.html.profileActivity.discussions(profileDiscussions))
+      }
+    }
+  }
+
+  def profileReplies(userId: String) = Action.async { implicit request =>
+    val page = request.getQueryString("page") getOrElse "1"
+    discussionApi.profileReplies(userId, page) map { profileDiscussions =>
+      Cached(60) {
+        JsonComponent("html" -> views.html.profileActivity.replies(profileDiscussions))
       }
     }
   }

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -81,13 +81,23 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
     }
   }
 
-  def profileDiscussions(userId: String, page: String, orderBy: String = "newest"): Future[ProfileDiscussions] = {
+  def profileDiscussions(userId: String, page: String): Future[ProfileDiscussions] = {
     def onError(r: Response) =
       s"Discussion API: Error loading discussions for User $userId, status: ${r.status}, message: ${r.statusText}, response: ${r.body}"
-    val apiUrl = s"$apiRoot/profile/$userId/discussions?pageSize=$pageSize&page=$page&orderBy=$orderBy&showSwitches=true"
+    val apiUrl = s"$apiRoot/profile/$userId/discussions?pageSize=$pageSize&page=$page&orderBy=newest&showSwitches=true"
 
     getJsonOrError(apiUrl, onError) map {
       json => ProfileDiscussions(json)
+    }
+  }
+
+  def profileReplies(userId: String, page: String): Future[ProfileReplies] = {
+    def onError(r: Response) =
+      s"Discussion API: Error loading replies for User $userId, status: ${r.status}, message: ${r.statusText}, response: ${r.body}"
+    val apiUrl = s"$apiRoot/profile/$userId/replies?pageSize=$pageSize&page=$page&orderBy=newest&showSwitches=true"
+
+    getJsonOrError(apiUrl, onError) map {
+      json => ProfileReplies(json)
     }
   }
 

--- a/discussion/app/discussion/model/Comment.scala
+++ b/discussion/app/discussion/model/Comment.scala
@@ -30,7 +30,7 @@ case class BlankComment() extends Comment{
   val id: Int = 0
   val body: String = ""
   val responses: Seq[Comment] = Nil
-  val profile: Profile = Profile("", "", "", isStaff = false, isContributor = false, None)
+  val profile: Profile = Profile("", "", "", "", isStaff = false, isContributor = false, None)
   val discussion: Discussion = Discussion.empty
   val date: DateTime = new DateTime()
   val isHighlighted: Boolean = false

--- a/discussion/app/discussion/model/Profile.scala
+++ b/discussion/app/discussion/model/Profile.scala
@@ -6,6 +6,7 @@ import play.api.libs.json.{JsObject, JsValue}
 case class Profile(
   userId: String,
   avatar: String,
+  secureAvatar: String,
   displayName: String,
   isStaff: Boolean = false,
   isContributor: Boolean = false,
@@ -13,7 +14,7 @@ case class Profile(
 )
 
 object Profile {
-  lazy val empty = Profile("", "", "")
+  lazy val empty = Profile("", "", "", "")
 
   def apply(json: JsValue): Profile = {
     val profileJson = json \ "userProfile"
@@ -21,6 +22,7 @@ object Profile {
     Profile(
       userId = (profileJson \ "userId").as[String],
       avatar = (profileJson \ "avatar").as[String],
+      secureAvatar = (profileJson \ "secureAvatarUrl").as[String],
       displayName = (profileJson \ "displayName").as[String],
       isStaff = badges.exists(_.as[String] == "Staff"),
       isContributor = badges.exists(_.as[String] == "Contributor"),

--- a/discussion/app/discussion/model/comments.scala
+++ b/discussion/app/discussion/model/comments.scala
@@ -62,8 +62,7 @@ case class ProfileDiscussions(
   profile: Profile,
   discussions: Seq[DiscussionComments]
 )
-
-object ProfileDiscussions{
+object ProfileDiscussions {
 
   def apply(json: JsValue): ProfileDiscussions = {
     val profile = Profile(json)
@@ -83,6 +82,24 @@ object ProfileDiscussions{
     ProfileDiscussions(
       profile = profile,
       discussions = discussions
+    )
+  }
+}
+
+case class ProfileReplies(
+  profile: Profile,
+  comments: Seq[Comment]
+)
+object ProfileReplies {
+
+  def apply(json: JsValue): ProfileReplies = {
+    val profile = Profile(json)
+    val comments = (json \ "comments").as[JsArray].value map { c =>
+      Comment(c, None, None)
+    }
+    ProfileReplies(
+      profile = profile,
+      comments = comments
     )
   }
 }

--- a/discussion/app/views/profileActivity/comment.scala.html
+++ b/discussion/app/views/profileActivity/comment.scala.html
@@ -15,7 +15,6 @@
     </div>
 
     <div class="disc-comment__body" itemprop="text">
-        <p>Maybe it was a little easier observing politics from a distance, but Tony Blair was never too difficult to figure out. You only had to look at his closest friends and cronies to wonder. With the exception of his Sedgefield constituency agent, all his friends were either aristos or the super rich. For a Labour Party leader, he seemed very ill at ease around working class people. Both he and the queen took a picture with a working class person in their home around the turn of the century. The queen for more at ease than the Labour prime minister. Remember, he lied about being a Newcastle United fan and standing on the terraces to watch Jackie Milburn. Even from these little vignettes you suspected he was a fraud. It isn't much of a stretch to see where his life is now. He was born into a Scottish Tory Family ( a fact he tried desperately to hide ) and he was a Tory himself right from the off.</p>
         @withJsoup(BulletCleaner(comment.body))(
             InBodyLinkCleaner("in body link")(Edition(request))
         )

--- a/discussion/app/views/profileActivity/comment.scala.html
+++ b/discussion/app/views/profileActivity/comment.scala.html
@@ -1,0 +1,22 @@
+@(comment: Comment, canRecommend: Boolean = false)(implicit request: RequestHeader)
+<div class="disc-comment u-cf">
+    <div class="disc-comment__meta u-cf">
+        <button
+            class="disc-comment__recommend u-button-reset @if(canRecommend){js-disc-recommend-comment}"
+            data-comment-id="@comment.id">
+            <div class="disc-comment__recommend-count js-disc-recommend-count">
+                @comment.numRecommends
+            </div>
+            <div class="disc-comment__recommend-button js-disc-recommend-button">
+                <i class="i i-recommend"></i>
+            </div>
+        </button>
+    </div>
+
+    <div class="disc-comment__body" itemprop="text">
+        <p>Maybe it was a little easier observing politics from a distance, but Tony Blair was never too difficult to figure out. You only had to look at his closest friends and cronies to wonder. With the exception of his Sedgefield constituency agent, all his friends were either aristos or the super rich. For a Labour Party leader, he seemed very ill at ease around working class people. Both he and the queen took a picture with a working class person in their home around the turn of the century. The queen for more at ease than the Labour prime minister. Remember, he lied about being a Newcastle United fan and standing on the terraces to watch Jackie Milburn. Even from these little vignettes you suspected he was a fraud. It isn't much of a stretch to see where his life is now. He was born into a Scottish Tory Family ( a fact he tried desperately to hide ) and he was a Tory himself right from the off.</p>
+        @withJsoup(BulletCleaner(comment.body))(
+            InBodyLinkCleaner("in body link")(Edition(request))
+        )
+    </div>
+</div>

--- a/discussion/app/views/profileActivity/comment.scala.html
+++ b/discussion/app/views/profileActivity/comment.scala.html
@@ -4,7 +4,7 @@
         <button
             class="disc-comment__recommend u-button-reset @if(canRecommend){js-disc-recommend-comment}"
             data-comment-id="@comment.id">
-            <div class="disc-comment__recommend-count js-disc-recommend-count">
+            <div class="disc-comment__recommend-count js-disc-recommend-count" itemprop="upvoteCount">
                 @comment.numRecommends
             </div>
             <div class="disc-comment__recommend-button js-disc-recommend-button">

--- a/discussion/app/views/profileActivity/comment.scala.html
+++ b/discussion/app/views/profileActivity/comment.scala.html
@@ -9,6 +9,7 @@
             </div>
             <div class="disc-comment__recommend-button js-disc-recommend-button">
                 <i class="i i-recommend"></i>
+                <span class="u-h">Recommend</span>
             </div>
         </button>
     </div>

--- a/discussion/app/views/profileActivity/discussions.scala.html
+++ b/discussion/app/views/profileActivity/discussions.scala.html
@@ -1,50 +1,28 @@
 @(profileDiscussions: discussion.model.ProfileDiscussions)(implicit request: RequestHeader)
-@import conf.Configuration
 
-<div class="profile-discussions">
-@profileDiscussions.discussions.map{ discussion =>
-     <div class="facia-container facia-container--default-heading facia-container--layout-article facia-container--layout-discussion">
-        <div class="container container--row-pattern">
-            <div class="facia-container__inner">
-                <div class="container__border tone-accent-border hide-on-mobile"></div>
-                <h3 class="container__title tone-news">
-                    <a href="@discussion.discussion.webUrl" class="container__title__label u-text-hyphenate">@discussion.discussion.title</a>
-                </h3>
-                <div class="container__body">
-                    <ul class="disc-discussions u-unstyled" itemprop itemtype="http://schema.org/UserComments">
-                        @discussion.comments.map{ comment =>
-                            <li class="disc-comment u-cf" itemprop itemtype="http://schema.org/Comment">
-                                <div class="disc-comment__meta">
-                                    <time class="disc-comment__date-published"
-                                          itemprop="datePublished"
-                                          datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
-                                          data-timestamp="@comment.date.getMillis">
-                                        <a class="disc-comment__permalink" href="@Configuration.discussion.url/comment-permalink/@comment.id" itemprop="url">@comment.date.toString("d MMM y HH:mm")</a>
-                                    </time>
+<div class="activity-stream activity-stream--discussions" itemprop itemtype="http://schema.org/UserComments">
+@profileDiscussions.discussions.map{ disc =>
+    <div class="activity-stream__item activity-item">
+        <div class="activity-item__title">
+            <a href="@disc.discussion.webUrl#comments">@disc.discussion.title</a>
+        </div>
 
-                                    <button
-                                        class="disc-comment__recommend u-button-reset @if(discussion.isClosedForRecommendation){js-disc-recommend-comment}"
-                                        data-comment-id="@comment.id">
-                                        <div class="disc-comment__recommend-count js-disc-recommend-count">
-                                            @comment.numRecommends
-                                        </div>
-                                        <div class="disc-comment__recommend-button js-disc-recommend-button">
-                                            <i class="i i-recommend"></i>
-                                        </div>
-                                    </button>
-                                </div>
+        @disc.comments.zipWithRowInfo.map{ case (c, row) =>
+            <div class="activity-item__content @if(row.isFirst){activity-item__content--no-border}" itemprop itemtype="http://schema.org/Comment">
+                <div class="activity-item__content-meta">
+                    <time class="disc-comment__date-published"
+                          itemprop="datePublished"
+                          datetime="@c.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
+                          data-timestamp="@c.date.getMillis">
+                        <a class="disc-comment__permalink" href="@Configuration.discussion.url/comment-permalink/@c.id" itemprop="url">@c.date.toString("d MMM y HH:mm")</a>
+                    </time>
+                </div>
 
-                                <div class="disc-comment__body" itemprop="text">
-                                    @withJsoup(BulletCleaner(comment.body))(
-                                        InBodyLinkCleaner("in body link")(Edition(request))
-                                    )
-                                </div>
-                            </li>
-                        }
-                    </ul>
+                <div class="activity-item__content-body">
+                    @comment(c, c.discussion.isClosedForRecommendation)
                 </div>
             </div>
-        </div>
+        }
     </div>
 }
 </div>

--- a/discussion/app/views/profileActivity/profile.scala.html
+++ b/discussion/app/views/profileActivity/profile.scala.html
@@ -1,0 +1,38 @@
+@(profile: discussion.model.Profile, date: Option[org.joda.time.DateTime] = None)(implicit request: RequestHeader)
+@import conf.Configuration
+
+<div class="disc-profile u-cf" itemscope itemtype="http://schema.org/Person" itemprop="author">
+    <div class="disc-profile__avatar">
+        <img class="disc-profile__avatar-image" src="@profile.secureAvatar" alt="@profile.displayName's avatar" itemprop="image" />
+    </div>
+    <div class="disc-profile__user-info">
+        <div class="disc-profile__name" itemprop="givenName">
+            <a href="@Configuration.id.url/user/id/@profile.userId" itemprop="url">
+                @profile.displayName
+            </a>
+        </div>
+
+        @if(profile.isContributor || profile.isStaff){
+            <div class="disc-profile__badges">
+                @if(profile.isContributor){
+                    <span class="disc-profile__badge" title="Guardian contributor" itemprop="jobTitle">
+                        <span class="u-h">Guardian </span>contributor
+                    </span>
+                }
+                @if(profile.isStaff){
+                    <span class="disc-profile__badge" title="Guardian staff" itemprop="jobTitle">
+                        <span class="u-h">Guardian</span>staff
+                    </span>
+                }
+            </div>
+        }
+        @date.map{ d =>
+            <time class="disc-profile__date"
+                  itemprop="datePublished"
+                  datetime="@d.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
+                  data-timestamp="@d.getMillis">
+                @d.toString("d MMM y HH:mm")
+            </time>
+        }
+    </div>
+</div>

--- a/discussion/app/views/profileActivity/replies.scala.html
+++ b/discussion/app/views/profileActivity/replies.scala.html
@@ -1,0 +1,21 @@
+@(profileReplies: discussion.model.ProfileReplies)(implicit request: RequestHeader)
+
+<div class="activity-stream activity-stream--replies" itemprop itemtype="http://schema.org/UserComments">
+    @profileReplies.comments.map{ c =>
+        <div class="activity-stream__item activity-item" itemprop itemtype="http://schema.org/Comment">
+            <div class="activity-item__title">
+                <a href="@c.discussion.webUrl#">@c.discussion.title</a>
+            </div>
+
+            <div class="activity-item__content">
+                <div class="activity-item__content-meta">
+                    @profile(c.profile, Some(c.date))
+                </div>
+
+                <div class="activity-item__content-body">
+                    @comment(c, c.discussion.isClosedForRecommendation)
+                </div>
+            </div>
+        </div>
+    }
+</div>

--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -19,7 +19,7 @@ class PublicProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
   with ExecutionContexts
   with SafeLogging{
 
-  def page(url: String) = IdentityPage(url, "Public profile", "public profile")
+  def page(url: String, username: Option[String]) = IdentityPage(url, username.get +"'s public profile", "public profile")
 
   def renderProfileFromVanityUrl(vanityUrl: String) = renderPublicProfilePage(
     "/user/" + vanityUrl,
@@ -38,7 +38,7 @@ class PublicProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
 
         case Right(user) =>
           val idRequest = idRequestParser(request)
-          Cached(60)(Ok(views.html.publicProfilePage(page(url), idRequest, idUrlBuilder, user)))
+          Cached(60)(Ok(views.html.publicProfilePage(page(url, user.publicFields.displayName), idRequest, idUrlBuilder, user)))
       }
   }
 }

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -1,54 +1,53 @@
 @(page: MetaData, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, user: com.gu.identity.model.User)(implicit request: RequestHeader)
-
 @import views.html.fragments.registrationFooter
 
 @identityMain(page, Switches.all){
 }{
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--stretched">
-    <div class="facia-container facia-container--layout-article facia-container--layout-identity container">
-        <div class="facia-container__inner">
-
-            <div class="user-profile u-cf">
-                <div class="identity-title identity-title--public-profile">
-                    <div class="user-profile__avatar user-avatar" data-userid="@user.id"></div>
-                    <h1 class="user-profile__name">@user.publicFields.displayName</h1>
-                    @user.publicFields.webPage.filter(_ != "").map { webPage =>
-                        <a href="@webPage" class="user-profile__web-page">
-                            <i class="i i-profile-small"></i>
-                            @webPage
-                        </a>
-                    }
-                    @user.dates.accountCreatedDate.map { accountCreatedDate =>
-                        <p class="user-profile__last-seen">
-                            <i class="i i-clock-light-grey"></i>
-                            Member since @accountCreatedDate.toString("d MMM yyyy")
-                        </p>
-                    }
-                </div>
-                @user.publicFields.aboutMe.map{ aboutMe =>
-                    <div class="user-profile__about">
-                        <p>@aboutMe</p>
-                        @user.publicFields.interests.map{ interests =>
-                            <p><b>Interests:</b> @interests</p>
-                        }
-                    </div>
+    <div class="identity-header">
+        <div class="user-profile u-cf">
+            <div class="identity-title identity-title--public-profile">
+                <div class="user-profile__avatar user-avatar" data-userid="@user.id"></div>
+                <h1 class="user-profile__name">@user.publicFields.displayName</h1>
+                @user.publicFields.webPage.filter(_!="").map { webPage =>
+                    <a href="@webPage" class="user-profile__web-page">
+                        <i class="i i-profile-small"></i>
+                        @webPage
+                    </a>
+                }
+                @user.dates.accountCreatedDate.map { accountCreatedDate =>
+                    <p class="user-profile__last-seen">
+                        <i class="i i-clock-light-grey"></i>
+                        Member since @accountCreatedDate.toString("d MMM yyyy")
+                    </p>
                 }
             </div>
+            @user.publicFields.aboutMe.map{ aboutMe =>
+                <div class="user-profile__about">
+                    <p>@aboutMe</p>
+
+                    <h1>@user.publicFields.interests</h1>
+                    @user.publicFields.interests.filter(_!="").map{ interests =>
+                        <h1>@interests</h1>
+                        <p><b>Interests:</b> @interests</p>
+                    }
+                </div>
+            }
+        </div>
+
+        <div class="tabs tabs--identity">
+            <ol class="tabs__container tabs__container--multiple">
+                <li class="tabs__tab tabs__tab--selected tone-colour tone-accent-border">
+                    <a href="" class="js-activity-stream-change" data-stream-type="discussions">Comment activity</a>
+                </li>
+                <li class="tabs__tab">
+                    <a href="" class="js-activity-stream-change" data-stream-type="replies">Replies to @user.publicFields.displayName</a>
+                </li>
+            </ol>
         </div>
     </div>
 
-    <div class="facia-container facia-container--layout-article container">
-        <div class="facia-container__inner">
-            <div class="container__border tone-news tone-accent-border"></div>
-            <div class="container__header">
-                <h2 class="container__title tone-news tone-background">
-                    Comment activity
-                </h2>
-            </div>
-        </div>
-    </div>
-
-    <div class="activity-stream activity-stream--comments js-comment-stream" data-user-id="@user.id" data-stream-type="discussions"></div>
+    <div class="js-activity-stream" data-user-id="@user.id" data-stream-type="discussions"></div>
     @registrationFooter(page, idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -25,10 +25,7 @@
             @user.publicFields.aboutMe.map{ aboutMe =>
                 <div class="user-profile__about">
                     <p>@aboutMe</p>
-
-                    <h1>@user.publicFields.interests</h1>
                     @user.publicFields.interests.filter(_!="").map{ interests =>
-                        <h1>@interests</h1>
                         <p><b>Interests:</b> @interests</p>
                     }
                 </div>

--- a/sport/app/football/views/fragments/matchNav.scala.html
+++ b/sport/app/football/views/fragments/matchNav.scala.html
@@ -11,7 +11,7 @@
 }
 
 @if(component.hasReports){
-    <ol class="tabs__container tabs__container--multiple @if(component.hasMinByMin && component.hasReport && component.hasPreview){ type-7 }" data-link-name="Football match nav">
+    <ol class="tabs__container tabs__container--multiple" data-link-name="Football match nav">
         @component.matchReport.map{ matchReport => @report(matchReport, "Report") }
         @component.minByMin.map{ minByMin => @report(minByMin, "Min-by-min") }
         @component.preview.map{ preview => @report(preview, "Preview") }


### PR DESCRIPTION
- Refactored out use of facia in identity as it has no suport team (as per @kaelig's request)
- Update to components `setOptions` to be better
- Getting closer to having the idea of an ActivityStream - which will hopefully usurp comments in general
- PROFILE REPLIES!
# Shut it and show me!

![profile-page-large](https://cloud.githubusercontent.com/assets/31692/3174854/b7600d1e-ebf5-11e3-96a5-fa1a04d5b826.png)
![profile-page-med](https://cloud.githubusercontent.com/assets/31692/3174855/b7601cf0-ebf5-11e3-9775-aa039dc8a5ef.png)
![profile-page-small](https://cloud.githubusercontent.com/assets/31692/3174853/b75fb85a-ebf5-11e3-97d6-09ca52ebcadb.png)

---

![You talk too much](http://static.fjcdn.com/gifs/such+talk+wow.+much+opinion_6b6a70_4742480.gif)
