### PR TITLE
fix fixtures redirect

### DIFF
--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -1,6 +1,7 @@
 package football.controllers
 
 import common._
+import model.TeamMap.findTeamIdByUrlName
 import model._
 import conf._
 import play.api.mvc.{ Controller, Action }
@@ -41,15 +42,13 @@ object MatchController extends Controller with Football with Requests with Loggi
   def renderMatchId(matchId: String) = render(Competitions().findMatch(matchId))
 
   def renderMatchJson(year: String, month: String, day: String, home: String, away: String) = renderMatch(year, month, day, home, away)
-  def renderMatch(year: String, month: String, day: String, home: String, away: String) = {
-
-    val date = dateFormat.parseDateTime(year + month + day).toLocalDate
-
-    (TeamMap.findTeamIdByUrlName(home), TeamMap.findTeamIdByUrlName(away)) match {
-      case (Some(homeId), Some(awayId)) => render(Competitions().matchFor(date, homeId, awayId))
+  def renderMatch(year: String, month: String, day: String, home: String, away: String) =
+    (findTeamIdByUrlName(home), findTeamIdByUrlName(away)) match {
+      case (Some(homeId), Some(awayId)) =>
+        val date = dateFormat.parseDateTime(year + month + day).toLocalDate
+        render(Competitions().matchFor(date, homeId, awayId))
       case _ => render(None)
     }
-  }
 
   private def render(maybeMatch: Option[FootballMatch]) = Action.async { implicit request =>
     val response = maybeMatch map { theMatch =>

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -67,7 +67,7 @@ trait CompetitionSupport extends implicits.Football {
   }
 
   def matchFor(date: LocalDate, homeTeamId: String, awayTeamId: String) =
-    matches.find(m => m.homeTeam.id == homeTeamId && m.awayTeam.id == awayTeamId)
+    matches.find(m => m.homeTeam.id == homeTeamId && m.awayTeam.id == awayTeamId && m.date.toLocalDate == date)
 
   // note team1 & team2 are the home and away team, but we do NOT know their order
   def matchFor(interval: Interval, team1: String, team2: String): Option[FootballMatch] = matches

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -18,11 +18,6 @@ trait CompetitionSupport extends implicits.Football {
 
   val competitions: Seq[Competition]
 
-  def withMatchesOn(date: LocalDate) = CompetitionSupport {
-    val competitionsWithMatches = competitions.filter(_.matches.exists(_.isOn(date)))
-    competitionsWithMatches.map(c => c.copy(matches = c.matches.filter(_.isOn(date))))
-  }
-
   def withCompetitionFilter(path: String) = CompetitionSupport(
     competitions.filter(_.url == path)
   )
@@ -71,8 +66,8 @@ trait CompetitionSupport extends implicits.Football {
     MatchDayTeam(teamId, unclean.name, None, None, None, None)
   }
 
-  def matchFor(date: LocalDate, homeTeamId: String, awayTeamId: String) = withMatchesOn(date).matches
-    .find(m => m.homeTeam.id == homeTeamId && m.awayTeam.id == awayTeamId)
+  def matchFor(date: LocalDate, homeTeamId: String, awayTeamId: String) =
+    matches.find(m => m.homeTeam.id == homeTeamId && m.awayTeam.id == awayTeamId)
 
   // note team1 & team2 are the home and away team, but we do NOT know their order
   def matchFor(interval: Interval, team1: String, team2: String): Option[FootballMatch] = matches

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -83,9 +83,9 @@ class CompetitionAgent(_competition: Competition) extends Fixtures with Results 
   }
 
   object MatchStatusOrdering extends Ordering[FootballMatch] {
-      private def statusValue(m: FootballMatch) = if (m.isResult) 1 else if (m.isLive) 2 else 3
-      def compare(a: FootballMatch, b: FootballMatch) = statusValue(a) - statusValue(b)
-    }
+    private def statusValue(m: FootballMatch) = if (m.isResult) 1 else if (m.isLive) 2 else 3
+    def compare(a: FootballMatch, b: FootballMatch) = statusValue(a) - statusValue(b)
+  }
 
   def addMatches(newMatches: Seq[FootballMatch]) = agent.send{ comp =>
 


### PR DESCRIPTION
Bug fix:
Clicking on any fixture on the football fixtures page (http://www.theguardian.com/football/premierleague/fixtures) takes the user to the results page rather than the specific fixture page.

Reason: match was not found by its date

![](http://media.giphy.com/media/Rk5z7Me51T4ju/giphy.gif)
