### PR TITLE
Fix fallback metric

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -367,11 +367,11 @@ object FaciaToolMetrics {
     "Number of times facia-tool has failed to made the request for SEO purposes of webTitle and section"
   )
 
-  object ContentApiFallbacks extends SimpleCountMetric(
+  object MemcachedFallbackMetric extends SimpleCountMetric(
     "facia-press-content-api",
-    "facia-press-content-api-fallbacks",
-    "Facia Content API Fall Backs",
-    "Number of queries to Content API that failed and were served by Memcached"
+    "facia-press-memcached-fallbacks",
+    "Facia Tool Memcached Fall Backs",
+    "Number of times the Memcached Fallback was used"
   )
 
   val all: Seq[Metric] = Seq(
@@ -379,7 +379,7 @@ object FaciaToolMetrics {
     DraftPublishCount, ContentApiPutSuccess, ContentApiPutFailure,
     FrontPressSuccess, FrontPressFailure, FrontPressCronSuccess,
     FrontPressCronFailure, InvalidContentExceptionMetric,
-    ContentApiSeoRequestSuccess, ContentApiSeoRequestFailure, ContentApiFallbacks
+    ContentApiSeoRequestSuccess, ContentApiSeoRequestFailure, MemcachedFallbackMetric
   ) ++ ContentApiMetrics.all ++ S3Metrics.all
 }
 

--- a/common/app/performance/MemcachedFallback.scala
+++ b/common/app/performance/MemcachedFallback.scala
@@ -10,6 +10,7 @@ import conf.Configuration
 import play.api.Play
 import Play.current
 import scala.util.Try
+import common.FaciaToolMetrics.ContentApiFallbacks
 
 object MemcachedFallback extends ExecutionContexts with Dates with Logging {
   private def connectToMemcached(host: String) = {
@@ -47,6 +48,7 @@ object MemcachedFallback extends ExecutionContexts with Dates with Logging {
         (memcached map { _.get[A](key) map {
             case None => throw error
             case Some(a) =>
+              ContentApiFallbacks.increment()
               log.logger.warn(s"Used Memcached value for $key to recover from Content API error", error)
               a
         }

--- a/common/app/performance/MemcachedFallback.scala
+++ b/common/app/performance/MemcachedFallback.scala
@@ -10,7 +10,7 @@ import conf.Configuration
 import play.api.Play
 import Play.current
 import scala.util.Try
-import common.FaciaToolMetrics.ContentApiFallbacks
+import common.FaciaToolMetrics.MemcachedFallbackMetric
 
 object MemcachedFallback extends ExecutionContexts with Dates with Logging {
   private def connectToMemcached(host: String) = {
@@ -48,7 +48,7 @@ object MemcachedFallback extends ExecutionContexts with Dates with Logging {
         (memcached map { _.get[A](key) map {
             case None => throw error
             case Some(a) =>
-              ContentApiFallbacks.increment()
+              MemcachedFallbackMetric.increment()
               log.logger.warn(s"Used Memcached value for $key to recover from Content API error", error)
               a
         }

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -36,7 +36,7 @@ object Global extends WithFilters(Gzipper)
     ("s3-client-exceptions", S3Metrics.S3ClientExceptionsMetric.getAndReset.toDouble),
     ("content-api-seo-request-success", FaciaToolMetrics.ContentApiSeoRequestSuccess.getAndReset.toDouble),
     ("content-api-seo-request-failure", FaciaToolMetrics.ContentApiSeoRequestFailure.getAndReset.toDouble),
-    ("content-api-fallbacks", FaciaToolMetrics.ContentApiFallbacks.getAndReset.toDouble)
+    ("content-api-fallbacks", FaciaToolMetrics.MemcachedFallbackMetric.getAndReset.toDouble)
   )
 
   override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration = {


### PR DESCRIPTION
Naming it to `MemcachedFallbackMetric`, because this is counting from the `MemcachedFallback`. Even though the content api fallbacks are the only thing using it.

This is still being pushed into `CloudWatch` as `content-api-fallbacks`. Only doing this to see the effect on the current graph, but maybe should generalize it there too?

@robertberry @stephanfowler 
