### PR TITLE
Tweak the top and bottom spacing on captions

### DIFF
--- a/common/app/assets/stylesheets/module/_layout-hints.scss
+++ b/common/app/assets/stylesheets/module/_layout-hints.scss
@@ -117,7 +117,7 @@ figure.element.element--supporting {
             position: absolute;
             top: 100%;
             @include rem((
-                padding-top: 21px
+                padding-top: ($gs-baseline/6)*5
             ));
             @include reduce-left;
         }

--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -189,17 +189,23 @@ figure {
             margin-top: ($gs-baseline/3)*4,
             margin-bottom: ($gs-baseline/3)*5
         ));
+
+        @include mq(tablet) {
+            @include rem((
+                margin-bottom: ($gs-baseline/2)*5
+            ));
+        }
     }
     &.img--landscape,
     &.img--portrait {
         figcaption {
             @include rem((
-                padding: $gs-baseline/3 0 $gs-baseline*2
+                padding-top: ($gs-baseline/6)*4
             ));
 
             @include mq(wide) {
                 @include rem((
-                    padding: $gs-baseline/2 0 $gs-row-height
+                    padding-top: ($gs-baseline/6)*5
                 ));
             }
         }


### PR DESCRIPTION
Some of the spacing was quite big since the caption background colour was removed, and we tried to make the spacing more uniform.
