### PR TITLE
Fall back to flash if source list is not compatible with browser

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -190,7 +190,9 @@ define([
             var err = player.error();
             if(err !== null) {
                 modules.beaconError(err);
+                return err.code === 4;
             }
+            return false;
         },
 
         bindErrorHandler: function(player) {
@@ -261,6 +263,21 @@ define([
                 '</div>';
         },
 
+        createVideoObject: function(el, options) {
+            var vjs;
+
+            options.techOrder = ['html5', 'flash'];
+            vjs = videojs(el, options);
+
+            if(modules.handleInitialMediaError(vjs)){
+                vjs.dispose();
+                options.techOrder = ['flash', 'html5'];
+                vjs = videojs(el, options);
+            }
+
+            return vjs;
+        },
+
         initPlayer: function() {
 
             require('bootstraps/video-player', function () {
@@ -274,7 +291,7 @@ define([
                     bonzo(el).addClass('vjs');
 
                     var mediaId = el.getAttribute('data-media-id'),
-                        vjs = videojs(el, {
+                        vjs = modules.createVideoObject(el, {
                             controls: true,
                             autoplay: false,
                             preload: 'metadata' // preload='none' & autoplay breaks ad loading on chrome35


### PR DESCRIPTION
Occasionally we have encoding issues, whereby a html5 enabled browser such as FireFox cannot play a video if their supported source mime types such as `video/webm` are missing or corrupted within our source list. This is due to issues in the multimedia transcoding pipeline and a race-condition in the editing tools. 

In these instances we want to attempt to play the `video/mp4` via the flash player instead. Unfortunately, VideoJS doesn't currently do this out of the box. Therefore, this – quite hacky– attempts to solve this problem in the interim until we have native functionality via VideoJS. I have started a separate thread on their repo to discuss this and offer to carry out the work.

/cc @rich-nguyen @ironsidevsquincy @mattosborn 
