### PR TITLE
Memcached switches

### DIFF
--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -14,6 +14,10 @@ class IndexControllerTest extends FlatSpec with Matchers with BeforeAndAfterAll 
     MemcachedSwitch.switchOff()
   }
 
+  override def afterAll(): Unit = {
+    MemcachedSwitch.switchOn()
+  }
+
   "Index Controller" should "200 when content type is front" in Fake {
     val result = controllers.IndexController.render(section)(TestRequest(s"/$section"))
     status(result) should be(200)

--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -2,13 +2,17 @@ package test
 
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.Matchers
-import org.scalatest.FlatSpec
+import org.scalatest.{BeforeAndAfterAll, Matchers, FlatSpec}
+import conf.Switches.MemcachedSwitch
 
-class IndexControllerTest extends FlatSpec with Matchers {
+class IndexControllerTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   val section = "books"
   val callbackName = "aFunction"
+
+  override def beforeAll(): Unit = {
+    MemcachedSwitch.switchOff()
+  }
 
   "Index Controller" should "200 when content type is front" in Fake {
     val result = controllers.IndexController.render(section)(TestRequest(s"/$section"))

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -56,6 +56,12 @@ object Switches extends Collections {
     sellByDate = never
   )
 
+  val MemcachedFallbackSwitch = Switch("Performance Switches", "memcached-fallback",
+    "If this switch is switched on then the MemcachedFallback will be operational",
+    safeState = On,
+    sellByDate = never
+  )
+
   val IncludeBuildNumberInMemcachedKey = Switch("Performance Switches", "memcached-build-number",
     "If this switch is switched on then the MemcacheFilter will include the build number in the cache key",
     safeState = Off,
@@ -473,6 +479,7 @@ object Switches extends Collections {
     WorldCupArticleContainerSwitch,
     IndiaRegionSwitch,
     MemcachedSwitch,
+    MemcachedFallbackSwitch,
     IncludeBuildNumberInMemcachedKey,
     GeoMostPopular,
     TagLinkingSwitch,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -52,13 +52,13 @@ object Switches extends Collections {
 
   val MemcachedSwitch = Switch("Performance Switches", "memcached-action",
     "If this switch is switched on then the MemcacheAction will be operational",
-    safeState = Off,
+    safeState = On,
     sellByDate = never
   )
 
   val MemcachedFallbackSwitch = Switch("Performance Switches", "memcached-fallback",
     "If this switch is switched on then the MemcachedFallback will be operational",
-    safeState = On,
+    safeState = Off,
     sellByDate = never
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -396,6 +396,16 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
+  val FaciaToolCachedContentApiSwitch = Switch("Front Press Switches", "facia-tool-cached-capi-requests",
+    "If this switch is on facia tool will cache responses from the content API and use them on failure",
+    safeState = On, sellByDate = never
+  )
+
+  val FaciaToolCachedZippingContentApiSwitch = Switch("Front Press Switches", "facia-tool-zipcached-capi-requests",
+    "If this switch is on facia tool will zip cache responses from the content API and use them on failure",
+    safeState = On, sellByDate = never
+  )
+
   // Front Press Switches
   val FrontPressJobSwitch = Switch("Front Press Switches", "front-press-job-switch",
     "If this switch is on then the jobs to push and pull from SQS will run",
@@ -491,7 +501,9 @@ object Switches extends Collections {
     SurveyBannerSwitch,
     ParameterlessImagesSwitch,
     FreshnessLoggingSwitch,
-    SeoOptimisedContentImageSwitch
+    SeoOptimisedContentImageSwitch,
+    FaciaToolCachedContentApiSwitch,
+    FaciaToolCachedZippingContentApiSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -50,7 +50,7 @@ object Switches extends Collections {
 
   // Load Switches
 
-  val MemcachedSwitch = Switch("Performance Switches", "memcached",
+  val MemcachedSwitch = Switch("Performance Switches", "memcached-action",
     "If this switch is switched on then the MemcacheAction will be operational",
     safeState = Off,
     sellByDate = never

--- a/common/app/performance/JsonCodecs.scala
+++ b/common/app/performance/JsonCodecs.scala
@@ -13,4 +13,14 @@ object JsonCodecs {
       Json.parse(Unzip(data)).as[A]
     }
   }
+
+  implicit def nonGzippedCodec[A: Format] = new Codec[A] {
+    override def serialize(value: A): Array[Byte] = {
+      Json.stringify(Json.toJson(value)).getBytes("utf-8")
+    }
+
+    override def deserialize(data: Array[Byte]): A = {
+      Json.parse(data).as[A]
+    }
+  }
 }

--- a/common/app/performance/JsonCodecs.scala
+++ b/common/app/performance/JsonCodecs.scala
@@ -2,6 +2,7 @@ package performance
 
 import play.api.libs.json.{Json, Format}
 import shade.memcached.Codec
+import org.xerial.snappy.Snappy
 
 object JsonCodecs {
   implicit def gzippedCodec[A: Format] = new Codec[A] {
@@ -11,6 +12,16 @@ object JsonCodecs {
 
     override def deserialize(data: Array[Byte]): A = {
       Json.parse(Unzip(data)).as[A]
+    }
+  }
+
+  implicit def snappyCodec[A: Format] = new Codec[A] {
+    override def serialize(value: A): Array[Byte] = {
+      Snappy.compress(Json.stringify(Json.toJson(value)).getBytes("utf-8"))
+    }
+
+    override def deserialize(data: Array[Byte]): A = {
+      Json.parse(Snappy.uncompress(data)).as[A]
     }
   }
 

--- a/common/app/performance/MemcachedFallback.scala
+++ b/common/app/performance/MemcachedFallback.scala
@@ -29,7 +29,7 @@ object MemcachedFallback extends ExecutionContexts with Dates with Logging {
     memcached <- connectToMemcached(host).toOption
   } yield memcached
 
-  private def memcached = maybeMemcached.filter(_ => MemcachedSwitch.isSwitchedOn && !Play.isTest)
+  private def memcached = maybeMemcached.filter(_ => MemcachedFallbackSwitch.isSwitchedOn && !Play.isTest)
 
   /** If the Future successfully completes, stores its value in Memcached for the cache duration. If the Future fails,
     * attempts to fallback to the value cached in Memcached.

--- a/common/app/performance/MemcachedFallback.scala
+++ b/common/app/performance/MemcachedFallback.scala
@@ -39,7 +39,7 @@ object MemcachedFallback extends ExecutionContexts with Dates with Logging {
     cacheTime: FiniteDuration
   )(f: Future[A]): Future[A] = {
     f onSuccess {
-      case a => memcached foreach { _.set(key, a, cacheTime) }
+      case a => memcached foreach { m => try { m.set(key, a, cacheTime) } catch { case e: Exception => log.warn(e.toString)} }
     }
     
     f recoverWith {

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -19,6 +19,7 @@ import com.gu.openplatform.contentapi.model.{Content => ApiContent}
 import play.api.libs.ws.Response
 import play.api.libs.json.JsObject
 import scala.concurrent.duration._
+import conf.Switches.{FaciaToolCachedContentApiSwitch, FaciaToolCachedZippingContentApiSwitch}
 
 
 object Path {
@@ -46,8 +47,18 @@ object Result {
 }
 
 trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging {
-  implicit val apiContentCodec = JsonCodecs.gzippedCodec[Option[ApiContent]]
-  implicit val resultCodec = JsonCodecs.gzippedCodec[Result]
+  implicit val apiContentCodec =
+    if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
+      JsonCodecs.gzippedCodec[Option[ApiContent]]
+    else
+      JsonCodecs.gzippedCodec[Option[ApiContent]]
+
+  implicit val resultCodec =
+    if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
+      JsonCodecs.gzippedCodec[Result]
+    else
+      JsonCodecs.gzippedCodec[Result]
+
   val cacheDuration: FiniteDuration = 5.minutes
 
   case class InvalidContent(id: String) extends Exception(s"Invalid Content: $id")

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -49,13 +49,13 @@ object Result {
 trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging {
   implicit def apiContentCodec =
     if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
-      JsonCodecs.gzippedCodec[Option[ApiContent]]
+      JsonCodecs.snappyCodec[Option[ApiContent]]
     else
       JsonCodecs.nonGzippedCodec[Option[ApiContent]]
 
   implicit def resultCodec =
     if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
-      JsonCodecs.gzippedCodec[Result]
+      JsonCodecs.snappyCodec[Result]
     else
       JsonCodecs.nonGzippedCodec[Result]
 

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -47,13 +47,13 @@ object Result {
 }
 
 trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging {
-  implicit val apiContentCodec =
+  implicit def apiContentCodec =
     if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
       JsonCodecs.gzippedCodec[Option[ApiContent]]
     else
       JsonCodecs.gzippedCodec[Option[ApiContent]]
 
-  implicit val resultCodec =
+  implicit def resultCodec =
     if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
       JsonCodecs.gzippedCodec[Result]
     else

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -51,13 +51,13 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
     if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
       JsonCodecs.gzippedCodec[Option[ApiContent]]
     else
-      JsonCodecs.gzippedCodec[Option[ApiContent]]
+      JsonCodecs.nonGzippedCodec[Option[ApiContent]]
 
   implicit def resultCodec =
     if (FaciaToolCachedZippingContentApiSwitch.isSwitchedOn)
       JsonCodecs.gzippedCodec[Result]
     else
-      JsonCodecs.gzippedCodec[Result]
+      JsonCodecs.nonGzippedCodec[Result]
 
   val cacheDuration: FiniteDuration = 5.minutes
 

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -32,6 +32,8 @@ object Frontend extends Build with Prototypes {
       "rome" % "rome" % "1.0",
       "org.rometools" % "rome-modules" % "1.0",
 
+      "org.xerial.snappy" % "snappy-java" % "1.0.5.1",
+
       filters
     )
   )


### PR DESCRIPTION
Ever since moving to the `MemcachedFallback`, we have seen `facia-tool` slow down significantly.

This is reflected in an increase in the graphs for GC time and average CPU load for `facia-tool` at the time of merge.

I am suspicious about the zipping that happens on the data before it is put into `memcache`; it is just using standard java Gzipping which I reckon is slow.

This PR contains:
- Seperate switches for the `MemcachedAction` and the `MemcachedFallback`. @gklopper This will need a reset of the switch on CODE and PROD since I have changed the name
- Switch around the use of the `MemcachedFallback` object
- [Snappy](https://code.google.com/p/snappy/) dependency; specifically [snappy-java](http://code.google.com/p/snappy-java/), a JNI based implementation
- New `Codec`s for the `Snappy` implementation and a non Gzipped implementation
- Switch around the `Codec` used for zipping

I have also switched over the zipping to the `Snappy` implementation.

I have not diluted the cache key; these all should get replaced on every request.

@robertberry 
