### PR TITLE
changing inline merchandising ad slot size to 88 x 85

### DIFF
--- a/commercial/app/views/books/bestsellersSuperHigh.scala.html
+++ b/commercial/app/views/books/bestsellersSuperHigh.scala.html
@@ -17,11 +17,13 @@
         </a>
         @books.take(1).map { book =>
             <div class="commercial--v-high__head">
-                <h4 itemprop="name" class="lineitem__title">
-                    @book.title
-                </h4>
-                <meta itemprop="isbn" content="@{book.isbn}" />
-                <p itemprop="author" class="lineitem__meta">@book.author</p>
+                <a href="@AdLink{@book.buyUrl}" class="lineitem__link" data-link-name="merchandising-bookshop-v@{version}_@{date}-superHigh-@{book.isbn}-@{book.author}-@{book.title}-title">
+                    <h4 itemprop="name" class="lineitem__title">
+                        @book.title
+                    </h4>
+                    <meta itemprop="isbn" content="@{book.isbn}" />
+                    <p itemprop="author" class="lineitem__meta">@book.author</p>
+                </a>
             </div>
             <div class="commercial--v-high__body">
                 <a href="@AdLink{@book.buyUrl}" class="lineitem__link" data-link-name="merchandising-bookshop-v@{version}_@{date}-superHigh-@{book.isbn}-@{book.author}-@{book.title}">

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -98,7 +98,7 @@ define([
                 label: false,
                 refresh: false,
                 sizeMappings: {
-                    mobile: '88,89'
+                    mobile: '88,85'
                 }
             },
             inline1: {

--- a/common/test/assets/javascripts/spec/commercial/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/dfp.spec.js
@@ -245,6 +245,13 @@ define([
                         'data-link-name="ad slot right" data-test-id="ad-slot-right" data-name="right" data-tabletlandscape="300,250|300,600"></div>'
                 },
                 {
+                    name: 'im',
+                    type: 'im',
+                    html: '<div id="dfp-ad--im" class="ad-slot ad-slot--dfp ad-slot--im ad-slot--im" ' +
+                        'data-link-name="ad slot im" data-test-id="ad-slot-im" data-name="im" data-mobile="88,85" ' +
+                        'data-refresh="false" data-label="false"></div>'
+                },
+                {
                     name: 'inline1',
                     type: 'inline',
                     html: '<div id="dfp-ad--inline1" class="ad-slot ad-slot--dfp ad-slot--inline1 ad-slot--inline" ' +


### PR DESCRIPTION
This just changes the inline merchandising adslot to 88 x 85 so that it now has a unique size and allows for better reporting.

Also add the link to the book title and author.
