### PR TITLE
facia-tool: fewer renders

### DIFF
--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -207,6 +207,8 @@ define([
             droppable.init();
 
             fetchSettings(function (config, switches) {
+                var fronts;
+
                 if (switches['facia-tool-disable']) {
                     terminate();
                     return;
@@ -215,17 +217,19 @@ define([
 
                 vars.state.config = config;
 
-                model.fronts(
-                    getFront() === 'testcard' ? ['testcard'] :
-                       _.chain(config.fronts)
-                        .map(function(front, path) {
-                            return front.priority === vars.priority ? path : undefined;
-                        })
-                        .without(undefined)
-                        .without('testcard')
-                        .sortBy(function(path) { return path; })
-                        .value()
-                );
+                fronts = getFront() === 'testcard' ? ['testcard'] :
+                   _.chain(config.fronts)
+                    .map(function(front, path) {
+                        return front.priority === vars.priority ? path : undefined;
+                    })
+                    .without(undefined)
+                    .without('testcard')
+                    .sortBy(function(path) { return path; })
+                    .value();
+
+                if (!_.isEqual(model.fronts(), fronts)) {
+                   model.fronts(fronts);
+                }
             }, vars.CONST.configSettingsPollMs, true)
             .done(function() {
                 var wasPopstate = false;


### PR DESCRIPTION
The fronts dropdown is re-rendered whenever the `config.json` file is polled. Make this only happen if the list of fronts had been modified since the last render (because it's annoying when an open dropdown suddenly resets its position.)
