### PR TITLE
fix tracking event not firing on mobile devices

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -95,7 +95,7 @@ define([
 
         // delegate, emit the derived tag
         if (opts.addListener !== false) {
-            bean.add(document.body, 'click', function (event) {
+            bean.add(document.body, 'click touchstart', function (event) {
                 var clickSpec = {el: event.target};
 
                 if (opts.withEvent !== false) {


### PR DESCRIPTION
Adding touchstart to event binding.
