### PR TITLE
Make facia video icons consistent

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_multimedia.scss
+++ b/common/app/assets/stylesheets/module/containers/_multimedia.scss
@@ -1,3 +1,14 @@
+@mixin video-icon($type) {
+    content: '';
+    @include icon($type);
+    @include background-size(auto 100%);
+    @include rem((
+        margin-right: $gs-gutter/10,
+        height: .75em !important,
+        width: 1.2em !important
+    ));
+}
+
 .container--multimedia {
     @include item--hide-tone-border;
 
@@ -27,15 +38,8 @@
     .item__meta {
         display: none;
     }
-    .item__title:before {
-        content: '';
-        @include icon(video-icon);
-        @include background-size(auto 100%);
-        @include rem((
-            margin-right: $gs-gutter/4,
-            height: 12px !important,
-            width: 18px !important
-        ));
+    .item__title--video-icon:before {
+        @include video-icon(video-icon);
     }
     .facia-slice__item:before {
         border-left-color: lighten($c-neutral1, 16%);
@@ -129,14 +133,7 @@
 
 .item--video {
     .item__title:before {
-        content: '';
-        @include icon(video-icon-black);
-        @include background-size(auto 100%);
-        @include rem((
-            margin-right: $gs-gutter/10,
-            height: 12px !important,
-            width: 18px !important
-        ));
+        @include video-icon(video-icon-black);
     }
 
     .l-row--background-features & {
@@ -146,20 +143,16 @@
     }
 }
 
-.facia-slice__item--content-type-video:first-child {
-    .item--video {
-        .item__title:before {
-            @include rem((
-                height: 14px !important,
-                width: 21px !important
-            ));
+.linkslist__item--video {
+    .linkslist__action:before {
+        @include video-icon(video-icon-black);
+    }
 
-            @include mq(rightCol) {
-                @include rem((
-                    height: 16px !important,
-                    width: 24px !important
-                ));
-            }
+    &.supporting__item {
+        .linkslist__action:before {
+            @include rem((
+                margin-top: -1 * $gs-baseline
+            ));
         }
     }
 }

--- a/common/app/views/fragments/items/linksList/video.scala.html
+++ b/common/app/views/fragments/items/linksList/video.scala.html
@@ -1,8 +1,8 @@
 @(trail: Video, index: Int, imageAdjustOverride: Option[String] = None)(implicit request: RequestHeader)
 
 @defining(imageAdjustOverride.getOrElse(trail.imageAdjust)) { imageAdjust =>
-<li class="l-columns__item linkslist__item" data-link-name="trail | @{index + 1}">
-    <a href="@LinkTo{@trail.url}" class="linkslist__action action--has-icon@if(imageAdjust == "boost" && trail.trailPicture(5,3).nonEmpty){ action--has-image}" data-link-name="article">
+<li class="l-columns__item linkslist__item linkslist__item--video" data-link-name="trail | @{index + 1}">
+    <a href="@LinkTo{@trail.url}" class="linkslist__action @if(imageAdjust == "boost" && trail.trailPicture(5,3).nonEmpty){ action--has-image}" data-link-name="article">
         @if(imageAdjust == "boost") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>
@@ -10,7 +10,6 @@
                 }
             }
         }
-        <span class="i i-video-yellow-small linkslist__icon"></span>
         @RemoveOuterParaHtml(trail.headline)
     </a>
 </li>

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -23,7 +23,7 @@
                         </div>
                     }
                 </div>
-                <h@if(isFirstContainer && index == 0){1}else{2} class="item__title">
+                <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--video-icon">
                     @RemoveOuterParaHtml(trail.headline)
                 </h@if(isFirstContainer && index == 0){1}else{2}>
             </a>

--- a/common/app/views/fragments/items/supporting/video.scala.html
+++ b/common/app/views/fragments/items/supporting/video.scala.html
@@ -1,8 +1,7 @@
 @(supporting: Video, index: Int)(implicit request: RequestHeader)
 
-<li class="linkslist__item supporting__item">
-    <a @LinkTo(supporting).map{url=>href="@url"} class="linkslist__action supporting__action action--has-icon" data-link-name="supporting | @{index + 1}">
-        <span class="i i-video-yellow-small"></span>
+<li class="linkslist__item linkslist__item--video supporting__item">
+    <a @LinkTo(supporting).map{url=>href="@url"} class="linkslist__action supporting__action" data-link-name="supporting | @{index + 1}">
         @Html(supporting.headline)
     </a>
 </li>


### PR DESCRIPTION
- Makes the video icon within facia items relative to the current text node and not the root (i.e use em's over rem's).
- Use the new icon for link lists and supporting links

![google chrome](https://cloud.githubusercontent.com/assets/80089/3738463/19d2e536-1741-11e4-8785-2d68ae90245d.png)

/cc @kaelig 
