### PR TITLE
fix for #4514

### DIFF
--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -35,7 +35,6 @@
         border-right: $gs-gutter/2 solid #ffffff;
         bottom: 0;
         left: 0;
-        position: absolute;
         width: 100%;
         z-index: 2;
 

--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -31,8 +31,7 @@
     .table__caption--bottom {
         @include box-sizing(border-box);
         background: $c-neutral8;
-        border-left: $gs-gutter/2 solid #ffffff;
-        border-right: $gs-gutter/2 solid #ffffff;
+        border-width: 0px;
         bottom: 0;
         left: 0;
         width: 100%;


### PR DESCRIPTION
fix #4514  'View All Fixtures' link is separated from Fixtures component on football front
![screen shot 2014-06-10 at 14 45 28](https://cloud.githubusercontent.com/assets/1492162/3230701/a2d84fbe-f0a5-11e3-96c2-3b0b5dbede06.png)
![screen shot 2014-06-10 at 14 45 15](https://cloud.githubusercontent.com/assets/1492162/3230702/a2f00fc8-f0a5-11e3-80e4-8b05e82c0b3d.png)
