### PR TITLE
Add timeout to loading sentimental comments

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comment-box.js
+++ b/common/app/assets/javascripts/modules/discussion/comment-box.js
@@ -177,29 +177,31 @@ CommentBox.prototype.ready = function() {
     // The check on this should be done through the discussion API
     // for now though this is a good (enough) check
     if (config.switches.sentimentalComments) {
-        var sentimentActiveClass = 'd-comment-box__sentiment--active';
-        $('.open a[href="#comments"]').each(function (openLink) {
-            $('.d-discussion').addClass('d-discussion--sentimental');
-            $('.discussion__show-threaded').remove();
-            this.setState('sentimental');
-            this.options.maxLength = 350;
+        setTimeout(function() {
+            var sentimentActiveClass = 'd-comment-box__sentiment--active';
+            $('.open a[href="#comments"]').each(function (openLink) {
+                $('.d-discussion').addClass('d-discussion--sentimental');
+                $('.discussion__show-threaded').remove();
+                this.setState('sentimental');
+                this.options.maxLength = 350;
 
-            $.create('<div>' + $('.open__head__accent').text() + '</div>')
-                .addClass('d-comment-box__sentiments-head tone-news tone-colour')
-                .insertAfter(this.getElem('sentiments'));
+                $.create('<div>' + $('.open__head__accent').text() + '</div>')
+                    .addClass('d-comment-box__sentiments-head tone-news tone-colour')
+                    .insertAfter(this.getElem('sentiments'));
 
-            bean.on(openLink, 'click', function (e) {
-                this.getElem('body').focus();
-                e.preventDefault();
+                bean.on(openLink, 'click', function (e) {
+                    this.getElem('body').focus();
+                    e.preventDefault();
+                }.bind(this));
+
+                bean.on(this.elem, 'click', this.getClass('sentiment'), function (e) {
+                    $('.' + sentimentActiveClass, this.elem).removeClass(sentimentActiveClass);
+                    $(e.currentTarget).addClass(sentimentActiveClass);
+                    this.elem.sentiment.value = e.currentTarget.getAttribute('data-value');
+                    this.getElem('body').focus();
+                }.bind(this));
             }.bind(this));
-
-            bean.on(this.elem, 'click', this.getClass('sentiment'), function (e) {
-                $('.' + sentimentActiveClass, this.elem).removeClass(sentimentActiveClass);
-                $(e.currentTarget).addClass(sentimentActiveClass);
-                this.elem.sentiment.value = e.currentTarget.getAttribute('data-value');
-                this.getElem('body').focus();
-            }.bind(this));
-        }.bind(this));
+        }.bind(this), 500); // used as we don't know when the open module loads.
     }
 };
 


### PR DESCRIPTION
It would be good to use some form of pubsub for this.

Unfortunately we can't as the open module uses a [boot script](http://open-module.appspot.com/boot.js) that doesn't use promises, so [our enhancer](https://github.com/guardian/frontend/blob/master/common/app/assets/javascripts/components/enhancer/enhancer.js) cannot use the `.then` or even callbacks to tell us when the XHR response is complete.

As this is an experimental feature, and needs fixing post haste, a `setTimeout` will do.

![TIMEOUT!](http://26.media.tumblr.com/tumblr_m0nnu3WW4j1qap9uuo1_500.gif)
