### PR TITLE
Fix facia pressing metrics

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -505,7 +505,7 @@ case class SimpleCountMetric(
 
   def getAndReset = currentCount.getAndSet(0)
   val getValue: () => Long = count.get
-  val getResettingValue: () => Long = count.get
+  val getResettingValue: () => Long = currentCount.get
 
   override def asJson: StatusMetric = super.asJson.copy(count = Some(getValue().toString))
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -505,6 +505,7 @@ case class SimpleCountMetric(
 
   def getAndReset = currentCount.getAndSet(0)
   val getValue: () => Long = count.get
+  val getResettingValue: () => Long = count.get
 
   override def asJson: StatusMetric = super.asJson.copy(count = Some(getValue().toString))
 

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -44,7 +44,7 @@ object Global extends WithFilters(Gzipper)
   )
 
   private def getTotalPressSuccessCount: Long =
-    FaciaToolMetrics.FrontPressLiveSuccess.getValue() + FaciaToolMetrics.FrontPressDraftSuccess.getValue()
+    FaciaToolMetrics.FrontPressLiveSuccess.getResettingValue() + FaciaToolMetrics.FrontPressDraftSuccess.getResettingValue()
 
   private def getTotalPressFailureCount: Long =
     FaciaToolMetrics.FrontPressLiveFailure.getValue() + FaciaToolMetrics.FrontPressDraftFailure.getValue()

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -47,7 +47,7 @@ object Global extends WithFilters(Gzipper)
     FaciaToolMetrics.FrontPressLiveSuccess.getResettingValue() + FaciaToolMetrics.FrontPressDraftSuccess.getResettingValue()
 
   private def getTotalPressFailureCount: Long =
-    FaciaToolMetrics.FrontPressLiveFailure.getValue() + FaciaToolMetrics.FrontPressDraftFailure.getValue()
+    FaciaToolMetrics.FrontPressLiveFailure.getResettingValue() + FaciaToolMetrics.FrontPressDraftFailure.getResettingValue()
 
   override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration = {
     val newConfig: Configuration = if (mode == Mode.Dev) config ++ devConfig else config


### PR DESCRIPTION
For the combined press success and press failure metrics, `getValue` returns the accumulating counter.
We want the resetting one.

@gklopper @stephanfowler 
