### PR TITLE
Fronts: meaningful data-link-names

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -5,7 +5,7 @@
         "facia-container--layout-front" -> true,
         "facia-container--sponsored" -> index.page.isSponsored,
         "facia-container--advertisement-feature" -> (index.page.isAdvertisementFeature && !index.page.isSponsored)))"
-    data-link-name="Front"
+    data-link-name="Front | @request.path"
     role="main">
 
     @if(index.page.hasPageSkin) {

--- a/common/app/views/fragments/containers/commentanddebate.scala.html
+++ b/common/app/views/fragments/containers/commentanddebate.scala.html
@@ -6,7 +6,7 @@
         @if(items.nonEmpty) {
             <section
                 class="@GetClasses.forContainer(style, config, containerIndex, title.nonEmpty)"
-                data-link-name="block | @config.id"
+                data-link-name="@FaciaComponentName(config, collection)"
                 data-id="@config.id"
                 data-type="@style.containerType"
                 @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/features.scala.html
+++ b/common/app/views/fragments/containers/features.scala.html
@@ -6,7 +6,7 @@
         @if(items.nonEmpty) {
             <section
                 class="@GetClasses.forContainer(style, config, containerIndex, title.nonEmpty)"
-                data-link-name="block | @config.id"
+                data-link-name="@FaciaComponentName(config, collection)"
                 data-id="@config.id"
                 data-type="@style.containerType"
                 @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/featuresauto.scala.html
+++ b/common/app/views/fragments/containers/featuresauto.scala.html
@@ -6,7 +6,7 @@
         @if(items.nonEmpty) {
             <section
                 class="@GetClasses.forContainer(style, config, containerIndex, title.nonEmpty)"
-                data-link-name="block | @config.id"
+                data-link-name="@FaciaComponentName(config, collection)"
                 data-id="@config.id"
                 data-type="@style.containerType"
                 @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/multimedia.scala.html
+++ b/common/app/views/fragments/containers/multimedia.scala.html
@@ -6,7 +6,7 @@
         @if(items.nonEmpty) {
             <section
                 class="@GetClasses.forContainer(style, config, containerIndex, title.nonEmpty)"
-                data-link-name="block | @config.id"
+                data-link-name="@FaciaComponentName(config, collection)"
                 data-id="@config.id"
                 data-type="@style.containerType"
                 @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/news.scala.html
+++ b/common/app/views/fragments/containers/news.scala.html
@@ -16,7 +16,7 @@
                         ("container--sponsored", config.isSponsored),
                         ("container--advertisement-feature", (config.isAdvertisementFeature && !config.isSponsored)),
                         ("container--first", (containerIndex == 0))))"
-                    data-link-name="block | @config.id"
+                    data-link-name="@FaciaComponentName(config, collection)"
                     data-id="@config.id"
                     data-type="@style.containerType"
                     @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/people.scala.html
+++ b/common/app/views/fragments/containers/people.scala.html
@@ -6,7 +6,7 @@
         @if(items.nonEmpty) {
             <section
                 class="@GetClasses.forContainer(style, config, containerIndex, title.nonEmpty)"
-                data-link-name="block | @config.id"
+                data-link-name="@FaciaComponentName(config, collection)"
                 data-id="@config.id"
                 data-type="@style.containerType"
                 @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/popular.scala.html
+++ b/common/app/views/fragments/containers/popular.scala.html
@@ -8,7 +8,7 @@
                 ("container", true),
                 (s"container--${style.containerType}", true),
                 ("container--first" -> (containerIndex == 0))))"
-            data-link-name="block | @config.id"
+            data-link-name="@FaciaComponentName(config, collection)"
             data-id="@config.id"
             data-type="@style.containerType"
             @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/series.scala.html
+++ b/common/app/views/fragments/containers/series.scala.html
@@ -9,7 +9,7 @@
                     ("container", true),
                     (s"container--${style.containerType}", true),
                     ("js-container--toggle", (containerIndex > 0 && title.nonEmpty))))"
-                data-link-name="block | @config.id"
+                data-link-name="@FaciaComponentName(config, collection)"
                 data-id="@config.id"
                 data-type="@style.containerType"
                 @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/special.scala.html
+++ b/common/app/views/fragments/containers/special.scala.html
@@ -6,7 +6,7 @@
         @if(items.nonEmpty) {
             <section
                 class="@GetClasses.forContainer(style, config, containerIndex, title.nonEmpty)"
-                data-link-name="block | @config.id"
+                data-link-name="@FaciaComponentName(config, collection)"
                 data-id="@config.id"
                 data-type="@style.containerType"
                 @config.sponsorshipKeyword.map { keyword =>

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -5,7 +5,7 @@
     @if(collection.items.nonEmpty) {
         <section
             class="@GetClasses.forContainer(style, config, containerIndex, false, Seq("container--tag"))"
-            data-link-name="block | @config.id"
+            data-link-name="@FaciaComponentName(config, collection)"
             data-id="@config.id"
             data-type="@style.containerType"
             @config.sponsorshipKeyword.map { keyword =>

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -6,7 +6,7 @@
             "facia-container--layout-front" -> true,
             "facia-container--sponsored" -> faciaPage.isSponsored,
             "facia-container--advertisement-feature" -> (faciaPage.isAdvertisementFeature && !faciaPage.isSponsored)))"
-        data-link-name="Front"
+        data-link-name="Front | @request.path"
         role="main">
 
         @if(faciaPage.hasPageSkin) {


### PR DESCRIPTION
Replaces this:
`Front | block | 3a51-a4e2-37e4-975d | trail | 5 | article`
with this:
`Front | /uk/culture | reviews | trail | 5 | article`
