### PR TITLE
Use bolder display sans font

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -509,8 +509,7 @@ module.exports = function (grunt) {
                     fonts: [
                         {
                             'font-family': '"Guardian Sans Web"',
-                            file: webfontsDir + 'hinting-off_kerning-off/latin1/GuardianSansWeb/GuardianSansWeb-Light.woff2',
-                            'font-weight': '200',
+                            file: webfontsDir + 'hinting-off_kerning-off/latin1/GuardianSansWeb/GuardianSansWeb-Regular.woff2',
                             format: 'woff'
                         }
                     ]
@@ -523,8 +522,7 @@ module.exports = function (grunt) {
                     fonts: [
                         {
                             'font-family': '"Guardian Sans Web"',
-                            file: webfontsDir + 'hinting-off_kerning-off/ascii/GuardianSansWeb/GuardianSansWeb-Light.woff',
-                            'font-weight': '200',
+                            file: webfontsDir + 'hinting-off_kerning-off/ascii/GuardianSansWeb/GuardianSansWeb-Regular.woff',
                             format: 'woff'
                         }
                     ]
@@ -537,8 +535,7 @@ module.exports = function (grunt) {
                     fonts: [
                         {
                             'font-family': '"Guardian Sans Web"',
-                            file: webfontsDir + 'hinting-off_kerning-off/ascii/GuardianSansWeb/GuardianSansWeb-Light.ttf',
-                            'font-weight': '200',
+                            file: webfontsDir + 'hinting-off_kerning-off/ascii/GuardianSansWeb/GuardianSansWeb-Regular.ttf',
                             format: 'ttf'
                         }
                     ]

--- a/common/app/assets/stylesheets/components/guss-typography/_typography.mixins.scss
+++ b/common/app/assets/stylesheets/components/guss-typography/_typography.mixins.scss
@@ -146,5 +146,4 @@
 
 @mixin f-headlineSans {
     font-family: $f-sans-serif-headline;
-    font-weight: 200;
 }


### PR DESCRIPTION
For advertisement features
## Before

![screen shot 2014-08-18 at 12 14 53](https://cloud.githubusercontent.com/assets/74132/3950647/02cc23ce-26c9-11e4-9f8e-c6f0ac72ff95.png)
## After

![screen shot 2014-08-18 at 12 14 56](https://cloud.githubusercontent.com/assets/74132/3950649/077de51a-26c9-11e4-9a77-c6a0548a69b9.png)

cc: @paulrobertlloyd 
