### PR TITLE
Increase press detection period

### DIFF
--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -21,7 +21,7 @@ define([
             {name: 'comment/comment-and-debate'}
         ],
 
-        detectPressFailureMs: 10000,
+        detectPressFailureMs: 15000,
 
         maxFronts: 200,
 


### PR DESCRIPTION
Until we split the tool from the presser, be more lenient on alerting that presses didn't succeed within the specified time.
