### PR TITLE
fix local nav inconsistency for mobile breakpoint

### DIFF
--- a/common/app/views/fragments/localNav.scala.html
+++ b/common/app/views/fragments/localNav.scala.html
@@ -2,9 +2,7 @@
 @import common._
 
 @Navigation.topLevelItem(Edition(request).navigation, metaData).filter(_.links.nonEmpty).map{ localNav =>
-    @defining(localNav.links.find(_.currentFor(metaData))){ currentSublink =>
-
-
+    @defining(localNav.searchForCurrentSublink(metaData)){ currentSublink =>
         <div class="localnav--small tone-@{metaData.visualTone} tone-accent-border js-visible js-localnav--small">
             <div class="localnav__inner u-cf">
                 <button class="u-button-reset localnav__cta" data-link-name="Popup Localnav" data-toggle="nav-popup--localnav">


### PR DESCRIPTION
Found (and fixed) an inconsistency we had for some time now on mobile breakpoints.
The subsection highlighting was not working properly.

URL: http://www.theguardian.com/world/2014/jun/11/egypt-president-sisi-tackle-sexual-violence

Before
![png-2](https://cloud.githubusercontent.com/assets/1492162/3497586/157c8b14-05ed-11e4-81e3-9b3cffa54c31.png)
![png](https://cloud.githubusercontent.com/assets/1492162/3497585/157a7d9c-05ed-11e4-88ac-fb7171e165bf.png)

After
![png-1](https://cloud.githubusercontent.com/assets/1492162/3497588/1956360e-05ed-11e4-9fc2-07e1a9794226.png)
