### PR TITLE
Test automation identity - Chrome

### DIFF
--- a/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/SeleniumTestSuite.scala
+++ b/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/SeleniumTestSuite.scala
@@ -6,7 +6,7 @@ import com.gu.integration.test.config.WebdriverInitialiser.augmentWebDriver
 import org.openqa.selenium.WebDriver
 import org.scalatest.Matchers
 
-abstract class SeleniumTestSuite extends WebDriverFeatureSpec with Matchers with TestRetries {
+abstract class SeleniumTestSuite extends WebDriverFeatureSpec with Matchers /*with TestRetries*/ {
 
   override protected def startDriver(testName: String, targetBrowser: Browser): WebDriver = {
     println("local conf location " + System.getProperty("local.conf.loc"))

--- a/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/SeleniumTestSuite.scala
+++ b/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/SeleniumTestSuite.scala
@@ -6,7 +6,7 @@ import com.gu.integration.test.config.WebdriverInitialiser.augmentWebDriver
 import org.openqa.selenium.WebDriver
 import org.scalatest.Matchers
 
-abstract class SeleniumTestSuite extends WebDriverFeatureSpec with Matchers /*with TestRetries*/ {
+abstract class SeleniumTestSuite extends WebDriverFeatureSpec with Matchers with TestRetries {
 
   override protected def startDriver(testName: String, targetBrowser: Browser): WebDriver = {
     println("local conf location " + System.getProperty("local.conf.loc"))

--- a/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/steps/BaseSteps.scala
+++ b/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/steps/BaseSteps.scala
@@ -2,15 +2,14 @@ package com.gu.integration.test.steps
 
 import com.gu.automation.support.TestLogging
 import com.gu.integration.test.pages.common.ParentPage
-import com.gu.integration.test.util.PageLoader
 import com.gu.integration.test.util.PageLoader._
 import org.openqa.selenium.WebDriver
 import org.scalatest.Matchers
 
 case class BaseSteps(implicit driver: WebDriver) extends TestLogging with Matchers {
-  def goToStartPage(): ParentPage = {
-    logger.step(s"I am on base page at url: ${PageLoader.frontsBaseUrl}")
+  def goToStartPage(useBetaRedirect: Boolean = true): ParentPage = {
+    logger.step(s"I am on base page at url: $frontsBaseUrl")
     lazy val parentPage = new ParentPage()
-    goTo(parentPage)
+    goTo(parentPage, frontsBaseUrl, useBetaRedirect)
   }
 }

--- a/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/util/PageLoader.scala
+++ b/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/util/PageLoader.scala
@@ -1,25 +1,24 @@
 package com.gu.integration.test.util
 
-import org.openqa.selenium.WebDriver
-
-import com.gu.automation.support.Config
-import com.gu.automation.support.TestLogging
+import com.gu.automation.support.{Config, TestLogging}
 import com.gu.integration.test.pages.common.ParentPage
+import org.openqa.selenium.WebDriver
 
 /**
  * This class is for loading and initializing pages and page objects. Example usage: <code></code>
  */
 object PageLoader extends TestLogging {
 
-  val frontsBaseUrl = Config().getTestBaseUrl //getProperty(BaseUrl)
+  val frontsBaseUrl = Config().getTestBaseUrl()
   val TestAttributeName = "data-test-id"
 
   /**
-   * This method goes to a particular URL and then initializes the provided page object and returns it. To property use it
-   * provide a lazy val page object
+   * This method goes to a particular URL and then initializes the provided page object and returns it. To properly use it
+   * provide a lazy val page object, otherwise Selenium initialized fields might occur before on the actual page.
    */
-  def goTo[Page <: ParentPage](pageObject: => Page, absoluteUrl: String=frontsBaseUrl)(implicit driver: WebDriver): Page = {
-    driver.get(forceBetaSite(turnOfPopups(absoluteUrl)))
+  def goTo[Page <: ParentPage](pageObject: => Page, absoluteUrl: String, useBetaRedirect: Boolean = true)
+                              (implicit driver: WebDriver): Page = {
+    driver.get(forceBetaSite(useBetaRedirect, turnOfPopups(absoluteUrl)))
     pageObject
   }
 
@@ -35,8 +34,8 @@ object PageLoader extends TestLogging {
    * This will append the request parameters needed to switch to beta site. However, for some reason, this does not work on
    * localhost so had to make a check
    */
-  def forceBetaSite(url: String): String = {
-    if (frontsBaseUrl.startsWith("http://localhost")) {
+  def forceBetaSite(useBetaRedirect: Boolean, url: String): String = {
+    if (frontsBaseUrl.startsWith("http://localhost") || !useBetaRedirect) {
       url
     } else {
       frontsBaseUrl + "/preference/platform/mobile?page=" + url + "&view=mobile"

--- a/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/util/PageLoader.scala
+++ b/integration-tests/common-test-lib/src/main/scala/com/gu/integration/test/util/PageLoader.scala
@@ -35,7 +35,7 @@ object PageLoader extends TestLogging {
    * localhost so had to make a check
    */
   def forceBetaSite(useBetaRedirect: Boolean, url: String): String = {
-    if (frontsBaseUrl.startsWith("http://localhost") || !useBetaRedirect) {
+    if (frontsBaseUrl.contains("localhost") || !useBetaRedirect) {
       url
     } else {
       frontsBaseUrl + "/preference/platform/mobile?page=" + url + "&view=mobile"

--- a/integration-tests/identity-tests/src/main/resources/project.conf
+++ b/integration-tests/identity-tests/src/main/resources/project.conf
@@ -1,24 +1,27 @@
-"environment" : "browserStack"
-"testBaseUrl" : "http://m.code.dev-theguardian.com"
+"environment": "browserStack"
+"testBaseUrl": "https://m.code.dev-theguardian.com"
 
-"browsers":[{"name":"firefox", "version":"30"}, {"name":"chrome", "version":"35"}]
+"browsers": [{"name": "firefox", "version": "30"}, {"name": "chrome", "version": "35"}]
 
-"environment" : "browserStack" //value of sauceLabs or browserStack will use the corresponding object below for picking up values
+"environment": "browserStack" //value of sauceLabs or browserStack will use the corresponding object below for picking up values
 
-"autoAcceptSSLCert"     : true //This tells the browser capability to automatically accept not validated SSL certs
-"browserStack":{
-  "platform" : "Windows" //use https://www.browserstack.com/automate/java to set this value
-  "platformVersion"    	: "7" //use https://www.browserstack.com/automate/java to set this value
-  "webDriverRemoteUrl" : "" //define this in your local config as the browserstack remote url.
-  "browserEnvironment" : "browserStack"
-  "browserStackVisualLog" : "true" //tells BrowserStack to create a log with screenshots
+"autoAcceptSSLCert": true //This tells the browser capability to automatically accept not validated SSL certs
+"browserStack": {
+  "platform": "Windows" //use https://www.browserstack.com/automate/java to set this value
+  "platformVersion": "7" //use https://www.browserstack.com/automate/java to set this value
+  "webDriverRemoteUrl": "" //define this in your local config as the browserstack remote url.
+  "browserEnvironment": "browserStack"
+  "browserStackVisualLog": "true" //tells BrowserStack to create a log with screenshots
 }
 
-"user" : { //enter all the below config values in your private local.conf
-  "loginEmail" : ""
-  "loginPwd" : ""
-  "loginName" : ""
-  "faceBookEmail" : ""
-  "faceBookPwd" : ""
-  "faceBookLoginName" : ""
+//enter all the below config values in your private local.conf
+"loginEmail": ""
+"loginPassword": ""
+"user": {
+  "loginName": ""
+  "faceBookEmail": ""
+  "faceBookPwd": ""
+  "faceBookLoginName": ""
 }
+
+

--- a/integration-tests/identity-tests/src/test/scala/com/gu/identity/integration/test/features/IdentityLoginTests.scala
+++ b/integration-tests/identity-tests/src/test/scala/com/gu/identity/integration/test/features/IdentityLoginTests.scala
@@ -10,14 +10,14 @@ class IdentityLoginTests extends IdentitySeleniumTestSuite {
 
   feature("Login feature") {
     scenarioWeb("should be able to login using credentials") { implicit driver: WebDriver =>
-      BaseSteps().goToStartPage()
+      BaseSteps().goToStartPage(useBetaRedirect = false)
       val signInPage = SignInSteps().openSignInPage()
       SignInSteps().signIn(signInPage)
       SignInSteps().checkUserIsLoggedIn(get("loginName"))
     }
 
     scenarioWeb("should be able to login using existing facebook account") { implicit driver: WebDriver =>
-      BaseSteps().goToStartPage()
+      BaseSteps().goToStartPage(useBetaRedirect = false)
       val signInPage = SignInSteps().openSignInPage()
       SignInSteps().signInUsingFaceBook(signInPage)
       SignInSteps().checkUserIsLoggedIn(get("faceBookLoginName"))

--- a/integration-tests/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/integration-tests/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.integration.test.steps
 
-import com.gu.automation.support.TestLogging
+import com.gu.automation.support.{Config, TestLogging}
 import com.gu.identity.integration.test.pages.{ContainerWithSigninModulePage, SignInPage}
 import com.gu.integration.test.util.UserConfig._
 import org.openqa.selenium.WebDriver
@@ -13,12 +13,14 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   }
 
   def signIn(signInPage: SignInPage) = {
-    signInPage.enterEmail(get("loginEmail"))
-    signInPage.enterPwd(get("loginPwd"))
+    logger.step(s"I am signing in using credentials")
+    signInPage.enterEmail(Config().getLoginEmail())
+    signInPage.enterPwd(Config().getLoginPassword())
     signInPage.signInButton.click()
   }
 
   def checkUserIsLoggedIn(expectedLoginName: String) = {
+    logger.step(s"Checking that user is logged in")
     val loginName = new ContainerWithSigninModulePage().signInModule().signInName.getText
     loginName should be(expectedLoginName)
 
@@ -30,6 +32,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   }
 
   def signInUsingFaceBook(signInPage: SignInPage) = {
+    logger.step(s"I am signing in using FaceBook")
     val faceBookSignInPage = signInPage.clickFaceBookSignInButton()
     faceBookSignInPage.enterEmail(get("faceBookEmail"))
     faceBookSignInPage.enterPwd(get("faceBookPwd"))
@@ -37,6 +40,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   }
 
   def checkLoggedInThroughFaceBook() = {
+    logger.step(s"Checking that user is logged in through Facebook")
     val loginCookieFB1 = driver.manage().getCookieNamed("GU_MI")
     loginCookieFB1.getValue should not be empty
 

--- a/integration-tests/project/Build.scala
+++ b/integration-tests/project/Build.scala
@@ -9,7 +9,7 @@ val commonSettings: Seq[Setting[_]] = Seq(
         "Sonatype OSS Staging" at "https://oss.sonatype.org/content/repositories/staging",
         "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"),
     libraryDependencies ++= Seq(
-      "com.gu" %% "scala-automation" % "1.30"
+      "com.gu" %% "scala-automation" % "1.31"
     )
   )
 


### PR DESCRIPTION
Two changes in this pull request. One was to use https when accessing the CODE website, this is because Chrome does not allow you to see secure cookies when not using https. 

Other change is a simple adaptation to use login data as provided by the framework.
