### PR TITLE
fix trailing ? in links

### DIFF
--- a/common/app/dev/HttpSwitch.scala
+++ b/common/app/dev/HttpSwitch.scala
@@ -38,8 +38,11 @@ trait HttpSwitchParameters extends EnvConfig{
       val on = onSwitches.map{switchesOn + "=" + _}
       val off = offSwitches.map{switchesOff + "=" + _}
       val separator = if(url.contains("?")) "&" else "?"
-      url + List(on, off).flatten.mkString(separator, "&", "")}
-    else url
+      url + (List(on, off).flatten match {
+        case Nil => ""
+        case ss => ss.mkString(separator, "&", "")
+      })
+    } else url
 
   def onSwitches(implicit request: RequestHeader) = queryParameter(switchesOn)
 

--- a/common/test/dev/HttpSwitchParametersTest.scala
+++ b/common/test/dev/HttpSwitchParametersTest.scala
@@ -18,14 +18,14 @@ class HttpSwitchParametersTest extends FlatSpec with Matchers with HttpSwitchHel
   "queryString" should "not leave URL unchanged if environment is PROD" in Fake {
     val url = httpSwitchInProd.queryString("/bla/bla?page=1")(requestWithSwitchesOnAndOff)
 
-    url should not contain "switchesOn"
-    url should not contain "switchesOff"
+    url should not include "switchesOn"
+    url should not include "switchesOff"
   }
 
   "queryString" should "not append anything if no switches overrides present" in Fake {
     val url = httpSwitchInNonProd.queryString("/bla/bla")(requestWithNoSwitches)
 
-    url should not contain "?"
+    url should not include "?"
   }
 
   "queryString" should "append ON/OFF switches overrides if present" in Fake {


### PR DESCRIPTION
Tests were using the wrong matcher and wrong implementation creeped in.
