### PR TITLE
Add internalContentCode to pressed.json & json.lite

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -44,7 +44,7 @@ trait QueryDefaults extends implicits.Collections with ExecutionContexts {
     val tag = "tag=type/gallery|type/article|type/video|type/sudoku"
     val editorsPicks = "show-editors-picks=true"
     val showInlineFields = s"show-fields=$trailFields"
-    val showFields = "trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent"
+    val showFields = "internalContentCode,trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent"
     val showFieldsWithBody = showFields + ",body"
 
     val all = Seq(tag, editorsPicks, showInlineFields, showFields)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -20,6 +20,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
 
   lazy val publication: String = fields.getOrElse("publication", "")
   lazy val lastModified: DateTime = fields.get("lastModified").map(_.parseISODateTime).getOrElse(DateTime.now)
+  lazy val internalContentCode: String = delegate.safeFields("internalContentCode")
   lazy val shortUrl: String = delegate.safeFields("shortUrl")
   lazy val shortUrlId: String = delegate.safeFields("shortUrl").replace("http://gu.com", "")
   lazy val webUrl: String = delegate.webUrl

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -43,6 +43,7 @@ trait FrontJsonLite extends ExecutionContexts{
       Json.obj(
         "headline" -> (j \ "safeFields" \ "headline"),
         "thumbnail" -> (j \ "safeFields" \ "thumbnail"),
+        "internalContentCode" -> (j \ "safeFields" \ "internalContentCode"),
         "id" -> (j \ "id")
       )
     }


### PR DESCRIPTION
Because we need it in the breaking-news feed to guard against alerting on the same article after a URL change.
