### PR TITLE
Ad units now contain Content Type and Platform

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -184,11 +184,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     height <- imageSrcHeight
   } yield ImageOverride.createElementWithOneAsset(src, width, height)
 
-  override lazy val adUnitSuffix: String = {
-    val prioritisedTagList: List[Tag] = blogs.toList ::: primaryKeyWordTag.toList
-    val prioritisedPossibleAdUnits: List[String] = prioritisedTagList.map{_.id} ::: section :: Nil
-    prioritisedPossibleAdUnits.headOption.getOrElse("")
-  }
+  override lazy val adUnitSuffix: String = super.adUnitSuffix + "/" + contentType.toLowerCase
 }
 
 object Content {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -41,7 +41,7 @@ trait MetaData extends Tags {
     ("analytics-name", analyticsName),
     ("blockVideoAds", false),
     ("is-front", isFront),
-    ("ad-unit", s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitRoot}/$adUnitSuffix"),
+    ("ad-unit", s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitRoot}/$adUnitSuffix/ng"),
     ("is-surging", isSurging)
   )
 


### PR DESCRIPTION
This should help us audit the performance of Next Gen slots and content types. 
