### PR TITLE
Fix Commercial Component Targeting on Section Fronts

### DIFF
--- a/common/app/assets/javascripts/modules/commercial/loader.js
+++ b/common/app/assets/javascripts/modules/commercial/loader.js
@@ -9,7 +9,6 @@ define([
     'common/utils/storage',
     'common/modules/lazyload',
     'common/modules/component',
-    'common/modules/onward/history',
     'common/modules/ui/images',
     'bean',
     'common/modules/ui/tabs'
@@ -20,7 +19,6 @@ define([
     storage,
     LazyLoad,
     Component,
-    History,
     images,
     bean,
     Tabs

--- a/common/app/assets/javascripts/modules/commercial/loader.js
+++ b/common/app/assets/javascripts/modules/commercial/loader.js
@@ -101,7 +101,7 @@ define([
                 return 'k=' + encodeURIComponent(keywordId.split('/').pop());
             }).join('&');
         } else {
-            return this.pageId.split('/').pop();
+            return 'k=' + this.pageId.split('/').pop();
         }
     };
 

--- a/common/app/assets/javascripts/modules/commercial/loader.js
+++ b/common/app/assets/javascripts/modules/commercial/loader.js
@@ -53,22 +53,21 @@ define([
         this.mobileUserVariant  = conf.ab_commercialInArticleMobile || '';
         this.oastoken           = options.oastoken || '';
         this.adType             = options.adType || 'desktop';
-        this.userSegments       = 'seg=' + (new History().getSize() <= 1 ? 'new' : 'repeat');
         this.components         = {
-            bestbuy:           this.host + 'money/bestbuys.json?'           + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            bestbuyHigh:       this.host + 'money/bestbuys-high.json?'      + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            book:              this.host + 'books/book/' + this.pageId      + '.json',
-            books:             this.host + 'books/bestsellers.json?'        + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            booksMedium:       this.host + 'books/bestsellers-medium.json?' + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            booksHigh:         this.host + 'books/bestsellers-high.json?'   + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            jobs:              this.host + 'jobs.json?'                     + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            jobsHigh:          this.host + 'jobs-high.json?'                + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            masterclasses:     this.host + 'masterclasses.json?'            + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            masterclassesHigh: this.host + 'masterclasses-high.json?'       + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            soulmates:         this.host + 'soulmates/mixed.json?'          + this.userSegments + '&s=' + this.section,
-            soulmatesHigh:     this.host + 'soulmates/mixed-high.json?'     + this.userSegments + '&s=' + this.section,
-            travel:            this.host + 'travel/offers.json?'            + this.userSegments + '&s=' + this.section + '&' + this.getKeywords(),
-            travelHigh:        this.host + 'travel/offers-high.json?'       + this.userSegments + '&s=' + this.section + '&' + this.getKeywords()
+            bestbuy:           this.host + 'money/bestbuys.json',
+            bestbuyHigh:       this.host + 'money/bestbuys-high.json',
+            book:              this.host + 'books/book/' + this.pageId + '.json',
+            books:             this.host + 'books/bestsellers.json?'        + this.getKeywords(),
+            booksMedium:       this.host + 'books/bestsellers-medium.json?' + this.getKeywords(),
+            booksHigh:         this.host + 'books/bestsellers-high.json?'   + this.getKeywords(),
+            jobs:              this.host + 'jobs.json?'                     + this.getKeywords(),
+            jobsHigh:          this.host + 'jobs-high.json?'                + this.getKeywords(),
+            masterclasses:     this.host + 'masterclasses.json?'            + this.getKeywords(),
+            masterclassesHigh: this.host + 'masterclasses-high.json?'       + this.getKeywords(),
+            soulmates:         this.host + 'soulmates/mixed.json',
+            soulmatesHigh:     this.host + 'soulmates/mixed-high.json',
+            travel:            this.host + 'travel/offers.json?'            + 's=' + this.section + '&' + this.getKeywords(),
+            travelHigh:        this.host + 'travel/offers-high.json?'       + 's=' + this.section + '&' + this.getKeywords()
         };
         this.postLoadEvents = {
             books: function(el) {

--- a/common/test/assets/javascripts/spec/CommercialLoader.spec.js
+++ b/common/test/assets/javascripts/spec/CommercialLoader.spec.js
@@ -72,7 +72,7 @@
 
 
         it("Passes section and keyword to a travel component from the commercial server", function() {
-            server.respondWith("/commercial/travel/offers.json?seg=new&s=s&k=a&k=b&k=c", [200, {}, '{ "html": "<b>advert</b>" }']);
+            server.respondWith("/commercial/travel/offers.json?s=s&k=a&k=b&k=c", [200, {}, '{ "html": "<b>advert</b>" }']);
             runs(function() {
                 new CommercialComponent(options).init('travel', adSlot);
             });
@@ -85,29 +85,9 @@
             });
         });
 
-        it("Passes segment information to the commercial component", function() {
-
-            // two visits = a return visitor
-            var history = '{"value":[{"id":"/"},{"id":"/"}]}';
-
-            // a repeat user
-            localStorage.setItem('gu.history', history);
-
-            server.respondWith("/commercial/masterclasses.json?seg=repeat&s=s&k=a&k=b&k=c", [200, {}, '{ "html": "<b>advert</b>" }']);
-            runs(function() {
-                new CommercialComponent(options).init('masterclasses', adSlot);
-            });
-            waitsFor(function () {
-                return callback.called === true;
-            }, 'success never called', 500);
-            runs(function(){
-                expect(callback).toHaveBeenCalledOnce();
-            });
-        });
-
         // OAS can inject a url in to the advert code to track clicks on the component
         it("Injects an OAS tracker URL in to the response", function() {
-            server.respondWith("/commercial/jobs.json?seg=new&s=s&k=a&k=b&k=c", [200, {}, '{ "html": "<b>%OASToken% - %OASToken%</b>" }']);
+            server.respondWith("/commercial/jobs.json?k=a&k=b&k=c", [200, {}, '{ "html": "<b>%OASToken% - %OASToken%</b>" }']);
             runs(function() {
                 options.oastoken = '123';
                 new CommercialComponent(options).init('jobs', adSlot);


### PR DESCRIPTION
This fixes a bug where commercial component targeting wasn't working on section fronts.
Eg. http://www.theguardian.com/travel#commercial-component=books just shows generic bestsellers.

It also gets rid of a lot of redundant targeting.  We're only using keywords at the moment, except for travel offers which are specific to the travel section.

/cc @ironsidevsquincy  
