### PR TITLE
Fix dev-build routes

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -245,7 +245,7 @@ GET         /sections.json                                                      
 # Facia
 GET         /                                                                                                        controllers.FaciaController.editionRedirect(path = "")
 GET         /$path<(lifeandstyle/love-and-sex|lifeandstyle/home-and-garden|world/asia|business/companies)>           controllers.FaciaController.renderFrontPressSpecial(path)
-GET         /$path<(\w+|(uk|au|us))?(/(culture|sport|commentisfree|business|money|travel|rss))?>                     controllers.FaciaController.renderFrontPress(path)
+GET         /$path<(uk|au|us)(/(culture|sport|commentisfree|business|money|travel|rss))?>                            controllers.FaciaController.renderFrontPress(path)
 
 GET         /*path/lite.json                                                                                         controllers.FaciaController.renderFrontJsonLite(path)
 


### PR DESCRIPTION
`dev-build` is routing requests to `facia` that it cannot handle. e.g. `/books`.
On `PROD` and `CODE`, `Nginx` takes us to the correct place.

On dev-build we need to be explicit.

This means that `dev-build` only handles what is in the routes file, and `applications` handles everything else.

@kaelig @stephanfowler 
