### PR TITLE
fixing button float bug

### DIFF
--- a/common/app/assets/stylesheets/module/commercial/_books.scss
+++ b/common/app/assets/stylesheets/module/commercial/_books.scss
@@ -209,6 +209,11 @@ $c-commercial-books-dark: #630d4c;
         }
     }
     &.commercial--high {
+        .highitem__details {
+            .lineitem__link {
+                width: 100%;
+            }
+        }
         .commercial__relevance-low {
             .lineitem__img {
                 @include rem((


### PR DESCRIPTION
Fixes a small bug on the commercial high relevance books component when the main book has no description.

Before;
![booksbroken](https://cloud.githubusercontent.com/assets/1303616/3218671/5ab2f0c6-efed-11e3-9943-6c78138b62eb.png)

After;
![screen shot 2014-06-09 at 16 47 36](https://cloud.githubusercontent.com/assets/1303616/3218677/688d9688-efed-11e3-908b-2b2d7554cd5d.png)
