### PR TITLE
football article header wrapping fix

### DIFF
--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -190,6 +190,7 @@ $football-crest--large: 60px;
         bottom: $gs-baseline / 3,
         padding-bottom: $gs-baseline / 2
     ));
+    
     @include mq(tablet) {
         padding-bottom: 0;
         position: absolute;

--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -185,10 +185,15 @@ $football-crest--large: 60px;
 }
 
 .match-summary__comment {
+    text-align: right;
     @include rem((
-        bottom: $gs-baseline / 3
+        bottom: $gs-baseline / 3,
+        padding-bottom: $gs-baseline / 2
     ));
-    position: absolute;
+    @include mq(tablet) {
+        padding-bottom: 0;
+        position: absolute;
+    }
 }
 
 .match-info {


### PR DESCRIPTION
As presented in below screenshots.
<b>before</b>
![screen shot 2014-08-05 at 15 47 35](https://cloud.githubusercontent.com/assets/1492162/3813022/bb9ca2da-1caf-11e4-9d9e-3f8fd818fc72.png)
<b>after</b>
![screen shot 2014-08-05 at 15 46 55](https://cloud.githubusercontent.com/assets/1492162/3813028/c1448f90-1caf-11e4-975a-99db1a9c14f2.png)

![](http://media.giphy.com/media/6Ty74pFLyrd2E/giphy.gif)
