### PR TITLE
Adding discussion link to profile comments

### DIFF
--- a/common/app/assets/stylesheets/module/_disc.scss
+++ b/common/app/assets/stylesheets/module/_disc.scss
@@ -97,6 +97,10 @@ $disc-avatar-size: 44px;
         border-left: 3px solid transparentize($c-neutral1, .75);
     }
 }
+.disc-comment__view-discussion {
+    @include fs-textsans(2);
+    display: inline-block;
+}
 
 
 /* ==========================================================================

--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -33,7 +33,7 @@
             padding: $gs-gutter/5 0 0 0
         ));
 
-        .football-matches__heading{
+        .football-matches__heading {
             @include rem((
                 padding: $gs-gutter/5
             ));
@@ -43,7 +43,7 @@
             @include rem((
                 padding: $gs-gutter/5,
             ));
-            border-top: 1px solid darken($c-neutral8, 4%)
+            border-top: 1px solid darken($c-neutral8, 4%);
         }
     }
 
@@ -200,12 +200,12 @@
         }
         .football-match__team--home {
             @include rem((
-                padding-right: $gs-gutter*0.5
+                padding-right: $gs-gutter*.5
             ));
         }
         .football-match__team--away {
             @include rem((
-                padding-left: $gs-gutter*0.5
+                padding-left: $gs-gutter*.5
             ));
         }
 

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -87,7 +87,7 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
     val apiUrl = s"$apiRoot/profile/$userId/replies?pageSize=$pageSize&page=$page&orderBy=newest&showSwitches=true"
 
     getJsonOrError(apiUrl, onError) map {
-      json => ProfileComments(json)
+      json => ProfileReplies(json)
     }
   }
 

--- a/discussion/app/discussion/model/comments.scala
+++ b/discussion/app/discussion/model/comments.scala
@@ -44,14 +44,24 @@ case class ProfileComments(
 ) extends Comments {
   val switches = Nil
 }
-
-object ProfileComments{
-
+object ProfileComments {
   def apply(json: JsValue): ProfileComments = {
     val profile = Profile(json)
-    val comments = (json \ "comments").as[JsArray].value map {Comment(_, Some(profile), None)}
+    val comments = (json \ "comments").as[JsArray].value map { Comment(_, Some(profile), None) }
     ProfileComments(
       profile = profile,
+      comments = comments,
+      pagination = Pagination(json)
+    )
+  }
+}
+object ProfileReplies {
+  def apply(json: JsValue): ProfileComments = {
+    val comments = (json \ "comments").as[JsArray].value map { commentJson =>
+      Comment(commentJson, Some(Profile((commentJson).as[JsObject])), None)
+    }
+    ProfileComments(
+      profile = Profile(json),
       comments = comments,
       pagination = Pagination(json)
     )

--- a/discussion/app/views/profileActivity/comment.scala.html
+++ b/discussion/app/views/profileActivity/comment.scala.html
@@ -14,9 +14,19 @@
         </button>
     </div>
 
+    @comment.responseTo.map{ responseTo =>
+        <a class="disc-comment__view-discussion" href="@comment.discussion.webUrl#comment-@responseTo.commentId">
+            In response to @responseTo.displayName
+        </a>
+    }
+
     <div class="disc-comment__body" itemprop="text">
         @withJsoup(BulletCleaner(comment.body))(
             InBodyLinkCleaner("in body link")(Edition(request))
         )
     </div>
+
+    <a class="disc-comment__view-discussion" href="@comment.discussion.webUrl#comment-@comment.id">
+        View discussion
+    </a>
 </div>

--- a/discussion/app/views/profileActivity/comments.scala.html
+++ b/discussion/app/views/profileActivity/comments.scala.html
@@ -4,7 +4,7 @@
     @profileComments.comments.zipWithRowInfo.map{ case(c, row) =>
         <div class="activity-stream__item activity-item @if(row.isFirst){activity-item--first}" itemprop itemtype="http://schema.org/Comment">
             <div class="activity-item__title">
-                <a href="@c.discussion.webUrl#">@c.discussion.title</a>
+                <a href="@c.discussion.webUrl">@c.discussion.title</a>
             </div>
 
             <div class="activity-item__content">


### PR DESCRIPTION
- Adding a link to the discussion a comments is in
- If a comment is a reply - it gets a "In response to" hat
- There was a bug that the users own profile was showing on his replies tab - this fixes that

As a note there are some `SaSS` fixes to get the linting passing. This means people aren't running the tests.
Ideas?

![repliesprofile](https://cloud.githubusercontent.com/assets/31692/3248199/51f49bf6-f18c-11e3-9b83-1072e6eb1d27.png)

---

![Alabama](http://stream1.gifsoup.com/view/1031993/i-love-alabama-o.gif)
