### PR TITLE
Enable Specific Items to Be Included in Commercial Components

### DIFF
--- a/commercial/app/controllers/commercial/TravelOffers.scala
+++ b/commercial/app/controllers/commercial/TravelOffers.scala
@@ -4,23 +4,22 @@ import model.commercial.travel.{Offer, OffersAgent}
 import model.{NoCache, Cached}
 import performance.MemcachedAction
 import play.api.mvc._
-import play.api.templates.Html
 import scala.concurrent.Future
 
 object TravelOffers extends Controller {
 
   object lowRelevance extends Relevance[Offer] {
-    def view(offers: Seq[Offer])(implicit request: RequestHeader): Html = views.html.travelOffers(offers)
+    def view(offers: Seq[Offer])(implicit request: RequestHeader) = views.html.travelOffers(offers)
   }
 
   object highRelevance extends Relevance[Offer] {
-    def view(offers: Seq[Offer])(implicit request: RequestHeader): Html = views.html.travelOffersHigh(offers)
+    def view(offers: Seq[Offer])(implicit request: RequestHeader) = views.html.travelOffersHigh(offers)
   }
 
   private def renderTravelOffers(relevance: Relevance[Offer], format: Format) =
     MemcachedAction { implicit request =>
       Future.successful {
-        OffersAgent.adsTargetedAt(segment) match {
+        (OffersAgent.specificTravelOffers(specificIds) ++ OffersAgent.adsTargetedAt(segment)).distinct match {
           case Nil => NoCache(format.nilResult)
           case offers => Cached(componentMaxAge) {
             format.result(relevance.view(offers take 4))

--- a/commercial/app/model/commercial/jobs/JobsAgent.scala
+++ b/commercial/app/model/commercial/jobs/JobsAgent.scala
@@ -7,6 +7,11 @@ object JobsAgent extends AdAgent[Job] with ExecutionContexts with Logging {
 
   override def defaultAds = currentAds filter (_.industries.contains("Media"))
 
+  def specificJobs(jobIdStrings: Seq[String]): Seq[Job] = {
+    val jobIds = jobIdStrings map (_.toInt)
+    currentAds filter (job => jobIds contains job.id)
+  }
+
   def refresh() {
     for {jobs <- JobsApi.loadAds()} {
       updateCurrentAds(populateKeywords(jobs))

--- a/commercial/app/model/commercial/travel/OffersAgent.scala
+++ b/commercial/app/model/commercial/travel/OffersAgent.scala
@@ -8,6 +8,11 @@ object OffersAgent extends AdAgent[Offer] with Logging with ExecutionContexts {
   // most popular Travel Offers
   override def defaultAds = currentAds.sortBy(_.position).take(4)
 
+  def specificTravelOffers(offerIdStrings: Seq[String]): Seq[Offer] = {
+    val offerIds = offerIdStrings map (_.toInt)
+    currentAds filter (offer => offerIds contains offer.id)
+  }
+
   def refresh() = {
     for {offers <- OffersApi.loadAds()}
     yield updateCurrentAds(populateKeywords(offers))

--- a/commercial/app/model/commercial/travel/OffersApi.scala
+++ b/commercial/app/model/commercial/travel/OffersApi.scala
@@ -17,14 +17,14 @@ object OffersApi extends XmlAdsApi[Offer] {
 
   private val dateFormat = DateTimeFormat.forPattern("dd-MMM-yyyy")
 
-  private def buildOffer(id: Int, node: Node): Offer = {
+  private def buildOffer(node: Node): Offer = {
 
     def textValue(nodeName: String): String = (node \ nodeName).text.trim()
 
     def textValues(nodeName: String): List[String] = (node \ nodeName).map(_.text.trim()).toList
 
     Offer(
-      id,
+      textValue("prodId").toInt,
       textValue("prodName"),
       textValue("prodUrl"),
       textValue("prodImage"),
@@ -39,9 +39,5 @@ object OffersApi extends XmlAdsApi[Offer] {
     )
   }
 
-  def parse(xml: Elem): Seq[Offer] = {
-    (xml \\ "offer").zipWithIndex map {
-      case (offerXml, idx) => buildOffer(idx, offerXml)
-    }
-  }
+  def parse(xml: Elem): Seq[Offer] = (xml \\ "offer") map buildOffer
 }

--- a/commercial/test/model/commercial/travel/Fixtures.scala
+++ b/commercial/test/model/commercial/travel/Fixtures.scala
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 object Fixtures {
 
   val untaggedOffers = List(
-    Offer(0,
+    Offer(5098,
       "Country houses of Northamptonshire and Lincolnshire",
       "http://www.guardianholidayoffers.co.uk/holiday/5098/country-houses-of-northamptonshire-and-lincolnshire",
       "http://www.guardianholidayoffers.co.uk/Image.aspx?id=37200&type=NoResize",
@@ -17,7 +17,7 @@ object Fixtures {
       List("Special interest holidays"),
       "4",
       1),
-    Offer(1,
+    Offer(3421,
       "Italian Riviera by rail",
       "http://www.guardianholidayoffers.co.uk/holiday/3421/italian-riviera",
       "http://www.guardianholidayoffers.co.uk/Image.aspx?id=27156&type=NoResize",
@@ -29,7 +29,7 @@ object Fixtures {
       List("Rail holidays", "Tours"),
       "7",
       2),
-    Offer(2,
+    Offer(3381,
       "Lake Annecy by rail",
       "http://www.guardianholidayoffers.co.uk/holiday/3381/lake-annecy-les-grillons-hotel-half-board-",
       "http://www.guardianholidayoffers.co.uk/Image.aspx?id=27167&type=NoResize",

--- a/commercial/test/model/commercial/travel/OffersApiTest.scala
+++ b/commercial/test/model/commercial/travel/OffersApiTest.scala
@@ -74,8 +74,8 @@ class OffersApiTest extends FlatSpec with Matchers with ExecutionContexts {
   "Hydrated Offers" should "provide duration in words" in {
     val offers = OffersApi.parse(xml)
 
-    offers.find(_.id == 2).head.durationInWords should be("5 nights")
-    offers.find(_.id == 0).head.durationInWords should be("4 nights")
+    offers.find(_.id == 3381).head.durationInWords should be("5 nights")
+    offers.find(_.id == 5098).head.durationInWords should be("4 nights")
   }
 
 }


### PR DESCRIPTION
This extends the use of the 't' parameter in commercial component requests so that it can specify:
- the ID of a job
- the ID of a travel offer

And the specified items will appear first in their respective components.
