### PR TITLE
Services navigation layout for tablet 

### DIFF
--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -23,6 +23,12 @@
     }
 }
 
+.tablet-only {
+    @include mq(tablet) {
+        display: none !important;
+    }
+}
+
 .hide-on-mobile {
     display: none !important;
 

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -22,13 +22,6 @@
         display: none !important;
     }
 }
-
-.tablet-only {
-    @include mq(tablet) {
-        display: none !important;
-    }
-}
-
 .hide-on-mobile {
     display: none !important;
 
@@ -41,6 +34,20 @@
 
     @include mq(tablet) {
         display: inline !important;
+    }
+}
+
+.tablet-only {
+    @include mq($to: mobile) {
+        display: none !important;
+    }
+    @include mq(desktop) {
+        display: none !important;
+    }
+}
+.hide-on-tablet {
+    @include mq(mobile, desktop) {
+        display: none !important;
     }
 }
 

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -133,11 +133,15 @@ a.edition {
     ));
 }
 .guardian-services__action {
-    @include fs-header(1);
+    @include fs-headline(1);
+    display: block;
     text-decoration: none;
     margin: 0;
     color: $c-neutral1;
     cursor: pointer;
+    @include rem((
+        line-height: $headerHeight
+    ));
 }
 .guardian-services__action__arrow {
     display: inline-block;
@@ -160,7 +164,6 @@ a.edition {
     background: $c-new-navigation-base;
 
     .guardian-services__action {
-        display: inline-block;
         color: $c-local-navigation-action;
     }
     .guardian-services__action__arrow {
@@ -175,11 +178,12 @@ a.edition {
     position: absolute;
     background: $c-new-navigation-base;
     margin: 0;
+    padding: 0;
     right: 0;
     list-style: none;
     @include rem((
         top: $headerHeight,
-        padding: $gs-baseline/2 $gs-gutter/2,
+        padding: 0 $gs-gutter/2,
         width: gs-span(3)
     ));
 }

--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -184,8 +184,13 @@ a.edition {
     @include rem((
         top: $headerHeight,
         padding: 0 $gs-gutter/2,
-        width: gs-span(3)
+        width: gs-span(2)
     ));
+    @include mq(desktop) {
+        @include rem((
+            width: gs-span(3)
+        ));
+    }
 }
 
 /* Main header (logo, actions)

--- a/common/app/assets/stylesheets/module/nav/_nav.scss
+++ b/common/app/assets/stylesheets/module/nav/_nav.scss
@@ -355,7 +355,7 @@
 
     .top-nav__item {
         @include rem((
-            padding: 2px+$gs-baseline/2 $gs-gutter 0 $gs-gutter/2
+            padding-right: $gs-gutter
         ));
         margin: 0;
     }

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -11,7 +11,7 @@
                 <a class="guardian-services__action" data-link-name="topNav : jobs"
                    href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS">jobs</a>
             </div>
-            <div class="top-nav__item">
+            <div class="top-nav__item hide-on-tablet">
                 <a class="guardian-services__action" data-link-name="topNav : soulmates"
                    href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
             </div>
@@ -21,6 +21,8 @@
                     <span class="guardian-services__action__arrow"></span>
                 </span>
                 <ul class="guardian-services__item--more-menu">
+                    <li class="tablet-only"><a class="guardian-services__action" data-link-name="topNav : soulmates"
+                           href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a></li>
                     <li><a class="guardian-services__action" data-link-name="topNav : masterclasses"
                            href="http://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES">masterclasses</a></li>
                     <li><a class="guardian-services__action" data-link-name="topNav : subscribe"


### PR DESCRIPTION
To avoid services links overlapping user's name (for long names only), on tablet, 'soulmates' link will be moved under the 'more' menu.
### Tablet

![screen shot 2014-07-17 at 17 01 39](https://cloud.githubusercontent.com/assets/1492162/3615810/fa74135a-0dcb-11e4-8348-454e95e4d78a.png)
### Desktop

![png](https://cloud.githubusercontent.com/assets/1492162/3615815/03f7eed8-0dcc-11e4-97a9-866f58b2e6b3.png)
