### PR TITLE
disabling prerolls on ff/opera temporarily

### DIFF
--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -149,15 +149,17 @@ define([
 
                         modules.bindPrerollEvents(player, el);
 
-                        player.adCountDown();
-
-                        // Init vast adverts.
-                        player.ads({
-                            timeout: 3000
-                        });
-                        player.vast({
-                            url: modules.getVastUrl()
-                        });
+                        // no prerolls on firefox or opera until we fix the flash fallback
+                        var buggyEnvironment = window.navigator.userAgent.match(/(Opera|Firefox)/i);
+                        if (!buggyEnvironment) {
+                            player.adCountDown();
+                            player.ads({
+                                timeout: 3000
+                            });
+                            player.vast({
+                                url: modules.getVastUrl()
+                            });
+                        }
                     });
 
                     // built in vjs-user-active is buggy so using custom implementation


### PR DESCRIPTION
disabling video prerolls on ff and opera until we fix the flash fallback switching
