### PR TITLE
Revert "Add require plugin for raven"

### DIFF
--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -145,12 +145,6 @@
                 }
             ).install();
 
-            @* see https://github.com/getsentry/raven-js/blob/master/plugins/require.js *@
-            if (typeof define === 'function' && define.amd) {
-                define = raven.wrap({deep: false}, define);
-                require = raven.wrap({deep: false}, require);
-            }
-
             if (guardian.config.switches.commercial) {
 
                 require(['bootstraps/commercial', 'js!googletag'], function(commercial) {


### PR DESCRIPTION
Reverts guardian/frontend#5040

Breaking interactives, for some reason. Not 100% sure we need it, so reverting
