### PR TITLE
Fix video byline

### DIFF
--- a/common/app/assets/stylesheets/module/content/_media.global.scss
+++ b/common/app/assets/stylesheets/module/content/_media.global.scss
@@ -126,10 +126,11 @@
 
     @include mq(tablet, rightCol) {
         .content__meta-container {
-            float: right;
+            float: left;
             @include rem((
                 width: 404px, //Magic, as video items below are off grid at 33.3% width
-                margin-right: $gs-gutter
+                margin-right: $gs-gutter,
+                margin-bottom: $gs-baseline*2
             ));
         }
         .social-wrapper--bottom {

--- a/common/app/assets/stylesheets/module/content/_media.global.scss
+++ b/common/app/assets/stylesheets/module/content/_media.global.scss
@@ -134,7 +134,7 @@
             ));
         }
         .social-wrapper--bottom {
-            float: left;
+            float: right;
             @include rem((
                 width: 192px
             ));


### PR DESCRIPTION
It seems the media byline on tablet has regressed, this fixes that.
### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/3842593/9208dcc4-1e38-11e4-81a2-c9f6ca9b6461.png)
### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/3842595/97507eee-1e38-11e4-90e1-2d3e5d02b424.png)
