### PR TITLE
Separate Editorial & Commercial tools

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -30,14 +30,14 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
   implicit val trailWrite = Json.writes[Trail]
   implicit val blockWrite = Json.writes[Block]
 
-  def collectionsEditor() = ExpiringAuthentication { request =>
+  def collectionsEditor(priority: String) = ExpiringAuthentication { request =>
     val identity = Identity(request).get
-    Cached(60) { Ok(views.html.collections(Configuration.environment.stage, Option(identity))) }
+    Cached(60) { Ok(views.html.collections(Configuration.environment.stage, priority, Option(identity))) }
   }
 
-  def configEditor() = ExpiringAuthentication { request =>
+  def configEditor(priority: String) = ExpiringAuthentication { request =>
     val identity = Identity(request).get
-    Cached(60) { Ok(views.html.config(Configuration.environment.stage, Option(identity))) }
+    Cached(60) { Ok(views.html.config(Configuration.environment.stage, priority, Option(identity))) }
   }
 
   def listCollections = AjaxExpiringAuthentication { request =>

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -30,7 +30,12 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
   implicit val trailWrite = Json.writes[Trail]
   implicit val blockWrite = Json.writes[Block]
 
-  def collectionsEditor(priority: String) = ExpiringAuthentication { request =>
+  def priorities() = ExpiringAuthentication { request =>
+    val identity = Identity(request).get
+    Cached(60) { Ok(views.html.priority(Configuration.environment.stage, "", Option(identity))) }
+  }
+
+  def collectionEditor(priority: String) = ExpiringAuthentication { request =>
     val identity = Identity(request).get
     Cached(60) { Ok(views.html.collections(Configuration.environment.stage, priority, Option(identity))) }
   }

--- a/facia-tool/app/views/admin_main.scala.html
+++ b/facia-tool/app/views/admin_main.scala.html
@@ -1,4 +1,4 @@
-@(title: String, priority: String, env: String, isAuthed: Boolean = false, identity: Option[Identity] = None)(content: Html)
+@(title: String, env: String, priority: Option[String] = None, isAuthed: Boolean = false, identity: Option[Identity] = None)(content: Html)
 
 <!DOCTYPE html>
 

--- a/facia-tool/app/views/admin_main.scala.html
+++ b/facia-tool/app/views/admin_main.scala.html
@@ -1,10 +1,10 @@
-@(title: String, env: String, isAuthed: Boolean = false, identity: Option[Identity] = None)(content: Html)
+@(title: String, priority: String, env: String, isAuthed: Boolean = false, identity: Option[Identity] = None)(content: Html)
 
 <!DOCTYPE html>
 
 <html ng-app>
     <head>
-        <title>@title</title>
+        <title>@priority @title</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <meta charset="utf-8"/>
 
@@ -43,6 +43,7 @@
             define('config', function() {
                 return {
                     env: '@env.toLowerCase',
+                    priority: '@priority',
                     editions: [@Html(Edition.all.map(_.id.toLowerCase).mkString("'","','", "'"))],
                     navSections: [@Html(FaciaToolConfiguration.sectionsFromNav.mkString("'", "', '", "'"))],
                     email: '@identity.map(_.email).getOrElse("")'
@@ -55,7 +56,7 @@
 
     <img class="logo" src="@routes.Assets.at("images/logo.png")" />
 
-    <h1 class="tool-title">Fronts Editor</h1>
+    <h1 class="tool-title">@priority @title</h1>
 
     @if(Switches.ToolDisable.isSwitchedOn) {
         <span class="message message--important">Temporarily disabled. Please try again shortly.</span>

--- a/facia-tool/app/views/admin_main.scala.html
+++ b/facia-tool/app/views/admin_main.scala.html
@@ -54,7 +54,7 @@
     </head>
     <body class="@if(isAuthed){is-authed}">
 
-    <img class="logo" src="@routes.Assets.at("images/logo.png")" />
+    <a href="/"><img class="logo" src="@routes.Assets.at("images/logo.png")" /></a>
 
     <h1 class="tool-title">@priority @title</h1>
 
@@ -62,12 +62,9 @@
         <span class="message message--important">Temporarily disabled. Please try again shortly.</span>
     } else {
         @if(isAuthed) {
-            <span class="message message--loading" data-bind="visible: false">loading...</span>
-
             @if(Play.isDev && Configuration.facia.stage.toLowerCase != "dev") {
                 <span class="message message--important">Editing @Configuration.facia.stage.toUpperCase!</span>
             }
-
             <a class="log-in-out" href="/logout">Logout</a>
             @content
         } else {

--- a/facia-tool/app/views/auth/login.scala.html
+++ b/facia-tool/app/views/auth/login.scala.html
@@ -1,6 +1,6 @@
 @(error: Option[String] = None, env: String)
 
-@admin_main("Login", env) {
+@admin_main("Login", "", env) {
         @if(error.isDefined) {
             <div class="alert alert-error">
                 <p>@error.get</p>

--- a/facia-tool/app/views/auth/login.scala.html
+++ b/facia-tool/app/views/auth/login.scala.html
@@ -1,6 +1,6 @@
 @(error: Option[String] = None, env: String)
 
-@admin_main("Login", "", env) {
+@admin_main("Login", env) {
         @if(error.isDefined) {
             <div class="alert alert-error">
                 <p>@error.get</p>

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -19,10 +19,8 @@
 
     <div class="toolbar" data-bind="visible: true" style="display: none">
 
-        <span data-bind="if: fronts().length > 1">
-            <span class="tool-label">Front</span>
-            <select class="tool-select" data-bind="options: fronts, value: front, optionsCaption: 'choose...'"></select>
-        </span>
+        <span class="tool-label">Front</span>
+        <select class="tool-select" data-bind="options: fronts, value: front, optionsCaption: 'choose...'"></select>
 
         <a class="spark" target="ophan" title="Dark blue: Guardian. Green: Google. Light blue: Other." data-bind="
             visible: frontSparkUrl,

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -1,6 +1,6 @@
 @(env: String, priority: String, identity: Option[Identity])
 
-@admin_main("fronts", priority, env, isAuthed = true, identity) {
+@admin_main("fronts", env, Some(priority), isAuthed = true, identity) {
 
 <div style="display: none;" data-bind="visible: true">
 

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -1,6 +1,6 @@
-@(env: String, identity: Option[Identity])
+@(env: String, priority: String, identity: Option[Identity])
 
-@admin_main("Fronts editor", env, isAuthed = true, identity) {
+@admin_main("fronts", priority, env, isAuthed = true, identity) {
 
 <div style="display: none;" data-bind="visible: true">
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -1,6 +1,6 @@
 @(env: String, priority: String, identity: Option[Identity])
 
-@admin_main("config", priority, env, isAuthed = true, identity) {
+@admin_main("config", env, Some(priority), isAuthed = true, identity) {
 
 <div style="display: none;" data-bind="
     visible: true,

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -1,6 +1,6 @@
-@(env: String, identity: Option[Identity])
+@(env: String, priority: String, identity: Option[Identity])
 
-@admin_main("Fronts editor", env, isAuthed = true, identity) {
+@admin_main("configuration", priority, env, isAuthed = true, identity) {
 
 <div style="display: none;" data-bind="
     visible: true,

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -1,6 +1,6 @@
 @(env: String, priority: String, identity: Option[Identity])
 
-@admin_main("configuration", priority, env, isAuthed = true, identity) {
+@admin_main("config", priority, env, isAuthed = true, identity) {
 
 <div style="display: none;" data-bind="
     visible: true,
@@ -202,7 +202,7 @@
                         <!-- ko if: !state.isOpenProps() -->
                             <span class="linky" data-bind="click: openProps">Edit metadata</span>
                             &middot;
-                            <a data-bind="attr: {href: '/?front=' + id()}">content</a>
+                            <a data-bind="attr: {href: '/@priority?front=' + id()}">content</a>
                         <!-- /ko -->
                     </div>
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -26,6 +26,7 @@
     </div>
 
     <script type="text/html" id="template_minimal_collection">
+      <!-- ko if: state.withinPriority -->
         <div class="cnf-collection">
             <a class="cnf-collection__name" data-bind="
                 click: toggleOpen,
@@ -41,6 +42,7 @@
                 </span>
             </span>
         </div>
+      <!-- /ko -->
     </script>
 
     <script type="text/html" id="template_collection">
@@ -136,6 +138,7 @@
     </script>
 
     <script type="text/html" id="template_front">
+      <!-- ko if: state.withinPriority -->
         <div class="cnf-front" data-bind="
             css: {open: state.isOpen}">
 
@@ -223,6 +226,7 @@
            </div>
 
         </div>
+      <!-- /ko -->
     </script>
 
 </div>

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -202,7 +202,7 @@
                         <!-- ko if: !state.isOpenProps() -->
                             <span class="linky" data-bind="click: openProps">Edit metadata</span>
                             &middot;
-                            <a data-bind="attr: {href: '/@priority?front=' + id()}">content</a>
+                            <a data-bind="attr: {href: '/@{priority}?front=' + id()}">content</a>
                         <!-- /ko -->
                     </div>
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -149,12 +149,6 @@
 
             <!-- ko if: !id() -->
                 <div class="cnf-front__inner cnf-form">
-                    <label>Type</label>
-                    <input type="radio" name="group01" data-bind="checkedValue: undefined, checked: props.priority" />
-                    <span class="radio-label">editorial</span>
-                    <input type="radio" name="group01" value="commercial" data-bind="checked: props.priority" />
-                    <span class="radio-label">commercial</span>
-
                     <label>URL path</label>
                     <input type="text" placeholder="eg. world/middleeast" data-bind="value: id"/>
 

--- a/facia-tool/app/views/priority.scala.html
+++ b/facia-tool/app/views/priority.scala.html
@@ -3,7 +3,7 @@
 @admin_main("Fronts Editor", priority, env, isAuthed = true, identity) {
 
 <div class="front-priorities">
-    <a class="front-priorities--priority" href="/editorial">Editorial Fronts</a>
+    <a class="front-priorities--priority" href="/editorial">Editorial Fronts</a> (editorial staff only)
     <a class="front-priorities--priority" href="/commercial">Commercial Fronts</a>
 </div>
 

--- a/facia-tool/app/views/priority.scala.html
+++ b/facia-tool/app/views/priority.scala.html
@@ -1,0 +1,10 @@
+@(env: String, priority: String, identity: Option[Identity])
+
+@admin_main("Fronts Editor", priority, env, isAuthed = true, identity) {
+
+<div class="front-priorities">
+    <a class="front-priorities--priority" href="/editorial">Editorial Fronts</a>
+    <a class="front-priorities--priority" href="/commercial">Commercial Fronts</a>
+</div>
+
+}

--- a/facia-tool/app/views/priority.scala.html
+++ b/facia-tool/app/views/priority.scala.html
@@ -1,6 +1,6 @@
 @(env: String, priority: String, identity: Option[Identity])
 
-@admin_main("Fronts Editor", priority, env, isAuthed = true, identity) {
+@admin_main("Fronts Editor", env, Some(priority), isAuthed = true, identity) {
 
 <div class="front-priorities">
     <a class="front-priorities--priority" href="/editorial">Editorial Fronts</a> (editorial staff only)

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -16,11 +16,12 @@ GET           /assets/*file              controllers.Assets.at(path="/public", f
 #######################################################
 
 # Fronts
-GET           /                          controllers.FaciaToolController.collectionsEditor(priority="editorial")
-GET           /commercial                controllers.FaciaToolController.collectionsEditor(priority="commercial")
+GET           /                          controllers.FaciaToolController.priorities()
+GET           /editorial                 controllers.FaciaToolController.collectionEditor(priority="editorial")
+GET           /commercial                controllers.FaciaToolController.collectionEditor(priority="commercial")
 
-GET           /configuration             controllers.FaciaToolController.configEditor(priority="editorial")
-GET           /commercial/configuration  controllers.FaciaToolController.configEditor(priority="commercial")
+GET           /editorial/config          controllers.FaciaToolController.configEditor(priority="editorial")
+GET           /commercial/config         controllers.FaciaToolController.configEditor(priority="commercial")
 
 GET           /publish-all               controllers.FaciaToolController.publishAll()
 GET           /publish-all/comet         controllers.FaciaToolController.publishAllStream()

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -16,8 +16,12 @@ GET           /assets/*file              controllers.Assets.at(path="/public", f
 #######################################################
 
 # Fronts
-GET           /                          controllers.FaciaToolController.collectionsEditor()
-GET           /configuration             controllers.FaciaToolController.configEditor()
+GET           /                          controllers.FaciaToolController.collectionsEditor(priority="editorial")
+GET           /commercial                controllers.FaciaToolController.collectionsEditor(priority="commercial")
+
+GET           /configuration             controllers.FaciaToolController.configEditor(priority="editorial")
+GET           /commercial/configuration  controllers.FaciaToolController.configEditor(priority="commercial")
+
 GET           /publish-all               controllers.FaciaToolController.publishAll()
 GET           /publish-all/comet         controllers.FaciaToolController.publishAllStream()
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -96,6 +96,17 @@ a:hover {
     margin: 13px 10px 0 0;
 }
 
+.front-priorities {
+    clear: both;
+    padding: 20px 0 0 20px;
+}
+
+.front-priorities--priority {
+    display: block;
+    font-size: 20px;
+    padding: 10px 0 0 0;
+}
+
 .left-col {
     -moz-box-sizing: border-box;
     box-sizing: border-box;

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -67,6 +67,7 @@ a:hover {
     line-height: 30px;
     color: #000;
     font-weight: normal;
+    text-transform: capitalize;
 }
 
 .message {

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -16,7 +16,7 @@ define([
     'models/collections/article',
     'models/collections/latest-articles'
 ], function(
-    config,
+    pageConfig,
     ko,
     vars,
     fetchSettings,
@@ -87,7 +87,7 @@ define([
         };
 
         model.previewUrl = ko.computed(function() {
-            return vars.CONST.viewer + '#env=' + config.env + '&url=' + model.front() + encodeURIComponent('?view=mobile');
+            return vars.CONST.viewer + '#env=' + pageConfig.env + '&url=' + model.front() + encodeURIComponent('?view=mobile');
         });
 
         function detectPressFailure() {
@@ -135,10 +135,6 @@ define([
 
         function getFront() {
             return queryParams().front;
-        }
-
-        function getPriority() {
-            return queryParams().priority;
         }
 
         function loadCollections(frontId) {
@@ -211,7 +207,7 @@ define([
             droppable.init();
 
             fetchSettings(function (config, switches) {
-                var priority = getPriority();
+                var priority = pageConfig.priority === 'editorial' ? undefined  : pageConfig.priority;
 
                 if (switches['facia-tool-disable']) {
                     terminate();

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -207,8 +207,6 @@ define([
             droppable.init();
 
             fetchSettings(function (config, switches) {
-                var priority = pageConfig.priority === 'editorial' ? undefined  : pageConfig.priority;
-
                 if (switches['facia-tool-disable']) {
                     terminate();
                     return;
@@ -221,7 +219,7 @@ define([
                     getFront() === 'testcard' ? ['testcard'] :
                        _.chain(config.fronts)
                         .map(function(front, path) {
-                            return front.priority === priority ? path : undefined;
+                            return front.priority === vars.priority ? path : undefined;
                         })
                         .without(undefined)
                         .without('testcard')

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -137,6 +137,10 @@ define([
             return queryParams().front;
         }
 
+        function getPriority() {
+            return queryParams().priority;
+        }
+
         function loadCollections(frontId) {
             model.collections(
                 ((vars.state.config.fronts[frontId] || {}).collections || [])
@@ -207,6 +211,8 @@ define([
             droppable.init();
 
             fetchSettings(function (config, switches) {
+                var priority = getPriority();
+
                 if (switches['facia-tool-disable']) {
                     terminate();
                     return;
@@ -217,9 +223,13 @@ define([
 
                 model.fronts(
                     getFront() === 'testcard' ? ['testcard'] :
-                       _.chain(_.keys(config.fronts))
+                       _.chain(config.fronts)
+                        .map(function(front, path) {
+                            return front.priority === priority ? path : undefined;
+                        })
+                        .without(undefined)
                         .without('testcard')
-                        .sortBy(function(id) { return id; })
+                        .sortBy(function(path) { return path; })
                         .value()
                 );
             }, vars.CONST.configSettingsPollMs, true)

--- a/facia-tool/public/javascripts/models/config/collection.js
+++ b/facia-tool/public/javascripts/models/config/collection.js
@@ -1,7 +1,8 @@
 /* global _: true */
 define([
-    'config',
     'knockout',
+    'config',
+    'priority',
     'modules/vars',
     'modules/content-api',
     'utils/strip-empty-query-params',
@@ -9,8 +10,9 @@ define([
     'utils/populate-observables',
     'utils/collection-guid'
 ], function(
-    pageConfig,
     ko,
+    pageConfig,
+    priority,
     vars,
     contentApi,
     stripEmptyQueryParams,
@@ -21,8 +23,6 @@ define([
     var checkCount = 0;
 
     function Collection(opts) {
-        var priority = pageConfig.priority === 'editorial' ? undefined  : pageConfig.priority;
-
         opts = opts || {};
 
         this.id = opts.id || collectionGuid();
@@ -49,7 +49,7 @@ define([
             'apiQueryStatus']);
 
         this.state.withinPriority = ko.computed(function() {
-            return _.some(this.parents(), function(front) {return front.props.priority() === priority; });
+            return _.some(this.parents(), function(front) {return front.props.priority() === priority(); });
         }, this);
 
         this.meta.apiQuery.subscribe(function(apiQuery) {

--- a/facia-tool/public/javascripts/models/config/collection.js
+++ b/facia-tool/public/javascripts/models/config/collection.js
@@ -1,5 +1,6 @@
 /* global _: true */
 define([
+    'config',
     'knockout',
     'modules/vars',
     'modules/content-api',
@@ -8,6 +9,7 @@ define([
     'utils/populate-observables',
     'utils/collection-guid'
 ], function(
+    pageConfig,
     ko,
     vars,
     contentApi,
@@ -19,6 +21,8 @@ define([
     var checkCount = 0;
 
     function Collection(opts) {
+        var priority = pageConfig.priority === 'editorial' ? undefined  : pageConfig.priority;
+
         opts = opts || {};
 
         this.id = opts.id || collectionGuid();
@@ -43,6 +47,10 @@ define([
             'isOpen',
             'underDrag',
             'apiQueryStatus']);
+
+        this.state.withinPriority = ko.computed(function() {
+            return _.some(this.parents(), function(front) {return front.props.priority() === priority; });
+        }, this);
 
         this.meta.apiQuery.subscribe(function(apiQuery) {
             if (this.state.isOpen()) {

--- a/facia-tool/public/javascripts/models/config/collection.js
+++ b/facia-tool/public/javascripts/models/config/collection.js
@@ -2,7 +2,6 @@
 define([
     'knockout',
     'config',
-    'priority',
     'modules/vars',
     'modules/content-api',
     'utils/strip-empty-query-params',
@@ -12,7 +11,6 @@ define([
 ], function(
     ko,
     pageConfig,
-    priority,
     vars,
     contentApi,
     stripEmptyQueryParams,
@@ -49,7 +47,7 @@ define([
             'apiQueryStatus']);
 
         this.state.withinPriority = ko.computed(function() {
-            return _.some(this.parents(), function(front) {return front.props.priority() === priority(); });
+            return _.some(this.parents(), function(front) {return front.props.priority() === vars.priority; });
         }, this);
 
         this.meta.apiQuery.subscribe(function(apiQuery) {

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -2,6 +2,7 @@
 define([
     'knockout',
     'config',
+    'priority',
     'modules/vars',
     'modules/content-api',
     'models/group',
@@ -12,6 +13,7 @@ define([
 ], function(
     ko,
     pageConfig,
+    priority,
     vars,
     contentApi,
     Group,
@@ -21,8 +23,7 @@ define([
     findFirstById
 ) {
     function Front(opts) {
-        var self = this,
-            priority = pageConfig.priority === 'editorial' ? undefined  : pageConfig.priority;
+        var self = this;
 
         opts = opts || {};
 
@@ -47,7 +48,7 @@ define([
             'isOpenProps']);
 
         this.state.withinPriority = ko.computed(function() {
-            return this.props.priority() === priority;
+            return this.props.priority() === priority();
         }, this);
 
         this.collections = new Group({

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -46,7 +46,7 @@ define([
             'isOpenProps']);
 
         this.state.withinPriority = ko.computed(function() {
-            return this.props.priority() === vars.priority;
+            return this.props.priority() === vars.priority || this.state.isOpenProps(); // last clause allows priority change
         }, this);
 
         this.collections = new Group({

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -11,7 +11,7 @@ define([
     'utils/find-first-by-id'
 ], function(
     ko,
-    config,
+    pageConfig,
     vars,
     contentApi,
     Group,
@@ -21,7 +21,8 @@ define([
     findFirstById
 ) {
     function Front(opts) {
-        var self = this;
+        var self = this,
+            priority = pageConfig.priority === 'editorial' ? undefined  : pageConfig.priority;
 
         opts = opts || {};
 
@@ -44,6 +45,10 @@ define([
         this.state = asObservableProps([
             'isOpen',
             'isOpenProps']);
+
+        this.state.withinPriority = ko.computed(function() {
+            return this.props.priority() === priority;
+        }, this);
 
         this.collections = new Group({
             parent: self,
@@ -72,7 +77,7 @@ define([
 
         this.placeholders.navSection = ko.computed(function() {
             var path = asPath(this.id()),
-                isEditionalised = [].concat(config.editions).some(function(edition) { return edition === path[0]; });
+                isEditionalised = [].concat(pageConfig.editions).some(function(edition) { return edition === path[0]; });
 
             return this.capiProps.section() || (isEditionalised ? path.length === 1 ? undefined : path[1] : path[0]);
         }, this);

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -2,7 +2,6 @@
 define([
     'knockout',
     'config',
-    'priority',
     'modules/vars',
     'modules/content-api',
     'models/group',
@@ -13,7 +12,6 @@ define([
 ], function(
     ko,
     pageConfig,
-    priority,
     vars,
     contentApi,
     Group,
@@ -48,7 +46,7 @@ define([
             'isOpenProps']);
 
         this.state.withinPriority = ko.computed(function() {
-            return this.props.priority() === priority();
+            return this.props.priority() === vars.priority;
         }, this);
 
         this.collections = new Group({

--- a/facia-tool/public/javascripts/models/config/main.js
+++ b/facia-tool/public/javascripts/models/config/main.js
@@ -58,7 +58,7 @@ define([
             var front;
 
             if (vars.model.fronts().length <= vars.CONST.maxFronts) {
-                front = new Front();
+                front = new Front({priority: vars.priority});
                 front.setOpen(true);
                 model.pinnedFront(front);
                 model.fronts.unshift(front);

--- a/facia-tool/public/javascripts/models/config/main.js
+++ b/facia-tool/public/javascripts/models/config/main.js
@@ -15,7 +15,7 @@ define([
     'models/config/front',
     'models/config/collection'
 ], function(
-    config,
+    pageConfig,
     ko,
     vars,
     authedAjax,
@@ -36,7 +36,7 @@ define([
 
         model.switches = ko.observable();
 
-        model.navSections = [].concat(config.navSections);
+        model.navSections = [].concat(pageConfig.navSections);
 
         model.collections = ko.observableArray();
 

--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -1,5 +1,11 @@
 /* global _: true */
-define(['knockout'], function(ko) {
+define([
+    'knockout',
+    'config'
+], function(
+    ko,
+    pageConfig
+){
     var CONST = {
         editions: ['uk', 'us', 'au'],
 
@@ -68,6 +74,7 @@ define(['knockout'], function(ko) {
         model: undefined,
         sparksBase:      sparksBaseUrl(CONST.sparksParams),
         sparksBaseFront: sparksBaseUrl(CONST.sparksFrontParams),
+        priority: pageConfig.priority === 'editorial' ? undefined : pageConfig.priority,
         state: {
             config: {},
             liveMode: ko.observable(false),
@@ -76,5 +83,3 @@ define(['knockout'], function(ko) {
         }
     };
 });
-
-

--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -23,7 +23,7 @@ define([
 
         detectPressFailureMs: 10000,
 
-        maxFronts: 100,
+        maxFronts: 200,
 
         imageCdnDomain: 'guim.co.uk',
 

--- a/facia-tool/public/javascripts/utils/priority.js
+++ b/facia-tool/public/javascripts/utils/priority.js
@@ -1,5 +1,0 @@
-define(['config'], function(pageConfig) {
-    return function() {
-        return (pageConfig.priority === 'editorial' ? undefined : pageConfig.priority);
-    };
-});

--- a/facia-tool/public/javascripts/utils/priority.js
+++ b/facia-tool/public/javascripts/utils/priority.js
@@ -1,0 +1,5 @@
+define(['config'], function(pageConfig) {
+    return function() {
+        return (pageConfig.priority === 'editorial' ? undefined : pageConfig.priority);
+    };
+});


### PR DESCRIPTION
Tools now only show fronts/containers relevant to editorial or commercial, depending on which tool url is used.

Fronts editor:

```
/
/commercial
```

Config editor:

```
/configuration
/commercial/configuration
```
