### PR TITLE
Fix config updates

### DIFF
--- a/facia-tool/app/config/UpdateManager.scala
+++ b/facia-tool/app/config/UpdateManager.scala
@@ -2,7 +2,7 @@ package config
 
 import controllers.CreateFront
 import frontsapi.model.{UpdateActions, Collection, Config, Front}
-import services.S3FrontsApi
+import services.{ConfigAgent, S3FrontsApi}
 import play.api.libs.json.Json
 import util.SanitizeInput
 import com.gu.googleauth.UserIdentity
@@ -21,13 +21,15 @@ object UpdateManager {
    * @param transform The transformation to apply
    */
   private def transformConfig(transform: Config => Config, identity: UserIdentity): Unit = {
-    S3FrontsApi.getMasterConfig map { configJson =>
-      val config = Json.parse(configJson).asOpt[Config] getOrElse {
+    S3FrontsApi.getMasterConfig map { configString =>
+      val configJson = Json.parse(configString)
+      val config = configJson.asOpt[Config] getOrElse {
         throw new RuntimeException(s"Unable to de-serialize config from S3: $configJson")
       }
 
       val newConfig = SanitizeInput.fromConfigSeo(Transformations.prune(transform(config)))
       UpdateActions.putMasterConfig(newConfig, identity)
+      ConfigAgent.refreshWith(configJson)
     }
   }
 

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -44,27 +44,6 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     }
   }
 
-  def updateConfig(): Action[AnyContent] = ExpiringActions.ExpiringAuthAction { request =>
-    FaciaToolMetrics.ApiUsageCount.increment()
-    val configJson: Option[JsValue] = request.body.asJson
-    NoCache {
-      configJson.flatMap(_.asOpt[Config]).map(SanitizeInput.fromConfigSeo).map {
-        case update: Config => {
-
-          //Only update if it is a valid Config object
-          configJson.foreach { json =>
-            ConfigAgent.refreshWith(json)
-          }
-
-          val identity = request.user
-          UpdateActions.putMasterConfig(update, identity)
-          Ok
-        }
-        case _ => NotFound
-      } getOrElse NotFound
-    }
-  }
-
   def readBlock(id: String) = ExpiringActions.ExpiringAuthAction { request =>
     FaciaToolMetrics.ApiUsageCount.increment()
     NoCache {


### PR DESCRIPTION
This updates the contents of the `ConfigAgent` on `facia-tool` on transformations of the `Config` JSON.

Before, we waiting for the cron to update the agents contents, but this would mean that the old contents would get pushed to the Content API. Now the transformations happen in both `S3` and `Agent`.

@stephanfowler 
