### PR TITLE
CDN health check once again mimics the instance health check.

### DIFF
--- a/article/app/conf/context.scala
+++ b/article/app/conf/context.scala
@@ -15,6 +15,7 @@ object HealthCheck extends AllGoodHealthcheckController("/world/2012/sep/11/barc
 
   // this is for an "offline" healthcheck that the CDN hits
   private val status = new AtomicBoolean(false)
+  def break() = status.set(false)
 
   override def healthcheck() = Action.async{ request =>
     val result = super.healthcheck()(request)
@@ -30,6 +31,8 @@ class HealthcheckPage(urls: String*) extends UrlPagesHealthcheckManagementPage(u
   import ExecutionContext.Implicits.global
 
   private lazy val status = new AtomicBoolean(false)
+
+  def break() = status.set(false)
 
 
   override def get(req: HttpRequest) = {

--- a/article/app/controllers/ArticleHealthcheckController.scala
+++ b/article/app/controllers/ArticleHealthcheckController.scala
@@ -1,10 +1,14 @@
 package controllers
 
 import play.api.mvc.{Action, Controller}
-import conf.HealthcheckPage
+import conf.{HealthCheck, HealthcheckPage}
 
 object ArticleHealthcheckController extends Controller {
 
-  def healthcheck() = Action(Ok("OK"))
+  // in the short term we have 2 healthchecks, either can be ok
+  private def isOk = HealthcheckPage.isOk || HealthCheck.isOk
+
+  def healthcheck() = Action(if (isOk) Ok("OK") else ServiceUnavailable("Service Unavailable"))
+
 
 }

--- a/article/test/CdnHealthCheckTest.scala
+++ b/article/test/CdnHealthCheckTest.scala
@@ -1,0 +1,22 @@
+package test
+
+import conf.{HealthCheck, HealthcheckPage}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.test.Helpers._
+
+class CdnHealthCheckTest extends FlatSpec with Matchers {
+
+  //wrapping this in an HtmlUnit as we need a server running in order for the healthcheck to complete
+  "CDN health check" should "mimic the instance health check" in HtmlUnit("/_cdn_healthcheck") { browser =>
+
+    HealthcheckPage.break()
+    HealthCheck.break()
+
+    status(controllers.ArticleHealthcheckController.healthcheck()(TestRequest("/_cdn_healthcheck"))) should be(503)
+
+    status(conf.HealthCheck.healthcheck()(TestRequest("/_healthcheck"))) should be (200)
+
+    status(controllers.ArticleHealthcheckController.healthcheck()(TestRequest("/_cdn_healthcheck"))) should be(200)
+
+  }
+}


### PR DESCRIPTION
Also added a test to assert this.

(no longer a quick fix)
