### PR TITLE
added a new SBT target to the integration test for CI builds

### DIFF
--- a/integration-tests/scala-fw-tests/build.sbt
+++ b/integration-tests/scala-fw-tests/build.sbt
@@ -9,3 +9,10 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "com.gu" %% "scala-automation" % "1.15-SNAPSHOT"
 )
+
+lazy val ciTest = taskKey[Unit]("Run tests for CI which will return exit code 0 even if a test fails") 
+
+ciTest := { 
+  val testResult = (test in Test).result.value 
+  0
+} 


### PR DESCRIPTION
New sbt target will run tests and if they fail, will return error code 0. For background as to why doing this please see this link: 

http://confluence.jetbrains.com/pages/viewpage.action?pageId=43680557

This will allow you to mute test failures in integration tests in order to build a fix.
