### PR TITLE
properly escape values in the js head

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -153,7 +153,7 @@ object RemoveOuterParaHtml {
 object JavaScriptValue {
   def apply(value: Any) = value match {
     case b: Boolean => b
-    case s => s""""${s.toString.trim.replace(""""""", """\"""")}""""
+    case s => s""""${StringEscapeUtils.escapeJavaScript(s.toString.trim)}""""
   }
 }
 


### PR DESCRIPTION
had another case similar to #4944 where newlines were breaking js. properly escaping them now.
