### PR TITLE
Add Timestamp to Surging Content Page

### DIFF
--- a/admin/app/controllers/CommercialController.scala
+++ b/admin/app/controllers/CommercialController.scala
@@ -39,11 +39,9 @@ object CommercialController extends Controller with Logging with AuthLogging {
     NoCache(Ok(views.html.commercial.pageskins(Configuration.environment.stage, pageskinnedAdUnits)))
   }
 
-  def renderSurgingContent = AuthActions.AuthActionTest {implicit request =>
-    val surging: Seq[(String, Int)] = SurgingContentAgent.getSurging.toSeq
-    val sortedSurging: Seq[(String, Int)] = surging.sortBy(_._2).reverse
-
-    NoCache(Ok(views.html.commercial.surgingpages(Configuration.environment.stage, sortedSurging)))
+  def renderSurgingContent = AuthActions.AuthActionTest { implicit request =>
+    val surging = SurgingContentAgent.getSurging
+    NoCache(Ok(views.html.commercial.surgingpages(Configuration.environment.stage, surging)))
   }
 
   def renderInlineMerchandisingTargetedTags = AuthActions.AuthActionTest { implicit request =>

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -1,8 +1,8 @@
 package dfp
 
 import common.ExecutionContexts
+import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json.Json.{toJson, _}
 import play.api.libs.json.{JsValue, Json, Writes}
 import tools.Store
@@ -141,8 +141,6 @@ object DfpDataCacheJob extends ExecutionContexts {
       )
     }
   }
-
-  private val londonTimeFormatter = DateTimeFormat.longDateTime().withZone(DateTimeZone.forID("Europe/London"))
 
   def run() {
     future {

--- a/admin/app/views/commercial/surgingpages.scala.html
+++ b/admin/app/views/commercial/surgingpages.scala.html
@@ -1,16 +1,17 @@
-@(env: String, surgingpages: Seq[(String, Int)])
-@import tools.DfpLink
+@(env: String, surgingContent: ophan.SurgingContent)
 
 @admin_main("Commercial", env, isAuthed = true, hasCharts = true) {
 
     <link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/commercial.css")">
 
     <h1>Surging Content</h1>
-<p>Guardian content that is currently surging</p>
+    <p>Guardian content that is currently surging.</p>
+    <p>Last updated: @surgingContent.lastUpdated</p>
 
     <ol>
-        @for((path, pvs) <- surgingpages) {
+        @for((path, pvs) <- surgingContent.sortedSurges) {
            <li><a href="http://www.theguardian.com/@path">@path</a> (@pvs)</li>
         }
     </ol>
+
 }

--- a/common/app/dfp/package.scala
+++ b/common/app/dfp/package.scala
@@ -1,3 +1,5 @@
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -7,4 +9,6 @@ package object dfp {
     (__ \ "tags").read[Seq[String]] and
     (__ \ "sponsor").readNullable[String]
   )(Sponsorship)
+
+  val londonTimeFormatter = DateTimeFormat.longDateTime().withZone(DateTimeZone.forID("Europe/London"))
 }


### PR DESCRIPTION
We read surging content from Ophan every 30 mins.

This shows us how old our cached data is.
