### PR TITLE
Change pressing variables

### DIFF
--- a/admin/app/Global.scala
+++ b/admin/app/Global.scala
@@ -1,5 +1,5 @@
 import common.{AkkaAsync, Jobs, CloudWatchApplicationMetrics}
-import conf.{Gzipper, Management}
+import conf.{Configuration, Gzipper, Management}
 import dfp.DfpDataCacheJob
 import jobs.RefreshFrontsJob
 import model.AdminLifecycle
@@ -9,13 +9,15 @@ import scala.concurrent.Future
 object Global extends WithFilters(Gzipper) with AdminLifecycle with CloudWatchApplicationMetrics with Results {
   override lazy val applicationName = Management.applicationName
 
+  val adminPressJobPushRateInMinutes: Int = Configuration.faciatool.adminPressJobPushRateInMinutes
+
   override def onError(request: RequestHeader, ex: Throwable) = Future.successful(InternalServerError(
     views.html.errorPage(ex)
   ))
 
   def scheduleJobs() {
     //Every 3 minutes
-    Jobs.schedule("FrontPressJob", "0 0/3 * 1/1 * ? *") {
+    Jobs.schedule("FrontPressJob", s"0 0/$adminPressJobPushRateInMinutes * 1/1 * ? *") {
       RefreshFrontsJob.run()
     }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -9,6 +9,7 @@ import java.io.{FileInputStream, File}
 import org.apache.commons.io.IOUtils
 import play.api.Play
 import play.api.Play.current
+import scala.util.Try
 
 class BadConfigurationException(property: String) extends RuntimeException(s"Property $property not configured")
 
@@ -257,6 +258,20 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val contentApiPostEndpoint: Option[String] = configuration.getStringProperty("contentapi.post.endpoint")
     lazy val frontPressQueueUrl: Option[String] = configuration.getStringProperty("frontpress.sqs.queue")
     lazy val configBeforePressTimeout: Int = 1000
+
+    //It's not possible to take a batch size above 10
+    lazy val pressJobBatchSize: Int =
+      Try(configuration.getStringProperty("faciapress.batch.size").get.toInt)
+        .filter(_ <= 10).getOrElse(10)
+
+    //Above 59 would probably break the cron expression
+    lazy val pressJobConsumeRateInSeconds: Int =
+      Try(configuration.getStringProperty("faciapress.rate.inseconds").get.toInt)
+        .filter(_ <= 59).filter(_ > 0).getOrElse(10)
+
+    lazy val adminPressJobPushRateInMinutes: Int =
+      Try(configuration.getStringProperty("admin.pressjob.push.rate.inminutes").get.toInt)
+        .getOrElse(3)
   }
 
   object pa {

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -74,3 +74,8 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
+
+#Pressing
+faciapress.batch.size=2
+faciapress.rate.inseconds=5
+admin.pressjob.push.rate.inminutes=5

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -69,3 +69,8 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
+
+# Pressing
+faciapress.batch.size=1
+faciapress.rate.inseconds=5
+admin.pressjob.push.rate.inminutes=5

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -21,6 +21,6 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // the properties needed to run this project. Make sure you update it if there
     // are any required changes, update the hash below, and off you go.
 
-    hash should be ("d4d0d518284787757a3014922f8a0b01")
+    hash should be ("038cca634e9f1d84fe0f177baa491156")
   }
 }

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -1,5 +1,5 @@
 import common._
-import conf.{Gzipper, Management}
+import conf.{Gzipper, Management, Configuration => GuardianConfiguration}
 import java.io.File
 import jobs.FrontPressJob
 import play.api._
@@ -12,6 +12,7 @@ object Global extends WithFilters(Gzipper)
   with ConfigAgentLifecycle {
 
   lazy val devConfig = Configuration.from(Map("session.secure" -> "false"))
+  val pressJobConsumeRateInSeconds: Int = GuardianConfiguration.faciatool.pressJobConsumeRateInSeconds
 
   override lazy val applicationName = Management.applicationName
   override def applicationMetrics: Map[String, Double] = Map(
@@ -55,7 +56,7 @@ object Global extends WithFilters(Gzipper)
   }
 
   def scheduleJobs() {
-    Jobs.schedule("FaciaToolPressJob", "0/10 * * * * ?") {
+    Jobs.schedule("FaciaToolPressJob", s"0/$pressJobConsumeRateInSeconds * * * * ?") {
       FrontPressJob.run()
     }
   }

--- a/facia-tool/app/frontpress/FrontPressJob.scala
+++ b/facia-tool/app/frontpress/FrontPressJob.scala
@@ -21,6 +21,8 @@ object FrontPressJob extends Logging with implicits.Collections {
   import play.api.Play.current
   private lazy implicit val frontPressContext = Akka.system.dispatchers.lookup("play.akka.actor.front-press")
 
+  val batchSize: Int = Configuration.faciatool.pressJobBatchSize
+
   def newClient: AmazonSQSAsyncClient = {
     val c = new AmazonSQSAsyncClient(Configuration.aws.credentials)
     c.setRegion(Region.getRegion(Regions.EU_WEST_1))
@@ -32,7 +34,7 @@ object FrontPressJob extends Logging with implicits.Collections {
       if (FrontPressJobSwitch.isSwitchedOn) {
         val client = newClient
         try {
-          val receiveMessageResult = client.receiveMessage(new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(10))
+          val receiveMessageResult = client.receiveMessage(new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(batchSize))
           Future.traverse(receiveMessageResult.getMessages.map(getConfigFromMessage).distinct) { path =>
             val f = FrontPress.pressByPathId(path)
             f onComplete {


### PR DESCRIPTION
We are having a few issues with pressing, which is causing the tool to slow down. From next week (hopefully), this will no longer slow down the tool, but these variables will still apply.

We would like to change the variables around while pressing happens on the tool to see how it behaves. 

Currently, we feel that we are taking too many items off the queue too frequently. Once there is more than one instance (3 on `PROD`), this is not a problem, but on `CODE` it tries to take so many things off the queue that if it gets held up, it gets stuck concurrently trying too many things at once, and doesn't give itself enough time to finish. This is also not helped by the amount of `paths` that exist for code.

Taking too many things off the queue causes a lot of spikes in the CPU load. Reducing this should make it less spikey and more flat. The knock on effect is that we should increase the duration to wait before filling the queue with jobs.

We have 3 new variables:
- `pressJobBatchSize` - The maximum amount of work requested from the queue
- `pressJobConsumeRateInSeconds` - The duration to wait before trying to take things off the queue to work on
- `adminPressJobPushRateInMinutes` - The duration to wait before pushing all the paths from `admin` to the queue.

@stephanfowler 
