### PR TITLE
dynamically create common:js:<task> tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -850,9 +850,15 @@ module.exports = function (grunt) {
     /**
      * compile:js:<requiretask> tasks. Generate one for each require task
      */
+    function compileSpecificJs(requirejsName) {
+        if (!isDev && requirejsName !== 'common') {
+            grunt.task.run('requirejs:common');
+        }
+        grunt.task.run(['requirejs:' + requirejsName, 'copy:javascript', 'asset_hash']);
+    }
     for (var requireTaskName in grunt.config('requirejs')) {
         if (requireTaskName !== 'options') {
-            grunt.registerTask('compile:js:' + requireTaskName, ['requirejs:' + requireTaskName, 'copy:javascript', 'asset_hash']);
+            grunt.registerTask('compile:js:' + requireTaskName, compileSpecificJs.bind(this, requireTaskName) );
         }
     }
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -847,7 +847,14 @@ module.exports = function (grunt) {
         'compile:conf'
     ]);
 
-    grunt.registerTask('compile:js:common', ['requirejs:common', 'copy:javascript', 'asset_hash']);
+    /**
+     * compile:js:<requiretask> tasks. Generate one for each require task
+     */
+    for (var requireTaskName in grunt.config('requirejs')) {
+        if (requireTaskName !== 'options') {
+            grunt.registerTask('compile:js:' + requireTaskName, ['requirejs:' + requireTaskName, 'copy:javascript', 'asset_hash']);
+        }
+    }
 
     /**
      * Test tasks


### PR DESCRIPTION
did this manually for common previously. now doing it dynamically for all requirejs tasks.
