### PR TITLE
Reduce padding below section title at tablet breakpoint

### DIFF
--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -148,7 +148,7 @@
 
     @include mq(tablet) {
         @include rem((
-            padding-bottom: ($gs-baseline/2) * 3
+            padding-bottom: $gs-baseline/2
         ));
     }
 


### PR DESCRIPTION
### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/3932485/2198c84e-246b-11e4-92eb-13bdad5112af.png)
### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/3932487/25102b0c-246b-11e4-825d-ad036a36a20f.png)
