### PR TITLE
adjust title and headings padding

### DIFF
--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -29,19 +29,22 @@
     }
 
     .table__caption--top {
+        $title-padding: $gs-baseline*(2/3);
         @include rem((
-            padding: $gs-gutter/5 0 0 0
+            padding: 0
         ));
 
         .football-matches__heading{
+            display: block;
             @include rem((
-                padding: $gs-gutter/5
+                padding: $title-padding
             ));
         }
 
         .football-matches__date {
             @include rem((
-                padding: $gs-gutter/5,
+                margin: 0,
+                padding: $title-padding,
             ));
             border-top: 1px solid darken($c-neutral8, 4%)
         }

--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -82,6 +82,10 @@
         display: none;
     }
 
+    .football-team__name {
+        text-overflow: ellipsis;
+    }
+
     .football-matches__day:last-child {
         .table__caption--bottom {
             display: table-caption;


### PR DESCRIPTION
adjust title and headings padding of football fixtures on facia front
before
![screen shot 2014-06-12 at 10 52 33](https://cloud.githubusercontent.com/assets/1492162/3256411/ff2c902c-f217-11e3-9c9f-8ff6761dbab6.png)
after
![screen shot 2014-06-12 at 10 32 55](https://cloud.githubusercontent.com/assets/1492162/3256414/056ab2c0-f218-11e3-9e53-3f0ca1645764.png)
