### PR TITLE
Fix preview routes

### DIFF
--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -2,6 +2,7 @@ package controllers.preview
 
 import controllers.FaciaController
 import controllers.front.FrontJson
+import services.ConfigAgent
 
 object FrontJsonDraft extends FrontJson {
   val bucketLocation: String = s"$stage/frontsapi/pressed/draft"
@@ -9,4 +10,12 @@ object FrontJsonDraft extends FrontJson {
 
 object FaciaDraftController extends FaciaController {
   val frontJson: FrontJson = FrontJsonDraft
+
+  override def renderFront(path: String) = {
+    log.info(s"Serving Path: $path")
+    if (!ConfigAgent.getPathIds.contains(path))
+      controllers.IndexController.render(path)
+    else
+      renderFrontPress(path)
+  }
 }

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -145,8 +145,8 @@ GET         /series/*path.json                                                  
 GET         /                                                                                                        controllers.preview.FaciaDraftController.editionRedirect(path = "")
 GET         /$path<(culture|sport|commentisfree|business|money|rss)>                                                 controllers.preview.FaciaDraftController.editionRedirect(path)
 GET         /$path<(\w\w)(/[\w\d-]+)?>/rss                                                                           controllers.preview.FaciaDraftController.renderFrontRss(path)
-GET         /$path<(\w\w)(/[\w\d-]+)?>.json                                                                          controllers.preview.FaciaDraftController.renderFrontJson(path)
-GET         /$path<(\w\w)(/[\w\d-]+)?>                                                                               controllers.preview.FaciaDraftController.renderFront(path)
+GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                                             controllers.preview.FaciaDraftController.renderFrontJson(path)
+GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                                  controllers.preview.FaciaDraftController.renderFront(path)
 
 GET         /container/*id.json                                                                                      controllers.preview.FaciaDraftController.renderContainerJson(id)
 
@@ -158,8 +158,6 @@ GET        /$path<.+>/all                                                       
 
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/trails.json                                                      controllers.IndexController.renderTrailsJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/trails                                                           controllers.IndexController.renderTrails(path)
-GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                                             controllers.IndexController.renderJson(path)
-GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                                  controllers.IndexController.render(path)
 
 # Applications
 GET         /sections                                                                                                controllers.SectionsController.renderSections()


### PR DESCRIPTION
In preview, only explicit `routes` are going to `facia` with the rest going to `applications`.

We want the same behaviour as `PROD`, with all fronts going to `facia`, and then issuing an `X-Accel-Redirect` to `applications` if it doesn't handle it.

To mimic this, we use direct calling of the `applications` controller instead of issuing an `X-Accel`.

@gklopper 
