### PR TITLE
Add 'pre' badge with sponsor's name

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -6,6 +6,9 @@
         "facia-container--sponsored" -> index.page.isSponsored,
         "facia-container--advertisement-feature" -> (index.page.isAdvertisementFeature && !index.page.isSponsored)))"
     data-link-name="Front | @request.path"
+    @index.page.sponsor.map { sponsor =>
+        data-sponsor="@sponsor"
+    }
     role="main">
 
     @if(index.page.hasPageSkin) {

--- a/common/app/assets/javascripts/modules/commercial/badges.js
+++ b/common/app/assets/javascripts/modules/commercial/badges.js
@@ -18,7 +18,7 @@ define([
         hadAdvertisementFeatureBadge = false,
         addPreBadge = function($adSlot, isSponsored, sponsor) {
             if (sponsor) {
-                var html = bonzo.create(template(
+                $adSlot.append(template(
                     '<div class="ad-slot--paid-for-badge__inner">' +
                         '<h3 class="ad-slot--paid-for-badge__header">{{header}}</h3>' +
                         '<p class="ad-slot--paid-for-badge__header">{{sponsor}}</p>' +
@@ -27,12 +27,11 @@ define([
                         header: isSponsored ? 'Sponsored by:' : 'Advertisement feature',
                         sponsor: sponsor
                     }
-                ))[0];
+                ));
                 if (!isSponsored) {
-                    $('.ad-slot--paid-for-badge__header', html).first()
-                        .after('<p class="ad-slot--paid-for-badge__label">in association with</p>')
+                    $('.ad-slot--paid-for-badge__header', $adSlot[0]).first()
+                        .after('<p class="ad-slot--paid-for-badge__label">in association with</p>');
                 }
-                $adSlot.append(html)
             }
         },
         createAdSlot = function(container, isSponsored, opts) {

--- a/common/app/assets/javascripts/modules/commercial/badges.js
+++ b/common/app/assets/javascripts/modules/commercial/badges.js
@@ -3,39 +3,71 @@ define([
     'bonzo',
     'common/utils/$',
     'common/modules/commercial/dfp',
-    'lodash/functions/once'
+    'lodash/functions/once',
+    'common/utils/template'
 ], function (
     qwery,
     bonzo,
     $,
     dfp,
-    once
+    once,
+    template
 ) {
 
     var hadSponsoredBadge = false,
         hadAdvertisementFeatureBadge = false,
-        createAdSlot = function(container, isSponsored, keywords) {
+        addPreBadge = function($adSlot, isSponsored, sponsor) {
+            if (sponsor) {
+                var html = bonzo.create(template(
+                    '<div class="ad-slot--paid-for-badge__inner">' +
+                        '<h3 class="ad-slot--paid-for-badge__header">{{header}}</h3>' +
+                        '<p class="ad-slot--paid-for-badge__header">{{sponsor}}</p>' +
+                    '</div>',
+                    {
+                        header: isSponsored ? 'Sponsored by:' : 'Advertisement feature',
+                        sponsor: sponsor
+                    }
+                ))[0];
+                if (!isSponsored) {
+                    $('.ad-slot--paid-for-badge__header', html).first()
+                        .after('<p class="ad-slot--paid-for-badge__label">in association with</p>')
+                }
+                $adSlot.append(html)
+            }
+        },
+        createAdSlot = function(container, isSponsored, opts) {
             if ((isSponsored && hadSponsoredBadge) || (!isSponsored && hadAdvertisementFeatureBadge)) {
                 return;
             }
-            $('.container__header', container)
-                .after(dfp.createAdSlot((isSponsored ? 'sp' : 'ad') + 'badge', ['paid-for-badge', 'paid-for-badge--front'], keywords));
+            var $adSlot = bonzo(dfp.createAdSlot(
+                (isSponsored ? 'sp' : 'ad') + 'badge', ['paid-for-badge', 'paid-for-badge--front'], opts.keywords
+            ));
             if (isSponsored) {
+                addPreBadge($adSlot, true, opts.sponsor);
                 hadSponsoredBadge = true;
             } else {
+                addPreBadge($adSlot, false, opts.sponsor);
                 hadAdvertisementFeatureBadge = true;
             }
+            $('.container__header', container)
+                .after($adSlot);
         },
         init = function() {
             $('.facia-container--sponsored, .facia-container--advertisement-feature').each(function(faciaContainer) {
+                var $faciaContainer = bonzo(faciaContainer);
                 createAdSlot(
-                    qwery('.container', faciaContainer)[0], $(faciaContainer).hasClass('facia-container--sponsored')
+                    qwery('.container', faciaContainer)[0],
+                    $faciaContainer.hasClass('facia-container--sponsored'),
+                    { sponsor: $faciaContainer.data('sponsor') }
                 );
             });
             $('.container--sponsored, .container--advertisement-feature').each(function(container) {
                 if (qwery('.ad-slot--paid-for-badge', container).length === 0) {
+                    var $container = bonzo(container);
                     createAdSlot(
-                        container, $(container).hasClass('container--sponsored'), bonzo(container).data('keywords')
+                        container,
+                        bonzo(container).hasClass('container--sponsored'),
+                        { keywords: $container.data('keywords'), sponsor: $container.data('sponsor') }
                     );
                 }
             });

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -275,6 +275,10 @@
         padding: 2px 0 $gs-baseline
     ));
 
+    // badges are always broken out, so hide the actual ad
+    iframe {
+        display: none;
+    }
     .ad-slot--paid-for-badge__inner {
         overflow: hidden;
 

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -30,6 +30,7 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
 
   override def isSponsored = DfpAgent.isSponsored(this.id)
   override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(this.id)
+  override def sponsor = DfpAgent.getSponsor(this.id)
   override lazy val hasPageSkin = DfpAgent.isPageSkinned(adUnitSuffix)
 
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -173,6 +173,7 @@ trait Tags {
 
   def isSponsored = DfpAgent.isSponsored(tags)
   def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(tags)
+  def sponsor = DfpAgent.getSponsor(tags)
 
   // Tones are all considered to be 'News' it is the default so we do not list news tones explicitly
   lazy val visualTone: String =

--- a/common/test/assets/javascripts/spec/commercial/badges.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/badges.spec.js
@@ -13,18 +13,31 @@ define([
     describe('Badges', function() {
 
         var fixtureConf = {
-            id: 'badges',
-            fixtures: [
-                '<div class="facia-container">\
-                    <div class="container">\
-                        <div class="container__header"></div>\
-                    </div>\
-                    <div class="container">\
-                        <div class="container__header"></div>\
-                    </div>\
-                </div>'
-            ]
-        };
+                id: 'badges',
+                fixtures: [
+                    '<div class="facia-container">\
+                        <div class="container">\
+                            <div class="container__header"></div>\
+                        </div>\
+                        <div class="container">\
+                            <div class="container__header"></div>\
+                        </div>\
+                    </div>'
+                ]
+            },
+            adPreBadgeHtml = function(sponsor) {
+                return '<div class="ad-slot--paid-for-badge__inner">' +
+                    '<h3 class="ad-slot--paid-for-badge__header">Advertisement feature</h3>' +
+                    '<p class="ad-slot--paid-for-badge__label">in association with</p>' +
+                    '<p class="ad-slot--paid-for-badge__header">' + sponsor + '</p>' +
+                '</div>';
+            },
+            spPreBadgeHtml = function(sponsor) {
+                return '<div class="ad-slot--paid-for-badge__inner">' +
+                    '<h3 class="ad-slot--paid-for-badge__header">Sponsored by:</h3>' +
+                    '<p class="ad-slot--paid-for-badge__header">' + sponsor + '</p>' +
+                '</div>';
+            };
 
         beforeEach(function() {
             fixtures.render(fixtureConf);
@@ -54,6 +67,17 @@ define([
                         var $adSlot = $('.facia-container .container:first-child .ad-slot').first();
                         expect($adSlot.data('name')).toBe(config.name);
                         expect($adSlot.hasClass('ad-slot--paid-for-badge--front')).toBeTruthy();
+                    });
+
+                    it('should add pre-badge if sponsor\'s name available', function() {
+                        var sponsor = 'Unilever',
+                            container = $('.facia-container').first()
+                                .addClass('facia-container--' + config.type)
+                                .attr('data-sponsor', sponsor)[0];
+                        badges.init();
+                        expect($('.ad-slot', container).html()).toBe(
+                                config.type === 'sponsored' ? spPreBadgeHtml(sponsor) : adPreBadgeHtml(sponsor)
+                        );
                     });
 
                 });
@@ -91,10 +115,31 @@ define([
                 });
             });
 
+            configs.forEach(function(config) {
+                it('should add pre-badge if sponsor\'s name available', function() {
+                    var sponsor = 'Unilever',
+                        container = $('.facia-container .container').first()
+                            .addClass('container--' + config.type)
+                            .attr('data-sponsor', sponsor)[0];
+                    badges.init();
+                    expect($('.ad-slot', container).html()).toBe(
+                        config.type === 'sponsored' ? spPreBadgeHtml(sponsor) : adPreBadgeHtml(sponsor)
+                    );
+                });
+            });
+
             it('should not add a badge if one already exists', function() {
                 $('.facia-container .container__header').first().after('<div class="ad-slot--paid-for-badge"></div>');
                 badges.init();
                 expect(qwery('.facia-container .ad-slot').length).toBe(0);
+            });
+
+            it('should add container\'s keywords to ad', function() {
+                $('.facia-container .container').first()
+                    .addClass('container--sponsored')
+                    .attr('data-keywords', 'russia,ukraine');
+                badges.init();
+                expect($('.facia-container .ad-slot').data('keywords')).toBe('russia,ukraine');
             });
 
             it('should add container\'s keywords to ad', function() {

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -29,9 +29,9 @@ case class FaciaPage(
 
   override lazy val contentType: String =   if (isNetworkFront) "Network Front" else "Section"
 
-  override def sponsor = DfpAgent.getSponsor(id)
-  override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
   override def isSponsored = DfpAgent.isSponsored(id)
+  override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
+  override def sponsor = DfpAgent.getSponsor(id)
   override lazy val hasPageSkin = DfpAgent.isPageSkinned(adUnitSuffix)
 }
 

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -29,8 +29,9 @@ case class FaciaPage(
 
   override lazy val contentType: String =   if (isNetworkFront) "Network Front" else "Section"
 
-  override def isSponsored = DfpAgent.isSponsored(id)
+  override def sponsor = DfpAgent.getSponsor(id)
   override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
+  override def isSponsored = DfpAgent.isSponsored(id)
   override lazy val hasPageSkin = DfpAgent.isPageSkinned(adUnitSuffix)
 }
 

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -7,6 +7,9 @@
             "facia-container--sponsored" -> faciaPage.isSponsored,
             "facia-container--advertisement-feature" -> (faciaPage.isAdvertisementFeature && !faciaPage.isSponsored)))"
         data-link-name="Front | @request.path"
+        @faciaPage.sponsor.map { sponsor =>
+            data-sponsor="@sponsor"
+        }
         role="main">
 
         @if(faciaPage.hasPageSkin) {


### PR DESCRIPTION
As we now have access to the sponsor's name, we can display it while the ad is actually loading - meaning if the ad call fails, the sponsor's name will still appear

![transition-3](https://cloud.githubusercontent.com/assets/74132/3482631/9571a326-0382-11e4-9801-fb15d213230a.gif)
