### PR TITLE
Video page polish

### DIFF
--- a/common/app/assets/images/global/video-icon-black.svg
+++ b/common/app/assets/images/global/video-icon-black.svg
@@ -1,0 +1,1 @@
+<svg width="36" height="23" viewBox="0 0 36 23" xmlns="http://www.w3.org/2000/svg" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"><title>Imported-Layers</title><desc>Created with Sketch.</desc><path d="M3.241 0l-3.241 3.286v16.428l3.26 3.286h18.74v-23h-18.759m30.393 1l-8.634 8.036v4.928l8.634 8.036h2.366v-21h-2.366" sketch:type="MSShapeGroup" fill="#333"/></svg>

--- a/common/app/assets/stylesheets/module/containers/_multimedia.scss
+++ b/common/app/assets/stylesheets/module/containers/_multimedia.scss
@@ -99,3 +99,29 @@
         }
     }
 }
+
+.item--video {
+    .item__title:before {
+        content: '';
+        @include icon(video-icon-black);
+        @include background-size(auto 100%);
+        @include rem((
+                margin-right: $gs-gutter/4,
+                height: 12px !important,
+                width: 18px !important
+        ));
+    }
+}
+
+.container--multimedia {
+    .item__title:before {
+        content: '';
+        @include icon(video-icon);
+        @include background-size(auto 100%);
+        @include rem((
+                margin-right: $gs-gutter/4,
+                height: 12px !important,
+                width: 18px !important
+        ));
+    }
+}

--- a/common/app/assets/stylesheets/module/containers/_multimedia.scss
+++ b/common/app/assets/stylesheets/module/containers/_multimedia.scss
@@ -27,6 +27,16 @@
     .item__meta {
         display: none;
     }
+    .item__title:before {
+        content: '';
+        @include icon(video-icon);
+        @include background-size(auto 100%);
+        @include rem((
+            margin-right: $gs-gutter/4,
+            height: 12px !important,
+            width: 18px !important
+        ));
+    }
     .facia-slice__item:before {
         border-left-color: lighten($c-neutral1, 16%);
     }
@@ -67,6 +77,16 @@
     }
     @include mq(rightCol) {
         .facia-slice-wrapper--position-1 {
+            .facia-slice__item:first-child {
+                .item__title {
+                    @include rem((
+                            min-height: $gs-baseline*4
+                    ));
+                    @include fs-headline(4, true);
+                }
+            }
+        }
+        .facia-slice-wrapper--position-1 {
             .facia-slice__item:nth-child(2),
             .facia-slice__item:nth-child(3) {
                 .item__standfirst {
@@ -98,6 +118,13 @@
             }
         }
     }
+    .facia-container--layout-content & {
+        .facia-container__inner {
+            @include rem((
+                margin-bottom: $gs-baseline*2
+            ));
+        }
+    }
 }
 
 .item--video {
@@ -106,22 +133,27 @@
         @include icon(video-icon-black);
         @include background-size(auto 100%);
         @include rem((
-                margin-right: $gs-gutter/4,
-                height: 12px !important,
-                width: 18px !important
+            margin-right: $gs-gutter/10,
+            height: 12px !important,
+            width: 18px !important
         ));
     }
 }
 
-.container--multimedia {
-    .item__title:before {
-        content: '';
-        @include icon(video-icon);
-        @include background-size(auto 100%);
-        @include rem((
-                margin-right: $gs-gutter/4,
-                height: 12px !important,
-                width: 18px !important
-        ));
+.facia-slice__item--content-type-video:first-child {
+    .item--video {
+        .item__title:before {
+            @include rem((
+                height: 14px !important,
+                width: 21px !important
+            ));
+
+            @include mq(rightCol) {
+                @include rem((
+                    height: 16px !important,
+                    width: 24px !important
+                ));
+            }
+        }
     }
 }

--- a/common/app/assets/stylesheets/module/containers/_popular.scss
+++ b/common/app/assets/stylesheets/module/containers/_popular.scss
@@ -26,3 +26,9 @@
         }
     }
 }
+
+.container--popular {
+    @include rem((
+        margin-top: $gs-baseline*2
+    ));
+}

--- a/common/app/assets/stylesheets/module/content/_video-player.scss
+++ b/common/app/assets/stylesheets/module/content/_video-player.scss
@@ -11,6 +11,7 @@
 
 .gu-video-wrapper {
     background: #000000;
+    @include transform(translateZ(0));
     @include rem((
         margin-bottom: $gs-baseline * 1.5
     ));

--- a/common/app/assets/stylesheets/module/content/_video.global.scss
+++ b/common/app/assets/stylesheets/module/content/_video.global.scss
@@ -39,15 +39,6 @@
                 display: none;
             }
         }
-        .meta__comment-count--bottom {
-            display: none;
-        }
-        .meta__comment-count--top {
-            display: block;
-            .commentcount {
-                display: block;
-            }
-        }
     }
 
     .player {
@@ -140,13 +131,16 @@
     @include mq(tablet, rightCol) {
         .content__meta-container {
             float: left;
-            width: gs-span(5) + $gs-gutter*2;
             @include rem((
+                width: 404px, //Magic, as video items below are off grid at 33.3% width
                 margin-right: $gs-gutter
             ));
         }
         .social-wrapper--bottom {
             float: left;
+            @include rem((
+                width: 192px
+            ));
         }
     }
 
@@ -179,10 +173,24 @@
     }
 }
 
+//This is temporary until facia headings are consistent.
+.onward {
+    .container--multimedia {
+        .container__title {
+            @include fs-header(3, true);
+        }
+    }
+}
+
 /* Most viewed container
    ========================================================================== */
 .most-viewed-video-container {
+    @include rem((
+        padding-top: $gs-baseline*2
+    ));
+
     @include mq(tablet) {
+        padding-top: 0;
         border-top: 1px solid $c-mediaDefault;
     }
 }
@@ -203,7 +211,8 @@
 
 .most-viewed-video {
     @include rem((
-        margin-left: -$gs-gutter/2
+        margin-left: -$gs-gutter/2,
+        margin-right: -$gs-gutter/2
     ));
 }
 
@@ -277,12 +286,13 @@
             &:nth-child(odd) {
                 border-right: 1px solid $c-neutral2;
             }
+            &:nth-child(n+5) {
+                margin-bottom: 0;
+            }
         }
 
         @include mq($from: tablet, $to: rightCol) {
-            @include rem((
-                width: gs-span(3) - $gs-gutter/2
-            ));
+            width: 33.3%;
 
             &:nth-child(-n+3) {
                 .video-item__container {
@@ -305,6 +315,10 @@
 
             &:nth-child(odd) {
                 border-right: 1px solid $c-neutral2;
+            }
+
+            &:nth-child(n+5) {
+                margin-bottom: 0;
             }
         }
     }
@@ -401,10 +415,4 @@
     @include fs-header(1);
     font-weight: bold;
     text-align: left;
-}
-
-.content-footer--video {
-    @include rem((
-        margin-top: $gs-baseline
-    ));
 }

--- a/common/app/assets/stylesheets/module/content/_video.global.scss
+++ b/common/app/assets/stylesheets/module/content/_video.global.scss
@@ -74,7 +74,7 @@
         @include icon(video-icon);
         @include background-size(auto 100%);
         @include rem((
-            margin-right: $gs-gutter/3,
+            margin-right: $gs-gutter/5,
             height: 20px !important,
             width: 34px !important
         ));
@@ -130,7 +130,7 @@
 
     @include mq(tablet, rightCol) {
         .content__meta-container {
-            float: left;
+            float: right;
             @include rem((
                 width: 404px, //Magic, as video items below are off grid at 33.3% width
                 margin-right: $gs-gutter
@@ -254,9 +254,9 @@
         @include icon(video-icon);
         @include background-size(auto 100%);
         @include rem((
-            margin-right: $gs-gutter/4,
-            height: 12px !important,
-            width: 18px !important
+            margin-right: $gs-gutter/5,
+            height: 10px !important,
+            width: 15px !important
         ));
     }
 }

--- a/common/app/assets/stylesheets/module/content/_video.head.scss
+++ b/common/app/assets/stylesheets/module/content/_video.head.scss
@@ -1,4 +1,6 @@
 .content__main-column--video {
+    overflow: hidden;
+
     @include mq(wide) {
         @include rem((
             width: gs-span(9)
@@ -20,6 +22,11 @@
 
     .byline {
         word-break: break-word;
+
+        a {
+            color: #ffffff;
+            text-decoration: underline;
+        }
     }
 
     .byline,

--- a/common/app/assets/stylesheets/module/content/_video.head.scss
+++ b/common/app/assets/stylesheets/module/content/_video.head.scss
@@ -7,10 +7,10 @@
 }
 
 .content--video {
-
     background-color: $c-neutral1;
     color: $c-neutral7;
     @include rem((
+        padding-bottom: $gs-baseline*2,
         padding-top: $gs-baseline/2
     ));
 

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -132,9 +132,6 @@
 @mixin facia-container--layout-content {
     .facia-container--layout-content {
         .facia-container__inner {
-            @include rem((
-                margin-bottom: $gs-baseline*2
-            ));
 
             @include mq(tablet) {
                 margin-left: auto;

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -9,11 +9,6 @@
 
             <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
                 <div class="item__media-wrapper item__media-wrapper--has-icon">
-                    <div class="item__cta item__cta--video">
-                        <span class="item__cta__icon">
-                            <span class="i i-play-black"></span>
-                        </span>
-                    </div>
                     @trail.trailPicture(5,3).map{ imageContainer =>
                         @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                             <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
@@ -28,8 +23,7 @@
                         </div>
                     }
                 </div>
-                <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--has-icon-mobile">
-                    <span class="i i-video-yellow-small"></span>
+                <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
                     @RemoveOuterParaHtml(trail.headline)
                 </h@if(isFirstContainer && index == 0){1}else{2}>
             </a>

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -31,11 +31,11 @@ id.membership.url=https://mem.thegulocal.com
 id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 
 # Discussion
-discussion.apiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion.code.dev-guardianapis.com/discussion-api
+discussion.apiRoot=http://discussion.guardianapis.com/discussion-api
+discussion.secureApiRoot=https://discussion-secure.guardianapis.com/discussion-api
 discussion.apiTimeout=2000
-discussion.apiClientHeader=nextgen-dev
-discussion.url=http://discussion.code.dev-theguardian.com
+discussion.apiClientHeader=nextgen
+discussion.url=http://discussion.theguardian.com
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -31,11 +31,11 @@ id.membership.url=https://mem.thegulocal.com
 id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 
 # Discussion
-discussion.apiRoot=http://discussion.guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion-secure.guardianapis.com/discussion-api
+discussion.apiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
+discussion.secureApiRoot=https://discussion.code.dev-guardianapis.com/discussion-api
 discussion.apiTimeout=2000
-discussion.apiClientHeader=nextgen
-discussion.url=http://discussion.theguardian.com
+discussion.apiClientHeader=nextgen-dev
+discussion.url=http://discussion.code.dev-theguardian.com
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/onward/app/views/fragments/mostViewedVideo.scala.html
+++ b/onward/app/views/fragments/mostViewedVideo.scala.html
@@ -5,7 +5,7 @@
     <div class="most-viewed-video-container__header">
         <h3 class="most-viewed-video-container__heading">Popular videos</h3>
     </div>
-    <ul class="most-viewed-video video-items video-items--most-viewed u-unstyled" data-link-name="Most viewed video">
+    <ul class="most-viewed-video video-items video-items--most-viewed u-cf u-unstyled" data-link-name="Most viewed video">
         @for(video <- videos) {
             @item(video)
         }


### PR DESCRIPTION
This is a final list of design tweaks and polishing from Chris P for the video page template and CSS.
#### Wide
- Reduce padding at bottom of top container to 24px
- Make spacing between containers consistent
- Comments count is wrapping round (global)
- Popular in RH col is being squished to 290px
- Reduce size of video icon next to most read, and headline
- Links in byline field. Currently blue, which does not contrast. Change to #fff with underline. See here...
#### Desktop
- Location of comment count not correct. Should be below byline and social to the right of byline. 
#### Tablet
- Location of comment count not correct. Should be below byline. 
- Rule above social not extending as far as edge of video.
#### Mobile
- No space between byline and popular container (24px)
- Add max width to bylines to stop them butting up against comment bubble.
- Reduce space above Related content
- Tapping standfirst seems to activate hover state of play button.
- Series label broken
#### All
- More from this section head > 20/24
- Change icon on more from this section container

/cc @mattosborn @rich-nguyen 
