### PR TITLE
Fix a Safari bug where local navigation would span on multiple lines

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_navigation.scss
+++ b/common/app/assets/stylesheets/module/nav/_navigation.scss
@@ -757,6 +757,11 @@ $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevelsWithWideToggle, mq-
                 height: $navigation-height
             ));
         }
+        .local-navigation {
+            // Fill the maximum available width (otherwise the element
+            // only fills half the width, shared with the signposting)
+            width: 100%;
+        }
         .local-navigation__action {
             display: table-cell;
             @include rem((
@@ -766,7 +771,8 @@ $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevelsWithWideToggle, mq-
 
         // Re-order top nav on top of local nav
         .navigation__container {
-            display: block !important;
+            display: table !important;
+            width: 100%;
         }
         .navigation__container--first {
             background: $c-local-navigation-background;


### PR DESCRIPTION
Thanks @alastairjardine for flagging this up!
### Before

![screen shot 2014-08-01 at 12 38 42](https://cloud.githubusercontent.com/assets/85783/3778276/8f002eb4-1970-11e4-860c-09cee60ad526.PNG)
### After

![screen shot 2014-08-01 at 12 38 24](https://cloud.githubusercontent.com/assets/85783/3778278/91daad08-1970-11e4-9a29-a8b867e7d2ac.PNG)

![ ](http://www.realfarmacy.com/wp-content/uploads/2014/07/141-1.gif)
