### PR TITLE
Add styling for thumbnail layout hints

### DIFF
--- a/common/app/assets/stylesheets/module/_layout-hints.scss
+++ b/common/app/assets/stylesheets/module/_layout-hints.scss
@@ -68,6 +68,34 @@ figure.element.element--supporting {
     }
 }
 
+figure.element.element--thumbnail {
+    float: left;
+    clear: left;
+    margin-bottom: 0;
+    @include rem((
+        width: gs-span(2) - $gs-gutter,
+        margin-right: $gs-gutter,
+        margin-top: $gs-baseline/2
+    ));
+
+    @include mq(tablet) {
+        @include rem((
+            width: gs-span(2)
+        ));
+    }
+
+    @include mq(leftCol) {
+        @include deport-left;
+        position: relative;
+    }
+
+    @include mq(wide) {
+        @include rem((
+            margin-left: -1 * (gs-span(2) + $gs-gutter)
+        ));
+    }
+}
+
 figure.element.element--showcase {
 
     @include mq(leftCol) {

--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -189,14 +189,13 @@ figure {
     &.img--landscape,
     &.img--portrait {
         figcaption {
-            background-color: $c-neutral7;
             @include rem((
-                padding: $gs-baseline/3 6px $gs-baseline*2 6px
+                padding: $gs-baseline/3 0 $gs-baseline*2
             ));
 
             @include mq(wide) {
                 @include rem((
-                    padding: $gs-baseline/2 8px $gs-row-height 8px
+                    padding: $gs-baseline/2 0 $gs-row-height
                 ));
             }
         }
@@ -221,6 +220,10 @@ p + video {
     @include rem((
         margin-top: $gs-baseline/3
     ));
+}
+
+figure.element--thumbnail + h2 {
+    display: inline;
 }
 
 


### PR DESCRIPTION
Adds styling for the latest layout hint **thumbnail**, i.e. smaller than supporting and used a lot in reviews, travel and food sections.
- Thumbnail styling
- Remove background colour from ficaptions globally
- Make adjacent headings to thumbnails inline
### Screenshots
#### Mobile

![google chrome](https://cloud.githubusercontent.com/assets/80089/3736188/6da480ae-172b-11e4-9aa9-0c850f24425a.png)
#### Tablet

![google chrome](https://cloud.githubusercontent.com/assets/80089/3736189/6fb0daa0-172b-11e4-844a-374ce3f6d6c6.png)
#### Desktop

![google chrome](https://cloud.githubusercontent.com/assets/80089/3736190/7134fa00-172b-11e4-8c3a-4465179c6cd6.png)

/cc @mattosborn @rich-nguyen @theefer 
