### PR TITLE
Remove theguardian.com from sentry whitelist

### DIFF
--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -130,7 +130,6 @@
                     whitelistUrls: [
                         /localhost/,
                         /assets\.guim\.co\.uk/,
-                        /theguardian\.com/,
                         /ophan\.co\.uk/,
                         /api\.nextgen\.guardianapps\.co\.uk/
                     ],


### PR DESCRIPTION
cc @ironsidevsquincy 
