### PR TITLE
Tag sentry errors with origin

### DIFF
--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -127,6 +127,7 @@
                 'http://' + config.page.sentryPublicApiKey + '@@' + config.page.sentryHost,
                 {
                     whitelistUrls: [
+                        'localhost',
                         /assets\.guim\.co\.uk/,
                         /ophan\.co\.uk/,
                     ],
@@ -134,6 +135,9 @@
                         edition: config.page.edition,
                         contentType: config.page.contentType,
                         buildNumber: config.page.buildNumber
+                    },
+                    dataCallback: function(data) {
+                        data.tags.origin = (/j.ophan.co.uk/.test(data.culprit)) ? 'ophan' : 'app';
                     },
                     shouldSendCallback: function(data) {
                         return Math.random() < 0.4 && guardian.config.switches.enableDiagnosticsLogging;

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -127,7 +127,6 @@
                 'http://' + config.page.sentryPublicApiKey + '@@' + config.page.sentryHost,
                 {
                     whitelistUrls: [
-                        'localhost',
                         /assets\.guim\.co\.uk/,
                         /ophan\.co\.uk/,
                     ],


### PR DESCRIPTION
As discussed with @ironsidevsquincy & @tackley this will allow us to easily filter error types in Sentry by their origin application. I.e. Ophan vs app.js
