### PR TITLE
Added some metrics to help us determine how 'fresh' our fronts are

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -29,6 +29,8 @@ object Edition {
 
   lazy val editionFronts = Edition.all.map {e => "/" + e.id.toLowerCase}
 
+  def isEditionFront(request: RequestHeader): Boolean = editionFronts.contains(request.path)
+
   def editionId(request: RequestHeader): String = {
     // override for Ajax calls
     val editionFromParameter = request.getQueryString("_edition").map(_.toUpperCase)

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -455,15 +455,23 @@ case class SimpleCountMetric(
   val currentCount = new AtomicLong(0)
   val `type` = "counter"
 
-  def increment() {
+  def increment(): Long = {
     count.incrementAndGet()
     currentCount.incrementAndGet()
   }
+
+  def add(value: Long): Long = count.addAndGet(value)
+
 
   def getAndReset = currentCount.getAndSet(0)
   val getValue: () => Long = count.get
 
   override def asJson: StatusMetric = super.asJson.copy(count = Some(getValue().toString))
+
+}
+
+object SimpleCountMetric {
+  def apply(group: String, name: String, title: String): SimpleCountMetric = SimpleCountMetric(group, name, title, title)
 }
 
 class FrontendTimingMetric(

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -215,6 +215,11 @@ object Switches extends Collections {
     safeState = Off, never
   )
 
+  val FreshnessLoggingSwitch = Switch("Diagnostics", "freshness",
+    "If this switch is on, page freshness will be logged.",
+    safeState = On, new DateMidnight(2014, 6, 30)
+  )
+
   val ScrollDepthSwitch = Switch("Analytics", "scroll-depth",
     "Enables tracking and measurement of scroll depth",
     safeState = Off, never
@@ -399,14 +404,12 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 6, 15)
   )
 
-  // Image Switch
-
   val ImageServerSwitch = Switch("Image Server", "image-server",
     "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
     safeState = On, sellByDate = never // this is a performance related switch, not a feature switch
   )
 
-  val ParameterlessImagesSwitch = Switch("Parameterless Images Server", "parameterless-images",
+  val ParameterlessImagesSwitch = Switch("Image Server", "parameterless-images",
     "If this switch is on images then image resize fields (width, height, quality) will be in the url and not in parameters.",
     safeState = Off, sellByDate = new DateMidnight(2014, 7, 31)
   )
@@ -477,7 +480,8 @@ object Switches extends Collections {
     SurveyBannerSwitch,
     FeaturesAutoContainerSwitch,
     ForcePageSkinSwitch,
-    ParameterlessImagesSwitch
+    ParameterlessImagesSwitch,
+    FreshnessLoggingSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/implicits/Numbers.scala
+++ b/common/app/implicits/Numbers.scala
@@ -9,4 +9,9 @@ trait Numbers {
   implicit class String2isInt(s: String) {
     lazy val isInt = s.matches("\\d+")
   }
+
+  // yep, just a copy of isInt - but I prefer it this way when handling Longs
+  implicit class String2isLong(s: String) {
+    lazy val isLong = s.matches("\\d+")
+  }
 }

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -1,5 +1,7 @@
 @(page: model.MetaData)( implicit request:RequestHeader)
+@import org.joda.time.DateTime
 @import conf.Configuration
+@import conf.Switches.FreshnessLoggingSwitch
 
 @*<!-- TODO temporary till after dotcom switch -->*@
 @defining(
@@ -61,6 +63,18 @@
 }
 
 @* there is currently no SSL version of the beacon *@
-@if(!Configuration.environment.secure){
-    <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display: none;" rel="nofollow"/>
+@if(!Configuration.environment.secure) {
+    <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
+
+    @if(FreshnessLoggingSwitch.isSwitchedOn) {
+        @defining(DateTime.now) { now =>
+
+            @if(Edition.isEditionFront(request)) {
+                <img src="@Configuration.debug.beaconUrl/freshness/front/@{now.getMillis}" alt="" style="display : none ;" rel="nofollow"/>
+            } else {
+                <img src="@Configuration.debug.beaconUrl/freshness/@{now.getMillis}" alt="" style="display : none ;" rel="nofollow"/>
+            }
+            <!-- @now.toString() -->
+        }
+    }
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -12,6 +12,8 @@ GET         /assets/*path                                                       
 GET         /ab.gif                                                                                                  controllers.DiagnosticsController.ab
 GET         /js.gif                                                                                                  controllers.DiagnosticsController.js
 GET         /count/$prefix<.+>.gif                                                                                   controllers.DiagnosticsController.analytics(prefix)
+GET         /freshness/front/*timestamp                                                                              controllers.FreshnessController.freshnessFront(timestamp)
+GET         /freshness/*timestamp                                                                                    controllers.FreshnessController.freshness(timestamp)
 
 # Discussion
 GET         /discussion/comment-box.json                                                                             controllers.DiscussionApp.commentBox()

--- a/diagnostics/app/common/DiagnosticsLifecycle.scala
+++ b/diagnostics/app/common/DiagnosticsLifecycle.scala
@@ -11,6 +11,7 @@ trait DiagnosticsLifecycle extends GlobalSettings with Logging {
       model.diagnostics.javascript.LoadJob.run()
       model.diagnostics.abtests.UploadJob.run()
       model.diagnostics.analytics.UploadJob.run()
+      model.diagnostics.freshness.UploadJob.run()
     }
   }
 

--- a/diagnostics/app/controllers/FreshnessController.scala
+++ b/diagnostics/app/controllers/FreshnessController.scala
@@ -1,0 +1,60 @@
+package controllers
+
+import common._
+import play.api.mvc.{ Content => _, _ }
+import model.diagnostics.freshness.FreshnessMetrics
+
+object FreshnessController extends Controller with implicits.Numbers with Logging {
+
+  private val hour = 60 * 60
+
+  import FreshnessMetrics._
+
+  def freshnessFront(timestamp: String) = Action { implicit request =>
+    if (timestamp.isLong) {
+      val secondsOld = (System.currentTimeMillis - timestamp.toLong) / 1000
+      frontFreshnessCount.increment()
+      frontFreshnessTotal.add(secondsOld)
+    }
+    OnePix()
+  }
+
+  def freshness(timestamp: String) = Action { implicit request =>
+
+    if (timestamp.isLong) {
+      (System.currentTimeMillis - timestamp.toLong) / 1000 match {
+        case seconds if seconds < 0 =>
+          lessThanZeroSeconds.increment()
+          logStale(seconds, request)
+        case seconds if seconds <= 60 => lessThanAMinute.increment()
+        case seconds if seconds <= 60 * 15 => lessThanFifteenMinutes.increment()
+
+        case seconds if seconds <= hour =>
+          lessThanAnHour.increment()
+          if (seconds > 60 * 18) {
+            // just giving it a bit of leeway here, 15 minutes is a valid time, and I am not interested in a little bit
+            // more than that
+            logStale(seconds, request)
+          }
+        case seconds if seconds <= hour * 2 =>
+          lessThanTwoHours.increment()
+          logStale(seconds, request)
+        case seconds if seconds <= hour * 24 =>
+          lessThanADay.increment()
+          logStale(seconds, request)
+        case seconds =>
+          moreThanADay.increment()
+          logStale(seconds, request)
+      }
+    }
+
+    OnePix()
+  }
+
+  private def logStale(seconds: Long, request: RequestHeader) = {
+    val originPage = request.headers.get("Referer").getOrElse("unknown page")
+    val browser = request.headers.get("User-Agent").getOrElse("unknown browser")
+    log.info(s"STALE ${seconds}s $originPage $browser")
+  }
+
+}

--- a/diagnostics/app/model/diagnostics/freshness/FreshnessMetrics.scala
+++ b/diagnostics/app/model/diagnostics/freshness/FreshnessMetrics.scala
@@ -1,0 +1,22 @@
+package model.diagnostics.freshness
+
+import common.SimpleCountMetric
+
+object FreshnessMetrics {
+
+  lazy val lessThanZeroSeconds: SimpleCountMetric = SimpleCountMetric("freshness", "less-than-0-seconds", "Less than 0 seconds")
+  lazy val lessThanAMinute: SimpleCountMetric = SimpleCountMetric("freshness", "less-than-1-minute", "Less than 1 minute")
+  lazy val lessThanFifteenMinutes: SimpleCountMetric = SimpleCountMetric("freshness", "less-than-15-minute", "Less than 15 minutes")
+
+  lazy val lessThanAnHour: SimpleCountMetric = SimpleCountMetric("freshness", "less-than-1-hour", "Less than 1 hour")
+  lazy val lessThanTwoHours: SimpleCountMetric = SimpleCountMetric("freshness", "less-than-2-hours", "Less than 2 hours")
+  lazy val lessThanADay: SimpleCountMetric = SimpleCountMetric("freshness", "less-than-1-day", "Less than 1 day")
+  lazy val moreThanADay: SimpleCountMetric = SimpleCountMetric("freshness", "more-than-a-day", "more than a day")
+
+  lazy val all: Seq[SimpleCountMetric] = lessThanZeroSeconds :: lessThanAMinute :: lessThanFifteenMinutes ::
+    lessThanAnHour :: lessThanTwoHours :: lessThanADay :: moreThanADay :: Nil
+
+  // these are handled separately, they are not included in all
+  lazy val frontFreshnessCount: SimpleCountMetric = SimpleCountMetric("freshness", "front-freshness-count", "Front freshness count")
+  lazy val frontFreshnessTotal: SimpleCountMetric = SimpleCountMetric("freshness", "front-freshness-total", "Front freshness total")
+}

--- a/diagnostics/app/model/diagnostics/freshness/UploadJob.scala
+++ b/diagnostics/app/model/diagnostics/freshness/UploadJob.scala
@@ -1,0 +1,24 @@
+package model.diagnostics.freshness
+
+import common.Logging
+import model.diagnostics.CloudWatch
+
+object UploadJob extends Logging {
+
+  import FreshnessMetrics._
+
+  def run() {
+
+    log.info("Uploading freshness metrics")
+
+    val metrics = FreshnessMetrics.all.map{ metric =>
+      s"${metric.group}-${metric.name}" -> metric.getAndReset.toDouble
+    } ++ Seq(
+      "front-freshness" -> (frontFreshnessTotal.getAndReset / frontFreshnessCount.getAndReset).toDouble
+    )
+
+    // Cloudwatch will not take more than 20 metrics at a time
+    metrics.grouped(20).map(_.toMap).foreach(CloudWatch.put("Diagnostics", _))
+  }
+
+}

--- a/diagnostics/conf/routes
+++ b/diagnostics/conf/routes
@@ -3,11 +3,14 @@
 # ~~~~
 
 # For dev machines
-GET        /                           controllers.Application.front
+GET        /                                controllers.Application.front
 
-GET        /js.gif                     controllers.DiagnosticsController.js
-GET        /ab.gif                     controllers.DiagnosticsController.ab
+GET        /js.gif                          controllers.DiagnosticsController.js
+GET        /ab.gif                          controllers.DiagnosticsController.ab
 
-GET        /count/$path<.+>.gif        controllers.DiagnosticsController.analytics(path)
+GET        /count/$path<.+>.gif             controllers.DiagnosticsController.analytics(path)
 
-GET        /robots.txt                 controllers.Assets.at(path="/public", file="robots.txt")
+GET        /robots.txt                      controllers.Assets.at(path="/public", file="robots.txt")
+
+GET        /freshness/front/*timestamp      controllers.FreshnessController.freshnessFront(timestamp)
+GET        /freshness/*timestamp            controllers.FreshnessController.freshness(timestamp)


### PR DESCRIPTION
For the 3 edition fronts (/uk, /us and /au) we will get the average time in seconds since the page was rendered.

For other pages we will get buckets, e.g. less than a minute, less than an hour and so on. 

The buckets are (slightly) arbitrary, but I want to get an idea of the distribution first, and then we can have a think about it.

Later on we can possibly set alerts based on this.
