### PR TITLE
Use classic static.guim.co.uk as original image for articles if possible

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -411,8 +411,8 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 7, 31)
   )
 
-  val LargerArticleImageSwitch = Switch("Image Server", "larger-article-image",
-    "If this switch is on images then articles will get a 460px image as the low-res version.",
+  val SeoOptimisedContentImageSwitch = Switch("Image Server", "seo-optimised-article-image",
+    "If this switch is on images then articles will get a 460px on static.guim.co.uk image as the low-res version.",
     safeState = On, sellByDate = new DateMidnight(2014, 6, 20)
   )
 
@@ -484,7 +484,7 @@ object Switches extends Collections {
     SurveyBannerSwitch,
     ParameterlessImagesSwitch,
     FreshnessLoggingSwitch,
-    LargerArticleImageSwitch
+    SeoOptimisedContentImageSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -1,6 +1,5 @@
 @(img: Option[model.ImageContainer], isShowcase: Boolean = false, isFeature: Boolean = false)
-@import views.support.{Item620, Item460, Item300, Showcase, Naked, Profile, ImgSrc}
-@import conf.Switches.LargerArticleImageSwitch
+@import views.support.{ImgSrc, Item620, Naked, Profile, SeoOptimisedContentImage, Showcase}
 
 @img.map{ picture =>
 
@@ -39,19 +38,16 @@
 }
 
 @image(picture: model.ImageContainer) = {
-    @defining(if (LargerArticleImageSwitch.isSwitchedOn) Item460 else Item300) { profile =>
-        <img src="@profile.bestFor(picture).map(Html(_))"
-            class="maxed responsive-img"
-            itemprop="contentURL representativeOfPage"
-            title="@profile.altTextFor(picture).getOrElse("")"
-            alt="@profile.altTextFor(picture).getOrElse("")" />
-    }
+    <img src="@SeoOptimisedContentImage.bestFor(picture).map(Html(_))"
+        class="maxed responsive-img"
+        itemprop="contentURL representativeOfPage"
+        title="@SeoOptimisedContentImage.altTextFor(picture).getOrElse("")"
+        alt="@SeoOptimisedContentImage.altTextFor(picture).getOrElse("")" />
+
 }
 
 @caption(picture: model.ImageContainer) = {
-    @defining(if (LargerArticleImageSwitch.isSwitchedOn) Item460 else Item300) { profile =>
-        @profile.captionFor(picture).map { caption =>
-            <figcaption class="main-caption" itemprop="description">@Html(caption)</figcaption>
-        }
+    @SeoOptimisedContentImage.captionFor(picture).map { caption =>
+        <figcaption class="main-caption" itemprop="description">@Html(caption)</figcaption>
     }
 }


### PR DESCRIPTION
Trawling forums indicates that it is possible that Google News does not pick up images from a CDN https://productforums.google.com/forum/#!topicsearchin/news/cdn$20images

It seems possible it only picks up images from domains it trusts (e.g. over time, or it has been asked to trust them).

We know it picks up images from static.guim.co.uk, so this is a test to check that hypotheses.

It will only use static.guim.co.uk if there is an **_exact match for the width**_.

**_Image upgrades still work.**_
