### PR TITLE
Better pageskin reports

### DIFF
--- a/admin/app/controllers/CommercialController.scala
+++ b/admin/app/controllers/CommercialController.scala
@@ -26,7 +26,7 @@ object CommercialController extends Controller with Logging with AuthLogging {
   def renderCommercial = Authenticated { implicit request =>
     val sponsoredTags = Store.getDfpSponsoredTags()
     val advertisementTags = Store.getDfpAdvertisementTags()
-    val pageskinnedAdUnits: Seq[String] = convertJsonToStringList(Store.getDfpPageSkinnedAdUnits()).sorted
+    val pageskinnedAdUnits = Store.getDfpPageSkinnedAdUnits()
 
     NoCache(Ok(views.html.commercial(Configuration.environment.stage, sponsoredTags, advertisementTags, pageskinnedAdUnits)))
   }

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -53,7 +53,8 @@ object DfpDataCacheJob extends ExecutionContexts with Dates{
         val advertisementTags: Seq[Sponsorship] = DfpApi.filterOutAdvertisementFeatureTagsFrom(lineItems)
         Store.putDfpAdvertisementFeatureTags(stringify(SponsorshipReport(now, advertisementTags).toJson))
 
-        Store.putDfpPageSkinAdUnits(stringify(toJson(DfpApi.fetchAdUnitsThatAreTargettedByPageSkins(dfpLineItems))))
+        val pageSkinSponsorships: Seq[PageSkinSponsorship] = DfpApi.fetchAdUnitsThatAreTargettedByPageSkins(dfpLineItems)
+        Store.putDfpPageSkinAdUnits(stringify(PageSkinSponsorshipReport(now, pageSkinSponsorships).toJson))
 
         Store.putDfpLineItemsReport(stringify(toJson(lineItems)))
       }

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -5,7 +5,7 @@ import conf.AdminConfiguration
 import conf.Configuration.commercial.{dfpAdvertisementFeatureTagsDataKey, dfpSponsoredTagsDataKey, dfpPageSkinnedAdUnitsKey, dfpLineItemsKey}
 import services.S3
 import play.api.libs.json.Json
-import dfp.{SponsorshipReport, SponsorshipReportParser}
+import dfp.{PageSkinSponsorshipReportParser, PageSkinSponsorshipReport, SponsorshipReport, SponsorshipReportParser}
 import org.joda.time.DateTime
 import implicits.Dates
 
@@ -44,7 +44,7 @@ trait Store extends Logging with Dates {
 
   def getDfpSponsoredTags() = S3.get(dfpSponsoredTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse(SponsorshipReport(now, Nil))
   def getDfpAdvertisementTags() = S3.get(dfpAdvertisementFeatureTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse(SponsorshipReport(now, Nil))
-  def getDfpPageSkinnedAdUnits() = S3.get(dfpPageSkinnedAdUnitsKey)
+  def getDfpPageSkinnedAdUnits() = S3.get(dfpPageSkinnedAdUnitsKey).flatMap(PageSkinSponsorshipReportParser(_)) getOrElse(PageSkinSponsorshipReport(now, Nil))
   def getDfpLineItemsReport() = S3.get(dfpLineItemsKey)
 }
 

--- a/admin/app/views/commercial.scala.html
+++ b/admin/app/views/commercial.scala.html
@@ -1,4 +1,4 @@
-@(env: String, sponsoredTags: dfp.SponsorshipReport, advertisementTags: dfp.SponsorshipReport, pageSkinnedAdUnits: Seq[String])
+@(env: String, sponsoredTags: dfp.SponsorshipReport, advertisementTags: dfp.SponsorshipReport, pageSkinnedAdUnits: dfp.PageSkinSponsorshipReport)
 
 @admin_main("Commercial", env, isAuthed = true, hasCharts = true) {
 
@@ -50,9 +50,17 @@
     </ol>
 
     <h3>Pageskinned Ad Units</h3>
+    <p>Last updated: @pageSkinnedAdUnits.updatedTimeStamp</p>
+
     <ol>
-        @for(adunit <- pageSkinnedAdUnits) {
-            <li>@adunit</li>
+        @for(sponsorship <- pageSkinnedAdUnits.sponsorships) {
+            <li>@sponsorship.lineItemName (@sponsorship.lineItemId)
+            <ul>
+                @for(adunit <- sponsorship.adUnits) {
+                <li>@adunit</li>
+                }
+            </ul>
+            </li>
         }
     </ol>
 }

--- a/commercial/test/model/commercial/masterclasses/EventbriteMasterClassFeedParsingTest.scala
+++ b/commercial/test/model/commercial/masterclasses/EventbriteMasterClassFeedParsingTest.scala
@@ -3,6 +3,8 @@ package model.commercial.masterclasses
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import play.api.libs.json._
+import play.api.test.Helpers._
+import play.api.test.FakeApplication
 
 class EventbriteMasterClassFeedParsingTest extends FlatSpec with Matchers {
   val rawEventBriteFeed = """{ "events" : [ { "event" : { "background_color" : "FFFFFF",
@@ -192,7 +194,7 @@ class EventbriteMasterClassFeedParsingTest extends FlatSpec with Matchers {
 
 
 
-  "MasterClassFeedParser" should "parse out a list of Event JsValues" in {
+  "MasterClassFeedParser" should "parse out a list of Event JsValues" in running(FakeApplication()) {
     val eventBriteFeed: JsValue = Json.parse(rawEventBriteFeed)
   
     val events: Seq[JsValue] = EventbriteApi.extractEventsFromFeed(eventBriteFeed)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -205,7 +205,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val dfpAdvertisementFeatureTagsDataKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/advertisement-feature-tags-v2.json"
     lazy val dfpPageSkinnedAdUnitsKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/pageskinned-adunits.json"
+      s"${environment.stage.toUpperCase}/commercial/dfp/pageskinned-adunits-v2.json"
     lazy val dfpLineItemsKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/lineitems.json"
   }

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -16,7 +16,7 @@ trait DfpAgent {
 
   protected def sponsoredTags: Seq[Sponsorship]
   protected def advertisementFeatureTags: Seq[Sponsorship]
-  protected def pageskinnedAdUnits: Seq[String]
+  protected def pageskinnedAdUnits: Seq[PageSkinSponsorship]
 
   private def containerSponsoredTags(config: Config, p: String => Boolean): Option[String] = {
     config.contentApiQuery.flatMap { encodedQuery =>
@@ -67,20 +67,15 @@ object DfpAgent extends DfpAgent with ExecutionContexts {
 
   private lazy val sponsoredTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
   private lazy val advertisementFeatureTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
-  private lazy val pageskinnedAdUnitAgent = AkkaAgent[Seq[String]](Nil)
+  private lazy val pageskinnedAdUnitAgent = AkkaAgent[Seq[PageSkinSponsorship]](Nil)
 
   protected def sponsoredTags: Seq[Sponsorship] = sponsoredTagsAgent get()
   protected def advertisementFeatureTags: Seq[Sponsorship] = advertisementFeatureTagsAgent get()
-  protected def pageskinnedAdUnits: Seq[String] = pageskinnedAdUnitAgent get()
+  protected def pageskinnedAdUnits: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent get()
 
   def refresh() {
 
     def stringFromS3(key: String) = S3.get(key)(UTF8)
-    def json(key: String) =  stringFromS3(key) map parse
-
-    def grabListFromStore(key: String): Seq[String] = {
-      json(key).fold(Seq[String]())(_.as[Seq[String]])
-    }
 
     def grabSponsorshipsFromStore(key: String): Seq[Sponsorship] = {
       val reportOption: Option[SponsorshipReport] = for {
@@ -89,6 +84,15 @@ object DfpAgent extends DfpAgent with ExecutionContexts {
       } yield report
       
       reportOption.fold(Seq[Sponsorship]())(_.sponsorships)
+    }
+
+    def   grabPageSkinSponsorshipsFromStore(key: String): Seq[PageSkinSponsorship] = {
+      val reportOption: Option[PageSkinSponsorshipReport] = for {
+        jsonString <- stringFromS3(key)
+        report <- PageSkinSponsorshipReportParser(jsonString)
+      } yield report
+
+      reportOption.fold(Seq[PageSkinSponsorship]())(_.sponsorships)
     }
 
     def update[T](agent: Agent[Seq[T]], freshData: Seq[T]) = {
@@ -103,7 +107,7 @@ object DfpAgent extends DfpAgent with ExecutionContexts {
 
     update(sponsoredTagsAgent, grabSponsorshipsFromStore(dfpSponsoredTagsDataKey))
     update(advertisementFeatureTagsAgent, grabSponsorshipsFromStore(dfpAdvertisementFeatureTagsDataKey))
-    update(pageskinnedAdUnitAgent, grabListFromStore(dfpPageSkinnedAdUnitsKey))
+    update(pageskinnedAdUnitAgent, grabPageSkinSponsorshipsFromStore(dfpPageSkinnedAdUnitsKey))
   }
 
   def stop() {

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -1,10 +1,5 @@
 package dfp
 
-import org.joda.time.DateTime
-import implicits.Dates
-import play.api.libs.json.{Json, JsValue, Writes}
-
-
 case class Target(name: String, op: String, values: Seq[String]) {
 
   def isPositive(targetName: String) = name == targetName && op == "IS"
@@ -37,60 +32,4 @@ case class LineItem(id: Long, sponsor: Option[String], targetSets: Seq[TargetSet
   val sponsoredTags = targetSets.flatMap(_.sponsoredTags).distinct
 
   val advertisementFeatureTags = targetSets.flatMap(_.advertisementFeatureTags).distinct
-}
-
-
-case class Sponsorship(tags: Seq[String], sponsor: Option[String]) {
-
-  def hasTag(tagId: String): Boolean = tags contains (tagId.split('/').last)
-}
-
-case class SponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[Sponsorship]) {
-  private implicit val sponsorshipWrites = new Writes[Sponsorship] {
-    def writes(sponsorship: Sponsorship): JsValue = {
-      Json.obj(
-        "sponsor" -> sponsorship.sponsor,
-        "tags" -> sponsorship.tags
-      )
-    }
-  }
-
-  private implicit val sponsorshipReportWrites = new Writes[SponsorshipReport] {
-    def writes(sponsorshipReport: SponsorshipReport): JsValue = {
-      Json.obj(
-        "updatedTimeStamp" -> sponsorshipReport.updatedTimeStamp,
-        "sponsorships" -> sponsorshipReport.sponsorships
-      )
-    }
-  }
-
-  def toJson() = {
-    Json.toJson(this)
-  }
-
-}
-
-object SponsorshipReportParser {
-  import play.api.libs.json._
-  import play.api.libs.functional.syntax._
-
-
-  def apply(jsonString: String) = {
-    implicit val sponsorshipReads: Reads[Sponsorship] = (
-      (JsPath \ "tags").read[Seq[String]] and
-        (JsPath \ "sponsor").read[Option[String]]
-      )(Sponsorship.apply _)
-
-    implicit val sponsorshipReportReads: Reads[SponsorshipReport] = (
-      (JsPath \ "updatedTimeStamp").read[String] and
-        (JsPath \ "sponsorships").read[Seq[Sponsorship]]
-      )(SponsorshipReport.apply _)
-
-
-    val result: JsResult[SponsorshipReport] = Json.parse(jsonString).validate[SponsorshipReport]
-    result match {
-      case s: JsSuccess[SponsorshipReport] => Some(s.get)
-      case e: JsError => println("Errors: " + JsError.toFlatJson(e).toString()); None
-    }
-  }
 }

--- a/common/app/dfp/PageSkinSponsorship.scala
+++ b/common/app/dfp/PageSkinSponsorship.scala
@@ -1,0 +1,53 @@
+package dfp
+
+import play.api.libs.json.{Json, JsValue, Writes}
+import common.Logging
+
+case class PageSkinSponsorship(lineItemName: String, lineItemId: Long, adUnits: Seq[String])
+
+case class PageSkinSponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[PageSkinSponsorship]) {
+  private implicit val pageSkinSponsorship = new Writes[PageSkinSponsorship] {
+    def writes(sponsorship: PageSkinSponsorship): JsValue = {
+      Json.obj(
+        "lineItem" -> sponsorship.lineItemName,
+        "lineItemId" -> sponsorship.lineItemId,
+        "adUnits" -> sponsorship.adUnits
+      )
+    }
+  }
+
+  private implicit val pageSkinSponsorshipReportWrites = new Writes[PageSkinSponsorshipReport] {
+    def writes(report: PageSkinSponsorshipReport): JsValue = {
+      Json.obj(
+        "updatedTimeStamp" -> report.updatedTimeStamp,
+        "sponsorships" -> report.sponsorships
+      )
+    }
+  }
+
+  def toJson() = Json.toJson(this)
+}
+
+object PageSkinSponsorshipReportParser extends Logging {
+  import play.api.libs.json._
+  import play.api.libs.functional.syntax._
+
+  def apply(jsonString: String) = {
+    implicit val pageskinSponsorShipReads: Reads[PageSkinSponsorship] = (
+      (JsPath \ "lineItem").read[String] and
+        (JsPath \ "lineItemId").read[Long] and
+        (JsPath \ "adUnits").read[Seq[String]]
+      )(PageSkinSponsorship.apply _)
+
+    implicit val reportReads: Reads[PageSkinSponsorshipReport] = (
+      (JsPath \ "updatedTimeStamp").read[String] and
+        (JsPath \ "sponsorships").read[Seq[PageSkinSponsorship]]
+      )(PageSkinSponsorshipReport.apply _)
+
+    val result: JsResult[PageSkinSponsorshipReport] = Json.parse(jsonString).validate[PageSkinSponsorshipReport]
+    result match {
+      case s: JsSuccess[PageSkinSponsorshipReport] => Some(s.get)
+      case e: JsError => println("Errors: " + JsError.toFlatJson(e).toString()); None
+    }
+  }
+}

--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -1,0 +1,57 @@
+package dfp
+
+import play.api.libs.json.{Json, JsValue, Writes}
+import common.Logging
+
+case class Sponsorship(tags: Seq[String], sponsor: Option[String]) {
+
+  def hasTag(tagId: String): Boolean = tags contains (tagId.split('/').last)
+}
+
+case class SponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[Sponsorship]) {
+  private implicit val sponsorshipWrites = new Writes[Sponsorship] {
+    def writes(sponsorship: Sponsorship): JsValue = {
+      Json.obj(
+        "sponsor" -> sponsorship.sponsor,
+        "tags" -> sponsorship.tags
+      )
+    }
+  }
+
+  private implicit val sponsorshipReportWrites = new Writes[SponsorshipReport] {
+    def writes(sponsorshipReport: SponsorshipReport): JsValue = {
+      Json.obj(
+        "updatedTimeStamp" -> sponsorshipReport.updatedTimeStamp,
+        "sponsorships" -> sponsorshipReport.sponsorships
+      )
+    }
+  }
+
+  def toJson() = Json.toJson(this)
+
+}
+
+object SponsorshipReportParser extends Logging {
+  import play.api.libs.json._
+  import play.api.libs.functional.syntax._
+
+
+  def apply(jsonString: String) = {
+    implicit val sponsorshipReads: Reads[Sponsorship] = (
+      (JsPath \ "tags").read[Seq[String]] and
+        (JsPath \ "sponsor").read[Option[String]]
+      )(Sponsorship.apply _)
+
+    implicit val sponsorshipReportReads: Reads[SponsorshipReport] = (
+      (JsPath \ "updatedTimeStamp").read[String] and
+        (JsPath \ "sponsorships").read[Seq[Sponsorship]]
+      )(SponsorshipReport.apply _)
+
+
+    val result: JsResult[SponsorshipReport] = Json.parse(jsonString).validate[SponsorshipReport]
+    result match {
+      case s: JsSuccess[SponsorshipReport] => Some(s.get)
+      case e: JsError => log.error("Errors: " + JsError.toFlatJson(e).toString()); None
+    }
+  }
+}

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -48,7 +48,7 @@ guardian.page.fbAppId=232588266837342
 guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.onwardWebSocket=wss://frontend-OnwardLo-G3SS42I4G3PN-384008737.eu-west-1.elb.amazonaws.com/recently-published
 guardian.page.dfpAccountId=158186692
-guardian.page.dfpAdUnitRoot=theguardian.com
+guardian.page.dfpAdUnitRoot=test-theguardian.com
 guardian.page.sentryApiKey=1b006169a5a64dc18e33105b259e81db
 guardian.page.sentryHost=frontend-SentryLo-35H427X3SDHB-2122817448.eu-west-1.elb.amazonaws.com/2
 

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -48,7 +48,7 @@ guardian.page.fbAppId=232588266837342
 guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.onwardWebSocket=wss://frontend-OnwardLo-G3SS42I4G3PN-384008737.eu-west-1.elb.amazonaws.com/recently-published
 guardian.page.dfpAccountId=158186692
-guardian.page.dfpAdUnitRoot=test-theguardian.com
+guardian.page.dfpAdUnitRoot=theguardian.com
 guardian.page.sentryApiKey=1b006169a5a64dc18e33105b259e81db
 guardian.page.sentryHost=frontend-SentryLo-35H427X3SDHB-2122817448.eu-west-1.elb.amazonaws.com/2
 

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -21,6 +21,6 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // the properties needed to run this project. Make sure you update it if there
     // are any required changes, update the hash below, and off you go.
 
-    hash should be ("29a4f7b09842625b4f423a3afce5878e")
+    hash should be ("f4dd399c7c90efecdad22a787e8b9303")
   }
 }

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -18,7 +18,7 @@ class DfpAgentTest extends FlatSpec with Matchers {
       Sponsorship(Seq("film"), None)
     )
 
-    override protected def pageskinnedAdUnits: Seq[String] = Seq("theguardian.com/business/front")
+    override protected def pageskinnedAdUnits: Seq[PageSkinSponsorship] = Seq(PageSkinSponsorship("lineItemName", 1234L, Seq("theguardian.com/business/front")))
   }
 
   def apiQuery(apiQuery: String) = {


### PR DESCRIPTION
The Commercial report in the admin console now provide the names of the PageSkin line items, as well as the actual ad units targetted.
