### PR TITLE
Facia tool: use viewer on preview site  

### DIFF
--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -91,10 +91,14 @@ define([
         };
 
         model.previewUrl = ko.computed(function() {
-            return vars.CONST.viewer +
-                '#env=' + pageConfig.env +
-                '&mode=' + (model.liveMode() ? 'live' : 'draft' ) +
-                '&url=' + model.front() + encodeURIComponent('?view=mobile');
+            if (pageConfig.env === 'prod' && !model.liveMode()) {
+                return vars.CONST.previewBase + '/responsive-viewer/' + model.front();
+            } else {
+                return vars.CONST.viewer +
+                    '#env=' + pageConfig.env +
+                    '&mode=' + (model.liveMode() ? 'live' : 'draft' ) +
+                    '&url=' + model.front();
+            }
         });
 
         model.detectPressFailureCount = 0;

--- a/preview/app/Global.scala
+++ b/preview/app/Global.scala
@@ -18,6 +18,7 @@ object FilterExemptions {
   lazy val exemptions: Seq[FilterExemption] = List(
     FilterExemption("/oauth2callback"),
     FilterExemption("/assets"),
+    FilterExemption("/favicon.ico"),
     FilterExemption("/_healthcheck"),
     FilterExemption("/world/2012/sep/11/barcelona-march-catalan-independence")
   )


### PR DESCRIPTION
In Fronts tool, when in PROD, use the responsive viewer on the preview server (to view draft fronts.)

@gklopper 
