### PR TITLE
Switch to HTTPS dependency repositories (where possible)

### DIFF
--- a/integration-tests/scala-fw-tests/build.sbt
+++ b/integration-tests/scala-fw-tests/build.sbt
@@ -3,8 +3,7 @@ name := "Fronts Scala fw integration tests"
 version := "0.1.0-SNAPSHOT"
 
 resolvers ++= Seq(
-  "Sonatype OSS Staging" at "https://oss.sonatype.org/content/repositories/staging",
-  "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/")
+  "Sonatype OSS Staging" at "https://oss.sonatype.org/content/repositories/staging"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "scala-automation" % "1.27"

--- a/integration-tests/scala-fw-tests/build.sbt
+++ b/integration-tests/scala-fw-tests/build.sbt
@@ -4,7 +4,7 @@ version := "0.1.0-SNAPSHOT"
 
 resolvers ++= Seq(
   "Sonatype OSS Staging" at "https://oss.sonatype.org/content/repositories/staging",
-  "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/")
+  "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/")
 
 libraryDependencies ++= Seq(
   "com.gu" %% "scala-automation" % "1.27"

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -36,9 +36,9 @@ trait Prototypes {
     resolvers := Seq(
       "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
       "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",
-      Resolver.url("Typesafe Ivy Releases", url("http://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns),
-      "JBoss Releases" at "http://repository.jboss.org/nexus/content/repositories/releases",
-      "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
+      Resolver.url("Typesafe Ivy Releases", url("https://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns),
+      "JBoss Releases" at "https://repository.jboss.org/nexus/content/repositories/releases",
+      "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
       "Akka" at "http://repo.akka.io/releases"
     ),
 
@@ -46,7 +46,7 @@ trait Prototypes {
       // where Shade lives
       "BionicSpirit Releases" at "http://maven.bionicspirit.com/releases/",
       // for SpyMemcached
-      "Spy" at "http://files.couchbase.com/maven2/"
+      "Spy" at "https://files.couchbase.com/maven2/"
     )
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers ++= Seq(
   "Guardian GitHub Releases" at "http://guardian.github.io/maven/repo-snapshots",
-  "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
+  "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
   "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/releases/",
   Classpaths.typesafeReleases
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,6 @@ logLevel := Level.Warn
 
 resolvers ++= Seq(
   "Guardian GitHub Releases" at "http://guardian.github.io/maven/repo-snapshots",
-  "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
   "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/releases/",
   Classpaths.typesafeReleases
 )


### PR DESCRIPTION
This is meant to improve the security of our deployables. We still depend on HTTP (only) repositories though.
The repos switched to HTTPS have properly signed X.509 certificates.
