### PR TITLE
Metrics switch

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -5,6 +5,7 @@ import java.lang.management.{GarbageCollectorMXBean, ManagementFactory}
 import java.util.concurrent.atomic.AtomicLong
 
 import com.amazonaws.services.cloudwatch.model.{Dimension, StandardUnit}
+import conf.{Switches, Configuration}
 import metrics.{CountMetric, FrontendMetric, FrontendTimingMetric, GaugeMetric}
 import model.diagnostics.CloudWatch
 import play.api.{GlobalSettings, Application => PlayApp}
@@ -359,9 +360,11 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
   private def report() {
     val systemMetrics  = this.systemMetrics
     val applicationMetrics  = this.applicationMetrics
-    CloudWatch.putSystemMetricsWithStage(systemMetrics, applicationDimension)
-    CloudWatch.putMetricsWithStage(applicationMetrics, applicationDimension)
-    CloudWatch.putMetricsWithStage(latencyMetrics, applicationDimension)
+    if (!Configuration.environment.isNonProd || Switches.MetricsSwitch.isSwitchedOn) {
+      CloudWatch.putSystemMetricsWithStage(systemMetrics, applicationDimension)
+      CloudWatch.putMetricsWithStage(applicationMetrics, applicationDimension)
+      CloudWatch.putMetricsWithStage(latencyMetrics, applicationDimension)
+    }
   }
 
   override def onStart(app: PlayApp) {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -355,15 +355,12 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
       )
     )}
 
-  def latencyMetrics: List[FrontendMetric] = Nil
-
   private def report() {
     val systemMetrics  = this.systemMetrics
     val applicationMetrics  = this.applicationMetrics
     if (!Configuration.environment.isNonProd || Switches.MetricsSwitch.isSwitchedOn) {
       CloudWatch.putSystemMetricsWithStage(systemMetrics, applicationDimension)
       CloudWatch.putMetricsWithStage(applicationMetrics, applicationDimension)
-      CloudWatch.putMetricsWithStage(latencyMetrics, applicationDimension)
     }
   }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -172,11 +172,6 @@ object AdminMetrics {
 
 object FaciaMetrics {
 
-  object JsonParsingErrorCount extends CountMetric(
-    "json-parsing-error",
-    "Number of errors whilst parsing JSON out of S3"
-  )
-
   object FaciaToApplicationRedirectMetric extends CountMetric(
     "redirects-to-applications",
     "Number of requests to facia that have been redirected to Applications via X-Accel-Redirect"

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -218,7 +218,7 @@ object Switches extends Collections {
 
   val MetricsSwitch = Switch("Diagnostics", "enable-metrics-non-prod",
     "If this switch is on, then metrics will be pushed to cloudwatch on DEV and CODE",
-    safeState = On, never
+    safeState = Off, never
   )
 
   val ScrollDepthSwitch = Switch("Analytics", "scroll-depth",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -216,6 +216,11 @@ object Switches extends Collections {
     safeState = On, never
   )
 
+  val MetricsSwitch = Switch("Diagnostics", "enable-metrics-non-prod",
+    "If this switch is on, then metrics will be pushed to cloudwatch on DEV and CODE",
+    safeState = On, never
+  )
+
   val ScrollDepthSwitch = Switch("Analytics", "scroll-depth",
     "Enables tracking and measurement of scroll depth",
     safeState = Off, never
@@ -492,7 +497,8 @@ object Switches extends Collections {
     BreakingNewsSwitch,
     ABNewsContainerNoImages,
     CenturyRedirectionSwitch,
-    ChildrensBooksSwitch
+    ChildrensBooksSwitch,
+    MetricsSwitch
   )
 
   val httpSwitches: List[Switch] = List(

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -94,8 +94,3 @@ object UsPressLatencyMetric extends DurationMetric("us-press-latency", StandardU
 object AuPressLatencyMetric extends DurationMetric("au-press-latency", StandardUnit.Milliseconds)
 
 object AllFrontsPressLatencyMetric extends DurationMetric("front-press-latency", StandardUnit.Milliseconds)
-
-object LatencyMetrics {
-  val all: List[DurationMetric] = List(UkPressLatencyMetric, UsPressLatencyMetric, AuPressLatencyMetric,
-    AllFrontsPressLatencyMetric)
-}

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -37,11 +37,12 @@ object Global extends GlobalSettings
     S3Metrics.S3AuthorizationError,
     FaciaPressMetrics.ContentApiSeoRequestSuccess,
     FaciaPressMetrics.ContentApiSeoRequestFailure,
-    FaciaPressMetrics.MemcachedFallbackMetric
+    FaciaPressMetrics.MemcachedFallbackMetric,
+    UkPressLatencyMetric,
+    UsPressLatencyMetric,
+    AuPressLatencyMetric,
+    AllFrontsPressLatencyMetric
   )
-
-  override def latencyMetrics: List[FrontendMetric] = List(UkPressLatencyMetric, UsPressLatencyMetric, AuPressLatencyMetric,
-                                     AllFrontsPressLatencyMetric)
 
   def scheduleJobs() {
     Jobs.schedule("FaciaToolPressJob", s"0/$pressJobConsumeRateInSeconds * * * * ?") {

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -23,10 +23,6 @@ object Global extends WithFilters(Gzipper)
     FaciaToolMetrics.ExpiredRequestCount,
     ContentApiMetrics.ElasticHttpTimingMetric,
     ContentApiMetrics.ElasticHttpTimeoutCountMetric,
-    ContentApiMetrics.ContentApi404Metric,
-    ContentApiMetrics.ContentApiJsonParseExceptionMetric,
-    ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
-    FaciaToolMetrics.InvalidContentExceptionMetric,
     S3Metrics.S3ClientExceptionsMetric
   )
 

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -18,9 +18,6 @@ with SurgingContentAgentLifecycle {
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
     S3Metrics.S3AuthorizationError,
-    ContentApiMetrics.ContentApiJsonParseExceptionMetric,
-    ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
-    FaciaToolMetrics.InvalidContentExceptionMetric,
     FaciaMetrics.FaciaToApplicationRedirectMetric
   )
 

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -18,9 +18,6 @@ with SurgingContentAgentLifecycle {
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
     S3Metrics.S3AuthorizationError,
-    FaciaMetrics.JsonParsingErrorCount,
-    ContentApiMetrics.ElasticHttpTimingMetric,
-    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiJsonParseExceptionMetric,
     ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
     FaciaToolMetrics.InvalidContentExceptionMetric,


### PR DESCRIPTION
Add `MetricsSwitch` around the metrics; Only pushing for `PROD` or when the switch is on.

@gklopper 

Remove unused `facia-tool` and `facia` metrics.
