### PR TITLE
Better press latency metrics

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -1,5 +1,6 @@
 package common
 
+import metrics.FrontendMetric
 import play.api.{Application => PlayApp, GlobalSettings}
 import java.lang.management.{GarbageCollectorMXBean, ManagementFactory}
 import model.diagnostics.CloudWatch
@@ -629,12 +630,16 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
     s"$applicationName-${gc.name}-gc-time-per-min" -> gc.gcTime
   )}.toMap
 
+  def latencyMetrics: List[FrontendMetric] = Nil
+
   private def report() {
     val systemMetrics  = this.systemMetrics
     val applicationMetrics  = this.applicationMetrics
     CloudWatch.put("ApplicationSystemMetrics", systemMetrics)
     for (metrics <- applicationMetrics.grouped(20))
       CloudWatch.putWithDimensions(applicationMetricsNamespace, metrics, Seq(applicationDimension))
+
+    CloudWatch.putMetricsWithStage(latencyMetrics, applicationDimension)
   }
 
   override def onStart(app: PlayApp) {

--- a/common/app/metrics/DurationMetric.scala
+++ b/common/app/metrics/DurationMetric.scala
@@ -32,7 +32,7 @@ case class DurationMetric(name: String, metricUnit: StandardUnit) extends Fronte
     points
   }
 
-  def putDataPoints(points: List[DataPoint]): Future[List[DataPoint]] = dataPoints.alter(_ ::: points)
+  def putDataPoints(points: List[DataPoint]): Future[List[DataPoint]] = dataPoints.alter(points ::: _)
 
   def record(dataPoint: DurationDataPoint): Unit = dataPoints.alter(dataPoint :: _)
 

--- a/common/app/metrics/DurationMetric.scala
+++ b/common/app/metrics/DurationMetric.scala
@@ -26,7 +26,7 @@ case class DurationMetric(name: String, metricUnit: StandardUnit) extends Fronte
 
   def getAndResetDataPoints: List[DataPoint] = {
     val points = dataPoints.get()
-    dataPoints.alter(_.dropWhile(points.contains(_)))
+    dataPoints.alter(_.diff(points))
     points
   }
 

--- a/common/app/metrics/DurationMetric.scala
+++ b/common/app/metrics/DurationMetric.scala
@@ -1,0 +1,68 @@
+package metrics
+
+import akka.agent.Agent
+import com.amazonaws.services.cloudwatch.model.{Dimension, StandardUnit, MetricDatum, PutMetricDataRequest}
+import common.AkkaAgent
+import model.diagnostics.CloudWatch
+import scala.collection.JavaConversions._
+import org.joda.time.DateTime
+
+trait DataPoint {
+  val value: Long
+  val time: Option[DateTime]
+}
+
+case class DurationDataPoint(value: Long, time: Option[DateTime] = None) extends DataPoint
+
+trait FrontendMetric {
+  val name: String
+  val metricUnit: StandardUnit
+  def getDataPoints: List[DurationDataPoint]
+}
+
+case class DurationMetric(name: String, metricUnit: StandardUnit) extends FrontendMetric {
+
+  private val dataPoints: Agent[List[DurationDataPoint]] = AkkaAgent(List[DurationDataPoint]())
+
+  def getDataPoints: List[DurationDataPoint] = dataPoints.get()
+
+  def record(dataPoint: DurationDataPoint) = dataPoints.alter(dataPoint :: _)
+
+  def recordDuration(timeInMillis: Long) = record(DurationDataPoint(timeInMillis, Option(DateTime.now)))
+
+}
+
+object CloudWatchMetrics {
+  def putMetrics(metrics: List[FrontendMetric], dimensions: List[Dimension]): Unit = {
+    for {
+      metric <- metrics
+      dataPoints <- metric.getDataPoints.grouped(20)
+      dataPoint <- dataPoints
+    } {
+      val request = new PutMetricDataRequest()
+        .withNamespace("Application")
+        .withMetricData {
+          val metricDatum = new MetricDatum()
+            .withValue(dataPoint.value)
+            .withUnit(metric.metricUnit)
+            .withMetricName(metric.name)
+            .withDimensions(dimensions)
+
+          dataPoint.time.fold(metricDatum) { t => metricDatum.withTimestamp(t.toDate)}
+        }
+
+      CloudWatch.cloudwatch.putMetricDataAsync(request)
+    }
+  }
+}
+
+object UkPressLatencyMetric extends DurationMetric("uk-press-latency", StandardUnit.Milliseconds)
+object UsPressLatencyMetric extends DurationMetric("us-press-latency", StandardUnit.Milliseconds)
+object AuPressLatencyMetric extends DurationMetric("au-press-latency", StandardUnit.Milliseconds)
+
+object AllFrontsPressLatencyMetric extends DurationMetric("front-press-latency", StandardUnit.Milliseconds)
+
+object LatencyMetrics {
+  val all: List[DurationMetric] = List(UkPressLatencyMetric, UsPressLatencyMetric, AuPressLatencyMetric,
+    AllFrontsPressLatencyMetric)
+}

--- a/common/app/metrics/DurationMetric.scala
+++ b/common/app/metrics/DurationMetric.scala
@@ -24,6 +24,8 @@ case class DurationMetric(name: String, metricUnit: StandardUnit) extends Fronte
 
   private val dataPoints: Agent[List[DataPoint]] = AkkaAgent(List[DurationDataPoint]())
 
+  def getDataPoints: List[DataPoint] = dataPoints.get()
+
   def getAndResetDataPoints: List[DataPoint] = {
     val points = dataPoints.get()
     dataPoints.alter(_.diff(points))

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -12,7 +12,7 @@ import services.AwsEndpoints
 
 trait CloudWatch extends Logging {
 
-  lazy val stage = new Dimension().withName("Stage").withValue(environment.stage)
+  lazy val stageDimension = new Dimension().withName("Stage").withValue(environment.stage)
 
   lazy val cloudwatch = {
     val client = new AmazonCloudWatchAsyncClient(Configuration.aws.credentials)
@@ -46,12 +46,15 @@ trait CloudWatch extends Logging {
     cloudwatch.putMetricDataAsync(request, asyncHandler)
   }
 
-  def put(namespace: String, metrics: Map[String, Double]): Any =
-    put(namespace, metrics, Seq(stage))
+  def put(namespace: String, metrics: Map[String, Double]): Unit =
+    put(namespace, metrics, Seq(stageDimension))
 
-  def putWithDimensions(namespace: String, metrics: Map[String, Double], dimensions: Seq[Dimension]) =
-    put(namespace, metrics, Seq(stage) ++ dimensions)
+  def putWithDimensions(namespace: String, metrics: Map[String, Double], dimensions: Seq[Dimension]): Unit =
+    put(namespace, metrics, Seq(stageDimension) ++ dimensions)
 
+
+  def putMetricsWithStage(metrics: List[FrontendMetric], applicationDimension: Dimension): Unit =
+    putMetrics(metrics, List(stageDimension, applicationDimension))
 
   def putMetrics(metrics: List[FrontendMetric], dimensions: List[Dimension]): Unit = {
     for {

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -21,7 +21,7 @@ trait CloudWatch extends Logging {
     client
   }
 
-  trait asyncHandler extends AsyncHandler[PutMetricDataRequest, Void] with Logging
+  trait LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, Void] with Logging
   {
     def onError(exception: Exception)
     {
@@ -33,9 +33,9 @@ trait CloudWatch extends Logging {
     }
   }
 
-  object asyncHandler extends asyncHandler
+  object LoggingAsyncHandler extends LoggingAsyncHandler
 
-  case class asyncHandlerForMetric(metric: FrontendMetric, points: List[DataPoint]) extends asyncHandler {
+  case class AsyncHandlerForMetric(metric: FrontendMetric, points: List[DataPoint]) extends LoggingAsyncHandler {
     override def onError(exception: Exception) = {
       metric.putDataPoints(points)
       super.onError(exception)
@@ -54,7 +54,7 @@ trait CloudWatch extends Logging {
         .withDimensions(dimensions)
     })
 
-    cloudwatch.putMetricDataAsync(request, asyncHandler)
+    cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
   }
 
   def put(namespace: String, metrics: Map[String, Double]): Unit =
@@ -85,7 +85,7 @@ trait CloudWatch extends Logging {
             dataPoint.time.fold(metricDatum) { t => metricDatum.withTimestamp(t.toDate)}
           }
         }
-      CloudWatch.cloudwatch.putMetricDataAsync(request, asyncHandlerForMetric(metric, dataPointGroup))
+      CloudWatch.cloudwatch.putMetricDataAsync(request, AsyncHandlerForMetric(metric, dataPointGroup))
     }
   }
 

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -71,7 +71,7 @@ trait CloudWatch extends Logging {
         dataPoint.time.fold(metricDatum) { t => metricDatum.withTimestamp(t.toDate)}
       }
 
-      CloudWatch.cloudwatch.putMetricDataAsync(request)
+      CloudWatch.cloudwatch.putMetricDataAsync(request, asyncHandler)
     }
   }
 

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -20,7 +20,7 @@ trait CloudWatch extends Logging {
     client
   }
 
-  object asyncHandler extends AsyncHandler[PutMetricDataRequest, Void] with Logging
+  trait asyncHandler extends AsyncHandler[PutMetricDataRequest, Void] with Logging
   {
     def onError(exception: Exception)
     {
@@ -30,6 +30,16 @@ trait CloudWatch extends Logging {
     {
       log.info("CloudWatch PutMetricDataRequest - success")
     }
+  }
+
+  object asyncHandler extends asyncHandler
+
+  case class asyncHandlerForMetric(metric: FrontendMetric, points: List[DataPoint]) extends asyncHandler {
+    override def onError(exception: Exception) = {
+      metric.putDataPoints(points)
+      super.onError(exception)
+    }
+    override def onSuccess(request: PutMetricDataRequest, result: Void ) = super.onSuccess(request, result)
   }
 
   def put(namespace: String, metrics: Map[String, Double], dimensions: Seq[Dimension]): Any = {

--- a/common/test/metrics/DurationMetricTest.scala
+++ b/common/test/metrics/DurationMetricTest.scala
@@ -2,9 +2,12 @@ package metrics
 
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Span}
 import org.scalatest.{FlatSpec, Matchers}
 
 class DurationMetricTest extends FlatSpec with Matchers with Eventually {
+
+  implicit val localPatience: PatienceConfig = PatienceConfig(scaled(Span(1000, Millis)), scaled(Span(100, Millis)))
 
   "DurationMetric" should "start off empty" in {
     val durationMetric: DurationMetric = DurationMetric("TestMetric", StandardUnit.Count)

--- a/common/test/metrics/DurationMetricTest.scala
+++ b/common/test/metrics/DurationMetricTest.scala
@@ -1,0 +1,52 @@
+package metrics
+
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FlatSpec, Matchers}
+
+class DurationMetricTest extends FlatSpec with Matchers with Eventually {
+
+  "DurationMetric" should "start off empty" in {
+    val durationMetric: DurationMetric = DurationMetric("TestMetric", StandardUnit.Count)
+
+    durationMetric.getAndResetDataPoints should be (List())
+  }
+
+  it should "record some metrics" in {
+    val durationMetric: DurationMetric = DurationMetric("TestMetric", StandardUnit.Count)
+
+    durationMetric.recordDuration(1000)
+    durationMetric.recordDuration(1000)
+    durationMetric.recordDuration(1000)
+
+    eventually {
+      val dataPoints = durationMetric.getAndResetDataPoints
+      dataPoints.length should be (3)
+      dataPoints.forall(_.value == 1000) should be (true)
+    }
+
+    durationMetric.getAndResetDataPoints.length should be(0)
+  }
+
+  it should "add datapoints to the head of the list" in {
+    val durationMetric: DurationMetric = DurationMetric("TestMetric", StandardUnit.Count)
+
+    val metricOne = DurationDataPoint(1000, None)
+    val metricTwo = DurationDataPoint(1000, None)
+    val metricThree = DurationDataPoint(1000, None)
+    val metricFour = DurationDataPoint(1000, None)
+    val allMetrics = List(metricOne, metricTwo, metricThree, metricFour)
+
+    durationMetric.recordDuration(1000)
+    durationMetric.recordDuration(1000)
+    durationMetric.recordDuration(1000)
+
+    durationMetric.putDataPoints(List(metricOne, metricTwo, metricThree, metricFour))
+
+    eventually {
+      val dataPoints = durationMetric.getDataPoints
+      dataPoints.length should be (7)
+      dataPoints.splitAt(4)._1 should be (allMetrics)
+    }
+  }
+}

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -1,6 +1,7 @@
 import common._
 import conf.{Configuration => GuardianConfiguration}
 import frontpress.{FrontPressCron, ToolPressQueueWorker}
+import metrics._
 import play.api.GlobalSettings
 import services.ConfigAgentLifecycle
 
@@ -42,6 +43,9 @@ object Global extends GlobalSettings
     ("us-network-front-press-latency", FaciaPressMetrics.UsFrontPressLatency.getAndResetTime.toDouble),
     ("au-network-front-press-latency", FaciaPressMetrics.AuFrontPressLatency.getAndResetTime.toDouble)
   )
+
+  override def latencyMetrics: List[FrontendMetric] = List(UkPressLatencyMetric, UsPressLatencyMetric, AuPressLatencyMetric,
+                                     AllFrontsPressLatencyMetric)
 
   def scheduleJobs() {
     Jobs.schedule("FaciaToolPressJob", s"0/$pressJobConsumeRateInSeconds * * * * ?") {

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -8,6 +8,7 @@ import common.{Edition, Logging}
 import common.SQSQueues._
 import conf.Configuration
 import conf.Switches.FrontPressJobSwitch
+import metrics.DurationDataPoint
 import play.api.libs.concurrent.Akka
 import play.api.libs.json.Json
 
@@ -45,7 +46,7 @@ object FrontPressCron extends Logging with implicits.Collections {
               case Success(_) =>
                 if (Edition.all.map(_.id.toLowerCase).exists(_ == path))
                   ToolPressQueueWorker.metricsByPath.get(path).foreach { metric =>
-                    metric.recordTimeSpent(DateTime.now.getMillis - start.getMillis)
+                    metric.recordDuration(DateTime.now.getMillis - start.getMillis)
                 }
                 deleteMessage(receiveMessageResult, queueUrl)
                 FrontPressCronSuccess.increment()


### PR DESCRIPTION
This is the start of the new metrics work.
This pull request is only the initial metrics for the front latency; it is work in progress with a bit of work still to do, and this is not the final implementation or interface.

I mainly want this out to see how it performs before doing the wider metric work.
#### Nice Metrics!

These metrics now work properly in `cloudwatch`. It is really nice to see. You get proper `Sum`, `Average`, `Minimum`, `Maximum` and `Data Samples`.
#### Future Metrics

The way the current metrics work is that all data points are rounded to the nearest minute when pushed. This makes it impossible to get the full features of `cloudwatch`.
These latency metrics just add the date (and also the Unit type), in which you then get better metrics in `cloudwatch`.
The way I would imagine future metrics to work would be to have both of these; One type of metric that stores each `DataPoint` along with a `DateTime`, and another metric type that works the way the current metrics work by rounding to the nearest minute on upload.
We don't want to be storing a `DateTime` for each `DataPoint` in some instances, for example a basic count.

@robertberry 
