### PR TITLE
Generate side margins of the displayed size

### DIFF
--- a/common/app/assets/stylesheets/layout/_side-margins.scss
+++ b/common/app/assets/stylesheets/layout/_side-margins.scss
@@ -7,17 +7,9 @@
  */
 
 @mixin side-margins-position($container-width) {
-    $negative-offset: (($container-width + $gs-gutter * 2) / 2) * -1;
-
-    &:before {
-        @include rem((
-            left: $negative-offset
-        ));
-    }
+    &:before,
     &:after {
-        @include rem((
-            right: $negative-offset
-        ));
+        width: calc((100% - #{rem($container-width + $gs-gutter * 2)}) / 2);
     }
 }
 
@@ -33,13 +25,18 @@
         &:after,
         &:before {
             content: '';
-            display: block;
             position: absolute;
             z-index: 1;
             background: rgba($c-neutral4, .2);
             top: 0;
             height: 100%;
-            width: 50%;
+            width: 0;
+        }
+        &:before {
+            left: 0;
+        }
+        &:after {
+            right: 0;
         }
         @include side-margins-position(gs-span(9));
     }


### PR DESCRIPTION
Uses `calc()` to display blocks of the correct size on the left and right of the content.

It avoids having two elements wide of thousands of pixels off-screen in memory and renders only the necessary size that is on screen.

Support of `calc()` is great on desktop (not so great in Android prior to 4.4: do we care?):

![screen shot 2014-07-24 at 12 07 15](https://cloud.githubusercontent.com/assets/85783/3687141/dc1e52a6-1322-11e4-8af9-cac3544de57f.PNG)

![ ](http://media1.giphy.com/media/mnFwhN0P2AVZS/giphy.gif)
