### PR TITLE
Make sure extras render correctly

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -133,7 +133,6 @@ define([
 
         page.isMatch(function(match) {
             extras[0] = { ready: false };
-            extras[1] = { ready: false };
             if (match.pageType === 'stats') {
                 renderNav(match);
             } else {
@@ -195,6 +194,7 @@ define([
 
                     // Group table & Match day
                     page.isCompetition(function(competition) {
+                        extras[1] = { ready: false };
                         // Group table
                         if (resp.group !== '') {
                             renderTable(competition +'/'+ resp.group, extras, dropdownTemplate);


### PR DESCRIPTION
Stats et al weren't showing on football matches.
This resets the `extras` var in the correct place.

![Oops](http://eldersouls.com/uploads/gallery/category_6/gallery_1_6_128960.gif)
