### PR TITLE
Commercial: don't show commercial components on fronts with page skins

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -18,5 +18,7 @@
         @fragments.footballNav(index.page)
     </section>
 
-    @fragments.commercial.adSlot(name="merchandising", adType="commercial-component", sizeMapping=Map("mobile" -> Seq("888,88")), showLabel=false, refresh=false)
+    @if(!index.page.hasPageSkin) {
+        @fragments.commercial.adSlot(name = "merchandising", adType = "commercial-component", sizeMapping = Map("mobile" -> Seq("888,88")), showLabel = false, refresh = false)
+    }
 </div>

--- a/common/app/assets/javascripts/modules/adverts/front-commercial-components.js
+++ b/common/app/assets/javascripts/modules/adverts/front-commercial-components.js
@@ -10,9 +10,9 @@ define([
 
     return {
 
-        init: once(function() {
+        init: once(function(config) {
             var $containers = $('.facia-container section.container');
-            if($containers.length < 4) {
+            if($containers.length < 4 && !config.page.hasPageSkin) {
                 return $containers.first().after(dfp.createAdSlot('merchandising-high', 'commercial-component-high'));
             }
         })

--- a/common/app/assets/javascripts/modules/experiments/tests/high-relevance-commercial-component.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/high-relevance-commercial-component.js
@@ -29,7 +29,8 @@ define([
             // only apply on fronts with at least 4 containers
             return (config.page.contentType === 'Tag' || config.page.isFront) &&
                 qwery('.facia-container section.container').length >= 4 &&
-                ['desktop', 'wide'].indexOf(detect.getBreakpoint()) !== -1;
+                ['desktop', 'wide'].indexOf(detect.getBreakpoint()) !== -1 &&
+                !config.page.hasPageSkin;
         };
 
         this.variants = [

--- a/common/app/assets/javascripts/modules/experiments/tests/high-relevance-commercial-component.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/high-relevance-commercial-component.js
@@ -28,9 +28,9 @@ define([
         this.canRun = function (config) {
             // only apply on fronts with at least 4 containers
             return (config.page.contentType === 'Tag' || config.page.isFront) &&
+                !config.page.hasPageSkin &&
                 qwery('.facia-container section.container').length >= 4 &&
-                ['desktop', 'wide'].indexOf(detect.getBreakpoint()) !== -1 &&
-                !config.page.hasPageSkin;
+                ['desktop', 'wide'].indexOf(detect.getBreakpoint()) !== -1;
         };
 
         this.variants = [

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -18,7 +18,10 @@
                 @fragments.frontCollection(faciaPage, block, collections.size, index)
             }
         }
-        @fragments.commercial.commercialComponent(name = "merchandising", adType = "commercial-component")
+
+        @if(!faciaPage.hasPageSkin) {
+            @fragments.commercial.commercialComponent(name = "merchandising", adType = "commercial-component")
+        }
     </div>
 }
 


### PR DESCRIPTION
For now, cos they're all bust and it'll be a big job to fix
