### PR TITLE
Move sponsored text closer to logo

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -371,9 +371,7 @@
         ));
     }
     @include mq(desktop) {
-        @include rem((
-            padding-left: $gs-gutter/2
-        ));
+        margin-left: 62%;
     }
     @include mq(tablet, $to: faciaLeftCol) {
         .container--has-toggle & {


### PR DESCRIPTION
### Before

![screen shot 2014-06-26 at 12 54 30](https://cloud.githubusercontent.com/assets/74132/3398029/d8d314ac-fd28-11e3-9a9e-8829a81a4fa1.jpeg)
### After

![screen shot 2014-06-26 at 12 54 36](https://cloud.githubusercontent.com/assets/74132/3398030/dc93f3cc-fd28-11e3-9e5d-c028da85e853.jpeg)
