### PR TITLE
new local navigation - rotate sections, starting from current section

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -22,19 +22,19 @@ case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
 
   def searchForCurrentSublink(page: MetaData): Option[SectionLink] =
     links.find(_.currentFor(page))
-    .orElse(links.find(_.currentForIncludingAllTags(page)))
+      .orElse(links.find(_.currentForIncludingAllTags(page)))
 
   def exactFor(page: MetaData): Boolean = page.section == name.href.dropWhile(_ == '/') || page.url == name.href
 }
 
-trait Navigation  {
+trait Navigation {
 
   //News
   val home = SectionLink("news", "home", "Home", "/")
-  val news  = SectionLink("news", "news","News", "/")
+  val news = SectionLink("news", "news", "News", "/")
   val world = SectionLink("world", "world", "World", "/world")
-  val uk    = SectionLink("uk-news", "UK", "UK News", "/uk-news")
-  val us    = SectionLink("world", "US", "US News", "/world/usa")
+  val uk = SectionLink("uk-news", "UK", "UK News", "/uk-news")
+  val us = SectionLink("world", "US", "US News", "/world/usa")
   val politics = SectionLink("politics", "politics", "Politics", "/politics")
   val technology = SectionLink("technology", "tech", "Technology", "/technology")
   val environment = SectionLink("environment", "environment", "Environment", "/environment")
@@ -51,7 +51,7 @@ trait Navigation  {
   val americas = SectionLink("world", "americas", "Americas", "/world/americas")
   val australia = SectionLink("world", "australia", "Australia", "/world/australia")
   val asia = SectionLink("world", "asia", "Asia", "/world/asia")
-  val africa = SectionLink("world", "africa","Africa", "/world/africa")
+  val africa = SectionLink("world", "africa", "Africa", "/world/africa")
   val middleEast = SectionLink("world", "middle east", "Middle east", "/world/middleeast")
 
   val health = SectionLink("society", "health", "Health", "/society/health")
@@ -78,7 +78,7 @@ trait Navigation  {
   val boxing = SectionLink("sport", "boxing", "Boxing", "/sport/boxing")
   val formulaOne = SectionLink("sport", "formula one", "Formula one", "/sport/formulaone")
 
-  val nfl = SectionLink("sport", "NFL","NFL", "/sport/nfl")
+  val nfl = SectionLink("sport", "NFL", "NFL", "/sport/nfl")
   val mlb = SectionLink("sport", "MLB", "MLB", "/sport/mlb")
   val nba = SectionLink("sport", "NBA", "NBA", "/sport/nba")
   val mls = SectionLink("football", "MLS", "MLS", "/football/mls")
@@ -113,14 +113,14 @@ trait Navigation  {
   val gadgets = SectionLink("technology", "gadgets", "Gadgets", "/technology/gadgets")
 
   //Business
-  val economy =  SectionLink("business", "economy", "Economy", "/business")
-  val business =  economy.copy(title = "business", breadcumbTitle = "Business")
-  val companies =  SectionLink("business", "companies", "Companies", "/business/companies")
+  val economy = SectionLink("business", "economy", "Economy", "/business")
+  val business = economy.copy(title = "business", breadcumbTitle = "Business")
+  val companies = SectionLink("business", "companies", "Companies", "/business/companies")
   val economics = SectionLink("business", "economics", "Economics", "/business/economics")
   val markets = SectionLink("business", "markets", "Markets", "/business/stock-markets")
   val useconomy = SectionLink("business", "US economy", "US economy", "/business/useconomy")
   val recession = SectionLink("business", "recession", "Recession", "/business/recession")
-  val  investing = SectionLink("business", "investing", "Investing", "/business/investing")
+  val investing = SectionLink("business", "investing", "Investing", "/business/investing")
   val banking = SectionLink("business", "banking", "Banking", "/business/banking")
   val marketforceslive = SectionLink("business", "market forces live", "Market Forces live", "/business/marketforceslive")
   val businessblog = SectionLink("business", "business blog", "Business blog", "/business/blog")
@@ -193,10 +193,10 @@ object Breadcrumbs {
 }
 
 
-  // helper for the views
-  object Navigation {
+// helper for the views
+object Navigation {
 
-    def topLevelItem(navigation: Seq[NavItem], page: MetaData): Option[NavItem] = navigation.find(_.exactFor(page))
+  def topLevelItem(navigation: Seq[NavItem], page: MetaData): Option[NavItem] = navigation.find(_.exactFor(page))
     .orElse(navigation.find(_.currentFor(page))) //This includes a search on the HEAD of Tags for (page: MetaData)
     .orElse(navigation.find(_.currentForIncludingAllTags(page))) //This is the search for ALL tags
 
@@ -206,10 +206,20 @@ object Breadcrumbs {
     .filter(_.links.nonEmpty)
 
   def sectionOverride(localNav: NavItem, currentSublink: Option[SectionLink]): String = currentSublink.map(_.title).getOrElse(localNav.name.title)
+
+  def localNavWithoutCurrent(localNav: NavItem, currentSublink: Option[SectionLink]) =
+    localNav.links.filter(_.href != currentSublink.map(_.href).getOrElse(""))
+
+  def rotateByOmittingCurrent(localNav: NavItem, currentSublink: Option[SectionLink]) = currentSublink match {
+    case Some(currentSection) =>
+      val navSlices = localNav.links.span(_.href != currentSection.href)
+      navSlices._2.drop(1) ++ navSlices._1
+    case None =>
+      localNav.links
+  }
 }
 
 trait Zones extends Navigation {
-
 
   val newsZone = Zone(news,
     Seq(world, uk, us, politics, technology, environment, media, education, society, development,
@@ -233,11 +243,11 @@ trait Zones extends Navigation {
   )
 
   val technologyZone = Zone(technology,
-    Seq(technologyblog, games, gamesblog, appsblog, askjack, internet, mobilephones, gadgets )
+    Seq(technologyblog, games, gamesblog, appsblog, askjack, internet, mobilephones, gadgets)
   )
 
   val businessZone = Zone(economy,
-    Seq(economics, useconomy, recession, investing, banking, marketforceslive, businessblog )
+    Seq(economics, useconomy, recession, investing, banking, marketforceslive, businessblog)
   )
 
   val moneyZone = Zone(money,

--- a/common/app/views/fragments/newNavigation.scala.html
+++ b/common/app/views/fragments/newNavigation.scala.html
@@ -26,7 +26,7 @@
                                         }
 
                                         @* remaining sub sections *@
-                                        @localNav.links.filter(_.href != currentSublink.map(_.href).getOrElse("")).map{ link =>
+                                        @Navigation.rotateByOmittingCurrent(localNav, currentSublink).map{ link =>
                                             <li class="local-navigation__child"><a class="local-navigation__action" href="@link.href">@Html(link.title)</a></li>
                                         }
                                     }


### PR DESCRIPTION
If we consider a list of local sections ("a", "b", "c", "d", "e"), and current section is "c", than
before
display: ("c", "a", "b", "d", "e")
![screen shot 2014-06-17 at 16 10 44](https://cloud.githubusercontent.com/assets/1492162/3302101/a0877cee-f631-11e3-9f97-6efe800c45b9.png)
after
display: ("c", "d", "e", "a", "b")
![screen shot 2014-06-17 at 16 09 30](https://cloud.githubusercontent.com/assets/1492162/3302103/a82b6442-f631-11e3-9df2-700bcdefd7c6.png)

We will consider the 'before' behaviour for a separate variant, so keeping the logic in a separate Navigation function, localNavWithoutCurrent.
