### PR TITLE
Revert "Integrate Foundation-Supported Pages"

### DIFF
--- a/admin/app/controllers/CommercialController.scala
+++ b/admin/app/controllers/CommercialController.scala
@@ -1,14 +1,16 @@
 package controllers.admin
 
-import common.Logging
-import conf.Configuration
-import controllers.AuthLogging
-import dfp.Sponsorship
-import model.NoCache
-import ophan.SurgingContentAgent
-import play.api.libs.json.Json
 import play.api.mvc.Controller
+import common.Logging
+import model.{AdReports, NoCache}
+import controllers.AuthLogging
+import conf.Configuration
 import tools.Store
+import play.api.libs.json.Json
+import dfp.{SponsorshipReport, Sponsorship}
+import implicits.Dates
+import org.joda.time.DateTime
+import ophan.SurgingContentAgent
 
 object CommercialController extends Controller with Logging with AuthLogging {
 
@@ -27,19 +29,14 @@ object CommercialController extends Controller with Logging with AuthLogging {
   }
 
   def renderSponsorships = Authenticated { implicit request =>
-    val sponsoredTags = Store.getDfpSponsoredTags
-    val advertisementFeatureTags = Store.getDfpAdvertisementFeatureTags
-    val foundationSupportedTags = Store.getDfpFoundationSupportedTags
+    val sponsoredTags = Store.getDfpSponsoredTags()
+    val advertisementTags = Store.getDfpAdvertisementTags()
 
-    NoCache(Ok(views.html.commercial.sponsorships(
-      Configuration.environment.stage,
-      sponsoredTags,
-      advertisementFeatureTags,
-      foundationSupportedTags)))
+    NoCache(Ok(views.html.commercial.sponsorships(Configuration.environment.stage, sponsoredTags, advertisementTags)))
   }
 
   def renderPageskins = Authenticated { implicit request =>
-    val pageskinnedAdUnits = Store.getDfpPageSkinnedAdUnits
+    val pageskinnedAdUnits = Store.getDfpPageSkinnedAdUnits()
 
     NoCache(Ok(views.html.commercial.pageskins(Configuration.environment.stage, pageskinnedAdUnits)))
   }

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -136,9 +136,6 @@ object DfpDataCacheJob extends ExecutionContexts with Dates{
         val advertisementFeatureSponsorships = data.advertisementFeatureSponsorships
         Store.putDfpAdvertisementFeatureTags(stringify(toJson(SponsorshipReport(now, advertisementFeatureSponsorships))))
 
-        val foundationSupported = data.foundationSupported
-        Store.putDfpFoundationSupportedTags(stringify(toJson(SponsorshipReport(now, foundationSupported))))
-
         val pageSkinSponsorships = data.pageSkinSponsorships
         Store.putDfpPageSkinAdUnits(stringify(toJson(PageSkinSponsorshipReport(now, pageSkinSponsorships))))
 

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -20,14 +20,6 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
     }.distinct
   }
 
-  val foundationSupported: Seq[Sponsorship] = {
-    lineItems.withFilter { lineItem =>
-      lineItem.foundationSupportedTags.nonEmpty && lineItem.isCurrent
-    }.map { lineItem =>
-      Sponsorship(lineItem.foundationSupportedTags, lineItem.sponsor)
-    }.distinct
-  }
-
   val pageSkinSponsorships: Seq[PageSkinSponsorship] = {
     lineItems withFilter { lineItem =>
       lineItem.isPageSkin && lineItem.isCurrent

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -32,9 +32,6 @@ trait Store extends Logging with Dates {
   def putDfpAdvertisementFeatureTags(keywordsJson: String) {
     S3.putPublic(dfpAdvertisementFeatureTagsDataKey, keywordsJson, defaultJsonEncoding)
   }
-  def putDfpFoundationSupportedTags(keywordsJson: String) {
-    S3.putPublic(dfpFoundationSupportedTagsDataKey, keywordsJson, defaultJsonEncoding)
-  }
   def putDfpPageSkinAdUnits(adUnitJson: String) {
     S3.putPublic(dfpPageSkinnedAdUnitsKey, adUnitJson, defaultJsonEncoding )
   }
@@ -47,15 +44,10 @@ trait Store extends Logging with Dates {
 
   val now: String = DateTime.now().toHttpDateTimeString
 
-  def getDfpSponsoredTags =
-    S3.get(dfpSponsoredTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse SponsorshipReport(now, Nil)
-  def getDfpAdvertisementFeatureTags =
-    S3.get(dfpAdvertisementFeatureTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse SponsorshipReport(now, Nil)
-  def getDfpFoundationSupportedTags =
-    S3.get(dfpFoundationSupportedTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse SponsorshipReport(now, Nil)
-  def getDfpPageSkinnedAdUnits =
-    S3.get(dfpPageSkinnedAdUnitsKey).flatMap(PageSkinSponsorshipReportParser(_)) getOrElse PageSkinSponsorshipReport(now, Nil)
-  def getDfpLineItemsReport = S3.get(dfpLineItemsKey)
+  def getDfpSponsoredTags() = S3.get(dfpSponsoredTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse(SponsorshipReport(now, Nil))
+  def getDfpAdvertisementTags() = S3.get(dfpAdvertisementFeatureTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse(SponsorshipReport(now, Nil))
+  def getDfpPageSkinnedAdUnits() = S3.get(dfpPageSkinnedAdUnitsKey).flatMap(PageSkinSponsorshipReportParser(_)) getOrElse(PageSkinSponsorshipReport(now, Nil))
+  def getDfpLineItemsReport() = S3.get(dfpLineItemsKey)
 }
 
 object Store extends Store

--- a/admin/app/views/commercial/sponsorships.scala.html
+++ b/admin/app/views/commercial/sponsorships.scala.html
@@ -1,8 +1,8 @@
-@(env: String, sponsoredTags: dfp.SponsorshipReport, advertisementTags: dfp.SponsorshipReport, foundationSupportedTags: dfp.SponsorshipReport)
+@(env: String, sponsoredTags: dfp.SponsorshipReport, advertisementTags: dfp.SponsorshipReport)
 
 @admin_main("Commercial", env, isAuthed = true, hasCharts = true) {
 
-<link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/commercial.css")">
+<link rel="stylesheet" type="text/css" href="@routes.Assets.at(" css/commercial.css")">
 
 <h1>Content Sponsorships:</h1>
 <p><a href="#criteria">Criteria for sponsorship</a></p>
@@ -23,18 +23,6 @@
 
 <ol>
     @for(sponsorship <- advertisementTags.sponsorships) {
-    <li>@{sponsorship.tags.mkString(", ")}@{sponsorship.sponsor.map(sponsor =>
-        <small>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[sponsored by <b>{sponsor}</b>]</small>
-        )}
-    </li>
-    }
-</ol>
-
-<h3>Foundation Supported Tags</h3>
-<p>Last updated: @foundationSupportedTags.updatedTimeStamp</p>
-
-<ol>
-    @for(sponsorship <- foundationSupportedTags.sponsorships) {
     <li>@{sponsorship.tags.mkString(", ")}@{sponsorship.sponsor.map(sponsor =>
         <small>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[sponsored by <b>{sponsor}</b>]</small>
         )}

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -214,8 +214,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       s"${environment.stage.toUpperCase}/commercial/dfp/sponsored-tags-v2.json"
     lazy val dfpAdvertisementFeatureTagsDataKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/advertisement-feature-tags-v2.json"
-    lazy val dfpFoundationSupportedTagsDataKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/foundation-supported-tags.json"
     lazy val dfpPageSkinnedAdUnitsKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/pageskinned-adunits-v3.json"
     lazy val dfpLineItemsKey =
@@ -346,6 +344,7 @@ object ManifestData {
 
 // AWSCredentialsProviderChain relies on these being null if not configured.
 private class NullableAWSCredentials(accessKeyId: Option[String], secretKey: Option[String]) extends AWSCredentials{
-  def getAWSAccessKeyId: String = accessKeyId.orNull
-  def getAWSSecretKey: String = secretKey.orNull
+  def getAWSAccessKeyId: String = accessKeyId.getOrElse(null)
+  def getAWSSecretKey: String = secretKey.getOrElse(null)
 }
+

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -4,7 +4,7 @@ import java.net.URLDecoder
 
 import akka.agent.Agent
 import common._
-import conf.Configuration.commercial._
+import conf.Configuration.commercial.{dfpAdUnitRoot, dfpAdvertisementFeatureTagsDataKey, dfpPageSkinnedAdUnitsKey, dfpSponsoredTagsDataKey}
 import model.{Config, Tag}
 import play.api.{Application, GlobalSettings}
 import services.S3
@@ -15,7 +15,6 @@ trait DfpAgent {
 
   protected def sponsorships: Seq[Sponsorship]
   protected def advertisementFeatureSponsorships: Seq[Sponsorship]
-  protected def foundationSupported: Seq[Sponsorship]
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship]
 
   private def containerSponsoredTag(config: Config, p: String => Boolean): Option[String] = {
@@ -38,15 +37,9 @@ trait DfpAgent {
   def isSponsored(tagId: String): Boolean = sponsorships exists (_.hasTag(tagId))
   def isSponsored(config: Config): Boolean = isSponsoredContainer(config, isSponsored)
 
-  def isAdvertisementFeature(tags: Seq[Tag]): Boolean =
-    getPrimaryKeywordOrSeriesTag(tags) exists (tag => isAdvertisementFeature(tag.id))
+  def isAdvertisementFeature(tags: Seq[Tag]): Boolean = getPrimaryKeywordOrSeriesTag(tags) exists (tag => isAdvertisementFeature(tag.id))
   def isAdvertisementFeature(tagId: String): Boolean = advertisementFeatureSponsorships exists (_.hasTag(tagId))
   def isAdvertisementFeature(config: Config): Boolean = isSponsoredContainer(config, isAdvertisementFeature)
-
-  def isFoundationSupported(tags: Seq[Tag]): Boolean =
-    getPrimaryKeywordOrSeriesTag(tags) exists (tag => isFoundationSupported(tag.id))
-  def isFoundationSupported(tagId: String): Boolean = foundationSupported exists (_.hasTag(tagId))
-  def isFoundationSupported(config: Config): Boolean = isSponsoredContainer(config, isFoundationSupported)
 
   def isPageSkinned(adUnitWithoutRoot: String, edition: Edition): Boolean = {
     if (adUnitWithoutRoot endsWith "front") {
@@ -69,7 +62,7 @@ trait DfpAgent {
 
   def getSponsor(tagId: String): Option[String] = {
     def sponsorOf(sponsorships: Seq[Sponsorship]) = sponsorships.find(_.hasTag(tagId)).flatMap(_.sponsor)
-    sponsorOf(sponsorships) orElse sponsorOf(advertisementFeatureSponsorships) orElse sponsorOf(foundationSupported)
+    sponsorOf(sponsorships) orElse sponsorOf(advertisementFeatureSponsorships)
   }
 
   def getSponsor(config: Config): Option[String] = {
@@ -85,13 +78,11 @@ object DfpAgent extends DfpAgent with ExecutionContexts {
 
   private lazy val sponsoredTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
   private lazy val advertisementFeatureTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
-  private lazy val foundationSupportedTagsAgent = AkkaAgent[Seq[Sponsorship]](Nil)
   private lazy val pageskinnedAdUnitAgent = AkkaAgent[Seq[PageSkinSponsorship]](Nil)
 
-  override protected def sponsorships: Seq[Sponsorship] = sponsoredTagsAgent get()
-  override protected def advertisementFeatureSponsorships: Seq[Sponsorship] = advertisementFeatureTagsAgent get()
-  override protected def foundationSupported: Seq[Sponsorship] = foundationSupportedTagsAgent get()
-  override protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent get()
+  protected def sponsorships: Seq[Sponsorship] = sponsoredTagsAgent get()
+  protected def advertisementFeatureSponsorships: Seq[Sponsorship] = advertisementFeatureTagsAgent get()
+  protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent get()
 
   def refresh() {
 
@@ -127,7 +118,6 @@ object DfpAgent extends DfpAgent with ExecutionContexts {
 
     update(sponsoredTagsAgent, grabSponsorshipsFromStore(dfpSponsoredTagsDataKey))
     update(advertisementFeatureTagsAgent, grabSponsorshipsFromStore(dfpAdvertisementFeatureTagsDataKey))
-    update(foundationSupportedTagsAgent, grabSponsorshipsFromStore(dfpFoundationSupportedTagsDataKey))
     update(pageskinnedAdUnitAgent, grabPageSkinSponsorshipsFromStore(dfpPageSkinnedAdUnitsKey))
   }
 }

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -12,8 +12,6 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
 
   val isAdvertisementFeatureSlot = isSlot("adbadge")
 
-  val isFoundationSupportedSlot = isSlot("fobadge")
-
   val isTag = isPositive("k") || isPositive("se")
 }
 
@@ -28,8 +26,6 @@ case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
   val sponsoredTags = filterTags(_.isSponsoredSlot)
 
   val advertisementFeatureTags = filterTags(_.isAdvertisementFeatureSlot)
-
-  val foundationSupportedTags = filterTags(_.isFoundationSupportedSlot)
 }
 
 
@@ -55,6 +51,4 @@ case class GuLineItem(id: Long,
   val sponsoredTags: Seq[String] = targeting.customTargetSets.flatMap(_.sponsoredTags).distinct
 
   val advertisementFeatureTags: Seq[String] = targeting.customTargetSets.flatMap(_.advertisementFeatureTags).distinct
-
-  val foundationSupportedTags: Seq[String] = targeting.customTargetSets.flatMap(_.foundationSupportedTags).distinct
 }

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -15,7 +15,7 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
 
   override lazy val isFront = true
 
-  override lazy val description = Some(s"Latest news and comment on ${webTitle.toLowerCase} from the Guardian")
+  override lazy val description = Some(s"Latest news and comment on ${webTitle.toLowerCase()} from the Guardian")
 
   override lazy val url: String = SupportedUrl(delegate)
 
@@ -28,9 +28,8 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
     "content-type" -> "Section"
   )
 
-  override lazy val isSponsored = DfpAgent.isSponsored(id)
-  override lazy val isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
-  override lazy val isFoundationSupported = DfpAgent.isFoundationSupported(id)
-  override lazy val sponsor = DfpAgent.getSponsor(id)
+  override def isSponsored = DfpAgent.isSponsored(this.id)
+  override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(this.id)
+  override def sponsor = DfpAgent.getSponsor(this.id)
   override def hasPageSkin(edition: Edition) = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 }

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -23,7 +23,6 @@ case class Config(
 
   lazy val isSponsored: Boolean = DfpAgent.isSponsored(this)
   lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(this)
-  lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(this)
 
   lazy val sponsorshipKeyword: Option[String] = DfpAgent.sponsorshipTag(this)
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -172,8 +172,7 @@ trait Tags {
 
   def isSponsored = DfpAgent.isSponsored(tags)
   def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(tags)
-  def isFoundationSupported = DfpAgent.isFoundationSupported(tags)
-  def sponsor: Option[String] = DfpAgent.getSponsor(tags)
+  def sponsor = DfpAgent.getSponsor(tags)
 
   // Tones are all considered to be 'News' it is the default so we do not list news tones explicitly
   lazy val visualTone: String =

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -1,10 +1,9 @@
 @(content: model.Content)
 @import conf.Switches._
-@import model.LiveBlog
 
-@if(SponsoredSwitch.isSwitchedOn && (content.isSponsored || content.isAdvertisementFeature || content.isFoundationSupported)) {
+@if(SponsoredSwitch.isSwitchedOn && (content.isSponsored || content.isAdvertisementFeature)) {
     @defining((
-        content match { case c if c.isSponsored => {"spbadge"} case c if c.isAdvertisementFeature => {"adbadge"} case _ => {"fobadge"} },
+        content match { case c if c.isSponsored => {"spbadge"} case _ => {"adbadge"} },
         content match { case _: LiveBlog => {"live-blog"} case _ => {"article"} }
     )) { case (name, badgeType) =>
         @fragments.commercial.adSlot(

--- a/common/test/common/GuardianConfigurationTest.scala
+++ b/common/test/common/GuardianConfigurationTest.scala
@@ -22,7 +22,7 @@ class GuardianConfigurationTest extends FlatSpec with Matchers {
     // are any required changes, update the hash below, and off you go.
 
     withClue("Look at comment in GuardianConfigurationTest.scala!") {
-      hash should be("ed923556e3663f4d21038c318a77b873")
+      hash should be("e18cf7f7d0c1c3fd2d804b06bb7ce134")
     }
   }
 }

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -21,11 +21,6 @@ class DfpAgentTest extends FlatSpec with Matchers {
       Sponsorship(Seq("film"), None)
     )
 
-    override protected def foundationSupported: Seq[Sponsorship] = Seq(
-      Sponsorship(Seq("music"), Some("Music Foundation")),
-      Sponsorship(Seq("chuckle"), None)
-    )
-
     override protected def pageSkinSponsorships: Seq[PageSkinSponsorship] =
       Seq(
         PageSkinSponsorship("lineItemName",
@@ -47,14 +42,6 @@ class DfpAgentTest extends FlatSpec with Matchers {
     Config("id", Some(apiQuery), None, None)
   }
 
-  "isSponsored" should "be true for a sponsored article" in {
-    testDfpAgent.isSponsored("spon-page") should be(true)
-  }
-
-  "isSponsored" should "be false for an unsponsored article" in {
-    testDfpAgent.isSponsored("article") should be(false)
-  }
-
   "isAdvertisementFeature" should "be true for an advertisement feature" in {
     testDfpAgent.isAdvertisementFeature("ad-feature") should be(true)
   }
@@ -63,12 +50,12 @@ class DfpAgentTest extends FlatSpec with Matchers {
     testDfpAgent.isAdvertisementFeature("article") should be(false)
   }
 
-  "isFoundationSupported" should "be true for a foundation-supported page" in {
-    testDfpAgent.isFoundationSupported("chuckle") should be(true)
+  "isSponsored" should "be true for a sponsored article" in {
+    testDfpAgent.isSponsored("spon-page") should be(true)
   }
 
-  "isFoundationSupported" should "be false for a non foundation-supported page" in {
-    testDfpAgent.isFoundationSupported("guffaw") should be(false)
+  "isSponsored" should "be false for an unsponsored article" in {
+    testDfpAgent.isSponsored("article") should be(false)
   }
 
   "isSponsored" should "be true for a sponsored container" in {
@@ -211,20 +198,8 @@ class DfpAgentTest extends FlatSpec with Matchers {
     testDfpAgent.getSponsor("ad-feature") should be(Some("spon2"))
   }
 
-  "getSponsor" should "have some value for a foundation-supported tag with a specified sponsor" in {
-    testDfpAgent.getSponsor("music") should be(Some("Music Foundation"))
-  }
-
-  "getSponsor" should "have no value for a sponsored tag without a specified sponsor" in {
-    testDfpAgent.getSponsor("media") should be(None)
-  }
-
   "getSponsor" should "have no value for an advertisement feature tag without a specified sponsor" in {
     testDfpAgent.getSponsor("film") should be(None)
-  }
-
-  "getSponsor" should "have no value for a foundation-supported tag without a specified sponsor" in {
-    testDfpAgent.getSponsor("chuckle") should be(None)
   }
 
   "getSponsor" should "have no value for an unsponsored tag" in {

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -29,10 +29,9 @@ case class FaciaPage(
 
   override lazy val contentType: String =   if (isNetworkFront) GuardianContentTypes.NETWORK_FRONT else GuardianContentTypes.SECTION
 
-  override lazy val isSponsored = DfpAgent.isSponsored(id)
-  override lazy val isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
-  override lazy val isFoundationSupported = DfpAgent.isFoundationSupported(id)
-  override lazy val sponsor = DfpAgent.getSponsor(id)
+  override def isSponsored = DfpAgent.isSponsored(id)
+  override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
+  override def sponsor = DfpAgent.getSponsor(id)
   override def hasPageSkin(edition: Edition) = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 }
 


### PR DESCRIPTION
We don't need to treat foundation-supported content as a special case it seems.
