### PR TITLE
Pass through the inline video player end slate path on fronts

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -295,7 +295,7 @@ define([
                                 }
 
                                 if (/desktop|wide/.test(detect.getBreakpoint())) {
-                                    modules.initEndSlate(player);
+                                    modules.initEndSlate(player, el.getAttribute('data-end-slate'));
                                 }
                             } else {
                                 vjs.playlist({
@@ -324,17 +324,17 @@ define([
                 });
             });
         },
-        generateEndSlateUrl: function() {
+        generateEndSlateUrlFromPage: function() {
             var seriesId = config.page.seriesId;
             var sectionId = config.page.section;
             var url = (seriesId)  ? '/video/end-slate/series/' + seriesId : '/video/end-slate/section/' + sectionId;
             return url + '.json?shortUrl=' + config.page.shortUrl;
         },
-        initEndSlate: function(player) {
+        initEndSlate: function(player, endSlatePath) {
             var endSlate = new Component(),
                 endState = 'vjs-has-ended';
 
-            endSlate.endpoint = modules.generateEndSlateUrl();
+            endSlate.endpoint = endSlatePath || modules.generateEndSlateUrlFromPage();
             endSlate.fetch(player.el(), 'html');
 
             player.one(constructEventName('content:play'), function() {

--- a/common/app/model/EndSlateComponents.scala
+++ b/common/app/model/EndSlateComponents.scala
@@ -1,0 +1,20 @@
+package model
+
+object EndSlateComponents {
+  def fromVideo(video: Video) = EndSlateComponents(
+      video.series collectFirst { case Tag(apiTag, _) => apiTag.id },
+      video.section,
+      video.shortUrl
+    )
+}
+
+case class EndSlateComponents(
+  seriesId: Option[String],
+  sectionId: String,
+  shortUrl: String
+) {
+  def toUriPath = {
+    val url = seriesId.fold(s"/video/end-slate/section/$sectionId")(id => s"/video/end-slate/series/$id")
+    s"$url.json?shortUrl=$shortUrl"
+  }
+}

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -455,6 +455,8 @@ class Video(content: ApiContentWithMeta) extends Media(content) {
     }
   ).flatten.mkString(", ")).filter(_.nonEmpty)
   lazy val videoLinkText: String = webTitle.stripSuffix(" - video").stripSuffix(" – video")
+
+  def endSlatePath = EndSlateComponents.fromVideo(this).toUriPath
 }
 
 object Video {

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -14,7 +14,7 @@
     <div class="item__container">
         @trail match {
             case v: Video if v.mainVideo.isDefined => {
-                @video(v.mainVideo.get, Item620, v.webTitle, 620, 350, true, false)
+                @video(v.mainVideo.get, Item620, v.webTitle, 620, 350, true, false, Some(v.endSlatePath))
                 <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
                     @fragments.items.elements.title(trail, index, 0)
                 </a>

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -19,7 +19,7 @@
         <div class="fromage__container">
             @trail match {
                 case v: Video if v.mainVideo.isDefined && imageAdjust == "boost" => {
-                    @fromageVideo(v.mainVideo.get, v.webTitle, true, true)
+                    @fromageVideo(v.mainVideo.get, v.webTitle, true, true, Some(v.endSlatePath))
 
                     <a @LinkTo(trail).map{url=>href=@url} class="fromage__link" data-link-name="article">
                         @fragments.items.elements.title(trail, index, 0)

--- a/common/app/views/fragments/items/fromageVideo.scala.html
+++ b/common/app/views/fragments/items/fromageVideo.scala.html
@@ -1,4 +1,4 @@
-@(videoElement: model.VideoElement, title: String, boost: Boolean, isFirst: Boolean)
+@(videoElement: model.VideoElement, title: String, boost: Boolean, isFirst: Boolean, endSlatePath: Option[String])
 
 @import views.html.fragments.media.video
 @import views.support.{Item300, Item220, RenderClasses}
@@ -11,9 +11,9 @@
 ))">
     <div class="fromage__video-container">
     @if(boost) {
-        @video(videoElement, Item300, title, 300, 180, true, false)
+        @video(videoElement, Item300, title, 300, 180, true, false, endSlatePath)
     } else {
-        @video(videoElement, Item220, title, 220, 132, true, false)
+        @video(videoElement, Item220, title, 220, 132, true, false, endSlatePath)
     }
     </div>
 </div>

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -17,7 +17,7 @@
                     <div class="item__top-border tone-accent-border">
                         <div class="item__media-wrapper item__media-wrapper--has-icon">
                             <div class="item__video-container">
-                                @video(videoItem.mainVideo.get, Item300, videoItem.webTitle, 300, 180, false, false)
+                                @video(videoItem.mainVideo.get, Item300, videoItem.webTitle, 300, 180, false, false, Some(videoItem.endSlatePath))
                             </div>
                         </div>
 

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -1,4 +1,4 @@
-@(video: model.VideoElement, profile: views.support.Profile, title: String, width: Int, height: Int, use16_9AspectRatio: Boolean = true, showControlsAtStart: Boolean = true)
+@(video: model.VideoElement, profile: views.support.Profile, title: String, width: Int, height: Int, use16_9AspectRatio: Boolean = true, showControlsAtStart: Boolean = true, endSlatePath: Option[String] = None)
 
 @import conf.Static
 @import views.support.RenderClasses
@@ -16,7 +16,7 @@
                 "gu-media--hide-endslate" -> (width < 620),
                 "js-gu-media" -> true
             ))" data-title="@title"
-                poster="@poster" data-duration="@video.duration.toString()" data-media-id="@video.id">
+                poster="@poster" data-duration="@video.duration.toString()" data-media-id="@video.id" @endSlatePath.map { path => data-end-slate="@path"}>
 
                 @video.encodings.map { encoding =>
                     <source src="@encoding.url" type="@encoding.format" />


### PR DESCRIPTION
The only player currently that displays an end slate on the fronts is when you have the biggest size story (so that the video player is full width).

It isn't currently, however, showing the correct content in the end slate (as it tries to extract metadata from the page about the content, but the page is the front, not the article) ... this sorts that out.
