### PR TITLE
lifting media-wrapper above u-faux-block-link__overlay

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -250,6 +250,7 @@
 }
 .item__media-wrapper {
     position: relative;
+    z-index: 1;
 }
 .item--has-image {
     .item__media-wrapper,


### PR DESCRIPTION
this makes it possible to interact with videos on fronts when they are in a container with a `u-faux-block-link__overlay` (which currently takes all mouse interaction)

@kaelig @robertberry 
