### PR TITLE
Remove zones (cnt'd)

### DIFF
--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -113,23 +113,6 @@ $c-liveAccent: guss-colour(tone-live-2);
 
 $c-mediaDefault: $c-commentAccent;
 
-
-// Zones
-// =============================================================================
-
-// Note: try to at least alphabetise these within sections
-
-$articleOrange: #e47a39; //Used for live-blogging
-$businessBlue: #004179;
-$commentBlue: #004179;
-$culturePink: #d1008b;
-$environmentGreen: #4a7801;
-$lifeandstyleOrange: #ea721e;
-$moneyPurple: #7d0068;
-$newsRed: #d61d00;
-$travelBlue: #066ec9;
-
-
 // Football
 // =============================================================================
 

--- a/common/app/assets/stylesheets/module/commercial/_travel.scss
+++ b/common/app/assets/stylesheets/module/commercial/_travel.scss
@@ -4,6 +4,7 @@
 
 $c-commercial-travel-light: #2cace7;
 $c-commercial-travel-dark: #002b6c;
+$travelBlue: #066ec9;
 
 .commercial--travel {
     .commercial__head {

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -13,8 +13,6 @@ case class SectionLink(zone: String, title: String, breadcumbTitle: String, href
   def currentForIncludingAllTags(page: MetaData): Boolean = page.tags.exists(t => s"/${t.id}" == href)
 }
 
-case class Zone(name: SectionLink, sections: Seq[SectionLink])
-
 case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
   def currentFor(page: MetaData): Boolean = name.currentFor(page) ||
     links.exists(_.currentFor(page)) || exactFor(page)
@@ -221,48 +219,4 @@ object Navigation {
   def isEditionFront(topSection: NavItem): Boolean = ("/" :: Edition.editionFronts).contains(topSection.name.href)
 
   def localLinks(navigation: Seq[NavItem], metaData: MetaData): Seq[SectionLink] = Navigation.topLevelItem(navigation, metaData).map(_.links).getOrElse(List())
-}
-
-trait Zones extends Navigation {
-
-  val newsZone = Zone(news,
-    Seq(world, uk, us, politics, technology, environment, media, education, society, development,
-      science, law, blogs, inpictures)
-  )
-
-  val sportZone = Zone(sport,
-    Seq(football, cricket, sportblog, rugbyunion, motorsport, tennis, golf, rugbyLeague, horseracing)
-  )
-
-  val sportsZone = Zone(sports,
-    Seq(football, cricket, sportblog, rugbyunion, motorsport, tennis, golf, rugbyLeague, horseracing)
-  )
-
-  val cifZone = Zone(cif,
-    Seq(cifbelief, cifgreen)
-  )
-
-  val cultureZone = Zone(culture,
-    Seq(artanddesign, books, film, music, stage, televisionAndRadio)
-  )
-
-  val technologyZone = Zone(technology,
-    Seq(technologyblog, games, gamesblog, appsblog, askjack, internet, mobilephones, gadgets)
-  )
-
-  val businessZone = Zone(economy,
-    Seq(economics, useconomy, recession, investing, banking, marketforceslive, businessblog)
-  )
-
-  val moneyZone = Zone(money,
-    Seq(property, houseprices, pensions, savings, borrowing, insurance, careers, consumeraffairs)
-  )
-
-  val lifeandstyleZone = Zone(lifeandstyle,
-    Seq(fashion, foodanddrink, family, lostinshowbiz)
-  )
-
-  val travelZone = Zone(travel,
-    Seq(shortbreaks, hotels, resturants, budget)
-  )
 }

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -8,7 +8,7 @@ import common.NavItem
 //All that is really being used is Edition.id, which is AU
 //It is not included in the Edition.all sequence
 object Au extends Edition(id = "AU", displayName = "Australia edition", DateTimeZone.forID("Australia/Sydney"))
-  with Zones with QueryDefaults {
+  with QueryDefaults {
 
   implicit val AU = Au
 

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -4,8 +4,7 @@ import common._
 import org.joda.time.DateTimeZone
 import model.MetaData
 
-object Uk extends Edition(id = "UK", displayName = "UK edition", timezone = DateTimeZone.forID("Europe/London"))
-  with Zones {
+object Uk extends Edition(id = "UK", displayName = "UK edition", timezone = DateTimeZone.forID("Europe/London")){
 
   implicit val UK = Uk
 

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -7,7 +7,7 @@ import contentapi.QueryDefaults
 import common.NavItem
 
 object Us extends Edition(id = "US", displayName = "US edition", timezone = DateTimeZone.forID("America/New_York"))
-  with Zones with QueryDefaults {
+  with QueryDefaults {
 
   implicit val US = Us
 


### PR DESCRIPTION
Further cleanup of old navigation zones.
Continuation of https://github.com/guardian/frontend/pull/5097

![](http://media0.giphy.com/media/lHutWkV2EOFmo/giphy.gif)
