### PR TITLE
Social most popular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ RUNNING_PID
 *.sublime-*
 
 local.sbt
+build.sbt
 
 node_modules
 screenshots

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -565,7 +565,7 @@ define([
             modules.initLightboxGalleries();
             modules.optIn();
             modules.displayReleaseMessage(config);
-            //modules.logReadingHistory();
+            modules.logReadingHistory();
             modules.unshackleParagraphs(config, context);
             modules.initAutoSignin(config);
             modules.loadTags(config);

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -17,7 +17,7 @@ define([
     //Modules
     'common/utils/storage',
     'common/utils/detect',
-    'common/modules/onward/popular',
+    'common/modules/onward/most-popular-factory',
     'common/modules/onward/related',
     'common/modules/onward/onward-content',
     'common/modules/ui/images',
@@ -74,7 +74,7 @@ define([
 
     storage,
     detect,
-    popular,
+    MostPopularFactory,
     Related,
     Onward,
     images,
@@ -148,10 +148,8 @@ define([
             r.renderRelatedComponent(config, context);
         },
 
-        transcludePopular: function () {
-            mediator.on('page:common:ready', function(config, context) {
-                popular(config, context);
-            });
+        transcludePopular: function (config) {
+            new MostPopularFactory(config);
         },
 
         transcludeOnwardContent: function(config, context){
@@ -539,6 +537,7 @@ define([
                 modules.loadAnalytics(config, context);
                 modules.cleanupCookies(context);
                 modules.runAbTests(config, context);
+                modules.transcludePopular(config);
                 modules.loadCommercialComponent(config, context);
                 modules.loadAdverts(config);
                 modules.transcludeRelated(config, context);
@@ -560,14 +559,13 @@ define([
             modules.initialiseNavigation(config);
             modules.showToggles();
             modules.showRelativeDates();
-            modules.transcludePopular();
             modules.loadVideoAdverts(config);
             modules.initClickstream();
             modules.transcludeCommentCounts();
             modules.initLightboxGalleries();
             modules.optIn();
             modules.displayReleaseMessage(config);
-            modules.logReadingHistory();
+            //modules.logReadingHistory();
             modules.unshackleParagraphs(config, context);
             modules.initAutoSignin(config);
             modules.loadTags(config);

--- a/common/app/assets/javascripts/modules/analytics/register.js
+++ b/common/app/assets/javascripts/modules/analytics/register.js
@@ -7,11 +7,13 @@
  */
 define([
     'common/utils/deferToLoad',
+    'common/utils/mediator',
     'common/modules/experiments/ab',
     'lodash/collections/where'
 
 ], function (
     deferToLoadEvent,
+    mediator,
     ab,
     _where
 ) {
@@ -49,6 +51,10 @@ define([
     }
 
     function initialise(config) {
+        mediator.on("register:begin", begin);
+        mediator.on("register:end", end);
+        mediator.on("register:error", error);
+
         deferToLoadEvent(function() {
             window.setTimeout(sendEvent(config), 5000);
         });

--- a/common/app/assets/javascripts/modules/analytics/register.js
+++ b/common/app/assets/javascripts/modules/analytics/register.js
@@ -51,9 +51,9 @@ define([
     }
 
     function initialise(config) {
-        mediator.on("register:begin", begin);
-        mediator.on("register:end", end);
-        mediator.on("register:error", error);
+        mediator.on('register:begin', begin);
+        mediator.on('register:end', end);
+        mediator.on('register:error', error);
 
         deferToLoadEvent(function() {
             window.setTimeout(sendEvent(config), 5000);

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -5,7 +5,8 @@ define([
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/high-relevance-commercial-component',
     'common/modules/experiments/tests/hide-supporting-links',
-    'common/modules/experiments/tests/across-the-guardian'
+    'common/modules/experiments/tests/across-the-guardian',
+    'common/modules/experiments/tests/display-socially-referred-burners'
 ], function (
     common,
     store,
@@ -13,13 +14,15 @@ define([
     mvtCookie,
     ABHighRelevanceCommercialComponent,
     ABHideSupportingLinks,
-    ABAcrossTheGuardian
+    ABAcrossTheGuardian,
+    ABSociallyReferredContent
     ) {
 
     var TESTS = [
             new ABHighRelevanceCommercialComponent(),
             new ABHideSupportingLinks(),
-            new ABAcrossTheGuardian()
+            new ABAcrossTheGuardian(),
+            new ABSociallyReferredContent()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
@@ -12,7 +12,7 @@ define([
 
         this.id = 'DisplaySociallyReferredBurners';
         this.start = '2014-06-08';
-        this.expiry = '2014-06-24';
+        this.expiry = '2014-06-26';
         this.author = 'Nathaniel Bennett';
         this.description = 'Will display content referred from social media to users who have visited less than 10 times in the previous month';
         this.audience = 0.4;

--- a/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
@@ -1,0 +1,52 @@
+define([
+    'common/$',
+    'common/modules/onward/most-popular-factory',
+    'common/modules/onward/history',
+],function(
+    $,
+    Factory,
+    History
+ ){
+
+    return function() {
+
+        this.id = 'DisplaySociallyReferredBurners';
+        this.start = '2014-06-08';
+        this.expiry = '2014-06-24';
+        this.author = 'Nathaniel Bennett';
+        this.description = 'Will display content referred from social media to users who have visited less than 10 times in the previous month';
+        this.audience = 0.4;
+        this.audienceOffset = 0.6;
+        this.successMeasure = 'Success';
+        this.audienceCriteria = 'Audience ';
+        this.dataLinkNames = 'Data link names';
+        this.idealOutcome = 'Outcome';
+
+
+
+
+        this.canRun = function () { return true; };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                    console.log('++ Control');
+                }
+            },
+            {
+                id: 'display-referred-content',
+                test: function () {
+                    var date = new Date();
+                    date.setMonth(date.getMonth()-1)
+                    var sessionsThisMonth = new History().numberOfSessionsSince(date);
+                    if ( sessionsThisMonth < 10) {
+                        $('.js-popular').remove()
+                        Factory.setShowReferred();
+                    }
+                }
+            }
+        ];
+    };
+
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
@@ -1,9 +1,11 @@
 define([
     'common/$',
+    'common/utils/config',
     'common/modules/onward/most-popular-factory',
-    'common/modules/onward/history',
+    'common/modules/onward/history'
 ],function(
     $,
+    config,
     Factory,
     History
  ){
@@ -17,31 +19,27 @@ define([
         this.description = 'Will display content referred from social media to users who have visited less than 10 times in the previous month';
         this.audience = 0.4;
         this.audienceOffset = 0.6;
-        this.successMeasure = 'Success';
-        this.audienceCriteria = 'Audience ';
-        this.dataLinkNames = 'Data link names';
-        this.idealOutcome = 'Outcome';
+        this.successMeasure = 'Increased CTR on component';
+        this.audienceCriteria = 'Social media to referrers on article pages ';
+        this.dataLinkNames = 'referred-content';
+        this.idealOutcome = 'Higher click-through rate on most popular component for users in the test variant.';
 
-
-
-
-        this.canRun = function () { return true; };
+        this.canRun = function () { return config.page.contentType === 'Article'; };
 
         this.variants = [
             {
                 id: 'control',
-                test: function () {
-                    console.log('++ Control');
-                }
+                test: function () { }
             },
             {
                 id: 'display-referred-content',
                 test: function () {
                     var date = new Date();
-                    date.setMonth(date.getMonth()-1)
+                    date.setMonth(date.getMonth()-1);
                     var sessionsThisMonth = new History().numberOfSessionsSince(date);
-                    if ( sessionsThisMonth < 10) {
-                        $('.js-popular').remove()
+
+                    if (sessionsThisMonth < 10) {
+                        $('.js-popular').remove();
                         Factory.setShowReferred();
                     }
                 }

--- a/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/display-socially-referred-burners.js
@@ -13,7 +13,7 @@ define([
     return function() {
 
         this.id = 'DisplaySociallyReferredBurners';
-        this.start = '2014-06-08';
+        this.start = '2014-06-11';
         this.expiry = '2014-06-26';
         this.author = 'Nathaniel Bennett';
         this.description = 'Will display content referred from social media to users who have visited less than 10 times in the previous month';

--- a/common/app/assets/javascripts/modules/onward/history.js
+++ b/common/app/assets/javascripts/modules/onward/history.js
@@ -69,8 +69,10 @@ define([
 
     History.prototype.recentVisits = function () {
         var sorted = _sortBy(this.get(), 'timestamp').reverse();
+        var curr_timestamp = 0,
+            session_array = [],
+            a_month_ago = new Date(Date.now());
 
-        var curr_timestamp = 0, session_array = [], a_month_ago = new Date(Date.now());
         a_month_ago.setMonth(a_month_ago.getMonth() - 1);
 
         sorted.map(function (i) {
@@ -88,7 +90,6 @@ define([
     };
 
     History.prototype.numberOfSessionsSince = function (date) {
-
         var aMonthAgoInMillis = date.getTime(), sessions = this.recentVisits();
         var sessionsInLastMonth = _filter(sessions, function(timestamp) { return parseInt(timestamp,10) > aMonthAgoInMillis; });
         return sessionsInLastMonth.length;

--- a/common/app/assets/javascripts/modules/onward/history.js
+++ b/common/app/assets/javascripts/modules/onward/history.js
@@ -4,9 +4,15 @@
  */
 define([
     'lodash/objects/assign',
+    'lodash/collections/map',
+    'lodash/collections/sortBy',
+    'lodash/collections/filter',
     'common/utils/storage'
 ], function(
     _assign,
+    _map,
+    _sortBy,
+    _filter,
     storage
     ) {
 
@@ -58,6 +64,34 @@ define([
 
         hist.unshift(newItem);
         this.set(hist);
+    };
+
+
+    History.prototype.recentVisits = function () {
+        var sorted = _sortBy(this.get(), 'timestamp').reverse();
+
+        var curr_timestamp = 0, session_array = [], a_month_ago = new Date(Date.now());
+        a_month_ago.setMonth(a_month_ago.getMonth() - 1);
+
+        sorted.map(function (i) {
+            function diffInMins() {
+                var diff = (parseInt(curr_timestamp, 10) - parseInt(i.timestamp, 10));
+                return Math.ceil(diff / 1000 / 60);
+            }
+
+            if (diffInMins() >= 30) {
+                session_array.push(i.timestamp);
+            }
+            curr_timestamp = i.timestamp;
+        });
+        return session_array;
+    };
+
+    History.prototype.numberOfSessionsSince = function (date) {
+
+        var aMonthAgoInMillis = date.getTime(), sessions = this.recentVisits();
+        var sessionsInLastMonth = _filter(sessions, function(timestamp) { return parseInt(timestamp,10) > aMonthAgoInMillis; });
+        return sessionsInLastMonth.length;
     };
 
     return History;

--- a/common/app/assets/javascripts/modules/onward/most-popular-factory.js
+++ b/common/app/assets/javascripts/modules/onward/most-popular-factory.js
@@ -1,0 +1,33 @@
+define([
+        'common/utils/context',
+        'qwery',
+        'common/modules/onward/popular',
+        'common/modules/onward/socially-referred-burners'
+    ],function(
+        context,
+        qwery,
+        popular,
+        SocialBurners
+        ) {
+
+        function MostPopularFactory(config) {
+            this.config = config;
+            this.context = context();
+            this.renderComponent();
+        }
+        MostPopularFactory.showReferredContent = false;
+        MostPopularFactory.setShowReferred = function() {
+            MostPopularFactory.showReferredContent = true;
+        };
+
+        MostPopularFactory.prototype.renderComponent = function() {
+
+            if(MostPopularFactory.showReferredContent) {
+                new SocialBurners(this.config, qwery('.js-referred', this.context));
+            } else {
+                popular(this.config, this.context);
+            }
+        };
+        return MostPopularFactory
+    }
+);

--- a/common/app/assets/javascripts/modules/onward/most-popular-factory.js
+++ b/common/app/assets/javascripts/modules/onward/most-popular-factory.js
@@ -21,13 +21,12 @@ define([
         };
 
         MostPopularFactory.prototype.renderComponent = function() {
-
             if(MostPopularFactory.showReferredContent) {
-                new SocialBurners(this.config, qwery('.js-referred', this.context));
+                new SocialBurners(this.config, qwery('.js-referred', this.context)).init();
             } else {
                 popular(this.config, this.context);
             }
         };
-        return MostPopularFactory
+        return MostPopularFactory;
     }
 );

--- a/common/app/assets/javascripts/modules/onward/popular.js
+++ b/common/app/assets/javascripts/modules/onward/popular.js
@@ -1,15 +1,16 @@
 define([
     'common/common',
     'common/modules/lazyload',
-    'common/modules/analytics/register'
+    'common/utils/mediator'
 ], function (
-    common,
-    LazyLoad,
-    register
+      common,
+      LazyLoad,
+      mediator
 ) {
 
+
     function popular(config, context, isExpandable, url, targetSelector) {
-        register.begin('popular-in-section');
+       mediator.emit('register:begin','popular-in-section');
 
         targetSelector = targetSelector || '.js-popular';
         var container = context.querySelector(targetSelector);
@@ -26,11 +27,11 @@ define([
                 success: function () {
                     common.mediator.emit('modules:popular:loaded', container);
                     common.mediator.emit('fragment:ready:images', container);
-                    register.end('popular-in-section');
+                    mediator.emit('register:end','popular-in-section');
                 },
                 error: function(req) {
                     common.mediator.emit('module:error', 'Failed to load most read: ' + req.statusText, 'common/modules/popular.js');
-                    register.error('popular-in-section');
+                    mediator.emit('register:error','popular-in-section');
                 }
             }).load();
         }
@@ -38,3 +39,4 @@ define([
 
     return popular;
 });
+

--- a/common/app/assets/javascripts/modules/onward/socially-referred-burners.js
+++ b/common/app/assets/javascripts/modules/onward/socially-referred-burners.js
@@ -1,0 +1,37 @@
+define([
+    'common/common',
+    'common/modules/ui/images',
+    'common/utils/mediator',
+    'lodash/objects/assign',
+    'common/modules/component'
+], function(
+    common,
+    images,
+    mediator,
+    extend,
+    Component
+    ){
+    function SocialBurners(config, context) {
+        mediator.emit('register:begin','social-content');
+        this.config = extend(this.config, config);
+        this.context = context;
+        this.endpoint = '/most-referred.json';
+
+        this.fetch(this.context, 'html');
+    }
+
+    Component.define(SocialBurners);
+
+    SocialBurners.prototype.ready = function() {
+        images.upgrade(this.context);
+        mediator.emit('register:end','social-content');
+    };
+
+    SocialBurners.prototype.error = function() {
+        common.mediator.emit('modules:error', 'Failed to load social burner content on page: ' + this.config.page.pageId + 'common/modules/onwards/related.js');
+        mediator.emit('register:error','social-content');
+    };
+
+
+    return SocialBurners;
+});

--- a/common/app/assets/javascripts/modules/onward/socially-referred-burners.js
+++ b/common/app/assets/javascripts/modules/onward/socially-referred-burners.js
@@ -1,11 +1,9 @@
 define([
-    'common/common',
     'common/modules/ui/images',
     'common/utils/mediator',
     'lodash/objects/assign',
     'common/modules/component'
 ], function(
-    common,
     images,
     mediator,
     extend,
@@ -16,11 +14,13 @@ define([
         this.config = extend(this.config, config);
         this.context = context;
         this.endpoint = '/most-referred.json';
-
-        this.fetch(this.context, 'html');
     }
 
     Component.define(SocialBurners);
+
+    SocialBurners.prototype.init = function() {
+        this.fetch(this.context, 'html');
+    };
 
     SocialBurners.prototype.ready = function() {
         images.upgrade(this.context);
@@ -28,7 +28,7 @@ define([
     };
 
     SocialBurners.prototype.error = function() {
-        common.mediator.emit('modules:error', 'Failed to load social burner content on page: ' + this.config.page.pageId + 'common/modules/onwards/related.js');
+        mediator.emit('modules:error', 'Failed to load social burner content on page: ' + this.config.page.pageId + 'common/modules/onwards/related.js');
         mediator.emit('register:error','social-content');
     };
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -317,6 +317,13 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 6, 25)
   )
 
+  val ABDisplaySociallyReferredBurners = Switch("A/B Tests", "ab-display-socially-referred-burners",
+    "If this switch is turned on, run the DisplayReferredContent A/B test",
+    safeState = Off, sellByDate = new DateMidnight(2014, 6, 24)
+  )
+
+
+
   // Dummy Switches
 
   val IntegrationTestSwitch = Switch("Unwired Test Switch", "integration-test-switch",
@@ -462,6 +469,7 @@ object Switches extends Collections {
     ABHighRelevanceCommercialComponent,
     ABHideSupportingLinks,
     ABAcrossTheGuardian,
+    ABDisplaySociallyReferredBurners,
     SmartBannerSwitch,
     SurveyBannerSwitch,
     FeaturesAutoContainerSwitch,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -322,8 +322,6 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 6, 24)
   )
 
-
-
   // Dummy Switches
 
   val IntegrationTestSwitch = Switch("Unwired Test Switch", "integration-test-switch",

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -39,4 +39,6 @@ object OphanApi extends ExecutionContexts with Logging {
   def getMostPopularOnward(path: String, hours: Int, count: Int, isContent: Boolean): Future[JsValue] =
     getBody(s"onward?path=/$path&is-content=true&hours=3&count=10")
 
+  def getMostReferredFromSocialMedia(days: Int): Future[JsValue] = getBody(s"mostread?days=$days&referrer=social%20media")
+
 }

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -17,6 +17,8 @@
         </div>
     }
 
+
+    @fragments.referredContentPlaceholder(content.visualTone)
     @fragments.storyPackagePlaceholder(storyPackage)
     @fragments.onwardPlaceholder(content.visualTone)
 

--- a/common/app/views/fragments/referredContentPlaceholder.scala.html
+++ b/common/app/views/fragments/referredContentPlaceholder.scala.html
@@ -1,0 +1,3 @@
+@(tone: String = "news")(implicit request: RequestHeader)
+<aside class="onward js-referred facia-container facia-container--default-heading facia-container--layout-article tone-@tone"
+role="complementary"></aside>

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -44,6 +44,7 @@ GET         /most-read/*path.json                                               
 GET         /most-read/*path                                                                                         controllers.MostPopularController.render(path)
 GET         /most-read-geo.json                                                                                      controllers.MostPopularController.renderPopularGeoJson()
 GET         /most-read-day.json                                                                                      controllers.MostPopularController.renderPopularDayJson(countryCode)
+GET         /most-referred.json                                                                                      controllers.MostPopularController.renderMostPopularReferralsJson()
 
 GET         /top-stories                                                                                             controllers.TopStoriesController.renderTopStories()
 GET         /top-stories.json                                                                                        controllers.TopStoriesController.renderTopStoriesJson()

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -68,7 +68,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
   def renderMostPopularReferralsJson() = Action { implicit request =>
     val mostReferred = SociallyReferredContentAgent.getReferrals.take(10)
 
-    implicit val config = Config(id = "referred-content", displayName = Some("Most Popular"))
+    implicit val config = Config(id = "referred-content", displayName = Some("Most popular"))
     val response = () => views.html.fragments.containers.series(Collection(mostReferred.take(7)), SeriesContainer(), 0)
     renderFormat(response, response, 900)
   }

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -2,15 +2,18 @@ package controllers
 
 import common._
 import conf._
-import feed.{MostPopularAgent, GeoMostPopularAgent, DayMostPopularAgent}
+import feed.{SociallyReferredContentAgent, MostPopularAgent, GeoMostPopularAgent, DayMostPopularAgent}
 import model._
 import play.api.mvc.{ RequestHeader, Controller, Action }
 import scala.concurrent.Future
-import views.support.PopularContainer
+import views.support.{SeriesContainer, TemplateDeduping, PopularContainer}
 import play.api.libs.json.{Json, JsArray}
 
 
 object MostPopularController extends Controller with Logging with ExecutionContexts {
+
+
+  implicit def getTemplateDedupingInstance: TemplateDeduping = TemplateDeduping()
 
   val page = new Page(
     "most-read",
@@ -59,6 +62,15 @@ object MostPopularController extends Controller with Logging with ExecutionConte
         "country" -> countryCode
       )
     }
+  }
+
+
+  def renderMostPopularReferralsJson() = Action { implicit request =>
+    val mostReferred = SociallyReferredContentAgent.getReferrals.take(10)
+
+    implicit val config = Config(id = "referred-content", displayName = Some("Most Popular"))
+    val response = () => views.html.fragments.containers.series(Collection(mostReferred.take(7)), SeriesContainer(), 0)
+    renderFormat(response, response, 900)
   }
 
   def renderPopularDayJson(countryCode: String) = Action { implicit request =>

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -21,6 +21,7 @@ trait OnwardJourneyLifecycle extends GlobalSettings {
       // fire every hour
       Jobs.schedule("OnwardJourneyAgentsRefreshHourlyJob", "0 0 * * * ?") {
         DayMostPopularAgent.refresh()
+        SociallyReferredContentAgent.update()
       }
 
       AkkaAsync {
@@ -33,6 +34,7 @@ trait OnwardJourneyLifecycle extends GlobalSettings {
       AkkaAsync{
         // kick off refresh now, as this happens hourly
         DayMostPopularAgent.refresh()
+        SociallyReferredContentAgent.update()
       }
   }
 
@@ -45,6 +47,7 @@ trait OnwardJourneyLifecycle extends GlobalSettings {
     MostPopularExpandableAgent.stop()
     GeoMostPopularAgent.stop()
     DayMostPopularAgent.stop()
+    SociallyReferredContentAgent.stop
 
     super.onStop(app)
   }

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -47,7 +47,7 @@ trait OnwardJourneyLifecycle extends GlobalSettings {
     MostPopularExpandableAgent.stop()
     GeoMostPopularAgent.stop()
     DayMostPopularAgent.stop()
-    SociallyReferredContentAgent.stop
+    SociallyReferredContentAgent.stop()
 
     super.onStop(app)
   }

--- a/onward/app/feed/SociallyReferredContentAgent.scala
+++ b/onward/app/feed/SociallyReferredContentAgent.scala
@@ -1,0 +1,65 @@
+package feed
+
+import common.{Edition, ExecutionContexts, Logging, AkkaAgent}
+import services.OphanApi
+import play.api.libs.json.{JsArray, JsValue}
+import java.net.URL
+import scala.concurrent.Future
+import model.Content
+import conf.ContentApi
+import scala.util.{Failure, Success}
+
+
+//TODO - move to trait
+object SociallyReferredContentAgent extends Logging with ExecutionContexts {
+
+  private val agent = AkkaAgent[Seq[Content]](Seq.empty)
+
+
+  def update() {
+
+    log.info("Refreshing most socially referred")
+
+    val ophanQuery = OphanApi.getMostReferredFromSocialMedia(7)
+
+    ophanQuery.map {
+      ophanResults =>
+
+        val socialReferrals: Seq[Future[Option[Content]]] = for {
+          item: JsValue <- ophanResults.asOpt[JsArray].map(_.value).getOrElse(Nil)
+          url <- ( item \ "url").asOpt[String]
+        } yield {
+          ContentApi.item(UrlToContentPath(url), Edition.defaultEdition).response.map( _.content.map( Content(_)))
+        }
+
+        val content: Seq[Content] = Seq.empty
+
+        Future.sequence(socialReferrals) map { contentSeq =>
+          val validContents = contentSeq.flatten
+          if(validContents.size > 0) {
+            agent.send ( currentMap => {
+              content ++ contentSeq.flatten
+            })
+          }
+        }
+        agent.update(content)
+    }
+  }
+
+  def getReferrals: Seq[Content] = {
+    agent.get()
+  }
+
+  def stop() {
+    agent.close()
+  }
+
+  private def UrlToContentPath(url: String): String = {
+    var contentId = new URL(url).getPath
+    if(contentId.startsWith("/")) {
+      contentId = contentId.substring(1)
+    }
+    contentId
+  }
+
+}

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -3,31 +3,32 @@
 # ~~~~
 
 # For dev machines
-GET        /assets/*path                            dev.DevAssetsController.at(path)
+GET        /assets/*path                              dev.DevAssetsController.at(path)
 
 # A websocket for recently published content
-GET        /onward/recently-published               controllers.LatestContentController.recentlyPublished()
+GET        /onward/recently-published                 controllers.LatestContentController.recentlyPublished()
 
-GET        /most-read                               controllers.MostPopularController.render(path = "")
-GET        /most-read.json                          controllers.MostPopularController.render(path = "")
-GET        /most-read/*path.json                    controllers.MostPopularController.renderJson(path)
-GET        /most-read/*path                         controllers.MostPopularController.render(path)
-GET        /most-read-geo.json                      controllers.MostPopularController.renderPopularGeoJson()
-GET        /most-read-day.json                      controllers.MostPopularController.renderPopularDayJson(countryCode)
+GET        /most-read                                 controllers.MostPopularController.render(path = "")
+GET        /most-read.json                            controllers.MostPopularController.render(path = "")
+GET        /most-read/*path.json                      controllers.MostPopularController.renderJson(path)
+GET        /most-read/*path                           controllers.MostPopularController.render(path)
+GET        /most-read-geo.json                        controllers.MostPopularController.renderPopularGeoJson()
+GET        /most-read-day.json                        controllers.MostPopularController.renderPopularDayJson(countryCode)
+GET        /most-referred.json                        controllers.MostPopularController.renderMostPopularReferralsJson()
 
-GET        /top-stories                             controllers.TopStoriesController.renderTopStories()
-GET        /top-stories.json                        controllers.TopStoriesController.renderTopStoriesJson()
-GET        /top-stories/trails                      controllers.TopStoriesController.renderTrails()
-GET        /top-stories/trails.json                 controllers.TopStoriesController.renderJsonTrails()
-GET        /related/*path.json                      controllers.RelatedController.renderJson(path)
-GET        /related/*path                           controllers.RelatedController.render(path)
-GET        /popular-in-tag/*tag.json                controllers.PopularInTag.renderJson(tag)
+GET        /top-stories                               controllers.TopStoriesController.renderTopStories()
+GET        /top-stories.json                          controllers.TopStoriesController.renderTopStoriesJson()
+GET        /top-stories/trails                        controllers.TopStoriesController.renderTrails()
+GET        /top-stories/trails.json                   controllers.TopStoriesController.renderJsonTrails()
+GET        /related/*path.json                        controllers.RelatedController.renderJson(path)
+GET        /related/*path                             controllers.RelatedController.render(path)
+GET        /popular-in-tag/*tag.json                  controllers.PopularInTag.renderJson(tag)
 
-GET        /preference/platform/:platform           controllers.ChangeViewController.render(platform, page)
-GET        /preference/edition/:edition             controllers.ChangeEditionController.render(edition)
-GET        /preference/front-alphas/:optAction      controllers.ChangeAlphaController.render(optAction, page)
+GET        /preference/platform/:platform             controllers.ChangeViewController.render(platform, page)
+GET        /preference/edition/:edition               controllers.ChangeEditionController.render(edition)
+GET        /preference/front-alphas/:optAction        controllers.ChangeAlphaController.render(optAction, page)
 
 # Experimental
-GET        /cards/opengraph/*path.json              controllers.CardController.opengraph(path)
-GET        /tagged.json                             controllers.TaggedContentController.renderJson(tag: String)
-GET        /series/*path.json                       controllers.SeriesController.renderSeriesStories(path)
+GET        /cards/opengraph/*path.json                controllers.CardController.opengraph(path)
+GET        /tagged.json                               controllers.TaggedContentController.renderJson(tag: String)
+GET        /series/*path.json                         controllers.SeriesController.renderSeriesStories(path)


### PR DESCRIPTION
Tests displaying a most popular to infrequent users containing content which has been most highly referred from social media. (See shot below) 

Server-side: 
  *Adds a social-referrals call to ophan
  *Adds an agent to retrieve content from ophan hourly 
  *Adds a socially referred content endpoint

JS: 
- Extends history API to provide ( crude ) session count over time
- For the test variant, displays the socially referred content to the user and hides the usual most-popular component

![social-referrals](https://cloud.githubusercontent.com/assets/986155/3233747/8ace6644-f0c1-11e3-9af4-85fc468b3b71.png)
