### PR TITLE
Run timestamp upgrade inside facia snaps callback

### DIFF
--- a/facia/app/assets/javascripts/modules/ui/snaps.js
+++ b/facia/app/assets/javascripts/modules/ui/snaps.js
@@ -4,14 +4,16 @@ define([
     'common/utils/ajax',
     'common/utils/mediator',
     'common/utils/template',
-    'common/utils/to-array'
+    'common/utils/to-array',
+    'common/modules/ui/relativeDates'
 ], function(
     $,
     bonzo,
     ajax,
     mediator,
     template,
-    toArray
+    toArray,
+    relativeDates
 ) {
 
     function init() {
@@ -71,6 +73,7 @@ define([
             $.create(asJson ? resp.html : resp).each(function(html) {
                 bonzo(el).html(html);
             });
+            relativeDates.init(el);
         });
     }
 


### PR DESCRIPTION
This ensures we run the relative timestamps upgrade on snaps components within facia fronts.

This is most important for world cup fixtures components so they display times to users locale.
#### Before in AUS timezone

![google chrome](https://cloud.githubusercontent.com/assets/80089/3316453/e35e4b2a-f702-11e3-86e7-867b7aea3084.png)
#### After in AUS timezone

![google chrome](https://cloud.githubusercontent.com/assets/80089/3316456/e7e93c68-f702-11e3-9e9f-b6e7678ac1d3.png)
