### PR TITLE
Sbt fixes and artifact resize

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -822,7 +822,12 @@ module.exports = function (grunt) {
      * Compile tasks
      */
     grunt.registerTask('compile:images', ['copy:images', 'shell:spriteGeneration', 'imagemin']);
-    grunt.registerTask('compile:css', ['sass:compile', 'replace:cssSourceMaps', 'copy:css']);
+    grunt.registerTask('compile:css', function() {
+        grunt.task.run('sass:compile');
+        if (isDev) {
+            grunt.task.run(['replace:cssSourceMaps', 'copy:css']);
+        }
+    });
     grunt.registerTask('compile:js', function() {
         grunt.task.run(['requirejs', 'copy:javascript']);
         if (!isDev) {

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -3,7 +3,7 @@ package com.gu
 import com.gu.versioninfo.VersionInfo
 import sbt._
 import sbt.Keys._
-import play._
+import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.typesafe.sbt.SbtNativePackager._
 import play.twirl.sbt.Import._
 
@@ -34,12 +34,12 @@ trait Prototypes {
       </dependencies>,
 
     resolvers := Seq(
+      Resolver.typesafeRepo("releases"),
+      Classpaths.typesafeReleases,
+      "Akka" at "http://repo.akka.io/releases",
       "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
       "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",
-      Resolver.url("Typesafe Ivy Releases", url("https://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns),
-      "JBoss Releases" at "https://repository.jboss.org/nexus/content/repositories/releases",
-      "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
-      "Akka" at "http://repo.akka.io/releases"
+      "JBoss Releases" at "https://repository.jboss.org/nexus/content/repositories/releases"
     ),
 
     resolvers ++= Seq(
@@ -51,6 +51,9 @@ trait Prototypes {
   )
 
   val frontendClientSideSettings = Seq(
+    sourceDirectory in Assets := (sourceDirectory in Compile).value / "assets.none",
+    sourceDirectory in TestAssets := (sourceDirectory in Test).value / "assets.none",
+
     TwirlKeys.templateImports ++= Seq(
       "common._",
       "model._",
@@ -73,8 +76,8 @@ trait Prototypes {
     unmanagedClasspath in Test <+= (baseDirectory) map { bd => Attributed.blank(bd / "test") },
 
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "2.2.0" % "test",
-      "org.mockito" % "mockito-all" % "1.9.5" % "test"
+      "org.scalatest" %% "scalatest" % "2.2.0" % Test,
+      "org.mockito" % "mockito-all" % "1.9.5" % Test
     ),
 
     // These settings are needed for forking, which in turn is needed for concurrent restrictions.
@@ -96,6 +99,6 @@ trait Prototypes {
         "commons-io" % "commons-io" % "2.4"
       )
     )
-      .settings(Seq(name in Universal := applicationName): _*)
+    .settings((name in Universal := applicationName))
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@
 logLevel := Level.Warn
 
 resolvers ++= Seq(
-  "Guardian GitHub Releases" at "http://guardian.github.io/maven/repo-snapshots",
-  "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/releases/",
-  Classpaths.typesafeReleases
+  Classpaths.typesafeReleases,
+  Resolver.sonatypeRepo("releases"),
+  Resolver.typesafeRepo("releases")
 )
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.2")


### PR DESCRIPTION
In this PR, we tidy sbt a little, and try to make the artifact smaller. Also allows devs to build frontend from a clean checkout (the resolvers were broken).
- Do not copy the sass source files unless you use dev mode.
- Update sbt resolvers.
- Null out the `sbt-web` packaging of the `assets` folder.
