### PR TITLE
Ensure interactives are augmented on live blogs

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -370,7 +370,7 @@ define([
 
         augmentInteractive: function() {
             mediator.on('page:common:ready', function(config, context) {
-                if (/Article|Interactive/.test(config.page.contentType)) {
+                if (/Article|Interactive|LiveBlog/.test(config.page.contentType)) {
                     $('figure.interactive').each(function (el) {
                         enhancer.render(el, context, config, mediator);
                     });


### PR DESCRIPTION
Since changed live blogs to have their own content type, we no longer augment interactives on those pages.

http://www.theguardian.com/football/2014/jul/13/world-cup-final-2014-countdown-live#block-53c2713be4b093fa8e0aac05

This fixes that. 

/cc @andymason 
