### PR TITLE
use a different fixtures link during world cup

### DIFF
--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -6,6 +6,7 @@ import model.Competition
 import pa.{Round, FootballMatch}
 import implicits.Football
 import football.collections.RichList
+import conf.Switches
 
 
 trait MatchesList extends Football with RichList {
@@ -68,7 +69,12 @@ trait MatchesList extends Football with RichList {
 }
 
 trait Fixtures extends MatchesList {
-  override val baseUrl: String = "/football/fixtures"
+  override val baseUrl: String =
+    if (Switches.WorldCupWallchartEmbedSwitch.isSwitchedOn)
+      "/football/ng-interactive/2014/may/23/-sp-world-cup-2014-brazil-results-fixtures-live-scores-tables-schedule"
+    else
+      "/football/fixtures"
+
   override val pageType = "fixtures"
   // ordering for the displayed matches
   override def timeComesFirstInList(d: DateTime, other: DateTime): Boolean = d.isBefore(other)

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -13,7 +13,7 @@
                     matchType = matchesList.pageType,
                     heading = if(dateRow.isFirst) Some((competition.fullName, Option(competition.url))) else None,
                     link = if(dateRow.isLast && matchRow.isLast)
-                            Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None
+                            Some(("View all "+matchesList.pageType, matchesList.baseUrl)) else None
                 )
             }
         </div>


### PR DESCRIPTION
Replace fixtures link  to point to http://www.theguardian.com/football/ng-interactive/2014/may/23/-sp-world-cup-2014-brazil-results-fixtures-live-scores-tables-schedule
instead of http://www.theguardian.com/football/fixtures
while "worldcup-wallchart-embed" switch is on
