### PR TITLE
Fix search dropdown overlapping sponsored badge

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -394,7 +394,7 @@
     @include clearfix;
     position: relative;
     min-height: 90px;
-    z-index: 99;
+    z-index: auto;
 
     .ad-slot--paid-for-badge__link {
         position: relative;


### PR DESCRIPTION
## Before

![screen shot 2014-08-18 at 12 43 57](https://cloud.githubusercontent.com/assets/74132/3950875/46fdb2de-26cd-11e4-8420-5ffcf313dc98.png)
## After

![screen shot 2014-08-18 at 12 44 04](https://cloud.githubusercontent.com/assets/74132/3950881/50e16f8e-26cd-11e4-8b48-4aa4cea5844b.png)
