### PR TITLE
Rolling back localisation of fixtures.

### DIFF
--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -1,4 +1,4 @@
-@(matchesList: List[FootballMatch],
+@(matchesList: List[pa.FootballMatch],
     competition: model.Competition,
     date: org.joda.time.DateMidnight,
     responsiveFont: Boolean = false,
@@ -7,6 +7,10 @@
     heading: Option[(String, Option[String])] = None,
     link: Option[(String, String)] = None)(implicit request: RequestHeader)
 @import implicits.Football._
+@import common.LinkTo
+@import views.support.RenderClasses
+@import views.MatchStatus
+@import conf.Switches
 
 <table class="table table--football football-matches@if(responsiveFont){ table--responsive-font}">
     <thead hidden>
@@ -32,9 +36,7 @@
                 ))">
                 <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub">
                     @if(theMatch.isFixture){
-                        <time datetime="@theMatch.date.toString("yyyy-MM-dd'T'HH:mm:ssZ")" data-timestamp="@theMatch.date.getMillis"
-                            class="js-locale-timestamp">
-                            @theMatch.date.toString("HH:mm")</time>
+                        @theMatch.date.toString("HH:mm")
                     }else{
                         @MatchStatus(theMatch.matchStatus)
                     }


### PR DESCRIPTION
Our PROD servers use `UTC` timezone. The underlying parser for PA Feeds is using the "default" timezone when it should be using `Europe/London` as this is what all dates in the feed are specified in.

So this works properly locally, but in PROD we are currently an hour out.

It can be fixed, but that is too risky for a Saturday morning.

cc @phamann 
