### PR TITLE
new article navigation that uses tags to highlight current local nav

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -1,11 +1,13 @@
 package common
 
-import model.{Content, Section, Tag, MetaData}
+import model.{Content, MetaData}
+import play.api.mvc.RequestHeader
+import conf.Switches._
+import dev.HttpSwitch
 
 case class SectionLink(zone: String, title: String, breadcumbTitle: String, href: String, newWindow: Boolean = false) {
   def currentFor(page: MetaData): Boolean = page.url == href ||
     s"/${page.section}" == href ||
-    page.url == href ||
     (Edition.all.exists(_.id.toLowerCase == page.id.toLowerCase) && href == "/")
 
   def currentForIncludingAllTags(page: MetaData): Boolean = page.tags.exists(t => s"/${t.id}" == href)
@@ -20,9 +22,17 @@ case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
   def currentForIncludingAllTags(page: MetaData): Boolean = name.currentForIncludingAllTags(page) ||
     links.exists(_.currentForIncludingAllTags(page))
 
-  def searchForCurrentSublink(page: MetaData): Option[SectionLink] =
-    links.find(_.currentFor(page))
+  def searchForCurrentSublink(page: MetaData)(implicit request: RequestHeader): Option[SectionLink] = {
+    lazy val oldCurrentSublink = links.find(_.currentFor(page))
       .orElse(links.find(_.currentForIncludingAllTags(page)))
+    if (HttpSwitch(NewNavigationHighlightingSwitch).isSwitchedOn) {
+      val localHrefs = links.map(_.href)
+      val currentHref = page.tags.find(tag => localHrefs.contains(tag.url)).map(_.url).getOrElse("")
+      links.find(_.href == currentHref)
+        .orElse(oldCurrentSublink)
+    }
+    else oldCurrentSublink
+  }
 
   def exactFor(page: MetaData): Boolean = page.section == name.href.dropWhile(_ == '/') || page.url == name.href
 }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -310,6 +310,11 @@ object Switches extends Collections {
     safeState = Off, sellByDate = new DateMidnight(2014, 9, 1)
   )
 
+  val NewNavigationHighlightingSwitch = Switch("Feature Switches", "nav-highlight",
+    "When this switch is on, navigation highlighting will become more relevant as they will be based on tags.",
+    safeState = Off, sellByDate = new DateMidnight(2014, 9, 1)
+  )
+
   // A/B Tests
 
   // Dummy Switches
@@ -486,6 +491,7 @@ object Switches extends Collections {
     IncludeBuildNumberInMemcachedKey,
     GeoMostPopular,
     ResponsiveNavSwitch,
+    NewNavigationHighlightingSwitch,
     SmartBannerSwitch,
     ParameterlessImagesSwitch,
     SeoOptimisedContentImageSwitch,
@@ -497,7 +503,8 @@ object Switches extends Collections {
   )
 
   val httpSwitches: List[Switch] = List(
-    ResponsiveNavSwitch
+    ResponsiveNavSwitch,
+    NewNavigationHighlightingSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }


### PR DESCRIPTION
Make local nav highlighting more relevant by taking article tags into consideration.
This change is hidden behind 'nav-highlight' http switch until it's fully validated.

Before - wrong local nav section highlighted 
![png](https://cloud.githubusercontent.com/assets/1492162/3510849/6f03f15a-06aa-11e4-98de-0b86bbc65d32.png)

Article tags
![png-2](https://cloud.githubusercontent.com/assets/1492162/3510852/730ac6de-06aa-11e4-987d-ebd96d7cda68.png)

After - closest match to current context
![png-1](https://cloud.githubusercontent.com/assets/1492162/3510874/9b043738-06aa-11e4-805c-edc53fa34ab4.png)
