### PR TITLE
facia tool: flush copied article

### DIFF
--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -12,6 +12,7 @@ define([
     'modules/list-manager',
     'modules/droppable',
     'modules/authed-ajax',
+    'modules/copied-article',
     'models/group',
     'models/collections/collection',
     'models/collections/article',
@@ -30,6 +31,7 @@ define([
     listManager,
     droppable,
     authedAjax,
+    copiedArticle,
     Group,
     Collection,
     Article,
@@ -292,6 +294,7 @@ define([
 
             listManager.init(newItems);
             droppable.init();
+            copiedArticle.flush();
         };
     };
 });

--- a/facia-tool/public/javascripts/modules/copied-article.js
+++ b/facia-tool/public/javascripts/modules/copied-article.js
@@ -8,6 +8,9 @@ define([
         storageKeyCopied ='gu.fronts-tool.copied';
 
     return {
+        flush: function() {
+            storage.removeItem(storageKeyCopied);
+        },
 
         set: function(article) {
             storage.setItem(storageKeyCopied, JSON.stringify({

--- a/facia-tool/public/javascripts/modules/droppable.js
+++ b/facia-tool/public/javascripts/modules/droppable.js
@@ -2,11 +2,13 @@
 define([
     'knockout',
     'models/group',
+    'modules/copied-article',
     'utils/mediator',
     'utils/parse-query-params'
 ], function(
     ko,
     Group,
+    copiedArticle,
     mediator,
     parseQueryParams
 ) {
@@ -83,6 +85,8 @@ define([
 
                     event.preventDefault();
                     event.stopPropagation();
+
+                    copiedArticle.flush();
 
                     if (!targetGroup) {
                         return;


### PR DESCRIPTION
To avoid inadvertent pastes, flush the copied article on login and after any drag/drop.
