### PR TITLE
Commercial dfp component

### DIFF
--- a/common/app/assets/stylesheets/commercial.scss
+++ b/common/app/assets/stylesheets/commercial.scss
@@ -9,6 +9,7 @@
 @import '_extends-only';
 
 @import 'module/commercial/_commercial-component';
+@import 'module/commercial/_dfp-component.scss';
 @import 'module/commercial/_bestbuys';
 @import 'module/commercial/_books';
 @import 'module/commercial/_jobs';

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -262,6 +262,7 @@ $comercial-comp-baseline: 10px;
     border-bottom: 1px solid $c-neutral4;
 }
 .lineitem {
+    list-style-type: none;
     @include box-sizing(border-box);
     position: relative;
     padding: 0;

--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -1,0 +1,81 @@
+/* ==========================================================================
+   DFP bespoke component
+   ========================================================================== */
+   
+.commercial--dfp {
+    .commercial__head {
+        height: auto;
+        border: 0;
+    }
+    .commercial__title {
+        float: none;
+        margin-bottom: 0;
+        @include fs-bodyHeading(3);
+        text-transform: lowercase;
+        color: $c-brandBlue;
+    }
+    .commercial__body {
+        padding: 0;
+    }
+    .lineitems {
+        @include rem((
+            margin: 0 -($gs-gutter/2)
+        ));
+    }
+    .lineitem {
+        width: 50%;
+        float: left;
+        @include rem((
+            padding: 0 $gs-gutter/2
+        ));
+        
+        &:nth-child(n+3) {
+            display: none;
+        }
+    }
+    .lineitem__image {
+        width: 100%;
+    }
+    .lineitem__link {
+        float: none;
+    }
+    
+    .commercial--generic__item__description {
+        @include rem((
+            margin-bottom: $gs-baseline
+        ));
+    }
+
+    @include mq(tablet) {
+        .lineitem {
+            width: 33%;
+            
+            &:nth-child(3) {
+                display: block;
+            }
+        }
+    }
+    
+    @include mq(rightCol) {
+        .lineitem {
+            width: 25%;
+            
+            &:nth-child(4) {
+                display: block;
+            }
+        }        
+    }
+    
+    @include mq(leftCol) {
+        .commercial__body {
+            @include rem((
+                padding-top: $gs-baseline
+            ));
+        }
+        .commercial__home-link {
+            @include rem((
+                line-height: $gs-baseline*1.5
+            ));
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -14,7 +14,6 @@
     .commercial__title {
         float: none;
         margin-bottom: 0;
-        @include fs-bodyHeading(3);
         text-transform: lowercase;
         color: $c-brandBlue;
     }

--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -6,6 +6,10 @@
     .commercial__head {
         height: auto;
         border: 0;
+        padding-top: 0;
+        @include rem((
+            margin-top: $gs-baseline
+        ));
     }
     .commercial__title {
         float: none;
@@ -19,7 +23,7 @@
     }
     .lineitems {
         @include rem((
-            margin: 0 -($gs-gutter/2)
+            margin: 0 (-$gs-gutter/2)
         ));
     }
     .lineitem {
@@ -39,13 +43,11 @@
     .lineitem__link {
         float: none;
     }
-    
     .commercial--generic__item__description {
         @include rem((
             margin-bottom: $gs-baseline
         ));
     }
-
     @include mq(tablet) {
         .lineitem {
             width: 33%;
@@ -54,8 +56,12 @@
                 display: block;
             }
         }
+        .commercial__home-link {
+            position: absolute;
+            right: 0;
+            top: 0;
+        }
     }
-    
     @include mq(rightCol) {
         .lineitem {
             width: 25%;
@@ -65,7 +71,16 @@
             }
         }        
     }
-    
+    @include mq(wide) {
+        .commercial__home-link {
+            @include rem((
+                width: gs-span(3)
+            ));
+        }
+    }
+}
+
+.facia-container--layout-article .commercial--dfp {
     @include mq(leftCol) {
         .commercial__body {
             @include rem((
@@ -73,9 +88,61 @@
             ));
         }
         .commercial__home-link {
+            top: auto;
+            right: auto;
             @include rem((
-                line-height: $gs-baseline*1.5
+                left: $gs-gutter,
+                width: gs-span(2) - $gs-gutter,
+                line-height: 18px,
+                bottom: $gs-baseline
             ));
+        }
+        .container__title {
+            position: static;
+        }        
+    }    
+}
+
+.facia-container--layout-front .commercial--dfp {
+    @include mq(desktop) {
+        .commercial__head {
+            width: auto;
+        }
+        .commercial__body {
+            padding-left: 0;
+        }
+    }
+    @include mq(leftCol) {
+        .container__title {
+            padding: 0;
+        }
+    }
+    @include mq(faciaLeftCol) {
+        .commercial__head {
+            @include rem((
+               width: gs-span(2) + $gs-gutter
+            ));
+        }
+        .commercial__body {
+            @include rem((
+                padding-top: $gs-baseline
+            ));
+        }
+        .commercial__home-link {
+            top: auto;
+            right: auto;
+            left: 0;
+            @include rem((
+                width: gs-span(2),
+                line-height: 18px,
+                bottom: $gs-baseline
+            ));
+        }
+        .container__title {
+            position: static;
+        }
+        .facia-container__inner {
+            position: relative;
         }
     }
 }

--- a/common/app/assets/stylesheets/module/commercial/_travel.scss
+++ b/common/app/assets/stylesheets/module/commercial/_travel.scss
@@ -12,7 +12,6 @@ $c-commercial-travel-dark: #002b6c;
         ));
     }
     .lineitem {
-        list-style-type: none;
         border-top: 0;
         @include box-sizing(border-box);
         float: left;


### PR DESCRIPTION
This creates a stylesheet for commercial components created in DFP. The component is created by using a DFP template, so the fields and html are in DFP. Ask if you want to see them.

Component works on both articles and fronts.

Outcome, (excuse pictures of my cars but it was all I have locally!)
![screen shot 2014-06-11 at 12 51 14](https://cloud.githubusercontent.com/assets/1303616/3243787/caf057da-f15e-11e3-8e20-418667344228.png)
