### PR TITLE
trimming values in the js head

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -153,7 +153,7 @@ object RemoveOuterParaHtml {
 object JavaScriptValue {
   def apply(value: Any) = value match {
     case b: Boolean => b
-    case s => s""""${s.toString.replace(""""""", """\"""")}""""
+    case s => s""""${s.toString.trim.replace(""""""", """\"""")}""""
   }
 }
 


### PR DESCRIPTION
This was causing js errors in the inlined js head.

```
"webTitle":"Tory summer party drew super-rich supporters with total wealth of £11bn\r\n\r\n\r\n"
```
