### PR TITLE
Revert "Distinguish liveblogs from articles."

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -403,8 +403,6 @@ class LiveBlog(content: ApiContentWithMeta) extends Article(content) {
   private lazy val soupedBody = Jsoup.parseBodyFragment(body).body()
   lazy val hasKeyEvents: Boolean = soupedBody.select(".is-key-event").nonEmpty
   lazy val isSport: Boolean = tags.exists(_.id == "sport/sport")
-  override lazy val contentType = "LiveBlog"
-
   override def cards: List[(String, Any)] = super.cards ++ List(
     "twitter:card" -> "summary"
   )


### PR DESCRIPTION
Reverting this commit as it had an unintentional knock-on effect of disabling article bootstrap and various other js modules that rely on the contentType value that gets passed through to the js environment
