### PR TITLE
Correct badge size for multimedia content

### DIFF
--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -5,7 +5,7 @@
     @defining((
         content match { case c if c.isSponsored => {"spbadge"} case _ => {"adbadge"} },
         content match { case _: LiveBlog => {"live-blog"} case _ => {"article"} },
-        content match { case _: Gallery | _: Video => "141" case _ => "140" }
+        content match { case _: Media => "141" case _ => "140" }
     )) { case (name, badgeType, adSlotWidth) =>
         @fragments.commercial.adSlot(
             name,


### PR DESCRIPTION
i.e. content with a grey background pulls in a different badge
