### PR TITLE
Fix text clipping on mobile

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_linkslist.scss
+++ b/common/app/assets/stylesheets/module/facia/_linkslist.scss
@@ -56,6 +56,10 @@
     &.show-more--hidden {
         display: none;
     }
+
+    @include mq($to: tablet) {
+        width: auto;
+    }
 }
 .linkslist__action {
     position: relative;


### PR DESCRIPTION
... yes, back from the grave :-) This fixes text being clipped on 320px mobile width
## Before

![screen shot 2014-06-06 at 12 12 15](https://cloud.githubusercontent.com/assets/518943/3202156/3be3690c-ed8e-11e3-86c4-2e943e9a7e6d.png)
## After

![screen shot 2014-06-06 at 12 12 08](https://cloud.githubusercontent.com/assets/518943/3202160/419e2558-ed8e-11e3-87f1-13495785d337.png)

@kaelig This is probably something for **guss-layout** though
