### PR TITLE
Drop support for SVG fonts

### DIFF
--- a/common/app/assets/stylesheets/webfonts.scss
+++ b/common/app/assets/stylesheets/webfonts.scss
@@ -3,8 +3,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Ag-Sans-1-Web-Reg.eot');
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Ag-Sans-1-Web-Reg.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Ag-Sans-1-Web-Reg.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Ag-Sans-1-Web-Reg.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Ag-Sans-1-Web-Reg.svg#Guardian-Text-Egyp-Web-Reg') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Ag-Sans-1-Web-Reg.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
@@ -14,8 +13,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-Regular.eot');
     src: url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-Regular.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-Regular.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-Regular.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-Regular.svg#Guardian Text Egyptian Web') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
@@ -25,8 +23,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-RegularItalic.eot');
     src: url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-RegularItalic.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-RegularItalic.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-RegularItalic.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-RegularItalic.svg#Guardian Text Egyptian Web') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/WebEgyptianHinted-RegularItalic.ttf') format('truetype');
     font-weight: normal;
     font-style: italic;
     font-stretch: normal;
@@ -36,8 +33,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Med.eot');
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Med.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Med.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Med.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Med.svg#Guardian-Text-Egyp-Web-Medium') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Med.ttf') format('truetype');
     font-weight: 700;
     font-style: normal;
     font-stretch: normal;
@@ -47,8 +43,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Light.eot');
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Light.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Light.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Light.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Light.svg#Guardian-Egyp-Web-Light') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Light.ttf') format('truetype');
     font-weight: 200;
     font-style: normal;
     font-stretch: normal;
@@ -58,8 +53,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Regular.eot');
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Regular.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Regular.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Regular.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Regular.svg#Guardian-Egyp-Web-Regular') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
@@ -69,8 +63,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Semibold.eot');
     src: url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Semibold.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Semibold.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Semibold.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Semibold.svg#Guardian-Egyp-Web-Semibold') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Semibold.ttf') format('truetype');
     font-weight: 900;
     font-style: normal;
     font-stretch: normal;
@@ -80,8 +73,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/TextSans-Regular.eot');
     src: url('http://pasteup.guim.co.uk/fonts/TextSans-Regular.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/TextSans-Regular.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/TextSans-Regular.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/TextSans-Regular.svg#TextSans-Regular') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/TextSans-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
@@ -91,8 +83,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/TextSans-RegularIt.eot');
     src: url('http://pasteup.guim.co.uk/fonts/TextSans-RegularIt.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/TextSans-RegularIt.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/TextSans-RegularIt.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/TextSans-RegularIt.svg#TextSans-RegularIt') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/TextSans-RegularIt.ttf') format('truetype');
     font-weight: normal;
     font-style: italic;
     font-stretch: normal;
@@ -102,8 +93,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/TextSans-Medium.eot');
     src: url('http://pasteup.guim.co.uk/fonts/TextSans-Medium.eot?#iefix') format('embedded-opentype'),
          url('http://pasteup.guim.co.uk/fonts/TextSans-Medium.woff') format('woff'),
-         url('http://pasteup.guim.co.uk/fonts/TextSans-Medium.ttf') format('truetype'),
-         url('http://pasteup.guim.co.uk/fonts/TextSans-Medium.svg#TextSans-Medium') format('svg');
+         url('http://pasteup.guim.co.uk/fonts/TextSans-Medium.ttf') format('truetype');
     font-weight: 700;
     font-style: normal;
     font-stretch: normal;
@@ -113,8 +103,7 @@
     src: url('http://pasteup.guim.co.uk/fonts/latin1/GuardianSansHeadline-Light.eot');
     src: url('http://pasteup.guim.co.uk/fonts/latin1/GuardianSansHeadline-Light?#iefix') format('embedded-opentype'),
     url('http://pasteup.guim.co.uk/fonts/latin1/GuardianSansHeadline-Light.woff') format('woff'),
-    url('http://pasteup.guim.co.uk/fonts/latin1/GuardianSansHeadline-Light.ttf') format('truetype'),
-    url('http://pasteup.guim.co.uk/fonts/latin1/GuardianSansHeadline-Light.svg#Guardian Sans Web') format('svg');
+    url('http://pasteup.guim.co.uk/fonts/latin1/GuardianSansHeadline-Light.ttf') format('truetype');
     font-weight: 200;
     font-style: normal;
     font-stretch: normal;


### PR DESCRIPTION
For these reasons:
1. We don't test in devices that support SVG fonts only
2. We don't even serve SVG fonts to devices that only support SVG

![ ](http://gifs.joelglovier.com/epic/stickman-adventure.gif)
