### PR TITLE
Remove HTML title attribute from some images

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -41,7 +41,6 @@
     <img src="@SeoOptimisedContentImage.bestFor(picture).map(Html(_))"
         class="maxed responsive-img"
         itemprop="contentURL representativeOfPage"
-        title="@SeoOptimisedContentImage.altTextFor(picture).getOrElse("")"
         alt="@SeoOptimisedContentImage.altTextFor(picture).getOrElse("")" />
 
 }


### PR DESCRIPTION
Removes the `title` attribute for main images on articles. Prevents the ugly default tooltip from appearing when you're hovering over "showcase" images, e.g.

![screen shot 2014-07-01 at 14 21 12](https://cloud.githubusercontent.com/assets/665572/3443436/add21386-0122-11e4-9e84-0489be949aa2.png)

At best, the `title` attribute is optional extra information for users with access to a mouse. Since we show the caption directly below the image this is redundant.

The `alt` attribute is what's used by screen readers, so there's no accessibility argument here. The HTML5 spec has this to say:

> The title attribute represents advisory information for the element, such as would be appropriate for a tooltip. On a link, this could be the title or a description of the target resource; on an image, it could be the image credit or a description of the image; on a paragraph, it could be a footnote or commentary on the text; on a citation, it could be further information about the source; and so forth.

There might be some situations where this would add value, but ours' isn't one of them. If you need further convincing of the uselessness of the `title` attribute, see [here](http://blog.silktide.com/2013/01/i-thought-title-text-improved-accessibility-i-was-wrong/), [here](http://blog.paciellogroup.com/2012/01/html5-accessibility-chops-title-attribute-use-and-abuse/) and [here](http://blog.paciellogroup.com/2010/11/using-the-html-title-attribute/).
