### PR TITLE
Article navigation improvements regression fix

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -209,8 +209,8 @@ object Navigation {
 
   def subNav(navigation: Seq[NavItem], page: MetaData): Option[SectionLink] = topLevelItem(navigation, page).flatMap(_.links.find(_.currentFor(page)))
 
-  def rotatedLocalNav(topSection: NavItem, metaData: MetaData): Seq[SectionLink] =
-    topSection.links.find(_.currentFor(metaData)) match {
+  def rotatedLocalNav(topSection: NavItem, metaData: MetaData)(implicit request: RequestHeader): Seq[SectionLink] =
+    topSection.searchForCurrentSublink(metaData) match {
       case Some(currentSection) =>
         val navSlices = topSection.links.span(_.href != currentSection.href)
         navSlices._2.drop(1) ++ navSlices._1

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -5,7 +5,7 @@ import play.api.mvc.RequestHeader
 import conf.Switches._
 import dev.HttpSwitch
 
-case class SectionLink(zone: String, title: String, breadcumbTitle: String, href: String, newWindow: Boolean = false) {
+case class SectionLink(zone: String, title: String, breadcumbTitle: String, href: String) {
   def currentFor(page: MetaData): Boolean = page.url == href ||
     s"/${page.section}" == href ||
     (Edition.all.exists(_.id.toLowerCase == page.id.toLowerCase) && href == "/")

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,6 +1,5 @@
 @(page: MetaData)(implicit request: RequestHeader)
 @import conf.Switches._
-@import dev.HttpSwitch
 @import org.joda.time.DateTime
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">

--- a/common/app/views/fragments/nav/signposting.scala.html
+++ b/common/app/views/fragments/nav/signposting.scala.html
@@ -15,7 +15,7 @@
                 <a class="signposting__action" href="@LinkTo(topLink.name.href)" data-link-name="nav : signposting : @topLink.name.title">@Html(topLink.name.title)</a>
             </li>
 
-            @Navigation.subNav(navigation, metaData).map{ subLink =>
+            @topLink.searchForCurrentSublink(metaData).map{ subLink =>
                 <li class="signposting__item signposting__item--current">
                     <span class="signposting__separator"><span class="signposting__separator__inner">›</span></span>
                     <a class="signposting__action" href="@LinkTo(subLink.href)" data-link-name="nav : signposting : @topLink.name.title &gt; @subLink.title">@Html(subLink.title)</a>

--- a/common/app/views/fragments/sections.scala.html
+++ b/common/app/views/fragments/sections.scala.html
@@ -1,7 +1,6 @@
 @(page: MetaData, isFooter: Boolean=false)(implicit request: RequestHeader)
 @import model._
 @import conf.Switches._
-@import dev.HttpSwitch
 @import common._
 @import common.Edition
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,7 +1,6 @@
 @(metaData: model.MetaData, projectName: Option[String] = None, curlPaths: Map[String, String] = Map())(head: Html)(body: Html)(implicit request: RequestHeader)
 @import conf.Switches._
 @import common.Edition
-@import dev.HttpSwitch
 
 @* Identity pages use identityMain.scala.html, most of which is shared fragments,
    be sure to apply any necessary changes to non-shared code there too. *@


### PR DESCRIPTION
This improvement has been reverted with the introduction of the new nav. Adding it back.
https://github.com/guardian/frontend/pull/5023 new article navigation that uses tags to highlight current local nav

![](http://media.giphy.com/media/KnhBjaI9loKIM/giphy.gif)
