### PR TITLE
New container no images test

### DIFF
--- a/common/app/assets/javascripts/modules/experiments/ab.js
+++ b/common/app/assets/javascripts/modules/experiments/ab.js
@@ -5,7 +5,8 @@ define([
     'common/utils/config',
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/high-commercial-component',
-    'common/modules/experiments/tests/right-most-popular-text'
+    'common/modules/experiments/tests/right-most-popular-text',
+    'common/modules/experiments/tests/news-container-no-images'
 ], function (
     assign,
     store,
@@ -13,12 +14,14 @@ define([
     globalConfig,
     mvtCookie,
     HighCommercialComponent,
-    RightMostPopularText
+    RightMostPopularText,
+    NewsContainerNoImages
     ) {
 
     var TESTS = [
             new HighCommercialComponent(),
-            new RightMostPopularText()
+            new RightMostPopularText(),
+            new NewsContainerNoImages()
         ],
         participationsKey = 'gu.ab.participations';
 

--- a/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
@@ -1,0 +1,41 @@
+define([
+    'common/utils/$',
+    'common/utils/config'
+], function(
+    $,
+    config
+) {
+    return function() {
+
+        this.id = 'NewsContainerNoImages';
+        this.start = '2014-08-04';
+        this.expiry = '2014-08-15';
+        this.author = 'James Gorrie';
+        this.description = 'Hide images on standard items in the news container';
+        this.audience = 0.2;
+        this.audienceOffset = 0.1;
+        this.successMeasure = 'More clickthroughs on the news container';
+        this.audienceCriteria = 'Everyone';
+        this.dataLinkNames = 'new-containers-no-images';
+        this.idealOutcome = 'Clicks do not drop on the news container, and hopefully increase on the stories above.';
+        this.canRun = function () { return config.page.contentType === 'Network Front'; };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {}
+            },
+            {
+                id: 'no-images-standard',
+                test: function () {
+                    $('.container--news').each(function(el) {
+                        $('.linkslist-container .linkslist__media-wrapper, .l-row--items-4 .item__media-wrapper', el)
+                            .css('display', 'none');
+                        $('.action--has-image', el).removeClass('action--has-image');
+                        $('.action--has-image', el).removeClass('action--has-image');
+                    });
+                }
+            }
+        ];
+    };
+});

--- a/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
@@ -16,7 +16,6 @@ define([
         this.audienceOffset = 0.75;
         this.successMeasure = 'More clickthroughs on the news container';
         this.audienceCriteria = 'Everyone';
-        this.dataLinkNames = 'new-containers-no-images';
         this.idealOutcome = 'Clicks do not drop on the news container, and hopefully increase on the stories above.';
         this.canRun = function () { return config.page.contentType === 'Network Front'; };
 
@@ -31,7 +30,6 @@ define([
                     $('.container--news').each(function(el) {
                         $('.linkslist-container .linkslist__media-wrapper, .l-row--items-4 .item__media-wrapper', el)
                             .css('display', 'none');
-                        $('.action--has-image', el).removeClass('action--has-image');
                         $('.action--has-image', el).removeClass('action--has-image');
                     });
                 }

--- a/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
@@ -28,8 +28,8 @@ define([
                 id: 'no-images-standard',
                 test: function () {
                     $('.container--news').each(function(el) {
-                        $('.linkslist-container .linkslist__media-wrapper, .l-row--items-4 .item__media-wrapper', el)
-                            .css('display', 'none');
+                        $('.linkslist-container .linkslist__media-wrapper, .l-row--items-4 .item__media-wrapper, .l-row--items-4 .item__image-container', el)
+                            .remove();
                         $('.action--has-image', el).removeClass('action--has-image');
                     });
                 }

--- a/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
+++ b/common/app/assets/javascripts/modules/experiments/tests/news-container-no-images.js
@@ -12,8 +12,8 @@ define([
         this.expiry = '2014-08-15';
         this.author = 'James Gorrie';
         this.description = 'Hide images on standard items in the news container';
-        this.audience = 0.2;
-        this.audienceOffset = 0.1;
+        this.audience = 0.5;
+        this.audienceOffset = 0.75;
         this.successMeasure = 'More clickthroughs on the news container';
         this.audienceCriteria = 'Everyone';
         this.dataLinkNames = 'new-containers-no-images';

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -326,6 +326,11 @@ object Switches extends Collections {
    safeState = Off, sellByDate = new LocalDate(2014, 8, 12)
   )
 
+  val ABNewsContainerNoImages = Switch("A/B Tests", "ab-news-container-no-images",
+    "If this switch is turned on, run the NewsContainerNoImages A/B test",
+   safeState = Off, sellByDate = new LocalDate(2014, 8, 15)
+  )
+
   // Dummy Switches
 
   val IntegrationTestSwitch = Switch("Unwired Test Switch", "integration-test-switch",
@@ -517,6 +522,7 @@ object Switches extends Collections {
     SeoBlockGooglebotFromJSPathsSwitch,
     EnhancedMediaPlayerSwitch,
     ABRightMostPopularText,
+    ABNewsContainerNoImages,
     CenturyRedirectionSwitch
   )
 


### PR DESCRIPTION
# What?

We're removing the images from stories that of `standard` volume in the news container.
# Why?

We are testing to see if the news stories will be more easily scanable / digestable.
Another interesting point will be to see whether it puts more emphasis on the bigger stories.
# What we're expecting

Either the standard images will be read more, or the bigger stories read more.
If it is more digestable, we expect users to spend less time on page, but return more often.
# Opt in/out

[Opt in (Live)](http://www.theguardian.com/uk#ab-NewsContainerNoImages=no-images-standard)
[Opt out (Live)](http://www.theguardian.com/uk#ab-NewsContainerNoImages=nointerest)
[Opt in (Preview)](http://preview.gutools.co.uk/uk#ab-NewsContainerNoImages=no-images-standard)
[Opt out (Preview)](http://preview.gutools.co.uk/uk#ab-NewsContainerNoImages=nointerest)
# Can I see it?
### Before

![before](https://cloud.githubusercontent.com/assets/31692/3810528/43064470-1c91-11e4-9ca1-fd8afb15f245.png)
### After

![after](https://cloud.githubusercontent.com/assets/31692/3810527/43025054-1c91-11e4-832a-0750a07f60e1.png)

---

![No pictures please](http://i.perezhilton.com/wp-content/uploads/2013/09/original%282%29.gif)
