### PR TITLE
Preroll countdown

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -762,7 +762,7 @@ module.exports = function (grunt) {
             },
             css: {
                 files: ['common/app/assets/stylesheets/**/*.scss'],
-                tasks: ['compile:css'],
+                tasks: ['compile:css', 'hash'],
                 options: {
                     spawn: false
                 }
@@ -893,7 +893,7 @@ module.exports = function (grunt) {
     grunt.registerTask('compile:flash', ['copy:flash']);
     grunt.registerTask('compile:conf', ['copy:headCss', 'copy:vendor', 'copy:assetMap']);
     grunt.registerTask('compile:videojs', ['shell:videojs', 'grunt:videojs']);
-    
+
     grunt.registerTask('compile', function(app) {
         grunt.task.run([
             'compile:images',
@@ -945,11 +945,9 @@ module.exports = function (grunt) {
             // compile just the project
             var project = filepath.split('/').shift();
             grunt.task.run('requirejs:' + project);
-        }
-        // TODO: decouple moving of files from hashing
-        //if (!isDev) {
+            // TODO: decouple moving of files from hashing
             grunt.task.run('hash');
-        //}
+        }
     });
 
 };

--- a/common/app/assets/stylesheets/module/_video.scss
+++ b/common/app/assets/stylesheets/module/_video.scss
@@ -454,3 +454,34 @@ $vjs-progress-inset-bottom: 4px;
 .vast-skip-button {
     display: none;
 }
+
+/* VJS: AD OVERLAY
+   ========================================================================== */
+.vjs-ads-overlay {
+    position: absolute;
+    z-index: 2;
+    top: 0;
+    left: 0;
+    width: 100%;
+    @include rem((
+        height: $gs-baseline*2,
+        padding: $gs-baseline/3 0 0 $gs-gutter/4
+    ));
+    background-color: rgba($c-neutral1, .8);
+    border-top: 1px solid $c-neutral2;
+    color: #ffffff;
+    text-align: left;
+    @include fs-textsans(1);
+
+    @include mq(tablet) {
+        @include fs-textsans(2, true);
+    }
+}
+
+.vjs-ads-overlay__label {
+    position: absolute;
+    @include rem((
+        top: $gs-baseline/3,
+        right: $gs-gutter/2
+    ));
+}

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -46,7 +46,7 @@ guardian.page.fbAppId=232588266837342
 guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.onwardWebSocket=wss://frontend-OnwardLo-G3SS42I4G3PN-384008737.eu-west-1.elb.amazonaws.com/recently-published
 guardian.page.dfpAccountId=158186692
-guardian.page.dfpAdUnitRoot=theguardian.com
+guardian.page.dfpAdUnitRoot=test-theguardian.com
 guardian.page.sentryApiKey=1b006169a5a64dc18e33105b259e81db
 guardian.page.sentryHost=frontend-SentryLo-35H427X3SDHB-2122817448.eu-west-1.elb.amazonaws.com/2
 


### PR DESCRIPTION
Adds a permanent label and countdown overlaid on top of preroll adverts within the video player.
- Fix grunt watch task for Sass compilation
- Reset dfpRoot to test-theguardian.com (this is to enable our test preroll campaigns)
- JS logic and styling for countdown
#### Screenshots (ignore the fonts)

![google chrome](https://cloud.githubusercontent.com/assets/80089/3327283/a8c91a6c-f7ac-11e3-9698-e6faac4e8957.png)

![littlesnapper](https://cloud.githubusercontent.com/assets/80089/3327287/ad3723aa-f7ac-11e3-8109-ea70cba20233.png)
