### PR TITLE
Skip validate css grunt target

### DIFF
--- a/dist-root-tc
+++ b/dist-root-tc
@@ -4,7 +4,7 @@ set -o xtrace
 set -o nounset
 set -o errexit
 
-./grunt-tc clean validate test:unit compile emitAbTestInfo
+./grunt-tc clean validate:sass validate:js test:unit compile emitAbTestInfo
 ./sbt-tc "project root" compile test dist
 
 echo "Disting everything."


### PR DESCRIPTION
On team city we currently the sass and image compilation twice, we should skip this step (it's for pre-commit only), and rely on the compile task.
