### PR TITLE
Deprecate $gutter in gallery and states

### DIFF
--- a/common/app/assets/stylesheets/module/_gallerythumbs.scss
+++ b/common/app/assets/stylesheets/module/_gallerythumbs.scss
@@ -102,9 +102,3 @@
         margin-right: 8px;
     }
 }
-
-.gallery-launch-cta--dark {
-    @include transparent-background(#000000, .9);
-    color: #f9af41 !important;
-    padding-left: $gutter;
-}

--- a/common/app/assets/stylesheets/module/_headline-list.scss
+++ b/common/app/assets/stylesheets/module/_headline-list.scss
@@ -49,7 +49,7 @@
 .headline-list__title {
     border-bottom: 1px solid $c-neutral6;
     @include rem((
-        padding: $gs-baseline/3 $gutter/4 $gs-baseline 0,
+        padding: $gs-baseline/3 $gs-gutter/5 $gs-baseline 0,
         margin: 0 $gs-gutter/2
     ));
 

--- a/common/app/assets/stylesheets/module/_lightbox-gallery.scss
+++ b/common/app/assets/stylesheets/module/_lightbox-gallery.scss
@@ -9,7 +9,7 @@ i.gallery__watermark {
     display: none;
     position: absolute;
     top: ($gs-baseline/3)*2;
-    left: $gutter;
+    left: $gs-gutter;
 
     @include mq(tablet) {
         display: block;
@@ -181,7 +181,7 @@ i.gallery__watermark {
     width: 20%;
 
     .gallery__arrow-cta {
-        left: $gutter;
+        left: $gs-gutter;
     }
 }
 
@@ -190,7 +190,7 @@ i.gallery__watermark {
     width: 80%;
 
     .gallery__arrow-cta {
-        right: $gutter;
+        right: $gs-gutter;
     }
 }
 
@@ -252,7 +252,7 @@ i.gallery__watermark {
 
 .gallerycaption__inner {
     @include transparent-background(rgb(34, 34, 34), .9);
-    padding: ($gs-baseline/3)*4 $gutter;
+    padding: ($gs-baseline/3)*4 $gs-gutter;
 }
 
 .gallerycaption__text {

--- a/common/app/assets/stylesheets/module/_live-filter.scss
+++ b/common/app/assets/stylesheets/module/_live-filter.scss
@@ -48,7 +48,7 @@
 .live-toggler__label {
     padding-left: 0;
     @include rem((
-        padding-right: $gutter/4
+        padding-right: $gs-gutter/5
     ));
     color: $c-neutral2;
     @include fs-textsans(2);

--- a/common/app/assets/stylesheets/module/_overlay.scss
+++ b/common/app/assets/stylesheets/module/_overlay.scss
@@ -48,15 +48,15 @@
 
 .overlay__cta {
     height: $gs-baseline*4;
-    padding: 0 $gutter / 2;
+    padding: 0 $gs-gutter / 2;
     color: #ffffff;
     float: left;
     border: 0;
     background: transparent;
-    margin-left: $gutter / 2;
+    margin-left: $gs-gutter / 2;
 }
 
 .overlay__cta--close {
     float: right;
-    margin-right: $gutter / 2;
+    margin-right: $gs-gutter / 2;
 }

--- a/common/app/assets/stylesheets/state/_state.scss
+++ b/common/app/assets/stylesheets/state/_state.scss
@@ -29,28 +29,8 @@
     width: 100%;
 }
 
-.collapsible {
-    // padding top/bottom looks like it should be 12, but this forces height to 42px which is desired
-    padding: 9px $gutter*2 9px $gutter/2; // double space on right to avoid icon
-    position: relative;
-    cursor: pointer;
-}
 
-.collapsible i {
-    position: absolute;
-    right: 14px;
-    display: inline-block;
-    top: 40%;
-}
-
-//These should be refactored to is-shut/is-open
-.rolled-out {
-    height: auto;
-    margin-bottom: 0;
-}
-
-.shut > .panel,
-.rolled-up {
+.shut > .panel {
     overflow: hidden;
     position: relative;
     max-height: 0;


### PR DESCRIPTION
- Remove unused classes that use gutters
- Change gutter dimensions to gs-gutter
- Convert spacings with gutter to gs-gutter
- Remove unused dark gallery cta variant

![ ](http://media.giphy.com/media/1yK0S7DIPBVyo/giphy.gif)
