### PR TITLE
World cup group table tweaks

### DIFF
--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -42,11 +42,7 @@
                                                 responsiveFont = true,
                                                 matchType = matchesList.pageType,
                                                 // this is a special case for the world cup, remove it afterwards
-                                                heading = if (competition.url == "/football/world-cup-2014" && Switches.WorldCupWallchartEmbedSwitch.isSwitchedOn) {
-                                                    Some(matches.headOption.flatMap(m => "World Cup 2014 " + m.round.name.getOrElse("")).getOrElse(competition.fullName), Option(competition.url))
-                                                } else {
-                                                    Some(competition.fullName, Option(competition.url))
-                                                }
+                                                heading = Some(competition.fullName, Option(competition.url))
                                             )
                                         </div>
                                     </div>

--- a/sport/app/football/views/tablesList/tablesComponent.scala.html
+++ b/sport/app/football/views/tablesList/tablesComponent.scala.html
@@ -3,7 +3,11 @@
 <div data-component="football-table-embed" class="c-football-table table--hide-from-importance-1">
     @tableView(competition, group,
         highlightTeamId = highlightTeamId,
-        heading = Option(competition.fullName),
+        heading = if (competition.url == "/football/world-cup-2014" && Switches.WorldCupWallchartEmbedSwitch.isSwitchedOn) {
+            Option(group.round.name.map(n => n).getOrElse(competition.fullName))
+        } else {
+            Option(competition.fullName)
+        },
         linkToCompetition = true
     )
 </div>

--- a/sport/app/football/views/tablesList/tablesComponent.scala.html
+++ b/sport/app/football/views/tablesList/tablesComponent.scala.html
@@ -4,9 +4,9 @@
     @tableView(competition, group,
         highlightTeamId = highlightTeamId,
         heading = if (competition.url == "/football/world-cup-2014" && Switches.WorldCupWallchartEmbedSwitch.isSwitchedOn) {
-            Option(group.round.name.map(n => n).getOrElse(competition.fullName))
+            group.round.name.orElse(Some(competition.fullName))
         } else {
-            Option(competition.fullName)
+            Some(competition.fullName)
         },
         linkToCompetition = true
     )


### PR DESCRIPTION
As requested from UX and editorial
- Remove group name from all fixtures list
- Add group name to table component

/cc @adamnfish 
#### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/3269361/f04daaa8-f2eb-11e3-8971-947f478dde48.png)
#### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/3269363/f75cc536-f2eb-11e3-844a-90ea63b8bf07.png)
