### PR TITLE
Revert "Discussion repeat fix"

### DIFF
--- a/common/app/assets/javascripts/bootstraps/app.js
+++ b/common/app/assets/javascripts/bootstraps/app.js
@@ -16,6 +16,7 @@ define([
     'common/bootstraps/common',
     'common/bootstraps/tag',
     'common/bootstraps/section',
+    'common/bootstraps/imagecontent',
 
     'common/bootstraps/football',
     'common/bootstraps/article',
@@ -40,6 +41,7 @@ define([
     bootstrapCommon,
     Tag,
     Section,
+    ImageContent,
 
     Football,
     Article,
@@ -130,6 +132,10 @@ define([
 
             if (config.page.contentType === 'Section' && !config.page.isFront) {
                 Section.init(config, context);
+            }
+
+            if (config.page.contentType === 'ImageContent') {
+                ImageContent.init(config, context);
             }
 
             if (config.page.section === 'football') {

--- a/common/app/assets/javascripts/bootstraps/imagecontent.js
+++ b/common/app/assets/javascripts/bootstraps/imagecontent.js
@@ -1,0 +1,34 @@
+define([
+    'common/utils/mediator',
+    'common/modules/discussion/loader',
+    'common/utils/$'
+], function(
+    mediator,
+    DiscussionLoader,
+    $
+) {
+    var modules = {
+
+        initDiscussion: function() {
+            mediator.on('page:imagecontent:ready', function(config, context) {
+                if (config.page.commentable) {
+                    var discussionLoader = new DiscussionLoader(context, mediator);
+                    discussionLoader.attachTo($('.discussion')[0]);
+                }
+            });
+        }
+    };
+
+    var ready = function (config, context) {
+        if (!this.initialised) {
+            this.initialised = true;
+            modules.initDiscussion();
+        }
+        mediator.emit('page:imagecontent:ready', config, context);
+    };
+
+    return {
+        init: ready
+    };
+
+});


### PR DESCRIPTION
Reverts guardian/frontend#4943

After this deploy, JS errors shot up. Can't think why this would have caused it, but doing a revert to test

cc: @jamesgorrie 

![screen shot 2014-07-02 at 12 06 21](https://cloud.githubusercontent.com/assets/74132/3454960/00ce555c-01d9-11e4-96e0-6fd9915d8d6a.png)
