### PR TITLE
Sentry cleanup

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -13,7 +13,8 @@ define([
     'bean',
     'bonzo',
     'common/modules/component',
-    'common/modules/analytics/beacon'
+    'common/modules/analytics/beacon',
+    'raven'
 ], function(
     $,
     ajax,
@@ -28,7 +29,8 @@ define([
     bean,
     bonzo,
     Component,
-    beacon
+    beacon,
+    Raven
 ) {
 
     var autoplay = config.isMedia && /desktop|wide/.test(detect.getBreakpoint());
@@ -332,7 +334,13 @@ define([
 
     var ready = function () {
         if(config.switches.enhancedMediaPlayer) {
-            modules.initPlayer();
+            Raven.context(function(){
+                Raven.setTagsContext({
+                    feature: 'media',
+                    contentType: config.page.contentType
+                });
+                modules.initPlayer();
+            });
         }
 
         if (config.isMedia) {

--- a/common/app/assets/javascripts/bower.json
+++ b/common/app/assets/javascripts/bower.json
@@ -19,7 +19,7 @@
     "videojs-vast": "guardian/videojs-vast-plugin#0a9b9de064f5ed31d436fc05b1d8dd6f504b6f96",
     "videojs-persistvolume": "~0.1.0",
     "socket.io-client": "1.0.6",
-    "raven-js": "~1.1.15",
+    "raven-js": "~1.1.16",
     "videojs-playlist-audio": "*"
   },
   "resolutions": {

--- a/common/app/assets/javascripts/components/raven-js/raven.js
+++ b/common/app/assets/javascripts/components/raven-js/raven.js
@@ -1,4 +1,4 @@
-/*! Raven.js 1.1.15 (bc060ae) | github.com/getsentry/raven-js */
+/*! Raven.js 1.1.16 (463f68f) | github.com/getsentry/raven-js */
 
 /*
  * Includes TraceKit
@@ -645,8 +645,8 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             return null;
         }
 
-        var chrome = /^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?((?:file|https?):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|https?).*?):(\d+)(?::(\d+))?\s*$/i,
+        var chrome = /^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?((?:file|https?|chrome-extension):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
+            gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|https?|chrome).*?):(\d+)(?::(\d+))?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],
             parts,
@@ -1108,7 +1108,8 @@ var _Raven = window.Raven,
         tags: {},
         extra: {}
     },
-    authQueryString;
+    authQueryString,
+    isRavenInstalled = false;
 
 /*
  * The core Raven singleton
@@ -1116,7 +1117,9 @@ var _Raven = window.Raven,
  * @this {Raven}
  */
 var Raven = {
-    VERSION: '1.1.15',
+    VERSION: '1.1.16',
+
+    debug: true,
 
     /*
      * Allow multiple versions of Raven to be installed.
@@ -1137,6 +1140,10 @@ var Raven = {
      * @return {Raven}
      */
     config: function(dsn, options) {
+        if (globalServer) {
+            logDebug('error', 'Error: Raven has already been configured');
+            return Raven;
+        }
         if (!dsn) return Raven;
 
         var uri = parseDSN(dsn),
@@ -1154,6 +1161,10 @@ var Raven = {
         // this is the result of a script being pulled in from an external domain and CORS.
         globalOptions.ignoreErrors.push('Script error.');
         globalOptions.ignoreErrors.push('Script error');
+
+        // Other variants of external script errors:
+        globalOptions.ignoreErrors.push('Javascript error: Script error on line 0');
+        globalOptions.ignoreErrors.push('Javascript error: Script error. on line 0');
 
         // join regexp rules into one big rule
         globalOptions.ignoreErrors = joinRegExp(globalOptions.ignoreErrors);
@@ -1198,8 +1209,9 @@ var Raven = {
      * @return {Raven}
      */
     install: function() {
-        if (isSetup()) {
+        if (isSetup() && !isRavenInstalled) {
             TraceKit.report.subscribe(handleStackInfo);
+            isRavenInstalled = true;
         }
 
         return Raven;
@@ -1273,7 +1285,7 @@ var Raven = {
 
         // copy over properties of the old function
         for (var property in func) {
-            if (func.hasOwnProperty(property)) {
+            if (hasKey(func, property)) {
                 wrapped[property] = func[property];
             }
         }
@@ -1293,6 +1305,7 @@ var Raven = {
      */
     uninstall: function() {
         TraceKit.report.uninstall();
+        isRavenInstalled = false;
 
         return Raven;
     },
@@ -1351,8 +1364,32 @@ var Raven = {
      * @param {object} user An object representing user data [optional]
      * @return {Raven}
      */
-    setUser: function(user) {
+    setUserContext: function(user) {
        globalUser = user;
+
+       return Raven;
+    },
+
+    /*
+     * Set extra attributes to be sent along with the payload.
+     *
+     * @param {object} extra An object representing extra data [optional]
+     * @return {Raven}
+     */
+    setExtraContext: function(extra) {
+       globalOptions.extra = extra || {};
+
+       return Raven;
+    },
+
+    /*
+     * Set tags to be sent along with the payload.
+     *
+     * @param {object} tags An object representing tags [optional]
+     * @return {Raven}
+     */
+    setTagsContext: function(tags) {
+       globalOptions.tags = tags || {};
 
        return Raven;
     },
@@ -1376,6 +1413,8 @@ var Raven = {
     }
 };
 
+Raven.setUser = Raven.setUserContext; // To be deprecated
+
 function triggerEvent(eventType, options) {
     var event, key;
 
@@ -1391,7 +1430,7 @@ function triggerEvent(eventType, options) {
         event.eventType = eventType;
     }
 
-    for (key in options) if (options.hasOwnProperty(key)) {
+    for (key in options) if (hasKey(options, key)) {
         event[key] = options[key];
     }
 
@@ -1468,7 +1507,7 @@ function each(obj, callback) {
 
     if (isUndefined(obj.length)) {
         for (i in obj) {
-            if (obj.hasOwnProperty(i)) {
+            if (hasKey(obj, i)) {
                 callback.call(null, i, obj[i]);
             }
         }
@@ -1541,7 +1580,7 @@ function normalizeFrame(frame) {
         // Now we check for fun, if the function name is Raven or TraceKit
         /(Raven|TraceKit)\./.test(normalized['function']) ||
         // finally, we do a last ditch effort and check for raven.min.js
-        /raven\.(min\.)js$/.test(normalized.filename)
+        /raven\.(min\.)?js$/.test(normalized.filename)
     );
 
     return normalized;
@@ -1736,9 +1775,7 @@ function makeRequest(data) {
 function isSetup() {
     if (!hasJSON) return false;  // needs JSON support
     if (!globalServer) {
-        if (window.console && console.error) {
-            console.error("Error: Raven has not been configured.");
-        }
+        logDebug('error', 'Error: Raven has not been configured.');
         return false;
     }
     return true;
@@ -1773,6 +1810,12 @@ function uuid4() {
             v = c == 'x' ? r : (r&0x3|0x8);
         return v.toString(16);
     });
+}
+
+function logDebug(level, message) {
+    if (window.console && console[level] && Raven.debug) {
+        console[level](message);
+    }
 }
 
 function afterLoad() {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -217,7 +217,7 @@ object Switches extends Collections {
 
   val DiagnosticsLogging = Switch("Diagnostics", "enable-diagnostics-logging",
     "If this switch is on, then js error reports and requests sent to the Diagnostics servers will be logged.",
-    safeState = Off, never
+    safeState = On, never
   )
 
   val ScrollDepthSwitch = Switch("Analytics", "scroll-depth",

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -139,7 +139,7 @@
                         buildNumber: config.page.buildNumber
                     },
                     shouldSendCallback: function(data) {
-                        return Math.random() < 0.1;
+                        return Math.random() < 0.1 && guardian.config.switches.enableDiagnosticsLogging;
                     }
                 }
             ).install();

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -124,7 +124,7 @@
         require(['raven', 'common/utils/config'], function(raven, config) {
 
             raven.config(
-                'http://' + config.page.sentryApiKey + '@@' + config.page.sentryHost,
+                'http://' + config.page.sentryPublicApiKey + '@@' + config.page.sentryHost,
                 {
                     logger: 'javascript',
                     whitelistUrls: [

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -52,8 +52,8 @@ guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.onwardWebSocket=wss://frontend-OnwardLo-G3SS42I4G3PN-384008737.eu-west-1.elb.amazonaws.com/recently-published
 guardian.page.dfpAccountId=158186692
 guardian.page.dfpAdUnitRoot=test-theguardian.com
-guardian.page.sentryApiKey=1b006169a5a64dc18e33105b259e81db
-guardian.page.sentryHost=frontend-SentryLo-35H427X3SDHB-2122817448.eu-west-1.elb.amazonaws.com/2
+guardian.page.sentryApiKey=db18a07145244f6facf63d4da5b650ac
+guardian.page.sentryHost=frontend.errors.guim.co.uk/2
 
 memcached.host=127.0.0.1:11211
 

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -52,7 +52,7 @@ guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.onwardWebSocket=wss://frontend-OnwardLo-G3SS42I4G3PN-384008737.eu-west-1.elb.amazonaws.com/recently-published
 guardian.page.dfpAccountId=158186692
 guardian.page.dfpAdUnitRoot=test-theguardian.com
-guardian.page.sentryApiKey=db18a07145244f6facf63d4da5b650ac
+guardian.page.sentryPublicApiKey=49094b9a8f3d48889e30b9f2f36b7d19
 guardian.page.sentryHost=frontend.errors.guim.co.uk/2
 
 memcached.host=127.0.0.1:11211

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -55,7 +55,7 @@ guardian.page.idApiJsClientToken=ARwXnPbUzJ9T2qcUJRv15DuT_LkxAKnUqtdrHdx7XXtQrKp
 guardian.page.onwardWebSocket=ws://api.nextgen.guardianapps.co.uk/recently-published
 guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
-guardian.page.sentryApiKey=db18a07145244f6facf63d4da5b650ac
+guardian.page.sentryPublicApiKey=49094b9a8f3d48889e30b9f2f36b7d19
 guardian.page.sentryHost=frontend.errors.guim.co.uk/2
 
 # Beacon

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -55,8 +55,8 @@ guardian.page.idApiJsClientToken=ARwXnPbUzJ9T2qcUJRv15DuT_LkxAKnUqtdrHdx7XXtQrKp
 guardian.page.onwardWebSocket=ws://api.nextgen.guardianapps.co.uk/recently-published
 guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
-guardian.page.sentryApiKey=fe3b8445ac0449bab7c9420cb5152b27
-guardian.page.sentryHost=frontend-sentrylo-35h427x3sdhb-2122817448.eu-west-1.elb.amazonaws.com/2
+guardian.page.sentryApiKey=db18a07145244f6facf63d4da5b650ac
+guardian.page.sentryHost=frontend.errors.guim.co.uk/2
 
 # Beacon
 beacon.url=//beacon.guim.co.uk


### PR DESCRIPTION
I have now migrated Sentry over to a persistent data store using Amazon RDS, we also decided to start with a fresh install, and therefore have a shiny new DNS name and API key.

This PR:
- Update env variables for dns and api key
- Update Raven.js client to 1.1.16 (needed for setContextTags method)
- Wrap media bootstrap init in its on Raven context to enable tagging and filtering.

Once this is released we can view media specfic errors at: http://frontend.errors.gutools.co.uk/guardian/frontend/?feature=media

I will now send out new Sentry user requests to those whom have asked.

/cc @ironsidevsquincy @mattosborn @rich-nguyen 
