### PR TITLE
Use correct section name for video component

### DIFF
--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -258,7 +258,7 @@ define([
         },
         initMoreInSection: function() {
             var section = new Component();
-            section.endpoint = '/video/section/' + config.page.section + '.json?shortUrl=' + config.page.shortUrl;
+            section.endpoint = '/video/section/' + config.page.section + '.json?shortUrl=' + config.page.shortUrl + '&sectionName=' + config.page.sectionName;
             section.fetch($('.js-onward')[0]);
         }
     };

--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -258,7 +258,7 @@ define([
         },
         initMoreInSection: function() {
             var section = new Component();
-            section.endpoint = '/video/section/' + config.page.section + '.json?shortUrl=' + config.page.shortUrl + '&sectionName=' + config.page.sectionName;
+            section.endpoint = '/video/section/' + config.page.section + '.json?shortUrl=' + config.page.shortUrl;
             section.fetch($('.js-onward')[0]);
         }
     };

--- a/common/app/assets/javascripts/bootstraps/video.js
+++ b/common/app/assets/javascripts/bootstraps/video.js
@@ -258,7 +258,7 @@ define([
         },
         initMoreInSection: function() {
             var section = new Component();
-            section.endpoint = '/video/section/' + config.page.section + '.json';
+            section.endpoint = '/video/section/' + config.page.section + '.json?shortUrl=' + config.page.shortUrl;
             section.fetch($('.js-onward')[0]);
         }
     };

--- a/common/app/views/fragments/containers/series.scala.html
+++ b/common/app/views/fragments/containers/series.scala.html
@@ -5,7 +5,8 @@
     @defining(templateDeduping(5, collection.items)) { items =>
         @if(items.nonEmpty) {
             <section
-                class="@RenderClasses(Map(
+                class="facia-container--default-heading
+                    @RenderClasses(Map(
                     ("container", true),
                     (s"container--${style.containerType}", true),
                     ("js-container--toggle", (containerIndex > 0 && title.nonEmpty))))"

--- a/onward/app/controllers/VideoInSectionController.scala
+++ b/onward/app/controllers/VideoInSectionController.scala
@@ -50,7 +50,7 @@ object VideoInSectionController extends Controller with Logging with Paging with
   }
 
   private def renderSectionTrails(trails: Seq[Content], sectionId: String)(implicit request: RequestHeader) = {
-    val sectionName = request.getQueryString("sectionName").getOrElse("")
+    val sectionName = trails.headOption.map(t => t.sectionName).getOrElse("")
     implicit val config = Config(id = sectionId, href = Option(sectionId), displayName = Some(s"More ${sectionName} videos") )
     val response = () => views.html.fragments.containers.multimedia(Collection(trails.take(3)), MultimediaContainer(), 1)
     renderFormat(response, response, 1)

--- a/onward/app/controllers/VideoInSectionController.scala
+++ b/onward/app/controllers/VideoInSectionController.scala
@@ -50,7 +50,8 @@ object VideoInSectionController extends Controller with Logging with Paging with
   }
 
   private def renderSectionTrails(trails: Seq[Content], sectionId: String)(implicit request: RequestHeader) = {
-    implicit val config = Config(id = sectionId, href = Option(sectionId), displayName = Some(s"More ${sectionId} videos") )
+    val sectionName = request.getQueryString("sectionName").getOrElse("")
+    implicit val config = Config(id = sectionId, href = Option(sectionId), displayName = Some(s"More ${sectionName} videos") )
     val response = () => views.html.fragments.containers.multimedia(Collection(trails.take(3)), MultimediaContainer(), 1)
     renderFormat(response, response, 1)
   }


### PR DESCRIPTION
- Use sectionName rather than sectionId for the video component label
- Fix styling of series component heading
- Add shortUrl for deduping
