### PR TITLE
Change over archive storage key

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -123,7 +123,7 @@ object S3FrontsApi extends S3 {
 
   def archive(id: String, json: String, identity: UserIdentity) = {
     val now = DateTime.now
-    putPrivate(s"$location/history/collection/$id/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/${now}.${identity.email}.json", json, "application/json")
+    putPrivate(s"$location/history/collection/${now.year.get}/${"%02d".format(now.monthOfYear.get)}/${"%02d".format(now.dayOfMonth.get)}/$id/${now}.${identity.email}.json", json, "application/json")
   }
 
   def putMasterConfig(json: String) =


### PR DESCRIPTION
This changes the format of `archive` from `{collectionid}/{year}/{month}/{day}` to `{year}/{month}/{day}/{collectionid}`.

This will allow us to take all the edits of a particular day or month more easily. Where as before it was hard to do this, although the advantage was you could get all history of edits to a particular collection since it was created.

@stephanfowler 
