### PR TITLE
Only bind video endslate init to content start event

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -272,8 +272,10 @@ define([
             endSlate.endpoint = modules.generateEndSlateUrl();
             endSlate.fetch(player.el(), 'html');
 
-            player.on('ended', function() {
-                bonzo(player.el()).addClass(endState);
+            player.one('video:content:play', function() {
+                player.on('ended', function () {
+                    bonzo(player.el()).addClass(endState);
+                });
             });
             player.on('playing', function() {
                 bonzo(player.el()).removeClass(endState);


### PR DESCRIPTION
Fixes race condition bug causing the endslate to sometimes show after video prerolls.

/cc @mattosborn 
