### PR TITLE
nav restructure

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -76,7 +76,8 @@ trait Navigation {
   val golf = SectionLink("sport", "golf", "Golf", "/sport/golf")
   val horseracing = SectionLink("sport", "horse racing", "Horse racing", "/sport/horse-racing")
   val boxing = SectionLink("sport", "boxing", "Boxing", "/sport/boxing")
-  val formulaOne = SectionLink("sport", "formula one", "Formula one", "/sport/formulaone")
+  val formulaOne = SectionLink("sport", "F1", "Formula one", "/sport/formulaone")
+  val racing = SectionLink("sport", "racing", "Racing", "/sport/racing")
 
   val nfl = SectionLink("sport", "NFL", "NFL", "/sport/nfl")
   val mlb = SectionLink("sport", "MLB", "MLB", "/sport/mlb")
@@ -101,6 +102,7 @@ trait Navigation {
   val music = SectionLink("culture", "music", "Music", "/music")
   val stage = SectionLink("culture", "stage", "Stage", "/stage")
   val televisionAndRadio = SectionLink("culture", "tv & radio", "TV & radio", "/tv-and-radio")
+  val classical = SectionLink("culture", "classical", "Classical", "/music/classicalmusicandopera")
 
   //Technology
   val technologyblog = SectionLink("technology", "technology blog", "Technology blog", "/technology/blog")

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -9,7 +9,8 @@ import common.NavItem
 //This object exists to be used with ItemTrailblockDescription and is not a real edition like the others.
 //All that is really being used is Edition.id, which is AU
 //It is not included in the Edition.all sequence
-object Au extends Edition(id = "AU", displayName = "Australia edition", DateTimeZone.forID("Australia/Sydney")) with Zones with QueryDefaults {
+object Au extends Edition(id = "AU", displayName = "Australia edition", DateTimeZone.forID("Australia/Sydney"))
+  with Zones with QueryDefaults {
 
   implicit val AU = Au
 

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -1,7 +1,6 @@
 package common.editions
 
 import org.joda.time.DateTimeZone
-import model._
 import common._
 import contentapi.QueryDefaults
 import common.NavItem
@@ -10,11 +9,7 @@ import common.NavItem
 //This object exists to be used with ItemTrailblockDescription and is not a real edition like the others.
 //All that is really being used is Edition.id, which is AU
 //It is not included in the Edition.all sequence
-object Au extends Edition(
-  id = "AU",
-  displayName = "Australia edition",
-  DateTimeZone.forID("Australia/Sydney")
-  ) with Zones with QueryDefaults {
+object Au extends Edition(id = "AU", displayName = "Australia edition", DateTimeZone.forID("Australia/Sydney")) with Zones with QueryDefaults {
 
   implicit val AU = Au
 
@@ -38,12 +33,13 @@ object Au extends Edition(
     NavItem(sport, Seq(australiaSport, football, cricket, rugbyunion, rugbyLeague , tennis, cycling, boxing, afl, nrl)),
     NavItem(football, aLeague :: footballNav.toList),
     NavItem(technology, Seq(games)),
-    NavItem(culture, Seq(film, music, books, televisionAndRadio , artanddesign, stage)),
+    NavItem(culture, Seq(film, music, books, televisionAndRadio , artanddesign, stage, classical)),
     NavItem(lifeandstyle, Seq(foodanddrink, healthandwellbeing, loveAndSex, family, women, fashion)),
-    NavItem(economy, Seq(markets, companies, money, media)),
+    NavItem(economy, Seq(markets, companies, money)),
     NavItem(travel, Seq(australasiaTravel, asiaTravel, uktravel, europetravel, usTravel)),
     NavItem(science),
     NavItem(environment, Seq(cities, globalDevelopment)),
-    NavItem(education, Seq(students))
+    NavItem(education, Seq(students)),
+    NavItem(media)
   )
 }

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -4,7 +4,8 @@ import common._
 import org.joda.time.DateTimeZone
 
 
-object Uk extends Edition(id = "UK", displayName = "UK edition", timezone = DateTimeZone.forID("Europe/London")) with Zones {
+object Uk extends Edition(id = "UK", displayName = "UK edition", timezone = DateTimeZone.forID("Europe/London"))
+  with Zones {
 
   implicit val UK = Uk
   val zones = Seq(

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -29,11 +29,11 @@ object Uk extends Edition(id = "UK", displayName = "UK edition", timezone = Date
     NavItem(culture, Seq(film, televisionAndRadio, music, books, artanddesign, stage, classical)),
     NavItem(economy, Seq(markets, companies)),
     NavItem(lifeandstyle, Seq(foodanddrink, healthandwellbeing, loveAndSex, family, women, homeAndGarden)),
+    NavItem(fashion),
     NavItem(environment, Seq(cities, globalDevelopment)),
     NavItem(technology, Seq(games)),
     NavItem(money, Seq(property, savings, borrowing, careers)),
     NavItem(travel, Seq(uktravel, europetravel, usTravel)),
-    NavItem(fashion),
     NavItem(media)
   )
 }

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -2,14 +2,9 @@ package common.editions
 
 import common._
 import org.joda.time.DateTimeZone
-import model.MetaData
 
 
-object Uk extends Edition(
-  id = "UK",
-  displayName = "UK edition",
-  timezone = DateTimeZone.forID("Europe/London")
-  ) with Zones {
+object Uk extends Edition(id = "UK", displayName = "UK edition", timezone = DateTimeZone.forID("Europe/London")) with Zones {
 
   implicit val UK = Uk
   val zones = Seq(
@@ -28,18 +23,17 @@ object Uk extends Edition(
     NavItem(home),
     NavItem(uk),
     NavItem(world, Seq(europeNews, us, americas, asia, australia, africa, middleEast)),
-    NavItem(sport, Seq(football, worldCup, rugbyunion, rugbyLeague, cricket, tennis, cycling, boxing, usSport, formulaOne)),
+    NavItem(sport, Seq(football, worldCup, rugbyunion, rugbyLeague, cricket, tennis, cycling, boxing, usSport, formulaOne, racing)),
     NavItem(football, footballNav),
     NavItem(cif),
-    NavItem(culture, Seq(film, televisionAndRadio, music, books, artanddesign, stage)),
-    NavItem(economy, Seq(markets, companies, media)),
+    NavItem(culture, Seq(film, televisionAndRadio, music, books, artanddesign, stage, classical)),
+    NavItem(economy, Seq(markets, companies)),
     NavItem(lifeandstyle, Seq(foodanddrink, healthandwellbeing, loveAndSex, family, women, homeAndGarden)),
     NavItem(environment, Seq(cities, globalDevelopment)),
     NavItem(technology, Seq(games)),
     NavItem(money, Seq(property, savings, borrowing, careers)),
     NavItem(travel, Seq(uktravel, europetravel, usTravel)),
     NavItem(fashion),
-    NavItem(science),
-    NavItem(education, Seq(students))
+    NavItem(media)
   )
 }

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -2,15 +2,10 @@ package common.editions
 
 import common._
 import org.joda.time.DateTimeZone
-import model.MetaData
 import contentapi.QueryDefaults
 import common.NavItem
 
-object Us extends Edition(
-  id = "US",
-  displayName = "US edition",
-  timezone = DateTimeZone.forID("America/New_York")
-  ) with Zones with QueryDefaults {
+object Us extends Edition(id = "US", displayName = "US edition", timezone = DateTimeZone.forID("America/New_York")) with Zones with QueryDefaults {
 
   implicit val US = Us
   val zones = Seq(
@@ -33,13 +28,13 @@ object Us extends Edition(
     NavItem(sports, Seq(soccer, mls, nfl, mlb, nba, nhl)),
     NavItem(soccer, footballNav),
     NavItem(technology, Seq(games)),
-    NavItem(culture, Seq(movies, televisionAndRadio, music, books, artanddesign, stage)),
+    NavItem(culture, Seq(movies, televisionAndRadio, music, books, artanddesign, stage, classical)),
     NavItem(lifeandstyle, Seq(foodanddrink, healthandwellbeing, loveAndSex, family, women, homeAndGarden)),
     NavItem(fashion),
-    NavItem(business, Seq(markets, companies, media)),
+    NavItem(business, Seq(markets, companies)),
     NavItem(money),
     NavItem(travel, Seq(usaTravel, europetravel, uktravel)),
     NavItem(environment, Seq(globalDevelopment, cities)),
-    NavItem(science)
+    NavItem(media)
   )
 }

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -5,7 +5,8 @@ import org.joda.time.DateTimeZone
 import contentapi.QueryDefaults
 import common.NavItem
 
-object Us extends Edition(id = "US", displayName = "US edition", timezone = DateTimeZone.forID("America/New_York")) with Zones with QueryDefaults {
+object Us extends Edition(id = "US", displayName = "US edition", timezone = DateTimeZone.forID("America/New_York"))
+  with Zones with QueryDefaults {
 
   implicit val US = Us
   val zones = Seq(


### PR DESCRIPTION
UK top nav:
Remove Science and Education
Move Fashion to after Life

US top nav:
Remove Science

All editions:
Remove 'media' from secondary economy nav

UK sport:
Change Formula 1 to F1 in secondary nav
Add Racing (http://www.theguardian.com/sport/racing) to Secondary nav last

Culture, all editions
Add 'Classical' (http://www.theguardian.com/music/classicalmusicandopera) to secondary nav

All editions:
Add 'Media' as a main section in Meganav
