### PR TITLE
Tag fronts are now considered Section/Subsections

### DIFF
--- a/common/app/model/AdSuffixHandlingForFronts.scala
+++ b/common/app/model/AdSuffixHandlingForFronts.scala
@@ -10,10 +10,14 @@ trait AdSuffixHandlingForFronts extends MetaData{
 
   def extractAdUnitSuffixFrom(path: String) = {
     val frontSuffixList = List("front")
+    val tagPageSuffixList = List("subsection")
+
     path.split("/").toList match {
       case cc :: Nil  if supportedCountries contains cc => (cc :: frontSuffixList).mkString("/")
-      case cc :: pathList if supportedCountries contains cc => (pathList ::: frontSuffixList).mkString("/")
-      case pathList => (pathList ::: frontSuffixList).mkString("/")
+      case cc :: bitsAfterTheEdition if (supportedCountries.contains(cc) &&
+        bitsAfterTheEdition == List(section))=> (section :: frontSuffixList).mkString("/")
+      case nonEditionalisedPath if nonEditionalisedPath == List(section) => (section :: frontSuffixList).mkString("/")
+      case _  => (section :: tagPageSuffixList).mkString("/")
     }
   }
 }

--- a/common/test/model/AdSuffixHandlingForFrontsTest.scala
+++ b/common/test/model/AdSuffixHandlingForFrontsTest.scala
@@ -3,7 +3,7 @@ package model
 import org.scalatest.{Matchers, FlatSpec}
 
 class AdSuffixHandlingForFrontsTest extends FlatSpec with Matchers  {
-  object Tester extends AdSuffixHandlingForFronts {
+  object NetworkFronts extends AdSuffixHandlingForFronts {
     override def id: String = ???
 
     override def section: String = ???
@@ -13,25 +13,46 @@ class AdSuffixHandlingForFrontsTest extends FlatSpec with Matchers  {
     override def webTitle: String = ???
   }
 
+  object SectionFront extends AdSuffixHandlingForFronts {
+    override def id: String = ???
+
+    override def section: String = "business"
+
+    override def analyticsName: String = ???
+
+    override def webTitle: String = ???
+  }
+
+  object TagFront extends AdSuffixHandlingForFronts {
+    override def id: String = ???
+
+    override def section: String = "education"
+
+    override def analyticsName: String = ???
+
+    override def webTitle: String = ???
+  }
+
+
+
   "Editionalised Network Front pages" should "have editions in the ad unit suffix and end with 'front'" in {
-    Tester.extractAdUnitSuffixFrom("uk") should equal("uk/front")
+    NetworkFronts.extractAdUnitSuffixFrom("uk") should equal("uk/front")
   }
 
   "Editionalised Section fronts" should "end with front, and do not have editions in the ad unit suffix" in {
-    Tester.extractAdUnitSuffixFrom("uk/money") should equal("money/front")
-  }
-
-  "Editionalised Tag Fronts" should "end with 'front', and do not have editions in the ad unit suffix" in {
-    // While we don't have editionalised tag fronts right now, at least we know it'll work
-    Tester.extractAdUnitSuffixFrom("uk/money/borrowing") should equal("money/borrowing/front")
+    SectionFront.extractAdUnitSuffixFrom("uk/business") should equal("business/front")
   }
 
   "Non-editionlised section fronts" should "end with 'front'" in {
-    Tester.extractAdUnitSuffixFrom("lifeandstyle") should equal("lifeandstyle/front")
+    SectionFront.extractAdUnitSuffixFrom("business") should equal("business/front")
   }
 
-  "Non-editionalised tag fronts" should "end with 'front" in {
-    Tester.extractAdUnitSuffixFrom("lifeandstyle/live-better") should equal("lifeandstyle/live-better/front")
+  "Tag Fronts ad units" should "be the section, plus the word 'subsection'" in {
+    TagFront.extractAdUnitSuffixFrom("education/universitytables") should equal("education/subsection")
+  }
+
+  "Tag fronts ad units" should "revert to their section, plus the world 'subsection'" in {
+    TagFront.extractAdUnitSuffixFrom("tagfronts/actuallydontneedtocopythesection") should equal("education/subsection")
   }
 
 }


### PR DESCRIPTION
We've cleaned up how we handle the AdUnits for tag fronts. They are now just considered section/subsections. 

For example:
www.theguardian.com/education/universityguides
used to be
theguardian.com/education/universityguides/front
Now it is just:
theguardian.com/education/subsection

This will look funny to keywords that have a path that is different to the section. 

Like:
www.theguardian.com/news/malaysia-airlines-flight-mh17
the section is actually "world", so the ad unit will now be:
theguardian.com/world/subsection
