### PR TITLE
Add content type for tag combiners

### DIFF
--- a/applications/app/services/repositories.scala
+++ b/applications/app/services/repositories.scala
@@ -79,7 +79,7 @@ trait Index extends ConciergeRepository with QueryDefaults {
             pageName,
             s"GFE:${tag1.section}:$pageName",
             pagination = pagination(response),
-            maybeContentType = Some(GuardianContentTypes.TAG_COMBINER)
+            maybeContentType = Some(GuardianContentTypes.TAG_INDEX)
           )
 
           Left(IndexPage(page, trails))

--- a/applications/app/services/repositories.scala
+++ b/applications/app/services/repositories.scala
@@ -79,7 +79,7 @@ trait Index extends ConciergeRepository with QueryDefaults {
             pageName,
             s"GFE:${tag1.section}:$pageName",
             pagination = pagination(response),
-            maybeContentType = Some(GuardianContentTypes.TAG_INDEX)
+            maybeContentType = Some(GuardianContentTypes.TagIndex)
           )
 
           Left(IndexPage(page, trails))

--- a/applications/app/services/repositories.scala
+++ b/applications/app/services/repositories.scala
@@ -73,8 +73,14 @@ trait Index extends ConciergeRepository with QueryDefaults {
           val tag1 = head.tags.find(_.id == firstTag).head
           val tag2 = head.tags.find(_.id == secondTag).head
           val pageName = s"${tag1.name} + ${tag2.name}"
-          val page = Page(s"$leftSide+$rightSide", tag1.section, pageName,
-            s"GFE:${tag1.section}:$pageName", pagination = pagination(response))
+          val page = Page(
+            s"$leftSide+$rightSide",
+            tag1.section,
+            pageName,
+            s"GFE:${tag1.section}:$pageName",
+            pagination = pagination(response),
+            maybeContentType = Some(GuardianContentTypes.TAG_COMBINER)
+          )
 
           Left(IndexPage(page, trails))
       }

--- a/commercial/app/controllers/commercial/CreativeTestPage.scala
+++ b/commercial/app/controllers/commercial/CreativeTestPage.scala
@@ -27,7 +27,7 @@ object TestPage extends model.MetaData  {
 
   val isNetworkFront: Boolean = false
 
-  override lazy val contentType: String =   if (isNetworkFront) GuardianContentTypes.NETWORK_FRONT else GuardianContentTypes.SECTION
+  override lazy val contentType: String =   if (isNetworkFront) GuardianContentTypes.NetworkFront else GuardianContentTypes.Section
 
 }
 

--- a/common/app/model/GuardianContentTypes.scala
+++ b/common/app/model/GuardianContentTypes.scala
@@ -23,5 +23,5 @@ object GuardianContentTypes {
   val VIDEO = "Video"
   val AUDIO = "Audio"
   val LIVEBLOG = "LiveBlog"
-  val TAG_COMBINER = NETWORK_FRONT
+  val TAG_INDEX = "Index"
 }

--- a/common/app/model/GuardianContentTypes.scala
+++ b/common/app/model/GuardianContentTypes.scala
@@ -14,14 +14,14 @@ object GuardianContentTypes {
   // cheers,
   // ken lim (8 July 2014)
 
-  val ARTICLE = "Article"
-  val NETWORK_FRONT = "Network Front"
-  val SECTION = "Section"
-  val IMAGE_CONTENT = "ImageContent"
-  val INTERACTIVE = "Interactive"
-  val GALLERY = "Gallery"
-  val VIDEO = "Video"
-  val AUDIO = "Audio"
-  val LIVEBLOG = "LiveBlog"
-  val TAG_INDEX = "Index"
+  val Article = "Article"
+  val NetworkFront = "Network Front"
+  val Section = "Section"
+  val ImageContent = "ImageContent"
+  val Interactive = "Interactive"
+  val Gallery = "Gallery"
+  val Video = "Video"
+  val Audio = "Audio"
+  val LiveBlog = "LiveBlog"
+  val TagIndex = "Index"
 }

--- a/common/app/model/GuardianContentTypes.scala
+++ b/common/app/model/GuardianContentTypes.scala
@@ -23,4 +23,5 @@ object GuardianContentTypes {
   val VIDEO = "Video"
   val AUDIO = "Audio"
   val LIVEBLOG = "LiveBlog"
+  val TAG_COMBINER = NETWORK_FRONT
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -366,7 +366,7 @@ object Snap {
 class Article(content: ApiContentWithMeta) extends Content(content) {
   lazy val main: String = delegate.safeFields.getOrElse("main","")
   lazy val body: String = delegate.safeFields.getOrElse("body","")
-  override lazy val contentType = GuardianContentTypes.ARTICLE
+  override lazy val contentType = GuardianContentTypes.Article
 
   lazy val hasVideoAtTop: Boolean = Jsoup.parseBodyFragment(body).body().children().headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")
@@ -416,7 +416,7 @@ class LiveBlog(content: ApiContentWithMeta) extends Article(content) {
   private lazy val soupedBody = Jsoup.parseBodyFragment(body).body()
   lazy val hasKeyEvents: Boolean = soupedBody.select(".is-key-event").nonEmpty
   lazy val isSport: Boolean = tags.exists(_.id == "sport/sport")
-  override lazy val contentType = GuardianContentTypes.LIVEBLOG
+  override lazy val contentType = GuardianContentTypes.LiveBlog
 
   override def cards: List[(String, Any)] = super.cards ++ List(
     "twitter:card" -> "summary"
@@ -441,7 +441,7 @@ class Audio(content: ApiContentWithMeta) extends Media(content) {
 
   lazy val body: String = delegate.safeFields.getOrElse("body", "")
 
-  override lazy val contentType = GuardianContentTypes.AUDIO
+  override lazy val contentType = GuardianContentTypes.Audio
 
   override lazy val metaData: Map[String, JsValue] =
     super.metaData ++ Map("contentType" -> JsString(contentType), "blockVideoAds" -> JsBoolean(blockVideoAds))
@@ -455,7 +455,7 @@ class Video(content: ApiContentWithMeta) extends Media(content) {
 
   override lazy val hasClassicVersion = false
 
-  override lazy val contentType = GuardianContentTypes.VIDEO
+  override lazy val contentType = GuardianContentTypes.Video
 
   lazy val source: Option[String] = videos.find(_.isMain).flatMap(_.source)
 
@@ -497,7 +497,7 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
   def imageContainer(index: Int): ImageElement = galleryImages(index)
 
   lazy val size = galleryImages.size
-  override lazy val contentType = GuardianContentTypes.GALLERY
+  override lazy val contentType = GuardianContentTypes.Gallery
   lazy val landscapes = largestCrops.filter(i => i.width > i.height).sortBy(_.index)
   lazy val portraits = largestCrops.filter(i => i.width < i.height).sortBy(_.index)
   lazy val isInPicturesSeries = tags.exists(_.id == "lifeandstyle/series/in-pictures")
@@ -541,7 +541,7 @@ object Gallery {
 }
 
 class Interactive(content: ApiContentWithMeta) extends Content(content) {
-  override lazy val contentType = GuardianContentTypes.INTERACTIVE
+  override lazy val contentType = GuardianContentTypes.Interactive
   lazy val body: Option[String] = delegate.safeFields.get("body")
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
 
@@ -553,8 +553,8 @@ object Interactive {
 }
 
 class ImageContent(content: ApiContentWithMeta) extends Content(content) {
-  override lazy val contentType = GuardianContentTypes.IMAGE_CONTENT
 
+  override lazy val contentType = GuardianContentTypes.ImageContent
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
 
   override lazy val metaData: Map[String, JsValue] =

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -88,7 +88,15 @@ object Page {
     webTitle: String,
     analyticsName: String,
     pagination: Option[Pagination] = None,
-    description: Option[String] = None) = new Page(id, section, webTitle, analyticsName, pagination, description)
+    description: Option[String] = None,
+    maybeContentType: Option[String] = None
+  ) = new Page(id, section, webTitle, analyticsName, pagination, description) {
+    override lazy val contentType = maybeContentType.getOrElse("")
+
+    override def metaData: Map[String, Any] = {
+      super.metaData ++ maybeContentType.map(contentType => List("content-type" -> contentType)).getOrElse(Nil)
+    }
+  }
 }
 
 trait Elements {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -93,9 +93,8 @@ object Page {
   ) = new Page(id, section, webTitle, analyticsName, pagination, description) {
     override lazy val contentType = maybeContentType.getOrElse("")
 
-    override def metaData: Map[String, Any] = {
-      super.metaData ++ maybeContentType.map(contentType => List("content-type" -> contentType)).getOrElse(Nil)
-    }
+    override def metaData: Map[String, JsValue] =
+      super.metaData ++ maybeContentType.map(contentType => List("content-type" -> JsString(contentType))).getOrElse(Nil)
   }
 }
 

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -28,7 +28,7 @@ case class FaciaPage(
 
   val isNetworkFront: Boolean = Edition.all.exists(edition => id.toLowerCase.endsWith(edition.id.toLowerCase))
 
-  override lazy val contentType: String =   if (isNetworkFront) GuardianContentTypes.NETWORK_FRONT else GuardianContentTypes.SECTION
+  override lazy val contentType: String = if (isNetworkFront) GuardianContentTypes.NETWORK_FRONT else GuardianContentTypes.SECTION
 
   override def isSponsored = DfpAgent.isSponsored(id)
   override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -28,7 +28,7 @@ case class FaciaPage(
 
   val isNetworkFront: Boolean = Edition.all.exists(edition => id.toLowerCase.endsWith(edition.id.toLowerCase))
 
-  override lazy val contentType: String = if (isNetworkFront) GuardianContentTypes.NETWORK_FRONT else GuardianContentTypes.SECTION
+  override lazy val contentType: String = if (isNetworkFront) GuardianContentTypes.NetworkFront else GuardianContentTypes.Section
 
   override def isSponsored = DfpAgent.isSponsored(id)
   override def isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)


### PR DESCRIPTION
For tracking on videos

@gklopper @kenlim For now I've set the content type to the same as network fronts. Do we need a separate content type for tag combiners?
