### PR TITLE
Show comment if permalinked

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -172,9 +172,11 @@ Comments.prototype.ready = function() {
 
     if (this.options.commentId) {
         var comment = $('#comment-'+ this.options.commentId);
+        this.showHiddenComments();
         if (comment.attr('hidden')) {
             bean.fire($(this.getClass('showReplies'), comment.parent())[0], 'click');
         }
+        
         window.location.replace('#comment-'+ this.options.commentId);
     }
 


### PR DESCRIPTION
Before: comment permalinks weren't working as they weren't expanding.
[e.g. Broken (live)](http://www.theguardian.com/info/developer-blog/2014/may/29/-sp-improving-the-beta-commenting-experience#comment-36469052)

[e.g. FIxed (local)](http://m.thegulocal.com/info/developer-blog/2014/may/29/-sp-improving-the-beta-commenting-experience#comment-36469052)

They now expand.

![Wat](http://saved.im/mtg3mzazazrq/troll.gif)
