### PR TITLE
Add libpng to the local install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Local Install Requirements
 * Installed Grunt (build tool) `sudo npm -g install grunt-cli`
 * Installed Ruby >= v1.9.x (on Ubuntu: `sudo apt-get install ruby ruby-dev`) & [bundler](http://gembundler.com/) (You may already have this installed, but run `ruby -v` to check version number)
 * Installed Memcached `sudo apt-get install memcached` - this is optional (most of the time you do not want to use it as caching makes local development harder)
+* Installed [libpng](http://libpng.org/pub/png/libpng.html): `brew install libpng` (Mac OSX with [Homebrew](http://brew.sh/)) or `sudo apt-get install libpng-dev` (Ubuntu)
 
 
 NPM ownership


### PR DESCRIPTION
Libpng is required for the image optimisation task (pngquant).

![ ](http://gifs.joelglovier.com/popcorn/popcorn-stuffing.gif)
