### PR TITLE
Normalise height of content meta data containers

### DIFF
--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -297,10 +297,11 @@
 
     @include mq(leftCol) {
         @include rem((
-            height: $gs-row-height,
+            height: gs-height(1) + $gs-baseline,
             padding-top: $gs-baseline/6,
             padding-bottom: $gs-baseline
         ));
+        margin-bottom: 0;
         border-top: 1px dotted $c-neutral5;
     }
 
@@ -492,8 +493,9 @@
         margin-bottom: 0;
         padding-right: 0;
         border-top: 1px dotted $c-neutral5;
+        @include box-sizing(border-box);
         @include rem((
-            min-height: gs-height(1),
+            min-height: gs-height(1) + $gs-baseline,
             padding-top: $gs-baseline/6,
             padding-bottom: $gs-baseline
         ));


### PR DESCRIPTION
### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/3933993/08cac478-2486-11e4-89c6-87c281224527.png)
### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/3934001/23024ec4-2486-11e4-8ac3-ba905c8fbda9.png)
