### PR TITLE
Fix latency metrics

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -583,6 +583,7 @@ class FrontendTimingMetric(
   override val getValue = () => totalTimeInMillis
 
   def getAndReset: Long = currentCount.getAndSet(0)
+  def getAndResetTime: Long = timeInMillis.getAndSet(0) / currentCount.getAndSet(0)
 }
 
 object PerformanceMetrics {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicLong
 import com.amazonaws.services.cloudwatch.model.Dimension
 import common.FaciaToolMetrics.InvalidContentExceptionMetric
 import scala.collection.JavaConversions._
+import scala.util.Try
 
 trait TimingMetricLogging extends Logging { self: TimingMetric =>
   override def measure[T](block: => T): T = {
@@ -583,7 +584,7 @@ class FrontendTimingMetric(
   override val getValue = () => totalTimeInMillis
 
   def getAndReset: Long = currentCount.getAndSet(0)
-  def getAndResetTime: Long = timeInMillis.getAndSet(0) / currentCount.getAndSet(0)
+  def getAndResetTime: Long = Try(timeInMillis.getAndSet(0) / currentCount.getAndSet(0)).getOrElse(0L)
 }
 
 object PerformanceMetrics {

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -38,9 +38,9 @@ object Global extends GlobalSettings
     ("content-api-seo-request-failure", FaciaPressMetrics.ContentApiSeoRequestFailure.getAndReset.toDouble),
     ("content-api-fallbacks", FaciaPressMetrics.MemcachedFallbackMetric.getAndReset.toDouble),
     ("front-press-latency", FaciaPressMetrics.FrontPressLatency.getAndReset.toDouble),
-    ("uk-network-front-press-latency", FaciaPressMetrics.UkFrontPressLatency.getAndReset.toDouble),
-    ("us-network-front-press-latency", FaciaPressMetrics.UsFrontPressLatency.getAndReset.toDouble),
-    ("au-network-front-press-latency", FaciaPressMetrics.AuFrontPressLatency.getAndReset.toDouble)
+    ("uk-network-front-press-latency", FaciaPressMetrics.UkFrontPressLatency.getAndResetTime.toDouble),
+    ("us-network-front-press-latency", FaciaPressMetrics.UsFrontPressLatency.getAndResetTime.toDouble),
+    ("au-network-front-press-latency", FaciaPressMetrics.AuFrontPressLatency.getAndResetTime.toDouble)
   )
 
   def scheduleJobs() {


### PR DESCRIPTION
Use the average time for the current period from a `FrontendTimingMetric`.

@stephanfowler 
