### PR TITLE
Hide endslate for videos that are not full size

### DIFF
--- a/common/app/assets/stylesheets/module/content/_media-player.scss
+++ b/common/app/assets/stylesheets/module/content/_media-player.scss
@@ -609,6 +609,9 @@ $vjs-progress-inset-bottom: 4px;
 
 /* End slate
    ========================================================================== */
+.gu-media--hide-endslate .end-slate-container {
+    display: none;
+}
 
 .end-slate-container {
     display: none;

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -13,6 +13,7 @@
                 "gu-media" -> true,
                 "gu-media--video" -> true,
                 "gu-media--show-controls-at-start" -> showControlsAtStart,
+                "gu-media--hide-endslate" -> (width < 620),
                 "js-gu-media" -> true
             ))" data-title="@title"
                 poster="@poster" data-duration="@video.duration.toString()" data-media-id="@video.id">


### PR DESCRIPTION
For smaller size players, the controls overlap the endslate, which looks ugly. The endslate is currently hidden by media queries for when the full size (article) player is on smaller screens. This allows us to hide the endslate for any videos that aren't full width.

![screen shot 2014-08-08 at 11 51 47](https://cloud.githubusercontent.com/assets/1001642/3855740/04c18d86-1eea-11e4-8065-a604dc08cd4c.png)
