### PR TITLE
Header fixes

### DIFF
--- a/common/app/assets/stylesheets/layout/_header.scss
+++ b/common/app/assets/stylesheets/layout/_header.scss
@@ -57,7 +57,7 @@ $servicesToggleArrowSize: 5px;
 .l-header-pre {
     float: left;
     min-width: gs-span(2);
-    z-index: 2;
+    z-index: 3;
     position: relative;
 
     @include mq(tablet) {
@@ -189,5 +189,5 @@ a.edition {
 
 .l-header-main {
     position: relative;
-    z-index: 1;
+    z-index: 2;
 }

--- a/common/app/assets/stylesheets/module/nav/_pop-up.scss
+++ b/common/app/assets/stylesheets/module/nav/_pop-up.scss
@@ -82,7 +82,7 @@
 
     @include mq(tablet) {
         right: auto;
-        top: -1px;
+        top: 0;
         border: 1px solid $c-neutral4;
 
         @include rem((
@@ -101,9 +101,9 @@
 .nav-popup--profile {
     @include mq(tablet) {
         right: auto;
-        top: -1px;
+        top: 0;
         @include rem((
-            left: 319px,
+            left: 321px,
             width: gs-span(3)
         ));
     }


### PR DESCRIPTION
Fix pop-un menus:
- display top border (no longer needs to be hidden)
- site navigation on top when menus are open

![png](https://cloud.githubusercontent.com/assets/1492162/3616167/1febb18e-0dd0-11e4-8745-163cdbbdbd82.png)
