### PR TITLE
Upgrade player on tag combiner pages

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -44,7 +44,7 @@ define([
             'content:play',
             'content:end'
         ],
-        contentType = config.page.contentType.toLowerCase(),
+        contentType = (config.page.contentType || '').toLowerCase(),
         constructEventName = function(eventName) {
             return contentType + ':' + eventName;
         };


### PR DESCRIPTION
e.g. http://www.theguardian.com/fashion+type/video

The player doesn't get upgraded because `app.js` crashes when trying to load `media.js` bootstrap. This fixes it, although perhaps we should use a better default value than an empty string here.
