### PR TITLE
Ensure video ready happens after analytics

### DIFF
--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -64,10 +64,8 @@ define([
         },
 
         initOmnitureTracking: function(playerEl) {
-            deferToAnalytics(function(){
-                new OmnitureMedia(playerEl).init();
-                bonzo(playerEl).addClass('tracking-applied');
-            });
+            new OmnitureMedia(playerEl).init();
+            bonzo(playerEl).addClass('tracking-applied');
         },
 
         bindPrerollEvents: function(player, videoEl) {
@@ -201,27 +199,29 @@ define([
                     });
 
                     vjs.ready(function () {
-                        var player = this;
-                        modules.initOmnitureTracking(el);
-                        modules.initOphanTracking(el);
-                        modules.bindPrerollEvents(player, el);
 
-                        // Init plugins
-                        player.adCountDown();
-                        player.ads({
-                            timeout: 3000
+                        deferToAnalytics(function () {
+                            var player = this;
+                            modules.initOmnitureTracking(el);
+                            modules.initOphanTracking(el);
+                            modules.bindPrerollEvents(player, el);
+
+                            // Init plugins
+                            player.adCountDown();
+                            player.ads({
+                                timeout: 3000
+                            });
+                            player.vast({
+                                url: modules.getVastUrl()
+                            });
+
+                            player.loadingSpinner.contentEl().innerHTML =
+                                '<div class="pamplemousse">' +
+                                '<div class="pamplemousse__pip"></div>' +
+                                '<div class="pamplemousse__pip"></div>' +
+                                '<div class="pamplemousse__pip"></div>' +
+                                '</div>';
                         });
-                        player.vast({
-                            url: modules.getVastUrl()
-                        });
-
-                        player.loadingSpinner.contentEl().innerHTML =
-                            '<div class="pamplemousse">' +
-                                '<div class="pamplemousse__pip"></div>' +
-                                '<div class="pamplemousse__pip"></div>' +
-                                '<div class="pamplemousse__pip"></div>' +
-                            '</div>';
-
                     });
 
                     // built in vjs-user-active is buggy so using custom implementation


### PR DESCRIPTION
I'm moving the `deferToAnalytics` to wrap around the post-ready video js code. This ensures that we begin the video events waterfall after the video tracking has bound.
