### PR TITLE
Forwarding the IP address to the ID API on registration/signin

### DIFF
--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -56,7 +56,7 @@ class SigninController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
     def onSuccess(form: (String, String, Boolean)): Future[SimpleResult] = form match {
       case (email, password, rememberMe) =>
         logger.trace("authing with ID API")
-        val authResponse = api.authBrowser(EmailPassword(email, password), idRequest.trackingData)
+        val authResponse = api.authBrowser(EmailPassword(email, password, idRequest.clientIp), idRequest.trackingData)
         signInService.getCookies(authResponse, rememberMe) map {
           case Left(errors) =>
             logger.error(errors.toString())

--- a/identity/app/idapiclient/Auth.scala
+++ b/identity/app/idapiclient/Auth.scala
@@ -3,9 +3,11 @@ package idapiclient
 import client.{Auth, Parameters}
 import java.net.URLEncoder
 
-
-case class EmailPassword(email: String, password: String) extends Auth {
-  override def parameters: Parameters = List(("email", email), ("password", password))
+case class EmailPassword(email: String, password: String, ipOpt: Option[String]) extends Auth {
+  override def parameters: Parameters = List(
+    "email" -> email,
+    "password" -> password
+  ) ++ (ipOpt map { "ip" -> _ })
 }
 
 case class UserToken(userAccessToken: String) extends Auth {

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -66,12 +66,11 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
       val email = "test@example.com"
       val username = "username"
       val password = "password"
-      val auth = EmailPassword(email, password)
       val fakeRequest = FakeRequest(POST, "/register")
         .withFormUrlEncodedBody("user.primaryEmailAddress" -> email, "user.publicFields.username" -> username, "user.password" -> password )
         .withHeaders("X-Forwarded-For" -> xForwardedFor)
       when(api.register(Matchers.same(user), Matchers.same(trackingData))).thenReturn(Future.successful(Right(createdUser)))
-      when(api.authBrowser(EmailPassword(email, password), trackingData)).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("testCookie", "testVal"), CookieResponse("SC_testCookie", "secureVal"))))))
+      when(api.authBrowser(EmailPassword(email, password, identityRequest.clientIp), trackingData)).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("testCookie", "testVal"), CookieResponse("SC_testCookie", "secureVal"))))))
       when(returnUrlVerifier.getVerifiedReturnUrl(fakeRequest)).thenReturn(Some("http://example.com/return"))
 
       "should create the user with the username, email and password required" in Fake {
@@ -152,7 +151,7 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
 
       when(api.register(Matchers.same(user), Matchers.same(trackingData)))
         .thenReturn(Future.successful(Right(createdUser)))
-      when(api.authBrowser(EmailPassword(email, password), trackingData)).thenReturn(Future.successful(Left(errors)))
+      when(api.authBrowser(EmailPassword(email, password, identityRequest.clientIp), trackingData)).thenReturn(Future.successful(Left(errors)))
       when(returnUrlVerifier.getVerifiedReturnUrl(fakeRequest)).thenReturn(Some("http://example.com/return"))
       when(returnUrlVerifier.getVerifiedReturnUrl(fakeRequest)).thenReturn(Some("http://example.com/return"))
 

--- a/identity/test/controllers/SigninControllerTest.scala
+++ b/identity/test/controllers/SigninControllerTest.scala
@@ -60,8 +60,7 @@ class SigninControllerTest extends path.FreeSpec with ShouldMatchers with Mockit
 
     "with valid API response" - {
       val fakeRequest = FakeRequest(POST, "/signin").withFormUrlEncodedBody("email" -> "test@example.com", "password" -> "testpassword")
-      val auth = EmailPassword("test@example.com", "testpassword")
-      val clientAuth = ClientAuth("frontend-dev-client-token")
+      val auth = EmailPassword("test@example.com", "testpassword", identityRequest.clientIp)
 
       "if api call succeeds" - {
         when(api.authBrowser(any[Auth], same(trackingData))).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("testCookie", "testVal"), CookieResponse("SC_testCookie", "secureVal"))))))


### PR DESCRIPTION
IDN-1814 - The Signin and Registration controllers should now correctly forward the users IP address to the ID API instead of giving the IP of the AWS instance.
