### PR TITLE
Expose Name of Sponsor of a Container

### DIFF
--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -18,7 +18,7 @@ trait DfpAgent {
   protected def advertisementFeatureSponsorships: Seq[Sponsorship]
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship]
 
-  private def containerSponsoredTags(config: Config, p: String => Boolean): Option[String] = {
+  private def containerSponsoredTag(config: Config, p: String => Boolean): Option[String] = {
     config.contentApiQuery.flatMap { encodedQuery =>
       val query = URLDecoder.decode(encodedQuery, "utf-8")
       val tokens = query.split( """\?|&|=|\(|\)|\||\,""").map(_.replaceFirst(".*/", ""))
@@ -27,7 +27,7 @@ trait DfpAgent {
   }
 
   private def isSponsoredContainer(config: Config, p: String => Boolean): Boolean = {
-    containerSponsoredTags(config, p).isDefined
+    containerSponsoredTag(config, p).isDefined
   }
 
   private def getPrimaryKeywordOrSeriesTag(tags: Seq[Tag]): Option[Tag] = tags find { tag =>
@@ -58,7 +58,7 @@ trait DfpAgent {
   }
 
   def sponsorshipTag(config: Config): Option[String] = {
-    containerSponsoredTags(config, isSponsored) orElse containerSponsoredTags(config, isAdvertisementFeature)
+    containerSponsoredTag(config, isSponsored) orElse containerSponsoredTag(config, isAdvertisementFeature)
   }
 
   def getSponsor(tags: Seq[Tag]): Option[String] = getPrimaryKeywordOrSeriesTag(tags) flatMap (tag => getSponsor(tag.id))
@@ -66,6 +66,13 @@ trait DfpAgent {
   def getSponsor(tagId: String): Option[String] = {
     def sponsorOf(sponsorships: Seq[Sponsorship]) = sponsorships.find(_.hasTag(tagId)).flatMap(_.sponsor)
     sponsorOf(sponsorships) orElse sponsorOf(advertisementFeatureSponsorships)
+  }
+
+  def getSponsor(config: Config): Option[String] = {
+    for {
+      tagId <- sponsorshipTag(config)
+      sponsor <- getSponsor(tagId)
+    } yield sponsor
   }
 }
 

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -13,7 +13,8 @@ class DfpAgentTest extends FlatSpec with Matchers {
 
     override protected def sponsorships: Seq[Sponsorship] = Seq(
       Sponsorship(Seq("spon-page"), Some("spon")),
-      Sponsorship(Seq("media"), None)
+      Sponsorship(Seq("media"), None),
+      Sponsorship(Seq("healthyliving"), Some("Squeegee"))
     )
 
     override protected def advertisementFeatureSponsorships: Seq[Sponsorship] = Seq(
@@ -200,6 +201,22 @@ class DfpAgentTest extends FlatSpec with Matchers {
 
   "getSponsor" should "have no value for an unsponsored tag" in {
     testDfpAgent.getSponsor("culture") should be(None)
+  }
+
+  "getSponsor" should "have some value for a sponsored container" in {
+    val containerQuery = apiQuery(
+      "search?tag=books/series/toptens|music/series/album-streams|music/series/new-music-from-around-the-world|music" +
+        "/series/10-of-the-best|culture/series/the-10-best|books/series/the-100-best-novels|artanddesign/series" +
+        "/exhibitionist|section7/healthyliving|stage/series/this-week-new-theatre")
+    testDfpAgent.getSponsor(containerQuery) should be(Some("Squeegee"))
+  }
+
+  "getSponsor" should "have no value for an unsponsored container" in {
+    val containerQuery = apiQuery(
+      "search?tag=books/series/toptens|music/series/album-streams|music/series/new-music-from-around-the-world|music" +
+        "/series/10-of-the-best|culture/series/the-10-best|books/series/the-100-best-novels|artanddesign/series" +
+        "/exhibitionist|stage/series/this-week-new-theatre")
+    testDfpAgent.getSponsor(containerQuery) should be(None)
   }
 
   "isPageSkinned" should "be true for a front with a pageskin in given edition" in {


### PR DESCRIPTION
This is so that we can show the name of the sponsor of a container before their logo appears.

/cc @ironsidevsquincy 
