### PR TITLE
Stop putting snaps to the Content API

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -353,6 +353,10 @@ class Snap(snapId: String,
   override lazy val webPublicationDate = snapWebPublicationDate
 }
 
+object Snap {
+  def isSnap(id: String): Boolean = id.startsWith("snap/")
+}
+
 class Article(content: ApiContentWithMeta) extends Content(content) {
   lazy val main: String = delegate.safeFields.getOrElse("main","")
   lazy val body: String = delegate.safeFields.getOrElse("body","")

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -216,7 +216,7 @@ object Content {
   def fromPressedJson(json: JsValue): Option[Content] = {
     val contentFields: Option[Map[String, String]] = (json \ "safeFields").asOpt[Map[String, String]]
     val itemId: String = (json \ "id").as[String]
-    if (itemId.startsWith("snap/")) {
+    if (Snap.isSnap(itemId)) {
       val snapMeta: Map[String, JsValue] = (json \ "meta").asOpt[Map[String, JsValue]].getOrElse(Map.empty)
       Option(
         new Snap(

--- a/common/app/services/ParseCollection.scala
+++ b/common/app/services/ParseCollection.scala
@@ -78,7 +78,7 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
   }
 
   case class CollectionItem(id: String, metaData: Option[Map[String, JsValue]], webPublicationDate: Option[DateTime]) {
-    val isSnap: Boolean = id.startsWith("snap/")
+    val isSnap: Boolean = Snap.isSnap(id)
   }
 
   def requestCollection(id: String): Future[WSResponse] = {

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -4,7 +4,7 @@ import common.FaciaToolMetrics.{ContentApiPutFailure, ContentApiPutSuccess}
 import common.{ExecutionContexts, Logging}
 import conf.Configuration
 import frontsapi.model.Trail
-import model.Config
+import model.{Snap, Config}
 import org.joda.time.DateTime
 import play.Play
 import play.api.libs.json.{JsNull, JsNumber, JsValue, Json}
@@ -88,9 +88,8 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
   }
 
   private def generateItems(items: List[Trail]): List[Item] =
-    items.map { trail =>
-    Item(trail.id, trail.meta.map(_.map(convertFields))
-    )
+    items.filterNot(t => Snap.isSnap(t.id)).map { trail =>
+      Item(trail.id, trail.meta.map(_.map(convertFields)))
     }
 
   //TODO: These are in transition and will be removed

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -37,7 +37,7 @@ trait FrontJsonLite extends ExecutionContexts{
 
     (curated ++ editorsPicks ++ results)
     .filterNot{ j =>
-      (j \ "id").asOpt[String].exists(_.startsWith("snap/"))
+      (j \ "id").asOpt[String].exists(Snap.isSnap)
      }
     .take(3).map{ j =>
       Json.obj(


### PR DESCRIPTION
We are unnecessarily putting snaps to the Content API.

This is fine, as the Content API just drops anything it doesn't understand.

@stephanfowler 
