### PR TITLE
Commercial: only send specific ad unit keywords if necessary

### DIFF
--- a/common/app/assets/javascripts/modules/adverts/dfp.js
+++ b/common/app/assets/javascripts/modules/adverts/dfp.js
@@ -256,6 +256,7 @@ define([
                 ct      : contentType,
                 pt      : contentType,
                 p       : 'ng',
+                k       : parseKeywords(conf.keywordIds || conf.pageId),
                 bp      : detect.getBreakpoint(),
                 a       : audienceScience.getSegments(),
                 at      : cookies.get('adtest') || '',
@@ -292,8 +293,8 @@ define([
             }
             return $adSlot[0];
         },
-        getKeywords = function($adSlot, conf) {
-            return ($adSlot.data('keywords') || conf.page.keywordIds || conf.page.pageId || '')
+        parseKeywords = function(keywords) {
+            return (keywords || '')
                 .split(',').map(function (keyword) {
                     return keyword.split('/').pop();
                 });
@@ -338,8 +339,11 @@ define([
                             ? googletag.defineOutOfPageSlot(adUnit, id) : googletag.defineSlot(adUnit, size, id))
                         .addService(googletag.pubads())
                         .defineSizeMapping(sizeMapping)
-                        .setTargeting('k', getKeywords($adSlot, config))
                         .setTargeting('slot', $adSlot.data('name'));
+
+                if ($adSlot.data('keywords')) {
+                    slot.setTargeting('k', parseKeywords($adSlot.data('keywords')));
+                }
 
                 // Add to the array of ads to be refreshed (when the breakpoint changes)
                 // only if it's `data-refresh` attribute isn't set to false.

--- a/common/test/assets/javascripts/spec/adverts/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/adverts/dfp.spec.js
@@ -276,11 +276,11 @@ define([
                     }
                 });
                 window.googletag.cmd.forEach(function(func) { func(); });
-                expect(window.googletag.setTargeting).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
+                expect(window.googletag.pubads().setTargeting).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
             });
 
             it('should send container level keywords', function() {
-                $('.ad-slot--dfp').first().data('keywords', 'china');
+                $('.ad-slot--dfp').first().data('keywords', 'country/china');
                 dfp.init();
                 window.googletag.cmd.forEach(function(func) { func(); });
                 expect(window.googletag.setTargeting).toHaveBeenCalledWith('k', ['china']);
@@ -293,7 +293,7 @@ define([
                     }
                 });
                 window.googletag.cmd.forEach(function(func) { func(); });
-                expect(window.googletag.setTargeting).toHaveBeenCalledWith('k', ['uk']);
+                expect(window.googletag.pubads().setTargeting).toHaveBeenCalledWith('k', ['uk']);
             });
 
         });


### PR DESCRIPTION
But always send service level keywords 
