### PR TITLE
Strip " - video" from video headlines globally

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -457,6 +457,7 @@ class Video(content: ApiContentWithMeta) extends Media(content) {
     }.sorted
   }
 
+  override lazy val headline: String = webTitle.stripSuffix(" - video").stripSuffix(" – video")
   override lazy val duration: Int = videoAssets.headOption.map(_.duration).getOrElse(0)
   override lazy val mediaId: Option[String] = mainVideo.map(_.id)
 
@@ -477,7 +478,6 @@ class Video(content: ApiContentWithMeta) extends Media(content) {
       case other => s"Source: $other"
     }
   ).flatten.mkString(", ")).filter(_.nonEmpty)
-  lazy val videoLinkText: String = webTitle.stripSuffix(" - video").stripSuffix(" – video")
 }
 
 object Video {

--- a/onward/app/views/fragments/mostViewedVideo.scala.html
+++ b/onward/app/views/fragments/mostViewedVideo.scala.html
@@ -22,7 +22,7 @@
                         <img class="responsiveimg" src="@Item140.bestFor(image)" alt="" />
                     </div>
                 }
-                <h4 class="video-item__headline">@content.videoLinkText</h4>
+                <h4 class="video-item__headline">@content.headline</h4>
             </a>
         </div>
     </li>

--- a/onward/app/views/fragments/videoEndSlate.scala.html
+++ b/onward/app/views/fragments/videoEndSlate.scala.html
@@ -22,7 +22,7 @@
                             <img class="responsiveimg" src="@Item140.bestFor(image)" alt="" />
                         </div>
                     }
-                    <h4 class="video-item__headline">@content.videoLinkText</h4>
+                    <h4 class="video-item__headline">@content.headline</h4>
                 </a>
             </div>
         </li>


### PR DESCRIPTION
This strips the _" - video"_ suffix from video headlines in all instances across the site, i.e facia items and onward journey components.

Pending sign-off from Nathan Good and editorial.

/cc @rich-nguyen @gklopper 
