### PR TITLE
Add facia container reminder switch category

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -314,6 +314,15 @@ object Switches extends Collections {
     safeState = On, sellByDate = never
   )
 
+  // Facia containers
+  // These are principally reminders to evaluate the value brought by each new container
+  // But don't necessarily mean the containers are behind a switch
+
+  val FaciaContainerSmallListSwitch = Switch("Facia containers", "facia-container-small-list",
+    "Reminder to keep/remove the news/small-list container after 6 weeks",
+    safeState = On, sellByDate = new LocalDate(2014, 9, 11)
+  )
+
   // A/B Tests
 
   val ABHighCommercialComponent = Switch("A/B Tests", "ab-high-commercial-component",
@@ -517,7 +526,8 @@ object Switches extends Collections {
     SeoBlockGooglebotFromJSPathsSwitch,
     EnhancedMediaPlayerSwitch,
     ABRightMostPopularText,
-    CenturyRedirectionSwitch
+    CenturyRedirectionSwitch,
+    FaciaContainerSmallListSwitch
   )
 
   val httpSwitches: List[Switch] = List(


### PR DESCRIPTION
…And add a reminder to assess the value of the "news/small-list" container in 6 weeks.

Not sure this is the best way to set reminders, but I wanted to encourage a way to re-think about all the containers that are going to be added (so that it does not end up with a massive amount of bloat thanks to useless containers).

![ ](http://www.realfarmacy.com/wp-content/uploads/2014/07/151.gif)
