### PR TITLE
Adding non-threaded view to discussion

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/activity-stream.js
+++ b/common/app/assets/javascripts/modules/discussion/activity-stream.js
@@ -1,0 +1,49 @@
+define([
+    'bonzo',
+    'common/$',
+    'common/modules/component',
+    'common/modules/discussion/api'
+], function(
+    bonzo,
+    $,
+    component,
+    discussionApi
+) {
+    function ActivityStream(opts) {
+        this.setOptions(opts);
+    }
+    component.define(ActivityStream);
+    ActivityStream.prototype.endpoint = '/discussion/profile/:userId/:streamType.json';
+    ActivityStream.prototype.componentClass = 'activity-stream';
+    ActivityStream.prototype.defaultOptions = {
+        userId: null,
+        streamType: 'discussions'
+    };
+    ActivityStream.prototype.ready = function() {
+        this.removeState('loading');
+        this.on('click', '.js-disc-recommend-comment', this.recommendComment);
+        $('.js-disc-recommend-comment').addClass('disc-comment__recommend--open');
+    };
+    ActivityStream.prototype.recommendComment = function(e) {
+        var el = e.currentTarget;
+        discussionApi.recommendComment(el.getAttribute('data-comment-id'));
+        bonzo(el).addClass('disc-comment__recommend--active');
+        $('.js-disc-recommend-count', el).each(function(countEl) {
+            countEl.innerHTML = parseInt(countEl.innerHTML, 10)+1;
+        });
+    };
+    ActivityStream.prototype.change = function(opts) {
+        var $el = bonzo(this.elem).empty();
+        this.setState('loading');
+        this.setOptions(opts);
+        this._fetch().then(function(resp) {
+            $.create(resp.html).each(function(el) {
+                this.elem = el;
+                $el.replaceWith(this.elem);
+            }.bind(this));
+            this.removeState('loading');
+        }.bind(this));
+    };
+
+    return ActivityStream;
+});

--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -261,6 +261,7 @@ Comments.prototype.unPickComment = function(commentId, $thisButton) {
  */
 Comments.prototype.gotoComment = function(id) {
     var comment = $('#comment-'+ id, this.elem);
+
     if (comment.length > 0) {
         window.location.replace('#comment-'+ id);
         return;
@@ -304,10 +305,11 @@ Comments.prototype.changePage = function(e) {
  * }
  */
 Comments.prototype.fetchComments = function(options) {
-    var url =
-        '/discussion/' + this.options.order + this.options.discussionId + '.json?' +
-        (options.page ? '&page=' + options.page : '') +
-        '&maxResponses=3';
+    var url = '/discussion/'+
+        (options.comment ? 'comment-permalink/' : '')+
+        this.options.order +'/'+
+        (options.comment ? options.comment : this.options.discussionId)+
+        '.json?'+ (options.page ? '&page=' + options.page : '') +'&maxResponses=3';
 
     return ajax({
         url: url,

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -11,7 +11,8 @@ define([
     'common/modules/discussion/api',
     'common/modules/discussion/comments',
     'common/modules/discussion/top-comments',
-    'common/modules/discussion/comment-box'
+    'common/modules/discussion/comment-box',
+    'common/modules/discussion/activity-stream'
 ], function(
     $,
     ajax,
@@ -25,14 +26,15 @@ define([
     DiscussionApi,
     Comments,
     TopComments,
-    CommentBox
+    CommentBox,
+    ActivityStream
 ) {
 
 /**
  * We have a few rendering hacks in here
  * We'll move the rendering to the play app once we
  * have the discussion stack up that can read cookies
- * This is true for the comment-box / sigin / closed discussion
+ * This is true for the comment-box / signin / closed discussion
  * And also the premod / banned state of the user
  * @constructor
  * @extends Component
@@ -145,7 +147,11 @@ Loader.prototype.loadComments = function(args) {
     var self = this,
         commentsContainer = this.getElem('commentsContainer'),
         commentsElem = this.getElem('comments'),
-        loadingElem = bonzo.create('<div class="preload-msg">Loading comments…<div class="is-updating"></div></div>')[0],
+        loadingElem = bonzo.create(
+            '<div class="preload-msg d-discussion__loader--comments">'+
+                'Loading comments…'+
+                '<div class="is-updating"></div>'+
+            '</div>')[0],
         commentId = this.getCommentIdFromHash(),
         showComments = args.showLoader || commentId || window.location.hash === '#comments';
 
@@ -155,7 +161,7 @@ Loader.prototype.loadComments = function(args) {
     }
 
     bonzo(self.topLoadingElem).addClass('u-h');
-    bonzo(loadingElem).insertAfter(commentsElem);
+    bonzo(loadingElem).insertAfter(commentsContainer);
 
     if (commentId) {
         this.mediator.emit('discussion:seen:comment-permalink');
@@ -173,7 +179,7 @@ Loader.prototype.loadComments = function(args) {
     // Within comments there is adding of reply buttons etc
     this.comments.fetch(commentsElem)
         .then(function killLoadingMessage() {
-            bonzo(loadingElem).remove();
+            bonzo(loadingElem).addClass('u-h');
             self.renderCommentBar(self.user);
 
             if (showComments) {
@@ -187,7 +193,56 @@ Loader.prototype.loadComments = function(args) {
                 self.cleanUpOnShowComments();
             });
             bonzo(commentsContainer).removeClass('js-hidden');
+            self.initUnthreaded();
         }).fail(self.loadingError.bind(self));
+};
+
+Loader.prototype.initUnthreaded = function() {
+    var self = this;
+    // Non threaded view
+    var $discussionContainer = $('.js-discussion-container', this.elem),
+        $nonThreadedContainer = $('.js-discussion__non-threaded', this.elem),
+        $loader = $('.d-discussion__loader--comments', this.elem);
+
+    this.on('click', '.js-show-threaded', function(e) {
+        var $el = bonzo(e.currentTarget),
+            $state = $('.discussion__show-threaded-state', $el[0]);
+
+        $state.toggleClass('u-h');
+        $nonThreadedContainer.toggleClass('u-h');
+        $discussionContainer.toggleClass('u-h');
+
+        if (!$el.data('loaded')) {
+            var activityStream = new ActivityStream();
+
+            $el.data('loaded', true);
+            $loader.removeClass('u-h');
+            activityStream.endpoint = '/discussion/non-threaded'+ this.getDiscussionId() + '.json';
+            activityStream
+                .fetch($nonThreadedContainer[0])
+                .then(function() {
+                    $loader.addClass('u-h');
+                });
+        }
+    });
+
+    this.on('click', '.js-comment-permalink', function(e) {
+        var p = self.comments.gotoComment(e.currentTarget.getAttribute('data-comment-id'));
+        e.preventDefault();
+        $nonThreadedContainer.addClass('u-h');
+        self.comments.showHiddenComments();
+
+        if (p) {
+            $loader.removeClass('u-h');
+            p.then(function() {
+                $loader.addClass('u-h');
+                $discussionContainer.removeClass('u-h');
+            });
+        } else {
+
+            $discussionContainer.removeClass('u-h');
+        }
+    });
 };
 
 /** @return {Reqwest|null} */

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -227,19 +227,18 @@ Loader.prototype.initUnthreaded = function() {
     });
 
     this.on('click', '.js-comment-permalink', function(e) {
-        var p = self.comments.gotoComment(e.currentTarget.getAttribute('data-comment-id'));
+        var promise = self.comments.gotoComment(e.currentTarget.getAttribute('data-comment-id'));
         e.preventDefault();
         $nonThreadedContainer.addClass('u-h');
         self.comments.showHiddenComments();
 
-        if (p) {
+        if (promise) {
             $loader.removeClass('u-h');
-            p.then(function() {
+            promise.then(function() {
                 $loader.addClass('u-h');
                 $discussionContainer.removeClass('u-h');
             });
         } else {
-
             $discussionContainer.removeClass('u-h');
         }
     });

--- a/common/app/assets/javascripts/modules/identity/public-profile.js
+++ b/common/app/assets/javascripts/modules/identity/public-profile.js
@@ -6,6 +6,7 @@ define([
     'common/utils/context',
     'common/modules/component',
     'common/modules/discussion/api',
+    'common/modules/discussion/activity-stream',
     'lodash/objects/mapValues'
 ],
 function(
@@ -16,44 +17,9 @@ function(
     context,
     component,
     discussionApi,
+    ActivityStream,
     mapValues
 ) {
-    function ActivityStream(opts) {
-        this.setOptions(opts);
-    }
-    component.define(ActivityStream);
-    ActivityStream.prototype.endpoint = '/discussion/profile/:userId/:streamType.json';
-    ActivityStream.prototype.componentClass = 'activity-stream';
-    ActivityStream.prototype.defaultOptions = {
-        userId: null,
-        streamType: 'discussions'
-    };
-    ActivityStream.prototype.ready = function() {
-        this.removeState('loading');
-        this.on('click', '.js-disc-recommend-comment', this.recommendComment);
-        $('.js-disc-recommend-comment').addClass('disc-comment__recommend--open');
-    };
-    ActivityStream.prototype.recommendComment = function(e) {
-        var el = e.currentTarget;
-        discussionApi.recommendComment(el.getAttribute('data-comment-id'));
-        bonzo(el).addClass('disc-comment__recommend--active');
-        $('.js-disc-recommend-count', el).each(function(countEl) {
-            countEl.innerHTML = parseInt(countEl.innerHTML, 10)+1;
-        });
-    };
-    ActivityStream.prototype.change = function(opts) {
-        var $el = bonzo(this.elem).empty();
-        this.setState('loading');
-        this.setOptions(opts);
-        this._fetch().then(function(resp) {
-            $.create(resp.html).each(function(el) {
-                this.elem = el;
-                $el.replaceWith(this.elem);
-            }.bind(this));
-            this.removeState('loading');
-        }.bind(this));
-    };
-
     function getActivityStream() {
         var activityStream, opts = {
             userId: 'data-user-id',

--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -43,6 +43,7 @@
 @import 'module/_circular-progress';
 
 @import 'module/_discussion';
+@import 'module/_disc';
 @import 'module/_interactive';
 
 @import 'module/_overlay';

--- a/common/app/assets/stylesheets/head.identity.scss
+++ b/common/app/assets/stylesheets/head.identity.scss
@@ -13,4 +13,3 @@
 
 @import 'base/_forms';
 @import 'module/_identity';
-@import 'module/_disc';

--- a/common/app/assets/stylesheets/module/_disc.scss
+++ b/common/app/assets/stylesheets/module/_disc.scss
@@ -199,6 +199,9 @@ $disc-avatar-size: 44px;
         ));
     }
 }
+.activity-item__content--boosted {
+    margin-left: 0;
+}
 .activity-item__content-meta {
     @include fs-textsans(4);
 

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -24,6 +24,27 @@ $avatarSize: 44px;
         display: none !important; // overriding .hide-on-mobile-inline
     }
 }
+.discussion__non-threaded {
+    @include rem((
+        margin-top: $gs-baseline
+    ));
+}
+.discussion__comments__container {
+    @include rem((
+        margin-bottom: $gs-baseline*3.5
+    ));
+    position: relative;
+}
+.discussion__comment-count {
+    color: $c-neutral3;
+}
+.discussion__show-threaded {
+    @include fs-textsans(2);
+    position: absolute;
+    right: 0;
+    top: $gs-baseline/2;
+    width: auto;
+}
 
 .discussion--lowered {
     @include mq(leftCol) {
@@ -97,14 +118,7 @@ $avatarSize: 44px;
     list-style: none;
     margin: 0;
 }
-.discussion__comments__container {
-    @include rem((
-        margin-bottom: $gs-baseline*3.5
-    ));
-}
-.discussion__comment-count {
-    color: $c-neutral3;
-}
+
 .show-more__container {
     @include rem((
         margin-bottom: ($gs-baseline/3)*2,

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -11,15 +11,21 @@
 
     <div class="discussion__comments__container js-hidden">
         <h2 class="page-sub-header discussion__heading js-visible">All Comments</h2>
+        <button class="u-button-reset u-fauxlink js-visible discussion__show-threaded js-show-threaded">
+            View <span class="discussion__show-threaded-state">non</span> threaded
+        </button>
 
-        <div class="discussion__comment-box discussion__comment-box--top u-cf"></div>
-        <div class="discussion__comments"></div>
-        <div class="discussion__comment-box discussion__comment-box--bottom u-cf"></div>
-        <a class="d-discussion__show-all-comments js-show-discussion" href="@LinkTo{/discussion@discussionId}"
-            data-is-ajax data-link-name="View all comments" rel="nofollow">
-            Show all comments…
-            <i class="i i-show-all-comments"></i>
-            <i class="i i-arrow-blue-down"></i>
-        </a>
+        <div class="discussion-container js-discussion-container">
+            <div class="discussion__comment-box discussion__comment-box--top u-cf"></div>
+            <div class="discussion__comments"></div>
+            <div class="discussion__comment-box discussion__comment-box--bottom u-cf"></div>
+            <a class="d-discussion__show-all-comments js-show-discussion" href="@LinkTo{/discussion@discussionId}"
+                data-is-ajax data-link-name="View all comments" rel="nofollow">
+                Show all comments…
+                <i class="i i-show-all-comments"></i>
+                <i class="i i-arrow-blue-down"></i>
+            </a>
+        </div>
+        <div class="discussion__non-threaded js-discussion__non-threaded u-h"></div>
     </div>
 </div>

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -12,7 +12,7 @@
     <div class="discussion__comments__container js-hidden">
         <h2 class="page-sub-header discussion__heading js-visible">All Comments</h2>
         <button class="u-button-reset u-fauxlink js-visible discussion__show-threaded js-show-threaded">
-            View <span class="discussion__show-threaded-state">non</span> threaded
+            View <span class="discussion__show-threaded-state">un</span>threaded
         </button>
 
         <div class="discussion-container js-discussion-container">

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -25,10 +25,11 @@ GET         /discussion/comment/*id                                             
 GET         /discussion/comment-permalink/*order/*commentId.json                                                     controllers.DiscussionApp.commentPermalinkJson(commentId: Int, order: String)
 GET         /discussion/comment-permalink/*order/*commentId                                                          controllers.DiscussionApp.commentPermalink(commentId: Int, order: String)
 
-
 GET         /discussion/top/*discussionKey.json                                                                      controllers.DiscussionApp.topCommentsJson(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/top/*discussionKey                                                                           controllers.DiscussionApp.topComments(discussionKey: discussion.model.DiscussionKey)
 
+GET         /discussion/non-threaded/$discussionKey</?p/\w+>.json                                                    controllers.DiscussionApp.commentsListJson(discussionKey: discussion.model.DiscussionKey)
+GET         /discussion/non-threaded/$discussionKey</?p/\w+>                                                         controllers.DiscussionApp.commentsList(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/$discussionKey</?p/\w+>.json                                                                 controllers.DiscussionApp.commentsJson(discussionKey: discussion.model.DiscussionKey, order: String = "newest")
 GET         /discussion/$order<(oldest|newest)>/$discussionKey</?p/\w+>.json                                         controllers.DiscussionApp.commentsJson(discussionKey: discussion.model.DiscussionKey, order: String)
 GET         /discussion/$discussionKey</?p/\w+>                                                                      controllers.DiscussionApp.comments(discussionKey: discussion.model.DiscussionKey, order: String = "newest")
@@ -39,6 +40,7 @@ GET         /discussion/profile/:id/replies.json                                
 GET         /discussion/profile/:id/picks.json                                                                       controllers.DiscussionApp.profilePicks(id: String)
 
 GET         /open/cta/article/*discussionKey.json                                                                    controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
+
 
 # Core Navigation
 GET         /most-read                                                                                               controllers.MostPopularController.render(path = "")

--- a/discussion/app/controllers/DiscussionApp.scala
+++ b/discussion/app/controllers/DiscussionApp.scala
@@ -11,6 +11,7 @@ trait DiscussionDispatcher
   with CommentsController
   with CommentBoxController
   with ProfileActivityController
+  with NonThreadedController
 
 object DiscussionApp extends DiscussionDispatcher {
   protected val discussionApi = current.plugin(classOf[DiscussionApi]) getOrElse {

--- a/discussion/app/controllers/NonThreadedController.scala
+++ b/discussion/app/controllers/NonThreadedController.scala
@@ -1,0 +1,36 @@
+package controllers
+
+import model.{Page, Cached}
+import scala.concurrent.Future
+import common.JsonComponent
+import play.api.mvc.{ Action, RequestHeader, SimpleResult }
+import discussion.model.{BlankComment, DiscussionKey}
+
+trait NonThreadedController extends DiscussionController {
+  def page(key: String, title: String, page: String) = Page(
+    id = key,
+    section = "Global",
+    webTitle = title,
+    analyticsName = s"GFE:Article:Comment discussion unthreaded page $page"
+  )
+
+  def commentsListJson(key: DiscussionKey) = commentsList(key)
+  def commentsList(key: DiscussionKey) = Action.async { implicit request =>
+    discussionApi.discussion(key).map { discussionComments =>
+      if (request.isJson)
+        Cached(60){
+          JsonComponent(
+            "html" -> views.html.unthreaded.commentsComponent(discussionComments)
+          )
+        }
+      else
+        Cached(60){
+          Ok(views.html.unthreaded.commentsPage(page(
+            discussionComments.discussion.key,
+            discussionComments.discussion.title,
+            discussionComments.pagination.currentPage.toString
+          ), discussionComments))
+        }
+    }
+  }
+}

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -33,7 +33,6 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
     }
   }
 
-
   def commentFor(id: Int): Future[Comment] = {
     getCommentJsonForId(id, s"$apiRoot/comment/$id?displayResponses=true&displayThreaded=true")
   }
@@ -101,6 +100,26 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
     }
   }
 
+  def discussion(key: DiscussionKey): Future[DiscussionComments] = {
+    def onError(r: Response) =
+      s"Get back in the past"
+    val apiUrl = s"$apiRoot/discussion/$key?displayThreaded=false&pageSize=50&orderBy=newest&showSwitches=true"
+
+    getJsonOrError(apiUrl, onError) map {
+      json => DiscussionComments(json)
+    }
+  }
+
+  def comment(id: Int): Future[Comment] = {
+    def onError(r: Response) =
+      s"Get back in the past"
+    val apiUrl = s"$apiRoot/comment/$id?displayThreaded=false&displayResponses=true&showSwitches=true"
+
+    getJsonOrError(apiUrl, onError) map {
+      json => Comment(json \ "comment", None, None)
+    }
+  }
+
   private def getJsonForUri(key: DiscussionKey, apiUrl: String): Future[CommentPage] = {
     def onError(r: Response) =
       s"Discussion API: Error loading comments id: $key status: ${r.status} message: ${r.statusText}"
@@ -114,7 +133,7 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
       s"Error loading comment id: $id status: ${r.status} message: ${r.statusText}"
 
     getJsonOrError(apiUrl, onError) map {
-      json =>  Comment(json \ "comment", None, None)
+      json => Comment(json \ "comment", None, None)
     }
   }
 

--- a/discussion/app/views/fragments/commentsBody.scala.html
+++ b/discussion/app/views/fragments/commentsBody.scala.html
@@ -16,12 +16,12 @@
         </div>
 
         <div class="d-discussion__meta d-dicussion__meta--sorting d-meta-item js-visible">
-            Comments sorted
+            View
             <select class="d-discussion__order-control">
                 <option value="oldest" @if(page.orderBy == "oldest"){selected="selected"}>oldest</option>
                 <option value="newest" @if(page.orderBy == "newest"){selected="selected"}>newest</option>
             </select>
-            first.
+            first
         </div>
         <div class="d-discussion__meta d-dicussion__meta--sorting js-hidden">
             Sort comments

--- a/discussion/app/views/profileActivity/comment.scala.html
+++ b/discussion/app/views/profileActivity/comment.scala.html
@@ -15,7 +15,9 @@
     </div>
 
     @comment.responseTo.map{ responseTo =>
-        <a class="disc-comment__view-discussion" href="@comment.discussion.webUrl#comment-@responseTo.commentId">
+        <a data-comment-id="@comment.id"
+           class="disc-comment__view-discussion js-comment-permalink"
+           href="@comment.discussion.webUrl">
             In response to @responseTo.displayName
         </a>
     }
@@ -26,7 +28,9 @@
         )
     </div>
 
-    <a class="disc-comment__view-discussion" href="@comment.discussion.webUrl#comment-@comment.id">
+    <a data-comment-id="@comment.id"
+       class="disc-comment__view-discussion js-comment-permalink"
+       href="@comment.discussion.webUrl">
         View discussion
     </a>
 </div>

--- a/discussion/app/views/unthreaded/commentsComponent.scala.html
+++ b/discussion/app/views/unthreaded/commentsComponent.scala.html
@@ -1,0 +1,5 @@
+@(discussion: DiscussionComments)(implicit request: RequestHeader)
+
+<div class="c-non-threaded-comments">
+    @commentsList(discussion)
+</div>

--- a/discussion/app/views/unthreaded/commentsList.scala.html
+++ b/discussion/app/views/unthreaded/commentsList.scala.html
@@ -1,0 +1,17 @@
+@(discussion: DiscussionComments)(implicit request: RequestHeader)
+
+<div class="activity-stream activity-stream--replies" itemprop itemtype="http://schema.org/UserComments">
+    @discussion.comments.map{ c =>
+        <div class="activity-stream__item activity-item" itemprop itemtype="http://schema.org/Comment">
+            <div class="activity-item__content activity-item__content--boosted">
+                <div class="activity-item__content-meta">
+                    @profileActivity.profile(c.profile, Some(c.date))
+                </div>
+
+                <div class="activity-item__content-body">
+                    @profileActivity.comment(c, c.discussion.isClosedForRecommendation)
+                </div>
+            </div>
+        </div>
+    }
+</div>

--- a/discussion/app/views/unthreaded/commentsPage.scala.html
+++ b/discussion/app/views/unthreaded/commentsPage.scala.html
@@ -1,0 +1,6 @@
+@(page: Page, discussion: DiscussionComments)(implicit request: RequestHeader)
+
+@main(page){
+}{
+    @commentsList(discussion)
+}

--- a/discussion/conf/routes
+++ b/discussion/conf/routes
@@ -19,6 +19,8 @@ GET         /discussion/comment-permalink/*order/*commentId                     
 GET         /discussion/top/*discussionKey.json                                 controllers.DiscussionApp.topCommentsJson(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/top/*discussionKey                                      controllers.DiscussionApp.topComments(discussionKey: discussion.model.DiscussionKey)
 
+GET         /discussion/non-threaded/$discussionKey</?p/\w+>.json               controllers.DiscussionApp.commentsListJson(discussionKey: discussion.model.DiscussionKey)
+GET         /discussion/non-threaded/$discussionKey</?p/\w+>                    controllers.DiscussionApp.commentsList(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/$discussionKey</?p/\w+>.json                            controllers.DiscussionApp.commentsJson(discussionKey: discussion.model.DiscussionKey, order: String = "newest")
 GET         /discussion/$order<(oldest|newest)>/$discussionKey</?p/\w+>.json    controllers.DiscussionApp.commentsJson(discussionKey: discussion.model.DiscussionKey, order: String)
 GET         /discussion/$discussionKey</?p/\w+>                                 controllers.DiscussionApp.comments(discussionKey: discussion.model.DiscussionKey, order: String = "newest")


### PR DESCRIPTION
New non-threaded view for users.

This is the last bit of discussion work for a bit as I am going to go into tidy-up-before-team explosion mode so it will be in a better state to be supported by he whole team and have some tests around it too. There is also loads of duplication etc which needs to be removed.
## See what?

![non-threaded](https://cloud.githubusercontent.com/assets/31692/3286682/b11e2368-f54c-11e3-9f44-c8ab5134a93b.png)
![non-threaded-](https://cloud.githubusercontent.com/assets/31692/3286683/b11faac6-f54c-11e3-9275-b8a2af197079.png)

![Troll](http://i739.photobucket.com/albums/xx36/alux23/troll.gif)
