### PR TITLE
Remove the century redirection switch

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -6,7 +6,6 @@ import services.{Archive, DynamoDB, Googlebot404Count}
 import java.net.URLDecoder
 import model.{NoCache, Cached}
 import scala.concurrent.Future.successful
-import conf.Switches.CenturyRedirectionSwitch
 
 object ArchiveController extends Controller with Logging with ExecutionContexts {
  
@@ -117,27 +116,23 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   }
 
   def newCenturyUrl(path: String): Option[String] = {
-    if (CenturyRedirectionSwitch.isSwitchedOn) {
-        val centuryUrlEx = """www.theguardian.com\/century(\/)?$""".r
-        val centuryDecadeUrlEx = """www.theguardian.com(\/\d{4}-\d{4})(\/)?$""".r
-        val centuryStoryUrlEx = """www.theguardian.com\/(\d{4}-\d{4})\/Story\/([0|1]?,[\d]*,-?\d+,[\d]*)(.*)""".r
-        val ngCenturyFront = "www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century"
-        path match {
-          case centuryUrlEx(_) => {
-            Some(ngCenturyFront)
-          }
-          case centuryDecadeUrlEx(centuryDecade, _) => {
-            Some(ngCenturyFront)
-          }
-          case centuryStoryUrlEx(decade, storyId, ext) => {
-            Some(s"www.theguardian.com/century/$decade/Story/$storyId$ext")
-          }
-          case _ => {
-            None
-          }
-        }
-      } else {
+    val centuryUrlEx = """www.theguardian.com\/century(\/)?$""".r
+    val centuryDecadeUrlEx = """www.theguardian.com(\/\d{4}-\d{4})(\/)?$""".r
+    val centuryStoryUrlEx = """www.theguardian.com\/(\d{4}-\d{4})\/Story\/([0|1]?,[\d]*,-?\d+,[\d]*)(.*)""".r
+    val ngCenturyFront = "www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century"
+    path match {
+      case centuryUrlEx(_) => {
+        Some(ngCenturyFront)
+      }
+      case centuryDecadeUrlEx(centuryDecade, _) => {
+        Some(ngCenturyFront)
+      }
+      case centuryStoryUrlEx(decade, storyId, ext) => {
+        Some(s"www.theguardian.com/century/$decade/Story/$storyId$ext")
+      }
+      case _ => {
         None
+      }
     }
   }
 

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -121,18 +121,10 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
     val centuryStoryUrlEx = """www.theguardian.com\/(\d{4}-\d{4})\/Story\/([0|1]?,[\d]*,-?\d+,[\d]*)(.*)""".r
     val ngCenturyFront = "www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century"
     path match {
-      case centuryUrlEx(_) => {
-        Some(ngCenturyFront)
-      }
-      case centuryDecadeUrlEx(centuryDecade, _) => {
-        Some(ngCenturyFront)
-      }
-      case centuryStoryUrlEx(decade, storyId, ext) => {
-        Some(s"www.theguardian.com/century/$decade/Story/$storyId$ext")
-      }
-      case _ => {
-        None
-      }
+      case centuryUrlEx(_) => Some(ngCenturyFront)
+      case centuryDecadeUrlEx(centuryDecade, _) => Some(ngCenturyFront)
+      case centuryStoryUrlEx(decade, storyId, ext) => Some(s"www.theguardian.com/century/$decade/Story/$storyId$ext")
+      case _ =>  None
     }
   }
 

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -4,7 +4,6 @@ import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.Matchers
 import org.scalatest.FlatSpec
-import conf.Switches.CenturyRedirectionSwitch
 
 class ArchiveControllerTest extends FlatSpec with Matchers {
 
@@ -51,21 +50,20 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
     location should be ("http://www.theguardian.com/football/News_Story/0,1563,1655638,00.html")
   }
 
-  it should "redirect century urls correctly when enabled" in Fake {
+  it should "redirect century urls correctly" in Fake {
     val tests = Map[String, Option[String]](
+      "www.theguardian.com" -> None,
       "www.theguardian.com/century" -> Some("www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
     )
-    CenturyRedirectionSwitch.switchOn()
     tests foreach {
       case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
     }
   }
 
-  it should "redirect decade urls correctly when enabled" in Fake {
+  it should "redirect decade urls correctly" in Fake {
     val tests = Map[String, Option[String]](
       "www.theguardian.com/1899-1909" -> Some("www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
     )
-    CenturyRedirectionSwitch.switchOn()
     tests foreach {
       case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
     }
@@ -75,67 +73,15 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
     val tests = Map[String, Option[String]](
       "www.theguardian.com/discover-culture/2014/jul/22/mid-century-textiles-then-and-now" -> None
     )
-    CenturyRedirectionSwitch.switchOn()
     tests foreach {
       case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
     }
   }
 
-  it should "redirect an R1 century article to a corrected decade story endpoint when enabled" in Fake {
+  it should "redirect an R1 century article to a corrected decade story endpoint" in Fake {
     val tests = Map[String, Option[String]](
       "www.theguardian.com/1899-1909/Story/0,,126404,00.html" -> Some("www.theguardian.com/century/1899-1909/Story/0,,126404,00.html")
     )
-    CenturyRedirectionSwitch.switchOn()
-    tests foreach {
-      case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
-    }
-  }
-
-  it should "not hijack www.theguardian.com by mistake when century redirection is enabled" in Fake {
-    val tests = Map[String, Option[String]](
-      "www.theguardian.com" -> None
-    )
-    CenturyRedirectionSwitch.switchOn()
-    tests foreach {
-      case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
-    }
-  }
-
-  it should "not redirect century urls when disabled" in Fake {
-    val tests = Map[String, Option[String]](
-      "www.theguardian.com/century" -> None
-    )
-    CenturyRedirectionSwitch.switchOff()
-    tests foreach {
-      case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
-    }
-  }
-
-  it should "not redirect century/decade urls when disabled" in Fake {
-    val tests = Map[String, Option[String]](
-      "www.theguardian.com/century/1899-1909" -> None
-    )
-    CenturyRedirectionSwitch.switchOff()
-    tests foreach {
-      case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
-    }
-  }
-
-  it should "not redirect decade urls when disabled" in Fake {
-    val tests = Map[String, Option[String]](
-      "www.theguardian.com/1899-1909" -> None
-    )
-    CenturyRedirectionSwitch.switchOff()
-    tests foreach {
-      case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
-    }
-  }
-
-  it should "not redirect a century story url when disabled" in Fake {
-    val tests = Map[String, Option[String]](
-      "www.theguardian.com/1899-1909/Story/0,,126404,00.html" -> None
-    )
-    CenturyRedirectionSwitch.switchOff()
     tests foreach {
       case (key, value) => controllers.ArchiveController.newCenturyUrl(key) should be (value)
     }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -404,14 +404,6 @@ object Switches extends Collections {
     safeState = On, sellByDate = new LocalDate(2014, 9, 30)
   )
 
-  val CenturyRedirectionSwitch = Switch("Feature Switches", "redirect-century-pages",
-    "If switched on, we redirect /century and /century/yyyy-yyyy to valid (non-R1) endpoints",
-    safeState = Off,
-
-    // extending as the owner of the switch is on holiday.
-    sellByDate = new LocalDate(2014, 8, 18)
-  )
-
   val ChildrensBooksSwitch = Switch("Feature Switches", "childrens-books-hide-popular",
     "If switched on, video pages in the childrens books section will not show popular videos",
     safeState = On, sellByDate = new LocalDate(2014, 9, 8)
@@ -485,7 +477,6 @@ object Switches extends Collections {
     ABHighCommercialComponent,
     EnhancedMediaPlayerSwitch,
     BreakingNewsSwitch,
-    CenturyRedirectionSwitch,
     ChildrensBooksSwitch
   )
 


### PR DESCRIPTION
Century pages are being redirected as expected from this round of changes so now we can remove the feature switch. 
