### PR TITLE
Revert "Add playable videos to multimedia container"

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_multimedia.scss
+++ b/common/app/assets/stylesheets/module/containers/_multimedia.scss
@@ -132,10 +132,6 @@
     }
 }
 
-.container--multimedia .item__video-container {
-    margin-top: 0;
-}
-
 .item--video {
     .item__title:before {
         @include video-icon(video-icon-black);

--- a/common/app/assets/stylesheets/module/containers/_news.scss
+++ b/common/app/assets/stylesheets/module/containers/_news.scss
@@ -47,9 +47,6 @@
     }
 }
 
-.container--news .facia-slice-wrapper:first-child .item__video-container {
-    margin-top: 0;
-}
 
 /**
  * Date

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -225,6 +225,9 @@
 .item__video-container {
     margin-top: 4px;
 }
+.container--news .facia-slice-wrapper:first-child .item__video-container {
+    margin-top: 0;
+}
 .item__image-container {
     margin-top: 4px;
 

--- a/common/app/views/fragments/collections/items/standard.scala.html
+++ b/common/app/views/fragments/collections/items/standard.scala.html
@@ -1,4 +1,4 @@
-@(trail: model.Trail, index: Int, containerIndex: Int, additionalClasses: String = "", forcePlayable: Boolean = false)(implicit request: RequestHeader, config: model.Config)
+@(trail: model.Trail, index: Int, containerIndex: Int, additionalClasses: String = "")(implicit request: RequestHeader, config: model.Config)
 
 @import model.{Gallery, Video}
 @import views.support.GetClasses
@@ -6,7 +6,7 @@
 <li class="@GetClasses.forCollectionItem(trail, additionalClasses)">
     @trail match {
         case g: Gallery => { @fragments.items.standardGallery(g, index, containerIndex, "div") }
-        case v: Video   => { @fragments.items.standardVideo(v, index, containerIndex, "div", forcePlayable) }
+        case v: Video   => { @fragments.items.standardVideo(v, index, containerIndex, "div") }
         case t          => { @fragments.items.standard(t, index, containerIndex, "div") }
     }
 </li>

--- a/common/app/views/fragments/containers/multimedia.scala.html
+++ b/common/app/views/fragments/containers/multimedia.scala.html
@@ -1,8 +1,4 @@
-@(collection: model.Collection, style: views.support.MultimediaContainer, containerIndex: Int, layoutType: String = "front")(implicit request: RequestHeader, templateDeduping: views.support.TemplateDeduping, config: model.Config)
-
-@import common.LinkTo
-@import model.{FaciaComponentName, Video}
-@import views.support.GetClasses
+@(collection: Collection, style: MultimediaContainer, containerIndex: Int, layoutType: String = "front")(implicit request: RequestHeader, templateDeduping: TemplateDeduping, config: Config)
 
 @defining((config.displayName.orElse(collection.displayName), config.href.orElse(collection.href))) { case (title, href) =>
 
@@ -34,8 +30,8 @@
                             <div class="container__body container--rolled-up-hide">
                                 <div class="facia-slice-wrapper facia-slice-wrapper--position-1">
                                     <ul class="u-unstyled l-row l-row--items-3 l-row--layout-m facia-slice">
-                                        @items.take(1).zipWithIndex.map { case (trail, index) =>
-                                            @fragments.collections.items.standard(trail, index, containerIndex, "l-row__item--break-m", forcePlayable = true)
+                                        @items.take(1).zipWithIndex.map{ case (trail, index) =>
+                                            @fragments.collections.items.standard(trail, index, containerIndex, "l-row__item--break-m")
                                         }
                                         @items.slice(1, 3).zipWithIndex.map{ case (trail, index) =>
                                             @fragments.collections.items.standard(trail, index + 1, containerIndex)
@@ -77,7 +73,13 @@
                                         <div class="linkslist-container @if(style.showMore){js-container--show-more container--show-more-dark} tone-@{style.tone}" data-tone="@style.tone">
                                             <ul class="l-columns linkslist">
                                             @items.zipWithIndex.map{ case (trail, index) =>
-                                                @fragments.items.linksList.trail(trail, index + 7, None)
+                                                @trail match {
+                                                    case l: LiveBlog if l.isLive         => { @fragments.items.linksList.live(l, index + 7) }
+                                                    case g: Gallery                      => { @fragments.items.linksList.gallery(g, index + 7) }
+                                                    case v: Video                        => { @fragments.items.linksList.video(v, index + 7) }
+                                                    case c if c.visualTone == "comment"  => { @fragments.items.linksList.comment(c, index + 7) }
+                                                    case t                               => { @fragments.items.linksList.standard(t, index + 7) }
+                                                }
                                             }
                                             </ul>
                                         </div>

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -1,4 +1,4 @@
-@(trail: model.Trail, index: Int, containerIndex: Int, element: String = "li", forcePlayable: Boolean = false)(implicit request: RequestHeader, config: model.Config)
+@(trail: model.Trail, index: Int, containerIndex: Int, element: String = "li")(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
 @import conf.Static
@@ -13,7 +13,7 @@
 
         <div class="item__container">
             @trail match {
-                case videoItem: Video if videoItem.mainVideo.isDefined && (trail.imageAdjust == "boost" || forcePlayable) => {
+                case videoItem: Video if videoItem.mainVideo.isDefined && trail.imageAdjust == "boost" => {
                     <div class="item__top-border tone-accent-border">
                         <div class="item__media-wrapper item__media-wrapper--has-icon">
                             <div class="item__video-container">


### PR DESCRIPTION
Reverts guardian/frontend#5470

There's an issue when two players appear on the video article page. It might autoplay the one in the multimedia container below
