### PR TITLE
Use Start and End Dates to Determine Current Pageskin Ads

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -63,10 +63,12 @@ object DfpDataCacheJob extends ExecutionContexts with Dates{
 
   private implicit val lineItemWrites = new Writes[GuLineItem] {
     def writes(lineItem: GuLineItem ): JsValue = {
+      val timePattern = DateTimeFormat.forPattern("dd-MMM-YYYY HH:mm z")
       Json.obj(
         "id" -> lineItem.id,
         "name" -> lineItem.name,
-        "startTime" -> DateTimeFormat.forPattern("dd-MMM-YYYY HH:mm z").print(lineItem.startTime),
+        "startTime" -> timePattern.print(lineItem.startTime),
+        "endTime" -> lineItem.endTime.map(endTime => timePattern.print(endTime)),
         "isPageSkin" -> lineItem.isPageSkin,
         "sponsor" -> lineItem.sponsor,
         "targeting" -> lineItem.targeting

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -3,6 +3,7 @@ package dfp
 import common.ExecutionContexts
 import implicits.Dates
 import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
 import play.api.libs.json.Json.{toJson, _}
 import play.api.libs.json.{JsValue, Json, Writes}
 import tools.Store
@@ -65,6 +66,7 @@ object DfpDataCacheJob extends ExecutionContexts with Dates{
       Json.obj(
         "id" -> lineItem.id,
         "name" -> lineItem.name,
+        "startTime" -> DateTimeFormat.forPattern("dd-MMM-YYYY HH:mm z").print(lineItem.startTime),
         "isPageSkin" -> lineItem.isPageSkin,
         "sponsor" -> lineItem.sponsor,
         "targeting" -> lineItem.targeting

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -5,19 +5,25 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
   val isValid = lineItems.nonEmpty
 
   val sponsorships: Seq[Sponsorship] = {
-    lineItems.withFilter(_.sponsoredTags.nonEmpty).map { lineItem =>
+    lineItems.withFilter { lineItem =>
+      lineItem.sponsoredTags.nonEmpty && lineItem.isCurrent
+    }.map { lineItem =>
       Sponsorship(lineItem.sponsoredTags, lineItem.sponsor)
     }.distinct
   }
 
   val advertisementFeatureSponsorships: Seq[Sponsorship] = {
-    lineItems.withFilter(_.advertisementFeatureTags.nonEmpty).map { lineItem =>
+    lineItems.withFilter { lineItem =>
+      lineItem.advertisementFeatureTags.nonEmpty && lineItem.isCurrent
+    }.map { lineItem =>
       Sponsorship(lineItem.advertisementFeatureTags, lineItem.sponsor)
     }.distinct
   }
 
   val pageSkinSponsorships: Seq[PageSkinSponsorship] = {
-    lineItems withFilter (_.isPageSkin) map { lineItem =>
+    lineItems withFilter { lineItem =>
+      lineItem.isPageSkin && lineItem.isCurrent
+    } map { lineItem =>
       val paths = lineItem.targeting.adUnits map { adUnit =>
         adUnit.path mkString "/"
       }

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -7,6 +7,7 @@ import com.google.api.ads.dfp.axis.v201403._
 import com.google.api.ads.dfp.lib.client.DfpSession
 import common.Logging
 import conf.{AdminConfiguration, Configuration}
+import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 
 object DfpDataHydrator extends Logging {
 
@@ -93,6 +94,7 @@ object DfpDataHydrator extends Logging {
         GuLineItem(
           dfpLineItem.getId,
           dfpLineItem.getName,
+          toJodaTime(dfpLineItem.getStartDateTime),
           isPageSkin(dfpLineItem),
           sponsor,
           GuTargeting(adUnits, geoTargets, customTargetSets)
@@ -186,6 +188,16 @@ object DfpDataHydrator extends Logging {
     customCriteriaSet.getChildren.flatMap { critSet =>
       buildTargetSet(critSet.asInstanceOf[CustomCriteriaSet])
     }.toSeq
+  }
+
+  private def toJodaTime(time: DateTime): JodaDateTime = {
+    val date = time.getDate
+    new JodaDateTime(date.getYear,
+      date.getMonth,
+      date.getDay,
+      time.getHour,
+      time.getMinute,
+      DateTimeZone.forID(time.getTimeZoneID))
   }
 
   private def optJavaInt(i: java.lang.Integer): Option[Int] = if (i == null) None else Some(i)

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -92,12 +92,13 @@ object DfpDataHydrator extends Logging {
         } getOrElse Nil
 
         GuLineItem(
-          dfpLineItem.getId,
-          dfpLineItem.getName,
-          toJodaTime(dfpLineItem.getStartDateTime),
-          isPageSkin(dfpLineItem),
-          sponsor,
-          GuTargeting(adUnits, geoTargets, customTargetSets)
+          id = dfpLineItem.getId,
+          name = dfpLineItem.getName,
+          startTime = toJodaTime(dfpLineItem.getStartDateTime),
+          endTime = if (dfpLineItem.getUnlimitedEndDateTime) None else Some(toJodaTime(dfpLineItem.getEndDateTime)),
+          isPageSkin = isPageSkin(dfpLineItem),
+          sponsor = sponsor,
+          targeting = GuTargeting(adUnits, geoTargets, customTargetSets)
         )
       }
 

--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -16,7 +16,7 @@
     <ol>
         @for(sponsorship <- pageSkinnedAdUnits.sponsorships) {
             <li style="margin: 20px">@sponsorship.lineItemName (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
-            @if(sponsorship.countries.nonEmpty){<br />Editions: @for(country <- sponsorship.countries){@{country.editionId}<span style="font-size:75%"> [deduced from country: @{country.name}]</span>}}
+            @if(sponsorship.countries.nonEmpty){<br />Editions: @for(country <- sponsorship.countries){@{country.editionId}<span style="font-size:75%">&nbsp;&nbsp;&nbsp;[deduced from country: @{country.name}]</span>}}
             <br />Ad Units:
             <ul>
             @for(adUnit <- sponsorship.adUnits) {

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -46,6 +46,8 @@ case class GuLineItem(id: Long,
                       sponsor: Option[String],
                       targeting: GuTargeting) {
 
+  val isCurrent = startTime.isBeforeNow && (endTime.isEmpty || endTime.exists(_.isAfterNow))
+
   val sponsoredTags: Seq[String] = targeting.customTargetSets.flatMap(_.sponsoredTags).distinct
 
   val advertisementFeatureTags: Seq[String] = targeting.customTargetSets.flatMap(_.advertisementFeatureTags).distinct

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -41,6 +41,7 @@ case class GuTargeting(adUnits: Seq[GuAdUnit], geoTargets: Seq[GeoTarget], custo
 case class GuLineItem(id: Long,
                       name: String,
                       startTime: DateTime,
+                      endTime: Option[DateTime],
                       isPageSkin: Boolean,
                       sponsor: Option[String],
                       targeting: GuTargeting) {

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -1,5 +1,7 @@
 package dfp
 
+import org.joda.time.DateTime
+
 case class CustomTarget(name: String, op: String, values: Seq[String]) {
 
   def isPositive(targetName: String) = name == targetName && op == "IS"
@@ -36,7 +38,12 @@ case class GuAdUnit(id: String, path: Seq[String])
 case class GuTargeting(adUnits: Seq[GuAdUnit], geoTargets: Seq[GeoTarget], customTargetSets: Seq[CustomTargetSet])
 
 
-case class GuLineItem(id: Long, name: String, isPageSkin: Boolean, sponsor: Option[String], targeting: GuTargeting) {
+case class GuLineItem(id: Long,
+                      name: String,
+                      startTime: DateTime,
+                      isPageSkin: Boolean,
+                      sponsor: Option[String],
+                      targeting: GuTargeting) {
 
   val sponsoredTags: Seq[String] = targeting.customTargetSets.flatMap(_.sponsoredTags).distinct
 


### PR DESCRIPTION
Whether to include pageskin and sponsor logo slots in page should take into account start and end dates of associated line items.
