### PR TITLE
Video end slate fullscreen styling

### DIFF
--- a/common/app/assets/stylesheets/module/content/_video.global.scss
+++ b/common/app/assets/stylesheets/module/content/_video.global.scss
@@ -365,9 +365,11 @@
 
     .vjs-fullscreen & {
         position: absolute;
+        top: 0;
+        left: 0;
+        margin: 0;
         width: 100%;
-        top: 25%;
-        left: -2.5%;
+        height: 100%;
     }
 
     @include mq($to: tablet) {
@@ -393,11 +395,16 @@
     }
 
     .vjs-fullscreen & {
-        position: relative;
-        margin: 0 auto;
+        position: absolute;
+        margin: auto;
+        left: 0;
+        right: 0;
+        bottom: 0;
         @include rem((
-            padding-bottom: $gs-baseline,
-            max-width: gs-span(11)
+            top: -1 * (gs-height(1) + $gs-baseline),
+            height: gs-height(6),
+            max-width: gs-span(11),
+            padding-bottom: $gs-baseline
         ));
     }
 }

--- a/common/app/assets/stylesheets/module/content/_video.global.scss
+++ b/common/app/assets/stylesheets/module/content/_video.global.scss
@@ -331,8 +331,8 @@
         }
 
         .video-item__headline {
-            @include rem ((
-                height: gs-height(2)
+            @include rem((
+                min-height: gs-height(2)
             ));
         }
     }
@@ -363,6 +363,13 @@
         display: block;
     }
 
+    .vjs-fullscreen & {
+        position: absolute;
+        width: 100%;
+        top: 25%;
+        left: -2.5%;
+    }
+
     @include mq($to: tablet) {
         .vjs-has-ended & {
             display: none;
@@ -382,6 +389,15 @@
     @include mq($from: leftCol, $to: wide) {
         @include rem((
             top: $gs-baseline*3.5
+        ));
+    }
+
+    .vjs-fullscreen & {
+        position: relative;
+        margin: 0 auto;
+        @include rem((
+            padding-bottom: $gs-baseline,
+            max-width: gs-span(11)
         ));
     }
 }

--- a/onward/app/views/fragments/videoEndSlate.scala.html
+++ b/onward/app/views/fragments/videoEndSlate.scala.html
@@ -5,16 +5,18 @@
         <div class="video-end-slate__header">
             <h3 class="video-end-slate__heading">@heading</h3>
         </div>
-        <ul class="video-items video-items--end-slate u-unstyled u-cf" data-link-name="Video end slate">
-            @videos.map(item(_))
+        <ul class="video-items video-items--end-slate u-unstyled u-cf" data-link-name="end slate">
+            @videos.zipWithRowInfo.map{ case (video, row) =>
+                @item(video, row.rowNum)
+            }
         </ul>
     </div>
 </div>
 
-    @item(content: model.Video) = {
+    @item(content: model.Video, index: Number) = {
         <li class="video-item">
             <div class="video-item__container">
-                <a class="video-item__action" href="@LinkTo{@content.url}">
+                <a class="video-item__action" href="@LinkTo{@content.url}" data-link-name="item @index">
                     @content.trailPicture(5, 3).map{ image =>
                         <div class="video-item__img u-responsive-ratio">
                             <img class="responsiveimg" src="@Item140.bestFor(image)" alt="" />


### PR DESCRIPTION
Seems like I forgot the styling for the video end slate whilst in fullscreen mode. This fixes that. 

I have also sneaked in some data-link-name changes to get more detailed reporting.

/cc @mattosborn @gklopper 
#### Screenshot

![google chrome](https://cloud.githubusercontent.com/assets/80089/3699745/fbbe376a-13d7-11e4-9d44-b34f27d0368a.png)
