### PR TITLE
Conditionally load mem sprite

### DIFF
--- a/common/app/assets/javascripts/modules/identity/membership-tab.js
+++ b/common/app/assets/javascripts/modules/identity/membership-tab.js
@@ -110,7 +110,7 @@ define(['common/$',
      *   Load the css file containing the base64 encoded sprites for the card icons
      */
     Membership.prototype.addSpriteCss = function () {
-        var spriteSheetUrl = 'https://profile.thegulocal.com/assets/stylesheets/membership-icons.css';
+        var spriteSheetUrl = config.page.idUrl+'/assets/stylesheets/membership-icons.css';
         var $head  = $('head');
         var link  = document.createElement('link');
         link.id   = 'membership-sprite';

--- a/common/app/assets/javascripts/modules/identity/membership-tab.js
+++ b/common/app/assets/javascripts/modules/identity/membership-tab.js
@@ -3,9 +3,8 @@
 */
 define(['common/$',
 'common/utils/ajax',
-'bonzo',
 'common/utils/config',
-'common/modules/component'], function ($, ajax, bonzo, config, Component) {
+'common/modules/component'], function ($, ajax, config, Component) {
 
     function Membership (context, mediator, options) {
 

--- a/common/app/assets/javascripts/modules/identity/membership-tab.js
+++ b/common/app/assets/javascripts/modules/identity/membership-tab.js
@@ -3,8 +3,9 @@
 */
 define(['common/$',
 'common/utils/ajax',
+'bonzo',
 'common/utils/config',
-'common/modules/component'], function ($, ajax, config, Component) {
+'common/modules/component'], function ($, ajax, bonzo, config, Component) {
 
     function Membership (context, mediator, options) {
 
@@ -106,9 +107,27 @@ define(['common/$',
 
     };
 
+    /**
+     *   Load the css file containing the base64 encoded sprites for the card icons
+     */
+    Membership.prototype.addSpriteCss = function () {
+        var spriteSheetUrl = 'https://profile.thegulocal.com/assets/stylesheets/membership-icons.css';
+        var $head  = $('head');
+        var link  = document.createElement('link');
+        link.id   = 'membership-sprite';
+        link.rel  = 'stylesheet';
+        link.type = 'text/css';
+        link.href = spriteSheetUrl;
+        link.media = 'all';
+        $head.append(link);
+    };
+
     /** @override */
     Membership.prototype.ready = function () {
         if (this.display) {
+
+            this.addSpriteCss();
+
             $(this.getClass('TAB_BUTTON'), this.context).removeClass('is-hidden');
             $(this.getClass('TAB_CONTAINER'), this.context).removeClass('is-hidden');
             $('.js-account-profile-forms').addClass('identity-wrapper--with-membership');

--- a/common/app/assets/stylesheets/head.identity.scss
+++ b/common/app/assets/stylesheets/head.identity.scss
@@ -14,10 +14,3 @@
 @import 'base/_forms';
 @import 'module/_identity';
 @import 'module/_disc';
-
-/* ==========================================================================
-   Membership
-   ========================================================================== */
-
-@import 'theme/_membership-icons-sprite';
-@import 'theme/_membership-icons-svg';

--- a/common/app/assets/stylesheets/membership-icons.scss
+++ b/common/app/assets/stylesheets/membership-icons.scss
@@ -1,0 +1,8 @@
+/* ==========================================================================
+   Membership
+   ========================================================================== */
+
+$svg-support: true;
+
+@import 'theme/_membership-icons-sprite';
+@import 'theme/_membership-icons-svg';

--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -34,7 +34,7 @@
             padding: 0
         ));
 
-        .football-matches__heading{
+        .football-matches__heading {
             display: block;
             @include rem((
                 padding: $title-padding


### PR DESCRIPTION
This change restricts the loading of the membership sprite even further to only those for whom the tab actually shows.

This is a hybrid of @phamann's and @jamesgorrie's suggestions here: https://github.com/guardian/frontend/pull/4636#discussion_r13587035

cc @kaelig 
