### PR TITLE
Messaging fixes

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -257,7 +257,7 @@ define([
 
             var path = (document.location.pathname) ? document.location.pathname : '/';
 
-            var releaseMessage = new Message('alpha');
+            var releaseMessage = new Message('alpha', {pinOnHide: true});
 
             // Do not show the release message on -sp- based paths.
             var spRegExp = new RegExp('.*-sp-.*');

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -269,13 +269,17 @@ define([
                 var exitLink = '/preference/platform/classic?page=' + encodeURIComponent(path + '?view=classic'),
                     msg = '<p class="site-message__message" id="site-message__message">' +
                             'You’re viewing a beta release of the Guardian’s responsive website.' +
-                            ' We’d love to hear your <a href="https://www.surveymonkey.com/s/theguardian-beta-feedback" data-link-name="feedback">feedback</a>' +
+                            ' We’d love to hear what you think.' +
                         '</p>' +
                         '<ul class="site-message__actions u-unstyled">' +
                             '<li class="site-message__actions__item">' +
                                '<i class="i i-back"></i>' +
                                    '<a class="js-main-site-link" rel="nofollow" href="' + exitLink + '"' +
-                                       'data-link-name="opt-out">Opt-out and return to our current site </a>' +
+                                       'data-link-name="opt-out">Use current version</a>' +
+                            '</li>' +
+                            '<li class="site-message__actions__item">' +
+                            '<i class="i i-arrow-white-right"></i>' +
+                            '<a href="https://www.surveymonkey.com/s/theguardian-beta-feedback" target="_blank">Leave feedback</a>' +
                             '</li>' +
                         '</ul>';
                 releaseMessage.show(msg);

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -438,7 +438,7 @@ define([
                     '</li>' +
                     '</ul>';
 
-            var releaseMessage = new Message('video');
+            var releaseMessage = new Message('video', {pinOnHide: true});
 
             releaseMessage.show(msg);
         }

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -430,11 +430,11 @@ define([
                     '<ul class="site-message__actions u-unstyled">' +
                     '<li class="site-message__actions__item">' +
                     '<i class="i i-arrow-white-right"></i>' +
-                    '<a href="https://www.surveymonkey.com/s/guardianvideo" target="_blank">Leave feedback</a>' +
+                    '<a href="http://next.theguardian.com/blog/video-redesign/" target="_blank">Find out more</a>' +
                     '</li>' +
                     '<li class="site-message__actions__item">' +
                     '<i class="i i-arrow-white-right"></i>' +
-                    '<a href="http://next.theguardian.com/blog/video-redesign/" target="_blank">Find out more</a>' +
+                    '<a href="https://www.surveymonkey.com/s/guardianvideo" target="_blank">Leave feedback</a>' +
                     '</li>' +
                     '</ul>';
 

--- a/common/app/assets/javascripts/modules/ui/message.js
+++ b/common/app/assets/javascripts/modules/ui/message.js
@@ -25,20 +25,21 @@ define([
         this.important = opts.important || false;
         this.permanent = opts.permanent || false;
         this.type = opts.type || 'banner';
+        this.pinOnHide = opts.pinOnHide || false;
         this.prefs = 'messages';
 
         this.$footerMessage = $('.js-footer-message');
     };
 
     Message.prototype.show = function(message) {
-        if(this.type === 'banner') {
+        if(this.pinOnHide) {
             $('.js-footer-site-message-copy').html(message);
         }
 
         // don't let messages unknowingly overwrite each other
         if ((!$('.site-message').hasClass('is-hidden') && !this.important) || this.hasSeen()) {
             // if we're not showing a banner message, display it in the footer
-            if(this.type === 'banner') {
+            if(this.pinOnHide) {
                 this.$footerMessage.removeClass('is-hidden');
             }
             return false;
@@ -68,7 +69,7 @@ define([
     Message.prototype.hide = function() {
         $('#header').removeClass('js-site-message');
         $('.site-message').addClass('is-hidden');
-        if(this.type === 'banner') {
+        if(this.pinOnHide) {
             this.$footerMessage.removeClass('is-hidden');
         }
     };

--- a/common/app/assets/stylesheets/module/_release-message.scss
+++ b/common/app/assets/stylesheets/module/_release-message.scss
@@ -232,6 +232,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 .site-message--android,
 .site-message--ios {
     position: relative;
+
     .site-message__media {
         display: none;
     }

--- a/common/app/assets/stylesheets/module/_release-message.scss
+++ b/common/app/assets/stylesheets/module/_release-message.scss
@@ -232,6 +232,9 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 .site-message--android,
 .site-message--ios {
     position: relative;
+    .site-message__media {
+        display: none;
+    }
 }
 
 .site-message--android {

--- a/common/test/assets/javascripts/spec/Message.spec.js
+++ b/common/test/assets/javascripts/spec/Message.spec.js
@@ -34,33 +34,33 @@ define([
         })
 
         it("Show a message", function(){
-            new Message('foo').show('hello world');
-            expect($('.js-site-message-copy').text()).toContain('hello world');
-            expect($('.js-footer-site-message-copy').text()).toContain('hello world');
-            expect($('.site-message').hasClass('is-hidden')).toBeFalsy();
-        })
-
-        it("Show any non-banner message", function(){
             new Message('foo', {type: 'foo'}).show('hello world');
             expect($('.js-site-message-copy').text()).toContain('hello world');
             expect($('.js-footer-site-message-copy').text()).not.toContain('hello world');
             expect($('.site-message').hasClass('is-hidden')).toBeFalsy();
         })
 
-        it("Hide a message", function(){
-            var m = new Message('foo');
-            m.show('hello world');
-            m.hide();
-            expect($('.site-message').hasClass('is-hidden')).toBeTruthy();
-            expect($('.js-footer-message').hasClass('is-hidden')).toBeFalsy();
+        it("Show a pinnable message", function(){
+            new Message('foo', {pinOnHide: true}).show('hello world');
+            expect($('.js-site-message-copy').text()).toContain('hello world');
+            expect($('.js-footer-site-message-copy').text()).toContain('hello world');
+            expect($('.site-message').hasClass('is-hidden')).toBeFalsy();
         })
 
-        it("Hide any non-banner message", function(){
+        it("Hide a message", function(){
             var m = new Message('foo', {type: 'foo'});
             m.show('hello world');
             m.hide();
             expect($('.site-message').hasClass('is-hidden')).toBeTruthy();
             expect($('.js-footer-message').hasClass('is-hidden')).toBeTruthy();
+        })
+
+        it("Hide a pinnable message", function(){
+            var m = new Message('foo', {pinOnHide: true});
+            m.show('hello world');
+            m.hide();
+            expect($('.site-message').hasClass('is-hidden')).toBeTruthy();
+            expect($('.js-footer-message').hasClass('is-hidden')).toBeFalsy();
         })
 
         it("Remember the user has acknowledged the message", function(){

--- a/common/test/assets/javascripts/spec/Message.spec.js
+++ b/common/test/assets/javascripts/spec/Message.spec.js
@@ -34,7 +34,7 @@ define([
         })
 
         it("Show a message", function(){
-            new Message('foo', {type: 'foo'}).show('hello world');
+            new Message('foo').show('hello world');
             expect($('.js-site-message-copy').text()).toContain('hello world');
             expect($('.js-footer-site-message-copy').text()).not.toContain('hello world');
             expect($('.site-message').hasClass('is-hidden')).toBeFalsy();
@@ -48,7 +48,7 @@ define([
         })
 
         it("Hide a message", function(){
-            var m = new Message('foo', {type: 'foo'});
+            var m = new Message('foo');
             m.show('hello world');
             m.hide();
             expect($('.site-message').hasClass('is-hidden')).toBeTruthy();


### PR DESCRIPTION
- messages must specify they are pinnable (prevents banner messages being pinnacle by default - was knackering the smart app message)
- style fixes to smart app banner on tablets (hides batwing)

![screen shot 2014-08-18 at 13 45 18](https://cloud.githubusercontent.com/assets/867233/3951393/c3047fea-26d5-11e4-85f6-34ca9a00a654.png)
- makes messaging copy/calls to action consistent (fixes #5605) and elevates the position of feedback

![screen shot 2014-08-18 at 13 46 22](https://cloud.githubusercontent.com/assets/867233/3951397/c7becd4c-26d5-11e4-9a8a-0dc39899df4a.png)
![screen shot 2014-08-18 at 13 45 43](https://cloud.githubusercontent.com/assets/867233/3951398/c7d48128-26d5-11e4-991f-606d2eb5a9dd.png)
