### PR TITLE
Report only when form submitted

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -602,11 +602,13 @@ Comments.prototype.reportComment = function(e) {
             var category = form.elements.category,
                 comment = form.elements.comment.value;
 
-            DiscussionApi.reportComment(commentId, {
-                emailAddress: form.elements.email.value,
-                categoryId: category.value,
-                reason: comment
-            });
+            if (category.value !== '0') {
+                DiscussionApi.reportComment(commentId, {
+                    emailAddress: form.elements.email.value,
+                    categoryId: category.value,
+                    reason: comment
+                });
+            }
 
             bonzo(form).addClass('u-h');
         });

--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -1,9 +1,13 @@
 <form class="d-report-comment-form js-report-comment-form u-h">
-    <button class="d-report-comment__close js-report-comment-close u-button-reset" data-link-name="Close report abuse">
+    <button
+        class="d-report-comment__close js-report-comment-close u-button-reset"
+        data-link-name="Close report abuse"
+        type="button">
         <span class="u-h">Close report comment form</span>
         <i class="i i-close-icon"></i>
     </button>
     <select class="d-report-comment__field d-report-comment__field--category" name="category">
+        <option value="0">Please select</option>
         <option value="1">Personal abuse</option>
         <option value="2">Off topic</option>
         <option value="3">Legal issue</option>


### PR DESCRIPTION
Form was submitting onclose as button wasn't `type="button"`. Now doesn't.
Also added a blank report option.
