### PR TITLE
Commercial highrelimgfix

### DIFF
--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -578,24 +578,26 @@ $commercial-cta-diameter: (
     }
 }
 
-@include mq($to: mobileLandscape) {
-    .highitem__img {
-        width: 100px;
-        float: none;
-        @include rem((
-            margin-bottom: $gs-baseline/2
-        ));
-    }
-}
+.commercial--v-high__body {
+	@include mq($to: mobileLandscape) {
+	    .highitem__img {
+	        width: 100px;
+	        float: none;
+	        @include rem((
+	            margin-bottom: $gs-baseline/2
+	        ));
+	    }
+	}
 
-@include mq(leftCol, wide) {
-    .highitem__img {
-        width: 100%;
-        float: none;
-        @include rem((
-            margin-bottom: $gs-baseline/2
-        ));
-    }
+	@include mq(leftCol, wide) {
+	    .highitem__img {
+	        width: 100%;
+	        float: none;
+	        @include rem((
+	            margin-bottom: $gs-baseline/2
+	        ));
+	    }
+	}
 }
 
 .commercial__home-link {

--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -579,25 +579,25 @@ $commercial-cta-diameter: (
 }
 
 .commercial--v-high__body {
-	@include mq($to: mobileLandscape) {
-	    .highitem__img {
-	        width: 100px;
-	        float: none;
-	        @include rem((
-	            margin-bottom: $gs-baseline/2
-	        ));
-	    }
-	}
+    @include mq($to: mobileLandscape) {
+        .highitem__img {
+            width: 100px;
+            float: none;
+            @include rem((
+                margin-bottom: $gs-baseline/2
+            ));
+        }
+    }
 
-	@include mq(leftCol, wide) {
-	    .highitem__img {
-	        width: 100%;
-	        float: none;
-	        @include rem((
-	            margin-bottom: $gs-baseline/2
-	        ));
-	    }
-	}
+    @include mq(leftCol, wide) {
+        .highitem__img {
+            width: 100%;
+            float: none;
+            @include rem((
+                margin-bottom: $gs-baseline/2
+            ));
+        }
+    }
 }
 
 .commercial__home-link {


### PR DESCRIPTION
Correcting a bug that came in from fixing image size in the inline component.

As the new rule wasn't specific enough it also made the image in the high relevance component much bigger for a specific brakpoint...

Before;
![screen shot 2014-08-08 at 12 00 45](https://cloud.githubusercontent.com/assets/1303616/3855824/5872f0ea-1eeb-11e4-838c-92c35602126e.png)

After;
![screen shot 2014-08-08 at 12 01 02](https://cloud.githubusercontent.com/assets/1303616/3855828/618da558-1eeb-11e4-9e88-628048875a3c.png)

![](http://www.allfunnystuff.com/wp-content/uploads/2013/11/vintage-car-scooper.gif)
