### PR TITLE
Only Show City in Masterclass Venues

### DIFF
--- a/commercial/app/model/commercial/masterclasses/MasterClass.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClass.scala
@@ -127,5 +127,5 @@ case class Venue(name: Option[String] = None,
                  country: Option[String] = None,
                  postcode: Option[String] = None) {
 
-  val description = Seq(name, address, address2, city, country, postcode).flatten.mkString(", ")
+  val description = Seq(name, city orElse country).flatten mkString ", "
 }

--- a/commercial/test/model/commercial/masterclasses/SingleEventbriteMasterClassParsingTest.scala
+++ b/commercial/test/model/commercial/masterclasses/SingleEventbriteMasterClassParsingTest.scala
@@ -36,7 +36,7 @@ class SingleEventbriteMasterClassParsingTest extends FlatSpec with Matchers {
     result.venue should be {
       Venue(None, Some("Kings Place"), Some("90 York Way"), Some("London"), Some("United Kingdom"), Some("N1 9GU"))
     }
-    result.venue.description should be("Kings Place, 90 York Way, London, United Kingdom, N1 9GU")
+    result.venue.description should be("London")
   }
 
   "MasterClass companion object" should "handle classes with 2 tickets as a range" in {


### PR DESCRIPTION
Commercial components now show, for example:
_The Guardian, London_
instead of:
_The Guardian, Kings Place, 90 York Way, London, United Kingdom, N1 9GU_
