### PR TITLE
Change meta font to Text Sans

### DIFF
--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -278,7 +278,7 @@
     position: relative;
     color: $c-neutral2;
     @include box-sizing(border-box);
-    @include fs-data(2);
+    @include fs-textSans(1);
     @include rem((
         padding-top: $gs-baseline/3
     ));
@@ -296,7 +296,6 @@
 
     @include mq(tablet) {
         padding-right: 0;
-        @include fs-data(3, true);
     }
 
     @include mq(leftCol) {
@@ -401,11 +400,10 @@
 }
 
 .content-meta {
-    @include fs-textSans(3);
+    @include fs-textSans(1);
     font-weight: bold;
     @include rem((
-        margin: 0 0 $gs-baseline/2,
-        line-height: 16px
+        margin: 0 0 $gs-baseline/2
     ));
 
     @include mq(tablet) {
@@ -546,7 +544,7 @@
 
 .commentcount {
     display: none;
-    @include fs-data(3);
+    @include fs-textSans(1);
 
     i {
         vertical-align: bottom;
@@ -568,7 +566,7 @@
         position: absolute;
         right: 0;
         @include rem((
-            top: $gs-baseline/2
+            top: $gs-baseline/3
         ));
 
         .content__head & {

--- a/common/app/assets/stylesheets/module/content/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/content/_live-blog.scss
@@ -84,7 +84,7 @@ $block-padding-right: $gs-gutter;
         margin: 0;
         padding: 0;
         height: auto;
-        @include fs-data(3);
+        @include fs-textSans(2);
         color: inherit;
         border: 0;
         @include mq($to: mobileLandscape) {

--- a/common/app/assets/stylesheets/module/facia/_items.scss
+++ b/common/app/assets/stylesheets/module/facia/_items.scss
@@ -97,7 +97,6 @@
 }
 .container__toggle,
 .item__live-indicator,
-.item__meta,
 .collection__show-more {
     @include f-data;
 }
@@ -400,11 +399,7 @@
 .item__meta {
     position: absolute;
     bottom: 0;
-    @include fs-data(2, $size-only: true);
-
-    @include mq(tablet) {
-        @include fs-data(3, $size-only: true);
-    }
+    @include fs-textSans(1);
 
     .item__timestamp,
     .trail__count {
@@ -428,16 +423,9 @@
             @include rem((
                 top: 3px
             ));
-            @include mq(tablet) {
-                @include rem((
-                    top: 2px
-                ));
-            }
         }
     }
     .trail__count {
-        top: 0;
-
         a {
             @include rem((
                 padding-left: 18px
@@ -447,9 +435,15 @@
         }
         i {
             @include rem((
-                top: 2px,
+                top: 3px, // Aligns well with system sans-serif font
                 left: 0
             ));
+
+            @include mq(desktop) {
+                @include rem((
+                    top: 1px // Align with Text Sans 1
+                ));
+            }
         }
     }
 }


### PR DESCRIPTION
Note that there are no changes on mobile, since we load Text Sans starting at desktop breakpoint only.

![screen shot 2014-08-18 at 17 00 21](https://cloud.githubusercontent.com/assets/85783/3954664/b47559b8-26f8-11e4-8712-d6d12e92aed0.PNG)
![screen shot 2014-08-18 at 17 00 11](https://cloud.githubusercontent.com/assets/85783/3954666/b480abb0-26f8-11e4-8ce4-23565ef68512.PNG)
![screen shot 2014-08-18 at 16 58 37](https://cloud.githubusercontent.com/assets/85783/3954665/b47fef7c-26f8-11e4-8096-3f6d493e23fb.PNG)
![screen shot 2014-08-18 at 18 12 18](https://cloud.githubusercontent.com/assets/85783/3954809/da00271a-26fa-11e4-8fad-910421be3dde.PNG)

![ ](http://media.giphy.com/media/mnEPOhKIE9iJq/giphy.gif)
