### PR TITLE
Facia tool: reduce draft pressing

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -16,6 +16,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 import play.api.libs.Comet
 import frontpress.PressCommand
+import frontpress.FrontPress.{pressLiveByPathId, pressDraftByPathId}
 import frontpress.CollectionPressing.pressCollectionIds
 
 object FaciaToolController extends Controller with Logging with ExecutionContexts {
@@ -160,9 +161,13 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     }
   }
 
-  def updateCollection(id: String) = AjaxExpiringAuthentication { request =>
-    pressCollectionIds(PressCommand.forOneId(id).withPressDraft().withPressLive())
-    notifyContentApi(id)
+  def pressLivePath(path: String) = AjaxExpiringAuthentication { request =>
+    pressLiveByPathId(path)
+    NoCache(Ok)
+  }
+
+  def pressDraftPath(path: String) = AjaxExpiringAuthentication { request =>
+    pressDraftByPathId(path)
     NoCache(Ok)
   }
 

--- a/facia-tool/app/frontpress/FrontPress.scala
+++ b/facia-tool/app/frontpress/FrontPress.scala
@@ -71,13 +71,6 @@ trait FrontPress extends Logging {
   import play.api.Play.current
   private lazy implicit val frontPressContext = Akka.system.dispatchers.lookup("play.akka.actor.front-press")
 
-  def pressByPathId(path: String): Future[JsValue] = {
-    val live: Future[JsObject] = pressLiveByPathId(path)
-    if (FaciaToolDraftPressSwitch.isSwitchedOn)
-      live.onComplete{ case _ => pressDraftByPathId(path) }
-    live
-  }
-
   def pressDraftByPathId(path: String): Future[JsObject] =
     FrontPress.generateDraftJson(path).map { json =>
       (json \ "id").asOpt[String].foreach(S3FrontsApi.putDraftPressedJson(_, Json.stringify(json)))

--- a/facia-tool/app/frontpress/FrontPress.scala
+++ b/facia-tool/app/frontpress/FrontPress.scala
@@ -78,13 +78,13 @@ trait FrontPress extends Logging {
     live
   }
 
-  private def pressDraftByPathId(path: String): Future[JsObject] =
+  def pressDraftByPathId(path: String): Future[JsObject] =
     FrontPress.generateDraftJson(path).map { json =>
       (json \ "id").asOpt[String].foreach(S3FrontsApi.putDraftPressedJson(_, Json.stringify(json)))
       json
     }
 
-  private def pressLiveByPathId(path: String): Future[JsObject] =
+  def pressLiveByPathId(path: String): Future[JsObject] =
     FrontPress.generateLiveJson(path).map { json =>
       (json \ "id").asOpt[String].foreach(S3FrontsApi.putLivePressedJson(_, Json.stringify(json)))
       json

--- a/facia-tool/app/frontpress/FrontPressJob.scala
+++ b/facia-tool/app/frontpress/FrontPressJob.scala
@@ -36,7 +36,7 @@ object FrontPressJob extends Logging with implicits.Collections {
         try {
           val receiveMessageResult = client.receiveMessage(new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(batchSize))
           Future.traverse(receiveMessageResult.getMessages.map(getConfigFromMessage).distinct) { path =>
-            val f = FrontPress.pressByPathId(path)
+            val f = FrontPress.pressLiveByPathId(path)
             f onComplete {
               case Success(_) =>
                 deleteMessage(receiveMessageResult, queueUrl)

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -6,13 +6,13 @@
 
     <div class="status status-danger" data-bind="visible: statusCapiErrors">
         Sorry, ContentApi is unhealthy. Fronts may fail to update.
-        <a data-bind="click: pressFront">Retry it?</a>  
+        <a data-bind="click: pressLiveFront">Retry it?</a>
         If this persists beyond a few minutes, <a href="https://sites.google.com/a/guardian.co.uk/digital-incident-management/">contact support</a>.
         <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>
     </div>
     <div class="status status-warning" data-bind="visible: statusPressFailure">
         Sorry, the latest edit to this front hasn't gone live.
-        <a data-bind="click: pressFront">Retry it?</a>
+        <a data-bind="click: pressLiveFront">Retry it?</a>
         If this persists beyond a few minutes, <a href="https://sites.google.com/a/guardian.co.uk/digital-incident-management/">contact support</a>.
         <i class="icon-remove icon-white" data-bind="click: clearStatuses"></i>
     </div>

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -28,7 +28,9 @@ GET           /publish-all/comet         controllers.FaciaToolController.publish
 
 POST          /collection/publish/*id    controllers.FaciaToolController.publishCollection(id)
 POST          /collection/discard/*id    controllers.FaciaToolController.discardCollection(id)
-POST          /collection/update/*id     controllers.FaciaToolController.updateCollection(id)
+
+POST          /press/live/*path          controllers.FaciaToolController.pressLivePath(path)
+POST          /press/draft/*path         controllers.FaciaToolController.pressDraftPath(path)
 
 GET           /front/lastmodified/*path  controllers.FaciaToolController.getLastModified(path)
 

--- a/facia-tool/public/javascripts/models/collections/article.js
+++ b/facia-tool/public/javascripts/models/collections/article.js
@@ -83,9 +83,9 @@ define([
             }, this);
 
             this.viewUrl = ko.computed(function() {
-                return this.fields.isLive() === 'true' ?
-                    (this.meta.href() || this.props.webUrl()) :
-                    vars.CONST.previewBase + '/' + urlAbsPath(this.props.webUrl());
+                return this.fields.isLive() === 'false' ?
+                    vars.CONST.previewBase + '/' + urlAbsPath(this.props.webUrl()) :
+                    this.meta.href() || this.props.webUrl();
             }, this);
 
             this.headlineInput  = this.overrider('headline');

--- a/facia-tool/public/javascripts/models/collections/latest-articles.js
+++ b/facia-tool/public/javascripts/models/collections/latest-articles.js
@@ -131,6 +131,8 @@ define([
                         var icc = internalContentCode(article);
 
                         article.id = icc;
+                        article.uneditable = true;
+
                         cache.put('contentApi', icc, article);
                         self.articles.push(new Article(article));
                     });

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -262,13 +262,13 @@ define([
                     }
                 });
 
-                model.liveMode.subscribe(function(isLive) {
+                model.liveMode.subscribe(function() {
                     _.each(model.collections(), function(collection) {
                         collection.closeAllArticles();
                         collection.populate();
                     });
 
-                    if (!isLive) {
+                    if (!model.liveMode()) {
                         model.pressDraftFront();
                     }
                 });

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -257,7 +257,7 @@ define([
                     wasPopstate = false;
                     loadCollections(front);
 
-                    if (front && !model.liveMode()) {
+                    if (!model.liveMode()) {
                         model.pressDraftFront();
                     }
                 });


### PR DESCRIPTION
Stops the cron'd pressing of draft fronts, on the basis that it's expensive and almost always redundant. Instead, only press the draft of a front in these events:
- the front is selected from the tool dropdown
- a collection on that front is edited in draft mode
- the user switches back to draft mode from live mode
