### PR TITLE
adjust display of fixtures list

### DIFF
--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -28,6 +28,25 @@
         border-top: 0 none;
     }
 
+    .table__caption--top {
+        @include rem((
+            padding: $gs-gutter/5 0 0 0
+        ));
+
+        .football-matches__heading{
+            @include rem((
+                padding: $gs-gutter/5
+            ));
+        }
+
+        .football-matches__date {
+            @include rem((
+                padding: $gs-gutter/5,
+                border-top: 1px solid darken($c-neutral8, 4%)
+            ));
+        }
+    }
+
     .table__caption--bottom {
         @include box-sizing(border-box);
         background: $c-neutral8;
@@ -181,12 +200,12 @@
         }
         .football-match__team--home {
             @include rem((
-                padding-right: $gs-gutter*0.75
+                padding-right: $gs-gutter*0.5
             ));
         }
         .football-match__team--away {
             @include rem((
-                padding-left: $gs-gutter*0.75
+                padding-left: $gs-gutter*0.5
             ));
         }
 

--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -42,8 +42,8 @@
         .football-matches__date {
             @include rem((
                 padding: $gs-gutter/5,
-                border-top: 1px solid darken($c-neutral8, 4%)
             ));
+            border-top: 1px solid darken($c-neutral8, 4%)
         }
     }
 


### PR DESCRIPTION
Add date separator and fix team names crop on iPhone
![screen shot 2014-06-11 at 15 35 39](https://cloud.githubusercontent.com/assets/1492162/3245814/ae83f52c-f175-11e3-9d8b-e8f01d8080a6.png)
![screen shot 2014-06-11 at 15 31 21](https://cloud.githubusercontent.com/assets/1492162/3245815/ae9afd4e-f175-11e3-8d8f-3fa119e734cb.png)
![687474703a2f2f676966732e6a6f656c676c6f766965722e636f6d2f7468756d62732d75702f73756974732d7468756d627375702e676966](https://cloud.githubusercontent.com/assets/1492162/3245823/c9527694-f175-11e3-909d-aafccdfe3ff7.gif)
