### PR TITLE
fix for current preroll campaign

### DIFF
--- a/common/app/assets/javascripts/bower.json
+++ b/common/app/assets/javascripts/bower.json
@@ -16,7 +16,7 @@
     "enhancer": "0.1.1",
     "videojs": "git://github.com/guardian/video.js.git#59d4443682bd578e03c3925ed40a623c466476c6",
     "videojs-contrib-ads": "guardian/videojs-contrib-ads#798b8a93cb293a95ede9af385c2354aa2c129216",
-    "videojs-vast": "guardian/videojs-vast-plugin#0a9b9de064f5ed31d436fc05b1d8dd6f504b6f96",
+    "videojs-vast": "guardian/videojs-vast-plugin#14432837c5f454b69659e60d4c65b4203fa13de8",
     "videojs-persistvolume": "~0.1.0",
     "socket.io-client": "1.0.6",
     "raven-js": "~1.1.16",

--- a/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
+++ b/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
@@ -16,7 +16,8 @@
 
   defaults = {
     skip: 5, // negative disables
-    vidFormats: ['video/mp4', 'video/webm', 'video/ogv']
+    vidFormats: ['video/mp4', 'video/webm', 'video/ogv'],
+    formatMap: {'video/x-mp4': 'video/mp4'}
   },
 
   vastPlugin = function(options) {
@@ -215,6 +216,7 @@
       // get a list of files with unique formats
       for (i = 0; i < media_files.length; i++) {
         format = media_files[i].mimeType;
+        format = settings.formatMap[format] || format;
 
         if (settings.vidFormats.indexOf(format) >= 0) {
           if(sourcesByFormat[format] === undefined) {

--- a/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
+++ b/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
@@ -128,7 +128,7 @@ define([
         this.sendDurationEvent = function() {
             var evts = this.baseDurationEvent();
             s.eVar48 = this.getSegmentInfo().omnitureName;
-            if (evts) {
+            if (evts && evts.length > 0) {
                 this.sendEvent(evts.join(','));
             }
             s.eVar48 = undefined;


### PR DESCRIPTION
Some campaigns have mp4 files marked as video/x-mp4 which breaks the player. Have tested and it seems to be compatible as video/mp4 so mapping to that.
