### PR TITLE
Add related keywords to Facia fronts

### DIFF
--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -100,6 +100,7 @@
 
 @import 'module/facia/_show-more';
 @import 'module/facia/_pagination';
+@import 'module/facia/_container-related-keywords';
 
 @import 'module/containers/_features';
 @import 'module/containers/_featuresauto';

--- a/common/app/assets/stylesheets/module/facia/_container-related-keywords.scss
+++ b/common/app/assets/stylesheets/module/facia/_container-related-keywords.scss
@@ -1,0 +1,48 @@
+.facia-container__related-keywords {
+    margin: $gs-baseline $gs-gutter;
+
+    @include mq(gs-span(7) + $gs-gutter*3, tablet) {
+        @include rem((
+            width: gs-span(7)
+        ));
+        margin: $gs-baseline auto;
+    }
+    @include mq(tablet) {
+        @include rem((
+            width: gs-span(9)
+        ));
+        margin-left: auto;
+        margin-right: auto;
+    }
+    @include mq(desktop) {
+        @include rem((
+            width: gs-span(12)
+        ));
+    }
+    @include mq(faciaLeftCol) {
+        @include rem((
+            width: gs-span(14)
+        ));
+    }
+    @include mq(wide) {
+        @include rem((
+            width: gs-span(16)
+        ));
+    }
+
+    @include fs-data(4);
+}
+
+.facia-container__related-keywords__body {
+    @include mq(faciaLeftCol) {
+        @include rem((
+            margin-left: gs-span(2) + $gs-gutter
+        ));
+    }
+
+    @include mq(wide) {
+        @include rem((
+            margin-left: gs-span(3) + $gs-gutter
+        ));
+    }
+}

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -2,7 +2,7 @@
 
 @import common.LinkTo
 @import model.FaciaComponentName
-@import views.html.fragments.seeAlsoTags
+@import views.html.fragments.keywordList
 @import views.support.GetClasses
 @import views.support.MostPopularTags.topTags
 
@@ -37,7 +37,13 @@
                 </div>
                 @pagination.map{ paginate => @fragments.pagination(page, paginate)}
 
-                @seeAlsoTags(topTags(collection.items).filterNot(_.id == page.id))
+                @defining(topTags(collection.items).filterNot(_.id == page.id)) { tags =>
+                    @if(tags.nonEmpty) {
+                        <div class="related-keywords">
+                        @keywordList(tags, 5, "See also")
+                        </div>
+                    }
+                }
             </div>
         </section>
     }

--- a/common/app/views/fragments/seeAlsoTags.scala.html
+++ b/common/app/views/fragments/seeAlsoTags.scala.html
@@ -1,9 +1,0 @@
-@(tags: Seq[model.Tag])(implicit request: RequestHeader)
-
-@import views.html.fragments.keywordList
-
-@if(tags.nonEmpty) {
-    <div class="related-keywords">
-        @keywordList(tags, 5, "See also")
-    </div>
-}

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -33,6 +33,8 @@ case class FaciaPage(
   override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
   override def sponsor = DfpAgent.getSponsor(id)
   override def hasPageSkin(edition: Edition) = DfpAgent.isPageSkinned(adUnitSuffix, edition)
+
+  def allItems = collections.map(_._2).flatMap(_.items).distinct
 }
 
 object FaciaPage {

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,5 +1,9 @@
-@(faciaPage: FaciaPage)(implicit request: RequestHeader, templateDeduping: TemplateDeduping)
+@(faciaPage: model.FaciaPage)(implicit request: RequestHeader, templateDeduping: views.support.TemplateDeduping)
+
 @import common.Edition
+@import views.support.RenderClasses
+@import views.html.fragments.keywordList
+@import views.support.MostPopularTags.topTags
 
 @if(faciaPage.collections.nonEmpty) {
     <div class="l-side-margins l-side-margins--layout-front">
@@ -25,6 +29,16 @@
             }
 
             @fragments.commercial.commercialComponent("merchandising", Seq("commercial-component"))
+
+            @defining(topTags(faciaPage.allItems)) { tags =>
+                @if(tags.nonEmpty) {
+                    <div class="facia-container__related-keywords">
+                        <div class="facia-container__related-keywords__body">
+                            @keywordList(tags, 5, "See also")
+                        </div>
+                    </div>
+                }
+            }
         </div>
     </div>
 }

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -30,7 +30,7 @@
 
             @fragments.commercial.commercialComponent("merchandising", Seq("commercial-component"))
 
-            @defining(topTags(faciaPage.allItems)) { tags =>
+            @defining(topTags(faciaPage.allItems).take(20)) { tags =>
                 @if(tags.nonEmpty) {
                     <div class="facia-container__related-keywords">
                         <div class="facia-container__related-keywords__body">


### PR DESCRIPTION
![screen shot 2014-07-29 at 13 03 28](https://cloud.githubusercontent.com/assets/1001642/3734553/9d6a6014-1718-11e4-8bdf-81ba698496b7.png)

![screen shot 2014-07-29 at 13 04 25](https://cloud.githubusercontent.com/assets/1001642/3734557/aa054a00-1718-11e4-9783-d2a361613151.png)

![screen shot 2014-07-29 at 13 04 45](https://cloud.githubusercontent.com/assets/1001642/3734560/af827fde-1718-11e4-9d34-d7c95690cac1.png)

@gklopper There can be a lot of keywords, so maybe we should trim them. e.g.,

![screen shot 2014-07-29 at 13 06 18](https://cloud.githubusercontent.com/assets/1001642/3734561/c490db50-1718-11e4-8e35-ac08a1aa4793.png)

@kaelig I'm mutilating your CSS again ;-)
