### PR TITLE
Fix DFP Ad Units for Fronts

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -30,7 +30,7 @@ trait MetaData extends Tags {
 
   lazy val adUnitSuffix = {
     val isSectionFront = id == section
-    if (isSectionFront) section + "/front" else section
+    if (isSectionFront) s"$section/front" else section
   }
 
   lazy val hasPageSkin = false

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -28,7 +28,10 @@ trait MetaData extends Tags {
   lazy val isFront = false
   lazy val contentType = ""
 
-  lazy val adUnitSuffix = if (isFront) section + "/front" else section
+  lazy val adUnitSuffix = {
+    val isSectionFront = id == section
+    if (isSectionFront) section + "/front" else section
+  }
 
   lazy val hasPageSkin = false
 

--- a/common/test/model/MetaDataTest.scala
+++ b/common/test/model/MetaDataTest.scala
@@ -1,0 +1,27 @@
+package model
+
+import org.scalatest.{Matchers, FlatSpec, FunSuite}
+
+class MetaDataTest extends FlatSpec with Matchers {
+
+  private case class TestMetaData(id: String, section: String) extends MetaData {
+    def analyticsName = "n"
+    def webTitle = "t"
+  }
+
+  "adUnitSuffix" should "just be section for a content page" in {
+    TestMetaData("world/2014/jun/19/obama-100-special-forces-iraq", "world").adUnitSuffix should be("world")
+  }
+
+  "adUnitSuffix" should "be front for a network front" in {
+    TestMetaData("us", "us").adUnitSuffix should be("us/front")
+  }
+
+  "adUnitSuffix" should "be front for a section front" in {
+    TestMetaData("lifeandstyle", "lifeandstyle").adUnitSuffix should be("lifeandstyle/front")
+  }
+
+  "adUnitSuffix" should "just be section for all other kinds of front" in {
+    TestMetaData("lifeandstyle/live-better", "lifeandstyle").adUnitSuffix should be("lifeandstyle")
+  }
+}


### PR DESCRIPTION
So that fronts that aren't section fronts or network fronts don't use front ad units.
