### PR TITLE
Football score autoupdate

### DIFF
--- a/common/app/assets/javascripts/modules/component.js
+++ b/common/app/assets/javascripts/modules/component.js
@@ -124,7 +124,7 @@ define([
     Component.prototype.fetch = function(parent, key) {
         this.checkAttached();
 
-        this.responseDataKey = key || 'html';
+        this.responseDataKey = key || this.responseDataKey;
         var self = this;
 
         return this._fetch().then(function render(resp) {
@@ -190,6 +190,8 @@ define([
                 if (self.autoupdated) {
                     self.t = setTimeout(update, self.updateEvery*1000);
                 }
+            }, function() {
+                self.t = setTimeout(update, self.updateEvery*1000);
             });
         }
 

--- a/common/app/assets/javascripts/modules/sport/football/score-board.js
+++ b/common/app/assets/javascripts/modules/sport/football/score-board.js
@@ -5,6 +5,7 @@ define([
 var ScoreBoard = function() {};
 component.define(ScoreBoard);
 ScoreBoard.prototype.componentClass = 'match-summary';
+ScoreBoard.prototype.responseDataKey = 'matchSummary';
 
 return ScoreBoard;
 

--- a/common/app/assets/javascripts/utils/page.js
+++ b/common/app/assets/javascripts/utils/page.js
@@ -28,6 +28,7 @@ function(
         assign(match, {
             date: config.webPublicationDateAsUrlPart(),
             teams: teams,
+            isLive: config.page.isLive,
             pageType: find([
                 ['minbymin', config.page.isLiveBlog],
                 ['report', config.hasTone('Match reports')],

--- a/common/test/assets/javascripts/spec/utils/page.spec.js
+++ b/common/test/assets/javascripts/spec/utils/page.spec.js
@@ -12,6 +12,7 @@ define([
             cb = sinon.spy();
             config.page.tones = '';
             config.page.series = '';
+            config.page.isLive = false;
             config.isLiveBlog = false;
         }
         beforeEach(reset);
@@ -26,7 +27,8 @@ define([
                 expect(cb.calledWith({
                     date: '2013/03/20',
                     teams: [34, 3],
-                    pageType: 'report'
+                    pageType: 'report',
+                    isLive: false
                 })).toBe(true);
             });
 
@@ -38,7 +40,8 @@ define([
                 expect(cb.calledWith({
                     date: '2013/03/20',
                     teams: [33, 1],
-                    pageType: 'minbymin'
+                    pageType: 'minbymin',
+                    isLive: false
                 })).toBe(true);
                 config.page.isLiveBlog = false;
             });
@@ -51,7 +54,8 @@ define([
                 expect(cb.calledWith({
                     date: '2013/03/20',
                     teams: [1, 2],
-                    pageType: 'preview'
+                    pageType: 'preview',
+                    isLive: false
                 })).toBe(true);
             });
 


### PR DESCRIPTION
As per request, scores on [match summaries at the top of pages](http://www.theguardian.com/football/2014/may/11/liverpool-v-newcastle-united-premier-league-title-race-live-football) now autoupdate when the blog is live (which generally corresponds with the match).

![Whammo](http://a.gifb.in/122011/1323369219_bicycle_kick_goal.gif)
