### PR TITLE
Fronts consistency (Episode II: attack of the tonal borders)

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -1,10 +1,6 @@
 .container--news {
     .container__border {
         display: none;
-
-        @include mq(faciaLeftCol) {
-            display: block;
-        }
     }
     .facia-slice-wrapper:first-child {
         .fromage {

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -7,11 +7,19 @@
         position: relative;
 
         @include rem((
-            padding-left: $gs-gutter / 2,
-            padding-right: $gs-gutter / 2
+            margin-left: $gs-gutter / 2,
+            margin-right: $gs-gutter / 2
         ));
 
         @include mq(mobileLandscape) {
+            @include rem((
+                margin-left: $gs-gutter,
+                margin-right: $gs-gutter
+            ));
+        }
+        @include mq(tablet) {
+            margin-left: 0;
+            margin-right: 0;
             @include rem((
                 padding-left: $gs-gutter,
                 padding-right: $gs-gutter

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -7,14 +7,14 @@
         position: relative;
 
         @include rem((
-            margin-left: $gs-gutter / 2,
-            margin-right: $gs-gutter / 2
+            padding-left: $gs-gutter / 2,
+            padding-right: $gs-gutter / 2
         ));
 
         @include mq(mobileLandscape) {
             @include rem((
-                margin-left: $gs-gutter,
-                margin-right: $gs-gutter
+                padding-left: $gs-gutter,
+                padding-right: $gs-gutter
             ));
         }
     }

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -15,7 +15,7 @@
     @include rem((
         margin: 0 $gs-gutter/2 $gs-baseline
     ));
-    border-top-width: 2px;
+    border-top-width: 1px;
     border-top-style: solid;
 
     @include mq(tablet) {

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -29,11 +29,7 @@
 }
 .container__border {
     border-top-style: solid;
-    border-top-width: 4px;
-
-    @include mq(tablet) {
-        border-top-width: 2px;
-    }
+    border-top-width: 1px;
 }
 .container__header {
     position: relative;

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -30,6 +30,13 @@
 .container__border {
     border-top-style: solid;
     border-top-width: 1px;
+
+    @include mq(tablet) {
+        @include rem((
+            margin-left: -$gs-gutter,
+            margin-right: -$gs-gutter
+        ));
+    }
 }
 .container__header {
     position: relative;

--- a/common/app/assets/stylesheets/module/facia/_linkslist.scss
+++ b/common/app/assets/stylesheets/module/facia/_linkslist.scss
@@ -9,7 +9,7 @@
  */
 .linkslist-container {
     position: relative;
-    padding-top: 1px;
+
     @include mq(tablet) {
         @include rem((
             margin-top: $gs-baseline*.75
@@ -23,7 +23,7 @@
         top: 0;
         left: 0;
         right: 0;
-        height: 2px;
+        height: 1px;
         width: 100%;
         background: $c-newsAccent;
         z-index: 1;
@@ -45,11 +45,6 @@
             display: none;
         }
     }
-}
-
-.linkslist-container--without-top-border {
-    position: relative;
-    padding-top: 1px;
 }
 
 .linkslist--without-top-borders .linkslist__item {

--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -1,4 +1,4 @@
-$item-top-border-height: 2px;
+$item-top-border-height: 1px;
 
 @mixin vertical-item-separator {
     &:before {


### PR DESCRIPTION
- Top border of items and containers is 1px thin
- Container borders go from edge to edge of containers
- Hide news container border at all breakpoints

![screen shot 2014-08-05 at 12 19 31](https://cloud.githubusercontent.com/assets/85783/3810649/d04179b2-1c92-11e4-91ee-283ce7128360.PNG)

![screen shot 2014-08-05 at 12 25 41](https://cloud.githubusercontent.com/assets/85783/3810669/44576df2-1c93-11e4-9412-ca3e16f8b644.PNG)

![ ](http://media.giphy.com/media/W2iiGdmoa0Qzm/giphy.gif)
