### PR TITLE
fix issue #4098

### DIFF
--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -165,6 +165,28 @@
         .match-info__venue {
             display: none;
         }
+
+        .football-match__status {
+            @include rem((
+                padding-right: $gs-gutter/5
+            ));
+        }
+        .football-match__team--home {
+            @include rem((
+                padding-right: $gs-gutter*1.25
+            ));
+        }
+        .football-match__team--away {
+            @include rem((
+                padding-left: $gs-gutter*1.25
+            ));
+        }
+
+        .table__caption--bottom {
+            position: absolute;
+            border-left: $gs-gutter/2 solid #ffffff;
+            border-right: $gs-gutter/2 solid #ffffff;
+        }
     }
 }
 


### PR DESCRIPTION
fix #4098 - Team names are cut off in Fixtures component at certain breakpoints
![screen shot 2014-06-10 at 16 42 03](https://cloud.githubusercontent.com/assets/1492162/3232673/224deca8-f0b6-11e3-89fd-36acf73b8316.png)
