### PR TITLE
json lite: shortUrl

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -44,7 +44,7 @@ trait QueryDefaults extends implicits.Collections with ExecutionContexts {
     val tag = "tag=type/gallery|type/article|type/video|type/sudoku"
     val editorsPicks = "show-editors-picks=true"
     val showInlineFields = s"show-fields=$trailFields"
-    val showFields = "internalContentCode,trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent"
+    val showFields = "trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent"
     val showFieldsWithBody = showFields + ",body"
 
     val all = Seq(tag, editorsPicks, showInlineFields, showFields)

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -43,7 +43,7 @@ trait FrontJsonLite extends ExecutionContexts{
       Json.obj(
         "headline" -> ((j \ "meta" \ "headline").asOpt[JsString].getOrElse(j \ "safeFields" \ "headline"): JsValue),
         "thumbnail" -> (j \ "safeFields" \ "thumbnail"),
-        "internalContentCode" -> (j \ "safeFields" \ "internalContentCode"),
+        "shortUrl" -> (j \ "safeFields" \ "shortUrl"),
         "id" -> (j \ "id")
       )
     }

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -39,7 +39,7 @@ trait FrontJsonLite extends ExecutionContexts{
     .filterNot{ j =>
       (j \ "id").asOpt[String].exists(_.startsWith("snap/"))
      }
-    .take(3).map{ j =>
+    .map{ j =>
       Json.obj(
         "headline" -> ((j \ "meta" \ "headline").asOpt[JsString].getOrElse(j \ "safeFields" \ "headline"): JsValue),
         "thumbnail" -> (j \ "safeFields" \ "thumbnail"),


### PR DESCRIPTION
Outputs `shortUrl` rather than `internalContentCode` in {front}/lite.json.

We need a stable article identifier (eg. so Pushy can avoid duplicate alerts if an article's url changes), but internalContentCode feels like it's leaking something not intended to be public.

Also removes arbitrary limit of three items per container in this feed.
