### PR TITLE
Normalise padding-top across all content pages

### DIFF
--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -152,7 +152,7 @@ $mpu-ad-label-height: 34px;
 
 $action-icon-width: 23px;
 $action-icon-rightspace: 7px;
-$content-top-padding: ($gs-baseline/6)*5;
+$content-top-padding: $gs-baseline;
 
 
 // Video.JS player

--- a/common/app/assets/stylesheets/module/content/_article.scss
+++ b/common/app/assets/stylesheets/module/content/_article.scss
@@ -1,10 +1,3 @@
-
-.content--article.tone-news--article .content__head {
-    @include rem((
-        padding-top: $content-top-padding
-    ));
-}
-
 .media-primary {
     @include rem((
         margin-left: $gs-gutter / -2,

--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -33,7 +33,7 @@
 .content__head {
     @include mq(tablet) {
         @include rem((
-            padding-top:$content-top-padding
+            padding-top: $content-top-padding
         ));
     }
 
@@ -43,7 +43,7 @@
         .tone-background {
             @include mq(tablet) {
                 @include rem((
-                    padding-top:$content-top-padding
+                    padding-top: $content-top-padding
                 ));
             }
         }

--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -30,6 +30,26 @@
     }
 }
 
+.content__head {
+    @include mq(tablet) {
+        @include rem((
+            padding-top:$content-top-padding
+        ));
+    }
+
+    &.content__head--tonal {
+        padding-top: 0;
+
+        .tone-background {
+            @include mq(tablet) {
+                @include rem((
+                    padding-top:$content-top-padding
+                ));
+            }
+        }
+    }
+}
+
 .content__main-column {
     position: relative;
 

--- a/common/app/assets/stylesheets/module/content/_media.head.scss
+++ b/common/app/assets/stylesheets/module/content/_media.head.scss
@@ -21,8 +21,7 @@
     background-color: $c-neutral1;
     color: $c-neutral7;
     @include rem((
-        padding-bottom: $gs-baseline*2,
-        padding-top: $content-top-padding
+        padding-bottom: $gs-baseline*2
     ));
 
     .content__section .tone-colour {

--- a/common/app/assets/stylesheets/theme/_tones-head.scss
+++ b/common/app/assets/stylesheets/theme/_tones-head.scss
@@ -15,11 +15,7 @@
 
     .content__head--tonal {
         background-color: #ffffff;
-        .tone-background {
-            @include rem((
-                padding-top: $content-top-padding
-            ));
-        }
+
         .tone-background--accent {
             @include rem((
                 padding: $gs-baseline/2 0 $gs-baseline


### PR DESCRIPTION
Due to lots of refactoring, the padding at the top of our content pages was inconsistent. Now articles, tones and media pages all have a consistent 6px -> 12px padding.

This is PR 1 of many from Chris Pearsons design snag list.

/cc @kaelig 
