### PR TITLE
reset kerning and ligatures for Chrome

### DIFF
--- a/common/app/assets/stylesheets/base/_type.scss
+++ b/common/app/assets/stylesheets/base/_type.scss
@@ -14,11 +14,12 @@ body {
 
 /**
  * Turn on kerning and ligatures
+ * Causes issues in Chrome at the moment
  */
 
 html,
 body {
-    -webkit-font-feature-settings: "kern" 1, "liga" 1;
+    -webkit-font-feature-settings: normal;
     -moz-font-feature-settings: "kern" 1, "liga" 1;
     font-feature-settings: "kern" 1, "liga" 1;
 }
@@ -30,9 +31,9 @@ body {
 
 pre,
 code {
-    -webkit-font-feature-settings: "kern" 0, "liga" 0;
-    -moz-font-feature-settings: "kern" 0, "liga" 0;
-    font-feature-settings: "kern" 0, "liga" 0;
+    -webkit-font-feature-settings: normal;
+    -moz-font-feature-settings: normal;
+    font-feature-settings: normal;
 }
 
 


### PR DESCRIPTION
This resets font-feature-settings for Chrome as it was causing wrappings issues across the site.

To repeat the issue (in Chrome only)
- The element is inline-block or has a float

Looking on Chromium bugs, there is this one;

https://code.google.com/p/chromium/issues/detail?id=393178&q=font&colspec=ID%20Pri%20M%20Iteration%20ReleaseBlock%20Cr%20Status%20Owner%20Summary%20OS%20Modified

Possibly related?
https://code.google.com/p/chromium/issues/detail?id=394333

Also changed the reset for pre and code, using values of 0 is not the same as setting to normal.

Before;
![screen shot 2014-07-25 at 15 28 25](https://cloud.githubusercontent.com/assets/1303616/3703361/02de8280-1409-11e4-8862-2ee06fca338c.png)

![screen shot 2014-07-25 at 15 29 44](https://cloud.githubusercontent.com/assets/1303616/3703366/09c29992-1409-11e4-9187-88a7a22f473b.png)

After;

![screen shot 2014-07-25 at 15 28 32](https://cloud.githubusercontent.com/assets/1303616/3703368/1719d57e-1409-11e4-8650-3a62123257e0.png)

![screen shot 2014-07-25 at 15 33 15](https://cloud.githubusercontent.com/assets/1303616/3703371/1c878f42-1409-11e4-80dc-9ae9a0c83a9f.png)
