### PR TITLE
Make All Bestsellers Available for ISBN Lookups

### DIFF
--- a/commercial/app/model/commercial/books/Book.scala
+++ b/commercial/app/model/commercial/books/Book.scala
@@ -48,10 +48,6 @@ object BestsellersAgent extends AdAgent[Book] with ExecutionContexts {
 
   def refresh() {
 
-    def takeFromEachList(allBooks: Seq[Seq[Book]], n: Int): Seq[Seq[Book]] = {
-      for (books <- allBooks) yield books take n
-    }
-
     val bookListsLoading: Future[Seq[Seq[Book]]] = Future.sequence {
       feeds.foldLeft(Seq[Future[Seq[Book]]]()) {
         (soFar, feed) =>
@@ -62,7 +58,7 @@ object BestsellersAgent extends AdAgent[Book] with ExecutionContexts {
     }
 
     for (books <- bookListsLoading) {
-      updateCurrentAds(takeFromEachList(books, 5).flatten)
+      updateCurrentAds(books.flatten.distinct)
     }
   }
 }


### PR DESCRIPTION
Instead of just keeping the top 5 from each list this change keeps all the books in each list.  This means that we can look up more ISBNs for the Inline Merchandising slot.
