### PR TITLE
Give badges height

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -358,6 +358,17 @@
         border-bottom-width: 0;
         border-top: 1px dotted $c-neutral5;
     }
+    // magic numbers, height of the ad badge
+    &.ad-slot--spbadge {
+        @include rem((
+            min-height: 135px
+        ));
+    }
+    &.ad-slot--adbadge {
+        @include rem((
+            min-height: 155px
+        ));
+    }
 }
 .ad-slot--paid-for-badge--live-blog {
     @include mq(rightCol) {

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -397,6 +397,7 @@
         padding: 0;
         margin: 0;
         float: left;
+        min-height: 0;
         @include rem((
             margin-top: 4px
         ));
@@ -436,6 +437,22 @@
         .has-page-skin .container--has-toggle & {
             @include rem((
                 margin-right: gs-span(1)
+            ));
+        }
+    }
+}
+.facia-container--sponsored .container:first-child,
+.facia-container--advertisement-feature .container:first-child,
+.container--sponsored,
+.container--advertisement-feature {
+    .container__header + .container__body {
+        @include rem((
+            margin-top: 104px
+        ));
+
+        @include mq(tablet) {
+            @include rem((
+                margin-top: 78px
             ));
         }
     }


### PR DESCRIPTION
Stops the page jumping around

Note, assumes the badge image is at least 90px high - if smaller, there'll be white space, if higher, it will jump up
## Before

![badge-before](https://cloud.githubusercontent.com/assets/74132/3705144/b07fdb98-141b-11e4-8d14-8a0ecea9f551.gif)
## After

![badge-after](https://cloud.githubusercontent.com/assets/74132/3705163/d5c608b4-141b-11e4-9dc0-57347a5054eb.gif)
