### PR TITLE
Changing commit from commit -> push

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -548,7 +548,7 @@ module.exports = function (grunt) {
              * Using this task to copy hooks, as Grunt's own copy task doesn't preserve permissions
              */
             copyHooks: {
-                command: 'cp git-hooks/pre-commit .git/hooks/',
+                command: 'ln -s ../git-hooks .git/hooks',
                 options: {
                     stdout: true,
                     stderr: true,
@@ -866,7 +866,7 @@ module.exports = function (grunt) {
             flash      : [staticTargetDir + 'flash', staticHashDir + 'flash'],
             fonts      : [staticTargetDir + 'fonts', staticHashDir + 'fonts'],
             // Clean any pre-commit hooks in .git/hooks directory
-            hooks      : ['.git/hooks/pre-commit'],
+            hooks      : ['.git/hooks'],
             assets     : ['common/conf/assets']
         },
 

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,11 +1,12 @@
 #!/bin/sh
 #
-# Pre-commit hooks
+# Pre-push hooks
 
+branch=$(git symbolic-ref --short HEAD)
 
 # Validate CSS
 CSS_SRC_PATTERN="\.scss"
-git diff --cached --name-only | if grep "$CSS_SRC_PATTERN"
+git diff "origin/$branch" --cached --name-only | if grep "$CSS_SRC_PATTERN"
 then
     grunt validate:css validate:sass
 fi
@@ -13,14 +14,14 @@ cssValidateResult=$?
 
 # Validate JS
 JS_SRC_PATTERN="\.js$"
-git diff --cached --name-only | if grep "$JS_SRC_PATTERN"
+git diff "origin/$branch" --cached --name-only | if grep "$JS_SRC_PATTERN"
 then
     grunt validate:js
 fi
 jsValidateResult=$?
 
 # Test JS
-git diff --cached --name-only | if grep "[^/]\+/\(app\|test\)/assets/javascripts/.*$JS_SRC_PATTERN"
+git diff "origin/$branch" --cached --name-only | if grep "[^/]\+/\(app\|test\)/assets/javascripts/.*$JS_SRC_PATTERN"
 then
     grunt test:unit
 fi


### PR DESCRIPTION
After chats with people such as @phamann and @adamnfish - it seems the pre-commit hook really gets in the way of certain workflows (i.e. Committing loads and rebasing later). Basically it caters for the simplest use of git only.

I also understand that the hook is necessary so eagle-eye @kaelig et al don't have to rummage through the SasS finding formatting problems.

This caters for both I feel.

![Push it](http://c0.thejournal.ie/media/2014/08/tumblr_mc2lfx6djp1qcvaxho1_r3_500.gif)
