### PR TITLE
Make football fixture listings relative to users locale time

### DIFF
--- a/common/app/assets/javascripts/modules/ui/relativedates.js
+++ b/common/app/assets/javascripts/modules/ui/relativedates.js
@@ -149,6 +149,21 @@ define([
         return common.$g('.js-timestamp, .js-item__timestamp', context);
     }
 
+    function replaceLocaleTimestamps(context) {
+        var cls = 'js-locale-timestamp';
+        common.$g('.' + cls, context).each(function(el){
+            var datetime,
+                $el = bonzo(el),
+                timestamp = parseInt($el.attr('data-timestamp'), 10);
+
+            if(timestamp) {
+                datetime = new Date(timestamp);
+                el.innerHTML = pad(datetime.getHours()) + ':' + pad(datetime.getMinutes());
+                $el.removeClass(cls);
+            }
+        });
+    }
+
     function replaceValidTimestamps(context, opts) {
         opts = opts || {};
 
@@ -186,6 +201,7 @@ define([
 
     function init(context, opts) {
         replaceValidTimestamps(context, opts);
+        replaceLocaleTimestamps(context, opts);
     }
 
     return {

--- a/common/test/assets/javascripts/spec/RelativeDates.spec.js
+++ b/common/test/assets/javascripts/spec/RelativeDates.spec.js
@@ -7,7 +7,8 @@ define(['common/modules/ui/relativedates',
             id: 'relative-dates',
             fixtures: [
                         '<time id="time-valid" class="js-timestamp" datetime="2012-08-12T18:43:00.000Z">12th August</time>',
-                        '<time id="time-invalid" class="js-timestamp" datetime="201-08-12agd18:43:00.000Z">Last Tuesday</time>'
+                        '<time id="time-invalid" class="js-timestamp" datetime="201-08-12agd18:43:00.000Z">Last Tuesday</time>',
+                        '<time id="time-locale" class="js-locale-timestamp" datetime="2014-06-13T17:00:00+0100" data-timestamp="1402675200000">17:00</time>'
                        ]
                 },
         // make the date static so tests are stable
@@ -163,6 +164,11 @@ define(['common/modules/ui/relativedates',
         it("Ignore invalid timestamps", function(){
             RelativeDates.init();
             expect(document.getElementById('time-invalid').innerHTML).toBe('Last Tuesday');
+        });
+
+        it("Should convert timestamps to users locale", function(){
+            RelativeDates.init();
+            expect(document.getElementById('time-locale').innerHTML).toBe('17:00');
         });
 
     });

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -30,9 +30,12 @@
                     "football-match--fixture" -> theMatch.isFixture,
                     "football-match--result" -> theMatch.isResult
                 ))">
-                <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub">
+                <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub"
+                    data>
                     @if(theMatch.isFixture){
-                        @theMatch.date.toString("HH:mm")
+                        <time datetime="@theMatch.date.toString("yyyy-MM-dd'T'HH:mm:ssZ")" data-timestamp="@theMatch.date.getMillis"
+                            class="js-locale-timestamp">
+                            @theMatch.date.toString("HH:mm")</time>
                     }else{
                         @MatchStatus(theMatch.matchStatus)
                     }

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -30,8 +30,7 @@
                     "football-match--fixture" -> theMatch.isFixture,
                     "football-match--result" -> theMatch.isResult
                 ))">
-                <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub"
-                    data>
+                <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub">
                     @if(theMatch.isFixture){
                         <time datetime="@theMatch.date.toString("yyyy-MM-dd'T'HH:mm:ssZ")" data-timestamp="@theMatch.date.getMillis"
                             class="js-locale-timestamp">


### PR DESCRIPTION
As requested by editorial, our football fixture listings are in UK time only, this PR uses JavaScript to parse to a users local time set by their system time. 

Achieved by adding a new helper method to the realtive-dates.js module to read the epoch timestamp and parse to local time in hours and minutes.

/cc @ironsidevsquincy @gklopper 
