### PR TITLE
CSS loaded asynchronously is appended to the head

### DIFF
--- a/common/app/views/fragments/commonJavaScriptSetup.scala.html
+++ b/common/app/views/fragments/commonJavaScriptSetup.scala.html
@@ -96,13 +96,13 @@
 
         @if(CssFromStorageSwitch.isSwitchedOn && !play.Play.isDev()) {
             function loadCssFromStorage() {
-                var c = localStorage.getItem('gu.css.@Static("stylesheets/global.css").md5Key'), s, sc;
+                var c = localStorage.getItem('gu.css.@Static("stylesheets/global.css").md5Key'), s, head;
                 if(c) {
                     s = document.createElement('style');
-                    sc = document.getElementsByTagName('script')[0];
+                    head = document.getElementsByTagName('head')[0];
                     s.innerHTML = c;
                     s.setAttribute('data-loaded-from', 'local');
-                    sc.parentNode.insertBefore(s, sc);
+                    head.appendChild(s);
                     guardian.css.loaded = true;
                 }
             }

--- a/common/app/views/fragments/loadCss.scala.html
+++ b/common/app/views/fragments/loadCss.scala.html
@@ -17,8 +17,8 @@
                 if(!guardian.css.loaded) {
 
                     function injectElement(e) {
-                        var sc = document.getElementsByTagName('script')[0];
-                        sc.parentNode.insertBefore(e, sc);
+                        var head = document.getElementsByTagName('head')[0];
+                        head.appendChild(e);
                     }
 
                     function inlineCss(c) {
@@ -29,7 +29,7 @@
                     }
 
                     function storeCss(c) {
-                        Object.keys(localStorage ).forEach(function(key) {
+                        Object.keys(localStorage).forEach(function(key) {
                             if(key.match(/^gu.css./g)) { localStorage.removeItem(key); }
                         });
                         try {


### PR DESCRIPTION
This fixes the issue with a bad ordering that broke the CSS cascade.

![ ](http://gifs.joelglovier.com/boom/headshot-bball.gif)
