### PR TITLE
New Interactive header layout

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -8,19 +8,24 @@ import scala.concurrent.Future
 import com.gu.openplatform.contentapi.model.ItemResponse
 import views.support.RenderOtherStatus
 
+case class InteractivePage (
+  val interactive: Interactive,
+  val storyPackage: Seq[Trail]
+)
+
 object InteractiveController extends Controller with Logging with ExecutionContexts {
 
   def renderInteractiveJson(path: String): Action[AnyContent] = renderInteractive(path)
   def renderInteractive(path: String): Action[AnyContent] = Action.async { implicit request =>
 
     lookup(path) map {
-      case Left(model) if model.isExpired => RenderOtherStatus(Gone) // TODO - delete this line after switching to new content api
+      case Left(model) if model.interactive.isExpired => RenderOtherStatus(Gone) // TODO - delete this line after switching to new content api
       case Left(model) => render(model)
       case Right(other) => RenderOtherStatus(other)
     }
   }
 
-  private def lookup(path: String)(implicit request: RequestHeader): Future[Either[Interactive, SimpleResult]] = {
+  private def lookup(path: String)(implicit request: RequestHeader): Future[Either[InteractivePage, SimpleResult]] = {
     val edition = Edition(request)
     log.info(s"Fetching interactive: $path for edition $edition")
     val response: Future[ItemResponse] = LiveContentApi.item(path, edition)
@@ -29,18 +34,20 @@ object InteractiveController extends Controller with Logging with ExecutionConte
       .response
 
     val result = response map { response =>
+      val storyPackage = response.storyPackage map { Content(_) }
       val interactive = response.content map { Interactive(_) }
+      val page = interactive.map(i => InteractivePage(i, storyPackage.filterNot(_.id == i.id)))
 
-      ModelOrResult(interactive, response)
+      ModelOrResult(page, response)
     }
 
     result recover convertApiExceptions
   }
 
 
-  private def render(model: Interactive)(implicit request: RequestHeader) = {
+  private def render(model: InteractivePage)(implicit request: RequestHeader) = {
     val htmlResponse = () => views.html.interactive(model)
     val jsonResponse = () => views.html.fragments.interactiveBody(model)
-    renderFormat(htmlResponse, jsonResponse, model, Switches.all)
+    renderFormat(htmlResponse, jsonResponse, model.interactive, Switches.all)
   }
 }

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -1,18 +1,29 @@
-@(interactive: Interactive)(implicit request: RequestHeader)
+@(page: InteractivePage)(implicit request: RequestHeader)
 @import conf.Switches.DiscussionSwitch
 
-<article class="content content--interactive tone-@interactive.visualTone"
+@defining((page.interactive, page.storyPackage)) { case (interactive, storyPackage) =>
+
+    <article class="content content--interactive tone-@interactive.visualTone"
     itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
 
-    @fragments.headDefault(interactive)
+        @fragments.headDefault(interactive)
+
+    <div class="gs-container u-cf">
+        @fragments.contentMeta(interactive)
+    </div>
 
     <div class="gs-container">
         <div class="content__main-column content__main-column--interactive">
-            @interactive.body.map { body =>
-                @HtmlFormat.raw(body)
-            }.getOrElse {
-                <figure class="interactive" data-interactive="@conf.Configuration.interactive.url@request.path.drop(1)/boot.js"></figure>
-            }
+
+        @interactive.body.map { body =>
+            @HtmlFormat.raw(body)
+        }.getOrElse {
+            <figure class="interactive" data-interactive="@conf.Configuration.interactive.url @request.path.drop(1)/boot.js"></figure>
+        }
         </div>
     </div>
-</article>
+    </article>
+
+    @fragments.contentFooter(interactive, storyPackage)
+
+}

--- a/applications/app/views/interactive.scala.html
+++ b/applications/app/views/interactive.scala.html
@@ -1,7 +1,7 @@
-@(interactive: Interactive)(implicit request: RequestHeader)
+@(model: InteractivePage)(implicit request: RequestHeader)
 
-@main(interactive){ }{
+@main(model.interactive){ }{
 
-    @fragments.interactiveBody(interactive)
+    @fragments.interactiveBody(model)
 
 }

--- a/common/app/assets/stylesheets/module/_interactive.scss
+++ b/common/app/assets/stylesheets/module/_interactive.scss
@@ -1,21 +1,159 @@
-.interactive {
-    margin: 1em 0;
+.content--interactive {
+
+    .social-wrapper--aside {
+        display: block;
+        max-width: none;
+        @include rem((
+            padding-top: $gs-baseline/2
+        ));
+
+        @include mq(rightCol) {
+            border-top: 0;
+            position: absolute;
+            padding-top: 0;
+            right: 0;
+            @include rem((
+                top: $gs-baseline/2,
+                right: -$gs-gutter/2
+            ));
+        }
+
+        @include mq(leftCol) {
+            right: 0;
+            @include rem((
+                top: $gs-baseline/2
+            ));
+        }
+
+        @include mq(wide) {
+            @include rem((
+                right: -$gs-gutter/2
+            ));
+        }
+    }
+
+    .social__head {
+        display: none;
+    }
+
+    .content__dateline {
+        border-top: 0;
+    }
+
+    .byline {
+        @include mq(leftCol) {
+            border-top: 0;
+            padding-bottom: 0;
+            @include rem((
+                min-height: $gs-baseline*2,
+                width: gs-span(6)
+            ));
+        }
+        @include mq(wide) {
+            @include rem((
+                width: gs-span(8)
+            ));
+        }
+    }
+
+    .content__section {
+        @include mq(leftCol) {
+            @include rem((
+                width: gs-span(6),
+                padding-bottom: $gs-baseline
+            ));
+        }
+    }
+
+    .content__meta-container {
+        border-bottom: 0;
+
+        @include mq(tablet, rightCol) {
+            margin: auto;
+            @include rem((
+                max-width: gs-span(8)
+            ));
+        }
+        @include mq(rightCol) {
+            max-width: none;
+        }
+        @include mq(leftCol) {
+            position: relative;
+            margin-left: 0;
+            border-top: 1px dotted $c-neutral5;
+            @include rem((
+                width: gs-span(14)
+            ));
+        }
+        @include mq(wide) {
+            @include rem((
+                width: gs-span(16)
+            ));
+        }
+    }
+
+    .content__headline {
+        @include mq(rightCol, leftCol) {
+            @include rem((
+                padding-bottom: $gs-baseline*2
+            ));
+        }
+    }
+
+    .content__headline,
+    .content-meta {
+        @include mq(leftCol) {
+            float: left;
+            clear: left;
+            @include rem((
+                margin-left: -(gs-span(2) + $gs-gutter),
+                width: gs-span(6),
+                margin-right: $gs-gutter
+            ));
+        }
+        @include mq(wide) {
+            @include rem((
+                margin-left: -(gs-span(3) + $gs-gutter),
+                width: gs-span(8)
+            ));
+        }
+    }
+
+    .content__standfirst {
+        @include mq(leftCol) {
+            @include rem((
+                margin-bottom: $gs-baseline*2
+            ));
+        }
+        @include mq(leftCol) {
+            float: left;
+            @include rem((
+                padding-top: $gs-baseline/6,
+                margin-right: -(gs-span(4) + $gs-gutter),
+                width: gs-span(6)
+            ));
+        }
+        @include mq(wide) {
+            @include rem((
+                margin-right: -(gs-span(5) + $gs-gutter),
+                width: gs-span(8)
+            ));
+        }
+    }
+
+    .content__head {
+        .content__main-column {
+            @include mq(rightCol, leftCol) {
+                margin-right: 0;
+                @include rem((
+                    max-width: gs-span(9)
+                ));
+            }
+        }
+    }
 }
 
 .content__main-column--interactive {
     max-width: none;
-    margin-right: 0;
-    @include rem((
-        margin: 0 $gs-gutter/2
-    ));
-    @include mq(mobileLandscape) {
-        @include rem((
-            margin: 0 $gs-gutter
-        ));
-    }
-}
-
-.content--interactive .content__section {
-    float: none;
-    margin-left: 0;
+    margin: 0;
 }

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -1,4 +1,4 @@
-@(content: model.Content, storyPackage: List[Trail])(implicit request: RequestHeader)
+@(content: model.Content, storyPackage: Seq[Trail])(implicit request: RequestHeader)
 @import conf.Switches._
 
 <div class="content-footer">

--- a/common/app/views/fragments/headDefault.scala.html
+++ b/common/app/views/fragments/headDefault.scala.html
@@ -1,6 +1,6 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
-<header class="content__head tone-accent-border">
+<header class="content__head tone-accent-border u-cf">
 
     <div class="gs-container">
         <div class="content__head__border-top"></div>
@@ -11,10 +11,6 @@
             </div>
 
             @fragments.meta.metaInline(content)
-
-            @if(content.delegate.isInteractive) {
-                @fragments.dateline(content.webPublicationDate)
-            }
 
             <h1 itemprop="headline" class="content__headline js-score">@Html(content.headline)</h1>
 

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -1,4 +1,4 @@
-@(storyPackage: List[Trail])(implicit request: RequestHeader)
+@(storyPackage: Seq[Trail])(implicit request: RequestHeader)
 
 @if(storyPackage.nonEmpty) {
     <aside role="complementary" class="related more-on-this-story@if(storyPackage.size == 1){ more-on-this-story--one-item}">


### PR DESCRIPTION
Introduces a new slim-line content header for the interactive template. This is to place more emphasis on the interactive content and reduce the scroll depth to content.
- Introduce social sharing at all breakpoints
- Two column layout from leftCol breakpoint
### Screenshots

![google chrome](https://cloud.githubusercontent.com/assets/80089/3399194/81ac3300-fd39-11e3-9d25-695bce6482b2.png)

![google chrome](https://cloud.githubusercontent.com/assets/80089/3399196/8336893c-fd39-11e3-920a-a9fc6964d1ba.png)

![google chrome](https://cloud.githubusercontent.com/assets/80089/3399197/84af0a00-fd39-11e3-8572-c8531d79216d.png)
