### PR TITLE
Fix inability to click page skins

### DIFF
--- a/common/app/assets/stylesheets/layout/_side-margins.scss
+++ b/common/app/assets/stylesheets/layout/_side-margins.scss
@@ -56,11 +56,13 @@
         @include side-margins-position(gs-span(14));
     }
     @include mq(wide) {
-        margin-left: auto;
-        margin-right: auto;
-        @include rem((
-            width: gs-span(12) + ($gs-gutter*2)
-        ));
+        .has-page-skin & {
+            margin-left: auto;
+            margin-right: auto;
+            @include rem((
+                width: gs-span(12) + ($gs-gutter*2)
+            ));
+        }
     }
 }
 .l-side-margins--layout-content {

--- a/common/app/assets/stylesheets/layout/_side-margins.scss
+++ b/common/app/assets/stylesheets/layout/_side-margins.scss
@@ -55,6 +55,13 @@
     @include mq(faciaLeftCol, wide) {
         @include side-margins-position(gs-span(14));
     }
+    @include mq(wide) {
+        margin-left: auto;
+        margin-right: auto;
+        @include rem((
+            width: gs-span(12) + ($gs-gutter*2)
+        ));
+    }
 }
 .l-side-margins--layout-content {
     @include mq(rightCol, leftCol) {

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -102,6 +102,13 @@
                 ));
             }
             .has-page-skin & {
+                overflow: hidden;
+                margin-left: auto;
+                margin-right: auto;
+                @include rem((
+                    width: gs-span(12) + ($gs-gutter*2)
+                ));
+
                 .facia-container__inner {
                     @include rem((
                         width: gs-span(12)

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -102,13 +102,6 @@
                 ));
             }
             .has-page-skin & {
-                overflow: hidden;
-                margin-left: auto;
-                margin-right: auto;
-                @include rem((
-                    width: gs-span(12) + ($gs-gutter*2)
-                ));
-
                 .facia-container__inner {
                     @include rem((
                         width: gs-span(12)


### PR DESCRIPTION
When refactoring fronts html structure, make sure to test page skins still work

See [here](https://frontend.code.dev-gutools.co.uk/analytics/commercial/pageskins) for a list of currently running page skins 
