### PR TITLE
Cap scss lint version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 gem "sass", "~> 3.3.7"
 
 group :development do
-  gem "scss-lint"
+  gem "scss-lint", "0.25.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     rainbow (2.0.0)
-    sass (3.3.7)
-    scss-lint (0.24.0)
+    sass (3.3.11)
+    scss-lint (0.25.1)
       rainbow (~> 2.0)
       sass (~> 3.3.0)
 
@@ -13,4 +13,4 @@ PLATFORMS
 
 DEPENDENCIES
   sass (~> 3.3.7)
-  scss-lint
+  scss-lint (= 0.25.1)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-karma": "^0.8.3",
     "grunt-mkdir": "~0.1.1",
     "grunt-pagespeed": "^0.2.0",
-    "grunt-scss-lint": "^0.1.7",
+    "grunt-scss-lint": "0.3.0",
     "grunt-shell": "^0.7.0",
     "grunt-text-replace": "~0.3.11",
     "grunt-webfontjson": "~0.0.3",
@@ -41,8 +41,5 @@
   },
   "scripts": {
     "postinstall": "grunt hookmeup"
-  },
-  "dependencies": {
-    "grunt-scss-lint": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   },
   "scripts": {
     "postinstall": "grunt hookmeup"
+  },
+  "dependencies": {
+    "grunt-scss-lint": "^0.3.0"
   }
 }


### PR DESCRIPTION
Fixes scss-lint to 0.25.1 until the task runner supports 0.26

![ ](http://gifs.joelglovier.com/oh-shit/tsunami.gif)
