### PR TITLE
Local storage check so as to not error

### DIFF
--- a/common/app/assets/javascripts/utils/storage.js
+++ b/common/app/assets/javascripts/utils/storage.js
@@ -40,6 +40,7 @@ define([
      *     {Date} expires - When should the storage expire
      */
     Storage.prototype.set = function(key, data, options) {
+        if (!w[this.type]) { return; }
         var opts = options || {},
             value = JSON.stringify({
                 'value': data,
@@ -52,6 +53,7 @@ define([
     };
 
     Storage.prototype.get = function(key) {
+        if (!w[this.type]) { return; }
         var data = w[this.type].getItem(key);
         if (data === null) {
             return null;


### PR DESCRIPTION
It seems we don't check this, we just assume it's available.
With the [football world cup we embed a page](http://www.theguardian.com/football/world-cup-2014/overview/embed) that break here and thus doesn't go to run any other JS.

It's a terrible fix, but the only one I can think of for now.

To replicate this bug [go to this article](http://www.theguardian.com/football/ng-interactive/2014/may/23/-sp-world-cup-2014-brazil-results-fixtures-live-scores-tables-schedule) in the app on android.

**CC:** @sammorrisdesign @adamnfish 

![Crumbs](http://i.minus.com/ipAGnlobSaC14.gif)
