### PR TITLE
Enable "days since last visit" tracking and RWD tracking in Omniture

### DIFF
--- a/common/app/assets/javascripts/components/omniture/omniture.js
+++ b/common/app/assets/javascripts/components/omniture/omniture.js
@@ -77,7 +77,7 @@ function s_doPlugins(s) {
 //    s.eVar40=s.crossVisitParticipation(s.campaign,'s_ev40','30','5','>','',1);
 
     /* Days Since Last Visit */
-//    s.eVar10=s.getDaysSinceLastVisit('s_lv');
+    s.eVar10=s.getDaysSinceLastVisit('s_lv');
 
     /* New/Repeat Status */
 //    s.prop16=s.eVar16=s.getNewRepeat(365);

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -147,6 +147,11 @@ define([
 
             s.prop13    = config.page.series || '';
 
+            // see http://blogs.adobe.com/digitalmarketing/mobile/responsive-web-design-and-web-analytics/
+            s.eVar18    = detect.getBreakpoint();
+            s.eVar21    = document.documentElement.clientWidth + 'x' + document.documentElement.clientHeight;
+            s.eVar32    = detect.getOrientation();
+
             /* Set Time Parting Day and Hour Combination - 0 = GMT */
             var tpA = s.getTimeParting('n','+0');
             s.prop20 = tpA[2] + ':' + tpA[1];


### PR DESCRIPTION
Working through the list of Omniture stuff that needs to be done.

You now get data like...

```
v10:Less than 1 day
v18:tablet
v21:738x805
v32:portrait
```
