### PR TITLE
Ad render tweaks

### DIFF
--- a/admin/app/assets/javascripts/bootstraps/commercial.js
+++ b/admin/app/assets/javascripts/bootstraps/commercial.js
@@ -1,13 +1,13 @@
 define([
     'qwery',
     'bean',
-    'lodash/arrays/first',
+    'lodash/collections/where',
     'common/$',
     'common/utils/ajax'
 ], function(
     qwery,
     bean,
-    first,
+    where,
     $,
     ajax
 ) {
@@ -28,20 +28,22 @@ define([
                 url: '/ophan/ads/render-time?platform=r2',
                 type: 'json'
             }).then(function(r2Data) {
-                var graphData = [['Time', 'Next-Gen', 'R2']].concat(nextGenData.buckets.map(function(bucket, i) {
-                    return [
-                        new Date(bucket.time),
-                        bucket.avgTimeToRenderEnded/1000,
-                        first(r2Data.buckets, {time: bucket.time}).avgTimeToRenderEnded || 0
-                    ];
-                }));
+                var r2Buckets = r2Data.buckets,
+                    graphData = [['Time', 'Next-Gen', 'R2']].concat(nextGenData.buckets.map(function(bucket) {
+                        var r2Bucket = where(r2Buckets, {time: bucket.time});
+                        return [
+                            new Date(bucket.time),
+                            bucket.avgTimeToRenderEnded/1000,
+                            r2Bucket.length ? r2Bucket.shift().avgTimeToRenderEnded/1000 : 0
+                        ];
+                    }));
+
 
                 new google.visualization.LineChart(qwery('#render-time--ads__graph')[0])
                     .draw(google.visualization.arrayToDataTable(graphData), {
                         fontName: 'Georgia',
                         title: 'Average render time across all ad slots (secs)',
                         titleTextStyle: {fontName: 'Georgia', color: '#222', italic: true, bold: false},
-                        vAxis: {format: '#,###'},
                         hAxis: {format: 'HH:mm'}
                     });
 
@@ -62,7 +64,7 @@ define([
                 .removeClass('ajax-failed')
                 .addClass('ajax-loading');
             ajax({
-                url: '/ophan/ads/render-time/' + adSlotName + '?platform=next-gen',
+                url: '/ophan/ads/render-time/dfp-ad--' + adSlotName + '?platform=next-gen',
                 type: 'json'
             }).then(function(data) {
                 var graphData = [['Time', 'Next-Gen']].concat(data.buckets.map(function(bucket) {
@@ -78,9 +80,8 @@ define([
                         legend: 'none',
                         title: 'Average render time for a particular ad slot (secs)',
                         titleTextStyle: {fontName: 'Georgia', color: '#222', italic: true, bold: false},
-                        vAxis: {format: '#,###'},
                         hAxis: {format: 'HH:mm'},
-                        trendlines: {0: {type: 'exponential', color: 'green'}}
+                        trendlines: {0: {color: 'green'}}
                     });
             }).always(function() {
                 $adRenderTime.removeClass('ajax-loading');
@@ -107,7 +108,7 @@ define([
             'merchandising'
         ].forEach(function(adSlotName, i) {
                 $.create('<option></option>')
-                    .val('dfp-ad--' + adSlotName)
+                    .val(adSlotName)
                     .text(adSlotName)
                     .attr('selected', adSlot ? adSlot[1] === adSlotName : i === 0)
                     .appendTo($select);
@@ -119,7 +120,7 @@ define([
 
         bean.on($select[0], 'change', function(e) {
             var adSlot = e.target.value;
-            window.history.pushState({}, '', '?adSlot=' + adSlot);
+            window.history.pushState({}, '', '?ad-slot=' + adSlot);
             $('#render-time--ad__graph').html('');
             daramAdRenderTime(adSlot);
         });

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -9,14 +9,14 @@ import play.api.libs.ws.WS
 
 object OphanApi extends ExecutionContexts with Logging {
 
-  private def getBody(path: String): Future[JsValue] = {
+  private def getBody(path: String, timeout: Int = ophanApi.timeout): Future[JsValue] = {
     (for {
       host <- ophanApi.host
       key <- ophanApi.key
     } yield {
       val url = s"$host/$path&api-key=$key"
       log.info("Making request to Ophan API: " + url)
-      WS.url(url) withRequestTimeout ophanApi.timeout get() map (_.json)
+      WS.url(url) withRequestTimeout timeout get() map (_.json)
     }) getOrElse {
       log.error("Ophan host or key not configured")
       Future.successful(JsObject(Nil))
@@ -41,9 +41,10 @@ object OphanApi extends ExecutionContexts with Logging {
 
   def getMostReferredFromSocialMedia(days: Int): Future[JsValue] = getBody(s"mostread?days=$days&referrer=social%20media")
 
-  def getAdsRenderTime(platform: String): Future[JsValue] = getBody(s"ads/render-time?platform=${platform}&hours=24")
+  def getAdsRenderTime(platform: String): Future[JsValue] =
+    getBody(s"ads/render-time?platform=${platform}&hours=24", 5000)
 
   def getAdsRenderTime(platform: String, slotName: String): Future[JsValue] =
-    getBody(s"ads/render-time?platform=${platform}&hours=24&ad-slot=$slotName")
+    getBody(s"ads/render-time?platform=${platform}&hours=24&ad-slot=$slotName", 5000)
 
 }


### PR DESCRIPTION
Now we have more sensible looking data, few JS fixes to the graphs

Also increased the Ophan api timeout to 5 secs for the ad render time calls, they're particularly slow due to parent/child type setup in elasticsearch

![screen shot 2014-06-18 at 14 27 57](https://cloud.githubusercontent.com/assets/74132/3314147/992c2212-f6ed-11e3-8136-a38c45910159.png)
