### PR TITLE
Faux block links (2/2: on other items)

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_commentanddebate.scss
+++ b/common/app/assets/stylesheets/module/containers/_commentanddebate.scss
@@ -1,6 +1,6 @@
 .container--commentanddebate {
     .l-row--items-3 {
-        .item__link {
+        .item__tonal-border {
             border-color: $c-commentAccent;
         }
         .item__byline {

--- a/common/app/assets/stylesheets/module/containers/_features.scss
+++ b/common/app/assets/stylesheets/module/containers/_features.scss
@@ -117,16 +117,6 @@
     .item__title {
         background-color: $c-featuresVariant;
     }
-    .item__link:hover,
-    .item__link:focus {
-        .item__title {
-            // Restore lost underline because of the absolute positioning
-            text-decoration: underline;
-        }
-    }
-    .item__link:active .item__title {
-        text-decoration: none;
-    }
 }
 
 .facia-container--layout-content {

--- a/common/app/assets/stylesheets/module/containers/_featuresvolumes.scss
+++ b/common/app/assets/stylesheets/module/containers/_featuresvolumes.scss
@@ -1,7 +1,6 @@
 .container--featuresvolumes {
     .container__body > .facia-slice-wrapper {
-        .tone-accent-border,
-        .item__link {
+        .item__tonal-border {
             border-top: 0;
         }
     }

--- a/common/app/assets/stylesheets/module/containers/_related.scss
+++ b/common/app/assets/stylesheets/module/containers/_related.scss
@@ -1,7 +1,11 @@
 .related {
-    .item__link {
+    .item__tonal-border {
         @include mq($to: tablet) {
             border-top: 1px solid $c-neutral5 !important;
+        }
+    }
+    .item__link {
+        @include mq($to: tablet) {
             @include rem((
                 padding-top: 7px,
                 margin-top: -12px

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -193,12 +193,11 @@
         }
     }
 }
-.item__top-border {
+.item__tonal-border {
     border-top: $item-top-border-height solid $c-newsAccent;
 }
 .item__link {
     display: block;
-    border-top: $item-top-border-height solid $c-newsAccent;
     color: $c-neutral1;
 
     &:visited {

--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -14,14 +14,11 @@ $item-top-border-height: 1px;
     }
 }
 @mixin item--hide-tone-border {
-    .item__link {
+    .item__tonal-border {
         border-top-width: 0 !important;
     }
     .item__image-container {
         margin-top: 0 !important;
-    }
-    .item__top-border {
-        border-top-width: 0 !important;
     }
 }
 @mixin show-only-if-svg-is-supported {

--- a/common/app/views/fragments/collections/headline.scala.html
+++ b/common/app/views/fragments/collections/headline.scala.html
@@ -6,7 +6,7 @@
             <ul class="headline-list headline-list--@bigItems.length-big headline-list--big">
                 @bigItems.zipWithIndex.map { case (trail, index) =>
                     <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
-                        <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
+                        <a @LinkTo(trail).map{url=>href="@url"} class="headline-item__body" data-link-name="article">
                             @trail.trailPicture(5,3).map{ imageContainer =>
                                 @ImgSrc.imager(imageContainer, 620).map { imgSrc =>
                                     <div class="item__image-container js-image-upgrade inlined-image" data-src="@imgSrc">
@@ -25,7 +25,7 @@
             <ul class="headline-list headline-list--standard">
                 @standardItems.slice(0, standardItemCount).zipWithIndex.map{ case (trail, index) =>
                     <li class="headline-list__item headline-item" data-link-name="trail | @{index + 1}">
-                        <a @LinkTo(trail).map{url=>href=@url} class="headline-item__body" data-link-name="article">
+                        <a @LinkTo(trail).map{url=>href="@url"} class="headline-item__body" data-link-name="article">
                             <div class="headline-item__title">@RemoveOuterParaHtml(trail.headline)</div>
                         </a>
                     </li>

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -21,7 +21,7 @@
                 @fragments.items.elements.image(trail, inlineImage = true, maxWidth = 940)
             }
         }
-        <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
+        <a @LinkTo(trail).map{url=>href="@url"} class="item__link" data-link-name="article">
             @fragments.items.elements.title(trail, index, 0)
         </a>
 
@@ -34,5 +34,5 @@
 
     @fragments.items.elements.supporting(trail.supporting, trail, style = "fullwidth")
 
-    <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+    <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 </div>

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -12,6 +12,7 @@
 >
 
     <div class="item__container">
+        <div class="item__tonal-border tone-accent-border"></div>
         @trail match {
             case v: Video if v.mainVideo.isDefined => {
                 @video(v.mainVideo.get, Item620, v.webTitle, 620, 350, true, false, Some(v.endSlatePath))

--- a/common/app/views/fragments/items/feature.scala.html
+++ b/common/app/views/fragments/items/feature.scala.html
@@ -28,7 +28,7 @@
                 }
             }
             <div class="item__header">
-                <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
+                <a @LinkTo(trail).map{url=>href="@url"} class="item__link" data-link-name="article">
                     <h2 class="item__title">
                         @if(trail.isBreaking){
                             <span class="item__live-indicator">Breaking News</span>
@@ -43,7 +43,7 @@
                     </h2>
                 </a>
             </div>
-            <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+            <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
         </div>
     </@element>
 }

--- a/common/app/views/fragments/items/feature.scala.html
+++ b/common/app/views/fragments/items/feature.scala.html
@@ -13,22 +13,22 @@
         @SnapData(trail)>
 
         <div class="item__container">
-
-            <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
-                @if(trail.imageAdjust != "hide") {
-                    @trail.trailPicture(5,3).map{ imageContainer =>
-                        @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                            <div class="item__media-wrapper">
-                                <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
-                                    @if(inlineImages){
-                                        @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
-                                    }
-                                </div>
+            <div class="item__tonal-border tone-accent-border"></div>
+            @if(trail.imageAdjust != "hide") {
+                @trail.trailPicture(5,3).map{ imageContainer =>
+                    @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
+                        <div class="item__media-wrapper">
+                            <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
+                                @if(inlineImages){
+                                    @Item300.bestFor(imageContainer).map{ url => <img src="@url" class="responsive-img" alt="" /> }
+                                }
                             </div>
-                        }
+                        </div>
                     }
                 }
-                <div class="item__header">
+            }
+            <div class="item__header">
+                <a @LinkTo(trail).map{url=>href=@url} class="item__link" data-link-name="article">
                     <h2 class="item__title">
                         @if(trail.isBreaking){
                             <span class="item__live-indicator">Breaking News</span>
@@ -39,11 +39,11 @@
                         @if(tone == "comment") {
                             <span class="i i-quote-orange"></span>
                         }
-                        @RemoveOuterParaHtml(trail.headline)
+                        <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
                     </h2>
-                </div>
-            </a>
-
+                </a>
+            </div>
+            <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
         </div>
     </@element>
 }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -39,7 +39,7 @@
                     }
                 }
             }
-            <a @LinkTo(trail).map{url=>href=@url} class="fromage__link" data-link-name="article">
+            <a @LinkTo(trail).map{url=>href="@url"} class="fromage__link" data-link-name="article">
                 @fragments.items.elements.title(trail, index, 0)
             </a>
 
@@ -56,7 +56,7 @@
             @if(imageAdjust == "default") {
                 @trail.trailPicture(5,3).map{ imageContainer =>
                     @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
-                        <a @LinkTo(trail).map{url=>href=@url} data-link-name="article">
+                        <a @LinkTo(trail).map{url=>href="@url"} data-link-name="article">
                             <div class="fromage__media-wrapper fromage__media-wrapper--second">
                                 <div class="fromage__image-container u-responsive-ratio">
                                     @Item220.bestFor(imageContainer).map{ url => <img src="@url" alt="" /> }
@@ -79,6 +79,6 @@
                 @fragments.items.elements.meta(trail)
             }
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </div>
 }

--- a/common/app/views/fragments/items/linksList/standard.scala.html
+++ b/common/app/views/fragments/items/linksList/standard.scala.html
@@ -2,7 +2,7 @@
 
 @defining(imageAdjustOverride.getOrElse(trail.imageAdjust)) { imageAdjust =>
 <li class="l-columns__item linkslist__item" data-link-name="trail | @{index + 1}">
-    <a @LinkTo(trail).map{url=>href=@url} class="linkslist__action@if(imageAdjust == "boost" && trail.trailPicture(5,3).nonEmpty){ action--has-image}" data-link-name="article">
+    <a @LinkTo(trail).map{url=>href="@url"} class="linkslist__action@if(imageAdjust == "boost" && trail.trailPicture(5,3).nonEmpty){ action--has-image}" data-link-name="article">
         @if(imageAdjust == "boost") {
             @trail.trailPicture(5,3).map{ imageContainer =>
                 @ImgSrc.imager(imageContainer, Item120).map { imgSrc =>

--- a/common/app/views/fragments/items/saucisson.scala.html
+++ b/common/app/views/fragments/items/saucisson.scala.html
@@ -15,7 +15,7 @@
         <div class="saucisson__container">
             @fragments.items.elements.image(trail)
 
-            <a @LinkTo(trail).map{url=>href=@url} class="saucisson__link" data-link-name="article">
+            <a @LinkTo(trail).map{url=>href="@url"} class="saucisson__link" data-link-name="article">
                 @fragments.items.elements.title(trail, index, 0)
             </a>
 
@@ -41,7 +41,7 @@
                 @fragments.items.elements.meta(trail)
             }
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 
     </div>
 }

--- a/common/app/views/fragments/items/simplecomment.scala.html
+++ b/common/app/views/fragments/items/simplecomment.scala.html
@@ -11,20 +11,24 @@
     data-link-name="trail | @{index + 1}">
 
     <div class="item__container">
+        <div class="item__tonal-border"></div>
+        @trail.contributorAvatar.map{ url =>
+            <div class="item__avatar">
+                <img src="@url" alt="" class="item__avatar__media" />
+            </div>
+        }
         <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
-            @trail.contributorAvatar.map{ url =>
-                <div class="item__avatar">
-                    <img src="@url" alt="" class="item__avatar__media" />
-                </div>
-            }
             <h2 class="item__title">
                 <span class="i i-quote-orange"></span>
-                @RemoveOuterParaHtml(trail.headline)
+                <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
             </h2>
         </a>
         @trail.byline.map { byLine =>
-            <p class="item__byline">@Html(byLine)</p>
+            @trail match { case content:model.Content =>
+                <p class="item__byline tone-colour tone-comment">@ContributorLinks(Html(byLine), content.contributors)</p>
+            }
         }
         <div class="item__meta"></div>
     </div>
+    <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 </@element>

--- a/common/app/views/fragments/items/simplecomment.scala.html
+++ b/common/app/views/fragments/items/simplecomment.scala.html
@@ -30,5 +30,5 @@
         }
         <div class="item__meta"></div>
     </div>
-    <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+    <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
 </@element>

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -26,7 +26,9 @@
 
             @if(tone == "comment") {
                 @trail.byline.map { byLine =>
-                    <p class="item__byline tone-colour">@Html(byLine)</p>
+                    @trail match { case content:model.Content =>
+                        <p class="item__byline tone-colour">@ContributorLinks(Html(byLine), content.contributors)</p>
+                    }
                 }
             }
 
@@ -36,5 +38,6 @@
 
             @fragments.items.elements.meta(trail)
         </div>
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -13,8 +13,8 @@
         @SnapData(trail)>
 
         <div class="item__container">
-
-            <a @LinkTo(trail).map{url=>href=@url} class="item__link tone-accent-border @if(linkToneBackground){tone-background}" data-link-name="article">
+            <div class="item__tonal-border"></div>
+            <a @LinkTo(trail).map{url=>href=@url} class="item__link @if(linkToneBackground){tone-background}" data-link-name="article">
                 @fragments.items.elements.image(trail, inlineImage = containerIndex == 0 && index < 4)
                 <div class="item__header">
                     @fragments.items.elements.title(trail, index, containerIndex)

--- a/common/app/views/fragments/items/standard.scala.html
+++ b/common/app/views/fragments/items/standard.scala.html
@@ -14,7 +14,7 @@
 
         <div class="item__container">
             <div class="item__tonal-border"></div>
-            <a @LinkTo(trail).map{url=>href=@url} class="item__link @if(linkToneBackground){tone-background}" data-link-name="article">
+            <a @LinkTo(trail).map{url=>href="@url"} class="item__link @if(linkToneBackground){tone-background}" data-link-name="article">
                 @fragments.items.elements.image(trail, inlineImage = containerIndex == 0 && index < 4)
                 <div class="item__header">
                     @fragments.items.elements.title(trail, index, containerIndex)
@@ -38,6 +38,6 @@
 
             @fragments.items.elements.meta(trail)
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -10,8 +10,8 @@
         data-link-name="trail | @{index + 1}">
 
         <div class="item__container">
-
-            <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="gallery" data-is-ajax>
+            <div class="item__tonal-border tone-accent-border"></div>
+            <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="gallery" data-is-ajax>
                 <div class="item__media-wrapper item__media-wrapper--has-icon js-gallerythumbs" data-gallery-url="@trail.url">
                     <div class="item__cta item__cta--gallery">
                         <p>Expand</p>

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -51,6 +51,6 @@
             }
 
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardGallery.scala.html
+++ b/common/app/views/fragments/items/standardGallery.scala.html
@@ -35,11 +35,11 @@
                     }
                 </div>
             </a>
-            <a href="@LinkTo{@trail.url}" class="item__link item__link--no-border" data-link-name="article">
+            <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
                 <div class="item__header">
                     <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--has-icon-mobile">
                         <span class="i i-gallery-yellow-small"></span>
-                        @RemoveOuterParaHtml(trail.headline)
+                        <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
                     </h@if(isFirstContainer && index == 0){1}else{2}>
                 </div>
             </a>
@@ -51,6 +51,6 @@
             }
 
         </div>
-
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -12,6 +12,7 @@
         data-link-name="trail | @{index + 1}">
 
         <div class="item__container">
+            <div class="item__tonal-border tone-accent-border"></div>
             @trail match {
                 case videoItem: Video if videoItem.mainVideo.isDefined && trail.imageAdjust == "boost" => {
                     <div class="item__top-border tone-accent-border">

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -15,25 +15,21 @@
             <div class="item__tonal-border tone-accent-border"></div>
             @trail match {
                 case videoItem: Video if videoItem.mainVideo.isDefined && trail.imageAdjust == "boost" => {
-                    <div class="item__top-border tone-accent-border">
-                        <div class="item__media-wrapper item__media-wrapper--has-icon">
-                            <div class="item__video-container">
-                                @video(videoItem.mainVideo.get, Item300, videoItem.webTitle, 300, 180, false, false, Some(videoItem.endSlatePath))
-                            </div>
+                    <div class="item__media-wrapper item__media-wrapper--has-icon">
+                        <div class="item__video-container">
+                            @video(videoItem.mainVideo.get, Item300, videoItem.webTitle, 300, 180, false, false, Some(videoItem.endSlatePath))
                         </div>
-
-                        <a href="@LinkTo{@trail.url}" class="item__link item__link--no-border" data-link-name="article">
-                            <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--video-icon item__title--inline-video">
-
-                            @RemoveOuterParaHtml(trail.headline)
-                            </h@if(isFirstContainer && index == 0){1}else{2}>
-                        </a>
                     </div>
+
+                    <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
+                        <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--video-icon item__title--inline-video">
+                            <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
+                        </h@if(isFirstContainer && index == 0){1}else{2}>
+                    </a>
                 }
 
                 case _ => {
-                    <a href="@LinkTo{@trail.url}" class="item__link tone-accent-border" data-link-name="article">
-                        <div class="item__media-wrapper item__media-wrapper--has-icon">
+                    <div class="item__media-wrapper item__media-wrapper--has-icon">
                         @trail.trailPicture(5,3).map{ imageContainer =>
                             @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                                 <div class="item__image-container u-responsive-ratio js-image-upgrade @if(inlineImages){ inlined-image}" data-src="@imgSrc">
@@ -47,9 +43,10 @@
                                 <img src="@Static("images/no-image.png")" class="responsive-img" alt="" />
                             </div>
                         }
-                        </div>
+                    </div>
+                    <a href="@LinkTo{@trail.url}" class="item__link" data-link-name="article">
                         <h@if(isFirstContainer && index == 0){1}else{2} class="item__title item__title--video-icon">
-                            @RemoveOuterParaHtml(trail.headline)
+                            <span class="u-faux-block-link__cta">@RemoveOuterParaHtml(trail.headline)</span>
                         </h@if(isFirstContainer && index == 0){1}else{2}>
                     </a>
                 }
@@ -61,6 +58,6 @@
                 <div class="item__standfirst">@Html(text)</div>
             }
         </div>
-
+        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -58,6 +58,6 @@
                 <div class="item__standfirst">@Html(text)</div>
             }
         </div>
-        <a @LinkTo(trail).map{url=>href=@url} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
+        <a @LinkTo(trail).map{url=>href="@url"} class="u-faux-block-link__overlay" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(trail.headline)</a>
     </@element>
 }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -769,6 +769,7 @@ object GetClasses {
       additionalClasses,
       "l-row__item",
       "facia-slice__item",
+      "u-faux-block-link",
       s"facia-slice__item--volume-${trail.group.getOrElse("0")}"
     )
     val classes = f.foldLeft(baseClasses){case (cl, fun) => cl :+ fun(trail)} ++ makeSnapClasses(trail)


### PR DESCRIPTION
I separated the changes in two PRs to make it easier to review and understand.

See #5542, the first part of the PR.
- [new] Tonal border element replaces the border initially on item links

![ ](http://media.giphy.com/media/mg9jKAcV3tmTK/giphy.gif)
