### PR TITLE
Normalise contributor tags to DFP style

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -222,7 +222,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val travel_url = configuration.getMandatoryStringProperty("commercial.travel_url")
     lazy val traveloffers_url = configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
 
-    lazy val dfpSponsoredTagsDataKey = 
+    lazy val dfpSponsoredTagsDataKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/sponsored-tags-v2.json"
     lazy val dfpAdvertisementFeatureTagsDataKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/advertisement-feature-tags-v2.json"

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -222,7 +222,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val travel_url = configuration.getMandatoryStringProperty("commercial.travel_url")
     lazy val traveloffers_url = configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
 
-    lazy val dfpSponsoredTagsDataKey =
+    lazy val dfpSponsoredTagsDataKey = 
       s"${environment.stage.toUpperCase}/commercial/dfp/sponsored-tags-v2.json"
     lazy val dfpAdvertisementFeatureTagsDataKey =
       s"${environment.stage.toUpperCase}/commercial/dfp/advertisement-feature-tags-v2.json"

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -32,7 +32,7 @@ trait DfpAgent {
   }
 
   private def getKeywordTags(tags: Seq[Tag]): Seq[Tag] = tags filter(_.isKeyword)
-
+  private def getContributorTags(tags: Seq[Tag]): Seq[Tag] = tags filter(_.isContributor)
   private def getKeywordOrSeriesTags(tags: Seq[Tag]): Seq[Tag] = tags.filter(t => t.isSeries || t.isKeyword)
 
   def isSponsored(tags: Seq[Tag]): Boolean = getKeywordOrSeriesTags(tags) exists (tag => isSponsored(tag.id))
@@ -45,7 +45,16 @@ trait DfpAgent {
 
   def isProd = !Configuration.environment.isNonProd
 
-  def hasInlineMerchandise(tags: Seq[Tag]): Boolean = getKeywordTags(tags)  exists (tag => hasInlineMerchandise(tag.id))
+  def hasInlineMerchandise(tags: Seq[Tag]): Boolean = {
+    val targettedKeywords = getKeywordTags(tags)  exists (tag => hasInlineMerchandise(tag.id))
+
+    val targettedContributors = getContributorTags(tags) exists {tag =>
+      val normalisedToDfpFormat: String = tag.webTitle.toLowerCase.replace(" ", "-")
+      println(s"I am $normalisedToDfpFormat")
+      hasInlineMerchandise(normalisedToDfpFormat)
+    }
+    targettedKeywords || targettedContributors
+  }
   def hasInlineMerchandise(tagId: String): Boolean = inlineMerchandisingDeals exists (_.hasTag(tagId))
   def hasInlineMerchandise(config: Config): Boolean = isSponsoredContainer(config, hasInlineMerchandise)
 

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -50,7 +50,6 @@ trait DfpAgent {
 
     val targettedContributors = getContributorTags(tags) exists {tag =>
       val normalisedToDfpFormat: String = tag.webTitle.toLowerCase.replace(" ", "-")
-      println(s"I am $normalisedToDfpFormat")
       hasInlineMerchandise(normalisedToDfpFormat)
     }
     targettedKeywords || targettedContributors


### PR DESCRIPTION
This is a bit messy, but we’ve always sent Contributor tags to DFP as
name-lastname. Unfortunately, the Tag id is “profile/nameLastname”, so
we’ll have to do this dance to make it right.
