### PR TITLE
Do not init the end slate if it's not needed

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -349,7 +349,7 @@ define([
                                     modules.bindContentEvents(player);
                                 }
 
-                                if (el.getAttribute("data-show-end-slate") === "true" &&
+                                if (el.getAttribute('data-show-end-slate') === 'true' &&
                                     /desktop|wide/.test(detect.getBreakpoint())) {
                                     modules.initEndSlate(player, el.getAttribute('data-end-slate'));
                                 }

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -297,7 +297,7 @@ define([
 
                     bonzo(el).addClass('vjs');
 
-                    var mediaId = el.getAttribute('data-media-id'),
+                    var mediaId = bonzo(el).attr('data-media-id'),
                         vjs = modules.createVideoObject(el, {
                             controls: true,
                             autoplay: false,
@@ -349,9 +349,9 @@ define([
                                     modules.bindContentEvents(player);
                                 }
 
-                                if (el.getAttribute('data-show-end-slate') === 'true' &&
+                                if (bonzo(el).attr('data-show-end-slate') === 'true' &&
                                     /desktop|wide/.test(detect.getBreakpoint())) {
-                                    modules.initEndSlate(player, el.getAttribute('data-end-slate'));
+                                    modules.initEndSlate(player, bonzo(el).attr('data-end-slate'));
                                 }
                             } else {
                                 vjs.playlist({

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -349,7 +349,8 @@ define([
                                     modules.bindContentEvents(player);
                                 }
 
-                                if (/desktop|wide/.test(detect.getBreakpoint())) {
+                                if (el.getAttribute("data-show-end-slate") === "true" &&
+                                    /desktop|wide/.test(detect.getBreakpoint())) {
                                     modules.initEndSlate(player, el.getAttribute('data-end-slate'));
                                 }
                             } else {

--- a/common/app/assets/stylesheets/module/content/_media-player.scss
+++ b/common/app/assets/stylesheets/module/content/_media-player.scss
@@ -609,10 +609,6 @@ $vjs-progress-inset-bottom: 4px;
 
 /* End slate
    ========================================================================== */
-.gu-media--hide-endslate .end-slate-container {
-    display: none;
-}
-
 .end-slate-container {
     display: none;
     position: absolute;

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -15,10 +15,9 @@
                 "gu-media" -> true,
                 "gu-media--video" -> true,
                 "gu-media--show-controls-at-start" -> showControlsAtStart,
-                "gu-media--hide-endslate" -> (width < Video640.width.get),
                 "js-gu-media" -> true
             ))" data-title="@title"
-                poster="@poster" data-duration="@video.duration.toString()" data-media-id="@video.id" @endSlatePath.map { path => data-end-slate="@path"}>
+                poster="@poster" data-duration="@video.duration.toString()" data-show-end-slate="@{width >= Video640.width.get}" data-media-id="@video.id" @endSlatePath.map { path => data-end-slate="@path"}>
 
                 @video.encodings.map { encoding =>
                     <source src="@encoding.url" type="@encoding.format" />


### PR DESCRIPTION
Rather than hiding the end slate with CSS (which wasn't working anyway), don't initialise it at all unless it's actually being used.
