### PR TITLE
change the container type in the series template

### DIFF
--- a/common/app/views/fragments/containers/series.scala.html
+++ b/common/app/views/fragments/containers/series.scala.html
@@ -1,4 +1,4 @@
-@(collection: Collection, style: SeriesContainer, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
+@(collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
 
 @defining((config.displayName.orElse(collection.displayName), config.href.orElse(collection.href))) { case (title, href) =>
 

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -6,7 +6,7 @@ import feed.{SociallyReferredContentAgent, MostPopularAgent, GeoMostPopularAgent
 import model._
 import play.api.mvc.{ RequestHeader, Controller, Action }
 import scala.concurrent.Future
-import views.support.{SeriesContainer, TemplateDeduping, PopularContainer}
+import views.support.{MostReferredContainer, SeriesContainer, TemplateDeduping, PopularContainer}
 import play.api.libs.json.{Json, JsArray}
 
 
@@ -69,7 +69,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
     val mostReferred = SociallyReferredContentAgent.getReferrals.take(10)
 
     implicit val config = Config(id = "referred-content", displayName = Some("Most popular"))
-    val response = () => views.html.fragments.containers.series(Collection(mostReferred.take(7)), SeriesContainer(), 0)
+    val response = () => views.html.fragments.containers.series(Collection(mostReferred.take(7)), MostReferredContainer(), 0)
     renderFormat(response, response, 900)
   }
 


### PR DESCRIPTION
This does what this
https://github.com/guardian/frontend/pull/4671/files
Should have done - but without breaking the build. 
We'll need different data-link-names and data-components for different container instantiations
