### PR TITLE
Make autoplay a parameter of the video player

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -1,6 +1,7 @@
 @(page: MediaPage)(implicit request: RequestHeader)
-@import model.{Audio, Video}
-@import views.support.{Video640, StripHtmlTags}
+
+@import model.{Audio, Video, VideoPlayer}
+@import views.support.{Video640, SeoOptimisedContentImage, StripHtmlTags}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }){ case (media, mediaType) =>
 <div class="l-side-margins l-side-margins--layout-content">
@@ -49,7 +50,14 @@
                                     <meta itemprop="image" content="@video.openGraphImage" />
                                     @video.thumbnail.map{ img => <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img)" /> }
                                     @video.mainVideo.map { videoElement =>
-                                        @fragments.media.video(videoElement, Video640, video.headline)
+                                        @fragments.media.video(VideoPlayer(
+                                            videoElement,
+                                            Video640,
+                                            video.headline,
+                                            autoPlay = true,
+                                            showControlsAtStart = true,
+                                            endSlatePath = video.endSlatePath
+                                        ))
                                     }
                                 </figure>
                             }

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -1,5 +1,7 @@
 @(article: model.Article)(implicit request: RequestHeader)
+@import model.EndSlateComponents
 
+@import model.VideoPlayer
 @import views.support.{Video640, SeoOptimisedContentImage}
 @import views.BodyCleaner
 
@@ -16,7 +18,14 @@
                     <figure itemprop="associatedMedia video" itemscope itemtype="http://schema.org/VideoObject" data-component="main video"
                     class="media-primary media-content">
                         @article.mainVideo.map { video =>
-                            @fragments.media.video(video, Video640, article.headline)
+                            @fragments.media.video(VideoPlayer(
+                                video,
+                                Video640,
+                                article.headline,
+                                autoPlay = true,
+                                showControlsAtStart = true,
+                                endSlatePath = EndSlateComponents.fromContent(article).toUriPath
+                            ))
                         }
 
                         @posters.headOption.map { image =>

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -55,7 +55,7 @@ define([
     }
 
     function shouldAutoPlay(player) {
-        return player.el().getAttribute("data-auto-play") == "true" && isDesktop;
+        return player.el().getAttribute('data-auto-play') === 'true' && isDesktop;
     }
 
     function constructEventName(eventName, player) {

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -55,7 +55,7 @@ define([
     }
 
     function shouldAutoPlay(player) {
-        return bonzo(player.el()).attr('data-auto-play') === 'true' && isDesktop;
+        return bonzo(player.el().children[0]).attr('data-auto-play') === 'true' && isDesktop;
     }
 
     function constructEventName(eventName, player) {

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -55,7 +55,7 @@ define([
     }
 
     function shouldAutoPlay(player) {
-        return player.el().getAttribute('data-auto-play') === 'true' && isDesktop;
+        return bonzo(player.el()).attr('data-auto-play') === 'true' && isDesktop;
     }
 
     function constructEventName(eventName, player) {
@@ -63,7 +63,6 @@ define([
     }
 
     var modules = {
-
         ophanRecord: function(id, event, player) {
             if(id) {
                 require('ophan/ng', function (ophan) {

--- a/common/app/model/EndSlateComponents.scala
+++ b/common/app/model/EndSlateComponents.scala
@@ -1,11 +1,11 @@
 package model
 
 object EndSlateComponents {
-  def fromVideo(video: Video) = EndSlateComponents(
-      video.series collectFirst { case Tag(apiTag, _) => apiTag.id },
-      video.section,
-      video.shortUrl
-    )
+  def fromContent(content: Content) = EndSlateComponents(
+    content.series collectFirst { case Tag(apiTag, _) => apiTag.id },
+    content.section,
+    content.shortUrl
+  )
 }
 
 case class EndSlateComponents(

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -17,5 +17,5 @@ case class VideoPlayer(
   def width = profile.width.get
   def height = profile.width.get
 
-  def hideEndSlate = width < Video640.width.get
+  def showEndSlate = width >= Video640.width.get
 }

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -1,0 +1,21 @@
+package model
+
+import conf.Static
+import views.support.{Video640, VideoProfile}
+
+case class VideoPlayer(
+  video: VideoElement,
+  profile: VideoProfile,
+  title: String,
+  autoPlay: Boolean,
+  showControlsAtStart: Boolean,
+  endSlatePath: String
+) {
+  def poster = profile.bestFor(video).getOrElse(Static("images/media-holding.jpg").path)
+
+  /** Width and height are always defined for video profile, so this is OK. */
+  def width = profile.width.get
+  def height = profile.width.get
+
+  def hideEndSlate = width < Video640.width.get
+}

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -462,7 +462,7 @@ class Video(content: ApiContentWithMeta) extends Media(content) {
   ).flatten.mkString(", ")).filter(_.nonEmpty)
   lazy val videoLinkText: String = webTitle.stripSuffix(" - video").stripSuffix(" – video")
 
-  def endSlatePath = EndSlateComponents.fromVideo(this).toUriPath
+  def endSlatePath = EndSlateComponents.fromContent(this).toUriPath
 }
 
 object Video {

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -1,7 +1,7 @@
 @(trail: model.Trail, index: Int)(implicit request: RequestHeader, config: Config)
 
 @import common.LinkTo
-@import model.Video
+@import model.{Video, VideoPlayer}
 @import views.html.fragments.media.video
 @import views.support.{GetClasses, SnapData, Video640}
 
@@ -17,7 +17,14 @@
             case v: Video if v.mainVideo.isDefined => {
                 <div class="item__media-wrapper item__media-wrapper--has-icon u-faux-block-link__promote">
                     <div class="item__video-container">
-                        @video(v.mainVideo.get, Video640, v.webTitle, false, Some(v.endSlatePath))
+                        @video(VideoPlayer(
+                            v.mainVideo.get,
+                            Video640,
+                            v.webTitle,
+                            autoPlay = false,
+                            showControlsAtStart = false,
+                            v.endSlatePath
+                        ))
                     </div>
                 </div>
             }

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -19,7 +19,7 @@
         <div class="fromage__container">
             @trail match {
                 case v: Video if v.mainVideo.isDefined && imageAdjust == "boost" => {
-                    @fromageVideo(v.mainVideo.get, v.webTitle, true, Some(v.endSlatePath))
+                    @fromageVideo(v.mainVideo.get, v.webTitle, true, v.endSlatePath)
                 }
                 case _ => {
                     @if(imageAdjust != Some("hide")) {

--- a/common/app/views/fragments/items/fromageVideo.scala.html
+++ b/common/app/views/fragments/items/fromageVideo.scala.html
@@ -1,5 +1,6 @@
-@(videoElement: model.VideoElement, title: String, isFirst: Boolean, endSlatePath: Option[String])
+@(videoElement: model.VideoElement, title: String, isFirst: Boolean, endSlatePath: String)
 
+@import model.VideoPlayer
 @import views.html.fragments.media.video
 @import views.support.{Video460, RenderClasses}
 
@@ -11,6 +12,13 @@
     "u-faux-block-link__promote" -> true
 ))">
     <div class="fromage__video-container">
-        @video(videoElement, Video460, title, false, endSlatePath)
+        @video(VideoPlayer(
+            videoElement,
+            Video460,
+            title,
+            autoPlay = false,
+            showControlsAtStart = false,
+            endSlatePath
+        ))
     </div>
 </div>

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -1,8 +1,7 @@
 @(trail: model.Trail, index: Int, containerIndex: Int, element: String = "li", forceTone: Option[String] = None)(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
-@import conf.Static
-@import model.Video
+@import model.{Video, VideoPlayer}
 @import views.html.fragments.media.video
 @import views.support.{GetClasses, ImgSrc, Video640, Item620, Item300, RemoveOuterParaHtml}
 
@@ -22,7 +21,14 @@
                 case videoItem: Video if videoItem.mainVideo.isDefined && trail.imageAdjust == "boost" => {
                     <div class="item__media-wrapper item__media-wrapper--has-icon u-faux-block-link__promote">
                         <div class="item__video-container">
-                            @video(videoItem.mainVideo.get, Video640, videoItem.webTitle, false, Some(videoItem.endSlatePath))
+                            @video(VideoPlayer(
+                                videoItem.mainVideo.get,
+                                Video640,
+                                videoItem.webTitle,
+                                autoPlay = false,
+                                showControlsAtStart = false,
+                                videoItem.endSlatePath
+                            ))
                         </div>
                     </div>
 

--- a/common/app/views/fragments/media/audio.scala.html
+++ b/common/app/views/fragments/media/audio.scala.html
@@ -1,9 +1,9 @@
-@(audio: Option[AudioElement], title: String)
+@(audio: Option[model.AudioElement], title: String)
 
 @audio.map { audio =>
     <div class="gu-media-wrapper gu-media-wrapper--audio">
         <audio controls="controls" class="gu-media gu-media--audio js-gu-media" data-title="@title"
-            data-duration="@audio.duration.toString()" data-media-id="@audio.id">
+            data-duration="@audio.duration.toString()" data-media-id="@audio.id" data-auto-play="true">
 
             @audio.encodings.map { encoding =>
                 <source src="@encoding.url" type="@encoding.format" />

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -1,42 +1,38 @@
-@(video: model.VideoElement, profile: views.support.VideoProfile, title: String, showControlsAtStart: Boolean = true, endSlatePath: Option[String] = None)
+@(player: model.VideoPlayer)
 
 @import conf.Static
-@import views.support.{Video640, RenderClasses}
+@import views.support.RenderClasses
 
-@mediaVideo(profile.bestFor(video).getOrElse(Static("images/media-holding.jpg").path), profile.width.get, profile.height.get)
+<div class="gu-media-wrapper gu-media-wrapper--video">
+    <div class="@RenderClasses(Map(
+        "u-responsive-ratio" -> true,
+        "u-responsive-ratio--hd" -> player.profile.isRatioHD
+    ))">
+        <video controls="controls" class="@RenderClasses(Map(
+            ("gu-media", true),
+            ("gu-media--video", true),
+            ("gu-media--show-controls-at-start", player.showControlsAtStart),
+            ("js-gu-media", true)
+        ))" data-title="@player.title" data-auto-play="@player.autoPlay" data-show-end-slate="@{!player.hideEndSlate}"
+            poster="@player.poster" data-duration="@player.video.duration.toString()" data-media-id="@player.video.id" data-end-slate="@player.endSlatePath">
 
-@mediaVideo(poster: String, width: Int, height: Int) = {
-    <div class="gu-media-wrapper gu-media-wrapper--video">
-        <div class="@RenderClasses(Map(
-            "u-responsive-ratio" -> true,
-            "u-responsive-ratio--hd" -> profile.isRatioHD
-        ))">
-            <video controls="controls" class="@RenderClasses(Map(
-                "gu-media" -> true,
-                "gu-media--video" -> true,
-                "gu-media--show-controls-at-start" -> showControlsAtStart,
-                "js-gu-media" -> true
-            ))" data-title="@title"
-                poster="@poster" data-duration="@video.duration.toString()" data-show-end-slate="@{width >= Video640.width.get}" data-media-id="@video.id" @endSlatePath.map { path => data-end-slate="@path"}>
+            @player.video.encodings.map { encoding =>
+                <source src="@encoding.url" type="@encoding.format" />
+            }
 
-                @video.encodings.map { encoding =>
-                    <source src="@encoding.url" type="@encoding.format" />
-                }
-
-                @video.encodings.find(_.format == "video/mp4").map { encoding =>
-                    <object type="application/x-shockwave-flash" data="@Static("flash/flashmediaelement.swf")" width="@width" height="@height">
-                        <param name="allowFullScreen" value="true" />
-                        <param name="movie" value="@Static("flash/flashmediaelement.swf")" />
-                        <param name="flashvars" value="controls=true&amp;file=@encoding.url" />
-                        <img src="@poster" alt="" width="@width" height="@height" />
-                        <div class="vjs-error-display">
-                            <div>Sorry, your browser is unable to play this video.<br/>
-                                Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a>™ and try again.
-                                Alternatively <a href="http://whatbrowser.org/">upgrade</a> to a modern browser.</div>
-                        </div>
-                    </object>
-                }
-            </video>
-        </div>
+            @player.video.encodings.find(_.format == "video/mp4").map { encoding =>
+                <object type="application/x-shockwave-flash" data="@Static("flash/flashmediaelement.swf")" width="@player.width" height="@player.height">
+                    <param name="allowFullScreen" value="true" />
+                    <param name="movie" value="@Static("flash/flashmediaelement.swf")" />
+                    <param name="flashvars" value="controls=true&amp;file=@encoding.url" />
+                    <img src="@player.poster" alt="" width="@player.width" height="@player.height" />
+                    <div class="vjs-error-display">
+                        <div>Sorry, your browser is unable to play this video.<br/>
+                            Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a>™ and try again.
+                            Alternatively <a href="http://whatbrowser.org/">upgrade</a> to a modern browser.</div>
+                    </div>
+                </object>
+            }
+        </video>
     </div>
-}
+</div>

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -13,7 +13,7 @@
             ("gu-media--video", true),
             ("gu-media--show-controls-at-start", player.showControlsAtStart),
             ("js-gu-media", true)
-        ))" data-title="@player.title" data-auto-play="@player.autoPlay" data-show-end-slate="@{!player.hideEndSlate}"
+        ))" data-title="@player.title" data-auto-play="@player.autoPlay" data-show-end-slate="@player.showEndSlate"
             poster="@player.poster" data-duration="@player.video.duration.toString()" data-media-id="@player.video.id" data-end-slate="@player.endSlatePath">
 
             @player.video.encodings.map { encoding =>


### PR DESCRIPTION
This will allow us to have multiple players on a page and choose which (if any) to autoplay.

I've also refactored the (now hideous) video player template, so that it takes a video player model (on the suggestion of @gklopper). It's much nicer now!

I've also removed duplicate logic for constructing the end slate url from the JavaScript - it's now required that you pass this in when you construct the player and becomes a data attribute, which I think will make it easier to understand in the future.
