### PR TITLE
Moving high relevance commercial component between 2nd and 3rd container

### DIFF
--- a/common/app/assets/javascripts/modules/commercial/front-commercial-components.js
+++ b/common/app/assets/javascripts/modules/commercial/front-commercial-components.js
@@ -16,10 +16,10 @@ define([
             if (config.page.isFront && !config.page.hasPageSkin) {
                 var $adSlot = bonzo(dfp.createAdSlot('merchandising-high', 'commercial-component-high')),
                     $containers = $('.container');
-                if ($containers.length < 4) {
+                if ($containers.length >= 4) {
+                    return $adSlot.insertAfter($containers[1]);
+                } else if ($containers.length >= 2) {
                     return $adSlot.insertAfter($containers[0]);
-                } else {
-                    return $adSlot.insertAfter($containers[2]);
                 }
             }
         })


### PR DESCRIPTION
Results from previous a/b test show it has no negative impact

Also, don't show component if there is only one container on a page 
