### PR TITLE
is-modern and is-not-modern browser support classes

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -14,7 +14,7 @@
                 @fragments.galleryThumbs(gallery, showCta=true)
 
                 <!-- Non-JS Gallery / LightboxSwitch off mode -->
-                <div class="js-hidden">
+                <div class="modern-hidden">
                     <p class="gallery-nav">
 
                         @if(index > 1) {

--- a/commercial/app/views/moneysupermarket/bestBuys.scala.html
+++ b/commercial/app/views/moneysupermarket/bestBuys.scala.html
@@ -45,7 +45,7 @@
                             <p class="lineitem__meta">Data provided by London &amp; Country Mortgages Ltd</p>
                         </div>
                     </div>
-                    <div class="tabs__pane current-accounts js-hidden" id="current-accounts" role="tabpanel" aria-labelledby="current-accounts-tab">
+                    <div class="tabs__pane current-accounts modern-hidden" id="current-accounts" role="tabpanel" aria-labelledby="current-accounts-tab">
                         <div class="commercial__head container__title">
                             <h4 class="commercial__explainer">Looking after your day-to-day finances</h4>
                         </div>
@@ -73,7 +73,7 @@
                             <p class="lineitem__meta">Data provided by Moneysupermarket.com. Moneysupermarket.com Limited is an appointed representative of Moneysupermarket.com Financial Group Limited &copy;, which is authorised and regulated by the Financial Services Authority (FSA FRN 303190). Moneysupermarket.com Financial group Limited, registered in England No. 3157344. Registered Office: Moneysupermarket House, St. David's Park, Ewloe, CH5 3UZ. Telephone 01244 665700.</p>
                         </div>
                     </div>
-                    <div class="tabs__pane savings js-hidden" id="savings-account" role="tabpanel" aria-labelledby="savings-tab">
+                    <div class="tabs__pane savings modern-hidden" id="savings-account" role="tabpanel" aria-labelledby="savings-tab">
                         <div class="commercial__head container__title">
                             <h4 class="commercial__explainer">A safe home for your nest egg</h4>
                         </div>

--- a/commercial/app/views/moneysupermarket/bestBuysHigh.scala.html
+++ b/commercial/app/views/moneysupermarket/bestBuysHigh.scala.html
@@ -45,7 +45,7 @@
                             <p class="lineitem__meta">Data provided by London &amp; Country Mortgages Ltd</p>
                         </div>
                     </div>
-                    <div class="tabs__pane current-accounts js-hidden" id="current-accounts" role="tabpanel" aria-labelledby="current-accounts-tab">
+                    <div class="tabs__pane current-accounts modern-hidden" id="current-accounts" role="tabpanel" aria-labelledby="current-accounts-tab">
                         <div class="commercial__head container__title">
                             <h4 class="commercial__explainer">Looking after your day-to-day finances</h4>
                         </div>
@@ -73,7 +73,7 @@
                             <p class="lineitem__meta">Data provided by Moneysupermarket.com. Moneysupermarket.com Limited is an appointed representative of Moneysupermarket.com Financial Group Limited &copy;, which is authorised and regulated by the Financial Services Authority (FSA FRN 303190). Moneysupermarket.com Financial group Limited, registered in England No. 3157344. Registered Office: Moneysupermarket House, St. David's Park, Ewloe, CH5 3UZ. Telephone 01244 665700.</p>
                         </div>
                     </div>
-                    <div class="tabs__pane savings js-hidden" id="savings-account" role="tabpanel" aria-labelledby="savings-tab">
+                    <div class="tabs__pane savings modern-hidden" id="savings-account" role="tabpanel" aria-labelledby="savings-tab">
                         <div class="commercial__head container__title">
                             <h4 class="commercial__explainer">A safe home for your nest egg</h4>
                         </div>

--- a/common/app/assets/javascripts/modules/discussion/loader.js
+++ b/common/app/assets/javascripts/modules/discussion/loader.js
@@ -199,7 +199,7 @@ Loader.prototype.loadComments = function(args) {
                 self.comments.removeState('shut');
             }
 
-            bonzo(commentsContainer).removeClass('js-hidden');
+            bonzo(commentsContainer).removeClass('modern-hidden');
             self.initUnthreaded();
         }).fail(self.loadingError.bind(self));
 };

--- a/common/app/assets/javascripts/modules/onward/more-tags.js
+++ b/common/app/assets/javascripts/modules/onward/more-tags.js
@@ -14,10 +14,10 @@ define([
         this.init = function() {
             var $more = $('.js-more-tags');
             if ($more.length !== 0) {
-                $more.removeClass('js-hidden');
+                $more.removeClass('modern-hidden');
                 bean.on(document.querySelector('.js-more-tags__link'), 'click', function(){
-                    $('.js-hidden-tag').removeClass('js-hidden');
-                    $more.addClass('js-hidden');
+                    $('.modern-hidden-tag').removeClass('modern-hidden');
+                    $more.addClass('modern-hidden');
                 });
             }
         };

--- a/common/app/assets/javascripts/modules/ui/relativedates.js
+++ b/common/app/assets/javascripts/modules/ui/relativedates.js
@@ -191,7 +191,7 @@ define([
                 }
                 targetEl.innerHTML = relativeDate;
             } else if (opts.notAfter) {
-                $el.addClass('js-hidden');
+                $el.addClass('modern-hidden');
             }
         });
     }

--- a/common/app/assets/javascripts/modules/ui/tabs.js
+++ b/common/app/assets/javascripts/modules/ui/tabs.js
@@ -19,7 +19,7 @@ define([
 
             <div class="tabs__content">
                  <div class="tabs__pane" id="foo" role="tabpanel" aria-labelledby="foo-tab">foo</div>
-                 <div class="tabs__pane js-hidden" id="bar" role="tabpanel" aria-labelledby="bar-tab">bar</div>
+                 <div class="tabs__pane modern-hidden" id="bar" role="tabpanel" aria-labelledby="bar-tab">bar</div>
             </div>
         </div>
     */
@@ -45,7 +45,7 @@ define([
                 bonzo(currentTab.parentNode).attr('aria-selected', false);
                 bonzo(clickedTab.parentNode).attr('aria-selected', true);
                 bonzo(paneToHide).hide();
-                bonzo(paneToShow).removeClass('js-hidden').show().focus();
+                bonzo(paneToShow).removeClass('modern-hidden').show().focus();
 
                 // only do this if we know the href was a tab ID, not a URL
                 originalEvent.preventDefault();

--- a/common/app/assets/stylesheets/base/_state.scss
+++ b/common/app/assets/stylesheets/base/_state.scss
@@ -1,7 +1,9 @@
 @charset 'UTF-8';
 
-.is-modern .js-hidden,
-.is-not-modern .js-visible {
+.js-on .js-hidden,
+.js-off .js-visible,
+/*.js-on*/.is-modern .modern-hidden,
+.is-not-modern .modern-visible {
     display: none;
 }
 

--- a/common/app/assets/stylesheets/module/_tabs.scss
+++ b/common/app/assets/stylesheets/module/_tabs.scss
@@ -19,7 +19,7 @@ category: Common
         <div id="tabs-example-1" class="tabs__pane u-cf" role="tabpanel" aria-labelledby="tabs-example-1-tab">
             <!-- Content of tab 1 -->
         </div>
-        <div id="tabs-example-2" class="tabs__pane js-hidden u-cf" role="tabpanel" aria-labelledby="tabs-example-2-tab">
+        <div id="tabs-example-2" class="tabs__pane modern-hidden u-cf" role="tabpanel" aria-labelledby="tabs-example-2-tab">
             <!-- Content of tab 2 -->
         </div>
     </div>

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -22,7 +22,7 @@
 
         @popular.zipWithRowInfo.map{ case (section, info) =>
             <div id="tabs-popular-@info.rowNum"
-                 class="@if(isTabbed){tabs__pane @if(!info.isFirst){js-hidden}} u-cf"
+                 class="@if(isTabbed){tabs__pane @if(!info.isFirst){modern-hidden}} u-cf"
                  @if(isTabbed){
                      role="tabpanel"
                      aria-labelledby="tabs-popular-@info.rowNum-tab"

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -9,9 +9,9 @@
         </div>
     </div>
 
-    <div class="discussion__comments__container js-hidden" data-test-id="comments-container">
-        <h2 class="page-sub-header discussion__heading js-visible">All Comments</h2>
-        <button class="u-button-reset u-fauxlink js-visible discussion__show-threaded js-show-threaded" data-test-id="comment-view-type">
+    <div class="discussion__comments__container modern-hidden" data-test-id="comments-container">
+        <h2 class="page-sub-header discussion__heading modern-visible">All Comments</h2>
+        <button class="u-button-reset u-fauxlink modern-visible discussion__show-threaded js-show-threaded" data-test-id="comment-view-type">
             View <span class="discussion__show-threaded-state">un</span>threaded
         </button>
 

--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -7,16 +7,16 @@
             aria-haspopup="true"
             aria-controls="@hash">
         <span class="dropdown__label">@name</span>
-        <span class="control js-visible">
+        <span class="control modern-visible">
             <i class="i i-arrow-down-white-mask tone-background"></i>
         </span>
     </button>
 
-    <label class="dropdown__toggle-label js-hidden"
+    <label class="dropdown__toggle-label modern-hidden"
            aria-haspopup="true"
            aria-controls="@hash"
            for="@{hash}__label">Show</label>
-    <input class="dropdown__toggle js-hidden"
+    <input class="dropdown__toggle modern-hidden"
             aria-haspopup="true"
             aria-controls="@hash"
             type="checkbox"

--- a/common/app/views/fragments/galleryThumbs.scala.html
+++ b/common/app/views/fragments/galleryThumbs.scala.html
@@ -2,7 +2,7 @@
 @import views.support.ImgSrc
 
 
-<div class="gallerythumbs js-visible u-cf js-gallerythumbs gallerythumbs--@if(gallery.landscapes.length >= 3) {landscapes} else {portraits}" data-link-name="Gallery thumbnail sheet">
+<div class="gallerythumbs modern-visible u-cf js-gallerythumbs gallerythumbs--@if(gallery.landscapes.length >= 3) {landscapes} else {portraits}" data-link-name="Gallery thumbnail sheet">
     @if(showCta) {
         <a class="gallery-launch-cta" data-link-name="Launch Gallery CTA" href="@LinkTo{@gallery.url}">
             Open gallery<i class="i i-double-arrow-right-yellow"></i>

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -99,25 +99,17 @@
         window.s_account = guardian.config.page.omnitureAccount;
 
         @* we want to add/remove classes to HTML ASAP to avoid FOUC *@
-        var currentClassName = document.documentElement.className,
-            htmlClassNames = currentClassName ? currentClassName.split(' ') : [];
-
-        if (!isModern) {
-            htmlClassNames.push('is-not-modern');
-        } else {
+        if (isModern) {
             @* http://modernizr.com/download/#-svg *@
             function hasSvgSupport() {
                 var ns = {'svg': 'http://www.w3.org/2000/svg'};
                 return !!document.createElementNS && !!document.createElementNS(ns.svg, 'svg').createSVGRect;
             }
             if (hasSvgSupport()) {
-                htmlClassNames.push('svg');
+                document.documentElement.className += ' svg';
             }
-            htmlClassNames.push('is-modern');
+            document.documentElement.className = document.documentElement.className.replace(/\bis-not-modern\b/g, 'is-modern');
         }
-
-        document.documentElement.className = htmlClassNames.join(' ');
-
     })(guardian.isModernBrowser);
 
     document.documentElement.className = document.documentElement.className.replace(/\bjs-off\b/g, 'js-on');

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -24,13 +24,13 @@
 
                 @if(hiddenKeywords.nonEmpty) {
 
-                    <li class="inline-list__item js-more-tags js-hidden">
+                    <li class="inline-list__item js-more-tags modern-hidden">
                         <button class="u-button-reset u-fauxlink show-more-tags js-more-tags__link"
                            data-link-name="more-tags">more…</button>
                     </li>
 
                     @hiddenKeywords.zipWithRowInfo.map{ case(keyword, row) =>
-                        @renderItem(keyword, row, clazz = "js-hidden js-hidden-tag")
+                        @renderItem(keyword, row, clazz = "modern-hidden modern-hidden-tag")
                     }
                 }
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -6,7 +6,7 @@
    be sure to apply any necessary changes to non-shared code there too. *@
 
 <!DOCTYPE html>
-<html id="js-context" class="js-off id--signed-out" lang="en-GB" data-page-path="@request.path">
+<html id="js-context" class="js-off is-not-modern id--signed-out" lang="en-GB" data-page-path="@request.path">
 <head>
     @fragments.head(metaData, projectName, head, curlPaths)
 </head>

--- a/common/test/assets/javascripts/spec/MoreTags.spec.js
+++ b/common/test/assets/javascripts/spec/MoreTags.spec.js
@@ -28,17 +28,17 @@ define([
                                     'data-link-name="keyword: world/usforeignpolicy"' +
                                     'itemprop="keywords">US foreign policy</a>,' +
                                 '</li>' +
-                                '<li class="inline-list__item js-more-tags js-hidden">' +
+                                '<li class="inline-list__item js-more-tags modern-hidden">' +
                                     '<button class="u-button-reset u-fauxlink js-more-tags__link"' +
                                     'data-link-name="more-tags">more…</button>' +
                                 '</li>' +
-                                '<li class="inline-list__item js-hidden js-hidden-tag">' +
+                                '<li class="inline-list__item modern-hidden modern-hidden-tag">' +
                                     '<a class=" "' +
                                     'href="/world/russia"' +
                                     'data-link-name="keyword: world/russia"' +
                                     'itemprop="keywords">Russia</a>,' +
                                 '</li>' +
-                                '<li class="inline-list__item js-hidden js-hidden-tag">' +
+                                '<li class="inline-list__item modern-hidden modern-hidden-tag">' +
                                     '<a class=" "' +
                                     'href="/world/vladimir-putin"' +
                                     'data-link-name="keyword: world/vladimir-putin"' +
@@ -58,18 +58,18 @@ define([
         });
 
         it("should initially hide the 'more...' link", function(){
-            expect($('.js-more-tags').hasClass('js-hidden')).toBeTruthy();
-            expect($('.js-hidden-tag').hasClass('js-hidden')).toBeTruthy();
+            expect($('.js-more-tags').hasClass('modern-hidden')).toBeTruthy();
+            expect($('.modern-hidden-tag').hasClass('modern-hidden')).toBeTruthy();
         });
 
         it("should reveal the 'more...' link when initialised", function(){
 
             new MoreTags().init();
 
-            expect($('.js-more-tags').hasClass('js-hidden')).toBeFalsy();
+            expect($('.js-more-tags').hasClass('modern-hidden')).toBeFalsy();
 
             // but the tags should remain hidden
-            expect($('.js-hidden-tag').hasClass('js-hidden')).toBeTruthy();
+            expect($('.modern-hidden-tag').hasClass('modern-hidden')).toBeTruthy();
         });
 
         it("should reveal the hidden keywords when clicked", function(){
@@ -78,10 +78,10 @@ define([
 
             document.querySelector('.js-more-tags__link').click();
 
-            expect($('.js-hidden-tag').hasClass('js-hidden')).toBeFalsy();
+            expect($('.modern-hidden-tag').hasClass('modern-hidden')).toBeFalsy();
 
             // but the more link should now be hidden
-            expect($('.js-more-tags').hasClass('js-hidden')).toBeTruthy();
+            expect($('.js-more-tags').hasClass('modern-hidden')).toBeTruthy();
         });
     });
 });

--- a/common/test/assets/javascripts/spec/Tabs.spec.js
+++ b/common/test/assets/javascripts/spec/Tabs.spec.js
@@ -23,7 +23,7 @@ define(['common/modules/ui/tabs', 'bean', 'helpers/fixtures'], function(Tabs, be
                             '</ol>' +
                             '<div class="tabs__content">' +
                                 '<div class="tabs__pane" id="tab1panel" role="tabpanel">foo</div>' +
-                                '<div class="tabs__pane js-hidden" id="tab2panel" role="tabpanel">bar</div>' +
+                                '<div class="tabs__pane modern-hidden" id="tab2panel" role="tabpanel">bar</div>' +
                             '</div>' +
                         '</div>' +
                         '<div class="tabs-container">' +
@@ -34,7 +34,7 @@ define(['common/modules/ui/tabs', 'bean', 'helpers/fixtures'], function(Tabs, be
                             '</ol>' +
                             '<div class="tabs-content">' +
                                 '<div class="tabs-pane" id="tab1panel_2" role="tabpanel" aria-labelledby="tab1_2-tab">foo</div>' +
-                                '<div class="tabs-pane js-hidden" id="tab2panel_2" role="tabpanel" aria-labelledby="tab2_2-tab">bar</div>' +
+                                '<div class="tabs-pane modern-hidden" id="tab2panel_2" role="tabpanel" aria-labelledby="tab2_2-tab">bar</div>' +
                             '</div>' +
                         '</div>' +
                     '</p>'
@@ -83,7 +83,7 @@ define(['common/modules/ui/tabs', 'bean', 'helpers/fixtures'], function(Tabs, be
 
         it("should show the correct panel when a tab is clicked", function(){
             bean.fire(tab2, 'click');
-            expect(tab2panel.getAttribute('class')).not.toContain('js-hidden');
+            expect(tab2panel.getAttribute('class')).not.toContain('modern-hidden');
         });
 
         it("should hide other panels when a tab is clicked", function(){
@@ -93,7 +93,7 @@ define(['common/modules/ui/tabs', 'bean', 'helpers/fixtures'], function(Tabs, be
 
         it("should operate independently of other tabsets on the page", function(){
             bean.fire(tab2, 'click');
-            expect(independentTabPanel.getAttribute('class')).toContain('js-hidden');
+            expect(independentTabPanel.getAttribute('class')).toContain('modern-hidden');
         });
 
         it("should allow 'fake' tabs with URL hrefs instead of ID selectors", function(){

--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -11,7 +11,7 @@
             }
         </div>
 
-        <div class="d-discussion__meta d-dicussion__meta--sorting d-meta-item js-visible">
+        <div class="d-discussion__meta d-dicussion__meta--sorting d-meta-item modern-visible">
             View
             <select class="d-discussion__order-control">
                 <option value="oldest" @if(page.orderBy == "oldest"){selected="selected"}>oldest</option>
@@ -19,10 +19,10 @@
             </select>
             first
         </div>
-        <div class="d-discussion__meta d-dicussion__meta--sorting js-hidden">
+        <div class="d-discussion__meta d-dicussion__meta--sorting modern-hidden">
             Sort comments
             @defining(if(page.orderBy == "oldest") "newest" else "oldest"){ orderTo =>
-                <span class="js-hidden">
+                <span class="modern-hidden">
                     <a href="@LinkTo{/discussion/@orderTo/@page.id}">@orderTo</a>
                 </span>
             }

--- a/identity/app/views/formstack/formstackForm.scala.html
+++ b/identity/app/views/formstack/formstackForm.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off id--signed-out" lang="en-GB">
+<html class="js-off is-not-modern id--signed-out" lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>

--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off id--signed-out" lang="en-GB">
+<html lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>@Html(metaData.webTitle)</title>

--- a/identity/app/views/identityMain.scala.html
+++ b/identity/app/views/identityMain.scala.html
@@ -1,7 +1,7 @@
 @(metaData: model.MetaData, switches: Seq[common.Switchable], projectName: Option[String] = Some(conf.Configuration.environment.projectName))(head: Html)(body: Html)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
-<html class="js-off id--signed-out" lang="en-GB">
+<html class="js-off is-not-modern id--signed-out" lang="en-GB">
 <head>
     @fragments.head(metaData, projectName, head, Map("bootstraps/membership" -> "javascripts/bootstraps/membership.js"))
 </head>

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -37,7 +37,7 @@
             }
         </div>
 
-        <div class="js-visible">
+        <div class="modern-visible">
             @defining("/user/id/"+user.id){ link =>
                 <div class="tabs tabs--identity">
                     <ol class="tabs__container">

--- a/sport/app/football/views/fragments/leagueSelector.scala.html
+++ b/sport/app/football/views/fragments/leagueSelector.scala.html
@@ -14,7 +14,7 @@
 }
 
 @if(filterGroups.nonEmpty){
-<form class="football-leagues js-visible" method="get">
+<form class="football-leagues modern-visible" method="get">
     <label for="football-leagues" class="football-leagues__label">Choose league: </label>
     <select class="football-leagues__list" name="competitionUrl" id="football-leagues">
         <option value="/football/@pageType">All @pageType</option>

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -21,7 +21,7 @@
 
                 <div class="article__columning-wrapper">
                     <div class="article__main-column">
-                        <div class="football-leagues football-leagues--list js-hidden">
+                        <div class="football-leagues football-leagues--list modern-hidden">
                             <ul class="football-leagues-list u-unstyled">
                                 @matchesList.competitions.competitions.map{ comp =>
                                     <li class="football-leagues__item"><a href="@comp.url/@matchesList.pageType" data-link-name="view @comp.fullName matches">@comp.fullName</option></a></li>

--- a/sport/app/football/views/wallchart/embed.scala.html
+++ b/sport/app/football/views/wallchart/embed.scala.html
@@ -1,6 +1,6 @@
 @(page: Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStage])(implicit request: RequestHeader)
 <!DOCTYPE html>
-<html class="js-off id--signed-out" lang="en-GB">
+<html class="js-off is-not-modern id--signed-out" lang="en-GB">
     <head>
         <meta name="robots" content="noindex, nofollow" />
         @fragments.head(page, "football", Html(""), Map())


### PR DESCRIPTION
Until a few days ago, a browser that did not cut the mustard was put in the "js-off" bucket. Modern browsers were in the "js-on" bucket.

We are introducing a new tier of support.
### Before
- `html.js-off`: browser has JavaScript switched off / does not support JavaScript
- `html.js-on`: browser cuts the mustard
### After
- `html.js-off`, aka `html.js-off.is-not-modern`: JavaScript switched off or browser does not support JavaScript
- `html.js-on`: JavaScript is switched on (and browser might or might not cut the mustard)
- `html.js-on.is-not-modern`: JavaScript is switched on, but browser does not cut the mustard
- `html.is-modern` aka `html.js-on.is-modern`: browser cuts the mustard
### On x-browser testing

To test rendering in older browsers without opening IE8, Safari on iPad 1 or Opera Mini, it's no longer enough to turn off JavaScript in developer tools, and we would need to actually test on a browser that has JS on, but does not cut the mustard. This comes in the way of fun and productivity.

I think the solution is a user preference switch that forces the "is-not-modern" state. /cc @ironsidevsquincy @phamann @sndrs what do you think?

![ ](http://gifs.joelglovier.com/high-five/awkward-high-five.gif)
