### PR TITLE
Hide video adverts and 'more in section' when told to

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -278,11 +278,11 @@ define([
                             if (mediaType === 'video') {
 
                                 modules.bindDiagnosticsEvents(player);
+                                player.fullscreener();
 
                                 // Init plugins
-                                if(config.switches.videoAdverts) {
+                                if (config.switches.videoAdverts && !config.page.shouldHideAdverts) {
                                     player.adCountDown();
-                                    player.fullscreener();
                                     player.ads({
                                         timeout: 3000
                                     });
@@ -295,7 +295,7 @@ define([
                                     modules.bindContentEvents(player);
                                 }
 
-                                if(/desktop|wide/.test(detect.getBreakpoint())) {
+                                if (/desktop|wide/.test(detect.getBreakpoint())) {
                                     modules.initEndSlate(player);
                                 }
                             } else {
@@ -402,11 +402,13 @@ define([
         }
 
         if (config.isMedia) {
-            modules.initMoreInSection();
+            if (config.page.showRelatedContent) {
+                modules.initMoreInSection();
+            }
             modules.initMostViewedMedia();
         }
 
-        if(config.page.contentType === 'Video' && detect.getBreakpoint() !== 'mobile') {
+        if (config.page.contentType === 'Video' && detect.getBreakpoint() !== 'mobile') {
             modules.displayReleaseMessage();
         }
     };


### PR DESCRIPTION
The rules are:
- if "shouldHideAdverts" is true, the video preroll will not be shown.
- if "showInRelatedContent" is false, the 'related content' and 'more in section' containers will not be shown. 
