### PR TITLE
Use default ivy cache on team city

### DIFF
--- a/sbt-tc
+++ b/sbt-tc
@@ -15,12 +15,7 @@ if [ -n "$BUILD_NUMBER" ]; then
 fi 
 if [ -n "$BUILD_VCS_NUMBER" ]; then
   BUILD_PARAMS="${BUILD_PARAMS} -Dbuild.vcs.number=\"$BUILD_VCS_NUMBER\""
-fi 
-
-# Ivy configuration
-echo "setting ivy cache dir"
-IVY_PARAMS="-Dsbt.ivy.home=.ivy -Divy.home=.ivy"
-echo $IVY_PARAMS
+fi
 
 DOMAIN=`hostname -d`
 
@@ -44,5 +39,4 @@ cat /dev/null | /usr/lib/jvm/java-1.7.0/bin/java -Xmx4096M -XX:MaxPermSize=2048m
   -DAPP_SECRET=$fake_secret \
   -Duser.timezone=Australia/Sydney \
   $BUILD_PARAMS \
-  $IVY_PARAMS \
   -jar `dirname $0`/dev/sbt-launch.jar "$@"


### PR DESCRIPTION
I wonder if this will help reduce disk usage and our clean-build time.
