### PR TITLE
Fix clickable page skin ads

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -91,14 +91,12 @@
             }
             .has-page-skin & {
                 overflow: hidden;
+                margin-left: auto;
+                margin-right: auto;
+                @include rem((
+                    width: gs-span(12) + ($gs-gutter*2)
+                ));
 
-                .container {
-                    margin-left: auto;
-                    margin-right: auto;
-                    @include rem((
-                        width: gs-span(12) + ($gs-gutter*2)
-                    ));
-                }
                 .facia-container__inner {
                     @include rem((
                         width: gs-span(12)

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -5,7 +5,7 @@
    be sure to apply any necessary changes to non-shared code there too. *@
 
 <!DOCTYPE html>
-<html class="js-off id--signed-out" lang="en-GB">
+<html id="js-context" class="js-off id--signed-out" lang="en-GB">
 <head>
     @fragments.head(metaData, projectName, head, curlPaths)
 </head>
@@ -28,21 +28,19 @@
 
         @fragments.header(metaData)
 
-        <div id="js-context">
-            @if(showAdverts) {
-                @fragments.commercial.topBannerMobile()
-            }
+        @if(showAdverts) {
+            @fragments.commercial.topBannerMobile()
+        }
 
-            @if(NewNavSwitch.isSwitchedOn){
-                <div class="localnav--small">
-                    @fragments.nav.newNav(metaData)
-                </div>
-            } else {
-                @fragments.localNav(metaData)
-            }
+        @if(NewNavSwitch.isSwitchedOn){
+            <div class="localnav--small">
+                @fragments.nav.newNav(metaData)
+            </div>
+        } else {
+            @fragments.localNav(metaData)
+        }
 
-            @body
-        </div>
+        @body
 
         @fragments.footer(metaData)
 


### PR DESCRIPTION
By removing the `js-context` wrapper (which was full-width and covering the ad)

Currently just moved the id to the `html` element so the js still works, but next step is to remove it completely (we shouldn't be using it now we've removed swipe)
