### PR TITLE
Bump up overlay z-index

### DIFF
--- a/common/app/assets/stylesheets/module/_overlay.scss
+++ b/common/app/assets/stylesheets/module/_overlay.scss
@@ -6,7 +6,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 100;
+    z-index: 1055;
 
     .is-updating {
         margin-top: ($gs-baseline/3)*20;


### PR DESCRIPTION
Creatives need a z-index of `1052` to go on top of the header. So the overlay then appears on top, need to increase its z-index 
### Before

![screen shot 2014-06-26 at 17 13 16](https://cloud.githubusercontent.com/assets/74132/3401155/06dc732e-fd4d-11e3-95f1-151006829264.jpeg)
### After

![screen shot 2014-06-26 at 17 12 17](https://cloud.githubusercontent.com/assets/74132/3401157/0abc55ae-fd4d-11e3-831a-17018b578508.jpeg)
