### PR TITLE
Facia tool: bugfixes

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -378,7 +378,7 @@
 
                 <div class="article_content" data-bind="if: !state.isEmpty()">
                     <a class="headline" target="article" data-bind="
-                        html: meta.headline() || fields.headline() || (isSnap() ? 'Add link text!' : id),
+                        html: meta.headline() || fields.headline() || (isSnap() ? 'Add link text!' : 'Loading...'),
                         css: {'is-empty': isSnap() && !meta.headline()},
                         attr: {href: id},
                         click: open"></a>

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -55,13 +55,13 @@ function (
                         err = 'Sorry, that article is malformed (has no internalContentCode)';
                     }
 
-                // A link off of the tool itself
-                } else if (_.some([window.location.hostname, vars.CONST.viewer], function(str) { return item.id().indexOf(str) > -1; })) {
-                    err = 'Sorry, adding that is a silly idea';
-
                 // A snap, but they're disabled
                 } else if (!vars.model.switches()['facia-tool-snaps']) {
-                    err = 'Sorry, that link wasn\'t recognised. It cannot be added to a front';
+                    err = 'Sorry, snaps are disabled';
+
+                // A snap, but a link off of the tool itself
+                } else if (_.some([window.location.hostname, vars.CONST.viewer], function(str) { return item.id().indexOf(str) > -1; })) {
+                    err = 'Sorry, that link cannot be added to a front';
 
                 // A snap, but cannot be added in live mode if it has no headline
                 } else if (vars.model.liveMode() &&

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -4,6 +4,7 @@ define([
     'modules/authed-ajax',
     'modules/cache',
     'utils/internal-content-code',
+    'utils/url-host',
     'utils/url-abs-path',
     'utils/snap'
 ],
@@ -12,6 +13,7 @@ function (
     authedAjax,
     cache,
     internalContentCode,
+    urlHost,
     urlAbsPath,
     snap
 ){
@@ -53,18 +55,22 @@ function (
                         err = 'Sorry, that article is malformed (has no internalContentCode)';
                     }
 
-                // Snap, but they're disabled
+                // A link off of the tool itself
+                } else if (_.some([window.location.hostname, vars.CONST.viewer], function(str) { return item.id().indexOf(str) > -1; })) {
+                    err = 'Sorry, adding that is a silly idea';
+
+                // A snap, but they're disabled
                 } else if (!vars.model.switches()['facia-tool-snaps']) {
                     err = 'Sorry, that link wasn\'t recognised. It cannot be added to a front';
 
-                // Snap, but cannot be added in live mode if it has no headline
+                // A snap, but cannot be added in live mode if it has no headline
                 } else if (vars.model.liveMode() &&
                     item.parentType !== 'Clipboard' &&
                     !item.fields.headline() &&
                     !item.meta.headline()) {
                     err = 'Sorry, snaps without headlines can\'t be added in live mode';
 
-                // Snap!
+                // A snap that's legitimate
                 } else {
                     item.convertToSnap();
                 }

--- a/facia-tool/public/javascripts/modules/droppable.js
+++ b/facia-tool/public/javascripts/modules/droppable.js
@@ -121,7 +121,7 @@ define([
                     if (sourceItem) {
                         sourceItem = JSON.parse(sourceItem);
 
-                    } else if ((unknownQueryParams.url || '').match(/^http:\/\/www.theguardian.com/)) {
+                    } else if ((unknownQueryParams.url || '').indexOf('http://www.theguardian.com/') === 0) {
                         sourceItem = { id: unknownQueryParams.url };
                         sourceGroup = undefined;
 

--- a/facia-tool/public/javascripts/modules/droppable.js
+++ b/facia-tool/public/javascripts/modules/droppable.js
@@ -84,7 +84,14 @@ define([
                     event.preventDefault();
                     event.stopPropagation();
 
-                    if (!targetGroup) { return; }
+                    if (!targetGroup) {
+                        return;
+                    }
+
+                    if (!id) {
+                        window.alert('Sorry, you can\'t add that to a front');
+                        return;
+                    }
 
                     targetGroup.underDrag(false);
                     _.each(targetGroup.items(), function(item) {
@@ -109,33 +116,24 @@ define([
                         }
                     }
 
-                    if (!id) {
-                        window.alert('Sorry, you can\'t add that to a front');
-                        return;
-                    }
-
                     sourceItem = event.dataTransfer.getData('sourceItem');
 
                     if (sourceItem) {
                         sourceItem = JSON.parse(sourceItem);
+
+                    } else if ((unknownQueryParams.url || '').match(/^http:\/\/www.theguardian.com/)) {
+                        sourceItem = { id: unknownQueryParams.url };
+                        sourceGroup = undefined;
+
                     } else {
-                        id = id.split('?')[0] + (_.isEmpty(unknownQueryParams) ? '' : '?' + _.map(unknownQueryParams, function(val, key) {
-                            return key + (val ? '=' + val : '');
-                        }).join('&'));
                         sourceItem = {
-                            id: id,
+                            id: id.split('?')[0] + (_.isEmpty(unknownQueryParams) ? '' : '?' + _.map(unknownQueryParams, function(val, key) {
+                                return key + (val ? '=' + val : '');
+                            }).join('&')),
                             meta: knownQueryParams
                         };
                         sourceGroup = undefined;
                     }
-
-                    // Parse url from links such as http://www.google.co.uk/?param-name=http://www.theguardian.com/foobar
-                    _.each(unknownQueryParams, function(val, key) {
-                        // Grab the last query param val that looks like a Guardian url
-                        if (key === 'url' && (val + '').match(/^http:\/\/www.theguardian.com/)) {
-                            id = val;
-                        }
-                    });
 
                     mediator.emit('collection:updates', {
                         sourceItem: sourceItem,


### PR DESCRIPTION
- prevent tool links (eg. "logout") being dragged in as snaps. Doh. 
- correctly identify Google result urls, e.g http://www.google.co.uk/?url=http://www.theguardian.com/foo/bar 
- show "Loading.." as an article's headline, while it loads from capi.
