### PR TITLE
Do not request "Related Content" if we do not want it.

### DIFF
--- a/common/app/assets/javascripts/modules/onward/related.js
+++ b/common/app/assets/javascripts/modules/onward/related.js
@@ -66,7 +66,7 @@ define([
             }).init();
             common.mediator.emit('modules:related:loaded', config, context);
 
-        } else if (config.switches && config.switches.relatedContent) {
+        } else if (config.switches && config.switches.relatedContent && config.page.showRelatedContent) {
             container = context.querySelector('.js-related');
             if (container) {
                 var popularInTag = this.popularInTagOverride(config),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -147,6 +147,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
       ("thumbnail", thumbnailPath.getOrElse(false)),
       ("references", delegate.references.map(r => Reference(r.id))),
       ("sectionName", sectionName),
+      ("showRelatedContent", showInRelated),
       ("productionOffice", productionOffice.getOrElse(""))
     ) ++ Map(seriesMeta : _*)
   }

--- a/common/test/assets/javascripts/spec/Related.spec.js
+++ b/common/test/assets/javascripts/spec/Related.spec.js
@@ -7,7 +7,8 @@ define(['common/utils/common', 'common/utils/ajax', 'common/modules/onward/relat
         beforeEach(function() {
             ajax.init({page: {
                 ajaxUrl: "",
-                edition: "UK"
+                edition: "UK",
+                showRelatedContent: true
             }});
             callback = sinon.stub();
             common.mediator.on('modules:related:loaded', callback);
@@ -39,7 +40,7 @@ define(['common/utils/common', 'common/utils/ajax', 'common/modules/onward/relat
             runs(function() {
                 var r = new Related();
                 r.renderRelatedComponent(
-                    {page: {pageId: pageId}, switches: {relatedContent: true}},
+                    {page: {pageId: pageId, showRelatedContent: true}, switches: {relatedContent: true}},
                     document
                 );
             });
@@ -60,6 +61,29 @@ define(['common/utils/common', 'common/utils/ajax', 'common/modules/onward/relat
             runs(function() {
                 new Related(
                     {switches: {relatedContent: false}, page: {}},
+                    document
+                );
+            });
+
+            waits(500);
+
+            runs(function(){
+                expect(appendTo.innerHTML).toBe('');
+            });
+        });
+
+        it("should not request related links if we do not want related content for this article", function(){
+
+            var pageId = 'some/news';
+
+            server.respondWith('/related/' + pageId + '.json', [200, {}, '{ "html": "<b>1</b>" }']);
+
+            appendTo = document.querySelector('.js-related');
+
+            runs(function() {
+                var r = new Related();
+                r.renderRelatedComponent(
+                    {page: {pageId: pageId, showRelatedContent: false}, switches: {relatedContent: true}},
                     document
                 );
             });


### PR DESCRIPTION
Currently this results in a server side 404, which accounts for a large chunk of our 404s.

I would appreciate if someone could merge/ deploy this for me

cc @ironsidevsquincy @rich-nguyen 
