### PR TITLE
Add better fallback for special chars in headlines

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -231,7 +231,7 @@ module.exports = function (grunt) {
                     fonts: [
                         {
                             'font-family': '"Guardian Text Egyptian Web"',
-                            file: webfontsDir + 'hinting-off-latin1/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff',
+                            file: webfontsDir + 'hinting-off-original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff',
                             format: 'woff'
                         },
                         {
@@ -276,7 +276,7 @@ module.exports = function (grunt) {
                     fonts: [
                         {
                             'font-family': '"Guardian Text Egyptian Web"',
-                            file: webfontsDir + 'hinting-off-latin1/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.ttf',
+                            file: webfontsDir + 'hinting-off-original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.ttf',
                             format: 'ttf'
                         },
                         {

--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -68,6 +68,7 @@ $mq-breakpoints: (
 // =============================================================================
 
 $guss-column-rule: none;
+$f-serif-headline: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', Georgia, serif;
 
 
 // Colours


### PR DESCRIPTION
What this PR does:
- load Text Egyptian with the largest character set (Latin extended). @paperboyo will be delighted.
- Add it as a fallback of headlines, so that when the text in a headline contains special characters, it shows a glyph coming from Text Egyptian instead of Georgia (not perfect, but Much Better!).

Cost of the operation: 36KB in Woff (that is negated by the optimisation previously made in #5162).

See this animation from James Cameron for a before/after comparison.

![webfont-fallback](https://cloud.githubusercontent.com/assets/85783/3687896/0f0c0292-132f-11e4-93c9-e9e6b4d89afc.gif)
