### PR TITLE
capping contributor image height from mobile

### DIFF
--- a/common/app/assets/stylesheets/theme/_tones-head.scss
+++ b/common/app/assets/stylesheets/theme/_tones-head.scss
@@ -98,7 +98,6 @@
             @include mq(tablet) {
                 height: 95%;
                 @include rem((
-                    right: gs-span(3),
                     min-height: gs-span(2) + ($gs-gutter*2)
                 ));
             }

--- a/common/app/assets/stylesheets/theme/_tones-head.scss
+++ b/common/app/assets/stylesheets/theme/_tones-head.scss
@@ -91,15 +91,15 @@
                 bottom: 0;
                 height: 95%;
                 @include rem((
-                    right: gs-span(3)
+                    right: gs-span(3),
+                    max-height: gs-height(4) + ($gs-baseline*2)
                 ));
             }
             @include mq(tablet) {
                 height: 95%;
                 @include rem((
                     right: gs-span(3),
-                    min-height: gs-span(2) + ($gs-gutter*2),
-                    max-height: gs-height(4) + ($gs-baseline*2)
+                    min-height: gs-span(2) + ($gs-gutter*2)
                 ));
             }
             @include mq(rightCol) {


### PR DESCRIPTION
Moving the max-height to cover mobileLandscape breakpoint too.
## Before

![image](https://cloud.githubusercontent.com/assets/960919/3300249/caca97ec-f61e-11e3-8838-156732d07724.png)
## After

![image](https://cloud.githubusercontent.com/assets/960919/3300245/c151d126-f61e-11e3-888d-33bad18a61c7.png)
