### PR TITLE
Use London Time in Jobs Feed URL

### DIFF
--- a/commercial/app/model/commercial/jobs/JobsApi.scala
+++ b/commercial/app/model/commercial/jobs/JobsApi.scala
@@ -3,7 +3,7 @@ package model.commercial.jobs
 import conf.{CommercialConfiguration, Switches}
 import model.commercial.{OptString, XmlAdsApi}
 import org.apache.commons.lang.StringEscapeUtils.unescapeHtml
-import org.joda.time.format.DateTimeFormat
+import org.joda.time._
 
 import scala.xml.Elem
 
@@ -17,7 +17,7 @@ object JobsApi extends XmlAdsApi[Job] {
 
   // url changes daily so cannot be val
   protected def url = {
-    val feedDate = DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC().print(System.currentTimeMillis)
+    val feedDate = new LocalDateTime(DateTimeZone.forID("Europe/London")).toString("yyyy-MM-dd")
     val urlTemplate = CommercialConfiguration.getProperty("jobs.api.url.template")
     urlTemplate map (_ replace("yyyy-MM-dd", feedDate))
   }

--- a/commercial/app/model/commercial/jobs/JobsApi.scala
+++ b/commercial/app/model/commercial/jobs/JobsApi.scala
@@ -17,7 +17,13 @@ object JobsApi extends XmlAdsApi[Job] {
 
   // url changes daily so cannot be val
   protected def url = {
+
+    /*
+     * Using London time because this appears to be how the URL is constructed.
+     * With UTC time we lose the feed for an hour at midnight every day.
+     */
     val feedDate = new LocalDateTime(DateTimeZone.forID("Europe/London")).toString("yyyy-MM-dd")
+
     val urlTemplate = CommercialConfiguration.getProperty("jobs.api.url.template")
     urlTemplate map (_ replace("yyyy-MM-dd", feedDate))
   }


### PR DESCRIPTION
If we use UTC time we don't get any feed for an hour at midnight.
