### PR TITLE
Fix #5424 - styling regressions on liveblogs

### DIFF
--- a/common/app/assets/stylesheets/module/content/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/content/_live-blog.scss
@@ -845,10 +845,13 @@ $timeline-width: 14px;
     .item {
         padding: 0;
         margin: 0;
-        border-top: 2px solid $c-neutral4;
     }
 
-    .item__tonal-border,
+    .item__tonal-border {
+        border-color: $c-neutral4;
+    }
+
+    & + &:before, // Vertical item separator
     .item__byline,
     .item__meta {
         display: none;

--- a/common/app/assets/stylesheets/module/content/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/content/_live-blog.scss
@@ -848,8 +848,7 @@ $timeline-width: 14px;
         border-top: 2px solid $c-neutral4;
     }
 
-    & + &:before,
-    .item:before,
+    .item__tonal-border,
     .item__byline,
     .item__meta {
         display: none;

--- a/common/app/assets/stylesheets/module/external/_from-content-api.scss
+++ b/common/app/assets/stylesheets/module/external/_from-content-api.scss
@@ -38,6 +38,11 @@
     > blockquote > ul,
     > ul {
         margin-top: .8em;
+    }
+    > li, // sometimes HTML is malformed on purpose by editors
+    > ol,
+    > blockquote > ul,
+    > ul {
         list-style: none;
     }
     > ol {


### PR DESCRIPTION
### Before

![screen shot 2014-08-15 at 12 36 10](https://cloud.githubusercontent.com/assets/85783/3932741/67369f8e-2470-11e4-8721-64d71dc039a4.PNG)

![screen shot 2014-08-15 at 13 05 06](https://cloud.githubusercontent.com/assets/85783/3932929/92821bd8-2474-11e4-9cfb-2c1141566682.PNG)
### After

![screen shot 2014-08-15 at 12 55 40](https://cloud.githubusercontent.com/assets/85783/3932856/25d08e8a-2473-11e4-8fc7-323ae2b046b5.PNG)

![screen shot 2014-08-15 at 13 04 56](https://cloud.githubusercontent.com/assets/85783/3932932/952b7ee2-2474-11e4-8cce-9f724338ca2e.PNG)

![ ](http://media.giphy.com/media/j4jmgRpJMhPYk/giphy.gif)
