### PR TITLE
We can now use 'parameterless' images for resizing

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -401,8 +401,8 @@ object Switches extends Collections {
     safeState = On, sellByDate = never // this is a performance related switch, not a feature switch
   )
 
-  val ParameterlessImagesSwitch = Switch("Image Server", "image-server",
-    "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
+  val ParameterlessImagesSwitch = Switch("Parameterless Images Server", "parameterless-images",
+    "If this switch is on images then image resize fields (width, height, quality) will be in the url and not in parameters.",
     safeState = Off, sellByDate = new DateMidnight(2014, 7, 31)
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -401,6 +401,11 @@ object Switches extends Collections {
     safeState = On, sellByDate = never // this is a performance related switch, not a feature switch
   )
 
+  val ParameterlessImagesSwitch = Switch("Image Server", "image-server",
+    "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
+    safeState = Off, sellByDate = new DateMidnight(2014, 7, 31)
+  )
+
   val all: List[Switch] = List(
     AutoRefreshSwitch,
     DoubleCacheTimesSwitch,
@@ -465,7 +470,8 @@ object Switches extends Collections {
     SmartBannerSwitch,
     SurveyBannerSwitch,
     FeaturesAutoContainerSwitch,
-    ForcePageSkinSwitch
+    ForcePageSkinSwitch,
+    ParameterlessImagesSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import model.{ImageContainer, ImageAsset}
 import com.gu.openplatform.contentapi.model.Asset
-import conf.Switches.ImageServerSwitch
+import conf.Switches.{ImageServerSwitch, ParameterlessImagesSwitch}
 import conf.Configuration
 
 
@@ -25,7 +25,12 @@ class ImgSrcTest extends FlatSpec with Matchers  {
 
   "ImgSrc" should "convert the URL of the image to the resizing endpoint" in {
     ImageServerSwitch.switchOn()
-    GalleryLargeTrail.bestFor(image) should be (Some(s"$imageHost/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?width=480&height=288&quality=95"))
+
+    ParameterlessImagesSwitch.switchOn()
+      GalleryLargeTrail.bestFor(image) should be (Some(s"$imageHost/w-480/h-288/q-95/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"))
+
+    ParameterlessImagesSwitch.switchOff()
+      GalleryLargeTrail.bestFor(image) should be (Some(s"$imageHost/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?width=480&height=288&quality=95"))
   }
 
   it should "not convert the URL of the image if it is disabled" in {


### PR DESCRIPTION
Width height and quality can now be encoded in the url instead of as parameters.

We think that Google (News) is not crawling images that have parameters and this is why our images are not showing up in News search results.

`/w-100/h-100/q-95/sys-images/Guardian/Pix/pictures/2014/4/28/1398679124634/de880ac6-cae1-41f5-ad6e-c7ddaf1590d8-2060x1342.jpeg`
