### PR TITLE
Commercial component - content API

### DIFF
--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -12,27 +12,25 @@
                 <ul class="lineitems">
                     @for(item <- items) {
                         <li class="lineitem">
-                            <div>
-                                <a class="lineitem__link" href="@AdLink{@item.webUrl}" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle">
-                                    <img class="lineitem__image" src="@item.mainPicture.map(_.largestImage.map(_.url))" />
-                                    <div class="lineitem__offer">
-                                        <h4 class="lineitem__title">@item.webTitle</h4>
-                                        <div class="item__meta">
-                                            <time
-                                                class="item__timestamp js-item__timestamp"
-                                                datetime="@item.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-                                                data-timestamp="@item.webPublicationDate.getMillis"
-                                                data-relativeformat="short">
-                                                <i class="i i-clock-light-grey"></i>
-                                                <span class="timestamp__text">
-                                                    <span class="u-h">Published: </span>
-                                                    @Format(item.webPublicationDate, "d MMM y")
-                                                </span>
-                                            </time>
-                                        </div>
+                            <a class="lineitem__link" href="@AdLink{@item.webUrl}" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle">
+                                <img class="lineitem__image" src="@item.mainPicture.map(_.largestImage.map(_.url))" />
+                                <div class="lineitem__offer">
+                                    <h4 class="lineitem__title">@item.webTitle</h4>
+                                    <div class="item__meta">
+                                        <time
+                                            class="item__timestamp js-item__timestamp"
+                                            datetime="@item.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                                            data-timestamp="@item.webPublicationDate.getMillis"
+                                            data-relativeformat="short">
+                                            <i class="i i-clock-light-grey"></i>
+                                            <span class="timestamp__text">
+                                                <span class="u-h">Published: </span>
+                                                @Format(item.webPublicationDate, "d MMM y")
+                                            </span>
+                                        </time>
                                     </div>
-                                </a>
-                            </div>
+                                </div>
+                            </a>
                         </li>
                     }
                 </ul>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,10 +1,42 @@
 @(items: Seq[model.Content])(implicit request: RequestHeader)
 
-@for(item <- items) {
-    <div>
-        <p>@item.webTitle</p>
-        <p>@item.webUrl</p>
-        <p>@item.webPublicationDate</p>
-        <p><img src="@item.mainPicture.map(_.largestImage.map(_.url))" /></p>
+@defining(("1_0", "2014-08-14")) { case (version, date) =>
+    <div class="commercial commercial--low commercial--capi">
+        <div class="facia-container__inner">
+            <div class="container__title commercial__head">
+                <h3 class="commercial__title">
+                    The Guardian
+                </h3>
+            </div>
+            <div class="container__body commercial__body">
+                <ul class="lineitems">
+                    @for(item <- items) {
+                        <li class="lineitem">
+                            <div>
+                                <a class="lineitem__link" href="@AdLink{@item.webUrl}" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle">
+                                    <img class="lineitem__image" src="@item.mainPicture.map(_.largestImage.map(_.url))" />
+                                    <div class="lineitem__offer">
+                                        <h4 class="lineitem__title">@item.webTitle</h4>
+                                        <div class="item__meta">
+                                            <time
+                                                class="item__timestamp js-item__timestamp"
+                                                datetime="@item.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                                                data-timestamp="@item.webPublicationDate.getMillis"
+                                                data-relativeformat="short">
+                                                <i class="i i-clock-light-grey"></i>
+                                                <span class="timestamp__text">
+                                                    <span class="u-h">Published: </span>
+                                                    @Format(item.webPublicationDate, "d MMM y")
+                                                </span>
+                                            </time>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+                        </li>
+                    }
+                </ul>
+            </div>
+        </div>
     </div>
 }

--- a/common/app/assets/javascripts/modules/commercial/loader.js
+++ b/common/app/assets/javascripts/modules/commercial/loader.js
@@ -51,6 +51,7 @@ define([
         this.oastoken           = options.oastoken || '';
         this.adType             = options.adType || 'desktop';
         this.multiComponents    = (options.components || []).map(function(c) { return 'c=' + c; }).join('&');
+        this.capi               = (options.capi || []).map(function(t) {return 't=' + t;}).join('&');
         this.components         = {
             bestbuy:           this.host + 'money/bestbuys.json',
             bestbuyHigh:       this.host + 'money/bestbuys-high.json',
@@ -66,6 +67,7 @@ define([
             soulmatesHigh:     this.host + 'soulmates/mixed-high.json',
             travel:            this.host + 'travel/offers.json?'            + 's=' + this.section + '&' + this.getKeywords(),
             travelHigh:        this.host + 'travel/offers-high.json?'       + 's=' + this.section + '&' + this.getKeywords(),
+            capi:              this.host + 'capi.json?'                     + this.capi + '&' + this.getKeywords(),
             multi:             this.host + 'multi.json?'                    + this.multiComponents
         };
         this.postLoadEvents = {

--- a/common/app/assets/stylesheets/module/commercial/_capi.scss
+++ b/common/app/assets/stylesheets/module/commercial/_capi.scss
@@ -1,0 +1,100 @@
+/* ==========================================================================
+Content API component
+========================================================================== */
+
+.commercial--capi {
+    .commercial__head {
+        border-top: 0;
+        @include rem((
+            margin-top: $gs-baseline
+        ));
+        height: auto;
+        position: relative;
+    }
+    .commercial__body {
+        @include rem((
+            padding: 0 0 $gs-baseline
+        ));
+    }
+    .lineitems {
+        @include rem((
+            margin: 0 (-$gs-gutter/2)
+        ));
+    }
+    .lineitem {
+        width: 50%;
+        float: left;
+        border-top: 0;
+        @include rem((
+            padding: 0 $gs-gutter/2
+        ));
+        
+        &:nth-child(n+3) {
+            display: none;
+        }
+        
+        + .lineitem {
+            border-left: 1px solid $c-neutral4;
+        }
+        
+        .item__meta {
+            position: static;
+        }
+    }
+    .lineitem__image {
+        width: 100%;
+    }
+    .lineitem__link {
+        float: none;
+    }
+    @include mq(tablet) {
+        .lineitem {
+            width: percentage(1/3);
+            
+            &:nth-child(3) {
+                display: block;
+            }
+        }
+    }
+    @include mq(rightCol) {
+        .facia-container__inner {
+            position: relative;
+        }
+        .lineitem {
+            width: percentage(1/4);
+            
+            &:nth-child(4) {
+                display: block;
+            }
+        }
+    }
+    @include mq(desktop) {
+        .commercial__head {
+            width: auto;
+        }
+    }
+}
+
+@mixin c-capi-leftCol {
+    .commercial__body {
+        @include rem((
+            padding-top: $gs-baseline
+        ));
+    }    
+}
+
+/* Fronts */
+
+.facia-container--layout-front .commercial--capi {
+    @include mq(faciaLeftCol) {
+        @include c-capi-leftCol;
+    }
+}
+
+/* Articles */
+
+.facia-container--layout-content .commercial--capi {
+    @include mq(leftCol) {
+        @include c-capi-leftCol;
+    }
+}

--- a/common/app/assets/stylesheets/module/commercial/_capi.scss
+++ b/common/app/assets/stylesheets/module/commercial/_capi.scss
@@ -4,11 +4,11 @@ Content API component
 
 .commercial--capi {
     .commercial__head {
+        height: auto;
         border-top: 0;
         @include rem((
             margin-top: $gs-baseline
         ));
-        height: auto;
         position: relative;
     }
     .commercial__body {
@@ -22,12 +22,12 @@ Content API component
         ));
     }
     .lineitem {
-        width: 50%;
-        float: left;
         border-top: 0;
         @include rem((
             padding: 0 $gs-gutter/2
         ));
+        width: 50%;
+        float: left;
         
         &:nth-child(n+3) {
             display: none;

--- a/common/app/assets/stylesheets/module/commercial/_capi.scss
+++ b/common/app/assets/stylesheets/module/commercial/_capi.scss
@@ -88,6 +88,13 @@ Content API component
 .facia-container--layout-front .commercial--capi {
     @include mq(faciaLeftCol) {
         @include c-capi-leftCol;
+        
+        .commercial__head {
+            @include rem((
+                width: gs-span(2),
+                margin-right: $gs-gutter
+            ));
+        }
     }
 }
 

--- a/common/app/assets/stylesheets/module/commercial/_commercial.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial.scss
@@ -7,6 +7,7 @@
 @import '_masterclasses';
 @import '_soulmates';
 @import '_travel';
+@import '_capi.scss';
 @import '_multi';
 @import '_dfp-component.scss';
 


### PR DESCRIPTION
This adds html and styling for the commercial component that is driven from DFP and uses the content API for it's content.

There is more work to be done on the DFP side to allow easier entry of chosen stories.

![screen shot 2014-08-14 at 15 20 18](https://cloud.githubusercontent.com/assets/1303616/3921152/7268d30c-23be-11e4-99d9-a92e271a5a54.png)
