### PR TITLE
Ophan video tracking data

### DIFF
--- a/applications/app/views/fragments/videoBody.scala.html
+++ b/applications/app/views/fragments/videoBody.scala.html
@@ -15,7 +15,7 @@
                 <div class="gu-video-wrapper">
                     <div class="u-responsive-ratio u-responsive-ratio--hd">
                         <video controls="controls" class="gu-video" @video.mainPicture.map{ img => poster="@Item620.bestFor(img)" }
-                                data-title="@video.headline" data-duration="@video.duration.toString()">
+                                data-title="@video.headline" data-duration="@video.duration.toString()" @video.mediaId.map{ id=> data-media-id="@id"}>
                         @video.encodings.map{ encoding =>
                             <source src="@encoding.url" type="@encoding.format" />
                         }

--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -36,14 +36,16 @@ define([
         ophanRecord: function(playerEl) {
             var id = playerEl.getAttribute('data-media-id');
             return function(event) {
-                require('ophan/ng', function (ophan) {
-                    ophan.record({
-                        'video': {
-                            id: id,
-                            eventType: event.type
-                        }
+                if(id) {
+                    require('ophan/ng', function (ophan) {
+                        ophan.record({
+                            'video': {
+                                id: id,
+                                eventType: event.type
+                            }
+                        });
                     });
-                });
+                }
             };
         },
 
@@ -131,7 +133,7 @@ define([
                     }
                 }
             };
-            
+
             if(instant) {
                 events.ready();
             } else {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -410,6 +410,7 @@ class Video(content: ApiContentWithMeta) extends Content(content) {
   override def mainPicture: Option[ImageContainer] = (images ++ videos).find(_.isMain)
 
   lazy val duration: Int = videoAssets.headOption.map(_.duration).getOrElse(0)
+  lazy val mediaId: Option[String] = mainVideo.map(_.id)
 
   override lazy val contentType = "Video"
   lazy val source: Option[String] = videoAssets.headOption.flatMap(_.source)


### PR DESCRIPTION
This setups Ophan to bind to our normal Omniture tracking events for video elements. This will allow us to for the first time ever create most popular video queries and play counts via the Ophan api.

/cc @rich-nguyen @tackley 
