### PR TITLE
add links to soulmates and jobs to the top nav

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -23,6 +23,7 @@ define([
     'common/modules/navigation/profile',
     'common/modules/navigation/sections',
     'common/modules/navigation/search',
+    'common/modules/navigation/servicesNav',
     'common/modules/navigation/newNavigation',
     'common/modules/ui/tabs',
     'common/modules/ui/toggles',
@@ -70,6 +71,7 @@ define([
     Profile,
     Sections,
     Search,
+    ServicesNav,
     newNavigation,
 
     Tabs,
@@ -119,6 +121,8 @@ define([
             }
 
             search.init(header);
+
+            ServicesNav.init(config);
         },
 
         initialiseNavigation: function (config) {

--- a/common/app/assets/javascripts/modules/navigation/servicesNav.js
+++ b/common/app/assets/javascripts/modules/navigation/servicesNav.js
@@ -1,0 +1,34 @@
+define([
+    'qwery',
+    'bean',
+    'common/utils/$'
+], function (
+    qwery,
+    bean,
+    $
+) {
+    var GuardianServicesNav = {
+        init: function(){
+            this.enableNavToggle();
+        },
+
+        enableNavToggle: function(){
+            qwery('.js-services-nav-toggle').forEach(function(elem) {
+                bean.on(elem, 'click touchstart', function (e) {
+                    e.preventDefault();
+                    if (qwery('.guardian-services__item-more--expanded').length > 0) {
+                        $('.guardian-services__item-more--expanded')
+                            .removeClass('guardian-services__item-more--expanded')
+                            .addClass('guardian-services__item-more--collapsed');
+                    } else {
+                        $('.guardian-services__item-more--collapsed')
+                            .removeClass('guardian-services__item-more--collapsed')
+                            .addClass('guardian-services__item-more--expanded');
+                    }
+                });
+            });
+        }
+    };
+
+    return GuardianServicesNav;
+});

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -90,6 +90,8 @@ $c-neutral8: guss-colour(neutral-8);
 
 $c-media-icon: #fbba0f;
 
+$c-new-navigation-base: #2479c3;
+$c-local-navigation-action: #ffffff;
 
 // Tones
 // =============================================================================

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -21,7 +21,7 @@ $browser-supports-flexbox: true !default;
 
 $unitHeight: 36px;
 $inArticleInlineImgWidth: 114px;
-$headerHeight: 32px;
+$headerHeight: 34px;
 
 @import 'components/guss-colours/helpers';
 @import 'components/guss-colours/colours';

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -21,7 +21,7 @@ $browser-supports-flexbox: true !default;
 
 $unitHeight: 36px;
 $inArticleInlineImgWidth: 114px;
-$headerHeight: 46px;
+$headerHeight: 32px;
 
 @import 'components/guss-colours/helpers';
 @import 'components/guss-colours/colours';

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -61,7 +61,7 @@
     @include mq(tablet) {
         float: none;
         background: $c-neutral8;
-        border-bottom: 0px solid $c-neutral4;
+        border-bottom: 0;
     }
 }
 .l-header-pre__inner {
@@ -125,33 +125,14 @@ a.edition {
     }
 }
 
-.preheader__guardian-services {
-    display: inline;
-}
 .guardian-services {
     @include fs-header(1);
     @include rem((
         padding: $gs-baseline/2 0
     ));
 }
-.guardian-services,
-.guardian-services__item {
-    margin: 0;
-    display: inline-block;
-}
-.guardian-services__title {
-    font-weight: normal;
-}
-.guardian-services__item {
-    color: $c-brandLightBlue;
-
-    & + .guardian-services__item {
-        @include rem((
-            margin-left: $gs-gutter/4
-        ));
-    }
-}
-.guardian-service {
+.guardian-services__action {
+    @include fs-header(1);
     text-decoration: none;
     margin: 0;
     color: $c-neutral1;
@@ -161,18 +142,14 @@ a.edition {
 }
 .guardian-services__item-more--expanded {
     position: relative;
+    background: $c-new-navigation-base;
 
-    &.top-nav__item {
-        background: $c-new-navigation-base;
-    }
-
-    .guardian-service {
+    .guardian-services__action {
         color: $c-local-navigation-action;
     }
 }
 .guardian-services__item--more-menu {
     position: absolute;
-    color: $c-local-navigation-action;
     background: $c-new-navigation-base;
     margin: 0;
     right: 0;
@@ -183,7 +160,7 @@ a.edition {
         width: 3 * $gs-column-width + $gs-gutter
     ));
 
-    .top-navigation__action {
+    .guardian-services__action {
         display: inline;
         color: $c-local-navigation-action;
     }

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -47,12 +47,6 @@
             font-size: 13px;
         }
     }
-    @include mq(desktop) {
-        @include rem((
-            margin-top: -$gs-row-height,
-            margin-bottom: $gs-baseline * 1.5
-        ));
-    }
 }
 
 /* Pre-header
@@ -68,9 +62,6 @@
         float: none;
         background: $c-neutral8;
         border-bottom: 1px solid $c-neutral4;
-    }
-    @include mq(desktop) {
-        border-bottom-color: $c-neutral8;
     }
 }
 .l-header-pre__inner {
@@ -127,6 +118,47 @@
     margin: 0;
 }
 a.edition {
+    &:hover,
+    &:focus {
+        color: $c-brandLightBlue;
+        text-decoration: none;
+    }
+}
+
+.guardian-services {
+    @include fs-header(1);
+}
+.guardian-services,
+.guardian-services__title,
+.guardian-services__item,
+.guardian-services {
+    padding: 0;
+    margin: 0;
+    display: inline-block;
+}
+.guardian-services__title {
+    font-weight: normal;
+}
+.guardian-services__title,
+.guardian-services {
+    @include rem((
+        padding: $gs-baseline/2 $gs-gutter/4
+    ));
+}
+.guardian-services__item {
+    color: $c-brandLightBlue;
+
+    & + .guardian-services__item {
+        @include rem((
+            margin-left: $gs-gutter/4
+        ));
+    }
+}
+.guardian-services {
+    text-decoration: none;
+    margin: 0;
+}
+a.guardian-services {
     &:hover,
     &:focus {
         color: $c-brandLightBlue;

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -1,6 +1,8 @@
 /* Global header and navigation
    ========================================================================== */
 
+$servicesToggleArrowSize: 5px;
+
 .l-header {
     position: relative;
     z-index: 1051; // On top of Google "Adchoices" label which has z-index: 1050
@@ -135,6 +137,19 @@ a.edition {
     text-decoration: none;
     margin: 0;
     color: $c-neutral1;
+    cursor: pointer;
+}
+.guardian-services__action__arrow {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    @include rem((
+        margin: 2px,
+        border-bottom: 0 solid transparent,
+        border-left: $servicesToggleArrowSize solid transparent,
+        border-right: $servicesToggleArrowSize solid transparent,
+        border-top: $servicesToggleArrowSize solid $c-neutral1
+    ));
 }
 .guardian-services__item-more--collapsed .guardian-services__item--more-menu {
     display: none;
@@ -144,7 +159,14 @@ a.edition {
     background: $c-new-navigation-base;
 
     .guardian-services__action {
+        display: inline-block;
         color: $c-local-navigation-action;
+    }
+    .guardian-services__action__arrow {
+        border-top: 0 solid transparent;
+        border-left: $servicesToggleArrowSize solid transparent;
+        border-right: $servicesToggleArrowSize solid transparent;
+        border-bottom: $servicesToggleArrowSize solid $c-local-navigation-action;
     }
 }
 .guardian-services__item--more-menu {
@@ -156,13 +178,8 @@ a.edition {
     @include rem((
         top: $headerHeight,
         padding: $gs-baseline/2 $gs-gutter/2,
-        width: gs-span(3) - $gs-gutter
+        width: gs-span(3) - $gs-gutter/2
     ));
-
-    .guardian-services__action {
-        display: inline;
-        color: $c-local-navigation-action;
-    }
 }
 
 /* Main header (logo, actions)

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -171,6 +171,7 @@ a.edition {
     }
 }
 .guardian-services__item--more-menu {
+    @include box-sizing(border-box);
     position: absolute;
     background: $c-new-navigation-base;
     margin: 0;
@@ -179,7 +180,7 @@ a.edition {
     @include rem((
         top: $headerHeight,
         padding: $gs-baseline/2 $gs-gutter/2,
-        width: gs-span(3) - $gs-gutter/2
+        width: gs-span(3)
     ));
 }
 

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -154,7 +154,7 @@ a.edition {
 .guardian-service {
     text-decoration: none;
     margin: 0;
-    color: $c-neutral1
+    color: $c-neutral1;
 }
 
 /* Main header (logo, actions)

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -55,7 +55,7 @@
 .l-header-pre {
     float: left;
     min-width: gs-span(2);
-    z-index: 1;
+    z-index: 2;
     position: relative;
 
     @include mq(tablet) {
@@ -156,11 +156,43 @@ a.edition {
     margin: 0;
     color: $c-neutral1;
 }
+.guardian-services__item-more--collapsed .guardian-services__item--more-menu {
+    display: none;
+}
+.guardian-services__item-more--expanded {
+    position: relative;
+
+    &.top-nav__item {
+        background: $c-new-navigation-base;
+    }
+
+    .guardian-service {
+        color: $c-local-navigation-action;
+    }
+}
+.guardian-services__item--more-menu {
+    position: absolute;
+    color: $c-local-navigation-action;
+    background: $c-new-navigation-base;
+    margin: 0;
+    right: 0;
+    list-style: none;
+    @include rem((
+        top: 3 * $gs-baseline,
+        padding: $gs-baseline/2,
+        width: 3 * $gs-column-width + $gs-gutter
+    ));
+
+    .top-navigation__action {
+        display: inline;
+        color: $c-local-navigation-action;
+    }
+}
 
 /* Main header (logo, actions)
    ========================================================================== */
 
 .l-header-main {
     position: relative;
-    z-index: 2;
+    z-index: 1;
 }

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -61,7 +61,6 @@
     @include mq(tablet) {
         float: none;
         background: $c-neutral8;
-        border-bottom: 0;
     }
 }
 .l-header-pre__inner {
@@ -156,8 +155,8 @@ a.edition {
     list-style: none;
     @include rem((
         top: 3 * $gs-baseline,
-        padding: $gs-baseline/2,
-        width: 3 * $gs-column-width + $gs-gutter
+        padding: $gs-baseline/2 $gs-gutter/2,
+        width: gs-span(3) + $gs-gutter
     ));
 
     .guardian-services__action {

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -141,11 +141,12 @@ a.edition {
 }
 .guardian-services__action__arrow {
     display: inline-block;
+    pointer-events: none;
     width: 0;
     height: 0;
+    border-bottom: 0 solid transparent;
     @include rem((
         margin: 2px,
-        border-bottom: 0 solid transparent,
         border-left: $servicesToggleArrowSize solid transparent,
         border-right: $servicesToggleArrowSize solid transparent,
         border-top: $servicesToggleArrowSize solid $c-neutral1
@@ -164,9 +165,9 @@ a.edition {
     }
     .guardian-services__action__arrow {
         border-top: 0 solid transparent;
-        border-left: $servicesToggleArrowSize solid transparent;
-        border-right: $servicesToggleArrowSize solid transparent;
-        border-bottom: $servicesToggleArrowSize solid $c-local-navigation-action;
+        @include rem((
+            border-bottom: $servicesToggleArrowSize solid $c-local-navigation-action
+        ));
     }
 }
 .guardian-services__item--more-menu {

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -154,9 +154,9 @@ a.edition {
     right: 0;
     list-style: none;
     @include rem((
-        top: 3 * $gs-baseline,
+        top: $headerHeight,
         padding: $gs-baseline/2 $gs-gutter/2,
-        width: gs-span(3) + $gs-gutter
+        width: gs-span(3) - $gs-gutter
     ));
 
     .guardian-services__action {

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -61,7 +61,7 @@
     @include mq(tablet) {
         float: none;
         background: $c-neutral8;
-        border-bottom: 1px solid $c-neutral4;
+        border-bottom: 0px solid $c-neutral4;
     }
 }
 .l-header-pre__inner {
@@ -125,25 +125,22 @@ a.edition {
     }
 }
 
+.preheader__guardian-services {
+    display: inline;
+}
 .guardian-services {
     @include fs-header(1);
+    @include rem((
+        padding: $gs-baseline/2 0
+    ));
 }
 .guardian-services,
-.guardian-services__title,
-.guardian-services__item,
-.guardian-services {
-    padding: 0;
+.guardian-services__item {
     margin: 0;
     display: inline-block;
 }
 .guardian-services__title {
     font-weight: normal;
-}
-.guardian-services__title,
-.guardian-services {
-    @include rem((
-        padding: $gs-baseline/2 $gs-gutter/4
-    ));
 }
 .guardian-services__item {
     color: $c-brandLightBlue;
@@ -154,18 +151,11 @@ a.edition {
         ));
     }
 }
-.guardian-services {
+.guardian-service {
     text-decoration: none;
     margin: 0;
+    color: $c-neutral1
 }
-a.guardian-services {
-    &:hover,
-    &:focus {
-        color: $c-brandLightBlue;
-        text-decoration: none;
-    }
-}
-
 
 /* Main header (logo, actions)
    ========================================================================== */

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -27,7 +27,7 @@
 }
 .top-banner-ad-container--desktop {
     background-color: $c-neutral8;
-    border-bottom: 2px solid $c-newsDefault;
+    border-bottom: 2px solid $c-neutral4;
     display: none;
 
     @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/_new-navigation.scss
+++ b/common/app/assets/stylesheets/module/_new-navigation.scss
@@ -8,8 +8,6 @@
 $new-navigation-toggler-width: 48px;
 $new-navigation-toggler-width-full: 130px;
 
-$c-new-navigation-base: #2479c3;
-
 $theme: default;
 
 $c-navigation-background: mix($c-new-navigation-base, #ffffff, 80%);
@@ -22,7 +20,6 @@ $c-top-navigation-action: #ffffff;
 $c-top-navigation-background: guss-colour(guardian-brand);
 
 $c-local-navigation-background: $c-new-navigation-base;
-$c-local-navigation-action: #ffffff;
 
 $c-local-navigation-parent-background: guss-colour(guardian-brand);
 

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -355,7 +355,7 @@
 
     .top-nav__item {
         @include rem((
-            padding: 0 $gs-gutter 0 $gs-gutter/2
+            padding: $gs-baseline/2 $gs-gutter 0 $gs-gutter/2
         ));
         margin: 0;
     }

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -336,6 +336,7 @@
     float: left;
 
     @include rem((
+        padding-top: 2px,
         margin-right: $gs-gutter/2
     ));
 
@@ -354,7 +355,7 @@
 
     .top-nav__item {
         @include rem((
-            padding: $gs-baseline/2 $gs-gutter 0 $gs-gutter/2
+            padding: 2px+$gs-baseline/2 $gs-gutter 0 $gs-gutter/2
         ));
         margin: 0;
     }

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -352,9 +352,8 @@
 .top-nav__item--right {
     @include box-sizing(border-box);
     float: right;
-    padding-top: 0,
-    padding-left: 0
-
+    padding-top: 0;
+    padding-left: 0;
 
     .top-nav__item {
         @include rem((
@@ -362,7 +361,7 @@
         ));
     }
     .top-nav__item:last-child {
-        margin-right: 0
+        margin-right: 0;
     }
 }
 .top-nav__item--mobile-only {

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -352,19 +352,17 @@
 .top-nav__item--right {
     @include box-sizing(border-box);
     float: right;
+    padding-top: 0,
+    padding-left: 0
 
-    @include rem((
-        padding-top: $gs-baseline/2,
-        margin-right: 0
-    ));
 
-    @include mq(tablet) {
-        & + .top-nav__item {
-            border-left: 1px solid $c-neutral4;
-        }
+    .top-nav__item {
         @include rem((
-            padding-left: $gs-gutter/2
+            margin-right: $gs-gutter
         ));
+    }
+    .top-nav__item:last-child {
+        margin-right: 0
     }
 }
 .top-nav__item--mobile-only {

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -328,7 +328,7 @@
 .top-nav,
 .top-nav__item {
     @include rem((
-        height: 44px
+        height: $headerHeight
     ));
 }
 .top-nav__item {
@@ -336,7 +336,6 @@
     float: left;
 
     @include rem((
-        padding-top: $gs-baseline/2,
         margin-right: $gs-gutter/2
     ));
 

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -352,16 +352,15 @@
 .top-nav__item--right {
     @include box-sizing(border-box);
     float: right;
-    padding-top: 0;
-    padding-left: 0;
 
     .top-nav__item {
         @include rem((
-            margin-right: $gs-gutter
+            padding: 0 $gs-gutter 0 $gs-gutter/2
         ));
+        margin: 0;
     }
     .top-nav__item:last-child {
-        margin-right: 0;
+        padding-right: 0;
     }
 }
 .top-nav__item--mobile-only {

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -349,6 +349,24 @@
         ));
     }
 }
+.top-nav__item--right {
+    @include box-sizing(border-box);
+    float: right;
+
+    @include rem((
+        padding-top: $gs-baseline/2,
+        margin-right: 0
+    ));
+
+    @include mq(tablet) {
+        & + .top-nav__item {
+            border-left: 1px solid $c-neutral4;
+        }
+        @include rem((
+            padding-left: $gs-gutter/2
+        ));
+    }
+}
 .top-nav__item--mobile-only {
     @include mq(tablet) {
         margin-right: 0;

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -275,6 +275,10 @@ object Switches extends Collections {
     sellByDate = new DateMidnight(2014, 10, 30)
   )
 
+  val GuardianServicesLinksSwitch = Switch("Feature Switches", "guardian-services-links",
+    "If this switch is switched on then Jobs and Soulmates links will be displayed on page headers",
+    safeState = Off,sellByDate = new DateMidnight(2014, 8, 12))
+
   val ResponsiveNavSwitch = Switch("Feature Switches", "responsive-nav",
     "If this switch is turned on then the new responsive navigation will be displayed.",
     safeState = Off, sellByDate = new DateMidnight(2014, 7, 22)
@@ -479,6 +483,7 @@ object Switches extends Collections {
     WorldCupArticleContainerSwitch,
     ProfileCommentsSearchSwitch,
     SentimentalCommentsSwitch,
+    GuardianServicesLinksSwitch,
     IndiaRegionSwitch,
     MemcachedSwitch,
     MemcachedFallbackSwitch,
@@ -498,7 +503,8 @@ object Switches extends Collections {
 
   val httpSwitches: List[Switch] = List(
     ResponsiveNavSwitch,
-    NewNavigationHighlightingSwitch
+    NewNavigationHighlightingSwitch,
+    GuardianServicesLinksSwitch
   )
 
   val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -87,6 +87,7 @@ to apply any necessary changes to non-shared code there too.
                         </div>
                     </div>
                 }
+                @fragments.topNav.servicesLinks(page)
             </div>
         </div>
     </div>

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -8,39 +8,22 @@
     @if(Edition(request) == Uk){
         <div class="top-nav__item--right hide-on-mobile" data-component="guardian-services">
             <div class="top-nav__item">
-                <div class="preheader__guardian-services">
-                    <dl class="guardian-services">
-                        <dd class="guardian-services__item">
-                            <a class="guardian-service" data-link-name="topNav : jobs"
-                               href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">jobs</a>
-                        </dd>
-                    </dl>
-                </div>
+                <a class="guardian-services__action" data-link-name="topNav : jobs"
+                   href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">jobs</a>
             </div>
             <div class="top-nav__item">
-                <div class="preheader__guardian-services">
-                    <dl class="guardian-services">
-                        <dd class="guardian-services__item">
-                            <a class="guardian-service" data-link-name="topNav : soulmates"
-                               href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
-                        </dd>
-                    </dl>
-                </div>
+                <a class="guardian-services__action" data-link-name="topNav : soulmates"
+                   href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
+
             </div>
             <div class="top-nav__item guardian-services__item-more--collapsed">
-                <div class="preheader__guardian-services">
-                    <dl class="guardian-services">
-                        <dd class="guardian-services__item">
-                            <span class="guardian-service js-services-nav-toggle" data-link-name="topNav : more">more</span>
-                            <ul class="guardian-services__item--more-menu">
-                                <li><a class="top-navigation__action" data-link-name="topNav : masterclasses"
-                                       href="http://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES">masterclasses</a></li>
-                                <li><a class="top-navigation__action" data-link-name="topNav : subscribe"
-                                       href="http://subscribe.theguardian.com??INTCMP=NGW_TOPNAV_UK_GU_SUBSCRIBE">subscribe</a></li>
-                            </ul>
-                        </dd>
-                    </dl>
-                </div>
+                <span class="guardian-services__action js-services-nav-toggle" data-link-name="topNav : more">more</span>
+                <ul class="guardian-services__item--more-menu">
+                    <li><a class="guardian-services__action" data-link-name="topNav : masterclasses"
+                           href="http://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES">masterclasses</a></li>
+                    <li><a class="guardian-services__action" data-link-name="topNav : subscribe"
+                           href="http://subscribe.theguardian.com??INTCMP=NGW_TOPNAV_UK_GU_SUBSCRIBE">subscribe</a></li>
+                </ul>
             </div>
         </div>
     }

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -1,28 +1,47 @@
 @(page: model.MetaData)(implicit request: RequestHeader)
 @import conf.Switches._
 @import dev.HttpSwitch
+@import common.Edition
+@import common.editions._
 
 @if(HttpSwitch(GuardianServicesLinksSwitch).isSwitchedOn){
-    <div class="top-nav__item--right hide-on-mobile" data-component="guardian-services">
-        <div class="top-nav__item">
-            <div class="preheader__guardian-services">
-                <dl class="guardian-services">
-                    <dd class="guardian-services__item">
-                        <a class="guardian-service" data-link-name="topNav : jobs"
-                           href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">Jobs</a>
-                    </dd>
-                </dl>
+    @if(Edition(request) == Uk){
+        <div class="top-nav__item--right hide-on-mobile" data-component="guardian-services">
+            <div class="top-nav__item">
+                <div class="preheader__guardian-services">
+                    <dl class="guardian-services">
+                        <dd class="guardian-services__item">
+                            <a class="guardian-service" data-link-name="topNav : jobs"
+                               href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">jobs</a>
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+            <div class="top-nav__item">
+                <div class="preheader__guardian-services">
+                    <dl class="guardian-services">
+                        <dd class="guardian-services__item">
+                            <a class="guardian-service" data-link-name="topNav : soulmates"
+                               href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+            <div class="top-nav__item guardian-services__item-more--collapsed">
+                <div class="preheader__guardian-services">
+                    <dl class="guardian-services">
+                        <dd class="guardian-services__item">
+                            <span class="guardian-service js-services-nav-toggle" data-link-name="topNav : more">more</span>
+                            <ul class="guardian-services__item--more-menu">
+                                <li><a class="top-navigation__action" data-link-name="topNav : masterclasses"
+                                       href="http://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES">masterclasses</a></li>
+                                <li><a class="top-navigation__action" data-link-name="topNav : subscribe"
+                                       href="http://subscribe.theguardian.com??INTCMP=NGW_TOPNAV_UK_GU_SUBSCRIBE">subscribe</a></li>
+                            </ul>
+                        </dd>
+                    </dl>
+                </div>
             </div>
         </div>
-        <div class="top-nav__item">
-            <div class="preheader__guardian-services">
-                <dl class="guardian-services">
-                    <dd class="guardian-services__item">
-                        <a class="guardian-service" data-link-name="topNav : soulmates"
-                           href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">Soulmates</a>
-                    </dd>
-                </dl>
-            </div>
-        </div>
-    </div>
+    }
 }

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -11,11 +11,11 @@
 
                 <dd class="guardian-services__item">
                     <a class="guardian-service" data-link-name="topNav : soulmates"
-                       href="https://soulmates.theguardian.com/?INTCMP=NGW_NAVBAR_UK_GU_SOULMATES">Soulmates</a>
+                       href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">Soulmates</a>
                 </dd>
                 <dd class="guardian-services__item">
                     <a class="guardian-service" data-link-name="topNav : jobs"
-                       href="http://jobs.theguardian.com/?INTCMP=NGW_NAVBAR_UK_GU_JOBS">Jobs</a>
+                       href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">Jobs</a>
                 </dd>
             </dl>
         </div>

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -16,7 +16,10 @@
                    href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
             </div>
             <div class="top-nav__item guardian-services__item-more--collapsed">
-                <span class="guardian-services__action js-services-nav-toggle" data-link-name="topNav : more">more</span>
+                <span class="guardian-services__action js-services-nav-toggle" data-link-name="topNav : more">
+                    <span>more</span>
+                    <span class="guardian-services__action__arrow"></span>
+                </span>
                 <ul class="guardian-services__item--more-menu">
                     <li><a class="guardian-services__action" data-link-name="topNav : masterclasses"
                            href="http://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES">masterclasses</a></li>

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -1,0 +1,23 @@
+@(page: model.MetaData)(implicit request: RequestHeader)
+@import conf.Switches._
+@import dev.HttpSwitch
+
+@if(HttpSwitch(GuardianServicesLinksSwitch).isSwitchedOn){
+    <div class="top-nav__item--right hide-on-mobile" data-component="guardian-services">
+        <div class="preheader__guardian-services">
+            <dl class="guardian-services">
+                <dt class="guardian-services__title">
+                </dt>
+
+                <dd class="guardian-services__item">
+                    <a class="guardian-service" data-link-name="topNav : soulmates"
+                       href="https://soulmates.theguardian.com/?INTCMP=NGW_NAVBAR_UK_GU_SOULMATES">Soulmates</a>
+                </dd>
+                <dd class="guardian-services__item">
+                    <a class="guardian-service" data-link-name="topNav : jobs"
+                       href="http://jobs.theguardian.com/?INTCMP=NGW_NAVBAR_UK_GU_JOBS">Jobs</a>
+                </dd>
+            </dl>
+        </div>
+    </div>
+}

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -14,7 +14,6 @@
             <div class="top-nav__item">
                 <a class="guardian-services__action" data-link-name="topNav : soulmates"
                    href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
-
             </div>
             <div class="top-nav__item guardian-services__item-more--collapsed">
                 <span class="guardian-services__action js-services-nav-toggle" data-link-name="topNav : more">more</span>

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -4,20 +4,25 @@
 
 @if(HttpSwitch(GuardianServicesLinksSwitch).isSwitchedOn){
     <div class="top-nav__item--right hide-on-mobile" data-component="guardian-services">
-        <div class="preheader__guardian-services">
-            <dl class="guardian-services">
-                <dt class="guardian-services__title">
-                </dt>
-
-                <dd class="guardian-services__item">
-                    <a class="guardian-service" data-link-name="topNav : soulmates"
-                       href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">Soulmates</a>
-                </dd>
-                <dd class="guardian-services__item">
-                    <a class="guardian-service" data-link-name="topNav : jobs"
-                       href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">Jobs</a>
-                </dd>
-            </dl>
+        <div class="top-nav__item">
+            <div class="preheader__guardian-services">
+                <dl class="guardian-services">
+                    <dd class="guardian-services__item">
+                        <a class="guardian-service" data-link-name="topNav : jobs"
+                           href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">Jobs</a>
+                    </dd>
+                </dl>
+            </div>
+        </div>
+        <div class="top-nav__item">
+            <div class="preheader__guardian-services">
+                <dl class="guardian-services">
+                    <dd class="guardian-services__item">
+                        <a class="guardian-service" data-link-name="topNav : soulmates"
+                           href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">Soulmates</a>
+                    </dd>
+                </dl>
+            </div>
         </div>
     </div>
 }


### PR DESCRIPTION
The links to Jobs and Soulmates are added to the top nav, for tablet and bigger screens. No changes on mobile.
Feature behind the switch: 'guardian-services-links'

![png](https://cloud.githubusercontent.com/assets/1492162/3597483/6386a1aa-0cd2-11e4-9438-e0a8d0d9e842.png)
![screen shot 2014-07-16 at 11 15 04](https://cloud.githubusercontent.com/assets/1492162/3597484/63b0c00c-0cd2-11e4-9d5a-f0e459b6cef7.png)
Mobile -- unchanged
![screen shot 2014-07-14 at 10 48 07](https://cloud.githubusercontent.com/assets/1492162/3569758/89e3a53a-0b44-11e4-9114-7b8fcddf4098.png)

![](http://media.giphy.com/media/43VhxnrEOQ44U/giphy.gif)
