### PR TITLE
Adding headline container

### DIFF
--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -111,6 +111,7 @@
 @import 'module/containers/_related';
 @import 'module/containers/_multimedia';
 @import 'module/containers/_series';
+@import 'module/containers/_headline';
 
 @import 'module/facia/snaps/_football';
 

--- a/common/app/assets/stylesheets/module/containers/_headline.scss
+++ b/common/app/assets/stylesheets/module/containers/_headline.scss
@@ -1,0 +1,117 @@
+.container--headline {
+    @include guss-columns(
+        $base-class: '.headline-list',
+        $css3-columns-support: false,
+        $columns-fallback-width: (
+            desktop: gs-span(12)
+        ),
+        $columns-fallback-columns: (
+            desktop: 4
+        )
+    );
+
+    .headline-list {
+        @include mq(desktop) {
+            float: left;
+            @include rem((
+                margin-top: $gs-baseline/3
+            ));
+        }
+    }
+    .headline-list__item {
+        @include fs-headline(2);
+        float: none;
+
+        @include mq(desktop) {
+            float: left;
+        }
+    }
+    .headline-list--standard {
+        .headline-list__item {
+            @include rem((
+                padding-bottom: $gs-baseline
+            ));
+            border-top: 0 none;
+        }
+    }
+    .headline-list--big {
+        .headline-list__item {
+            border-top: 2px solid $c-newsAccent;
+            padding-bottom: 0;
+
+            @include mq(desktop) {
+                border-top: 0 none;
+                padding-top: 0;
+            }
+        }
+
+        .headline-item__title {
+            @include rem((
+                margin-top: -4px
+            ));
+        }
+
+        .item__media-wrapper,
+        .item__image-container {
+            display: block;
+        }
+
+        .item__image-container {
+            @include box-sizing(border-box);
+            @include rem((
+                margin-right: $gs-gutter/2
+            ));
+            float: left;
+            margin-top: 0;
+            width: 50%;
+
+            .responsive-img {
+                width: 100%;
+            }
+
+            @include mq(desktop) {
+                float: none;
+                margin-top: 0;
+                width: 100%;
+            }
+        }
+    }
+
+    @for $i from 1 through 3 {
+        $inverse-i: 4 - $i;
+        .headline-list--#{$i}-big {
+            @include mq(desktop) {
+                @include rem((
+                    width: gs-span($i*3)+($gs-gutter*2)
+                ));
+            }
+        }
+        .headline-list--#{$i}-big + .headline-list--standard {
+            @include mq(desktop) {
+                @include rem((
+                    width: gs-span(3*$inverse-i)+$gs-gutter
+                ));
+
+                .headline-list__item {
+                    clear: none;
+
+                    &:nth-child(#{$inverse-i}n+1) {
+                        clear: both;
+                    }
+
+                    &:nth-child(n+#{$i+1}) {
+                        border-top: 1px solid $c-neutral6;
+                    }
+
+                    &:nth-child(-n+#{$i}) {
+                        padding-top: 0;
+                    }
+                }
+            }
+        }
+    }
+
+    .headline-item__body {
+        color: $c-neutral1;
+    }
+}

--- a/common/app/views/fragments/collections/headline.scala.html
+++ b/common/app/views/fragments/collections/headline.scala.html
@@ -7,11 +7,10 @@
                 @bigItems.zipWithIndex.map { case (trail, index) =>
                     <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
                         <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
-
                             @trail.trailPicture(5,3).map{ imageContainer =>
                                 @ImgSrc.imager(imageContainer, 620).map { imgSrc =>
                                     <div class="item__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
-                                        @Item300.bestFor(imageContainer).map{ url =>
+                                        @Item220.bestFor(imageContainer).map{ url =>
                                             <img src="@url" class="responsive-img" alt="" />
                                         }
                                     </div>

--- a/common/app/views/fragments/collections/headline.scala.html
+++ b/common/app/views/fragments/collections/headline.scala.html
@@ -1,0 +1,37 @@
+@(items: Seq[model.Trail], containerIndex: Int)(implicit request: RequestHeader, config: model.Config)
+
+@defining(items.filter(item => item.group == Option("0") || item.group == None), items.filter(_.group == Option("1"))) { case (standardItems, bigItems) =>
+    @defining(8 - bigItems.length * 2) { standardItemCount =>
+        <div class="headline-list-container">
+            <ul class="headline-list headline-list--@bigItems.length-big headline-list--big">
+                @bigItems.zipWithIndex.map { case (trail, index) =>
+                    <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
+                        <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
+
+                            @trail.trailPicture(5,3).map{ imageContainer =>
+                                @ImgSrc.imager(imageContainer, 620).map { imgSrc =>
+                                    <div class="item__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
+                                        @Item300.bestFor(imageContainer).map{ url =>
+                                            <img src="@url" class="responsive-img" alt="" />
+                                        }
+                                    </div>
+                                }
+                            }
+                            <div class="headline-item__title">@RemoveOuterParaHtml(trail.headline)</div>
+                        </a>
+                    </li>
+                }
+            </ul>
+
+            <ul class="headline-list headline-list--standard">
+                @standardItems.slice(0, standardItemCount).zipWithIndex.map{ case (trail, index) =>
+                    <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
+                        <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
+                            <div class="headline-item__title">@RemoveOuterParaHtml(trail.headline)</div>
+                        </a>
+                    </li>
+                }
+            </ul>
+        </div>
+    }
+}

--- a/common/app/views/fragments/containers/headline.scala.html
+++ b/common/app/views/fragments/containers/headline.scala.html
@@ -1,0 +1,36 @@
+@(collection: Collection, style: Container, containerIndex: Int)(implicit request: RequestHeader, config: Config)
+
+@defining((config.displayName.orElse(collection.displayName), config.href.orElse(collection.href))) { case (title, href) =>
+    @if(collection.items.nonEmpty) {
+        <section
+            class="@RenderClasses(Map(
+                ("container", true),
+                (s"container--${style.containerType}", true),
+                ("container--first" -> (containerIndex == 0))))"
+            data-link-name="@FaciaComponentName(config, collection)"
+            data-id="@config.id"
+            data-type="@style.containerType"
+            data-component="@FaciaComponentName(config, collection)"
+            @config.sponsorshipKeyword.map { keyword =>
+                data-keywords="@keyword"
+            }>
+            <div class="facia-container__inner">
+                <div class="container__border tone-@style.tone tone-accent-border"></div>
+                <div class="container__header">
+                    @title.map { title =>
+                        <h2 class="container__title tone-@style.tone tone-background">
+                        @href.map { href =>
+                            <a data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                        }.getOrElse{
+                            @Html(title)
+                        }
+                        </h2>
+                    }
+                </div>
+                <div class="container__body container--rolled-up-hide">
+                    @fragments.collections.headline(collection.items, containerIndex)
+                </div>
+            </div>
+        </section>
+    }
+}

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -104,6 +104,10 @@ case class MostReferredContainer(showMore: Boolean = true) extends Container {
   val containerType = "most-referred"
   val tone = "news"
 }
+case class HeadlineContainer(showMore: Boolean = true) extends Container {
+  val containerType = "headline"
+  val tone = "news"
+}
 
 
 /**

--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -15,6 +15,7 @@ define([
             {name: 'news/most-popular'},
             {name: 'news/people'},
             {name: 'news/special'},
+            {name: 'news/headline', groups: ['standard', 'big']},
             {name: 'features'},
             {name: 'features/auto'},
             {name: 'features/multimedia'},

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -4,12 +4,13 @@
 @block._1.collectionType match {
     case Some("news")                       => { @containers.news(front, block._2, NewsContainer(), index)(request, templateDeduping, block._1) }
     case Some("news/auto")                  => { @containers.news(front, ForceGroupsCollection.firstTwoBig(block._2), NewsContainer(), index)(request, templateDeduping, block._1) }
-    case Some("comment/comment-and-debate") => { @containers.commentanddebate(block._2, CommentAndDebateContainer(), index)(request, templateDeduping, block._1) }
-    case Some("features")                   => { @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1) }
     case Some("news/most-popular")          => { @containers.popular(block._2, PopularContainer(), index)(request, block._1) }
     case Some("news/people")                => { @containers.people(block._2, PeopleContainer(), index)(request, templateDeduping, block._1) }
     case Some("news/special")               => { @containers.special(block._2, SpecialContainer(), index)(request, templateDeduping, block._1) }
+    case Some("news/headline")              => { @containers.headline(block._2, HeadlineContainer(), index)(request, block._1) }
+    case Some("features")                   => { @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1) }
     case Some("features/multimedia")        => { @containers.multimedia(block._2, MultimediaContainer(), index)(request, templateDeduping, block._1) }
     case Some("features/auto")              => { @containers.featuresauto(block._2, FeaturesAutoContainer(), index)(request, templateDeduping, block._1) }
+    case Some("comment/comment-and-debate") => { @containers.commentanddebate(block._2, CommentAndDebateContainer(), index)(request, templateDeduping, block._1) }
     case _                                  => { @containers.special(block._2, SpecialContainer(), index)(request, templateDeduping, block._1) }
 }


### PR DESCRIPTION
Adding a new container for the days headlines.
Allows for standard and big size stories only.

Logic is:
- 2 standard stories per column
- 1 big story per column
- Max 4 columns
# What?
### mobile

![mobile](https://cloud.githubusercontent.com/assets/31692/3746844/fb20b796-17c5-11e4-8339-35194ea4a0d5.png)
### desktop

![desktop](https://cloud.githubusercontent.com/assets/31692/3749300/525c6db0-17ea-11e4-911b-29cdb6d96a07.png)

---

![Illusions](http://static.paulboxley.com/2014/monument_valley_penrose.gif)
