### PR TITLE
fixing layout for DFP component between faciaLeftCol and wide

### DIFF
--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -101,7 +101,7 @@
                             <div class="commercial--v-high__body">
                                 <a href="http://adclick.g.doubleclick.net/aclk%253Fsa%253DL%2526ai%253DBtdlPTiPSU9vAFsqZigb12YGYA_fhkJMFAAAAEAEg75TfITgAWJeKiNqiAWC7vq6D0AqyAQlsb2NhbGhvc3S6AQlnZnBfaW1hZ2XIAQnaAXZodHRwOi8vbG9jYWxob3N0OjkwMDAvYm9va3MvYm9va3NibG9nLzIwMTQvanVsLzI0L2Jvb2stZm9yLXRoZS1iZWFjaC10d2VudHktdGhvdXNhbmQtbGVhZ3Vlcy11bmRlci10aGUtc2VhLWp1bGVzLXZlcm5lqQKY-ncJR3q8PsACAuACAOoCKS81OTY2NjA0Ny90aGVndWFyZGlhbi5jb20vYm9va3MvYm9va3NibG9n-AL50R6AAwGQA4wGmAOMBqgDAeAEAaAGHw%2526num%253D0%2526sig%253DAOD64_04uVjvjKcSOt1Pw_sspwn5MRBdHg%2526client%253Dca-pub-4830087483992392%2526adurl%253Dhttp://www.austinharris.co.uk/offer1" class="lineitem__link" data-link-name="merchandising-123456789-lineitemlink">
                                     <img class="highitem__img" src="http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKCToPeYcRABGAEyCL27FJtXKuKj" alt="">
-                                    <p class="commercial--v-high__price">Some more stuff<br>
+                                    <p class="commercial--v-high__price">A bit of content and some more stuff<br>
                     about this<br>
                     offer</p>
                                 </a>

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -578,6 +578,26 @@ $commercial-cta-diameter: (
     }
 }
 
+@include mq($to: mobileLandscape){
+    .highitem__img {
+        width: 100px;
+        float: none;
+        @include rem((
+            margin-bottom: $gs-baseline/2
+        ));
+    }
+}
+
+@include mq($from: leftCol, $to: wide){
+    .highitem__img {
+        width: 100%;
+        float: none;
+        @include rem((
+            margin-bottom: $gs-baseline/2
+        ));
+    }
+}
+
 .commercial__home-link {
     position: relative;
     display: inline-block;

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -578,7 +578,7 @@ $commercial-cta-diameter: (
     }
 }
 
-@include mq($to: mobileLandscape){
+@include mq($to: mobileLandscape) {
     .highitem__img {
         width: 100px;
         float: none;
@@ -588,7 +588,7 @@ $commercial-cta-diameter: (
     }
 }
 
-@include mq($from: leftCol, $to: wide){
+@include mq(leftCol, wide) {
     .highitem__img {
         width: 100%;
         float: none;


### PR DESCRIPTION
This fixes a layout issue when text can "slip" into the gap between the image and edge of the component at some breakpoints.

Before;
![screen shot 2014-08-07 at 11 21 57](https://cloud.githubusercontent.com/assets/1303616/3840924/dae0dd0c-1e24-11e4-8437-bc3b28877487.png)

After;
![screen shot 2014-08-07 at 12 10 01](https://cloud.githubusercontent.com/assets/1303616/3840926/e0c7b524-1e24-11e4-927b-5cfff44fa365.png)

![](http://i.guim.co.uk/w-1024/h--/q-95/sys-images/Guardian/Pix/pictures/2014/8/5/1407251887770/fc7e082a-6ec1-44ed-9f99-7e3f8b60e65d-2060x1545.jpeg)
