### PR TITLE
Really hide related container in IE8

### DIFF
--- a/common/app/assets/stylesheets/module/containers/_related.scss
+++ b/common/app/assets/stylesheets/module/containers/_related.scss
@@ -56,8 +56,6 @@
     // Temporarily hide story package from IE8
     // TODO find a fix!
     @if $old-ie {
-        &.more-on-this-story {
-            display: none;
-        }
+        display: none;
     }
 }


### PR DESCRIPTION
It was still showing in some instances /cc @phamann 

![ ](http://gifs.joelglovier.com/high-five/pokemon-high-five.gif)
