### PR TITLE
Asynchronously start omniture media tracking

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -32,7 +32,6 @@ define([
     'common/modules/analytics/omniture',
     'common/modules/analytics/scrollDepth',
     'common/utils/cookies',
-    'common/modules/analytics/omnitureMedia',
     'common/modules/analytics/livestats',
     'common/modules/experiments/ab',
     'common/modules/discussion/comment-count',
@@ -89,7 +88,6 @@ define([
     Omniture,
     ScrollDepth,
     Cookies,
-    OmnitureMedia,
     liveStats,
     ab,
     CommentCount,
@@ -236,16 +234,7 @@ define([
         loadAnalytics: function (config, context) {
             var omniture = new Omniture();
 
-            omniture.go(config, function(){
-                // callback:
-
-                Array.prototype.forEach.call(context.getElementsByTagName('video'), function(video){
-                    if (!bonzo(video).hasClass('tracking-applied')) {
-                        bonzo(video).addClass('tracking-applied');
-                        new OmnitureMedia(video).init();
-                    }
-                });
-            });
+            omniture.go(config);
 
             if (config.switches.ophan && !config.page.isSSL) {
                 require('ophan/ng', function (ophan) {

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -231,7 +231,7 @@ define([
             liveStats.log(config);
         },
 
-        loadAnalytics: function (config, context) {
+        loadAnalytics: function (config) {
             var omniture = new Omniture();
 
             omniture.go(config);

--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -9,7 +9,8 @@ define([
     'common/modules/adverts/dfp',
     'common/modules/analytics/omnitureMedia',
     'lodash/functions/throttle',
-    'bean'
+    'bean',
+    'bonzo'
 ], function(
     $,
     ajax,
@@ -20,7 +21,8 @@ define([
     dfp,
     OmnitureMedia,
     _throttle,
-    bean
+    bean,
+    bonzo
 ) {
 
     var autoplay = config.page.contentType === 'Video' && /desktop|wide/.test(detect.getBreakpoint());
@@ -64,7 +66,7 @@ define([
         initOmnitureTracking: function(playerEl) {
             deferToAnalytics(function(){
                 new OmnitureMedia(playerEl).init();
-                $(playerEl).addClass('tracking-applied');
+                bonzo(playerEl).addClass('tracking-applied');
             });
         },
 

--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -4,8 +4,10 @@ define([
     'common/utils/ajax',
     'common/utils/detect',
     'common/utils/config',
+    'common/utils/deferToAnalytics',
     'common/modules/adverts/query-string',
     'common/modules/adverts/dfp',
+    'common/modules/analytics/omnitureMedia',
     'lodash/functions/throttle',
     'bean'
 ], function(
@@ -13,8 +15,10 @@ define([
     ajax,
     detect,
     config,
+    deferToAnalytics,
     queryString,
     dfp,
+    OmnitureMedia,
     _throttle,
     bean
 ) {
@@ -54,6 +58,13 @@ define([
                 bean.one(playerEl, event, function(event) {
                     modules.ophanRecord(playerEl, event);
                 });
+            });
+        },
+
+        initOmnitureTracking: function(playerEl) {
+            deferToAnalytics(function(){
+                new OmnitureMedia(playerEl).init();
+                $(playerEl).addClass('tracking-applied');
             });
         },
 
@@ -195,7 +206,7 @@ define([
 
                     vjs.ready(function () {
                         var player = this;
-
+                        modules.initOmnitureTracking(el);
                         modules.initOphanTracking(el);
                         modules.bindPrerollEvents(player, el);
 

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -23,8 +23,7 @@ define([
     mvtCookie,
     beacon,
     pad,
-    mediator,
-    analytics
+    mediator
     ) {
 
     // https://developer.omniture.com/en_US/content_page/sitecatalyst-tagging/c-tagging-overview

--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -9,7 +9,9 @@ define([
     'omniture',
     'common/modules/analytics/mvt-cookie',
     'common/modules/analytics/beacon',
-    'common/utils/pad'
+    'common/utils/pad',
+    'common/utils/mediator',
+    'common/utils/deferToAnalytics' // Ensure that 'analytics:ready' is handled.
 ], function(
     common,
     detect,
@@ -20,7 +22,9 @@ define([
     s,
     mvtCookie,
     beacon,
-    pad
+    pad,
+    mediator,
+    analytics
     ) {
 
     // https://developer.omniture.com/en_US/content_page/sitecatalyst-tagging/c-tagging-overview
@@ -254,16 +258,7 @@ define([
             s.eVar75 = config.page.wordCount || 0;
         };
 
-        this.loaded = function(callback) {
-            this.populatePageProperties();
-            this.logView();
-            if (typeof callback === 'function') {
-                callback();
-            }
-        };
-
-        this.go = function(c, callback) {
-            var that = this;
+        this.go = function(c) {
 
             config = c; // update the module-wide config
 
@@ -271,7 +266,9 @@ define([
             window.s_account = config.page.omnitureAccount;
 
             s = window.s;
-            that.loaded(callback);
+            this.populatePageProperties();
+            this.logView();
+            mediator.emit('analytics:ready');
         };
 
         this.confirmPageView = function() {

--- a/common/app/assets/javascripts/utils/deferToAnalytics.js
+++ b/common/app/assets/javascripts/utils/deferToAnalytics.js
@@ -1,0 +1,22 @@
+define([
+    'common/utils/mediator'
+], function(mediator) {
+
+var analyticsReady = false;
+
+mediator.on('analytics:ready', function() {
+    analyticsReady = true;
+});
+
+function deferToAnalytics(afterAnalytics) {
+    if (analyticsReady) {
+        afterAnalytics();
+    } else {
+        mediator.on('analytics:ready', function() {
+            afterAnalytics();
+        });
+    }
+}
+return deferToAnalytics;
+
+}); // define


### PR DESCRIPTION
This change defers the execution of omniture media tracking until the omniture log view has been sent.
