### PR TITLE
fix for wrapping in football results

### DIFF
--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -221,6 +221,7 @@ $football-crest--large: 60px;
 
     .match-summary__teams {
         border-top: 0 none;
+        white-space: nowrap;
     }
     .match-summary__team {
         @include box-sizing(border-box);


### PR DESCRIPTION
not an ideal fix for #5094. not ideal as the right alignment now hangs a few pixels over in buggy environments. this should only be chrome 35 as the was a bug introduced in chrome 35 (and is hopefully fixed in 36)
