### PR TITLE
Simplify gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -875,34 +875,19 @@ module.exports = function (grunt) {
 
     // Test tasks
     grunt.registerTask('test:integration', function(app) {
-        if (!app) {
-            grunt.fail.fatal('No app specified.');
-        }
-        // does a casperjs setup exist for this app
-        grunt.config.requires(['casperjs', app]);
+        app = app || 'all';
         grunt.config('casperjsLogFile', app + '.xml');
         grunt.task.run(['env:casperjs', 'casperjs:' + app]);
     });
     grunt.registerTask('test:unit', function(app) {
-        var apps = [];
-        // have we supplied an app
-        if (app) {
-            // does a karma setup exist for this app
-            if (!grunt.config('karma')[app]) {
-                grunt.log.warn('No tests for app "' + app + '"');
-                return true;
-            }
-            apps = [app];
-        } else { // otherwise run all
-            apps = Object.keys(grunt.config('karma')).filter(function(app) { return app !== 'options'; });
-        }
         grunt.config.set('karma.options.singleRun', (singleRun === false) ? false : true);
-        apps.forEach(function(app) {
-            grunt.task.run(['karma:' + app]);
-        });
+        if (app) {
+            grunt.task.run('karma:' + app);
+        } else {
+            grunt.task.run('karma');
+        }
     });
-    // TODO - don't have common as default?
-    grunt.registerTask('test', ['jshint:common', 'test:unit:common', 'test:integration:common']);
+    grunt.registerTask('test', ['test:unit', 'test:integration:all']);
 
     // Analyse tasks
     grunt.registerTask('analyse:performance', function(app) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -709,8 +709,8 @@ module.exports = function (grunt) {
         // Recompile on change
         watch: {
             js: {
-                files: ['common/app/{assets, public}/javascripts/**/*.js'],
-                tasks: ['compile:js'],
+                // using watch event to just compile changed project
+                files: ['*/app/{assets, public}/javascripts/**/*.js'],
                 options: {
                     spawn: false
                 }
@@ -884,5 +884,16 @@ module.exports = function (grunt) {
     grunt.registerTask('hookmeup', ['clean:hooks', 'shell:copyHooks']);
     grunt.registerTask('snap', ['clean:screenshots', 'mkdir:screenshots', 'env:casperjs', 'casperjs:screenshot', 's3:screenshots']);
     grunt.registerTask('emitAbTestInfo', 'shell:abTestInfo');
+
+    grunt.event.on('watch', function(action, filepath, target) {
+        if (target === 'js') {
+            // compile just the project
+            var project = filepath.split('/').shift();
+            grunt.task.run('requirejs:' + project);
+        }
+        if (!isDev) {
+            grunt.task.run('hash');
+        }
+    });
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -794,29 +794,25 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-reloadlet');
     grunt.loadNpmTasks('grunt-pagespeed');
 
-    grunt.registerTask('default', ['compile', 'test', 'analyse']);
+    // Default task
+    grunt.registerTask('default', ['clean', 'validate', 'compile', 'test', 'analyse']);
 
+    /**
+     * Validate tasks
+     */
     grunt.registerTask('validate:css', ['sass:compile']);
     grunt.registerTask('validate:sass', ['scsslint']);
     grunt.registerTask('validate:js', function(app) {
-        if (!app) {
-            grunt.task.run('jshint');
-        } else {
-            // target exist?
-            if (grunt.config('jshint')[app]) {
-                grunt.task.run('jshint:' + app);
-            }
-        }
+        var target = (app) ? ':' + app : '';
+        grunt.task.run('jshint' + target);
     });
     grunt.registerTask('validate', function(app) {
-        grunt.task.run([
-            'validate:css',
-            'validate:sass',
-            'validate:js:' + (app || '')
-        ]);
+        grunt.task.run(['validate:css', 'validate:sass', 'validate:js:' + (app || '')]);
     });
 
-    // Compile tasks
+    /**
+     * Compile tasks
+     */
     grunt.registerTask('compile:images', ['generate:images', 'hash']);
     grunt.registerTask('generate:images', ['clean:images', 'copy:images', 'shell:spriteGeneration', 'imagemin']);
 
@@ -873,36 +869,37 @@ module.exports = function (grunt) {
     });
     grunt.registerTask('generate:conf', ['clean:assets', 'copy:headCss', 'copy:vendor', 'copy:assetMap']);
 
-    // Test tasks
+    /**
+     * Test tasks
+     */
     grunt.registerTask('test:integration', function(app) {
-        app = app || 'all';
+        var target = app || 'all';
         grunt.config('casperjsLogFile', app + '.xml');
-        grunt.task.run(['env:casperjs', 'casperjs:' + app]);
+        grunt.task.run(['env:casperjs', 'casperjs:' + target]);
     });
     grunt.registerTask('test:unit', function(app) {
+        var target = app ? ':' + app : '';
         grunt.config.set('karma.options.singleRun', (singleRun === false) ? false : true);
-        if (app) {
-            grunt.task.run('karma:' + app);
-        } else {
-            grunt.task.run('karma');
-        }
+        grunt.task.run('karma' + target);
     });
     grunt.registerTask('test', ['test:unit', 'test:integration:all']);
 
-    // Analyse tasks
+    /**
+     * Analyse tasks
+     */
     grunt.registerTask('analyse:performance', function(app) {
-        if (app && !grunt.config('pagespeed')[app]) {
-            grunt.log.warn('No pagespeed config for app "' + app + '"'); return true;
-        }
-        grunt.task.run([(app) ?  'pagespeed:' + app : 'pagespeed']);
+        var target = app ? ':' + app : '';
+        grunt.task.run('pagespeed' + target);
     });
     grunt.registerTask('analyse:css', ['compile:css', 'cssmetrics:common']);
     grunt.registerTask('analyse:monitor', ['monitor:common']);
     grunt.registerTask('analyse', ['analyse:css', 'analyse:performance']);
 
-    // Miscellaneous task
+    /**
+     * Miscellaneous tasks
+     */
     grunt.registerTask('hookmeup', ['clean:hooks', 'shell:copyHooks']);
     grunt.registerTask('snap', ['clean:screenshots', 'mkdir:screenshots', 'env:casperjs', 'casperjs:screenshot', 's3:screenshots']);
-    grunt.registerTask('emitAbTestInfo', ['shell:abTestInfo']);
+    grunt.registerTask('emitAbTestInfo', 'shell:abTestInfo');
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -813,16 +813,9 @@ module.exports = function (grunt) {
     /**
      * Compile tasks
      */
-    grunt.registerTask('compile:images', ['generate:images', 'hash']);
-    grunt.registerTask('generate:images', ['copy:images', 'shell:spriteGeneration', 'imagemin']);
-
-    grunt.registerTask('compile:css', ['generate:css', 'hash']);
-    grunt.registerTask('generate:css', ['sass:compile', 'replace:cssSourceMaps', 'copy:css']);
-
+    grunt.registerTask('compile:images', ['copy:images', 'shell:spriteGeneration', 'imagemin', 'hash']);
+    grunt.registerTask('compile:css', ['sass:compile', 'replace:cssSourceMaps', 'copy:css', 'hash']);
     grunt.registerTask('compile:js', function(app) {
-        grunt.task.run(['generate:js:' + (app || ''), 'hash']);
-    });
-    grunt.registerTask('generate:js', function(app) {
         var target = app ? ':' + app : app;
         if (grunt.config('copy')['javascript-' + app]) {
             grunt.task.run('copy:javascript-' + app);
@@ -831,26 +824,21 @@ module.exports = function (grunt) {
         if (!isDev) {
             grunt.task.run('uglify:components');
         }
+        grunt.task.run('hash');
     });
-
-    grunt.registerTask('compile:fonts', ['generate:fonts', 'hash']);
-    grunt.registerTask('generate:fonts', ['webfontjson']);
-
-    grunt.registerTask('compile:flash', ['generate:flash', 'hash']);
-    grunt.registerTask('generate:flash', ['copy:flash']);
-
+    grunt.registerTask('compile:fonts', ['webfontjson', 'hash']);
+    grunt.registerTask('compile:flash', ['copy:flash', 'hash']);
+    grunt.registerTask('compile:conf', ['copy:headCss', 'copy:vendor', 'copy:assetMap']);
     grunt.registerTask('compile', function(app) {
         grunt.task.run([
-            'generate:images',
-            'generate:css',
-            'generate:js:' + (app || ''),
-            'generate:fonts',
-            'generate:flash',
-            'hash',
-            'generate:conf'
+            'compile:images',
+            'compile:css',
+            'compile:js:' + (app || ''),
+            'compile:fonts',
+            'compile:flash',
+            'compile:conf'
         ]);
     });
-    grunt.registerTask('generate:conf', ['copy:headCss', 'copy:vendor', 'copy:assetMap']);
 
     /**
      * Test tasks

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -820,8 +820,7 @@ module.exports = function (grunt) {
     grunt.registerTask('generate:css', ['sass:compile', 'replace:cssSourceMaps', 'copy:css']);
 
     grunt.registerTask('compile:js', function(app) {
-        var target = app ? ':' + app : app;
-        grunt.task.run(['generate:js' + target, 'hash']);
+        grunt.task.run(['generate:js:' + (app || ''), 'hash']);
     });
     grunt.registerTask('generate:js', function(app) {
         var target = app ? ':' + app : app;
@@ -835,10 +834,10 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('compile:fonts', ['generate:fonts', 'hash']);
-    grunt.registerTask('generate:fonts', ['clean:fonts', 'mkdir:fontsTarget', 'webfontjson']);
+    grunt.registerTask('generate:fonts', ['webfontjson']);
 
     grunt.registerTask('compile:flash', ['generate:flash', 'hash']);
-    grunt.registerTask('generate:flash', ['clean:flash', 'copy:flash']);
+    grunt.registerTask('generate:flash', ['copy:flash']);
 
     grunt.registerTask('compile', function(app) {
         grunt.task.run([
@@ -851,7 +850,7 @@ module.exports = function (grunt) {
             'generate:conf'
         ]);
     });
-    grunt.registerTask('generate:conf', ['clean:assets', 'copy:headCss', 'copy:vendor', 'copy:assetMap']);
+    grunt.registerTask('generate:conf', ['copy:headCss', 'copy:vendor', 'copy:assetMap']);
 
     /**
      * Test tasks

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -814,37 +814,21 @@ module.exports = function (grunt) {
      * Compile tasks
      */
     grunt.registerTask('compile:images', ['generate:images', 'hash']);
-    grunt.registerTask('generate:images', ['clean:images', 'copy:images', 'shell:spriteGeneration', 'imagemin']);
+    grunt.registerTask('generate:images', ['copy:images', 'shell:spriteGeneration', 'imagemin']);
 
     grunt.registerTask('compile:css', ['generate:css', 'hash']);
-    grunt.registerTask('generate:css', ['clean:css', 'sass:compile', 'replace:cssSourceMaps', 'copy:css']);
+    grunt.registerTask('generate:css', ['sass:compile', 'replace:cssSourceMaps', 'copy:css']);
 
     grunt.registerTask('compile:js', function(app) {
-        if (app) {
-            grunt.task.run('generate:js:' + app);
-        } else {
-            grunt.task.run('generate:js');
-        }
-        grunt.task.run('hash');
+        var target = app ? ':' + app : app;
+        grunt.task.run(['generate:js' + target, 'hash']);
     });
     grunt.registerTask('generate:js', function(app) {
-        grunt.task.run(['clean:js']);
-        var apps = ['common', 'ophan'];
-        if (!app || app === 'preview') { // if no app supplied, compile all apps ('preview' is an amalgamation of other apps)
-            apps = apps.concat(Object.keys(grunt.config('requirejs')).filter(function(app) { return ['options', 'common', 'ophan'].indexOf(app) === -1; }));
-        } else if (app !== 'common' && app !== 'ophan') {
-            if (grunt.config('requirejs')[app]) {
-                apps.push(app);
-            } else {
-                grunt.log.warn('No compile target for app "' + app + '"');
-            }
+        var target = app ? ':' + app : app;
+        if (grunt.config('copy')['javascript-' + app]) {
+            grunt.task.run('copy:javascript-' + app);
         }
-        apps.forEach(function(app) {
-            if (grunt.config('copy')['javascript-' + app]) {
-                grunt.task.run('copy:javascript-' + app);
-            }
-            grunt.task.run('requirejs:' + app);
-        });
+        grunt.task.run('requirejs' + target);
         if (!isDev) {
             grunt.task.run('uglify:components');
         }

--- a/dist-tc
+++ b/dist-tc
@@ -11,7 +11,7 @@ set -o errexit
 #
 ################################################################################
 
-./grunt-tc clean validate:js:common validate:js:$1 test:unit:common test:unit:$1 compile:$1 emitAbTestInfo
+./grunt-tc clean validate:js test:unit compile emitAbTestInfo
 ./sbt-tc "project $1" compile test dist
 
 


### PR DESCRIPTION
Was getting crazy in there, what with trying to maintain dependencies between js compiles.

Now it just compiles only the project you tell it

Also, speed up `watch:js` by only compiling the project you change, and only running hash if in dev mode. Downside of this is if you add a new file, you'll need to run `compile:js` manually
