### PR TITLE
Fix show/hiding of containers

### DIFF
--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -25,7 +25,7 @@
                             </span>
                         </h2>
                     </div>
-                    <div class="container__body">
+                    <div class="container__body container--rolled-up-hide">
                         @fragments.collections.index(items, style, containerIndex)
                         @if(nav.isDefined) {
                             <div class="pagination u-cf">

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -28,7 +28,7 @@
                                 @fragments.containers.elements.dateOrTitle(collection, items)
                             </h2>
                         </div>
-                        <div class="container__body">
+                        <div class="container__body container--rolled-up-hide">
                             @fragments.collections.news(items, style, containerIndex)
                         </div>
                     </div>

--- a/common/app/views/fragments/containers/series.scala.html
+++ b/common/app/views/fragments/containers/series.scala.html
@@ -36,7 +36,7 @@
                             </div>
                         }
                     }
-                    <div class="container__body">
+                    <div class="container__body container--rolled-up-hide">
                         @fragments.collections.series(items, style, containerIndex)
                     </div>
                 </div>

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -22,7 +22,7 @@
                         </h2>
                     }
                 </div>
-                <div class="container__body">
+                <div class="container__body container--rolled-up-hide">
                     @fragments.contributor(page)
                     @fragments.collections.tag(collection.items, style, containerIndex)
                 </div>


### PR DESCRIPTION
Add `container--rolled-up-hide` class to all containers

Currently, only rule is the first container on a page, or a container without a title, does not have a show/hide button - https://github.com/guardian/frontend/blob/master/common/app/views/support/package.scala#L823
