### PR TITLE
Preventing container titles from pushing content down

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_tag.scss
+++ b/common/app/assets/stylesheets/module/containers/_tag.scss
@@ -4,15 +4,11 @@
 
         @include mq(tablet) {
             @include rem((
-                margin-bottom: 12px
+                margin-bottom: $gs-baseline
             ));
         }
     }
     @include mq(faciaLeftCol, wide) {
-        .container__title {
-            margin: 0 !important;
-            float: none !important;
-        }
         .container__body {
             @include rem((
                 margin-left: 160px !important


### PR DESCRIPTION
As reported by Patrick S earlier.
## Before

![screen shot 2014-08-07 at 14 38 53](https://cloud.githubusercontent.com/assets/85783/3842567/60bfc0ce-1e38-11e4-8187-c22f17c76eed.PNG)
## After

![screen shot 2014-08-07 at 14 39 30](https://cloud.githubusercontent.com/assets/85783/3842568/632c05ca-1e38-11e4-90df-ec66680d5125.PNG)

![ ](http://media.giphy.com/media/CBzidwd0Fm4MM/giphy.gif)
