### PR TITLE
Break the navigation on two levels at a new breakpoint

### DIFF
--- a/common/app/assets/stylesheets/module/_new-navigation.scss
+++ b/common/app/assets/stylesheets/module/_new-navigation.scss
@@ -46,6 +46,8 @@ $new-navigation-h-space-between-items: $gs-gutter;
 
 $c-navigation-expandable-background: guss-colour(neutral-1);
 
+$mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevels, gs-span(14));
+
 
 /* Overrides (to be incorporated into the global CSS when killing the old nav)
    ========================================================================== */
@@ -94,7 +96,7 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
         }
     }
 
-    @include mq(wide) {
+    @include mq(navigationBreakOnTwoLevels) {
         &.has-page-skin .l-header .gs-container {
             @include rem((
                 width: auto
@@ -257,6 +259,7 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
     position: relative;
     background: $c-signposting-background;
     border-right: 1px solid $c-global-navigation-border;
+    @include box-sizing(border-box);
     @include rem((
         padding-right: $new-navigation-h-space-between-items
     ));
@@ -266,7 +269,12 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
             padding-left: $new-navigation-h-space-between-items/2
         ));
     }
-    @include mq(wide) {
+    .new-navigation--expanded.new-navigation--has-local-navigation & {
+        @include mq($to: navigationBreakOnTwoLevels) {
+            border-bottom: 1px solid $c-global-navigation-border;
+        }
+    }
+    @include mq(tablet) {
         border-right-width: 0;
 
         .new-navigation--has-local-navigation & {
@@ -275,12 +283,17 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
     }
 
     .new-navigation--expanded & {
-        @include mq($to: wide) {
+        @include mq($to: tablet) {
             border-right: 0;
+        }
+        @include mq(tablet) {
+            @include rem((
+                min-width: $global-navigation-title-width
+            ));
         }
         @include mq(wide) {
             @include rem((
-                min-width: gs-span(2) + $gs-gutter
+                min-width: $global-navigation-title-width-wide
             ));
         }
     }
@@ -551,6 +564,15 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
         display: table-cell;
         position: relative;
     }
+    .top-navigation {
+        @include mq(navigationBreakOnTwoLevels) {
+            @include box-sizing(border-box);
+            @include rem((
+                min-width: gs-span(12),
+                padding-right: $new-navigation-toggler-width-full + $gs-gutter
+            ));
+        }
+    }
     .top-navigation__item:last-child {
         @include rem((
             padding-right: $new-navigation-toggler-width + $gs-gutter
@@ -560,6 +582,9 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
             @include rem((
                 padding-right: $new-navigation-toggler-width-full + $gs-gutter
             ));
+        }
+        @include mq(navigationBreakOnTwoLevels) {
+            padding-right: 0;
         }
     }
 }
@@ -641,7 +666,7 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
 /* Side breakpoint: navigation goes on two levels
    ========================================================================== */
 
-@include mq(wide) {
+@include mq(navigationBreakOnTwoLevels) {
     .new-navigation--has-signposting {
         .new-navigation__inner:before {
             content: '';
@@ -717,7 +742,7 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
         display: none;
     }
     .top-navigation__item--current {
-        @include mq(wide) {
+        @include mq(navigationBreakOnTwoLevels) {
             display: table-cell;
         }
     }
@@ -771,7 +796,7 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
         ));
         text-align: left;
     }
-    @include mq(wide) {
+    @include mq(navigationBreakOnTwoLevels) {
         border-left: 0;
     }
 }
@@ -842,5 +867,18 @@ $c-navigation-expandable-background: guss-colour(neutral-1);
         @include mq(tablet) {
             @include transition(all .1s ease-in);
         }
+    }
+}
+
+
+/**
+ * Super dirty way to hide some navigation items
+ */
+
+$hidden-top-nav-sections: (science, education);
+
+@each $section in $hidden-top-nav-sections {
+    .top-navigation [data-link-name='nav : primary : #{$section}'] {
+        display: none;
     }
 }


### PR DESCRIPTION
We now break the navigation on two levels for a much larger share of our audience, especially laptops with screens with a resolution of 1280x800px (eg: Macbook Pro 13").
- [new] Hide science and education sections (disclaimer: dirty hack until it's done properly by @tudorraul)
- [new] New breakpoint `navigationBreakOnTwoLevels` (13 grid columns, which is 1100px)

![screen shot 2014-07-16 at 16 33 00](https://cloud.githubusercontent.com/assets/85783/3601129/a4f046ba-0cfe-11e4-800e-355d4c8c54d0.PNG)

![ ](http://gifs.joelglovier.com/dancing/advance-break-dans.gif)
