### PR TITLE
Add very big to tool for headline container

### DIFF
--- a/facia-tool/public/javascripts/modules/vars.js
+++ b/facia-tool/public/javascripts/modules/vars.js
@@ -12,7 +12,7 @@ define([
         types: [
             {name: 'news', groups: ['standard', 'big', 'very big', 'huge']},
             {name: 'news/auto'},
-            {name: 'news/headline', groups: ['standard', 'big']},
+            {name: 'news/headline', groups: ['standard', 'big', 'very big']},
             {name: 'news/most-popular'},
             {name: 'news/people'},
             {name: 'news/small-list'},


### PR DESCRIPTION
Adding the option to the tool for easier testing.
As this container isn't used in PROD, no need to worry about confusing anyone.

![So complicated](https://d2t1xqejof9utc.cloudfront.net/screenshots/pics/28ee561c68d5cbea46859194c4c348b9/large.gif)
