### PR TITLE
Fix navigation bottom row size when there is no current site/beta switch

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_navigation.scss
+++ b/common/app/assets/stylesheets/module/nav/_navigation.scss
@@ -120,10 +120,12 @@ $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevelsWithWideToggle, mq-
         }
 
         @include mq(tablet) {
+            @include box-sizing(border-box);
             padding-top: 0;
             float: right;
             text-align: right;
             @include rem((
+                min-height: $gs-row-height,
                 padding-top: 7px,
                 width: gs-span(3)
             ));


### PR DESCRIPTION
### Before

![screen shot 2014-07-28 at 11 25 44](https://cloud.githubusercontent.com/assets/85783/3719336/e3bf2798-1641-11e4-94bd-502cf9e0a944.PNG)

![screen shot 2014-07-28 at 11 29 25](https://cloud.githubusercontent.com/assets/85783/3719349/0e65a2e2-1642-11e4-9f4f-a4fb6657d726.PNG)
### After

![screen shot 2014-07-28 at 11 25 30](https://cloud.githubusercontent.com/assets/85783/3719338/e6911486-1641-11e4-96ab-ba325a0733c9.PNG)

![screen shot 2014-07-28 at 11 29 20](https://cloud.githubusercontent.com/assets/85783/3719351/1164748c-1642-11e4-864c-cdca078628d1.PNG)

![ ](http://gifs.joelglovier.com/ohhh/ohhh-minion.gif)
