### PR TITLE
Contributors now get sent to DFP as a param called 'co'

### DIFF
--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -274,7 +274,8 @@ define([
                 a       : audienceScience.getSegments(),
                 at      : cookies.get('adtest') || '',
                 gdncrm  : userAdTargeting.getUserSegments(),
-                ab      : ab.makeOmnitureTag()
+                ab      : ab.makeOmnitureTag(),
+                co      : parseContributors(page.author)
             }, audienceScienceGateway.getSegments(), criteo.getSegments());
         },
         createAdSlot = function(name, types, keywords) {
@@ -310,6 +311,12 @@ define([
                 .split(',').map(function (keyword) {
                     return keyword.split('/').pop();
                 });
+        };
+        parseContributors = function(contributors) {
+            var contributorArray = parseKeywords(contributors);
+            return contributorArray.map(function(contrib) {
+               return keywords.format(contrib);
+            });
         };
 
     /**


### PR DESCRIPTION
Here's how it works:
when there isn't an author (like a syndicated article from Reuters)
&co=
(like this one: http://www.theguardian.com/world/2014/jul/06/hillary-clinton-angela-merkel-leader)

When there is a single author:
&co=alex-hern
(like this one: http://www.theguardian.com/technology/2014/jul/25/us-congress-banned-editing-wikipedia-trolling)

When there are multiple authors:
&co=angela-monaghan,phillip-inman
(use this as a test: http://www.theguardian.com/business/2014/jul/25/gdp-recession-high-economy-growth-osborne)
