### PR TITLE
Refactor headline container to use items

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_headline.scss
+++ b/common/app/assets/stylesheets/module/containers/_headline.scss
@@ -1,140 +1,145 @@
-.container--headline {
-    @include guss-columns(
-        $base-class: '.headline-list',
-        $css3-columns-support: false,
-        $columns-fallback-width: (
-            desktop: gs-span(12)
-        ),
-        $columns-fallback-columns: (
-            desktop: 4
-        )
-    );
+@include guss-columns(
+    $base-class: '.story-list-columns',
+    $css3-columns-support: false,
+    $columns-fallback-width: (
+        desktop: gs-span(12)
+    ),
+    $columns-fallback-columns: (
+        desktop: 4
+    )
+);
 
-    .headline-list {
-        @include mq(desktop) {
-            float: left;
-            @include rem((
-                margin-top: $gs-baseline/3
-            ));
-        }
+.story-list-columns {
+    @include mq(desktop) {
+        float: left;
+        @include rem((
+            margin-top: $gs-baseline/3
+        ));
     }
-    .headline-list__item {
-        @include fs-headline(2);
-        @include box-sizing(border-box);
-        float: none;
+}
+.story-list-columns__item {
+    @include fs-headline(2);
+    @include box-sizing(border-box);
+    float: none;
 
-        @include mq(desktop) {
-            float: left;
-        }
+    @include mq(desktop) {
+        float: left;
     }
-    .headline-list--standard {
-        .headline-list__item {
-            @include rem((
-                padding-bottom: $gs-baseline
-            ));
-            border-top: 0 none;
-
+}
+.story-list-columns--standard {
+    .headline-item {
+        @include mq(desktop) {
             &:nth-child(-n+4) {
-                padding-top: 0;
-            }
-
-            &:nth-child(n+5) {
-                border-top: 1px solid $c-neutral6;
-            }
-        }
-    }
-    .headline-list--big {
-        .headline-list__item {
-            border-top: 2px solid $c-newsAccent;
-            padding-bottom: 0;
-
-            @include mq(desktop) {
-                border-top: 0 none;
+                border-top: 0;
                 padding-top: 0;
             }
         }
-
-        .headline-item__title {
-            @include rem((
-                margin-top: -$gs-baseline/3
-            ));
-
-            @include mq(desktop) {
-                @include fs-headline(4, true);
-            }
-        }
-
-        .item__media-wrapper,
-        .item__image-container {
-            display: block;
-        }
-
-        .item__image-container {
-            @include box-sizing(border-box);
-            @include rem((
-                margin-right: $gs-gutter/2
-            ));
-            float: left;
-            margin-top: 0;
-            width: 50%;
-
-            .responsive-img {
-                width: 100%;
-            }
-
-            @include mq(desktop) {
-                float: none;
-                margin-top: 0;
-                width: 100%;
-            }
-        }
     }
-
-    .headline-list--big + .headline-list--standard {
-        .headline-list__item {
-            @include rem((
-                min-height: $gs-baseline*5
-            ));
-        }
+}
+.story-list-columns--big + .story-list-columns--standard {
+    .story-list-columns__item {
+        @include rem((
+            min-height: $gs-baseline*5
+        ));
     }
-
+}
+.story-list-columns {
     @for $i from 1 through 3 {
         $inverse-i: 4 - $i;
-        .headline-list--#{$i}-big {
+        &.story-list-columns--#{$i}-big {
             @include mq(desktop) {
                 @include rem((
                     width: gs-span($i*3)+($gs-gutter*2)
                 ));
             }
         }
-        .headline-list--#{$i}-big + .headline-list--standard {
+        &.story-list-columns--standard-#{$inverse-i}-col {
             @include mq(desktop) {
                 @include rem((
                     width: gs-span(3*$inverse-i)+$gs-gutter
                 ));
 
-                .headline-list__item {
+                .headline-item {
+                    @include rem((
+                        padding-top: $gs-baseline/1.5
+                    ));
+                    border-top: 1px solid $c-neutral5;
                     clear: none;
-                    border-top: 0 none;
-                    padding-top: 0;
 
                     &:nth-child(#{$inverse-i}n+1) {
                         clear: both;
                     }
 
-                    &:nth-child(n+#{$inverse-i+1}) {
-                        border-top: 1px solid $c-neutral6;
-                    }
-
                     &:nth-child(-n+#{$inverse-i}) {
+                        border-top: 0;
                         padding-top: 0;
                     }
                 }
             }
         }
     }
+}
 
-    .headline-item__body {
-        color: $c-neutral1;
+.headline-item {
+    @include rem((
+        padding-bottom: $gs-baseline,
+        padding-top: $gs-baseline/1.5
+    ));
+    border-top: 1px solid $c-neutral6;
+}
+.headline-item__body {
+    color: $c-neutral1;
+}
+
+.headline-item--big {
+    border-top: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+
+    .item {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .item__link {
+        @include mq(desktop) {
+            border-top-style: none;
+        }
+    }
+
+    .item__byline {
+        display: none;
+    }
+
+    .item__meta {
+        display: none;
+    }
+
+    .item__title {
+        @include mq(desktop) {
+            @include fs-headline(4, true);
+        }
+    }
+
+    .item__media-wrapper {
+        width: 50%;
+
+        @include mq(desktop) {
+            width: 100%;
+        }
+    }
+
+    .item__image-container {
+        @include box-sizing(border-box);
+        @include rem((
+            margin-right: $gs-gutter/2
+        ));
+        float: left;
+        margin-top: 0;
+
+        @include mq(desktop) {
+            float: none;
+            margin-top: 0;
+        }
     }
 }

--- a/common/app/views/fragments/collections/headline.scala.html
+++ b/common/app/views/fragments/collections/headline.scala.html
@@ -1,36 +1,25 @@
 @(items: Seq[model.Trail], containerIndex: Int)(implicit request: RequestHeader, config: model.Config)
 
-@defining(items.filter(item => item.group == Option("0") || item.group == None), items.filter(_.group == Option("1"))) { case (standardItems, bigItems) =>
-    @defining(16 - bigItems.length * 4) { standardItemCount =>
-        <div class="headline-list-container">
-            <ul class="headline-list headline-list--@bigItems.length-big headline-list--big">
+@defining(items.filter(item => item.group == Some("0") || item.group == None), items.filter(_.group == Some("1")), items.filter(_.group == Some("2"))) { case (standardItems, bigItems, veryBigItems) =>
+    <div class="headline-list-container">
+        @defining(16 - bigItems.length * 4) { standardItemCount =>
+            <ul class="story-list-columns story-list-columns--big story-list-columns--@bigItems.length-big">
                 @bigItems.zipWithIndex.map { case (trail, index) =>
-                    <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
-                        <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
-                            @trail.trailPicture(5,3).map{ imageContainer =>
-                                @ImgSrc.imager(imageContainer, 620).map { imgSrc =>
-                                    <div class="item__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
-                                        @Item220.bestFor(imageContainer).map{ url =>
-                                            <img src="@url" class="responsive-img" alt="" />
-                                        }
-                                    </div>
-                                }
-                            }
-                            <div class="headline-item__title">@RemoveOuterParaHtml(trail.headline)</div>
-                        </a>
+                    <li class="story-list-columns__item headline-item headline-item--big">
+                        @fragments.items.standard(trail, index, containerIndex, "div")
                     </li>
                 }
             </ul>
 
-            <ul class="headline-list headline-list--standard">
+            <ul class="story-list-columns story-list-columns--standard story-list-columns--standard-@{standardItemCount/4}-col">
                 @standardItems.slice(0, standardItemCount).zipWithIndex.map{ case (trail, index) =>
-                    <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
+                    <li class="story-list-columns__item headline-item headline-item--standard" data-link-name="trail | @{index + 1}">
                         <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
                             <div class="headline-item__title">@RemoveOuterParaHtml(trail.headline)</div>
                         </a>
                     </li>
                 }
             </ul>
-        </div>
-    }
+        }
+    </div>
 }


### PR DESCRIPTION
- :repeat:: decoupled columns (`.story-list-columns`) and headline items (`.headline__item`)
- :cool:: removed some specificity

This is because I will be using `.headline-item`s elsewhere in  PR coming up soon.
