### PR TITLE
Fix Getting Sponsors

### DIFF
--- a/admin/app/dfp/DfpApiWrapper.scala
+++ b/admin/app/dfp/DfpApiWrapper.scala
@@ -1,11 +1,10 @@
 package dfp
 
-import com.google.api.ads.dfp.axis.utils.v201403.StatementBuilder
-import com.google.api.ads.dfp.axis.v201403._
-import com.google.api.ads.dfp.axis.v201403.{LineItem => DfpApiLineItem}
-import common.Logging
-import com.google.api.ads.dfp.lib.client.DfpSession
 import com.google.api.ads.dfp.axis.factory.DfpServices
+import com.google.api.ads.dfp.axis.utils.v201403.StatementBuilder
+import com.google.api.ads.dfp.axis.v201403.{LineItem => DfpApiLineItem, _}
+import com.google.api.ads.dfp.lib.client.DfpSession
+import common.Logging
 
 object DfpApiWrapper extends Logging {
 
@@ -46,8 +45,22 @@ object DfpApiWrapper extends Logging {
     try {
       fetch(Nil)
     } catch {
+
+      case e: ApiException =>
+        e.getErrors foreach { err =>
+          val reasonMsg = err match {
+            case freqCapErr: FrequencyCapError => s", with the reason '${freqCapErr.getReason}'"
+            case notNullErr: NotNullError => s", with the reason '${notNullErr.getReason}'"
+            case _ => ""
+          }
+          log.error(s"API Exception fetching: type '${err.getApiErrorType}', on the field '${err.getFieldPath}', " +
+            s"caused by an invalid value '${err.getTrigger}', with the error message '${err.getErrorString}'" +
+            reasonMsg)
+        }
+        Nil
+
       case e: Exception =>
-        log.error(s"Exception fetching: $e")
+        log.error(s"Exception fetching: ${e.getMessage}")
         Nil
     }
   }

--- a/admin/app/views/commercial/sponsorships.scala.html
+++ b/admin/app/views/commercial/sponsorships.scala.html
@@ -10,9 +10,9 @@
 <h3>Sponsored Tags</h3>
 <p>Last updated: @sponsoredTags.updatedTimeStamp</p>
 <ol>
-    @for(tag <- sponsoredTags.sponsorships) {
-    <li>@{tag.tags.mkString(", ")}@{tag.sponsor.map(sponsor =>
-        <small>[sponsored by <b>@sponsor</b>]</small>
+    @for(sponsorship <- sponsoredTags.sponsorships) {
+    <li>@{sponsorship.tags.mkString(", ")}@{sponsorship.sponsor.map(sponsor =>
+        <small>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[sponsored by <b>{sponsor}</b>]</small>
         )}
     </li>
     }
@@ -22,9 +22,9 @@
 <p>Last updated: @advertisementTags.updatedTimeStamp</p>
 
 <ol>
-    @for(tag <- advertisementTags.sponsorships) {
-    <li>@{tag.tags.mkString(", ")}@{tag.sponsor.map(sponsor =>
-        <small>[sponsored by <b>@sponsor</b>]</small>
+    @for(sponsorship <- advertisementTags.sponsorships) {
+    <li>@{sponsorship.tags.mkString(", ")}@{sponsorship.sponsor.map(sponsor =>
+        <small>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[sponsored by <b>{sponsor}</b>]</small>
         )}
     </li>
     }


### PR DESCRIPTION
Sponsors now available in Sponsorship instances.

Main problem was permission to read custom fields, but this change improves DFP API exception reporting and fixes showing sponsors in the [Sponsorship Diagnostics Page](https://frontend.gutools.co.uk/analytics/commercial/sponsorships)

/cc @ironsidevsquincy 
