### PR TITLE
Use Placement Ad Units to Open Pageskin Ad Slots

### DIFF
--- a/admin/app/dfp/DfpApiWrapper.scala
+++ b/admin/app/dfp/DfpApiWrapper.scala
@@ -26,6 +26,9 @@ object DfpApiWrapper extends Logging {
   private def suggestedAdUnitService(session: DfpSession): SuggestedAdUnitServiceInterface =
     dfpServices.get(session, classOf[SuggestedAdUnitServiceInterface])
 
+  private def placementService(session: DfpSession): PlacementServiceInterface =
+    dfpServices.get(session, classOf[PlacementServiceInterface])
+
   case class Page[T](rawResults: Array[T], totalResultSetSize: Int) {
     def results: Seq[T] = Option(rawResults) map (_.toSeq) getOrElse Nil
   }
@@ -113,6 +116,14 @@ object DfpApiWrapper extends Logging {
     fetch(statementBuilder) { statement =>
       val service = suggestedAdUnitService(session)
       val page = service.getSuggestedAdUnitsByStatement(statementBuilder.toStatement)
+      Page(page.getResults, page.getTotalResultSetSize)
+    }
+  }
+
+  def fetchPlacements(session: DfpSession, statementBuilder: StatementBuilder): Seq[Placement] = {
+    fetch(statementBuilder) { statement =>
+      val service = placementService(session)
+      val page = service.getPlacementsByStatement(statementBuilder.toStatement)
       Page(page.getResults, page.getTotalResultSetSize)
     }
   }

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -7,10 +7,10 @@ import com.google.api.ads.dfp.axis.v201403._
 import com.google.api.ads.dfp.lib.client.DfpSession
 import common.Logging
 import conf.{AdminConfiguration, Configuration}
-import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
-import java.io.Serializable
-import scala.util.{Failure, Try, Success}
 import dfp.DfpApiWrapper.DfpSessionException
+import org.joda.time.{DateTimeZone, DateTime => JodaDateTime}
+
+import scala.util.{Failure, Try}
 
 object DfpDataHydrator extends Logging {
 
@@ -54,6 +54,7 @@ object DfpDataHydrator extends Logging {
       val optSponsorFieldId = loadCustomFieldId("sponsor")
 
       val allAdUnits = loadActiveDescendantAdUnits(Configuration.commercial.dfpAdUnitRoot)
+      val placementAdUnits = loadAdUnitIdsByPlacement()
 
       val allCustomTargetingKeys = loadAllCustomTargetKeys()
       val allCustomTargetingValues = loadAllCustomTargetValues()
@@ -72,11 +73,27 @@ object DfpDataHydrator extends Logging {
 
         val dfpTargeting = dfpLineItem.getTargeting
 
-        val adUnits = Option(dfpTargeting.getInventoryTargeting.getTargetedAdUnits) map { adUnits =>
+        val directAdUnits = Option(dfpTargeting.getInventoryTargeting.getTargetedAdUnits) map { adUnits =>
           adUnits.flatMap { adUnit =>
             allAdUnits get adUnit.getAdUnitId
           }.toSeq
         } getOrElse Nil
+
+        val adUnitsDerivedFromPlacements = {
+          Option(dfpTargeting.getInventoryTargeting.getTargetedPlacementIds).map { placementIds =>
+
+            def adUnitsInPlacement(id: Long) = {
+              placementAdUnits get id map {
+                _ flatMap allAdUnits.get
+              } getOrElse Nil
+            }
+
+            placementIds.flatMap(adUnitsInPlacement).toSeq
+
+          } getOrElse Nil
+        }
+
+        val adUnits = (directAdUnits ++ adUnitsDerivedFromPlacements).sortBy(_.path.mkString).distinct
 
         val geoTargets = Option(dfpTargeting.getGeoTargeting) flatMap { geoTargeting =>
           Option(geoTargeting.getTargetedLocations) map { locations =>
@@ -176,6 +193,11 @@ object DfpDataHydrator extends Logging {
     }.toMap
   }
 
+  def loadAdUnitIdsByPlacement(): Map[Long, Seq[String]] = dfpSession.fold(Map[Long, Seq[String]]()) { session =>
+    DfpApiWrapper.fetchPlacements(session, new StatementBuilder()).map { placement =>
+      placement.getId.toLong -> placement.getTargetedAdUnitIds.toSeq
+    }.toMap
+  }
 
   private def isPageSkin(dfpLineItem: LineItem) = {
 

--- a/admin/app/tools/DfpLink.scala
+++ b/admin/app/tools/DfpLink.scala
@@ -13,9 +13,18 @@ object DfpLink {
 object SiteLink {
 
   def adUnit(path: String): Option[String] = {
+
+    def getRelativePath(dropFromRight: Int) = path.split("/").drop(1).dropRight(dropFromRight).mkString("/")
+
+    lazy val relativePath = getRelativePath(1)
+    lazy val relativeEditionalisedPath = getRelativePath(2)
+
     if (path endsWith "/front") {
-      val relativePath = path.split("/").drop(1).dropRight(1).mkString("/")
       Some(s"${site.host}/${relativePath}")
+    } else if (path endsWith "/front/ng") {
+      Some(s"${site.host}/${relativeEditionalisedPath}?view=mobile")
+    } else if (path endsWith "/front/r2") {
+      Some(s"${site.host}/${relativeEditionalisedPath}?view=classic")
     } else {
       None
     }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -222,19 +222,14 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val travel_url = configuration.getMandatoryStringProperty("commercial.travel_url")
     lazy val traveloffers_url = configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
 
-    lazy val dfpSponsoredTagsDataKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/sponsored-tags-v2.json"
-    lazy val dfpAdvertisementFeatureTagsDataKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/advertisement-feature-tags-v2.json"
-    lazy val inlineMerchandisingSponsorshipsDataKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/inline-merchandising-tags-v2.json"
-    lazy val dfpPageSkinnedAdUnitsKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/pageskinned-adunits-v4.json"
-    lazy val dfpLineItemsKey =
-      s"${environment.stage.toUpperCase}/commercial/dfp/lineitems.json"
-    lazy val travelOffersS3Key =
-      s"${environment.stage.toUpperCase}/commercial/cache/traveloffers.xml"
+    private lazy val dfpRoot = s"${environment.stage.toUpperCase}/commercial/dfp"
+    lazy val dfpSponsoredTagsDataKey = s"$dfpRoot/sponsored-tags-v2.json"
+    lazy val dfpAdvertisementFeatureTagsDataKey = s"$dfpRoot/advertisement-feature-tags-v2.json"
+    lazy val inlineMerchandisingSponsorshipsDataKey = s"$dfpRoot/inline-merchandising-tags-v2.json"
+    lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v4.json"
+    lazy val dfpLineItemsKey = s"$dfpRoot/lineitems.json"
 
+    lazy val travelOffersS3Key = s"${environment.stage.toUpperCase}/commercial/cache/traveloffers.xml"
   }
 
   object open {


### PR DESCRIPTION
This changes the logic of when to show a pageskin ad slot.

The decision now takes into account ad units derived from targeted placements along with directly targeted ad units. 
