### PR TITLE
Use content.api.elastic.host for contentApiLiveHost for now

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -64,7 +64,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
   object contentApi {
     val defaultContentApi: String = "http://content.guardianapis.com"
-    lazy val contentApiLiveHost: String = configuration.getStringProperty("content.api.live.host").getOrElse(defaultContentApi)
+    lazy val contentApiLiveHost: String = configuration.getStringProperty("content.api.elastic.host").getOrElse(defaultContentApi)
     lazy val contentApiDraftHost: String = configuration.getStringProperty("content.api.draft.host").getOrElse(contentApiLiveHost)
 
     lazy val key: Option[String] = configuration.getStringProperty("content.api.key")

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -21,6 +21,6 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // the properties needed to run this project. Make sure you update it if there
     // are any required changes, update the hash below, and off you go.
 
-    hash should be ("ce17ab88f0e88a2a2b8bb4421147420f")
+    hash should be ("44ec7f0864fb2e92c72ba09a7924caeb")
   }
 }


### PR DESCRIPTION
@tudorraul Is blocked by teamcity.

We will use `content.api.elastic.host` until the new property is introduced into TeamCity.

@gklopper 
