### PR TITLE
firefox preroll fix

### DIFF
--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -149,16 +149,13 @@ define([
 
                         modules.bindPrerollEvents(player, el);
 
-                        var buggyEnvironment = window.navigator.userAgent.match(/(Opera|Firefox)/i);
-                        if (!buggyEnvironment) {
-                            player.adCountDown();
-                            player.ads({
-                                timeout: 3000
-                            });
-                            player.vast({
-                                url: modules.getVastUrl()
-                            });
-                        }
+                        player.adCountDown();
+                        player.ads({
+                            timeout: 3000
+                        });
+                        player.vast({
+                            url: modules.getVastUrl()
+                        });
                     });
 
                     // built in vjs-user-active is buggy so using custom implementation

--- a/common/app/assets/javascripts/bower.json
+++ b/common/app/assets/javascripts/bower.json
@@ -14,9 +14,12 @@
     "reqwest": "~1.1.0",
     "domready": "~1.0.4",
     "enhancer": "0.1.1",
-    "videojs": "guardian/video.js#master",
+    "videojs": "git://github.com/guardian/video.js.git#1272601954b4931ffb70c096f7fa183aebefe1fe",
     "videojs-contrib-ads": "guardian/videojs-contrib-ads#master",
     "videojs-vast": "~0.1.5",
     "videojs-persistvolume": "~0.1.0"
+  },
+  "resolutions": {
+    "videojs": "1272601954b4931ffb70c096f7fa183aebefe1fe"
   }
 }

--- a/common/app/assets/javascripts/components/videojs-contrib-ads/bower.json
+++ b/common/app/assets/javascripts/components/videojs-contrib-ads/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "videojs-contrib-ads",
+  "version": "0.2.0",
+  "homepage": "https://github.com/videojs/videojs-contrib-ads",
+  "authors": [
+    "Brightcove"
+  ],
+  "description": "A plugin that provides common functionality needed by video advertisement libraries working with video.js",
+  "main": "src/videojs.ads.js",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "videojs",
+    "html5",
+    "video",
+    "ads",
+    "advertisements"
+  ],
+  "license": "Apache-2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/common/app/assets/javascripts/components/videojs/.bower.json
+++ b/common/app/assets/javascripts/components/videojs/.bower.json
@@ -13,13 +13,12 @@
     "player"
   ],
   "homepage": "https://github.com/guardian/video.js",
-  "_release": "0fdc3519b7",
+  "_release": "1272601954",
   "_resolution": {
-    "type": "branch",
-    "branch": "master",
-    "commit": "0fdc3519b70026859c0d4af0df92f7dd7fc3c3a2"
+    "type": "commit",
+    "commit": "1272601954b4931ffb70c096f7fa183aebefe1fe"
   },
   "_source": "git://github.com/guardian/video.js.git",
-  "_target": "master",
-  "_originalSource": "guardian/video.js"
+  "_target": "1272601954b4931ffb70c096f7fa183aebefe1fe",
+  "_originalSource": "git://github.com/guardian/video.js.git"
 }

--- a/common/app/assets/javascripts/components/videojs/composer.json
+++ b/common/app/assets/javascripts/components/videojs/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "videojs/video.js",
+    "description": "An HTML5 and Flash video player with a common API and skin for both.",
+    "type": "library",
+    "keywords": [
+        "videojs",
+        "html5",
+        "flash",
+        "video",
+        "player"
+    ],
+    "homepage": "http://www.videojs.com/",
+    "license": "Apache-2.0"
+}

--- a/common/app/assets/javascripts/components/videojs/src/js/player.externs.js
+++ b/common/app/assets/javascripts/components/videojs/src/js/player.externs.js
@@ -81,3 +81,9 @@ videojs.Player.prototype.userActive = function(){};
  * Native controls
  */
 videojs.Player.prototype.usingNativeControls = function(){};
+
+/**
+ * Tech
+ */
+videojs.Player.prototype.techName = function(){};
+videojs.Player.prototype.loadTech = function(){};


### PR DESCRIPTION
updating bower to point to specific video.js version (this should fix ff/opera prerolls)
