### PR TITLE
Speed up Grunt a bit, especially JS compilation with --dev

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,7 +83,7 @@ module.exports = function (grunt) {
                     stripe:       '../../../../common/app/assets/javascripts/components/stripe/stripe.min',
                     raven:        '../../../../common/app/assets/javascripts/components/raven-js/raven'
                 },
-                optimize: 'uglify2',
+                optimize: (isDev) ? 'none' : 'uglify2',
                 generateSourceMaps: true,
                 preserveLicenseComments: false,
                 fileExclusionRegExp: /^bower_components$/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,8 @@ var pngquant = require('imagemin-pngquant');
 
 module.exports = function (grunt) {
 
+    require('time-grunt')(grunt);
+
     var isDev = (grunt.option('dev') !== undefined) ? Boolean(grunt.option('dev')) : process.env.GRUNT_ISDEV === '1',
         singleRun = grunt.option('single-run') !== false,
         staticTargetDir = './static/target/',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,13 @@ module.exports = function (grunt) {
 
     require('time-grunt')(grunt);
 
+    // Load the plugins
+    require('jit-grunt')(grunt, {
+        replace: 'grunt-text-replace',
+        scsslint: 'grunt-scss-lint',
+        cssmetrics: 'grunt-css-metrics'
+    });
+
     var isDev = (grunt.option('dev') !== undefined) ? Boolean(grunt.option('dev')) : process.env.GRUNT_ISDEV === '1',
         singleRun = grunt.option('single-run') !== false,
         staticTargetDir = './static/target/',
@@ -920,28 +927,6 @@ module.exports = function (grunt) {
             }
         }
     });
-
-    // Load the plugins
-    grunt.loadNpmTasks('grunt-karma');
-    grunt.loadNpmTasks('grunt-contrib-sass');
-    grunt.loadNpmTasks('grunt-scss-lint');
-    grunt.loadNpmTasks('grunt-css-metrics');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-contrib-requirejs');
-    grunt.loadNpmTasks('grunt-webfontjson');
-    grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-shell');
-    grunt.loadNpmTasks('grunt-mkdir');
-    grunt.loadNpmTasks('grunt-contrib-imagemin');
-    grunt.loadNpmTasks('grunt-asset-hash');
-    grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-asset-monitor');
-    grunt.loadNpmTasks('grunt-text-replace');
-    grunt.loadNpmTasks('grunt-pagespeed');
-    grunt.loadNpmTasks('grunt-csdevmode');
-    grunt.loadNpmTasks('grunt-hologram');
 
     // Default task
     grunt.registerTask('default', ['clean', 'validate', 'compile', 'test', 'analyse']);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-text-replace": "~0.3.11",
     "grunt-webfontjson": "~0.0.3",
     "imagemin-pngquant": "^0.1.2",
+    "jit-grunt": "^0.8.0",
     "karma": "^0.12.16",
     "karma-chrome-launcher": "~0.1.0",
     "karma-coffee-preprocessor": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "mkdirp": "^0.5.0",
     "moment": "^2.7.0",
     "phantomjs": "~1.9.1",
-    "svgo": "0.4.4"
+    "svgo": "0.4.4",
+    "time-grunt": "^0.4.0"
   },
   "scripts": {
     "postinstall": "grunt hookmeup"


### PR DESCRIPTION
running `grunt compile:js --dev`:

before
![screen shot 2014-08-13 at 14 51 17](https://cloud.githubusercontent.com/assets/867233/3906351/2eb99988-22f2-11e4-8a87-6f2d6266ffce.png)

after
![screen shot 2014-08-13 at 14 50 34](https://cloud.githubusercontent.com/assets/867233/3906329/0f58f6c4-22f2-11e4-9f9b-8c5765194cac.png)

@ironsidevsquincy @mattosborn @phamann i’m aware there’s a lot going on the grunt file, and I may well have missed a good reason for optimize being on by default in requirejs - is this ok?
