### PR TITLE
Revive google RSS feeds

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -114,6 +114,7 @@ class FaciaController extends Controller with Logging with ExecutionContexts wit
       })
     }.getOrElse(Future.successful(None))
 
+  /* Google news hits this endpoint */
   def renderCollectionRss(id: String) = MemcachedAction { implicit request =>
       log.info(s"Serving collection ID: $id")
       getPressedCollection(id).map { collectionOption =>

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -15,6 +15,7 @@ GET        /$path<(culture|sport|commentisfree|business|money|rss)>    controlle
 #Facia Press
 GET        /pressed/*path                                              controllers.FaciaController.renderFrontPress(path)
 
+GET        /collection/*id/rss                                         controllers.FaciaController.renderCollectionRss(id)
 GET        /container/*id.json                                         controllers.FaciaController.renderContainerJson(id)
 
 # Editionalised pages


### PR DESCRIPTION
#4574 broke google RSS.

This fixes it. This is quite serious.

Fastly tests are failing; [here](https://github.com/guardian/fastly-edge-cache/blob/4c60ae686adc52a167f96c53527eec4c5a53a251/theguardiancom/src/test/scala/com/gu/NextGenIntegrationTest.scala#L60).

This PR introduced RSS on collections (Used by google news)
https://github.com/guardian/frontend/pull/2450

@gklopper @kaelig @ironsidevsquincy 
