### PR TITLE
Output only the necessary vendor prefixes

### DIFF
--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -554,14 +554,28 @@ $avatarSize: 44px;
     }
 }
 
-@include keyframes(pulse) {
+@-webkit-keyframes pulse {
     0% {
         opacity: 1;
-        @include transform(scale(1));
+        -webkit-transform: scale(1);
+        transform: scale(1);
     }
+
     100% {
         opacity: 0;
-        @include transform(scale(2));
+        -webkit-transform: scale(2);
+        transform: scale(2);
+    }
+}
+@keyframes pulse {
+    0% {
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    100% {
+        opacity: 0;
+        transform: scale(2);
     }
 }
 


### PR DESCRIPTION
- Firefox supports both animations and transforms since version 15 with the standard notation, so no need for `-moz` vendor prefixes
## Before

Using CSS3 mixins with both transforms and animations leads to this kind of nonsense:

``` css
@-webkit-keyframes pulse {
  0% {
    opacity: 1;
    -webkit-transform: scale(1);
    -moz-transform: scale(1);
    -ms-transform: scale(1);
    -o-transform: scale(1);
    transform: scale(1);
  }

  100% {
    opacity: 0;
    -webkit-transform: scale(2);
    -moz-transform: scale(2);
    -ms-transform: scale(2);
    -o-transform: scale(2);
    transform: scale(2);
  }
}
@-moz-keyframes pulse {
  0% {
    opacity: 1;
    -webkit-transform: scale(1);
    -moz-transform: scale(1);
    -ms-transform: scale(1);
    -o-transform: scale(1);
    transform: scale(1);
  }

  100% {
    opacity: 0;
    -webkit-transform: scale(2);
    -moz-transform: scale(2);
    -ms-transform: scale(2);
    -o-transform: scale(2);
    transform: scale(2);
  }
}
@keyframes pulse {
  0% {
    opacity: 1;
    -webkit-transform: scale(1);
    -moz-transform: scale(1);
    -ms-transform: scale(1);
    -o-transform: scale(1);
    transform: scale(1);
  }

  100% {
    opacity: 0;
    -webkit-transform: scale(2);
    -moz-transform: scale(2);
    -ms-transform: scale(2);
    -o-transform: scale(2);
    transform: scale(2);
  }
}
```
## After

``` css
@-webkit-keyframes pulse {
    0% {
        opacity: 1;
        -webkit-transform: scale(1);
        transform: scale(1);
    }

    100% {
        opacity: 0;
        -webkit-transform: scale(2);
        transform: scale(2);
    }
}
@keyframes pulse {
    0% {
        opacity: 1;
        transform: scale(1);
    }

    100% {
        opacity: 0;
        transform: scale(2);
    }
}
```

![ ](http://gifs.joelglovier.com/no/dikembe-mutumbo-nope.gif)
