### PR TITLE
Fix Bug in Masterclass Commercial Component

### DIFF
--- a/commercial/app/model/commercial/masterclasses/EventbriteApi.scala
+++ b/commercial/app/model/commercial/masterclasses/EventbriteApi.scala
@@ -1,20 +1,26 @@
 package model.commercial.masterclasses
 
 import play.api.libs.json.JsValue
-import conf.{Switches, CommercialConfiguration}
+import conf.{Configuration, Switches, CommercialConfiguration}
 import model.commercial.JsonAdsApi
 
 object EventbriteApi extends JsonAdsApi[EventbriteMasterClass] {
+
+  protected val adTypeName = "Masterclasses"
 
   protected val switch = Switches.MasterclassFeedSwitch
 
   lazy val organiserId = "684756979"
   lazy val apiKeyOption = CommercialConfiguration.getProperty("masterclasses.api.key")
 
-  val adTypeName = "Masterclasses"
+  lazy val devUrl = CommercialConfiguration.getProperty("masterclasses.dev.url")
 
   protected val url: Option[String] = {
-    apiKeyOption map (apiKey => s"https://www.eventbrite.com/json/organizer_list_events?app_key=$apiKey&id=$organiserId")
+    val env = Configuration.environment
+    if (env.isNonProd) devUrl
+    else apiKeyOption map { apiKey =>
+      s"https://www.eventbrite.com/json/organizer_list_events?app_key=$apiKey&id=$organiserId"
+    }
   }
 
   override protected val characterEncoding = "utf-8"

--- a/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
@@ -16,9 +16,14 @@ object MasterClassAgent extends AdAgent[MasterClass] with ExecutionContexts {
     adsToShow sortBy(_.eventBriteEvent.startDate.getMillis)
   }
 
-  def specificClasses(eventBriteIdStrings: Seq[String]): Seq[MasterClass] = {
-    val eventBriteIds = eventBriteIdStrings map (_.toLong)
-    currentAds filter (masterclass => eventBriteIds contains masterclass.eventBriteEvent.id)
+  def specificClasses(eventBriteIds: Seq[String]): Seq[MasterClass] = {
+    for {
+      masterclass <- currentAds
+      eventId <- eventBriteIds
+      if masterclass.eventBriteEvent.id == eventId
+    } yield {
+      masterclass
+    }
   }
 
   def wrapEventbriteWithContentApi(eventbriteEvents: Seq[EventbriteMasterClass]): Future[Seq[MasterClass]] = {

--- a/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
@@ -41,7 +41,18 @@ object MasterClassAgent extends AdAgent[MasterClass] with ExecutionContexts {
 
     def populateKeywordIds(events: Seq[EventbriteMasterClass]):Seq[EventbriteMasterClass] = {
       val populated = events map { event =>
-        val eventKeywordIds = MasterClassTagsAgent.forTag(event.name)
+
+        val keywordIdsFromTitle = MasterClassTagsAgent.forTag(event.name)
+
+        val keywordIdsFromTags = (event.tags flatMap MasterClassTagsAgent.forTag).distinct
+
+        val eventKeywordIds = {
+          if (keywordIdsFromTitle.nonEmpty) {
+            keywordIdsFromTitle
+          } else {
+            keywordIdsFromTags
+          }
+        }
         event.copy(keywordIds = eventKeywordIds)
       }
 
@@ -100,5 +111,5 @@ object MasterClassTagsAgent extends ExecutionContexts with Logging {
     tagKeywordIds.close()
   }
 
-  def forTag(name: String) = tagKeywordIds().get(name).getOrElse(Nil)
+  def forTag(name: String) = tagKeywordIds().getOrElse(name, Nil)
 }


### PR DESCRIPTION
Specific parameter wasn't working because of type comparison of IDs: 'contains' doesn't do a type check so I'm avoiding it.
There's also an improvement on masterclass tagging so that the first load of masterclasses doesn't go untagged.
