### PR TITLE
fix fronts links and remove redundant redirects

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -25,7 +25,7 @@ trait LinkTo extends Logging {
   def apply(link: String)(implicit request: RequestHeader): String = this(link, Edition(request), Region(request))
 
   def apply(url: String, edition: Edition, region: Option[Region] = None)(implicit request : RequestHeader): String =
-    (HttpSwitch.queryString(url) match {
+    HttpSwitch.queryString(url match {
       case "http://www.theguardian.com" => homeLink(edition, region)
       case "/" => homeLink(edition, region)
       case protocolRelative if protocolRelative.startsWith("//") => protocolRelative


### PR DESCRIPTION
For some front links, URL rewrite is dependent on edition and did not work properly.
i.e Sport front has <code>/sport</code> link but gets rewritten to <code>/uk/sport</code> (for UK edition).
This failed to happen when http switches were present. Current change fixes that.
