### PR TITLE
hiding pamplemoose vs native controls and play button size tweak

### DIFF
--- a/common/app/assets/stylesheets/module/content/_video-player.scss
+++ b/common/app/assets/stylesheets/module/content/_video-player.scss
@@ -78,9 +78,13 @@ $vjs-control-height: $gs-baseline*4;
         @include icon(play-60-transparent);
         @include background-size(100%);
         height: 0 !important;
-        // % widths and margins are relative to parent element width
-        width: 12% !important;
-        padding-bottom: 12.5%; // +0.5% stops clipping
+
+        width: 17% !important;
+        padding-bottom: 17.5%; // +0.5% stops clipping
+        @include mq(mobileLandscape) {
+            width: 12% !important;
+            padding-bottom: 12.5%; // +0.5% stops clipping
+        }
         @include rem((
             max-width: $gs-baseline*7.5
         ));
@@ -102,6 +106,10 @@ $vjs-control-height: $gs-baseline*4;
     left: 50%;
     margin-left: -23px;
     margin-top: -15px;
+
+    .vjs-using-native-controls & {
+        display: none;
+    }
 }
 
 /* VJS: CONTROL BAR


### PR DESCRIPTION
- hide video loading spinner on mobile 
- play button bigger on mobile
