### PR TITLE
Add press time metrics

### DIFF
--- a/common/app/common/SQSQueues.scala
+++ b/common/app/common/SQSQueues.scala
@@ -4,11 +4,12 @@ import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.model._
 import com.amazonaws.regions.{Region => AwsRegion}
+import org.joda.time.DateTime
 import play.api.libs.json.{Writes, Json, Reads}
 import java.util.concurrent.{Future => JavaFuture}
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success}
+import scala.util.{Try, Failure, Success}
 
 object SQSQueues {
   implicit class RichAmazonSQSAsyncClient(client: AmazonSQSAsyncClient) {
@@ -48,7 +49,7 @@ object SQSQueues {
 
 case class MessageId(get: String) extends AnyVal
 case class ReceiptHandle(get: String) extends AnyVal
-case class Message[A](id: MessageId, get: A, handle: ReceiptHandle)
+case class Message[A](id: MessageId, get: A, handle: ReceiptHandle, sentAt: Option[DateTime])
 
 /** Utility class for SQS queues that use JSON to serialize their messages */
 case class JsonMessageQueue[A](client: AmazonSQSAsyncClient, queueUrl: String)
@@ -57,14 +58,21 @@ case class JsonMessageQueue[A](client: AmazonSQSAsyncClient, queueUrl: String)
   import scala.collection.JavaConverters._
 
   def receive(request: ReceiveMessageRequest)(implicit reads: Reads[A]): Future[Seq[Message[A]]] =
-    client.receiveMessageFuture(request.withQueueUrl(queueUrl)) map { response =>
+    client.receiveMessageFuture(
+      request.withQueueUrl(queueUrl).withAttributeNames("SentTimestamp")
+    ) map { response =>
       response.getMessages.asScala.toSeq map { message =>
         Message(
           MessageId(message.getMessageId),
           Json.fromJson[A](Json.parse(message.getBody)) getOrElse {
             throw new RuntimeException(s"Couldn't parse JSON for message with ID ${message.getMessageId}")
           },
-          ReceiptHandle(message.getReceiptHandle)
+          ReceiptHandle(message.getReceiptHandle),
+          message.getAttributes.asScala.get("SentTimestamp") flatMap { timeStampString =>
+            Try {
+              new DateTime(timeStampString.toLong)
+            }.toOption
+          }
         )
     }
   }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -358,6 +358,20 @@ object FaciaPressMetrics {
     "Time from press command for UK front being queued to being processed"
   )
 
+  object UsFrontPressLatency extends FrontendTimingMetric(
+    "facia-front-press",
+    "us-network-front-press-latency",
+    "US Network Front Press Latency",
+    "Time from press command for US front being queued to being processed"
+  )
+
+  object AuFrontPressLatency extends FrontendTimingMetric(
+    "facia-front-press",
+    "au-network-front-press-latency",
+    "AU Network Front Press Latency",
+    "Time from press command for AU front being queued to being processed"
+  )
+
   val all: Seq[Metric] = Seq(
     FrontPressSuccess,
     FrontPressLiveSuccess,
@@ -371,7 +385,9 @@ object FaciaPressMetrics {
     ContentApiSeoRequestSuccess,
     ContentApiSeoRequestFailure,
     FrontPressLatency,
-    UkFrontPressLatency
+    UkFrontPressLatency,
+    UsFrontPressLatency,
+    AuFrontPressLatency
   )
 }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -344,6 +344,20 @@ object FaciaPressMetrics {
     "Number of times facia-tool has failed to made the request for SEO purposes of webTitle and section"
   )
 
+  object FrontPressLatency extends FrontendTimingMetric(
+    "facia-front-press",
+    "front-press-latency",
+    "Front Press Latency",
+    "Time from press command being queued to being processed"
+  )
+
+  object UkFrontPressLatency extends FrontendTimingMetric(
+    "facia-front-press",
+    "uk-network-front-press-latency",
+    "UK Network Front Press Latency",
+    "Time from press command for UK front being queued to being processed"
+  )
+
   val all: Seq[Metric] = Seq(
     FrontPressSuccess,
     FrontPressLiveSuccess,
@@ -355,7 +369,9 @@ object FaciaPressMetrics {
     FrontPressCronFailure,
     MemcachedFallbackMetric,
     ContentApiSeoRequestSuccess,
-    ContentApiSeoRequestFailure
+    ContentApiSeoRequestFailure,
+    FrontPressLatency,
+    UkFrontPressLatency
   )
 }
 

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -35,7 +35,9 @@ object Global extends GlobalSettings
     ("s3-client-exceptions", S3Metrics.S3ClientExceptionsMetric.getAndReset.toDouble),
     ("content-api-seo-request-success", FaciaPressMetrics.ContentApiSeoRequestSuccess.getAndReset.toDouble),
     ("content-api-seo-request-failure", FaciaPressMetrics.ContentApiSeoRequestFailure.getAndReset.toDouble),
-    ("content-api-fallbacks", FaciaPressMetrics.MemcachedFallbackMetric.getAndReset.toDouble)
+    ("content-api-fallbacks", FaciaPressMetrics.MemcachedFallbackMetric.getAndReset.toDouble),
+    ("front-press-latency", FaciaPressMetrics.FrontPressLatency.getAndReset.toDouble),
+    ("uk-network-front-press-latency", FaciaPressMetrics.UkFrontPressLatency.getAndReset.toDouble)
   )
 
   def scheduleJobs() {

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -37,7 +37,9 @@ object Global extends GlobalSettings
     ("content-api-seo-request-failure", FaciaPressMetrics.ContentApiSeoRequestFailure.getAndReset.toDouble),
     ("content-api-fallbacks", FaciaPressMetrics.MemcachedFallbackMetric.getAndReset.toDouble),
     ("front-press-latency", FaciaPressMetrics.FrontPressLatency.getAndReset.toDouble),
-    ("uk-network-front-press-latency", FaciaPressMetrics.UkFrontPressLatency.getAndReset.toDouble)
+    ("uk-network-front-press-latency", FaciaPressMetrics.UkFrontPressLatency.getAndReset.toDouble),
+    ("us-network-front-press-latency", FaciaPressMetrics.UsFrontPressLatency.getAndReset.toDouble),
+    ("au-network-front-press-latency", FaciaPressMetrics.AuFrontPressLatency.getAndReset.toDouble)
   )
 
   def scheduleJobs() {

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -2,15 +2,16 @@ package frontpress
 
 import com.amazonaws.regions.{Regions, Region}
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
-import common.{FaciaPressMetrics, JsonMessageQueue}
+import common.{Logging, Message, FaciaPressMetrics, JsonMessageQueue}
 import common.SQSQueues._
 import conf.Configuration
+import org.joda.time.DateTime
 import services.{Live, Draft, FrontPath, PressJob}
 
 import scala.concurrent.Future
 import scala.util.{Success, Failure}
 
-object ToolPressQueueWorker extends JsonQueueWorker[PressJob] {
+object ToolPressQueueWorker extends JsonQueueWorker[PressJob] with Logging {
   override val queue = (Configuration.faciatool.frontPressToolQueue map { queueUrl =>
     JsonMessageQueue[PressJob](
       new AmazonSQSAsyncClient(Configuration.aws.credentials).withRegion(Region.getRegion(Regions.EU_WEST_1)),
@@ -20,8 +21,8 @@ object ToolPressQueueWorker extends JsonQueueWorker[PressJob] {
     throw new RuntimeException("Required property 'frontpress.sqs.tool_queue_url' not set")
   }
 
-  override def process(job: PressJob): Future[Unit] = {
-    val PressJob(FrontPath(path), pressType) = job
+  override def process(message: Message[PressJob]): Future[Unit] = {
+    val PressJob(FrontPath(path), pressType) = message.get
 
     log.info(s"Processing job from tool to update $path on $pressType")
 
@@ -34,9 +35,29 @@ object ToolPressQueueWorker extends JsonQueueWorker[PressJob] {
       case Success(_) =>
         pressType match {
           case Draft => FaciaPressMetrics.FrontPressDraftSuccess.increment()
-          case Live => FaciaPressMetrics.FrontPressLiveSuccess.increment()
+          case Live =>
+            FaciaPressMetrics.FrontPressLiveSuccess.increment()
+
+            message.sentAt match {
+              case Some(start) =>
+                val millisToPress = DateTime.now.getMillis - start.getMillis
+
+                if (millisToPress < 0) {
+                  log.error(s"Tachyons messing up our pressing! (pressed in ${millisToPress}ms)")
+                  log.info(s"Successfully pressed $path on $pressType")
+                } else {
+                  log.info(s"Pressed $path on $pressType in ${millisToPress}ms")
+                  FaciaPressMetrics.FrontPressLatency.recordTimeSpent(millisToPress)
+
+                  if (path == "uk") {
+                    FaciaPressMetrics.UkFrontPressLatency.recordTimeSpent(millisToPress)
+                  }
+                }
+
+              case None =>
+                log.error("Asked SQS for SentTimestamp but it wasn't sent")
+            }
         }
-        log.info(s"Successfully pressed $path on $pressType")
       case Failure(error) =>
         pressType match {
           case Draft => FaciaPressMetrics.FrontPressDraftFailure.increment()


### PR DESCRIPTION
Adds two metrics
- Press time (how long it takes from putting a job to press on the queue to its actually being pressed by Facia Press)
- UK network front press time - the above metric just for the UK network front
