### PR TITLE
Adding new flexible container

### DIFF
--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -103,6 +103,7 @@
 
 @import 'module/containers/_features';
 @import 'module/containers/_featuresauto';
+@import 'module/containers/_featuresvolumes';
 @import 'module/containers/_special';
 @import 'module/containers/_commentanddebate';
 @import 'module/containers/_people';

--- a/common/app/assets/stylesheets/module/containers/_featuresvolumes.scss
+++ b/common/app/assets/stylesheets/module/containers/_featuresvolumes.scss
@@ -1,0 +1,7 @@
+.container--featuresvolumes {
+    .container__body > .facia-slice-wrapper {
+        .tone-accent-border {
+            border-top: 0;
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia/_row-pattern.scss
+++ b/common/app/assets/stylesheets/module/facia/_row-pattern.scss
@@ -14,6 +14,10 @@
             margin-top: ($gs-baseline/3)*2
         ));
     }
+
+    .show-more--hidden & {
+        display: none;
+    }
 }
 
 .facia-slice-wrapper--no-outer-margins {

--- a/common/app/views/fragments/collections/featuresvolumes.scala.html
+++ b/common/app/views/fragments/collections/featuresvolumes.scala.html
@@ -1,0 +1,104 @@
+@(items: Seq[model.Trail], style: views.support.Container, containerIndex: Int)(implicit request: RequestHeader, config: model.Config)
+@import views.helpers.CSS.bigItemCssClass
+
+@defining(
+    items.filter(_.group == Option("3")),
+    items.filter(_.group == Option("2")),
+    items.filter(_.group == Option("1")),
+    items.filter(items => items.group == Option("0") || items.group == None)
+) { case (hugeItems, veryBigItems, bigItems, standardItems) =>
+@defining(
+    hugeItems.nonEmpty && veryBigItems.nonEmpty,
+    hugeItems.isEmpty && veryBigItems.nonEmpty && bigItems.nonEmpty,
+    hugeItems.isEmpty && veryBigItems.isEmpty && bigItems.nonEmpty && standardItems.nonEmpty,
+    hugeItems.isEmpty && veryBigItems.isEmpty && bigItems.isEmpty && standardItems.size > 3
+) { case (showMoreAtVeryBig, showMoreAtBig, showMoreAtStandard, showMoreAtStandardLinks) =>
+
+    @hugeItems.zipWithIndex.map { case (trail, index) =>
+        <div class="facia-slice-wrapper">
+            @fragments.items.baguette(trail, index)
+        </div>
+    }
+
+    @if(showMoreAtVeryBig){<div class="facia-slices-container js-container--show-more">}
+    @veryBigItems.zipWithIndex.map{ case (trail, index) =>
+        <div class="facia-slice-wrapper">
+            @fragments.items.saucisson(trail, index)
+        </div>
+    }
+
+    @if(showMoreAtBig){<div class="facia-slices-container js-container--show-more">}
+    @bigItems.grouped(2).map{ items =>
+        <div class="facia-slice-wrapper">
+            @if(items.size == 1) {
+                @items.zipWithIndex.map{ case (trail, index) =>
+                    @fragments.items.fromage(trail, index + hugeItems.size + veryBigItems.size + bigItems.size)
+                }
+            }else{
+                <ul class="row-of-two @bigItemCssClass(items(0).imageAdjust, items(1).imageAdjust) u-unstyled l-row l-row--items-2 facia-slice">
+                    @items.zipWithIndex.map{ case (trail, index) =>
+                        @fragments.collections.items.standard(trail, index + hugeItems.size + veryBigItems.size + bigItems.size, containerIndex)
+                    }
+                </ul>
+            }
+        </div>
+    }
+
+    @if(showMoreAtStandard){<div class="facia-slices-container js-container--show-more">}
+    @standardItems.slice(0, 3) match {
+        case Nil => {}
+        case i => {
+            <div class="facia-slice-wrapper">
+                <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m facia-slice">
+                    @i.zipWithIndex.map { case (trail, index) =>
+                        @fragments.collections.items.standard(trail, index + 1, containerIndex)
+                    }
+                </ul>
+            </div>
+        }
+    }
+
+    @if(showMoreAtStandardLinks){<div class="facia-slices-container js-container--show-more">}
+    @standardItems.slice(3, 9) match {
+        case Nil => {}
+        case i => {
+            <div class="facia-slice-wrapper">
+                <div class="linkslist-container tone-@{style.tone} js-slice--ad-candidate" data-tone="@style.tone">
+                    <ul class="l-columns linkslist">
+                        @i.zipWithIndex.map{ case (trail, index) =>
+                            @trail match {
+                                case l: LiveBlog if l.isLive         => { @fragments.items.linksList.live(l, index + 4, Some("boost")) }
+                                case g: Gallery                      => { @fragments.items.linksList.gallery(g, index + 4, Some("boost")) }
+                                case v: Video                        => { @fragments.items.linksList.video(v, index + 4, Some("boost")) }
+                                case c if c.visualTone == "comment"  => { @fragments.items.linksList.comment(c, index + 4, Some("boost")) }
+                                case t                               => { @fragments.items.linksList.standard(t, index + 4, Some("boost")) }
+                            }
+                        }
+                    </ul>
+                </div>
+            </div>
+        }
+    }
+
+    @standardItems.drop(9) match {
+        case Nil => {}
+        case i => {
+            <div class="facia-slice-wrapper">
+                <div class="linkslist-container tone-@{style.tone}" data-tone="@style.tone">
+                    <ul class="l-columns linkslist">
+                        @i.zipWithIndex.map{ case (trail, index) =>
+                            @trail match {
+                                case l: LiveBlog if l.isLive           => { @fragments.items.linksList.live(l, index + 10) }
+                                case g: Gallery                        => { @fragments.items.linksList.gallery(g, index + 10) }
+                                case v: Video                          => { @fragments.items.linksList.video(v, index + 10) }
+                                case c if c.visualTone == "comment"    => { @fragments.items.linksList.comment(c, index + 10) }
+                                case t                                 => { @fragments.items.linksList.standard(t, index + 10) }
+                            }
+                        }
+                    </ul>
+                </div>
+            </div>
+        }
+    }
+    </div>
+}}

--- a/common/app/views/fragments/containers/featuresvolumes.scala.html
+++ b/common/app/views/fragments/containers/featuresvolumes.scala.html
@@ -1,0 +1,47 @@
+@(page: MetaData, collection: Collection, style: FeaturesVolumesContainer, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
+@import common.Edition
+
+@import org.joda.time.DateTime
+
+@defining(config.displayName.orElse(collection.displayName), config.href.orElse(collection.href)) { case (title, href) =>
+    @defining(templateDeduping(10, collection.items)) { items =>
+        @defining(Edition.editionFronts.contains(request.uri.toLowerCase)) { isEdition =>
+            @if(items.nonEmpty) {
+                <section
+                    class="@RenderClasses(Map(
+                        ("container", true),
+                        (s"container--${style.containerType}", true),
+                        (s"container--tag", !isEdition),
+                        ("js-container--toggle", (containerIndex > 0 && title.nonEmpty)),
+                        ("container--sponsored", config.isSponsored),
+                        ("container--advertisement-feature", (config.isAdvertisementFeature && !config.isSponsored)),
+                        ("container--first", (containerIndex == 0))))"
+                    data-link-name="@FaciaComponentName(config, collection)"
+                    data-id="@config.id"
+                    data-type="@style.containerType"
+                    @config.sponsorshipKeyword.map { keyword =>
+                        data-keywords="@keyword"
+                    }
+                    data-component="@FaciaComponentName(config, collection)">
+                    <div class="facia-container__inner">
+                        <div class="container__border tone-@style.tone tone-accent-border"></div>
+                        <div class="container__header">
+                            @title.map { title =>
+                                <h2 class="container__title tone-@style.tone tone-background">
+                                    @href.map { href =>
+                                        <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                                    }.getOrElse{
+                                        <span class="container__title__label u-text-hyphenate">@Html(title)</span>
+                                    }
+                                </h2>
+                            }
+                        </div>
+                        <div class="container__body container--rolled-up-hide">
+                            @fragments.collections.featuresvolumes(items, style, containerIndex)
+                        </div>
+                    </div>
+                </section>
+            }
+        }
+    }
+}

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -76,6 +76,10 @@ case class FeaturesContainer(showMore: Boolean = true) extends Container {
   val containerType = "features"
   val tone = "feature"
 }
+case class FeaturesVolumesContainer(showMore: Boolean = true) extends Container {
+  val containerType = "featuresvolumes"
+  val tone = "feature"
+}
 case class FeaturesAutoContainer(showMore: Boolean = true) extends Container {
   val containerType = "featuresauto"
   val tone = "feature"

--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -18,6 +18,7 @@ define([
             {name: 'news/headline', groups: ['standard', 'big']},
             {name: 'features'},
             {name: 'features/auto'},
+            {name: 'features/volumes', groups: ['standard', 'big', 'very big', 'huge']},
             {name: 'features/multimedia'},
             {name: 'comment/comment-and-debate'}
         ],

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -9,6 +9,7 @@
     case Some("news/special")               => { @containers.special(block._2, SpecialContainer(), index)(request, templateDeduping, block._1) }
     case Some("news/headline")              => { @containers.headline(block._2, HeadlineContainer(), index)(request, block._1) }
     case Some("features")                   => { @containers.features(block._2, FeaturesContainer(), index)(request, templateDeduping, block._1) }
+    case Some("features/volumes")           => { @containers.featuresvolumes(front, block._2, FeaturesVolumesContainer(), index)(request, templateDeduping, block._1) }
     case Some("features/multimedia")        => { @containers.multimedia(block._2, MultimediaContainer(), index)(request, templateDeduping, block._1) }
     case Some("features/auto")              => { @containers.featuresauto(block._2, FeaturesAutoContainer(), index)(request, templateDeduping, block._1) }
     case Some("comment/comment-and-debate") => { @containers.commentanddebate(block._2, CommentAndDebateContainer(), index)(request, templateDeduping, block._1) }


### PR DESCRIPTION
There is nothing new in this container, it is a cocktail of things that have been used before, namely:
- **Standard**: 3 in a row then the list view.
- **Big:** same as news big.
- **Very big:** Same as [`featuresauto` first stories](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/containers/featuresauto.scala.html#L44).
- **Huge:** same as news Huge.

There's a few copy/paste jobs going on here and across the whole containers codebase.
Next round I will try to abstract the bits of functionalise the template bits that are being reused a lot.
## Have a look anyway

![mixcontainer](https://cloud.githubusercontent.com/assets/31692/3781402/dc99eece-1995-11e4-8413-ac8a3cd657bf.png)

---

![Uncontained](http://cdn.gifstache.com/2012/9/20/gifstache.com_2044_1348354800.gif)
