### PR TITLE
fixing flash prerolls

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -227,7 +227,8 @@ define([
                                 modules.bindPrerollEvents(player);
 
                                 player.vast({
-                                    url: modules.getVastUrl()
+                                    url: modules.getVastUrl(),
+                                    vidFormats: ['video/mp4', 'video/webm', 'video/ogv', 'video/x-flv']
                                 });
 
                                 if(/desktop|wide/.test(detect.getBreakpoint())) {

--- a/common/app/assets/javascripts/bower.json
+++ b/common/app/assets/javascripts/bower.json
@@ -16,7 +16,7 @@
     "enhancer": "0.1.1",
     "videojs": "git://github.com/guardian/video.js.git#59d4443682bd578e03c3925ed40a623c466476c6",
     "videojs-contrib-ads": "guardian/videojs-contrib-ads#798b8a93cb293a95ede9af385c2354aa2c129216",
-    "videojs-vast": "~0.1.5",
+    "videojs-vast": "guardian/videojs-vast-plugin#a630848c033322cb79467434318116f7cf181f31",
     "videojs-persistvolume": "~0.1.0",
     "socket.io-client": "1.0.6",
     "raven-js": "~1.1.15",

--- a/common/app/assets/javascripts/bower.json
+++ b/common/app/assets/javascripts/bower.json
@@ -16,7 +16,7 @@
     "enhancer": "0.1.1",
     "videojs": "git://github.com/guardian/video.js.git#59d4443682bd578e03c3925ed40a623c466476c6",
     "videojs-contrib-ads": "guardian/videojs-contrib-ads#798b8a93cb293a95ede9af385c2354aa2c129216",
-    "videojs-vast": "guardian/videojs-vast-plugin#a630848c033322cb79467434318116f7cf181f31",
+    "videojs-vast": "guardian/videojs-vast-plugin#0a9b9de064f5ed31d436fc05b1d8dd6f504b6f96",
     "videojs-persistvolume": "~0.1.0",
     "socket.io-client": "1.0.6",
     "raven-js": "~1.1.15",

--- a/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
+++ b/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
@@ -15,7 +15,8 @@
   },
 
   defaults = {
-    skip: 5 // negative disables
+    skip: 5, // negative disables
+    vidFormats: ['video/mp4', 'video/webm', 'video/ogv']
   },
 
   vastPlugin = function(options) {
@@ -210,12 +211,12 @@
     };
     player.vast.createSourceObjects = function(media_files) {
       var sourcesByFormat = {}, format, i;
-      var vidFormats = ['video/mp4', 'video/webm', 'video/ogv', 'video/x-flv'];
+      
       // get a list of files with unique formats
       for (i = 0; i < media_files.length; i++) {
         format = media_files[i].mimeType;
 
-        if (vidFormats.indexOf(format) >= 0) {
+        if (settings.vidFormats.indexOf(format) >= 0) {
           if(sourcesByFormat[format] === undefined) {
             sourcesByFormat[format] = [];
           }
@@ -230,8 +231,8 @@
 
       // Create sources in preferred format order
       var sources = [];
-      for (var j=0; j < vidFormats.length; j++) {
-        format = vidFormats[j];
+      for (var j=0; j < settings.vidFormats.length; j++) {
+        format = settings.vidFormats[j];
         if (sourcesByFormat[format] !== undefined) {
           for (i = 0; i < sourcesByFormat[format].length; i++) {
             sources.push(sourcesByFormat[format][i]);

--- a/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
+++ b/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
@@ -210,7 +210,7 @@
     };
     player.vast.createSourceObjects = function(media_files) {
       var sourcesByFormat = {}, format, i;
-      var vidFormats = ['video/mp4', 'video/webm', 'video/ogv'];
+      var vidFormats = ['video/mp4', 'video/webm', 'video/ogv', 'video/x-flv'];
       // get a list of files with unique formats
       for (i = 0; i < media_files.length; i++) {
         format = media_files[i].mimeType;


### PR DESCRIPTION
Not sure what happened here.. thought I'd already made this change. Adds x-flv to the list of supported preroll formats
