### PR TITLE
Commercial: Sponsored containers need to send container's keyword to DFP

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/badges.js
+++ b/common/app/assets/javascripts/modules/adverts/badges.js
@@ -1,10 +1,12 @@
 define([
     'qwery',
+    'bonzo',
     'common/$',
     'common/modules/adverts/dfp',
     'lodash/functions/once'
 ], function (
     qwery,
+    bonzo,
     $,
     dfp,
     once
@@ -12,12 +14,12 @@ define([
 
     var hadSponsoredBadge = false,
         hadAdvertisementFeatureBadge = false,
-        createAdSlot = function(container, isSponsored) {
+        createAdSlot = function(container, isSponsored, keywords) {
             if ((isSponsored && hadSponsoredBadge) || (!isSponsored && hadAdvertisementFeatureBadge)) {
                 return;
             }
             $('.container__header', container)
-                .after(dfp.createAdSlot((isSponsored ? 'sp' : 'ad') + 'badge', 'paid-for-badge'));
+                .after(dfp.createAdSlot((isSponsored ? 'sp' : 'ad') + 'badge', 'paid-for-badge', keywords));
             if (isSponsored) {
                 hadSponsoredBadge = true;
             } else {
@@ -32,8 +34,8 @@ define([
                 createAdSlot(qwery('.container', faciaContainer)[0], $(faciaContainer).hasClass('facia-container--sponsored'));
             });
             $('.container--sponsored, .container--advertisement-feature').each(function(container) {
-                if (qwery('.paid-for-badge', container).length === 0) {
-                    createAdSlot(container, $(container).hasClass('container--sponsored'));
+                if (qwery('.ad-slot--paid-for-badge', container).length === 0) {
+                    createAdSlot(container, $(container).hasClass('container--sponsored'), bonzo(container).data('keywords'));
                 }
             });
         })

--- a/common/app/assets/javascripts/modules/adverts/badges.js
+++ b/common/app/assets/javascripts/modules/adverts/badges.js
@@ -25,11 +25,8 @@ define([
             } else {
                 hadAdvertisementFeatureBadge = true;
             }
-        };
-
-    return {
-
-        init: once(function() {
+        },
+        init = function() {
             $('.facia-container--sponsored, .facia-container--advertisement-feature').each(function(faciaContainer) {
                 createAdSlot(qwery('.container', faciaContainer)[0], $(faciaContainer).hasClass('facia-container--sponsored'));
             });
@@ -38,8 +35,20 @@ define([
                     createAdSlot(container, $(container).hasClass('container--sponsored'), bonzo(container).data('keywords'));
                 }
             });
-        })
+        },
+        badges = {
 
-    };
+            init: once(init),
+
+            // really only useful for testing
+            reset: function() {
+                badges.init = once(init);
+                hadSponsoredBadge = false;
+                hadAdvertisementFeatureBadge = false;
+            }
+
+        };
+
+    return badges;
 
 });

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -238,34 +238,17 @@ define([
                 return value ? queryString.formatKeyword(value).replace(/&/g, 'and').replace(/'/g, '') : '';
             }
 
-            function lastPart(keywordId) {
-                if (keywordId) {
-                    return keywordId.split('/').pop();
-                } else {
-                    return '';
-                }
-            }
-
             var conf        = config.page,
                 section     = encodeTargetValue(conf.section),
                 series      = encodeTargetValue(conf.series),
                 contentType = encodeTargetValue(conf.contentType),
-                edition     = encodeTargetValue(conf.edition),
-                keywords;
-            if (conf.keywordIds) {
-                keywords = conf.keywordIds.split(',').map(function (keywordId) {
-                    return lastPart(keywordId);
-                });
-            } else {
-                keywords = lastPart(conf.pageId);
-            }
+                edition     = encodeTargetValue(conf.edition);
 
             return defaults({
                 url     : window.location.pathname,
                 edition : edition,
                 cat     : section,
                 se      : series,
-                k       : keywords,
                 ct      : contentType,
                 pt      : contentType,
                 p       : 'ng',
@@ -286,24 +269,38 @@ define([
             }
             return '/' + config.page.dfpAccountId + '/' + config.page.dfpAdUnitRoot + '/' + adUnitSuffix;
         },
-        createAdSlot = function(name, type) {
-            var definition = adSlotDefinitions[name];
-            return template(
-                '<div id="dfp-ad--{{name}}" ' +
-                    'class="ad-slot ad-slot--dfp ad-slot--{{type}}" ' +
-                    'data-link-name="ad slot {{name}}" ' +
-                    'data-name="{{name}}" ' +
-                    'data-refresh="{{refresh}}" ' +
-                    'data-label="{{label}}"' +
-                    '{{sizeMappings}}></div>',
-                {
-                    name: name,
-                    type: type,
+        createAdSlot = function(name, type, keywords) {
+            var definition = adSlotDefinitions[name],
+                dataAttrs = {
                     refresh: definition.refresh !== undefined ? definition.refresh : true,
-                    label: definition.label !== undefined ? definition.label : true,
-                    sizeMappings: pairs(definition.sizeMappings).map(function(size) { return ' data-' + size[0] + '="' + size[1] + '"'; }).join('')
+                    label: definition.label !== undefined ? definition.label : true
+                },
+                $adSlot = $.create(template(
+                    '<div id="dfp-ad--{{name}}" ' +
+                        'class="ad-slot ad-slot--dfp ad-slot--{{type}}" ' +
+                        'data-link-name="ad slot {{name}}" ' +
+                        'data-name="{{name}}"' +
+                        '{{sizeMappings}}></div>',
+                    {
+                        name: name,
+                        type: type,
+                        sizeMappings: pairs(definition.sizeMappings).map(function(size) { return ' data-' + size[0] + '="' + size[1] + '"'; }).join('')
+                    }));
+            for (var attrName in dataAttrs) {
+                if (dataAttrs[attrName] === false) {
+                    $adSlot.data(attrName, false);
                 }
-            );
+            }
+            if (keywords) {
+                $adSlot.data('keywords', keywords);
+            }
+            return $adSlot[0];
+        },
+        getKeywords = function($adSlot, conf) {
+            return ($adSlot.data('keywords') || conf.page.keywordIds || conf.page.pageId || '')
+                .split(',').map(function (keyword) {
+                    return keyword.split('/').pop();
+                });
         };
 
     /**
@@ -345,6 +342,7 @@ define([
                             ? googletag.defineOutOfPageSlot(adUnit, id) : googletag.defineSlot(adUnit, size, id))
                         .addService(googletag.pubads())
                         .defineSizeMapping(sizeMapping)
+                        .setTargeting('k', getKeywords($adSlot, config))
                         .setTargeting('slot', $adSlot.data('name'));
 
                 // Add to the array of ads to be refreshed (when the breakpoint changes)

--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -288,11 +288,11 @@ define([
                     }));
             for (var attrName in dataAttrs) {
                 if (dataAttrs[attrName] === false) {
-                    $adSlot.data(attrName, false);
+                    $adSlot.attr('data-' + attrName, 'false');
                 }
             }
             if (keywords) {
-                $adSlot.data('keywords', keywords);
+                $adSlot.attr('data-keywords', keywords);
             }
             return $adSlot[0];
         },

--- a/common/app/assets/javascripts/modules/adverts/slice-adverts.js
+++ b/common/app/assets/javascripts/modules/adverts/slice-adverts.js
@@ -20,7 +20,7 @@ define([
 
         this.config = defaults(c || {}, {
             containerSelector: '.container',
-            sliceSelector: '.slice--ad-candidate',
+            sliceSelector: '.js-slice--ad-candidate',
             page: {},
             switches: {}
         });

--- a/common/app/views/fragments/collections/features.scala.html
+++ b/common/app/views/fragments/collections/features.scala.html
@@ -12,7 +12,7 @@
 </div>
 @defining(items.slice(3, 11)) { items =>
     @if(items.nonEmpty) {
-        <div class="linkslist-container tone-@{style.tone} slice--ad-candidate">
+        <div class="linkslist-container tone-@{style.tone} js-slice--ad-candidate">
             <ul class="l-columns linkslist">
                 @items.zipWithIndex.map{ case (trail, index) =>
                     @trail match {

--- a/common/app/views/fragments/collections/news.scala.html
+++ b/common/app/views/fragments/collections/news.scala.html
@@ -77,7 +77,7 @@
 
         @defining(standardItems.slice(4, 10), hugeItemsCount + veryBigItemsCount + bigItemsCount + 4) { case (items, offset) =>
             @if(items.nonEmpty) {
-                <div class="linkslist-container tone-@{style.tone} slice--ad-candidate">
+                <div class="linkslist-container tone-@{style.tone} js-slice--ad-candidate">
                     <ul class="l-columns linkslist linkslist--with-images">
                         @items.zipWithIndex.map{ case (trail, index) =>
                             @trail match {

--- a/common/app/views/fragments/collections/people.scala.html
+++ b/common/app/views/fragments/collections/people.scala.html
@@ -10,7 +10,7 @@
 
 @defining(items.slice(3, 11)) { items =>
     @if(items.nonEmpty) {
-        <div class="linkslist-container tone-@{style.tone} slice--ad-candidate">
+        <div class="linkslist-container tone-@{style.tone} js-slice--ad-candidate">
             <ul class="l-columns linkslist">
                 @items.zipWithIndex.map{ case (trail, index) =>
                     @trail match {

--- a/common/app/views/fragments/collections/tag.scala.html
+++ b/common/app/views/fragments/collections/tag.scala.html
@@ -43,7 +43,7 @@
             }
             @defining(items.slice(baguetteCount + 6, baguetteCount + 14)) { items =>
                 @if(items.nonEmpty) {
-                    <div class="linkslist-container tone-@{style.tone} slice--ad-candidate">
+                    <div class="linkslist-container tone-@{style.tone} js-slice--ad-candidate">
                         <ul class="l-columns linkslist linkslist--with-images">
                             @items.zipWithIndex.map{ case (trail, index) =>
                                 @trail match {

--- a/common/app/views/fragments/containers/commentanddebate.scala.html
+++ b/common/app/views/fragments/containers/commentanddebate.scala.html
@@ -9,6 +9,9 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -9,6 +9,9 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/featuresauto.scala.html
+++ b/common/app/views/fragments/containers/featuresauto.scala.html
@@ -58,7 +58,7 @@
                         <div class="container__body">
                             @defining(items.slice(4, 10)) { items =>
                                 @if(items.nonEmpty) {
-                                    <div class="linkslist-container tone-@{style.tone} slice--ad-candidate" data-tone="@style.tone">
+                                    <div class="linkslist-container tone-@{style.tone} js-slice--ad-candidate" data-tone="@style.tone">
                                         <ul class="l-columns linkslist">
                                             @items.zipWithIndex.map{ case (trail, index) =>
                                                 @trail match {

--- a/common/app/views/fragments/containers/featuresauto.scala.html
+++ b/common/app/views/fragments/containers/featuresauto.scala.html
@@ -9,6 +9,9 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="container__banding">
                     <div class="facia-container__inner">

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -10,6 +10,9 @@
                 class="@GetClasses.forContainer(style, config, containerIndex, title.nonEmpty)"
                 data-link-name="all index"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="all index">
                 <div class="facia-container__inner">
                     <div class="tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/multimedia.scala.html
+++ b/common/app/views/fragments/containers/multimedia.scala.html
@@ -9,6 +9,9 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="container__border tone-@style.tone tone-accent-border"></div>
 

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -19,6 +19,9 @@
                     data-link-name="block | @config.id"
                     data-id="@config.id"
                     data-type="@style.containerType"
+                    @config.sponsorshipKeyword.map { keyword =>
+                        data-keyword="@keyword"
+                    }
                     data-component="@FaciaComponentName(config, collection)">
                     <div class="facia-container__inner">
                         <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -20,7 +20,7 @@
                     data-id="@config.id"
                     data-type="@style.containerType"
                     @config.sponsorshipKeyword.map { keyword =>
-                        data-keyword="@keyword"
+                        data-keywords="@keyword"
                     }
                     data-component="@FaciaComponentName(config, collection)">
                     <div class="facia-container__inner">

--- a/common/app/views/fragments/containers/people.scala.html
+++ b/common/app/views/fragments/containers/people.scala.html
@@ -9,6 +9,9 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/popular.scala.html
+++ b/common/app/views/fragments/containers/popular.scala.html
@@ -11,6 +11,9 @@
             data-link-name="block | @config.id"
             data-id="@config.id"
             data-type="@style.containerType"
+            @config.sponsorshipKeyword.map { keyword =>
+                data-keywords="@keyword"
+            }
             data-component="@FaciaComponentName(config, collection)">
             <div class="facia-container__inner">
                 <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/series.scala.html
+++ b/common/app/views/fragments/containers/series.scala.html
@@ -12,6 +12,9 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="@style.containerType">
                 <div class="facia-container__inner">
                     <div class="container__border"></div>

--- a/common/app/views/fragments/containers/special.scala.html
+++ b/common/app/views/fragments/containers/special.scala.html
@@ -9,6 +9,9 @@
                 data-link-name="block | @config.id"
                 data-id="@config.id"
                 data-type="@style.containerType"
+                @config.sponsorshipKeyword.map { keyword =>
+                    data-keywords="@keyword"
+                }
                 data-component="@FaciaComponentName(config, collection)">
                 <div class="facia-container__inner">
                     <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -8,6 +8,9 @@
             data-link-name="block | @config.id"
             data-id="@config.id"
             data-type="@style.containerType"
+            @config.sponsorshipKeyword.map { keyword =>
+                data-keyword="@keyword"
+            }
             data-component="@FaciaComponentName(config, collection)">
             <div class="facia-container__inner">
                 <div class="container__border tone-@style.tone tone-accent-border"></div>

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -9,7 +9,7 @@
             data-id="@config.id"
             data-type="@style.containerType"
             @config.sponsorshipKeyword.map { keyword =>
-                data-keyword="@keyword"
+                data-keywords="@keyword"
             }
             data-component="@FaciaComponentName(config, collection)">
             <div class="facia-container__inner">

--- a/common/test/assets/javascripts/spec/adverts/badges.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/badges.spec.js
@@ -1,0 +1,107 @@
+define([
+    'common/modules/adverts/badges',
+    'common/$',
+    'qwery',
+    'helpers/fixtures'
+], function(
+    badges,
+    $,
+    qwery,
+    fixtures
+) {
+
+    describe('Badges', function() {
+
+        var fixtureConf = {
+            id: 'badges',
+            fixtures: [
+                '<div class="facia-container">\
+                    <div class="container">\
+                        <div class="container__header"></div>\
+                    </div>\
+                    <div class="container">\
+                        <div class="container__header"></div>\
+                    </div>\
+                </div>'
+            ]
+        };
+
+        beforeEach(function() {
+            fixtures.render(fixtureConf);
+        });
+
+        afterEach(function() {
+            fixtures.clean(fixtureConf.id);
+            badges.reset();
+        });
+
+        describe('sponsored pages', function() {
+
+            [
+                {
+                    type: 'sponsored',
+                    name: 'spbadge'
+                },
+                {
+                    type: 'advertisement-feature',
+                    name: 'adbadge'
+                }
+            ].forEach(function(config) {
+
+                    it('should add "' + config.name + '" badge to first container if page is ' + config.type, function() {
+                        $('.facia-container').addClass('facia-container--' + config.type);
+                        badges.init();
+                        expect($('.facia-container .container:first-child .ad-slot').first().data('name')).toBe(config.name);
+                    });
+
+                });
+
+        });
+
+        describe('sponsored containers', function() {
+
+            var configs = [
+                {
+                    type: 'sponsored',
+                    name: 'spbadge'
+                },
+                {
+                    type: 'advertisement-feature',
+                    name: 'adbadge'
+                }
+            ];
+
+            configs.forEach(function(config) {
+                it('should add "' + config.name + '" badge to ' + config.type + ' container', function() {
+                    $('.container').first().addClass('container--' + config.type);
+                    badges.init();
+                    expect($('.facia-container .container:first-child .ad-slot').first().data('name')).toBe(config.name);
+                });
+            });
+
+            configs.forEach(function(config) {
+                it('should not add more than one of the same badge', function () {
+                    $('.container').addClass('container--' + config.type);
+                    badges.init();
+                    expect(qwery('.facia-container .ad-slot').length).toBe(1);
+                });
+            });
+
+            it('should not add a badge if one already exists', function() {
+                $('.facia-container .container__header').first().after('<div class="ad-slot--paid-for-badge"></div>');
+                badges.init();
+                expect(qwery('.facia-container .ad-slot').length).toBe(0);
+            });
+
+            it('should add container\'s keywords to ad', function() {
+                $('.facia-container .container').first()
+                    .addClass('container--sponsored')
+                    .attr('data-keywords', 'russia,ukraine');
+                badges.init();
+                expect($('.facia-container .ad-slot').data('keywords')).toBe('russia,ukraine');
+            });
+
+        });
+
+    });
+});

--- a/common/test/assets/javascripts/spec/adverts/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/dfp.spec.js
@@ -79,7 +79,7 @@ define([
                 defineOutOfPageSlot: sinon.spy(function() { return window.googletag; }),
                 addService: sinon.spy(function() { return window.googletag; }),
                 defineSizeMapping: sinon.spy(function() { return window.googletag; }),
-                setTargeting: sinon.spy(function(type, id) { return id; }),
+                setTargeting: sinon.spy(function() { return window.googletag; }),
                 enableServices: sinon.spy(),
                 display: sinon.spy()
             };
@@ -121,9 +121,7 @@ define([
                 section: 'news',
                 series: 'happy times',
                 contentType: 'Article',
-                edition: 'us',
-                keywords: 'korea,ukraine',
-                keywordIds: 's1/korea,s2/ukraine'
+                edition: 'us'
             };
             dfp.init({ page: page });
             window.googletag.cmd.forEach(function(func) { func(); });
@@ -132,7 +130,6 @@ define([
                 ['edition', 'us'],
                 ['cat', 'news'],
                 ['se', 'happy-times'],
-                ['k', ['korea', 'ukraine']],
                 ['ct', 'article'],
                 ['pt', 'article'],
                 ['p', 'ng'],
@@ -180,7 +177,7 @@ define([
                 return googletag.pubads().refresh.called;
             });
             runs(function() {
-                expect(googletag.pubads().refresh).toHaveBeenCalledWith(['html-slot', 'already-labelled', 'dont-label']);
+                expect(googletag.pubads().refresh.firstCall.args[0].length).toBe(3);
             })
         });
 
@@ -195,7 +192,14 @@ define([
 
         it('should create ad slot', function() {
             var adSlot = dfp.createAdSlot('right', 'right-type');
-            expect(adSlot).toBe('<div id="dfp-ad--right" class="ad-slot ad-slot--dfp ad-slot--right-type" data-link-name="ad slot right" data-name="right" data-refresh="true" data-label="true" data-tabletlandscape="300,250|300,600"></div>')
+                expectedAdSlot = $.create(
+                    '<div id="dfp-ad--right" ' +
+                        'class="ad-slot ad-slot--dfp ad-slot--right-type" ' +
+                        'data-link-name="ad slot right" ' +
+                        'data-name="right" ' +
+                        'data-tabletlandscape="300,250|300,600">' +
+                    '</div>')[0];
+            expect(adSlot.outerHTML).toBe(expectedAdSlot.outerHTML)
         });
 
         it('should be able to create "out of page" ad slot', function() {
@@ -211,6 +215,38 @@ define([
             window.googletag.cmd.forEach(function(func) { func(); });
             expect(window.googletag.defineOutOfPageSlot).toHaveBeenCalledWith('/123456/theguardian.com/front', 'dfp-ad-html-slot');
         });
+
+        describe('keyword targeting', function() {
+
+            it('should send page level keywords', function() {
+                dfp.init({
+                    page: {
+                        keywordIds: 'world/korea,world/ukraine'
+                    }
+                });
+                window.googletag.cmd.forEach(function(func) { func(); });
+                expect(window.googletag.setTargeting).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
+            });
+
+            it('should send container level keywords', function() {
+                $('.ad-slot--dfp').first().data('keywords', 'china');
+                dfp.init();
+                window.googletag.cmd.forEach(function(func) { func(); });
+                expect(window.googletag.setTargeting).toHaveBeenCalledWith('k', ['china']);
+            });
+
+            it('should use pageId if no keywords ', function() {
+                dfp.init({
+                    page: {
+                        pageId: 'world/uk'
+                    }
+                });
+                window.googletag.cmd.forEach(function(func) { func(); });
+                expect(window.googletag.setTargeting).toHaveBeenCalledWith('k', ['uk']);
+            });
+
+        });
+
 
         describe('labelling', function() {
 

--- a/common/test/assets/javascripts/spec/adverts/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/dfp.spec.js
@@ -190,16 +190,57 @@ define([
             expect(window.googletag.display).toHaveBeenCalled('dfp-ad-html-slot');
         });
 
-        it('should create ad slot', function() {
-            var adSlot = dfp.createAdSlot('right', 'right-type');
-                expectedAdSlot = $.create(
-                    '<div id="dfp-ad--right" ' +
-                        'class="ad-slot ad-slot--dfp ad-slot--right-type" ' +
-                        'data-link-name="ad slot right" ' +
-                        'data-name="right" ' +
-                        'data-tabletlandscape="300,250|300,600">' +
-                    '</div>')[0];
-            expect(adSlot.outerHTML).toBe(expectedAdSlot.outerHTML)
+        describe('create ad', function() {
+
+            [
+                {
+                    name: 'right',
+                    type: 'mpu-banner-ad',
+                    html: '<div id="dfp-ad--right" class="ad-slot ad-slot--dfp ad-slot--mpu-banner-ad" ' +
+                        'data-link-name="ad slot right" data-name="right" data-tabletlandscape="300,250|300,600"></div>'
+                },
+                {
+                    name: 'inline1',
+                    type: 'inline',
+                    html: '<div id="dfp-ad--inline1" class="ad-slot ad-slot--dfp ad-slot--inline" ' +
+                        'data-link-name="ad slot inline1" data-name="inline1" data-mobile="300,50" ' +
+                        'data-mobilelandscape="300,50|320,50" data-tabletportrait="300,250"></div>'
+                },
+                {
+                    name: 'inline2',
+                    type: 'inline',
+                    html: '<div id="dfp-ad--inline2" class="ad-slot ad-slot--dfp ad-slot--inline" ' +
+                        'data-link-name="ad slot inline2" data-name="inline2" data-mobile="300,50" ' +
+                        'data-mobilelandscape="300,50|320,50" data-tabletportrait="300,250"></div>'
+                },
+                {
+                    name: 'merchandising-high',
+                    type: 'commercial-component',
+                    html: '<div id="dfp-ad--merchandising-high" class="ad-slot ad-slot--dfp ad-slot--commercial-component" ' +
+                        'data-link-name="ad slot merchandising-high" data-name="merchandising-high" data-desktop="888,88" ' +
+                        'data-refresh="false" data-label="false"></div>'
+                },
+                {
+                    name: 'adbadge',
+                    type: 'paid-for-badge',
+                    html: '<div id="dfp-ad--adbadge" class="ad-slot ad-slot--dfp ad-slot--paid-for-badge" ' +
+                        'data-link-name="ad slot adbadge" data-name="adbadge" data-mobile="140,90" ' +
+                        'data-refresh="false" data-label="false"></div>'
+                },
+                {
+                    name: 'spbadge',
+                    type: 'paid-for-badge',
+                    html: '<div id="dfp-ad--spbadge" class="ad-slot ad-slot--dfp ad-slot--paid-for-badge" ' +
+                        'data-link-name="ad slot spbadge" data-name="spbadge" data-mobile="140,90" ' +
+                        'data-refresh="false" data-label="false"></div>'
+                }
+            ].forEach(function(expectation) {
+                it('should create "' + expectation.name + '" ad slot', function() {
+                    var adSlot = dfp.createAdSlot(expectation.name, expectation.type);
+                    expect(adSlot.outerHTML).toBe(expectation.html)
+                });
+            });
+
         });
 
         it('should be able to create "out of page" ad slot', function() {

--- a/common/test/assets/javascripts/spec/adverts/slice-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/slice-adverts.spec.js
@@ -19,11 +19,11 @@ define([
         var fixturesConfig = {
                 id: 'slice-adverts',
                 fixtures: [
-                    '<div class="container container-first"><div class="linkslist-container slice--ad-candidate"><div class="slice"></div></div></div>',
+                    '<div class="container container-first"><div class="linkslist-container js-slice--ad-candidate"><div class="slice"></div></div></div>',
                     '<div class="container container-second"></div>',
-                    '<div class="container container-third"><div class="slice--ad-candidate"><div class="slice"></div></div></div>',
-                    '<div class="container container-fourth"><div class="slice--ad-candidate"><div class="slice"></div></div></div>',
-                    '<div class="container container-fifth"><div class="slice--ad-candidate"><div class="slice"></div></div></div>'
+                    '<div class="container container-third"><div class="js-slice--ad-candidate"><div class="slice"></div></div></div>',
+                    '<div class="container container-fourth"><div class="js-slice--ad-candidate"><div class="slice"></div></div></div>',
+                    '<div class="container container-fifth"><div class="js-slice--ad-candidate"><div class="slice"></div></div></div>'
                 ]
             },
             createSwitch = function(isOn){


### PR DESCRIPTION
As opposed to using the page's keywords
