### PR TITLE
Faux block links (1/2: on fromage and saucisson patterns)

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -105,6 +105,25 @@ define([
             images.listen();
         },
 
+        initialiseFauxBlockLinks: function(context){
+            bean.on(
+                context,
+                'mouseenter',
+                '.u-faux-block-link__overlay',
+                function(e) {
+                    $(e.currentTarget).parent().addClass('u-faux-block-link--hover');
+                }
+            );
+            bean.on(
+                context,
+                'mouseleave',
+                '.u-faux-block-link__overlay',
+                function(e) {
+                    $(e.currentTarget).parent().removeClass('u-faux-block-link--hover');
+                }
+            );
+        },
+
         initialiseTopNavItems: function(config){
             var search = new Search(config),
                 header = document.getElementById('header');
@@ -405,6 +424,7 @@ define([
             this.initialised = true;
             modules.testCookie();
             modules.windowEventListeners();
+            modules.initialiseFauxBlockLinks(context);
             modules.checkIframe();
             modules.upgradeImages();
             modules.showTabs();

--- a/common/app/assets/stylesheets/base/_links.scss
+++ b/common/app/assets/stylesheets/base/_links.scss
@@ -28,13 +28,15 @@ clickable areas within it as directly nesting a tags breaks things.
 <div class="u-faux-block-link">
     <img src="" alt="This image is magically clickable" />
 
-    <h3><a href="#">headline</a></h3>
+    <h3><a href="#">This headline is clickable as a normal link</a></h3>
 
     Lorem ipsum dolor sit amet.
 
     <a href="#">another link</a>
 
     <abbr title="Hoverable!">An hoverable abbreviation</abbr>
+
+    <video class="u-faux-block-link__promote">I can interact with that video</video>
 
     <a href="#" class="u-faux-block-link__overlay">headline</a>
 </div>
@@ -46,7 +48,8 @@ clickable areas within it as directly nesting a tags breaks things.
     position: relative;
 }
 .u-faux-block-link a,
-.u-faux-block-link abbr[title] {
+.u-faux-block-link abbr[title],
+.u-faux-block-link__promote {
     position: relative;
     z-index: 1;
 }

--- a/common/app/assets/stylesheets/base/_links.scss
+++ b/common/app/assets/stylesheets/base/_links.scss
@@ -13,3 +13,62 @@ a,
         text-decoration: none;
     }
 }
+
+/*doc
+---
+title: Faux block link utility
+name: u-faux-block-link
+category: Utilities
+---
+
+A Faux block-level link. Used for when you need a block-level link with
+clickable areas within it as directly nesting a tags breaks things.
+
+```html_example
+<div class="u-faux-block-link">
+    <img src="" alt="This image is magically clickable" />
+
+    <h3><a href="#">headline</a></h3>
+
+    Lorem ipsum dolor sit amet.
+
+    <a href="#">another link</a>
+
+    <abbr title="Hoverable!">An hoverable abbreviation</abbr>
+
+    <a href="#" class="u-faux-block-link__overlay">headline</a>
+</div>
+```
+*/
+// Thanks to @BPScott http://codepen.io/BPScott/pen/Erwan
+// for this great technique
+.u-faux-block-link {
+    position: relative;
+}
+.u-faux-block-link a,
+.u-faux-block-link abbr[title] {
+    position: relative;
+    z-index: 1;
+}
+.u-faux-block-link__overlay {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow: hidden;
+    text-indent: 200%;
+    white-space: nowrap;
+    background: rgba(0, 0, 0, 0); // IE9 fix
+}
+// Increased specificity so it trumps ".block-link a"
+a.u-faux-block-link__overlay {
+    position: absolute;
+    z-index: 0;
+    // this line is needed as all elements have a solid black
+    // background in high contrast mode
+    opacity: 0;
+}
+// Underline cta when block is hovered
+.u-faux-block-link--hover .u-faux-block-link__cta {
+    text-decoration: underline;
+}

--- a/common/app/assets/stylesheets/module/containers/_commentanddebate.scss
+++ b/common/app/assets/stylesheets/module/containers/_commentanddebate.scss
@@ -1,6 +1,6 @@
 .container--commentanddebate {
     .l-row--items-3 {
-        .item__link {
+        .item__tonal-border {
             border-color: $c-commentAccent;
         }
         .item__byline {

--- a/common/app/assets/stylesheets/module/containers/_features.scss
+++ b/common/app/assets/stylesheets/module/containers/_features.scss
@@ -117,16 +117,6 @@
     .item__title {
         background-color: $c-featuresVariant;
     }
-    .item__link:hover,
-    .item__link:focus {
-        .item__title {
-            // Restore lost underline because of the absolute positioning
-            text-decoration: underline;
-        }
-    }
-    .item__link:active .item__title {
-        text-decoration: none;
-    }
 }
 
 .facia-container--layout-content {

--- a/common/app/assets/stylesheets/module/containers/_featuresvolumes.scss
+++ b/common/app/assets/stylesheets/module/containers/_featuresvolumes.scss
@@ -1,7 +1,6 @@
 .container--featuresvolumes {
     .container__body > .facia-slice-wrapper {
-        .tone-accent-border,
-        .item__link {
+        .item__tonal-border {
             border-top: 0;
         }
     }

--- a/common/app/assets/stylesheets/module/containers/_related.scss
+++ b/common/app/assets/stylesheets/module/containers/_related.scss
@@ -1,7 +1,11 @@
 .related {
-    .item__link {
+    .item__tonal-border {
         @include mq($to: tablet) {
             border-top: 1px solid $c-neutral5 !important;
+        }
+    }
+    .item__link {
+        @include mq($to: tablet) {
             @include rem((
                 padding-top: 7px,
                 margin-top: -12px

--- a/common/app/assets/stylesheets/module/facia/_fromage.scss
+++ b/common/app/assets/stylesheets/module/facia/_fromage.scss
@@ -109,12 +109,12 @@
     &:focus {
         text-decoration: none;
 
-        .item__title {
+        .u-faux-block-link__cta {
             text-decoration: underline;
         }
     }
     &:active {
-        .item__title {
+        .u-faux-block-link__cta {
             text-decoration: none;
         }
     }

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -193,12 +193,11 @@
         }
     }
 }
-.item__top-border {
+.item__tonal-border {
     border-top: $item-top-border-height solid $c-newsAccent;
 }
 .item__link {
     display: block;
-    border-top: $item-top-border-height solid $c-newsAccent;
     color: $c-neutral1;
 
     &:visited {

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -210,7 +210,13 @@
     &:active {
         color: $c-neutral1;
     }
-    &:hover {
+    &:hover,
+    &:focus {
+        text-decoration: none;
+
+        .u-faux-block-link__cta {
+            text-decoration: underline;
+        }
         .item__cta {
             background-color: rgba($c-neutral2, 1);
         }
@@ -219,9 +225,11 @@
             background-color: $c-media-icon;
         }
     }
-}
-.item__link--no-border {
-    border-width: 0;
+    &:active {
+        .u-faux-block-link__cta {
+            text-decoration: none;
+        }
+    }
 }
 .item__video-container {
     margin-top: 4px;

--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -14,14 +14,11 @@ $item-top-border-height: 1px;
     }
 }
 @mixin item--hide-tone-border {
-    .item__link {
+    .item__tonal-border {
         border-top-width: 0 !important;
     }
     .item__image-container {
         margin-top: 0 !important;
-    }
-    .item__top-border {
-        border-top-width: 0 !important;
     }
 }
 @mixin show-only-if-svg-is-supported {

--- a/common/app/views/fragments/collections/headline.scala.html
+++ b/common/app/views/fragments/collections/headline.scala.html
@@ -6,7 +6,7 @@
             <ul class="headline-list headline-list--@bigItems.length-big headline-list--big">
                 @bigItems.zipWithIndex.map { case (trail, index) =>
                     <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
-                        <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
+                        <a @LinkTo(trail).map{url=>href="@url"} class="headline-item__body" data-link-name="article">
                             @trail.trailPicture(5,3).map{ imageContainer =>
                                 @ImgSrc.imager(imageContainer, 620).map { imgSrc =>
                                     <div class="item__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
@@ -25,7 +25,7 @@
             <ul class="headline-list headline-list--standard">
                 @standardItems.slice(0, standardItemCount).zipWithIndex.map{ case (trail, index) =>
                     <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
-                        <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
+                        <a @LinkTo(trail).map{url=>href="@url"} class="headline-item__body" data-link-name="article">
                             <div class="headline-item__title">@RemoveOuterParaHtml(trail.headline)</div>
                         </a>
                     </li>

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -21,7 +21,7 @@
                 @fragments.items.elements.image(trail, inlineImage = true, maxWidth = 940)
             }
         }
-        <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
+        <a @LinkTo(trail).map{url=>href="@url"} class="item__link" data-link-name="article">
             @fragments.items.elements.title(trail, index, 0)
         </a>
 
@@ -34,5 +34,5 @@
 
     @fragments.items.elements.supporting(trail.supporting, trail, style = "fullwidth")
 
-    <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+    <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 </div>

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -6,7 +6,7 @@
 @import views.support.{GetClasses, SnapData, Item620}
 
 <div
-    class="@GetClasses.forItem(trail, true) baguette"
+    class="@GetClasses.forItem(trail, true) baguette u-faux-block-link"
     data-link-name="trail | @{index + 1}"
     @SnapData(trail)
 >
@@ -15,17 +15,14 @@
         @trail match {
             case v: Video if v.mainVideo.isDefined => {
                 @video(v.mainVideo.get, Item620, v.webTitle, 620, 350, true, false, Some(v.endSlatePath))
-                <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
-                    @fragments.items.elements.title(trail, index, 0)
-                </a>
             }
             case _ => {
-                <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
-                    @fragments.items.elements.image(trail, inlineImage = true, maxWidth = 940)
-                    @fragments.items.elements.title(trail, index, 0)
-                </a>
+                @fragments.items.elements.image(trail, inlineImage = true, maxWidth = 940)
             }
         }
+        <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
+            @fragments.items.elements.title(trail, index, 0)
+        </a>
 
         @trail match { case content:model.Content => @fragments.items.elements.starRating(content) }
 
@@ -36,4 +33,5 @@
 
     @fragments.items.elements.supporting(trail.supporting, trail, style = "fullwidth")
 
+    <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 </div>

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -12,6 +12,7 @@
 >
 
     <div class="item__container">
+        <div class="item__tonal-border tone-accent-border"></div>
         @trail match {
             case v: Video if v.mainVideo.isDefined => {
                 @video(v.mainVideo.get, Item620, v.webTitle, 620, 350, true, false, Some(v.endSlatePath))

--- a/common/app/views/fragments/items/elements/title.scala.html
+++ b/common/app/views/fragments/items/elements/title.scala.html
@@ -1,4 +1,4 @@
-@(trail: Trail, itemIndex: Int, containerIndex: Int)(implicit request: RequestHeader)
+@(trail: Trail, itemIndex: Int, containerIndex: Int, labelCssClasses: String = "u-faux-block-link__cta")(implicit request: RequestHeader)
 
 @defining((trail.visualTone, if (containerIndex == 0 && itemIndex == 0) { "1" } else { "2" })) { case (tone, headerLevel) =>
     <h@headerLevel class="item__title">
@@ -11,6 +11,6 @@
         @if(tone == "comment") {
             <span class="i i-quote-orange"></span>
         }
-        @RemoveOuterParaHtml(trail.headline)
+        <span class="@labelCssClasses">@RemoveOuterParaHtml(trail.headline)</span>
     </h@headerLevel>
 }

--- a/common/app/views/fragments/items/feature.scala.html
+++ b/common/app/views/fragments/items/feature.scala.html
@@ -28,7 +28,7 @@
                 }
             }
             <div class="item__header">
-                <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
+                <a @LinkTo(trail).map{url=>href="@url"} class="item__link" data-link-name="article">
                     <h2 class="item__title">
                         @if(trail.isBreaking){
                             <span class="item__live-indicator">Breaking News</span>
@@ -43,7 +43,7 @@
                     </h2>
                 </a>
             </div>
-            <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+            <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
         </div>
     </@element>
 }

--- a/common/app/views/fragments/items/feature.scala.html
+++ b/common/app/views/fragments/items/feature.scala.html
@@ -13,22 +13,22 @@
         @SnapData(trail)>
 
         <div class="item__container">
-
-            <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
-                @if(trail.imageAdjust != "hide") {
-                    @trail.trailPicture(5,3).map{ imageContainer =>
-                        @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__media-wrapper">
-                                <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
-                                    @if(inlineImages){
-                                        @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
-                                    }
-                                </div>
+            <div class="item__tonal-border tone-accent-border"></div>
+            @if(trail.imageAdjust != "hide") {
+                @trail.trailPicture(5,3).map{ imageContainer =>
+                    @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
+                        <div class="item__media-wrapper">
+                            <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
+                                @if(inlineImages){
+                                    @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                }
                             </div>
-                        }
+                        </div>
                     }
                 }
-                <div class="item__header">
+            }
+            <div class="item__header">
+                <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
                     <h2 class="item__title">
                         @if(trail.isBreaking){
                             <span class="item__live-indicator">Breaking News</span>
@@ -39,11 +39,11 @@
                         @if(tone == "comment") {
                             <span class="i i-quote-orange"></span>
                         }
-                        @RemoveOuterParaHtml(trail.headline)
+                        <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
                     </h2>
-                </div>
-            </a>
-
+                </a>
+            </div>
+            <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
         </div>
     </@element>
 }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -39,7 +39,7 @@
                     }
                 }
             }
-            <a @LinkTo(trail).map{url=>href=@url} class="fromage__link" data-link-name="article">
+            <a @LinkTo(trail).map{url=>href="@url"} class="fromage__link" data-link-name="article">
                 @fragments.items.elements.title(trail, index, 0)
             </a>
 
@@ -56,7 +56,7 @@
             @if(imageAdjust == "default") {
                 @trail.trailPicture(5,3).map{ imageContainer =>
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                        <a @LinkTo(trail).map{url=>href=@url} data-link-name="article">
+                        <a @LinkTo(trail).map{url=>href="@url"} data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
                                 <div class="fromage__image-container u-responsive-ratio">
                                     @Item220.bestFor(imageContainer).map{ url => <img src="@url" alt="" /> }
@@ -79,6 +79,6 @@
                 @fragments.items.elements.meta(trail)
             }
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </div>
 }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -20,14 +20,8 @@
             @trail match {
                 case v: Video if v.mainVideo.isDefined && imageAdjust == "boost" => {
                     @fromageVideo(v.mainVideo.get, v.webTitle, true, true, Some(v.endSlatePath))
-
-                    <a @LinkTo(trail).map{url=>href=@url} class="fromage__link" data-link-name="article">
-                        @fragments.items.elements.title(trail, index, 0)
-                    </a>
                 }
-
                 case _ => {
-                    <a @LinkTo(trail).map{url=>href=@url} class="fromage__link" data-link-name="article">
                     @if(imageAdjust != Some("hide")) {
                         @trail.trailPicture(5,3).map{ imageContainer =>
                             @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
@@ -43,10 +37,11 @@
                             }
                         }
                     }
-                    @fragments.items.elements.title(trail, index, 0)
-                    </a>
                 }
             }
+            <a @LinkTo(trail).map{url=>href=@url} class="fromage__link" data-link-name="article">
+                @fragments.items.elements.title(trail, index, 0)
+            </a>
 
             @trail match { case content:model.Content => @fragments.items.elements.starRating(content) }
 

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -52,7 +52,9 @@
 
             @if(tone == "comment") {
                 @trail.byline.map { byLine =>
-                    <p class="fromage__byline tone-colour">@Html(byLine)</p>
+                    @trail match { case content:model.Content =>
+                        <p class="fromage__byline tone-colour">@ContributorLinks(Html(byLine), content.contributors)</p>
+                    }
                 }
             }
 
@@ -82,6 +84,6 @@
                 @fragments.items.elements.meta(trail)
             }
         </div>
-
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </div>
 }

--- a/common/app/views/fragments/items/fromageVideo.scala.html
+++ b/common/app/views/fragments/items/fromageVideo.scala.html
@@ -7,7 +7,8 @@
     "fromage__video-wrapper" -> true,
     "fromage__video-wrapper--boost" -> boost,
     "fromage__video-wrapper--first" -> isFirst,
-    "fromage__video-wrapper--second" -> !isFirst
+    "fromage__video-wrapper--second" -> !isFirst,
+    "u-faux-block-link__promote" -> true
 ))">
     <div class="fromage__video-container">
     @if(boost) {

--- a/common/app/views/fragments/items/linksList/standard.scala.html
+++ b/common/app/views/fragments/items/linksList/standard.scala.html
@@ -2,7 +2,7 @@
 
 @defining(imageAdjustOverride.getOrElse(trail.imageAdjust)) { imageAdjust =>
 <li class="l-columns__item linkslist__item" data-link-name="trail | @{index + 1}">
-    <a @LinkTo(trail).map{url=>href=@url} class="linkslist__action@if(imageAdjust == "boost" && trail.trailPicture(5,3).nonEmpty){ action--has-image}" data-link-name="article">
+    <a @LinkTo(trail).map{url=>href="@url"} class="linkslist__action@if(imageAdjust == "boost" && trail.trailPicture(5,3).nonEmpty){ action--has-image}" data-link-name="article">
         @if(imageAdjust == "boost") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>

--- a/common/app/views/fragments/items/saucisson.scala.html
+++ b/common/app/views/fragments/items/saucisson.scala.html
@@ -13,8 +13,9 @@
         @SnapData(trail)>
 
         <div class="saucisson__container">
+            @fragments.items.elements.image(trail)
+
             <a @LinkTo(trail).map{url=>href=@url} class="saucisson__link" data-link-name="article">
-                @fragments.items.elements.image(trail)
                 @fragments.items.elements.title(trail, index, 0)
             </a>
 
@@ -22,7 +23,9 @@
 
             @if(tone == "comment") {
                 @trail.byline.map { byLine =>
-                    <p class="item__byline tone-colour">@Html(byLine)</p>
+                    @trail match { case content:model.Content =>
+                        <p class="item__byline tone-colour">@ContributorLinks(Html(byLine), content.contributors)</p>
+                    }
                 }
             }
 
@@ -38,6 +41,7 @@
                 @fragments.items.elements.meta(trail)
             }
         </div>
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 
     </div>
 }

--- a/common/app/views/fragments/items/saucisson.scala.html
+++ b/common/app/views/fragments/items/saucisson.scala.html
@@ -15,7 +15,7 @@
         <div class="saucisson__container">
             @fragments.items.elements.image(trail)
 
-            <a @LinkTo(trail).map{url=>href=@url} class="saucisson__link" data-link-name="article">
+            <a @LinkTo(trail).map{url=>href="@url"} class="saucisson__link" data-link-name="article">
                 @fragments.items.elements.title(trail, index, 0)
             </a>
 
@@ -41,7 +41,7 @@
                 @fragments.items.elements.meta(trail)
             }
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 
     </div>
 }

--- a/common/app/views/fragments/items/simplecomment.scala.html
+++ b/common/app/views/fragments/items/simplecomment.scala.html
@@ -11,20 +11,24 @@
     data-link-name="trail | @{index + 1}">
 
     <div class="item__container">
+        <div class="item__tonal-border"></div>
+        @trail.contributorAvatar.map{ url =>
+            <div class="item__avatar">
+                <img src="@url" alt="" class="item__avatar__media" />
+            </div>
+        }
         <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
-            @trail.contributorAvatar.map{ url =>
-                <div class="item__avatar">
-                    <img src="@url" alt="" class="item__avatar__media" />
-                </div>
-            }
             <h2 class="item__title">
                 <span class="i i-quote-orange"></span>
-                @RemoveOuterParaHtml(trail.headline)
+                <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
             </h2>
         </a>
         @trail.byline.map { byLine =>
-            <p class="item__byline">@Html(byLine)</p>
+            @trail match { case content:model.Content =>
+                <p class="item__byline tone-colour tone-comment">@ContributorLinks(Html(byLine), content.contributors)</p>
+            }
         }
         <div class="item__meta"></div>
     </div>
+    <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 </@element>

--- a/common/app/views/fragments/items/simplecomment.scala.html
+++ b/common/app/views/fragments/items/simplecomment.scala.html
@@ -30,5 +30,5 @@
         }
         <div class="item__meta"></div>
     </div>
-    <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+    <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 </@element>

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -26,7 +26,9 @@
 
             @if(tone == "comment") {
                 @trail.byline.map { byLine =>
-                    <p class="item__byline tone-colour">@Html(byLine)</p>
+                    @trail match { case content:model.Content =>
+                        <p class="item__byline tone-colour">@ContributorLinks(Html(byLine), content.contributors)</p>
+                    }
                 }
             }
 
@@ -36,5 +38,6 @@
 
             @fragments.items.elements.meta(trail)
         </div>
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -13,8 +13,8 @@
         @SnapData(trail)>
 
         <div class="item__container">
-
-            <a @LinkTo(trail).map{url=>href=@url} class="item__link tone-accent-border @if(linkToneBackground){tone-background}" data-link-name="article">
+            <div class="item__tonal-border"></div>
+            <a @LinkTo(trail).map{url=>href=@url} class="item__link @if(linkToneBackground){tone-background}" data-link-name="article">
                 @fragments.items.elements.image(trail, inlineImage = containerIndex == 0 && index < 4)
                 <div class="item__header">
                     @fragments.items.elements.title(trail, index, containerIndex)

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -14,7 +14,7 @@
 
         <div class="item__container">
             <div class="item__tonal-border"></div>
-            <a @LinkTo(trail).map{url=>href=@url} class="item__link @if(linkToneBackground){tone-background}" data-link-name="article">
+            <a @LinkTo(trail).map{url=>href="@url"} class="item__link @if(linkToneBackground){tone-background}" data-link-name="article">
                 @fragments.items.elements.image(trail, inlineImage = containerIndex == 0 && index < 4)
                 <div class="item__header">
                     @fragments.items.elements.title(trail, index, containerIndex)
@@ -38,6 +38,6 @@
 
             @fragments.items.elements.meta(trail)
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -10,8 +10,8 @@
         data-link-name="trail | @{index + 1}">
 
         <div class="item__container">
-
-            <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="gallery" data-is-ajax>
+            <div class="item__tonal-border tone-accent-border"></div>
+            <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="gallery" data-is-ajax>
                 <div class="item__media-wrapper item__media-wrapper--has-icon js-gallerythumbs" data-gallery-url="@trail.url">
                     <div class="item__cta item__cta--gallery">
                         <p>Expand</p>

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -51,6 +51,6 @@
             }
 
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -35,11 +35,11 @@
                     }
                 </div>
             </a>
-            <a href="@LinkTo{@trail.url}" class="item__link item__link--no-border" data-link-name="article">
+            <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
                 <div class="item__header">
                     <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--has-icon-mobile">
                         <span class="i i-gallery-yellow-small"></span>
-                        @RemoveOuterParaHtml(trail.headline)
+                        <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
                     </h@if(isFirstContainer && index == 0){1}else{2}>
                 </div>
             </a>
@@ -51,6 +51,6 @@
             }
 
         </div>
-
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -12,6 +12,7 @@
         data-link-name="trail | @{index + 1}">
 
         <div class="item__container">
+            <div class="item__tonal-border tone-accent-border"></div>
             @trail match {
                 case videoItem: Video if videoItem.mainVideo.isDefined && trail.imageAdjust == "boost" => {
                     <div class="item__top-border tone-accent-border">

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -15,25 +15,21 @@
             <div class="item__tonal-border tone-accent-border"></div>
             @trail match {
                 case videoItem: Video if videoItem.mainVideo.isDefined && trail.imageAdjust == "boost" => {
-                    <div class="item__top-border tone-accent-border">
-                        <div class="item__media-wrapper item__media-wrapper--has-icon">
-                            <div class="item__video-container">
-                                @video(videoItem.mainVideo.get, Item300, videoItem.webTitle, 300, 180, false, false, Some(videoItem.endSlatePath))
-                            </div>
+                    <div class="item__media-wrapper item__media-wrapper--has-icon">
+                        <div class="item__video-container">
+                            @video(videoItem.mainVideo.get, Item300, videoItem.webTitle, 300, 180, false, false, Some(videoItem.endSlatePath))
                         </div>
-
-                        <a href="@LinkTo{@trail.url}" class="item__link item__link--no-border" data-link-name="article">
-                            <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--video-icon item__title--inline-video">
-
-                            @RemoveOuterParaHtml(trail.headline)
-                            </h@if(isFirstContainer && index == 0){1}else{2}>
-                        </a>
                     </div>
+
+                    <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
+                        <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--video-icon item__title--inline-video">
+                            <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
+                        </h@if(isFirstContainer && index == 0){1}else{2}>
+                    </a>
                 }
 
                 case _ => {
-                    <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
-                        <div class="item__media-wrapper item__media-wrapper--has-icon">
+                    <div class="item__media-wrapper item__media-wrapper--has-icon">
                         @trail.trailPicture(5,3).map{ imageContainer =>
                             @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                                 <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
@@ -47,9 +43,10 @@
                                 <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                             </div>
                         }
-                        </div>
+                    </div>
+                    <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
                         <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--video-icon">
-                            @RemoveOuterParaHtml(trail.headline)
+                            <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
                         </h@if(isFirstContainer && index == 0){1}else{2}>
                     </a>
                 }
@@ -61,6 +58,6 @@
                 <div class="item__standfirst">@Html(text)</div>
             }
         </div>
-
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -58,6 +58,6 @@
                 <div class="item__standfirst">@Html(text)</div>
             }
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -769,6 +769,7 @@ object GetClasses {
       additionalClasses,
       "l-row__item",
       "facia-slice__item",
+      "u-faux-block-link",
       s"facia-slice__item--volume-${trail.group.getOrElse("0")}"
     )
     val classes = f.foldLeft(baseClasses){case (cl, fun) => cl :+ fun(trail)} ++ makeSnapClasses(trail)

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -811,6 +811,7 @@ object GetClasses {
     val baseClasses: Seq[String] = Seq(
       "fromage",
       s"tone-${trail.visualTone}",
+      "u-faux-block-link",
       "tone-accent-border"
     )
     val f: Seq[(Trail, String) => String] = Seq(

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -836,6 +836,7 @@ object GetClasses {
     val baseClasses: Seq[String] = Seq(
       "saucisson",
       s"tone-${trail.visualTone}",
+      "u-faux-block-link",
       "tone-accent-border"
     )
     val f: Seq[(Trail) => String] = Seq(


### PR DESCRIPTION
To accomodate upcoming design changes where we'll have links between the item image and the title, here 
- [new] `.u-faux-block-link` CSS utility: see http://codepen.io/BPScott/pen/Erwan (thanks to @BPScott)
- [new] Entire surface of saucisson and fromage items are clickable
- [new] Byline is clickable in saucisson and fromage

![ ](http://media.giphy.com/media/Dto9XLxyCzyE/giphy.gif)
