### PR TITLE
test cookie querystring and cookie

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -414,7 +414,7 @@ define([
         testCookie: function() {
             var queryParams = Url.getUrlVars();
             if (queryParams.test) {
-                Cookies.addSessionCookie('GU_TEST', queryParams.test);
+                Cookies.addSessionCookie('GU_TEST', encodeURIComponent(queryParams.test));
             }
         }
     };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -441,6 +441,7 @@ define([
     var ready = function (config, context) {
         if (!this.initialised) {
             this.initialised = true;
+            modules.testCookie();
             modules.displayOnboardMessage(config);
             modules.windowEventListeners();
             modules.checkIframe();
@@ -465,7 +466,6 @@ define([
             modules.showMoreTagsLink();
             modules.showSmartBanner(config);
             modules.initDiscussion();
-            modules.testCookie();
         }
         mediator.emit('page:common:ready', config, context);
     };

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -7,6 +7,7 @@ define([
     'common/utils/deferToLoad',
     'common/utils/ajax',
     'common/modules/userPrefs',
+    'common/utils/url',
     //Vendor libraries
     'bonzo',
     'bean',
@@ -53,6 +54,7 @@ define([
     deferToLoadEvent,
     ajax,
     userPrefs,
+    Url,
 
     bonzo,
     bean,
@@ -407,6 +409,13 @@ define([
                     discussionLoader.attachTo($('.discussion')[0]);
                 }
             });
+        },
+
+        testCookie: function() {
+            var queryParams = Url.getUrlVars();
+            if (queryParams.test) {
+                Cookies.addSessionCookie('GU_TEST', queryParams.test);
+            }
         }
     };
 
@@ -456,6 +465,7 @@ define([
             modules.showMoreTagsLink();
             modules.showSmartBanner(config);
             modules.initDiscussion();
+            modules.testCookie();
         }
         mediator.emit('page:common:ready', config, context);
     };

--- a/common/app/assets/javascripts/modules/analytics/foresee-survey.js
+++ b/common/app/assets/javascripts/modules/analytics/foresee-survey.js
@@ -6,7 +6,7 @@ define(['common/utils/cookies'], function(Cookie) {
             hasForcedOptIn = /forceForesee/.test(location.hash);
 
         // the Foresee code is large, we only want to load it in when necessary.
-        if (!Cookie.get('gu.test') && (sample || hasForcedOptIn)) {
+        if (!Cookie.get('GU_TEST') && (sample || hasForcedOptIn)) {
             require(['js!foresee'], function() {});
         }
     }

--- a/common/app/assets/javascripts/utils/cookies.js
+++ b/common/app/assets/javascripts/utils/cookies.js
@@ -58,6 +58,10 @@ define(function () {
         }
     }
 
+    function addSessionCookie(name, value) {
+        document.cookie = name + '=' + value + '; path=/; domain=' + getShortDomain() + ';';
+    }
+
     function getCookieValues(name) {
         var cookieVals = [],
             nameEq = name + '=',
@@ -90,6 +94,7 @@ define(function () {
         cleanUp: cleanUp,
         cleanUpDuplicates: cleanUpDuplicates,
         add: add,
+        addSessionCookie: addSessionCookie,
         addForMinutes: addForMinutes,
         remove: remove,
         get: get

--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -27,7 +27,8 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
     "shortUrl", // Used by series component in onwards journeys
     "t", // specific item targetting
     "switchesOn", // turn switches on for non-prod, http requests
-    "switchesOff" // turn switches off for non-prod, http requests
+    "switchesOff", // turn switches off for non-prod, http requests
+    "test" // used for integration tests
   )
 
   val allowedParams = CanonicalLink.significantParams ++ insignificantParams


### PR DESCRIPTION
setting GU_TEST cookie to the value of the ?test querystring parameter for integration testing purposes (e.g. disabling foresee survey)

NOTE: you can't set cookies on localhost so you'll need to use 127.0.0.1 or set up a domain in your hosts file if you want to use this locally

@gklopper @johnduffell @glockett @Shakor 
