### PR TITLE
Copy non-hashed js files to s3

### DIFF
--- a/dist-tc
+++ b/dist-tc
@@ -34,6 +34,7 @@ mkdir -p "$1/target/dist/packages/frontend-static/"
 # Copy packages to dist directory
 cp "$1/conf/deploy.json" "$1/target/dist/"
 cp -r static/hash/* "$1/target/dist/packages/frontend-static"
+cp -r static/target/* "$1/target/dist/packages/frontend-static"
 cp -r "$PWD/static/abtests.json" "$1/target/dist/packages/frontend-abtests"
 
 # Generate folder for the application zip.


### PR DESCRIPTION
We (@phamann and myself) would like to enable the copying of the non-hashed js files to s3 so that url references can remain unchanged in certain circumstances.

For now this is primarily so that a non hashed version of this formstack url can be generated;

https://assets-secure.guim.co.uk/javascripts/vendor/formstack-interactive-boot.03e0d0dfd005f551febc8caa63566ca4.js

cc @rich-nguyen 
