### PR TITLE
Persistent commercial ab test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -814,7 +814,12 @@ module.exports = function (grunt) {
      */
     grunt.registerTask('compile:images', ['copy:images', 'shell:spriteGeneration', 'imagemin']);
     grunt.registerTask('compile:css', ['sass:compile', 'replace:cssSourceMaps', 'copy:css']);
-    grunt.registerTask('compile:js', ['requirejs', 'copy:javascript', 'uglify:javascript']);
+    grunt.registerTask('compile:js', function() {
+        grunt.task.run(['requirejs', 'copy:javascript']);
+        if (!isDev) {
+            grunt.task.run('uglify:javascript');
+        }
+    });
     grunt.registerTask('compile:fonts', ['mkdir:fontsTarget', 'webfontjson']);
     grunt.registerTask('compile:flash', ['copy:flash']);
     grunt.registerTask('compile:conf', ['copy:headJs', 'copy:headCss', 'copy:assetMap']);

--- a/common/app/assets/javascripts/core.js
+++ b/common/app/assets/javascripts/core.js
@@ -52,6 +52,7 @@ require([
     'common/modules/commercial/user-ad-targeting',
     'common/modules/commercial/dfp',
     'common/modules/component',
+    'common/modules/experiments/ab',
     'common/modules/lazyload',
     'common/modules/ui/tabs'
 ], function() {});

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -19,7 +19,8 @@ define([
     'common/modules/commercial/tags/audience-science-gateway',
     'common/modules/commercial/tags/criteo',
     'common/modules/commercial/keywords',
-    'common/modules/commercial/user-ad-targeting'
+    'common/modules/commercial/user-ad-targeting',
+    'common/modules/experiments/ab'
 ], function (
     bonzo,
     qwery,
@@ -40,7 +41,8 @@ define([
     audienceScienceGateway,
     criteo,
     keywords,
-    userAdTargeting
+    userAdTargeting,
+    ab
 ) {
 
     /**
@@ -264,7 +266,8 @@ define([
                 bp      : detect.getBreakpoint(),
                 a       : audienceScience.getSegments(),
                 at      : cookies.get('adtest') || '',
-                gdncrm  : userAdTargeting.getUserSegments()
+                gdncrm  : userAdTargeting.getUserSegments(),
+                ab      : ab.makeOmnitureTag()
             }, audienceScienceGateway.getSegments(), criteo.getSegments());
         },
         createAdSlot = function(name, types, keywords) {

--- a/common/app/assets/javascripts/modules/commercial/front-commercial-components.js
+++ b/common/app/assets/javascripts/modules/commercial/front-commercial-components.js
@@ -24,11 +24,7 @@ define([
             }
         );
 
-        if (
-            !config.switches.commercialComponents ||
-            !config.page.isFront ||
-            config.page.hasPageSkin
-        ) {
+        if (!config.switches.commercialComponents || !config.page.isFront || config.page.hasPageSkin ) {
             return false;
         }
 

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -1,14 +1,17 @@
 define([
     'common/utils/storage',
     'common/utils/mediator',
-    'common/modules/analytics/mvt-cookie'
+    'common/modules/analytics/mvt-cookie',
+    'common/modules/experiments/tests/high-commercial-component'
 ], function (
     store,
     mediator,
-    mvtCookie
+    mvtCookie,
+    HighCommercialComponent
     ) {
 
     var TESTS = [
+            new HighCommercialComponent()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -1,10 +1,12 @@
 define([
+    'lodash/objects/assign',
     'common/utils/storage',
     'common/utils/mediator',
     'common/utils/config',
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/high-commercial-component'
 ], function (
+    assign,
     store,
     mediator,
     globalConfig,
@@ -45,7 +47,7 @@ define([
         // renamed/deleted from the backend
         var participations = getParticipations();
         Object.keys(participations).forEach(function (k) {
-            if (typeof(config.switches['ab' + k]) === 'undefined') {
+            if (typeof(assign(globalConfig, config).switches['ab' + k]) === 'undefined') {
                 removeParticipation({ id: k });
             } else {
                 var testExists = TESTS.some(function (element) {
@@ -148,7 +150,7 @@ define([
     }
 
     function isTestSwitchedOn(test, config) {
-        return config.switches['ab' + test.id];
+        return assign(globalConfig, config).switches['ab' + test.id];
     }
 
     function getTestVariant(testId) {

--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -78,7 +78,7 @@ define([
 
     function testCanBeRun(test, config) {
         var expired = (new Date() - new Date(test.expiry)) > 0;
-        return (test.canRun() && !expired && isTestSwitchedOn(test));
+        return (test.canRun(config) && !expired && isTestSwitchedOn(test, config));
     }
 
     function getTest(id) {
@@ -103,7 +103,7 @@ define([
 
     // Finds variant in specific tests and runs it
     function run(test, config, context) {
-        if (isParticipating(test) && testCanBeRun(test)) {
+        if (isParticipating(test) && testCanBeRun(test, config)) {
             var participations = getParticipations(),
                 variantId = participations[test.id].variant;
             test.variants.some(function(variant) {

--- a/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
@@ -5,7 +5,7 @@ define(function () {
         this.start = '2014-07-09';
         this.expiry = '2015-07-09';
         this.author = 'Darren Hurley';
-        this.description = 'Increase the size of inline1 ad slot to 300x250 for mobile users';
+        this.description = 'Using as a DFP targeting hook to test different high relevance components';
         this.audience = 0.1;
         this.audienceOffset = 0;
         this.successMeasure = '';

--- a/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
@@ -2,7 +2,7 @@ define(function () {
 
     return function () {
         this.id = 'HighCommercialComponent';
-        this.start = '2014-07-09';
+        this.start = '2014-07-22';
         this.expiry = '2015-07-09';
         this.author = 'Darren Hurley';
         this.description = 'Using as a DFP targeting hook to test different high relevance components';

--- a/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
@@ -3,6 +3,7 @@ define(function () {
     return function () {
         this.id = 'HighCommercialComponent';
         this.start = '2014-07-22';
+        // far future expiration, only really using the test to bucket users, which we can use for targeting in dfp
         this.expiry = '2015-07-09';
         this.author = 'Darren Hurley';
         this.description = 'Using as a DFP targeting hook to test different high relevance components';

--- a/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/high-commercial-component.js
@@ -1,0 +1,35 @@
+define(function () {
+
+    return function () {
+        this.id = 'HighCommercialComponent';
+        this.start = '2014-07-09';
+        this.expiry = '2015-07-09';
+        this.author = 'Darren Hurley';
+        this.description = 'Increase the size of inline1 ad slot to 300x250 for mobile users';
+        this.audience = 0.1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return true;
+        };
+
+        /**
+         * nothing happens in here, we just use this to bucket users
+         */
+        this.variants = [
+            {
+                id: 'control',
+                test: function () { }
+            },
+            {
+                id: 'variant',
+                test: function () { }
+            }
+        ];
+    };
+
+});

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -312,6 +312,11 @@ object Switches extends Collections {
 
   // A/B Tests
 
+  val ABHighCommercialComponent = Switch("A/B Tests", "ab-high-commercial-component",
+    "Switch for the High Commercial Component A/B test.",
+    safeState = Off, sellByDate = never
+  )
+
   // Dummy Switches
 
   val IntegrationTestSwitch = Switch("Unwired Test Switch", "integration-test-switch",
@@ -493,7 +498,8 @@ object Switches extends Collections {
     FaciaToolCachedZippingContentApiSwitch,
     FaciaToolDraftPressSwitch,
     FaciaToolDraftContent,
-    GuShiftCookieSwitch
+    GuShiftCookieSwitch,
+    ABHighCommercialComponent
   )
 
   val httpSwitches: List[Switch] = List(

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -145,25 +145,31 @@
                 }
             ).install();
 
-            if (guardian.config.switches.commercial) {
+            require(['common/modules/experiments/ab'], function(ab) {
 
-                require(['bootstraps/commercial', 'js!googletag'], function(commercial) {
-                    commercial.init();
-                });
+                ab.segmentUser();
+                ab.run();
 
-            }
+                if (guardian.config.switches.commercial) {
 
-            if (guardian.isModernBrowser) {
-
-                @if(play.Play.isDev()) {
-                    require(['bootstraps/dev'], function (devmode) { devmode.init(); });
+                    require(['bootstraps/commercial', 'js!googletag'], function(commercial) {
+                        commercial.init();
+                    });
                 }
 
-                require(['bootstraps/app'], function(bootstrap) {
-                    bootstrap.go();
-                });
+                if (guardian.isModernBrowser) {
 
-            }
+                    @if(play.Play.isDev()) {
+                        require(['bootstraps/dev'], function (devmode) { devmode.init(); });
+                    }
+
+                    require(['bootstraps/app'], function(bootstrap) {
+                        bootstrap.go();
+                    });
+
+                }
+
+            });
 
         });
 


### PR DESCRIPTION
This sets up a persistent ab test, for the commercial component. As we're sending the ab test segment to DFP, they can now use that as a targeting hook, e.g. show a different component if they're in the test or not

So not a true ab test, but allows us to get the benefits of it, i.e. remember what test you're in, pass the segment on to omniture, etc 
