### PR TITLE
fix football fronts on iOS

### DIFF
--- a/common/app/assets/stylesheets/module/facia/snaps/_football.scss
+++ b/common/app/assets/stylesheets/module/facia/snaps/_football.scss
@@ -1,26 +1,28 @@
 .facia-snap--football {
     // Dealing with the double embedding of snaps
     overflow: hidden;
-    .facia-snap--football {
-        overflow: visible;
-    }
+    padding: 0;
 
     // Generic
     &.facia-snap-embed {
         @include rem((
-            border-left-width: $gs-gutter/2,
-            border-right-width: $gs-gutter/2
+            margin: 0 $gs-gutter/2
         ));
         background: #ffffff;
     }
 
     // Matches and tables
     // =============================================================================
-    .c-football-matches,
     .c-football-table {
         // this works as a min-height
         height: $gs-baseline*14;
         overflow: visible;
+    }
+
+    .c-football-matches {
+        height: $gs-baseline*14;
+        overflow: hidden;
+        position: relative;
     }
 
     .table,
@@ -58,6 +60,9 @@
         left: 0;
         width: 100%;
         z-index: 2;
+        position: absolute;
+        margin: 0;
+        padding: 10px 0;
 
         .full-table-link {
             @include rem((
@@ -169,14 +174,6 @@
         .team__info {
             @include fs-headline(1, true)
         }
-
-        .table__caption--bottom {
-            position: absolute;
-            @include rem((
-                border-left: $gs-gutter/2 solid #ffffff,
-                border-right: $gs-gutter/2 solid #ffffff
-            ));
-        }
     }
 
     &.facia-snap-point--mini,
@@ -213,14 +210,6 @@
         .football-match__team--away {
             @include rem((
                 padding-left: $gs-gutter*.5
-            ));
-        }
-
-        .table__caption--bottom {
-            position: absolute;
-            @include rem((
-                border-left: $gs-gutter/2 solid #ffffff,
-                border-right: $gs-gutter/2 solid #ffffff
             ));
         }
 


### PR DESCRIPTION
Fixing display of the 'View all ...' button. 
Known issue: the snap doesn't occupy all available height on iPad (landscape) if placed in a standard news container.

Before
![before iphone](https://cloud.githubusercontent.com/assets/1492162/3320315/565ae4e6-f729-11e3-96a1-670c47f6229f.PNG)

After on iPhone
- fixtures
  ![fixtures big](https://cloud.githubusercontent.com/assets/1492162/3320317/610b326a-f729-11e3-82be-d4cb2c4271b4.png)
  ![fixtures huge very big](https://cloud.githubusercontent.com/assets/1492162/3320319/613dae7a-f729-11e3-9853-29375b54d1ce.png)
  ![fixtures standard](https://cloud.githubusercontent.com/assets/1492162/3320320/615c4bd2-f729-11e3-918b-8f95693e55d5.png)
- live

![live huge very big big](https://cloud.githubusercontent.com/assets/1492162/3320373/e1a39386-f729-11e3-9fc0-28de4acef5f2.png)
![live standard](https://cloud.githubusercontent.com/assets/1492162/3320374/e1a850c4-f729-11e3-9f6f-b02e90226bc2.png)
- results
  ![results standard](https://cloud.githubusercontent.com/assets/1492162/3320332/7b50782e-f729-11e3-815e-3242d14b8c6f.png)
  ![results huge very big big](https://cloud.githubusercontent.com/assets/1492162/3320333/7b9f3bda-f729-11e3-9f08-c45bda945dfb.png)

After on iPad
![ipad live](https://cloud.githubusercontent.com/assets/1492162/3320337/85d1069c-f729-11e3-9c16-6cf306e9412d.png)
![ipad landscape live](https://cloud.githubusercontent.com/assets/1492162/3320339/86a9b8e8-f729-11e3-81b0-0cc2be642b14.png)
