### PR TITLE
Fix localStorage cache keys for CSS and Fonts

### DIFF
--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -9,7 +9,7 @@ import collection.mutable.{ Map => MutableMap }
 
 case class Asset(path: String) {
   val asModulePath = path.replace(".js", "")
-  lazy val md5Key = path.split('.').dropRight(1).last
+  lazy val md5Key = path.split('/').dropRight(1).last
 
   override def toString = path
 }

--- a/common/app/assets/javascripts/modules/ui/fonts.js
+++ b/common/app/assets/javascripts/modules/ui/fonts.js
@@ -77,7 +77,7 @@ define([
         };
 
         function getNameAndCacheKey(style) {
-            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.json$/);
+            var nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\/(.*)\.woff.json$/);
             nameAndCacheKey.shift();
             return nameAndCacheKey;
         }
@@ -87,7 +87,7 @@ define([
             // Because it would be horrible if people downloaded fonts and then couldn't cache them.
             if (storage.local.isAvailable()) {
                 var nameAndCacheKey =  getNameAndCacheKey(style);
-                var cachedValue = storage.local.get(storagePrefix + nameAndCacheKey[0] + '.' + nameAndCacheKey[1]);
+                var cachedValue = storage.local.get(storagePrefix + nameAndCacheKey[1] + '.' + nameAndCacheKey[0]);
 
                 var widthMatches = true;
                 var minWidth = style.getAttribute('data-min-width');

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -81,7 +81,7 @@ object Switches extends Collections {
 
   val CssFromStorageSwitch = Switch("Performance Switches", "css-from-storage",
     "If this switch is on CSS will be cached in users localStorage and read from there on subsequent requests.",
-    safeState = Off, sellByDate = never
+    safeState = On, sellByDate = never
   )
 
   val ShowAllArticleEmbedsSwitch = Switch("Performance Switches", "show-all-embeds",
@@ -230,7 +230,7 @@ object Switches extends Collections {
 
   val FontSwitch = Switch("Feature Switches", "web-fonts",
     "If this is switched on then the custom Guardian web font will load.",
-    safeState = Off, sellByDate = never
+    safeState = On, sellByDate = never
   )
 
   val SearchSwitch = Switch("Feature Switches", "google-search",

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -76,8 +76,8 @@
                 var styleNodes = document.querySelectorAll('[data-cache-name]');
                 for (var i = 0, j = styleNodes.length; i<j; ++i) {
                     var style = styleNodes[i],
-                        nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\.woff(?:\.(.*))?\.json$/),
-                        cachedCss = localStorage.getItem('gu.fonts.' + nameAndCacheKey[1] + '.' + nameAndCacheKey[2]);
+                        nameAndCacheKey = style.getAttribute('data-cache-file-woff').match(/fonts\/(.*)\/(.*)\.woff.json$/),
+                        cachedCss = localStorage.getItem('gu.fonts.' + nameAndCacheKey[2] + '.' + nameAndCacheKey[1]);
                         @* try to parse it (should really use the storage module) *@
                         try {
                             cachedCss = JSON.parse(cachedCss).value;


### PR DESCRIPTION
Since the refactoring of our hashing policy on static assets, we were generating incorrect cache keys for CSS and fonts in localStorage. This fixes both to use our standard pattern.

I have also taken the liberty to default both of these features to be on by default.

/cc @rich-nguyen 
