### PR TITLE
hide fullscreener when using native controls

### DIFF
--- a/common/app/assets/stylesheets/module/content/_media-player.scss
+++ b/common/app/assets/stylesheets/module/content/_media-player.scss
@@ -157,6 +157,7 @@ $vjs-control-height: $gs-baseline*4;
     padding-bottom: $vjs-control-height;
     position: absolute;
     z-index: 2;
+    
     .vjs-using-native-controls & {
         display: none;
     }

--- a/common/app/assets/stylesheets/module/content/_media-player.scss
+++ b/common/app/assets/stylesheets/module/content/_media-player.scss
@@ -157,6 +157,9 @@ $vjs-control-height: $gs-baseline*4;
     padding-bottom: $vjs-control-height;
     position: absolute;
     z-index: 2;
+    .vjs-using-native-controls & {
+        display: none;
+    }
 }
 
 .vjs-loading-spinner {


### PR DESCRIPTION
hiding fullscreen clickbox element when native controls are shown as it isn't needed and was causing pause/play issues.
