### PR TITLE
Tag descriptions

### DIFF
--- a/applications/test/SectionTemplateTest.scala
+++ b/applications/test/SectionTemplateTest.scala
@@ -1,12 +1,11 @@
 package test
 
 import org.scalatest.{Matchers,FlatSpec}
-import scala.collection.JavaConversions._
 
 class SectionTemplateTest extends FlatSpec with Matchers {
 
   it should "render front title" in HtmlUnit("/uk-news") { browser =>
-    browser.$(".container__title").first.getText should be ("UK news")
+    browser.$(".container__meta__title").first.getText should be ("UK news")
   }
 
   ignore should "Link to an RSS feed" in HtmlUnit("/books") { browser =>

--- a/applications/test/TagTemplateTest.scala
+++ b/applications/test/TagTemplateTest.scala
@@ -5,6 +5,6 @@ import org.scalatest.{Matchers, FlatSpec}
 class TagTemplateTest extends FlatSpec with Matchers {
 
   it should "render tag headline" in HtmlUnit("/world/turkey") { browser =>
-    browser.$(".container__title").first.getText should be ("Turkey")
+    browser.$(".container__meta__title").first.getText should be ("Turkey")
   }
 }

--- a/applications/test/common/CombinerFeatureTest.scala
+++ b/applications/test/common/CombinerFeatureTest.scala
@@ -29,7 +29,7 @@ class CombinerFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         import browser._
         val trails = $(".fromage, .facia-slice__item, .linkslist__item")
         Then("I should see content tagged with both the section and the tag")
-        findFirst(".container__title").getText.toLowerCase should be ("science + apple")
+        findFirst(".container__meta__title").getText.toLowerCase should be ("science + apple")
         trails.length should be > 10
       }
     }

--- a/common/app/assets/stylesheets/global.scss
+++ b/common/app/assets/stylesheets/global.scss
@@ -119,6 +119,7 @@
 @import 'module/containers/_picks';
 
 @import 'module/facia/snaps/_football';
+@import 'module/facia/_tag-meta';
 
 
 /* ==========================================================================

--- a/common/app/assets/stylesheets/module/containers/_series.scss
+++ b/common/app/assets/stylesheets/module/containers/_series.scss
@@ -2,43 +2,6 @@
     @include rem((
         min-height: 30px
     ));
-
-    .container__label {
-        @include rem((
-            padding-top: $gs-baseline/2,
-            line-height: get-line-height($fs-headers, 2) !important
-        ));
-        @include fs-header(3);
-        color: $c-neutral2;
-    }
-    .content-meta-series {
-        margin: 0;
-    }
-    .content-meta__title {
-        @include mq($to: tablet) {
-            @include rem((
-                padding: $gs-baseline/4 0 $gs-baseline/3
-            ));
-        }
-        @include fs-header(3);
-        @include rem((
-            line-height: get-line-height($fs-headers, 2) !important
-        ));
-
-        a {
-            color: inherit;
-        }
-    }
-    .content-meta__item {
-        @include rem((
-            padding: $gs-baseline/3 0 $gs-baseline
-        ));
-        @include fs-headline(2);
-        color: $c-neutral2;
-        @include mq(rightCol, leftCol) {
-            max-width: 50%;
-        }
-    }
     .item__byline {
         display: none;
     }

--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -133,6 +133,7 @@ $mq-breakpoints: mq-add-breakpoint(faciaWidestMobile, $mobile-max-container-widt
                 }
             }
         }
+        @include container__meta(faciaLeftCol, desktop);
     }
 }
 @mixin facia-container--layout-content {
@@ -158,17 +159,13 @@ $mq-breakpoints: mq-add-breakpoint(faciaWidestMobile, $mobile-max-container-widt
             }
         }
         @include mq(leftCol) {
-            .container__title,
-            .container__meta {
+            .container__title {
                 margin-bottom: 0;
                 float: left;
                 @include rem((
                     width: $left-column !important,
                     margin-right: $gs-gutter
                 ));
-            }
-            .container__meta {
-                clear: left;
             }
             .container__body {
                 overflow: hidden;
@@ -178,8 +175,7 @@ $mq-breakpoints: mq-add-breakpoint(faciaWidestMobile, $mobile-max-container-widt
             }
         }
         @include mq(wide) {
-            .container__title,
-            .container__meta {
+            .container__title {
                 @include rem((
                     width: $left-column-wide !important
                 ));
@@ -190,6 +186,7 @@ $mq-breakpoints: mq-add-breakpoint(faciaWidestMobile, $mobile-max-container-widt
                 ));
             }
         }
+        @include container__meta(leftCol, rightCol);
     }
 }
 @mixin facia-container--layout-discussion {
@@ -204,6 +201,35 @@ $mq-breakpoints: mq-add-breakpoint(faciaWidestMobile, $mobile-max-container-widt
         .container__border,
         .container__border.tone-accent-border {
             border-top: 1px solid $c-neutral4;
+        }
+    }
+}
+@mixin container__meta($leftColumn, $halfWidthBreakpoint) {
+    .container__meta {
+        @include rem((
+            padding-top: $gs-baseline/2
+        ));
+        @include mq($halfWidthBreakpoint) {
+            @include rem((
+                padding-top: $gs-baseline/1.5
+            ));
+        }
+        @include mq($halfWidthBreakpoint, $leftColumn) {
+            max-width: 50%;
+        }
+        @include mq($leftColumn) {
+            margin-bottom: 0;
+            float: left;
+            clear: left;
+            @include rem((
+                width: $left-column !important,
+                margin-right: $gs-gutter
+            ));
+        }
+        @include mq(wide) {
+            @include rem((
+                width: $left-column-wide !important
+            ));
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia/_tag-meta.scss
+++ b/common/app/assets/stylesheets/module/facia/_tag-meta.scss
@@ -1,0 +1,33 @@
+.container__meta {
+    .container__meta__label {
+        @include rem((
+            line-height: get-line-height($fs-headers, 2) !important));
+        @include fs-header(3);
+        color: $c-neutral2;
+    }
+    .container__meta__description {
+        margin: 0;
+    }
+    .container__meta__title {
+        @include mq($to: tablet) {
+            @include rem((
+                padding: $gs-baseline/4 0 $gs-baseline/3
+            ));
+        }
+        @include fs-header(3);
+        @include rem((
+            line-height: get-line-height($fs-headers, 2) !important));
+
+        a {
+            color: inherit;
+        }
+    }
+    .container__meta__item {
+        @include rem((
+            padding: $gs-baseline/3 0 $gs-baseline
+        ));
+        margin: 0;
+        @include fs-headline(2);
+        color: $c-neutral2;
+    }
+}

--- a/common/app/assets/stylesheets/module/facia/_tag-meta.scss
+++ b/common/app/assets/stylesheets/module/facia/_tag-meta.scss
@@ -1,8 +1,9 @@
 .container__meta {
     .container__meta__label {
-        @include rem((
-            line-height: get-line-height($fs-headers, 2) !important));
         @include fs-header(3);
+        @include rem((
+            line-height: get-line-height($fs-headers, 2) !important
+        ));
         color: $c-neutral2;
     }
     .container__meta__description {
@@ -16,7 +17,8 @@
         }
         @include fs-header(3);
         @include rem((
-            line-height: get-line-height($fs-headers, 2) !important));
+            line-height: get-line-height($fs-headers, 2) !important
+        ));
 
         a {
             color: inherit;

--- a/common/app/views/fragments/containers/elements/tagMeta.scala.html
+++ b/common/app/views/fragments/containers/elements/tagMeta.scala.html
@@ -1,0 +1,16 @@
+@(displayName: Option[String], href: Option[String], description: Option[String], tagId: String)(implicit request: RequestHeader)
+@import common.LinkTo
+
+<div class="container__meta">
+    @displayName.map { name =>
+        <h2 class="container__meta__label hide-on-mobile">@name</h2>
+    }
+    <dl class="container__meta__description">
+        <dt class="container__meta__title">
+            <a href="@LinkTo{/@href}" data-link-name="tag heading">@tagId</a>
+        </dt>
+        @description.map { desc =>
+            <dd class="container__meta__item hide-on-mobile">@Html(desc)</dd>
+        }
+    </dl>
+</div>

--- a/common/app/views/fragments/containers/series.scala.html
+++ b/common/app/views/fragments/containers/series.scala.html
@@ -19,17 +19,7 @@
                 data-component="@style.containerType">
                 <div class="facia-container__inner">
                     <div class="container__border"></div>
-                    <div class="container__meta">
-                        <h2 class="container__label hide-on-mobile">@displayName</h2>
-                        <dl class="content-meta-series">
-                            <dt class="content-meta__title">
-                                <a href="@LinkTo{/@href}" data-link-name="series heading">@config.id</a>
-                            </dt>
-                            @description.map { desc =>
-                                <dd class="content-meta__item hide-on-mobile">@Html(desc)</dd>
-                            }
-                        </dl>
-                    </div>
+                    @fragments.containers.elements.tagMeta(displayName, href, description, config.id)
                     <div class="container__body container--rolled-up-hide">
                         @fragments.collections.series(items, style, containerIndex)
                     </div>

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -1,6 +1,5 @@
 @(page: model.MetaData, collection: model.Collection, style: views.support.NewsContainer, containerIndex: Int, pagination: Option[common.Pagination] = None)(implicit request: RequestHeader, templateDeduping: views.support.TemplateDeduping, config: model.Config)
 
-@import common.LinkTo
 @import model.FaciaComponentName
 @import views.html.fragments.keywordList
 @import views.support.GetClasses
@@ -22,13 +21,7 @@
                 <div class="container__border tone-@style.tone tone-accent-border"></div>
                 <div class="container__header">
                     @title.map { title =>
-                        <h2 class="container__title">
-                            @collection.href.map { href =>
-                                <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                            }.getOrElse{
-                                <span class="container__title__label u-text-hyphenate">@Html(title)</span>
-                            }
-                        </h2>
+                        @fragments.containers.elements.tagMeta(None, collection.href, page.description, title)
                     }
                 </div>
                 <div class="container__body container--rolled-up-hide">

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -29,21 +29,19 @@ object SeriesController extends Controller with Logging with Paging with Executi
     def isCurrentStory(content: ApiContent) = content.safeFields.get("shortUrl").map{shortUrl => shortUrl.equals(currentShortUrl)}.getOrElse(false)
 
     val seriesResponse: Future[Option[Series]] = LiveContentApi.item(seriesId, edition)
-      .showTags("all")
       .showFields("all")
       .response
-      .map {
-        response =>
-          response.tag.flatMap { tag =>
-            val trails = response.results filterNot (isCurrentStory(_)) map (Content(_))
-            if (!trails.isEmpty) {
-              Some(Series(seriesId, Tag(tag,None), trails))
-            } else { None }
-          }
+      .map { response =>
+        response.tag.flatMap { tag =>
+          val trails = response.results filterNot (isCurrentStory(_)) map (Content(_))
+          if (!trails.isEmpty) {
+            Some(Series(seriesId, Tag(tag,None), trails))
+          } else { None }
+        }
       }
       seriesResponse.recover{ case ApiError(404, message) =>
-         log.info(s"Got a 404 calling content api: $message" )
-         None
+        log.info(s"Got a 404 calling content api: $message" )
+        None
       }
   }
 


### PR DESCRIPTION
Both 'series content containers' and 'tag front containers' may have a description. Their appearance is similar, aside from variations in breakpoints.

This PR generalises the existing series description so it can be used by both tags and series. There should be no visible change to the series container, only changes to the tag page, which follows similar breakpoint behaviour (except there is no 'series' label).

**Before (tag page with an ignored description)**
![screen shot 2014-08-15 at 16 10 19](https://cloud.githubusercontent.com/assets/4549425/3934710/83446882-248e-11e4-82be-ea833eb842e8.png)

**After (wide breakpoint)**
![screen shot 2014-08-15 at 16 10 27](https://cloud.githubusercontent.com/assets/4549425/3934716/8d38a416-248e-11e4-916b-a507b08b3226.png)

**After (desktop breakpoint, known as half-width breakpoint in code)**
![screen shot 2014-08-15 at 16 10 58](https://cloud.githubusercontent.com/assets/4549425/3934739/d68d9ffe-248e-11e4-894a-b4b1ac8e45fc.png)

**After (tablet breakpoint, hidden on mobile)**
![screen shot 2014-08-15 at 16 14 42](https://cloud.githubusercontent.com/assets/4549425/3934765/0acaf208-248f-11e4-9560-0816d104ec62.png)

Another perilous friday shipping.

![megalodon_takes_a_bite_of_ship_wallpaper](https://cloud.githubusercontent.com/assets/4549425/3934778/36aa26b4-248f-11e4-8e75-0f1d3dc5a42c.jpg)
