### PR TITLE
pass GU_TEST cookie value through to dfp

### DIFF
--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -284,7 +284,7 @@ define([
                 su      : page.isSurging ? '1' : '0',
                 bp      : detect.getBreakpoint(),
                 a       : audienceScience.getSegments(),
-                at      : cookies.get('adtest') || '',
+                at      : cookies.get('adtest') || cookies.get('GU_TEST') || '',
                 gdncrm  : userAdTargeting.getUserSegments(),
                 ab      : abParam(),
                 co      : parseContributors(page.author)


### PR DESCRIPTION
So the url parameter `?test=ng1` will pass the value `ng1` to dfp in the same way the `adtest` cookie does.

Doesn't work on localhost. Use a hosts entry to get around this on local instance.
