### PR TITLE
Proper use of assign

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -47,7 +47,7 @@ define([
         // renamed/deleted from the backend
         var participations = getParticipations();
         Object.keys(participations).forEach(function (k) {
-            if (typeof(assign(globalConfig, config).switches['ab' + k]) === 'undefined') {
+            if (typeof(assign({}, globalConfig, config).switches['ab' + k]) === 'undefined') {
                 removeParticipation({ id: k });
             } else {
                 var testExists = TESTS.some(function (element) {
@@ -150,7 +150,7 @@ define([
     }
 
     function isTestSwitchedOn(test, config) {
-        return assign(globalConfig, config).switches['ab' + test.id];
+        return assign({}, globalConfig, config).switches['ab' + test.id];
     }
 
     function getTestVariant(testId) {


### PR DESCRIPTION
Was overriding values in the `globalConfig` object
