### PR TITLE
grunt-pagespeed task to analyse and monitor performance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -641,6 +641,24 @@ module.exports = function (grunt) {
                 }
             }
         },
+        pagespeed: {
+            options: {
+                nokey: false,
+                key: 'AIzaSyAKNTuqwtrbsCLw8htzvzshxLxmeWb3i4s',
+                strategy: 'mobile',
+                locale: 'en_GB',
+                threshold: 80
+            },
+            facia: {
+                url: 'http://www.theguardian.com/uk?view=mobile'
+            },
+            article: {
+                url: 'http://www.theguardian.com/world/2014/jun/07/stephen-fry-denounces-uk-government-edward-snowden-nsa-revelations?view=mobile'
+            },
+            applications: {
+                url: 'http://www.theguardian.com/world/video/2014/jun/07/stephan-fry-surveillance-squalid-rancid-video?view=mobile'
+            }
+        },
 
         /*
          * Miscellaneous
@@ -773,6 +791,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-asset-monitor');
     grunt.loadNpmTasks('grunt-text-replace');
     grunt.loadNpmTasks('grunt-reloadlet');
+    grunt.loadNpmTasks('grunt-pagespeed');
 
     grunt.registerTask('default', ['compile', 'test', 'analyse']);
 
@@ -885,9 +904,15 @@ module.exports = function (grunt) {
     grunt.registerTask('test', ['jshint:common', 'test:unit:common', 'test:integration:common']);
 
     // Analyse tasks
+    grunt.registerTask('analyse:performance', function(app) {
+        if (app && !grunt.config('pagespeed')[app]) {
+            grunt.log.warn('No pagespeed config for app "' + app + '"'); return true;
+        }
+        grunt.task.run([(app) ?  'pagespeed:' + app : 'pagespeed']);
+    });
     grunt.registerTask('analyse:css', ['compile:css', 'cssmetrics:common']);
     grunt.registerTask('analyse:monitor', ['monitor:common']);
-    grunt.registerTask('analyse', ['analyse:css']);
+    grunt.registerTask('analyse', ['analyse:css', 'analyse:performance']);
 
     // Miscellaneous task
     grunt.registerTask('hookmeup', ['clean:hooks', 'shell:copyHooks']);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-env": "~0.4.1",
     "grunt-scss-lint": "^0.1.7",
-    "grunt-reloadlet": "~0.1.3"
+    "grunt-reloadlet": "~0.1.3",
+    "grunt-pagespeed": "^0.1.3"
   },
   "scripts": {
     "postinstall": "grunt hookmeup"


### PR DESCRIPTION
As I have mentioned recently Google's [PageSpeed Insight](https://developers.google.com/speed/pagespeed/insights/?url=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile) suite of tests is a very good and quick indicator of a sites performance baseline. 

This task allows you to run the psi test against our production applications from your command line via a grunt task. I.e. run `grunt analyse:performance:article` to see the result for an article page or just `grunt analyse:performance` for all of the applications.

I've set the current threshold to `80` (we currently maintain a median baseline ~88-92)
#### Next steps:
- Add to the `grunt analyse:monitor` task to beacon the information back to CloudWatch
- Configure in TeamCity monitor project as a post-deploy hook
- Set CloudWatch alarms when certain thresholds change
  -- such as total image bytes
- Visualise data on the static assets dashboard
#### Example output:

![iterm](https://cloud.githubusercontent.com/assets/80089/3209218/8526d8ec-ee60-11e3-9421-00fd344fe972.png)

Thanks to @addyosmani for making me aware of the plugin.
