### PR TITLE
Fix 'FB undefined' issue

### DIFF
--- a/common/app/assets/javascripts/modules/identity/facebook-authorizer.js
+++ b/common/app/assets/javascripts/modules/identity/facebook-authorizer.js
@@ -102,10 +102,14 @@ define([''], function() {
     };
 
     FacebookAuthorizer.prototype._loadFacebookScript = function () {
-        require(['js!facebook'], this._handleScriptLoaded.bind(this));
+        require(['js!facebook!exports=FB'], this._handleScriptLoaded.bind(this));
     };
 
     FacebookAuthorizer.prototype._handleScriptLoaded = function () {
+
+        if (!FB) {
+            return;
+        }
 
         FB.init({
             appId: this.appId,


### PR DESCRIPTION
http://frontend.errors.guim.co.uk/guardian/frontend/group/5/

Uses `!exports` - see https://github.com/cujojs/curl/wiki/js
Also explicitly checks `FB` exists

Means you can also get a reference to `fb`, rather than pulling it from the `window` object. If you want
