### PR TITLE
Use new beacon url in PROD. Fixes #2663

### DIFF
--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -59,7 +59,7 @@ guardian.page.sentryApiKey=17a0e3a79ce7454383be5e410e649750
 guardian.page.sentryHost=frontend-sentrylo-35h427x3sdhb-2122817448.eu-west-1.elb.amazonaws.com/2
 
 # Beacon
-beacon.url=//beacon.www.theguardian.com
+beacon.url=//beacon.guim.co.uk
 
 contentapi.post.endpoint=http://coolproxy.mobile-apps.guardianapis.com
 


### PR DESCRIPTION
Moves our beacon url to a cookie less domain as discussed in #2663 
# perfmatters
