### PR TITLE
Fix dev build clash

### DIFF
--- a/admin/app/controllers/IndexController.scala
+++ b/admin/app/controllers/IndexController.scala
@@ -17,7 +17,7 @@ object AuthActions extends Actions {
   object AuthActionTest extends AuthenticatedBuilder(r => UserIdentity.fromRequest(r).orElse(testUser), r => sendForAuth(r))
 }
 
-object IndexController extends Controller {
+object AdminIndexController extends Controller {
 
   def index() = Action { Redirect("/admin") }
 

--- a/admin/app/controllers/OAuthLoginController.scala
+++ b/admin/app/controllers/OAuthLoginController.scala
@@ -66,7 +66,7 @@ object OAuthLoginController extends Controller with ExecutionContexts {
               // Redirect a user back there now if it exists
               val redirect = request.session.get(LOGIN_ORIGIN_KEY) match {
                 case Some(url) => Redirect(url)
-                case None => Redirect(routes.IndexController.index())
+                case None => Redirect(routes.AdminIndexController.admin())
               }
               // Store the JSON representation of the identity in the session - this is checked byAuthActions.AuthActionTest later
               val sessionAdd: Seq[(String, String)] = Seq(

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -20,8 +20,8 @@ GET         /assets/*path                 dev.DevAssetsController.at(path)
 #######################################################
 
 #Index page
-GET         /                             controllers.admin.IndexController.index()
-GET         /admin                        controllers.admin.IndexController.admin()
+GET         /                             controllers.admin.AdminIndexController.index()
+GET         /admin                        controllers.admin.AdminIndexController.admin()
 
 # API endpoint proxying for https
 GET         /api/proxy/*path              controllers.admin.Api.proxy(path, callback)

--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -42,7 +42,7 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
       if (
         !isProd &&
         !request.isJson &&
-        !request.uri.startsWith("/openIDCallback") &&
+        !request.uri.startsWith("/oauth2callback") &&
         !request.uri.startsWith("/px.gif")  && // diagnostics box
         !request.uri.startsWith("/ab.gif") &&
         !request.uri.startsWith("/js.gif")

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -234,6 +234,8 @@ GET         /commercial/money/credit-cards/:creditCardType                      
 GET         /commercial/money/loans/:loanType                                                                        controllers.commercial.MoneyOffers.loans(loanType)
 GET         /commercial/capi/*contentId.json                                                                         controllers.commercial.ContentApiOffers.itemJson(contentId)
 GET         /commercial/capi/*contentId                                                                              controllers.commercial.ContentApiOffers.itemHtml(contentId)
+GET         /commercialtools/adunits/toapprove                                                                       controllers.admin.CommercialAdUnitController.renderToApprove()
+POST        /commercialtools/adunits/toapprove                                                                      controllers.admin.CommercialAdUnitController.approve()
 
 # Onward journeys
 GET         /series/*path.json                                                                                       controllers.SeriesController.renderSeriesStories(path)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -141,7 +141,7 @@ GET         /login                                                              
 POST        /login                                                                                                   controllers.admin.OAuthLoginController.loginAction
 GET         /oauth2callback                                                                                          controllers.admin.OAuthLoginController.oauth2Callback
 GET         /logout                                                                                                  controllers.admin.OAuthLoginController.logout
-GET         /admin                                                                                                   controllers.admin.IndexController.admin()
+GET         /admin                                                                                                   controllers.admin.AdminIndexController.admin()
 GET         /api/proxy/*path                                                                                         controllers.admin.Api.proxy(path, callback)
 GET         /api/tag                                                                                                 controllers.admin.Api.tag(q, callback)
 GET         /api/item/*path                                                                                          controllers.admin.Api.item(path, callback)


### PR DESCRIPTION
The `/oauth2callback` method was being picked up by the `DevParametersLifecycle` in `dev-build`. It has now been white listed.

Redirecting didn't work because of clashing names for `IndexController`; renamed `IndexController` to `AdminIndexController`.

Added missing endpoints for `CommercialAdTools` @kenlim 

@NathanielBennett 
