### PR TITLE
Only run football snap JS on footaball snaps

### DIFF
--- a/facia/app/assets/javascripts/modules/ui/snaps.js
+++ b/facia/app/assets/javascripts/modules/ui/snaps.js
@@ -34,7 +34,9 @@ define([
 
     function addCss(el, isResize){
         setSnapPoint(el, isResize);
-        FootballSnaps.resizeIfPresent(el);
+        if($(el).hasClass('facia-snap--football')) {
+            FootballSnaps.resizeIfPresent(el);
+        }
     }
 
     function setSnapPoint(el, isResize) {


### PR DESCRIPTION
Running the football JS on non-football snaps will cause trouble.
In fact it has already with the fronts team.

[This was the original commit](https://github.com/guardian/frontend/pull/5443).

**//cc** @sammorrisdesign @tudorraul 

![Snap](http://stream1.gifsoup.com/view6/3968873/zoidberg-z-snap-o.gif)
