### PR TITLE
Push metric type

### DIFF
--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -2,6 +2,7 @@ import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
 import conf.{Configuration, Filters}
 import dev.DevParametersLifecycle
 import dfp.DfpAgentLifecycle
+import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
 import play.api.mvc.WithFilters
 
@@ -13,8 +14,8 @@ object Global
   with SurgingContentAgentLifecycle {
   override lazy val applicationName = "frontend-article"
 
-  override def applicationMetrics: Map[String, Double] = super.applicationMetrics ++ Map(
-    ("elastic-content-api-calls", ContentApiMetrics.ElasticHttpTimingMetric.getAndReset.toDouble),
-    ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble)
+  override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
+    ContentApiMetrics.ElasticHttpTimingMetric,
+    ContentApiMetrics.ElasticHttpTimeoutCountMetric
   )
 }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -357,10 +357,8 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
   private def report() {
     val systemMetrics  = this.systemMetrics
     val applicationMetrics  = this.applicationMetrics
-    CloudWatch.put("ApplicationSystemMetrics", systemMetrics)
-    for (metrics <- applicationMetrics.grouped(20))
-      CloudWatch.putWithDimensions(applicationMetricsNamespace, metrics, Seq(applicationDimension))
-
+    CloudWatch.putSystemMetricsWithStage(systemMetrics, applicationDimension)
+    CloudWatch.putMetricsWithStage(applicationMetrics, applicationDimension)
     CloudWatch.putMetricsWithStage(latencyMetrics, applicationDimension)
   }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -344,11 +344,13 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
     SystemMetrics.TotalPhysicalMemoryMetric, SystemMetrics.FreePhysicalMemoryMetric, SystemMetrics.AvailableProcessorsMetric,
     SystemMetrics.BuildNumberMetric, SystemMetrics.FreeDiskSpaceMetric, SystemMetrics.TotalDiskSpaceMetric) ++
     SystemMetrics.garbageCollectors.flatMap{ gc => List(
-      GaugeMetric(s"$applicationName-${gc.name}-gc-count-per-min" , "Used heap memory (MB)",
-        () => gc.gcCount.toLong
+      GaugeMetric(s"${gc.name}-gc-count-per-min" , "Used heap memory (MB)",
+        () => gc.gcCount.toLong,
+        StandardUnit.Count
       ),
-      GaugeMetric(s"$applicationName-${gc.name}-gc-time-per-min", "Used heap memory (MB)",
-        () => gc.gcTime.toLong
+      GaugeMetric(s"${gc.name}-gc-time-per-min", "Used heap memory (MB)",
+        () => gc.gcTime.toLong,
+        StandardUnit.Count
       )
     )}
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -100,12 +100,12 @@ object SystemMetrics extends implicits.Numbers {
 
 object S3Metrics {
   object S3ClientExceptionsMetric extends CountMetric(
-    "s3-client-exception",
+    "s3-client-exceptions",
     "Number of times the AWS S3 client has thrown an Exception"
   )
 
   object S3AuthorizationError extends CountMetric(
-    "facia-s3-authorization-403",
+    "s3-authorization-errors",
     "Number of requests to S3 by facia that have resulted in a 403"
   )
 }
@@ -122,17 +122,17 @@ object ContentApiMetrics {
   )
 
   object ContentApi404Metric extends CountMetric(
-    "content-api-404-responses",
+    "content-api-404",
     "Number of times the Content API has responded with a 404"
   )
 
   object ContentApiJsonParseExceptionMetric extends CountMetric(
-    "content-api-parse-exception",
+    "content-api-client-parse-exceptions",
     "Number of times the Content API client has thrown a ParseException"
   )
 
   object ContentApiJsonMappingExceptionMetric extends CountMetric(
-    "content-api-mapping-exception",
+    "content-api-client-mapping-exceptions",
     "Number of times the Content API client has thrown a MappingException"
   )
 }
@@ -172,12 +172,12 @@ object AdminMetrics {
 object FaciaMetrics {
 
   object JsonParsingErrorCount extends CountMetric(
-    "facia-json-error",
+    "json-parsing-error",
     "Number of errors whilst parsing JSON out of S3"
   )
 
   object FaciaToApplicationRedirectMetric extends CountMetric(
-    "facia-applications-redirects",
+    "redirects-to-applications",
     "Number of requests to facia that have been redirected to Applications via X-Accel-Redirect"
   )
 }
@@ -189,12 +189,12 @@ object FaciaPressMetrics {
   )
 
   object FrontPressLiveSuccess extends CountMetric(
-    "facia-front-press-live-success",
+    "front-press-live-success",
     "Number of times facia-tool has successfully pressed live"
   )
 
   object FrontPressLiveFailure extends CountMetric(
-    "facia-front-press-live-failure",
+    "front-press-live-failure",
     "Number of times facia-tool has had a failure in pressing live"
   )
 
@@ -204,37 +204,37 @@ object FaciaPressMetrics {
   )
 
   object FrontPressDraftSuccess extends CountMetric(
-    "facia-front-press-draft-success",
+    "front-press-draft-success",
     "Number of times facia-tool has successfully pressed draft"
   )
 
   object FrontPressDraftFailure extends CountMetric(
-    "facia-front-press-draft-failure",
+    "front-press-draft-failure",
     "Number of times facia-tool has had a failure in pressing draft"
   )
 
   object FrontPressCronSuccess extends CountMetric(
-    "facia-front-press-cron-success",
+    "front-press-cron-success",
     "Number of times facia-tool cron job has successfully pressed"
   )
 
   object FrontPressCronFailure extends CountMetric(
-    "facia-front-press-cron-failure",
+    "front-press-cron-failure",
     "Number of times facia-tool cron job has had a failure in pressing"
   )
 
   object MemcachedFallbackMetric extends CountMetric(
-    "facia-press-memcached-fallbacks",
+    "content-api-fallbacks",
     "Number of times the Memcached Fallback was used"
   )
 
   object ContentApiSeoRequestSuccess extends CountMetric(
-    "facia-seo-request-success",
+    "content-api-seo-request-success",
     "Number of times facia-tool has successfully made the request for SEO purposes of webTitle and section"
   )
 
   object ContentApiSeoRequestFailure extends CountMetric(
-    "facia-seo-request-failure",
+    "content-api-seo-request-failure",
     "Number of times facia-tool has failed to made the request for SEO purposes of webTitle and section"
   )
 
@@ -242,37 +242,37 @@ object FaciaPressMetrics {
 
 object FaciaToolMetrics {
   object ApiUsageCount extends CountMetric(
-    "facia-api-usage",
+    "api-usage",
     "Number of requests to the Facia API from clients (The tool)"
   )
 
   object ProxyCount extends CountMetric(
-    "facia-proxy-usage",
+    "api-proxy-usage",
     "Number of requests to the Facia proxy endpoints (Ophan and Content API) from clients"
   )
 
   object ExpiredRequestCount extends CountMetric(
-    "facia-auth-expired",
+    "auth-expired",
     "Number of expired requests coming into an endpoint using ExpiringAuthAction"
   )
 
   object DraftPublishCount extends CountMetric(
-    "facia-draft-publish",
+    "draft-publish",
     "Number of drafts that have been published"
   )
 
   object ContentApiPutSuccess extends CountMetric(
-    "faciatool-contentapi-put-success",
+    "content-api-put-success",
     "Number of PUT requests that have been successful to the content api"
   )
 
   object ContentApiPutFailure extends CountMetric(
-    "faciatool-contentapi-put-failure",
+    "content-api-put-failure",
     "Number of PUT requests that have failed to the content api"
   )
 
   object InvalidContentExceptionMetric extends CountMetric(
-    "facia-invalid-content",
+    "content-api-invalid-content-exceptions",
     "Number of times facia/facia-tool has thrown InvalidContent exceptions"
   )
 

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -24,7 +24,7 @@ case class GaugeDataPoint(value: Long) extends DataPoint {
   val time: Option[DateTime] = None
 }
 
-trait FrontendMetric {
+sealed trait FrontendMetric {
   val name: String
   val metricUnit: StandardUnit
   def getAndResetDataPoints: List[DataPoint]

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -65,15 +65,18 @@ trait CloudWatch extends Logging {
 
 
   def putMetricsWithStage(metrics: List[FrontendMetric], applicationDimension: Dimension): Unit =
-    putMetrics(metrics, List(stageDimension, applicationDimension))
+    putMetrics("Application", metrics, List(stageDimension, applicationDimension))
 
-  def putMetrics(metrics: List[FrontendMetric], dimensions: List[Dimension]): Unit = {
+  def putSystemMetricsWithStage(namespace: String, metrics: List[FrontendMetric], applicationDimension: Dimension): Unit =
+    putMetrics("ApplicationSystemMetrics", metrics, List(stageDimension, applicationDimension))
+
+  def putMetrics(metricNamespace: String, metrics: List[FrontendMetric], dimensions: List[Dimension]): Unit = {
     for {
       metric <- metrics
       dataPointGroup <- metric.getAndResetDataPoints.grouped(20)
     } {
       val request = new PutMetricDataRequest()
-        .withNamespace("Application")
+        .withNamespace(metricNamespace)
         .withMetricData {
           for (dataPoint <- dataPointGroup) yield {
             val metricDatum = new MetricDatum()

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -67,7 +67,7 @@ trait CloudWatch extends Logging {
   def putMetricsWithStage(metrics: List[FrontendMetric], applicationDimension: Dimension): Unit =
     putMetrics("Application", metrics, List(stageDimension, applicationDimension))
 
-  def putSystemMetricsWithStage(namespace: String, metrics: List[FrontendMetric], applicationDimension: Dimension): Unit =
+  def putSystemMetricsWithStage(metrics: List[FrontendMetric], applicationDimension: Dimension): Unit =
     putMetrics("ApplicationSystemMetrics", metrics, List(stageDimension, applicationDimension))
 
   def putMetrics(metricNamespace: String, metrics: List[FrontendMetric], dimensions: List[Dimension]): Unit = {

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -18,26 +18,26 @@ object Global extends GlobalSettings
 
   override def applicationName = "frontend-facia-press"
 
-  override def applicationMetrics = Map(
-    ("front-press-failure", getTotalPressFailureCount.toDouble),
-    ("front-press-success", getTotalPressSuccessCount.toDouble),
-    ("front-press-draft-failure", FaciaPressMetrics.FrontPressDraftFailure.getAndReset.toDouble),
-    ("front-press-draft-success", FaciaPressMetrics.FrontPressDraftSuccess.getAndReset.toDouble),
-    ("front-press-live-failure", FaciaPressMetrics.FrontPressLiveFailure.getAndReset.toDouble),
-    ("front-press-live-success", FaciaPressMetrics.FrontPressLiveSuccess.getAndReset.toDouble),
-    ("front-press-cron-success", FaciaPressMetrics.FrontPressCronSuccess.getAndReset.toDouble),
-    ("front-press-cron-failure", FaciaPressMetrics.FrontPressCronFailure.getAndReset.toDouble),
-    ("elastic-content-api-calls", ContentApiMetrics.ElasticHttpTimingMetric.getAndReset.toDouble),
-    ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
-    ("content-api-404", ContentApiMetrics.ContentApi404Metric.getAndReset.toDouble),
-    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
-    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble),
-    ("content-api-invalid-content-exceptions", FaciaToolMetrics.InvalidContentExceptionMetric.getAndReset.toDouble),
-    ("s3-client-exceptions", S3Metrics.S3ClientExceptionsMetric.getAndReset.toDouble),
-    ("s3-authorization-errors", S3Metrics.S3AuthorizationError.getAndReset.toDouble),
-    ("content-api-seo-request-success", FaciaPressMetrics.ContentApiSeoRequestSuccess.getAndReset.toDouble),
-    ("content-api-seo-request-failure", FaciaPressMetrics.ContentApiSeoRequestFailure.getAndReset.toDouble),
-    ("content-api-fallbacks", FaciaPressMetrics.MemcachedFallbackMetric.getAndReset.toDouble)
+  override def applicationMetrics = List(
+    GaugeMetric("front-press-failure", "", () => getTotalPressFailureCount),
+    GaugeMetric("front-press-success", "", () => getTotalPressSuccessCount),
+    FaciaPressMetrics.FrontPressDraftFailure,
+    FaciaPressMetrics.FrontPressDraftSuccess,
+    FaciaPressMetrics.FrontPressLiveFailure,
+    FaciaPressMetrics.FrontPressLiveSuccess,
+    FaciaPressMetrics.FrontPressCronSuccess,
+    FaciaPressMetrics.FrontPressCronFailure,
+    ContentApiMetrics.ElasticHttpTimingMetric,
+    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.ContentApi404Metric,
+    ContentApiMetrics.ContentApiJsonParseExceptionMetric,
+    ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
+    FaciaToolMetrics.InvalidContentExceptionMetric,
+    S3Metrics.S3ClientExceptionsMetric,
+    S3Metrics.S3AuthorizationError,
+    FaciaPressMetrics.ContentApiSeoRequestSuccess,
+    FaciaPressMetrics.ContentApiSeoRequestFailure,
+    FaciaPressMetrics.MemcachedFallbackMetric
   )
 
   override def latencyMetrics: List[FrontendMetric] = List(UkPressLatencyMetric, UsPressLatencyMetric, AuPressLatencyMetric,

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -19,8 +19,8 @@ object Global extends GlobalSettings
   override def applicationName = "frontend-facia-press"
 
   override def applicationMetrics = List(
-    GaugeMetric("front-press-failure", "", () => getTotalPressFailureCount),
-    GaugeMetric("front-press-success", "", () => getTotalPressSuccessCount),
+    GaugeMetric("front-press-failure", "Total number of front press failure", () => getTotalPressFailureCount),
+    GaugeMetric("front-press-success", "Total number of front press success", () => getTotalPressSuccessCount),
     FaciaPressMetrics.FrontPressDraftFailure,
     FaciaPressMetrics.FrontPressDraftSuccess,
     FaciaPressMetrics.FrontPressLiveFailure,

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -2,6 +2,7 @@ import java.io.File
 
 import common._
 import conf.{Gzipper, Configuration => GuardianConfiguration}
+import metrics.FrontendMetric
 import play.api._
 import play.api.mvc.WithFilters
 import services.ConfigAgentLifecycle
@@ -13,20 +14,20 @@ object Global extends WithFilters(Gzipper)
   lazy val devConfig = Configuration.from(Map("session.secure" -> "false"))
 
   override lazy val applicationName = "frontend-facia-tool"
-  override def applicationMetrics: Map[String, Double] = Map(
-    ("api-usage", FaciaToolMetrics.ApiUsageCount.getAndReset.toDouble),
-    ("api-proxy-usage", FaciaToolMetrics.ProxyCount.getAndReset.toDouble),
-    ("content-api-put-failure", FaciaToolMetrics.ContentApiPutFailure.getAndReset.toDouble),
-    ("content-api-put-success", FaciaToolMetrics.ContentApiPutSuccess.getAndReset.toDouble),
-    ("draft-publish", FaciaToolMetrics.DraftPublishCount.getAndReset.toDouble),
-    ("auth-expired", FaciaToolMetrics.ExpiredRequestCount.getAndReset.toDouble),
-    ("elastic-content-api-calls", ContentApiMetrics.ElasticHttpTimingMetric.getAndReset.toDouble),
-    ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
-    ("content-api-404", ContentApiMetrics.ContentApi404Metric.getAndReset.toDouble),
-    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
-    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble),
-    ("content-api-invalid-content-exceptions", FaciaToolMetrics.InvalidContentExceptionMetric.getAndReset.toDouble),
-    ("s3-client-exceptions", S3Metrics.S3ClientExceptionsMetric.getAndReset.toDouble)
+  override def applicationMetrics: List[FrontendMetric] = List(
+    FaciaToolMetrics.ApiUsageCount,
+    FaciaToolMetrics.ProxyCount,
+    FaciaToolMetrics.ContentApiPutFailure,
+    FaciaToolMetrics.ContentApiPutSuccess,
+    FaciaToolMetrics.DraftPublishCount,
+    FaciaToolMetrics.ExpiredRequestCount,
+    ContentApiMetrics.ElasticHttpTimingMetric,
+    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.ContentApi404Metric,
+    ContentApiMetrics.ContentApiJsonParseExceptionMetric,
+    ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
+    FaciaToolMetrics.InvalidContentExceptionMetric,
+    S3Metrics.S3ClientExceptionsMetric
   )
 
   def secureCookie(mode: Mode.Mode): Boolean = mode == Mode.Dev || GuardianConfiguration.environment.stage == "dev"

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -14,7 +14,7 @@ object Global extends WithFilters(Gzipper)
   lazy val devConfig = Configuration.from(Map("session.secure" -> "false"))
 
   override lazy val applicationName = "frontend-facia-tool"
-  override def applicationMetrics: List[FrontendMetric] = List(
+  override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
     FaciaToolMetrics.ApiUsageCount,
     FaciaToolMetrics.ProxyCount,
     FaciaToolMetrics.ContentApiPutFailure,

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -2,6 +2,7 @@ import common._
 import conf.{Configuration, Filters}
 import dev.DevParametersLifecycle
 import dfp.DfpAgentLifecycle
+import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
 import play.api.mvc.WithFilters
 import services.ConfigAgentLifecycle
@@ -15,15 +16,15 @@ with DfpAgentLifecycle
 with SurgingContentAgentLifecycle {
   override lazy val applicationName = "frontend-facia"
 
-  override def applicationMetrics: Map[String, Double] = super.applicationMetrics ++ Map(
-    ("s3-authorization-error", S3Metrics.S3AuthorizationError.getAndReset.toDouble),
-    ("json-parsing-error", FaciaMetrics.JsonParsingErrorCount.getAndReset.toDouble),
-    ("elastic-content-api-calls", ContentApiMetrics.ElasticHttpTimingMetric.getAndReset.toDouble),
-    ("elastic-content-api-timeouts", ContentApiMetrics.ElasticHttpTimeoutCountMetric.getAndReset.toDouble),
-    ("content-api-client-parse-exceptions", ContentApiMetrics.ContentApiJsonParseExceptionMetric.getAndReset.toDouble),
-    ("content-api-client-mapping-exceptions", ContentApiMetrics.ContentApiJsonMappingExceptionMetric.getAndReset.toDouble),
-    ("content-api-invalid-content-exceptions", FaciaToolMetrics.InvalidContentExceptionMetric.getAndReset.toDouble),
-    ("redirects-to-applications", FaciaMetrics.FaciaToApplicationRedirectMetric.getAndReset.toDouble)
+  override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
+    S3Metrics.S3AuthorizationError,
+    FaciaMetrics.JsonParsingErrorCount,
+    ContentApiMetrics.ElasticHttpTimingMetric,
+    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.ContentApiJsonParseExceptionMetric,
+    ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
+    FaciaToolMetrics.InvalidContentExceptionMetric,
+    FaciaMetrics.FaciaToApplicationRedirectMetric
   )
 
 }


### PR DESCRIPTION
This carries the type `FrontendMetric` as far as the `trait` `CloudWatch` so that we can push the unit type with the metric, which comes from `FrontendMetric.metricUnit`.

Also, the `systemMetrics` no longer prefix the `applicationName`, instead this is done using `Dimension`s.

@gklopper 
