### PR TITLE
Commercial single dfp unit styling

### DIFF
--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -99,6 +99,11 @@
         .commercial--generic__item__description {
             margin-bottom: 0;
         }
+        .lineitem__meta {
+            @include rem((
+                margin: $gs-baseline/2 0
+            ));
+        }
         @include mq(mobileLandscape) {
             .lineitem__link-image,
             .lineitem__offer {

--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -79,6 +79,26 @@
         }
     }
     &.commercial--dfp-single {
+        .commercial__head {
+            margin-bottom: 0;
+        }
+        .commercial__body {
+            @include rem((
+                padding: $gs-baseline 0
+            ));
+        }
+        .commercial__footer {
+            @include box-sizing(border-box);
+            @include rem((
+                padding-bottom: $gs-baseline/2
+            ));
+        }
+        .commercial__home-link {
+            position: relative;
+        }
+        .commercial--generic__item__description {
+            margin-bottom: 0;
+        }
         @include mq(mobileLandscape) {
             .lineitem__link-image,
             .lineitem__offer {
@@ -88,6 +108,9 @@
                 @include rem((
                     padding: 0 $gs-gutter/2 0 0
                 ));
+            }
+            .lineitem__link-image {
+                line-height: 0;
             }
             .lineitem__offer {
                 @include rem((
@@ -102,6 +125,11 @@
             .lineitem__offer {
                 width: 66%;
             }
+            .commercial__body {
+                @include rem((
+                    padding-top: $gs-baseline
+                ));
+            }
         }
     }
 }
@@ -111,7 +139,13 @@
         .commercial__head {
             width: 25%;
             float: left;
-        }        
+        }
+        .commercial__footer {
+            position: absolute;
+            @include rem((
+                bottom: $gs-baseline/2
+            ));
+        }     
     }
     @include mq(leftCol) {
         .commercial__body {
@@ -123,6 +157,43 @@
         .lineitem__offer {
             width: 50%;
         }
+        .commercial__footer {
+            position: absolute;
+            top: 0;
+            height: 100%;
+            @include rem((
+                width: gs-span(3) + $gs-gutter/2,
+                padding: $gs-baseline 0,
+                left: gs-span(11) + ($gs-gutter/2)
+            ));
+        }
+        .commercial__footer-inner {
+            height: 100%;
+            border-left: 1px solid $c-neutral4;
+        }
+        .commercial__home-link {
+            @include rem((
+                margin-left: $gs-gutter/2
+            ));
+            left: auto;
+            bottom: auto;
+            right: auto;
+            top: auto;
+        }
+    }
+    @include mq(faciaLeftCol) {
+        .commercial__footer {
+            @include rem((
+                left: gs-span(11) + ($gs-gutter*1.5)
+            ));
+        }
+    }
+    @include mq(wide) {
+        .commercial__footer {
+            @include rem((
+                left: gs-span(12) + ($gs-gutter*1.5)
+            ));
+        }
     }
 }
 
@@ -131,6 +202,12 @@
         .commercial__head {
             width: 25%;
             float: left;
+        }
+        .commercial__footer {
+            position: absolute;
+            @include rem((
+                bottom: $gs-baseline/2
+            ));
         }
     }
     @include mq(faciaLeftCol) {
@@ -144,6 +221,36 @@
         }
         .lineitem__offer {
             width: 50%;
+        }
+        .commercial__footer {
+            position: absolute;
+            height: 100%;
+            top: 0;
+            @include rem((
+                width: gs-span(3) + $gs-gutter/2,
+                padding: $gs-baseline 0,
+                left: gs-span(11) + ($gs-gutter/2)
+            ));
+        }
+        .commercial__footer-inner {
+            height: 100%;
+            border-left: 1px solid $c-neutral4;
+        }
+        .commercial__home-link {
+            @include rem((
+                margin-left: $gs-gutter/2
+            ));
+            left: auto;
+            bottom: auto;
+            right: auto;
+            top: auto;
+        }
+    }
+    @include mq(wide) {
+        .commercial__footer {
+            @include rem((
+                left: gs-span(12) + ($gs-gutter/2)
+            ));
         }
     }
 }

--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -76,7 +76,75 @@
             &:nth-child(4) {
                 display: block;
             }
+        }
+    }
+    &.commercial--dfp-single {
+        @include mq(mobileLandscape) {
+            .lineitem__link-image,
+            .lineitem__offer {
+                @include box-sizing(border-box);
+                width: 50%;
+                float: left;
+                @include rem((
+                    padding: 0 $gs-gutter/2 0 0
+                ));
+            }
+            .lineitem__offer {
+                @include rem((
+                    padding: 0 0 0 $gs-gutter/2
+                ));                
+            }
+        }
+        @include mq(tablet) {
+            .lineitem__link-image {
+                width: 33%;
+            }
+            .lineitem__offer {
+                width: 66%;
+            }
+        }
+    }
+}
+
+.facia-container--layout-article .commercial--dfp.commercial--dfp-single {
+    @include mq(rightCol) {
+        .commercial__head {
+            width: 25%;
+            float: left;
         }        
+    }
+    @include mq(leftCol) {
+        .commercial__body {
+            @include box-sizing(border-box);
+        }
+        .lineitem__link-image {
+            width: 25%;
+        }
+        .lineitem__offer {
+            width: 50%;
+        }
+    }
+}
+
+.facia-container--layout-front .commercial--dfp.commercial--dfp-single {
+    @include mq(tablet) {
+        .commercial__head {
+            width: 25%;
+            float: left;
+        }
+    }
+    @include mq(faciaLeftCol) {
+        .commercial__head {
+            @include rem((
+                width: gs-span(2) + $gs-gutter
+            ));
+        }
+        .lineitem__link-image {
+            width: 25%;
+        }
+        .lineitem__offer {
+            width: 50%;
+        }
     }
 }
 


### PR DESCRIPTION
This adds the required styling for single unit commercial units created within DFP.

Html template is created in DFP and creatives are made in DFP. Separate pull request coming to store these templates and to give a test page.

Works across both fronts and articles at all breakpoints

![screen shot 2014-06-20 at 15 11 07](https://cloud.githubusercontent.com/assets/1303616/3341040/cce3c2de-f884-11e3-8232-3cea67c3ab74.png)

![screen shot 2014-06-20 at 15 10 34](https://cloud.githubusercontent.com/assets/1303616/3341028/aeeeec90-f884-11e3-8daa-9b00e9547f73.png)
