### PR TITLE
fix close button of top page message overlap text

### DIFF
--- a/common/app/assets/stylesheets/module/_release-message.scss
+++ b/common/app/assets/stylesheets/module/_release-message.scss
@@ -106,9 +106,9 @@
 }
 
 .site-message__inner {
-    rem((
-        padding: $gs-baseline 42px $gs-baseline $gs-gutter/2;
-    ))
+    @include rem((
+        padding: $gs-baseline 42px $gs-baseline $gs-gutter/2
+    ));
 
     @include mq(mobileLandscape) {
         padding-left: $gs-gutter;

--- a/common/app/assets/stylesheets/module/_release-message.scss
+++ b/common/app/assets/stylesheets/module/_release-message.scss
@@ -106,7 +106,7 @@
 }
 
 .site-message__inner {
-    padding: $gs-baseline $gs-gutter/2;
+    padding: $gs-baseline 42px $gs-baseline $gs-gutter/2;
     @include box-sizing(border-box);
 
     @include mq(mobileLandscape) {

--- a/common/app/assets/stylesheets/module/_release-message.scss
+++ b/common/app/assets/stylesheets/module/_release-message.scss
@@ -106,8 +106,9 @@
 }
 
 .site-message__inner {
-    padding: $gs-baseline 42px $gs-baseline $gs-gutter/2;
-    @include box-sizing(border-box);
+    rem((
+        padding: $gs-baseline 42px $gs-baseline $gs-gutter/2;
+    ))
 
     @include mq(mobileLandscape) {
         padding-left: $gs-gutter;

--- a/common/app/views/fragments/message.scala.html
+++ b/common/app/views/fragments/message.scala.html
@@ -4,12 +4,14 @@
 @import common.ClassicLink
 
 <div class="site-message js-site-message is-hidden" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
-    <div class="site-message__inner js-site-message-inner gs-container">
-        <div class="js-site-message-copy u-cf">
+    <div class="gs-container">
+        <div class="site-message__inner js-site-message-inner">
+            <div class="js-site-message-copy u-cf">
+            </div>
+            <button class="site-message__close js-site-message-close" data-link-name="hide release message">
+                <i class="i i-message-close"></i>
+                <span class="u-h">Hide this message</span>
+            </button>
         </div>
-        <button class="site-message__close js-site-message-close" data-link-name="hide release message">
-            <i class="i i-message-close"></i>
-            <span class="u-h">Hide this message</span>
-        </button>
     </div>
 </div>


### PR DESCRIPTION
before
![png-1](https://cloud.githubusercontent.com/assets/1492162/3190250/770ee550-eccc-11e3-96fe-dd726f13748d.png)
after
![png](https://cloud.githubusercontent.com/assets/1492162/3190253/7c2b23aa-eccc-11e3-9e7d-c35436a84be0.png)
