### PR TITLE
Put top bar icons where they used to be on mobile

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_top-bar.scss
+++ b/common/app/assets/stylesheets/module/nav/_top-bar.scss
@@ -9,17 +9,19 @@
     float: left;
 
     @include rem((
-        padding-top: 2px,
+        padding-top: $gs-baseline/2,
         margin-right: $gs-gutter/2
     ));
 
     @include mq(tablet) {
+        @include rem((
+            padding-top: 2px,
+            padding-left: $gs-gutter/2
+        ));
+
         & + .top-bar__item {
             border-left: 1px solid $c-neutral4;
         }
-        @include rem((
-            padding-left: $gs-gutter/2
-        ));
     }
 }
 .top-bar__item--right {


### PR DESCRIPTION
### Before

![screen shot 2014-07-23 at 14 47 46](https://cloud.githubusercontent.com/assets/85783/3673778/3a22e366-1270-11e4-9b3a-f199a93b16a4.PNG)
### After

![screen shot 2014-07-23 at 14 47 31](https://cloud.githubusercontent.com/assets/85783/3673779/3d541a8c-1270-11e4-80ae-acecca6ea1b3.PNG)

![ ](http://gifs.joelglovier.com/classics/drinking-from-teh-firehose.gif)
