### PR TITLE
Discussion bug fix #4826

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -178,6 +178,7 @@ Comments.prototype.ready = function() {
     if (this.options.commentId) {
         var comment = $('#comment-'+ this.options.commentId);
         this.showHiddenComments();
+        $('.d-discussion__show-all-comments').addClass('u-h');
         if (comment.attr('hidden')) {
             bean.fire($(this.getClass('showReplies'), comment.parent())[0], 'click');
         }


### PR DESCRIPTION
Hide the 'Show All Comments' button when going directly to a comment permalink from another page.
