### PR TITLE
Revert "Adding InlineMerchandising slot targeting"

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -136,9 +136,6 @@ object DfpDataCacheJob extends ExecutionContexts with Dates{
         val advertisementFeatureSponsorships = data.advertisementFeatureSponsorships
         Store.putDfpAdvertisementFeatureTags(stringify(toJson(SponsorshipReport(now, advertisementFeatureSponsorships))))
 
-        val inlineMerchandisingSponsorships = data.inlineMerchandisingSponsorships
-        Store.putInlineMerchandisingSponsorships(stringify(toJson(SponsorshipReport(now, inlineMerchandisingSponsorships))))
-
         val pageSkinSponsorships = data.pageSkinSponsorships
         Store.putDfpPageSkinAdUnits(stringify(toJson(PageSkinSponsorshipReport(now, pageSkinSponsorships))))
 

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -20,14 +20,6 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
     }.distinct
   }
 
-  val inlineMerchandisingSponsorships: Seq[Sponsorship] = {
-    lineItems.withFilter { lineItem =>
-      lineItem.inlineMerchandisingTargettedTags.nonEmpty && lineItem.isCurrent
-    }.map { lineItem =>
-      Sponsorship(lineItem.inlineMerchandisingTargettedTags, lineItem.sponsor)
-    }.distinct
-  }
-
   val pageSkinSponsorships: Seq[PageSkinSponsorship] = {
     lineItems withFilter { lineItem =>
       lineItem.isPageSkin && lineItem.isCurrent

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -32,9 +32,6 @@ trait Store extends Logging with Dates {
   def putDfpAdvertisementFeatureTags(keywordsJson: String) {
     S3.putPublic(dfpAdvertisementFeatureTagsDataKey, keywordsJson, defaultJsonEncoding)
   }
-  def putInlineMerchandisingSponsorships(keywordsJson: String) {
-    S3.putPublic(inlineMerchandisingSponsorshipsDataKey, keywordsJson, defaultJsonEncoding)
-  }
   def putDfpPageSkinAdUnits(adUnitJson: String) {
     S3.putPublic(dfpPageSkinnedAdUnitsKey, adUnitJson, defaultJsonEncoding )
   }

--- a/common/app/assets/javascripts/modules/commercial/article-body-adverts.js
+++ b/common/app/assets/javascripts/modules/commercial/article-body-adverts.js
@@ -17,12 +17,10 @@ define([
 ) {
 
     var ads = [],
-        adNames = [['im', 'im'], ['inline1', 'inline'], ['inline2', 'inline']],
         insertAdAtP = function(para) {
             if (para) {
-                var adName = adNames[ads.length],
-                    $ad = $.create(dfp.createAdSlot(adName[0], adName[1]))
-                        .insertBefore(para);
+                var $ad = $.create(dfp.createAdSlot('inline' + (ads.length + 1), 'inline'))
+                    .insertBefore(para);
                 ads.push($ad);
             }
         },
@@ -37,7 +35,11 @@ define([
             );
 
             // is the switch off, or not an article, or a live blog
-            if (!config.switches.standardAdverts || config.page.contentType !== 'Article' || config.page.isLiveBlog) {
+            if (
+                !config.switches.standardAdverts ||
+                config.page.contentType !== 'Article' ||
+                config.page.isLiveBlog
+            ) {
                 return false;
             }
 
@@ -54,12 +56,10 @@ define([
 
             if ((/wide|desktop|tablet/).test(breakpoint)) {
                 insertAdAtP(spacefinder.getParaWithSpace(rules));
-                insertAdAtP(spacefinder.getParaWithSpace(rules));
                 if (window.innerWidth < 900) {
                     insertAdAtP(spacefinder.getParaWithSpace(rules));
                 }
             } else {
-                insertAdAtP(spacefinder.getParaWithSpace(rules));
                 insertAdAtP(spacefinder.getParaWithSpace(rules));
                 insertAdAtP(spacefinder.getParaWithSpace(rules));
             }

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -92,14 +92,6 @@ define([
                     tabletlandscape: '300,250|300,600'
                 }
             },
-            im: {
-                label: false,
-                sizeMappings: {
-                    mobile: '300,50',
-                    mobilelandscape: '300,50|320,50',
-                    tabletportrait: '300,250'
-                }
-            },
             inline1: {
                 sizeMappings: {
                     mobile: '300,50',

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -214,8 +214,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       s"${environment.stage.toUpperCase}/commercial/dfp/sponsored-tags-v2.json"
     lazy val dfpAdvertisementFeatureTagsDataKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/advertisement-feature-tags-v2.json"
-    lazy val inlineMerchandisingSponsorshipsDataKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/inline-merchandising-tags-v2.json"
     lazy val dfpPageSkinnedAdUnitsKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/pageskinned-adunits-v3.json"
     lazy val dfpLineItemsKey =

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -4,7 +4,7 @@ import java.net.URLDecoder
 
 import akka.agent.Agent
 import common._
-import conf.Configuration.commercial.{dfpAdUnitRoot, dfpAdvertisementFeatureTagsDataKey, dfpPageSkinnedAdUnitsKey, dfpSponsoredTagsDataKey, inlineMerchandisingSponsorshipsDataKey}
+import conf.Configuration.commercial.{dfpAdUnitRoot, dfpAdvertisementFeatureTagsDataKey, dfpPageSkinnedAdUnitsKey, dfpSponsoredTagsDataKey}
 import model.{Config, Tag}
 import play.api.{Application, GlobalSettings}
 import services.S3
@@ -15,7 +15,6 @@ trait DfpAgent {
 
   protected def sponsorships: Seq[Sponsorship]
   protected def advertisementFeatureSponsorships: Seq[Sponsorship]
-  protected def inlineMerchandisingDeals: Seq[Sponsorship]
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship]
 
   private def containerSponsoredTag(config: Config, p: String => Boolean): Option[String] = {
@@ -34,10 +33,6 @@ trait DfpAgent {
     (tag.tagType == "keyword" && !tag.isSectionTag) || tag.tagType == "series"
   }
 
-  private def getPrimaryKeywordSeriesOrSectionTag(tags: Seq[Tag]): Option[Tag] =  {
-    tags find {_.isSectionTag} orElse getPrimaryKeywordOrSeriesTag(tags)
-  }
-
   def isSponsored(tags: Seq[Tag]): Boolean = getPrimaryKeywordOrSeriesTag(tags) exists (tag => isSponsored(tag.id))
   def isSponsored(tagId: String): Boolean = sponsorships exists (_.hasTag(tagId))
   def isSponsored(config: Config): Boolean = isSponsoredContainer(config, isSponsored)
@@ -45,12 +40,6 @@ trait DfpAgent {
   def isAdvertisementFeature(tags: Seq[Tag]): Boolean = getPrimaryKeywordOrSeriesTag(tags) exists (tag => isAdvertisementFeature(tag.id))
   def isAdvertisementFeature(tagId: String): Boolean = advertisementFeatureSponsorships exists (_.hasTag(tagId))
   def isAdvertisementFeature(config: Config): Boolean = isSponsoredContainer(config, isAdvertisementFeature)
-
-
-  def hasInlineMerchandise(tags: Seq[Tag]): Boolean = getPrimaryKeywordSeriesOrSectionTag(tags)  exists (tag => hasInlineMerchandise(tag.id))
-  def hasInlineMerchandise(tagId: String): Boolean = inlineMerchandisingDeals exists (_.hasTag(tagId))
-  def hasInlineMerchandise(config: Config): Boolean = isSponsoredContainer(config, hasInlineMerchandise)
-
 
   def isPageSkinned(adUnitWithoutRoot: String, edition: Edition): Boolean = {
     if (adUnitWithoutRoot endsWith "front") {
@@ -89,12 +78,10 @@ object DfpAgent extends DfpAgent with ExecutionContexts {
 
   private lazy val sponsoredTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
   private lazy val advertisementFeatureTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
-  private lazy val inlineMerchandisingTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
   private lazy val pageskinnedAdUnitAgent = AkkaAgent[Seq[PageSkinSponsorship]](Nil)
 
   protected def sponsorships: Seq[Sponsorship] = sponsoredTagsAgent get()
   protected def advertisementFeatureSponsorships: Seq[Sponsorship] = advertisementFeatureTagsAgent get()
-  protected def inlineMerchandisingDeals: Seq[Sponsorship] = inlineMerchandisingTagsAgent get()
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent get()
 
   def refresh() {
@@ -131,14 +118,12 @@ object DfpAgent extends DfpAgent with ExecutionContexts {
 
     update(sponsoredTagsAgent, grabSponsorshipsFromStore(dfpSponsoredTagsDataKey))
     update(advertisementFeatureTagsAgent, grabSponsorshipsFromStore(dfpAdvertisementFeatureTagsDataKey))
-    update(inlineMerchandisingTagsAgent, grabSponsorshipsFromStore(inlineMerchandisingSponsorshipsDataKey))
     update(pageskinnedAdUnitAgent, grabPageSkinSponsorshipsFromStore(dfpPageSkinnedAdUnitsKey))
   }
 
   def stop() {
     sponsoredTagsAgent close()
     advertisementFeatureTagsAgent close()
-    inlineMerchandisingTagsAgent close()
     pageskinnedAdUnitAgent close()
   }
 }

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -11,8 +11,6 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   val isSponsoredSlot = isSlot("spbadge")
 
   val isAdvertisementFeatureSlot = isSlot("adbadge")
-  
-  val isInlineMerchandisingSlot = isSlot("im")
 
   val isTag = isPositive("k") || isPositive("se")
 }
@@ -28,8 +26,6 @@ case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
   val sponsoredTags = filterTags(_.isSponsoredSlot)
 
   val advertisementFeatureTags = filterTags(_.isAdvertisementFeatureSlot)
-  
-  val inlineMerchandisingTargettedTags = filterTags(_.isInlineMerchandisingSlot)
 }
 
 
@@ -55,6 +51,4 @@ case class GuLineItem(id: Long,
   val sponsoredTags: Seq[String] = targeting.customTargetSets.flatMap(_.sponsoredTags).distinct
 
   val advertisementFeatureTags: Seq[String] = targeting.customTargetSets.flatMap(_.advertisementFeatureTags).distinct
-
-  val inlineMerchandisingTargettedTags: Seq[String] = targeting.customTargetSets.flatMap(_.inlineMerchandisingTargettedTags).distinct
 }

--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -5,9 +5,7 @@ import common.Logging
 
 case class Sponsorship(tags: Seq[String], sponsor: Option[String]) {
 
-  def hasTag(tagId: String): Boolean = {
-    tags contains (tagId.split('/').last)
-  }
+  def hasTag(tagId: String): Boolean = tags contains (tagId.split('/').last)
 }
 
 case class SponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[Sponsorship])

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -371,10 +371,6 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
   override def trailPicture: Option[ImageContainer] = thumbnail.find(_.imageCrops.exists(_.width >= 620))
     .orElse(mainPicture).orElse(videos.headOption)
 
-  override def hasInlineMerchandise = {
-    isbn.isDefined || super.hasInlineMerchandise
-  }
-
   lazy val linkCounts = LinkTo.countLinks(body) + standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
   override lazy val metaData: Map[String, Any] = {
     val bookReviewIsbns = isbn.map { i: String => Map("isbn" -> i)}.getOrElse(Map())
@@ -384,8 +380,7 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
       ("isLiveBlog", isLiveBlog),
       ("inBodyInternalLinkCount", linkCounts.internal),
       ("inBodyExternalLinkCount", linkCounts.external),
-      ("shouldHideAdverts", shouldHideAdverts),
-      ("hasInlineMerchandise", hasInlineMerchandise)
+      ("shouldHideAdverts", shouldHideAdverts)
     ) ++ bookReviewIsbns
   }
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -172,9 +172,6 @@ trait Tags {
 
   def isSponsored = DfpAgent.isSponsored(tags)
   def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(tags)
-  def hasInlineMerchandise = {
-    DfpAgent.hasInlineMerchandise(tags)
-  }
   def sponsor = DfpAgent.getSponsor(tags)
 
   // Tones are all considered to be 'News' it is the default so we do not list news tones explicitly

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -22,7 +22,7 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // are any required changes, update the hash below, and off you go.
 
     withClue("Look at comment in GuardianConfigurationTest.scala!") {
-      hash should be("1ab10f16df4a596aba2f22529d978c64")
+      hash should be("e18cf7f7d0c1c3fd2d804b06bb7ce134")
     }
   }
 }

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -21,11 +21,6 @@ class DfpAgentTest extends FlatSpec with Matchers {
       Sponsorship(Seq("film"), None)
     )
 
-    override protected def inlineMerchandisingDeals: Seq[Sponsorship] = Seq(
-      Sponsorship(Seq("ad-feature"), None),
-      Sponsorship(Seq("film"), None)
-    )
-
     override protected def pageSkinSponsorships: Seq[PageSkinSponsorship] =
       Seq(
         PageSkinSponsorship("lineItemName",


### PR DESCRIPTION
Reverts guardian/frontend#5070

The IM slot was being inserted without a check. Oops
