### PR TITLE
Different badge slot size (141x90) on multimedia (video) pages

### DIFF
--- a/common/app/assets/stylesheets/module/content/_video.head.scss
+++ b/common/app/assets/stylesheets/module/content/_video.head.scss
@@ -43,8 +43,10 @@
         color: $c-commentAccent;
     }
 
+    .ad-slot--paid-for-badge__header,
+    .ad-slot--paid-for-badge__label,
     .ad-slot--paid-for-badge__help {
-        color: $c-neutral2;
+        color: $c-neutral7;
     }
 
     .content__standfirst {

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -4,12 +4,13 @@
 @if(SponsoredSwitch.isSwitchedOn && (content.isSponsored || content.isAdvertisementFeature)) {
     @defining((
         content match { case c if c.isSponsored => {"spbadge"} case _ => {"adbadge"} },
-        content match { case _: LiveBlog => {"live-blog"} case _ => {"article"} }
-    )) { case (name, badgeType) =>
+        content match { case _: LiveBlog => {"live-blog"} case _ => {"article"} },
+        content match { case _: Gallery | _: Video => "141" case _ => "140" }
+    )) { case (name, badgeType, adSlotWidth) =>
         @fragments.commercial.adSlot(
             name,
             Seq("paid-for-badge", s"paid-for-badge--$badgeType"),
-            Map("mobile" -> Seq("140,90")),
+            Map("mobile" -> Seq(s"${adSlotWidth},90")),
             showLabel=false,
             refresh=false
         )


### PR DESCRIPTION
i.e. pages with a grey background

Also fixed the badges' text colour

![screen shot 2014-07-22 at 15 03 46](https://cloud.githubusercontent.com/assets/74132/3658989/a832a17e-11a9-11e4-9ecf-cbad321c89ab.png)
