### PR TITLE
Fix mirroring of facia metrics

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -342,7 +342,7 @@ object FaciaToolMetrics {
   object FrontPressCronFailure extends SimpleCountMetric(
     "facia-front-press",
     "facia-front-press-cron-failure",
-    "Facia front press cron failue count",
+    "Facia front press cron failure count",
     "Number of times facia-tool has has a failure in pressing"
   )
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -329,21 +329,21 @@ object FaciaToolMetrics {
     "facia-front-press",
     "facia-front-press-failure",
     "Facia front press failue count",
-    "Number of times facia-tool has has a failure in pressing"
+    "Number of times facia-tool has had a failure in pressing"
   )
 
   object FrontPressCronSuccess extends SimpleCountMetric(
     "facia-front-press",
     "facia-front-press-cron-success",
     "Facia front press cron success count",
-    "Number of times facia-tool has successfully pressed"
+    "Number of times facia-tool cron job has successfully pressed"
   )
 
   object FrontPressCronFailure extends SimpleCountMetric(
     "facia-front-press",
     "facia-front-press-cron-failure",
     "Facia front press cron failure count",
-    "Number of times facia-tool has has a failure in pressing"
+    "Number of times facia-tool cron job has had a failure in pressing"
   )
 
   object InvalidContentExceptionMetric extends SimpleCountMetric(

--- a/facia-tool/app/frontpress/FrontPress.scala
+++ b/facia-tool/app/frontpress/FrontPress.scala
@@ -78,16 +78,7 @@ trait FrontPress extends Logging {
   private def retrieveFrontByPath(id: String): Future[Iterable[(Config, Collection)]] = {
     val collectionIds: List[Config] = ConfigAgent.getConfigForId(id).getOrElse(Nil)
     val collections = collectionIds.map(config => FaciaToolCollectionParser.getCollection(config.id, config, Uk).map((config, _)))
-    val futureSequence = Future.sequence(collections)
-    futureSequence.onFailure{case t: Throwable =>
-      FrontPressFailure.increment()
-      log.warn(t.toString)
-    }
-    futureSequence.onSuccess{case _ =>
-      FrontPressSuccess.increment()
-      log.info(s"Successful press of $id")
-    }
-    futureSequence
+    Future.sequence(collections)
   }
 
   private def generateCollectionJson(config: Config, collection: Collection): JsValue =

--- a/facia-tool/app/frontpress/FrontPressJob.scala
+++ b/facia-tool/app/frontpress/FrontPressJob.scala
@@ -11,13 +11,12 @@ import play.api.libs.json.{JsObject, Json}
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Await}
 import frontpress.FrontPress
-import common.FaciaToolMetrics.{FrontPressCronFailure, FrontPressCronSuccess}
+import common.FaciaToolMetrics.{FrontPressSuccess, FrontPressFailure, FrontPressCronFailure, FrontPressCronSuccess}
 import play.api.libs.concurrent.Akka
 import scala.util.{Failure, Success}
 import conf.Switches.FrontPressJobSwitch
 
 object FrontPressJob extends Logging with implicits.Collections {
-
   val queueUrl: Option[String] = Configuration.faciatool.frontPressQueueUrl
 
   import play.api.Play.current
@@ -35,27 +34,24 @@ object FrontPressJob extends Logging with implicits.Collections {
         val client = newClient
         try {
           val receiveMessageResult = client.receiveMessage(new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(10))
-          receiveMessageResult.getMessages
-            .map(getConfigFromMessage)
-            .distinct
-            .map { path =>
-              val f = pressByPathId(path)
-              f.onComplete {
-                case Success(_) =>
-                  deleteMessage(receiveMessageResult, queueUrl)
-                  FrontPressCronSuccess.increment()
-                case Failure(t) =>
-                  deleteMessage(receiveMessageResult, queueUrl)
-                  log.warn(t.toString)
-                  FrontPressCronFailure.increment()
-              }
-              Await.ready(f, 20.seconds) //Block until ready!
+          Future.traverse(receiveMessageResult.getMessages.map(getConfigFromMessage).distinct) { path =>
+            val f = pressByPathId(path)
+            f onComplete {
+              case Success(_) =>
+                deleteMessage(receiveMessageResult, queueUrl)
+                FrontPressCronSuccess.increment()
+              case Failure(error) =>
+                deleteMessage(receiveMessageResult, queueUrl)
+                log.warn("Error updating collection via cron", error)
+                FrontPressCronFailure.increment()
+            }
+
+            f
           }
         } catch {
-          case t: Throwable => {
-            log.warn(t.toString)
+          case error: Throwable =>
+            log.error("Error updating collection via cron", error)
             FrontPressCronFailure.increment()
-          }
         }
       }
     }
@@ -72,14 +68,24 @@ object FrontPressJob extends Logging with implicits.Collections {
   }
 
   def pressByCollectionIds(ids: Set[String]): Future[Set[JsObject]] = {
-    //Give it one second to update
-    Await.ready(ConfigAgent.refreshAndReturn(), Configuration.faciatool.configBeforePressTimeout.millis)
-    val paths: Set[String] = for {
-      id <- ids
-      path <- ConfigAgent.getConfigsUsingCollectionId(id)
-    } yield path
-    val setOfFutureJson: Set[Future[JsObject]] = paths.map(pressByPathId)
-    Future.sequence(setOfFutureJson) //To a Future of Set Json
+    ConfigAgent.refreshAndReturn() flatMap { _ =>
+      val paths: Set[String] = for {
+        id <- ids
+        path <- ConfigAgent.getConfigsUsingCollectionId(id)
+      } yield path
+      val ftr = Future.sequence(paths.map(pressByPathId))
+
+      ftr onComplete {
+        case Failure(error) =>
+          FrontPressFailure.increment()
+          log.error("Error manually pressing collection through update from tool", error)
+
+        case Success(_) =>
+          FrontPressSuccess.increment()
+      }
+
+      ftr
+    }
   }
 
   def pressByPathId(path: String): Future[JsObject] = {
@@ -91,5 +97,4 @@ object FrontPressJob extends Logging with implicits.Collections {
 
   def getConfigFromMessage(message: Message): String =
     (Json.parse(message.getBody) \ "Message").as[String]
-
 }

--- a/facia-tool/app/frontpress/FrontPressJob.scala
+++ b/facia-tool/app/frontpress/FrontPressJob.scala
@@ -8,8 +8,7 @@ import com.amazonaws.regions.{Regions, Region}
 import scala.collection.JavaConversions._
 import services.{ConfigAgent, S3FrontsApi}
 import play.api.libs.json.{JsObject, Json}
-import scala.concurrent.duration._
-import scala.concurrent.{Future, Await}
+import scala.concurrent.Future
 import frontpress.FrontPress
 import common.FaciaToolMetrics.{FrontPressSuccess, FrontPressFailure, FrontPressCronFailure, FrontPressCronSuccess}
 import play.api.libs.concurrent.Akka


### PR DESCRIPTION
Separates out the metric that records successful or unsuccessful presses triggered by users of the tool from the metric that records successful or unsuccessful presses triggered by the cron job.

Also removes some `Await.result`s ... 
