### PR TITLE
Logic tidy of sentimental comments

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comment-box.js
+++ b/common/app/assets/javascripts/modules/discussion/comment-box.js
@@ -174,14 +174,10 @@ CommentBox.prototype.ready = function() {
         this.getElem('body').focus();
     }
 
-    // The check on this should be done through the discussion API
-    // for now though this is a good (enough) check
     if (config.switches.sentimentalComments) {
         setTimeout(function() {
-            var sentimentActiveClass = 'd-comment-box__sentiment--active';
             $('.open a[href="#comments"]').each(function (openLink) {
-                $('.d-discussion').addClass('d-discussion--sentimental');
-                $('.discussion__show-threaded').remove();
+                var sentimentActiveClass = 'd-comment-box__sentiment--active';
                 this.setState('sentimental');
                 this.options.maxLength = 350;
 
@@ -200,8 +196,8 @@ CommentBox.prototype.ready = function() {
                     this.elem.sentiment.value = e.currentTarget.getAttribute('data-value');
                     this.getElem('body').focus();
                 }.bind(this));
-            }.bind(this));
-        }.bind(this), 500); // used as we don't know when the open module loads.
+            });
+        }, 500);
     }
 };
 

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -1,6 +1,7 @@
 define([
     'common/utils/$',
     'common/utils/ajax',
+    'common/utils/config',
     'bonzo',
     'qwery',
     'bean',
@@ -16,6 +17,7 @@ define([
 ], function(
     $,
     ajax,
+    config,
     bonzo,
     qwery,
     bean,
@@ -135,6 +137,17 @@ Loader.prototype.ready = function() {
     // More for analytics than anything
     if (window.location.hash === '#comments') {
         this.mediator.emit('discussion:seen:comments-anchor');
+    }
+
+    // The check on this should be done through the discussion API
+    // for now though this is a good (enough) check
+    if (config.switches.sentimentalComments) {
+        setTimeout(function() {
+            $('.open a[href="#comments"]').each(function () {
+                $('.d-discussion').addClass('d-discussion--sentimental');
+                $('.discussion__show-threaded').remove();
+            }.bind(this));
+        }.bind(this), 500); // used as we don't know when the open module loads.
     }
 
     register.end('discussion');
@@ -325,6 +338,7 @@ Loader.prototype.renderCommentBox = function() {
             switches: this.options.switches
         });
         this.commentBox.render(this.getElem('commentBox'));
+
         this.commentBox.on('post:success', this.commentPosted.bind(this));
         this.canComment = true;
     }

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -135,6 +135,9 @@ $avatarSize: 44px;
     .d-discussion--sentimental & {
         display: block;
     }
+    .d-discussion--shut & {
+        display: none;
+    }
 }
 .d-discussion__sentiment {
     @include box-sizing(border-box);

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -392,14 +392,14 @@ $avatarSize: 44px;
 
 .d-comment__sentiment {
     @include border-radius(8px);
-    float: left;
     @include rem((
         height: 8px,
         width: 8px,
-        margin-right: $gs-gutter/3,
+        margin-right: $gs-gutter/4,
         margin-top: $gs-baseline/2
     ));
     background-color: $c-neutral4;
+    float: left;
 }
 .d-comment__sentiment--for {
     background-color: $c-statusPositive;

--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -30,11 +30,13 @@
         </div>
     </div>
 
-    <div class="d-discussion__sentiments">
-        <a class="js-discussion-sentiment-changer d-discussion__sentiment d-discussion__sentiment--active">All</a>
-        <a class="js-discussion-sentiment-changer d-discussion__sentiment" href="?index=0" data-sentiment="0">Yes</a>
-        <a class="js-discussion-sentiment-changer d-discussion__sentiment" href="?index=1" data-sentiment="1">No</a>
-    </div>
+    @if(!isTopComments){
+        <div class="d-discussion__sentiments">
+            <a class="js-discussion-sentiment-changer d-discussion__sentiment d-discussion__sentiment--active">All</a>
+            <a class="js-discussion-sentiment-changer d-discussion__sentiment" href="?index=0" data-sentiment="0">Yes</a>
+            <a class="js-discussion-sentiment-changer d-discussion__sentiment" href="?index=1" data-sentiment="1">No</a>
+        </div>
+    }
 
     <div class="preload-msg d-discussion__loader u-h">Loading comments…<div class="is-updating"></div></div>
     <div class="discussion-content js-discussion-content">


### PR DESCRIPTION
- Makes a discussion sentimental from `loader` not `comment-box` as the latter is only loaded if the discussion is open
- Removes Sentimental filter from top comments
- Hide sentiment filter if the comments are hidden
