### PR TITLE
Revert "Fix: Front ad units don't have the ng tag"

### DIFF
--- a/common/app/model/AdSuffixHandlingForFronts.scala
+++ b/common/app/model/AdSuffixHandlingForFronts.scala
@@ -9,7 +9,7 @@ trait AdSuffixHandlingForFronts extends MetaData{
   }
 
   def extractAdUnitSuffixFrom(path: String) = {
-    val frontSuffixList = List("front", "ng")
+    val frontSuffixList = List("front")
     path.split("/").toList match {
       case cc :: Nil  if supportedCountries contains cc => (cc :: frontSuffixList).mkString("/")
       case cc :: pathList if supportedCountries contains cc => (pathList ::: frontSuffixList).mkString("/")

--- a/common/test/model/AdSuffixHandlingForFrontsTest.scala
+++ b/common/test/model/AdSuffixHandlingForFrontsTest.scala
@@ -14,24 +14,24 @@ class AdSuffixHandlingForFrontsTest extends FlatSpec with Matchers  {
   }
 
   "Editionalised Network Front pages" should "have editions in the ad unit suffix and end with 'front'" in {
-    Tester.extractAdUnitSuffixFrom("uk") should equal("uk/front/ng")
+    Tester.extractAdUnitSuffixFrom("uk") should equal("uk/front")
   }
 
   "Editionalised Section fronts" should "end with front, and do not have editions in the ad unit suffix" in {
-    Tester.extractAdUnitSuffixFrom("uk/money") should equal("money/front/ng")
+    Tester.extractAdUnitSuffixFrom("uk/money") should equal("money/front")
   }
 
   "Editionalised Tag Fronts" should "end with 'front', and do not have editions in the ad unit suffix" in {
     // While we don't have editionalised tag fronts right now, at least we know it'll work
-    Tester.extractAdUnitSuffixFrom("uk/money/borrowing") should equal("money/borrowing/front/ng")
+    Tester.extractAdUnitSuffixFrom("uk/money/borrowing") should equal("money/borrowing/front")
   }
 
   "Non-editionlised section fronts" should "end with 'front'" in {
-    Tester.extractAdUnitSuffixFrom("lifeandstyle") should equal("lifeandstyle/front/ng")
+    Tester.extractAdUnitSuffixFrom("lifeandstyle") should equal("lifeandstyle/front")
   }
 
   "Non-editionalised tag fronts" should "end with 'front" in {
-    Tester.extractAdUnitSuffixFrom("lifeandstyle/live-better") should equal("lifeandstyle/live-better/front/ng")
+    Tester.extractAdUnitSuffixFrom("lifeandstyle/live-better") should equal("lifeandstyle/live-better/front")
   }
 
 }


### PR DESCRIPTION
Reverts guardian/frontend#5212
