### PR TITLE
Show error message for older browsers lacking flash

### DIFF
--- a/common/app/assets/stylesheets/module/content/_media-player.scss
+++ b/common/app/assets/stylesheets/module/content/_media-player.scss
@@ -135,7 +135,7 @@ $vjs-progress-inset-bottom: 4px;
             left: 0;
             margin-top: -.9em;
             margin-left: 2.2em;
-            
+
             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
                 @include border-radius(.2em);
             }
@@ -162,7 +162,7 @@ $vjs-progress-inset-bottom: 4px;
     padding-bottom: $vjs-control-height;
     position: absolute;
     z-index: 2;
-    
+
     .vjs-using-native-controls & {
         display: none;
     }
@@ -451,8 +451,12 @@ $vjs-progress-inset-bottom: 4px;
     top: 40%;
     display: none;
 
-    .gu-media--video.vjs-error & {
+    .gu-media--video.vjs-error &,
+    .gu-media__flash-fallback & {
         display: block;
+    }
+    .gu-media__flash-fallback & {
+        background-color: #000000;
     }
     > div {
         color: #ffffff;
@@ -477,6 +481,11 @@ $vjs-progress-inset-bottom: 4px;
                 margin-top: -22px // half icon height for centering
             ));
         }
+    }
+
+    a {
+        color: #ffffff;
+        text-decoration: underline;
     }
 }
 

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -12,12 +12,15 @@
                     }
 
                     @video.encodings.find(_.format == "video/mp4").map { encoding =>
-                        <object type="application/x-shockwave-flash" data="@Static("flash/flashmediaelement.swf")" width="620" height="350">
+                        <object class="gu-media__flash-fallback" type="application/x-shockwave-flash" data="@Static("flash/flashmediaelement.swf")" width="620" height="350">
                             <param name="allowFullScreen" value="true" />
                             <param name="movie" value="@Static("flash/flashmediaelement.swf")" />
                             <param name="flashvars" value="controls=true&amp;file=@encoding.url" />
                             <img src="@poster" alt="" width="620" height="350" />
-                            Sorry, your browser is unable to play this video.
+                            <div class="vjs-error-display">
+                                <div>Sorry, your browser is unable to play this video.<br/>
+                                    Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a> and try again.</div>
+                            </div>
                         </object>
                     }
                 </video>

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -19,7 +19,7 @@
                             <img src="@poster" alt="" width="620" height="350" />
                             <div class="vjs-error-display">
                                 <div>Sorry, your browser is unable to play this video.<br/>
-                                    Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a> and try again.</div>
+                                    Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a>™ and try again.</div>
                             </div>
                         </object>
                     }

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -19,7 +19,8 @@
                             <img src="@poster" alt="" width="620" height="350" />
                             <div class="vjs-error-display">
                                 <div>Sorry, your browser is unable to play this video.<br/>
-                                    Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a>™ and try again.</div>
+                                    Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a>™ and try again.
+                                    Alternatively <a href="http://whatbrowser.org/">upgrade</a> to a modern browser.</div>
                             </div>
                         </object>
                     }


### PR DESCRIPTION
We currently aren't showing the message to tell a user they need to install flash for the non-html5 video fallabck to work correctly.

![littlesnapper](https://cloud.githubusercontent.com/assets/80089/3840956/45821e50-1e25-11e4-9c88-39ef8a769031.png)

/cc @rich-nguyen @gklopper 
