### PR TITLE
Fix styling of main media embeds

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -1,8 +1,8 @@
-@(article: Article)
+@(article: Article)(implicit request: RequestHeader)
 
 @if(article.hasMainEmbed) {
     <div class="media-primary">
-        @Html(article.main)
+        @BodyCleaner(article, article.main)
     </div>
 } else {
     @if(!article.hasVideoAtTop) {


### PR DESCRIPTION
We now allow the ability for embeds to be used as the article main media, but we were not apllying the correct CSS classes for these to behave correctly and responsively.

This corrects that.
##### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/3312328/577d7cca-f6d0-11e3-8187-5d09c48fcaa6.png)
##### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/3312329/5dce86c8-f6d0-11e3-8af9-f767723f2b3f.png)
