### PR TITLE
preventing breadcrumbs from wrapping when two words

### DIFF
--- a/common/app/assets/stylesheets/module/_breadcrumbs.scss
+++ b/common/app/assets/stylesheets/module/_breadcrumbs.scss
@@ -1,6 +1,7 @@
 .breadcrumb-list__item {
     color: lighten($c-neutral2, 15%);
     @include fs-data(1);
+    white-space: nowrap;
 }
 
 .breadcrumb-list__item + .breadcrumb-list__item {


### PR DESCRIPTION
This stops the breadcrumb wrapping.

Before;
![screen shot 2014-07-16 at 14 29 59](https://cloud.githubusercontent.com/assets/1303616/3599630/d27d806a-0cf0-11e4-9fd2-5dad8a384215.png)

After;
![screen shot 2014-07-16 at 14 42 55](https://cloud.githubusercontent.com/assets/1303616/3599631/d92ffdca-0cf0-11e4-89cd-e8b8778bf04c.png)
