### PR TITLE
Conditional closing div on Features/Volumes container

### DIFF
--- a/common/app/views/fragments/collections/featuresvolumes.scala.html
+++ b/common/app/views/fragments/collections/featuresvolumes.scala.html
@@ -13,7 +13,8 @@
     hugeItems.isEmpty && veryBigItems.isEmpty && bigItems.nonEmpty && standardItems.nonEmpty,
     hugeItems.isEmpty && veryBigItems.isEmpty && bigItems.isEmpty && standardItems.size > 3
 ) { case (showMoreAtVeryBig, showMoreAtBig, showMoreAtStandard, showMoreAtStandardLinks) =>
-
+@defining(showMoreAtVeryBig && showMoreAtBig && showMoreAtStandard && showMoreAtStandardLinks) { showMore =>
+        
     @hugeItems.zipWithIndex.map { case (trail, index) =>
         <div class="facia-slice-wrapper">
             @fragments.items.baguette(trail, index)
@@ -100,5 +101,5 @@
             </div>
         }
     }
-    </div>
-}}
+    @if(showMore){</div>}
+}}}


### PR DESCRIPTION
Fixes the bug you can [see here](http://m.code.dev-theguardian.com/cm).
Ultimately only closes of the `js-container--show-more` if it's created.

I will revisit this after releasing the fix as to a nicer way of doing this.

---

![Clooooosing](http://www.pop.com.br/imagens/casa/viagem/ferias/1162958_como-deixar-a-casa-segura-enquanto-voce-viaja.gif)
