### PR TITLE
Move preroll request event to advert plugin init

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -335,9 +335,9 @@ define([
 
                                 // Init plugins
                                 if (config.switches.videoAdverts && !config.page.blockVideoAds) {
-                                    player.trigger(constructEventName('preroll:request', player));
                                     modules.bindPrerollEvents(player);
                                     player.adCountDown();
+                                    player.trigger(constructEventName('preroll:request', player));
                                     player.ads({
                                         timeout: 3000
                                     });

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -41,6 +41,7 @@ define([
         QUARTILES = [25, 50, 75],
         // Advert and content events used by analytics. The expected order of bean events is:
         EVENTS = [
+            'preroll:request',
             'preroll:ready',
             'preroll:play',
             'preroll:end',
@@ -334,6 +335,8 @@ define([
 
                                 // Init plugins
                                 if (config.switches.videoAdverts && !config.page.blockVideoAds) {
+                                    player.trigger(constructEventName('preroll:request', player));
+                                    modules.bindPrerollEvents(player);
                                     player.adCountDown();
                                     player.ads({
                                         timeout: 3000
@@ -342,7 +345,6 @@ define([
                                         url: modules.getVastUrl(),
                                         vidFormats: ['video/mp4', 'video/webm', 'video/ogv', 'video/x-flv']
                                     });
-                                    modules.bindPrerollEvents(player);
                                 } else {
                                     modules.bindContentEvents(player);
                                 }

--- a/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
+++ b/common/app/assets/javascripts/modules/analytics/omnitureMedia.js
@@ -170,7 +170,7 @@ define([
             player.on('play', this.play.bind(this));
             player.on('pause', this.pause.bind(this));
 
-            player.one('adsready', this.sendNamedEvent.bind(this, 'preroll:request', true));
+            player.one('video:preroll:request', this.sendNamedEvent.bind(this, 'preroll:request', true));
             player.one('video:preroll:play', this.sendNamedEvent.bind(this, 'preroll:play', true));
             player.one('video:preroll:end', this.sendNamedEvent.bind(this, 'preroll:end', true));
             player.one('video:content:play', function() {


### PR DESCRIPTION
This moves the 'preroll:request' event closer to the start of advert initialisation. It is expected that this will increase the number of preroll:request events observed, close to the number of 'video:request' events.

A small discrepancy is expected due to natural decay of delayed events, noise, and a small fraction of blocked video adverts.
