### PR TITLE
Adding books schema to commercial books components

### DIFF
--- a/commercial/app/views/books/bestsellers.scala.html
+++ b/commercial/app/views/books/bestsellers.scala.html
@@ -49,6 +49,7 @@
                         @if(book.author) {
                             <p class="lineitem__meta" itemprop="author">By @book.author</p>
                         }
+                            <meta itemprop="isbn" content="@{book.isbn}" />
                             <p class="commercial--books__price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
                             @book.price.map { price =>
                                 <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>

--- a/commercial/app/views/books/bestsellers.scala.html
+++ b/commercial/app/views/books/bestsellers.scala.html
@@ -55,7 +55,7 @@
                                 <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                             }
                             @book.offerPrice.map { price =>
-                                <span class="commercial--books__price__our" itemprop="price">Our price: &pound;@("%.2f".format(price))</span>
+                                <span class="commercial--books__price__our">Our price: <span itemprop="price">&pound;@("%.2f".format(price))</span></span>
                                 <meta itemprop="priceCurrency" content="GBP" />
                             }
                             </p>

--- a/commercial/app/views/books/bestsellers.scala.html
+++ b/commercial/app/views/books/bestsellers.scala.html
@@ -40,21 +40,22 @@
             <div class="commercial__body">
                 <ul class="u-unstyled lineitems">
                 @books.map { book =>
-                    <li class="lineitem u-cf">
+                    <li class="lineitem u-cf" itemscope itemtype="http://schema.org/Book">
                         <a href="@AdLink{@book.buyUrl}" class="lineitem__link" data-link-name="merchandising-bookshop-v@{version}_@{date}-low-@{book.isbn}-@{book.author}-@{book.title}">
-                        @book.jacketUrl.map { url =>
-                            <div class="lineitem__img js-image-upgrade" data-src="@url"></div>
-                        }
-                            <h4 class="lineitem__title">@book.title</h4>
+                            @book.jacketUrl.map { url =>
+                            <img itemprop="image" class="lineitem__img" src="@url" alt="" />
+                            }
+                            <h4 class="lineitem__title" itemprop="name">@book.title</h4>
                         @if(book.author) {
-                            <p class="lineitem__meta">By @book.author</p>
+                            <p class="lineitem__meta" itemprop="author">By @book.author</p>
                         }
-                            <p class="commercial--books__price">
+                            <p class="commercial--books__price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
                             @book.price.map { price =>
                                 <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                             }
                             @book.offerPrice.map { price =>
-                                <span class="commercial--books__price__our">Our price: &pound;@("%.2f".format(price))</span>
+                                <span class="commercial--books__price__our" itemprop="price">Our price: &pound;@("%.2f".format(price))</span>
+                                <meta itemprop="priceCurrency" content="GBP" />
                             }
                             </p>
                         </a>

--- a/commercial/app/views/books/bestsellersHigh.scala.html
+++ b/commercial/app/views/books/bestsellersHigh.scala.html
@@ -59,7 +59,7 @@
                                     <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                                     }
                                     @book.offerPrice.map { price =>
-                                    <span itemprop="price" class="commercial--books__price__our">Our price: &pound;@("%.2f".format(price))</span>
+                                    <span class="commercial--books__price__our">Our price: <span itemprop="price">&pound;@("%.2f".format(price))</span></span>
                                     <meta itemprop="priceCurrency" content="GBP" />
                                     }
                                 </p>
@@ -91,7 +91,7 @@
                                         <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                                         }
                                         @book.offerPrice.map { price =>
-                                        <span class="commercial--books__price__our" itemprop="price">Our price: &pound;@("%.2f".format(price))</span>
+                                        <span class="commercial--books__price__our">Our price: <span itemprop="price">&pound;@("%.2f".format(price))</span></span>
                                         <meta itemprop="priceCurrency" content="GBP" />
                                         }
                                     </p>

--- a/commercial/app/views/books/bestsellersHigh.scala.html
+++ b/commercial/app/views/books/bestsellersHigh.scala.html
@@ -52,6 +52,7 @@
                                 @if(book.author) {
                                     <p itemprop="author" class="lineitem__meta">By @book.author</p>
                                 }
+                                <meta itemprop="isbn" content="@{book.isbn}" />
                                 <p itemprop="description" class="commercial--books__description">@book.description</p>
                                 <p itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="commercial--books__price">
                                     @book.price.map { price =>
@@ -84,6 +85,7 @@
                                     @if(book.author) {
                                     <p class="lineitem__meta" itemprop="author">By @book.author</p>
                                     }
+                                    <meta itemprop="isbn" content="@{book.isbn}" />
                                     <p class="commercial--books__price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
                                         @book.price.map { price =>
                                         <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>

--- a/commercial/app/views/books/bestsellersHigh.scala.html
+++ b/commercial/app/views/books/bestsellersHigh.scala.html
@@ -38,27 +38,28 @@
             </div>
             <div class="commercial__body container__body">
                 <div class="commercial__relevance commercial__relevance-high u-cf">
-                    <div class="highitem">
+                    <div class="highitem" itemscope itemtype="http://schema.org/Book">
                         <h4 class="commercial__relevance-title commercial__relevance-title-high">Featured book</h4>
                         @books.take(1).map { book =>
                         <a href="@AdLink{@book.buyUrl}" class="lineitem__link" data-link-name="merchandising-bookshop-v@{version}_@{date}-high-@{book.isbn}-@{book.author}-@{book.title}-image">
                             @book.jacketUrl.map { url =>
-                            <img class="highitem__img" src="@url" alt="" />
+                            <img itemprop="image" class="highitem__img" src="@url" alt="" />
                             }
                         </a>
                         <div class="highitem__details">
                             <a href="@AdLink{@book.buyUrl}" class="lineitem__link" data-link-name="merchandising-bookshop-v@{version}_@{date}-high-@{book.isbn}-@{book.author}-@{book.title}">
-                                <h4 class="lineitem__title">@book.title</h4>
+                                <h4 itemprop="name" class="lineitem__title">@book.title</h4>
                                 @if(book.author) {
-                                    <p class="lineitem__meta">By @book.author</p>
+                                    <p itemprop="author" class="lineitem__meta">By @book.author</p>
                                 }
-                                <p class="commercial--books__description">@book.description</p>
-                                <p class="commercial--books__price">
+                                <p itemprop="description" class="commercial--books__description">@book.description</p>
+                                <p itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="commercial--books__price">
                                     @book.price.map { price =>
                                     <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                                     }
                                     @book.offerPrice.map { price =>
-                                    <span class="commercial--books__price__our">Our price: &pound;@("%.2f".format(price))</span>
+                                    <span itemprop="price" class="commercial--books__price__our">Our price: &pound;@("%.2f".format(price))</span>
+                                    <meta itemprop="priceCurrency" content="GBP" />
                                     }
                                 </p>
                             </a>
@@ -71,24 +72,25 @@
                     <h4 class="commercial__relevance-title commercial__relevance-title-low">You also might like</h4>
                     <ul class="u-unstyled lineitems">
                         @books.drop(1).take(2).map { book =>
-                        <li class="lineitem u-cf">
+                        <li itemscope itemtype="http://schema.org/Book" class="lineitem u-cf">
                             <a href="@AdLink{@book.buyUrl}" data-link-name="merchandising-bookshop-v@{version}_@{date}-high-@{book.isbn}-@{book.author}-@{book.title}-cover">
                                 @book.jacketUrl.map { url =>
-                                <img class="lineitem__img" src="@url" alt="" />
+                                <img itemprop="image" class="lineitem__img" src="@url" alt="" />
                                 }
                             </a>
                             <div class="lowitem__details">
                                 <a href="@AdLink{@book.buyUrl}" data-link-name="merchandising-bookshop-v@{version}_@{date}-high-@{book.isbn}-@{book.author}-@{book.title}">
-                                    <h4 class="lineitem__title">@book.title</h4>
+                                    <h4 class="lineitem__title" itemprop="name">@book.title</h4>
                                     @if(book.author) {
-                                    <p class="lineitem__meta">By @book.author</p>
+                                    <p class="lineitem__meta" itemprop="author">By @book.author</p>
                                     }
-                                    <p class="commercial--books__price">
+                                    <p class="commercial--books__price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
                                         @book.price.map { price =>
                                         <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                                         }
                                         @book.offerPrice.map { price =>
-                                        <span class="commercial--books__price__our">Our price: &pound;@("%.2f".format(price))</span>
+                                        <span class="commercial--books__price__our" itemprop="price">Our price: &pound;@("%.2f".format(price))</span>
+                                        <meta itemprop="priceCurrency" content="GBP" />
                                         }
                                     </p>
                                 </a>

--- a/commercial/app/views/books/bestsellersMedium.scala.html
+++ b/commercial/app/views/books/bestsellersMedium.scala.html
@@ -49,6 +49,7 @@
                         @if(book.author) {
                             <p class="lineitem__meta" itemprop="author">By @book.author</p>
                         }
+                            <meta itemprop="isbn" content="@{book.isbn}" />
                             <p class="commercial--books__price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
                             @book.price.map { price =>
                                 <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>

--- a/commercial/app/views/books/bestsellersMedium.scala.html
+++ b/commercial/app/views/books/bestsellersMedium.scala.html
@@ -55,7 +55,7 @@
                                 <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                             }
                             @book.offerPrice.map { price =>
-                                <span class="commercial--books__price__our" itemprop="price">Our price: &pound;@("%.2f".format(price))</span>
+                                <span class="commercial--books__price__our">Our price: <span itemprop="price">&pound;@("%.2f".format(price))</span></span>
                                 <meta itemprop="priceCurrency" content="GBP" />
                             }
                             </p>

--- a/commercial/app/views/books/bestsellersMedium.scala.html
+++ b/commercial/app/views/books/bestsellersMedium.scala.html
@@ -40,21 +40,22 @@
             <div class="commercial__body">
                 <ul class="u-unstyled lineitems">
                 @books.map { book =>
-                    <li class="lineitem u-cf">
+                    <li class="lineitem u-cf" itemscope itemtype="http://schema.org/Book">
                         <a href="@AdLink{@book.buyUrl}" class="lineitem__link" data-link-name="merchandising-bookshop-v@{version}_@{date}-medium-@{book.isbn}-@{book.author}-@{book.title}">
-                        @book.jacketUrl.map { url =>
-                            <div class="lineitem__img js-image-upgrade" data-src="@url"></div>
-                        }
-                            <h4 class="lineitem__title">@book.title</h4>
+                            @book.jacketUrl.map { url =>
+                            <img itemprop="image" class="lineitem__img" src="@url" alt="" />
+                            }
+                            <h4 class="lineitem__title" itemprop="name">@book.title</h4>
                         @if(book.author) {
-                            <p class="lineitem__meta">By @book.author</p>
+                            <p class="lineitem__meta" itemprop="author">By @book.author</p>
                         }
-                            <p class="commercial--books__price">
+                            <p class="commercial--books__price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
                             @book.price.map { price =>
                                 <span class="commercial--books__price__rrp">RRP &pound;@("%.2f".format(price))</span>
                             }
                             @book.offerPrice.map { price =>
-                                <span class="commercial--books__price__our">Our price: &pound;@("%.2f".format(price))</span>
+                                <span class="commercial--books__price__our" itemprop="price">Our price: &pound;@("%.2f".format(price))</span>
+                                <meta itemprop="priceCurrency" content="GBP" />
                             }
                             </p>
                         </a>


### PR DESCRIPTION
This adds the book schema (http://schema.org/Book) to the commercial books components.

No visual change to the page but code has been checked via http://www.google.com/webmasters/tools/richsnippets

Example of check for high relevance component;

![screen shot 2014-06-23 at 14 48 04](https://cloud.githubusercontent.com/assets/1303616/3358330/107b91de-fadd-11e3-9796-54eed618beed.png)
