### PR TITLE
Ads Target Multiple Surge Levels

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -123,7 +123,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   override lazy val description: Option[String] = trailText
   override lazy val headline: String = apiContent.metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(fields("headline"))
   override lazy val trailText: Option[String] = apiContent.metaData.get("trailText").flatMap(_.asOpt[String]).orElse(fields.get("trailText"))
-  override def isSurging: Int = SurgingContentAgent.getSurgingLevelFor(id)
+  override def isSurging: Seq[Int] = SurgingContentAgent.getSurgingLevelsFor(id)
 
   // Meta Data used by plugins on the page
   // people (including 3rd parties) rely on the names of these things, think carefully before changing them

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -37,7 +37,7 @@ trait MetaData extends Tags {
 
   def hasPageSkin(edition: Edition) = false
 
-  def isSurging = 0
+  def isSurging: Seq[Int] = Seq(0)
 
   def metaData: Map[String, Any] = Map(
     ("page-id", id),
@@ -48,7 +48,7 @@ trait MetaData extends Tags {
     ("blockVideoAds", false),
     ("is-front", isFront),
     ("ad-unit", s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitRoot}/$adUnitSuffix/ng"),
-    ("is-surging", isSurging),
+    ("is-surging", isSurging.mkString(",")),
     ("has-classic-version", hasClassicVersion)
   )
 

--- a/common/app/ophan/SurgingContentAgent.scala
+++ b/common/app/ophan/SurgingContentAgent.scala
@@ -1,11 +1,9 @@
 package ophan
 
-import common._
+import common.{AkkaAsync, Jobs, _}
 import play.api.libs.json.{JsArray, JsValue}
-import java.net.URL
+import play.api.{GlobalSettings, Application => PlayApp}
 import services.OphanApi
-import play.api.{Application => PlayApp, GlobalSettings}
-import common.{AkkaAsync, Jobs}
 
 object SurgingContentAgent extends Logging with ExecutionContexts {
 
@@ -28,18 +26,22 @@ object SurgingContentAgent extends Logging with ExecutionContexts {
     agent.get()
   }
 
-  def getSurgingLevelFor(id: String): Int = SurgeUtils.levelProvider(agent.get().get(id))
+  def getSurgingLevelsFor(id: String): Seq[Int] = SurgeUtils.levelProvider(agent.get().get(id))
 }
 
 object SurgeUtils {
-  def levelProvider(surgeLevel: Option[Int]) = {
-    surgeLevel match {
+
+  def levelProvider(surgeLevel: Option[Int]): Seq[Int] = {
+
+    val level = surgeLevel match {
       case Some(x) if x >= 400 => 1
       case Some(x) if x >= 300 => 2
       case Some(x) if x >= 200 => 3
       case Some(x) if x >= 100 => 4
       case _ => 0
     }
+
+    if (level == 0) Seq(0) else Seq.range(level, 5)
   }
 
   def parse(json: JsValue) = {

--- a/common/test/ophan/SurgeUtilsTest.scala
+++ b/common/test/ophan/SurgeUtilsTest.scala
@@ -21,13 +21,13 @@ class SurgeUtilsTest extends FlatSpec with Matchers {
   }
 
   "surgeLevelProvider" should "return a numerical representation of the surge level" in {
-    SurgeUtils.levelProvider(Some(500)) should be (1)
-    SurgeUtils.levelProvider(Some(401)) should be (1)
-    SurgeUtils.levelProvider(Some(301)) should be (2)
-    SurgeUtils.levelProvider(Some(201)) should be (3)
-    SurgeUtils.levelProvider(Some(101)) should be (4)
-    SurgeUtils.levelProvider(Some(99))  should be (0)
-    SurgeUtils.levelProvider(None) should be (0)
+    SurgeUtils.levelProvider(Some(500)) should be (Seq(1, 2, 3, 4))
+    SurgeUtils.levelProvider(Some(401)) should be (Seq(1, 2, 3, 4))
+    SurgeUtils.levelProvider(Some(301)) should be (Seq(2, 3, 4))
+    SurgeUtils.levelProvider(Some(201)) should be (Seq(3, 4))
+    SurgeUtils.levelProvider(Some(101)) should be (Seq(4))
+    SurgeUtils.levelProvider(Some(99))  should be (Seq(0))
+    SurgeUtils.levelProvider(None) should be (Seq(0))
   }
 
   lazy val jsonString =


### PR DESCRIPTION
We used to send surge targets in our ad calls corresponding to a range of Ophan surge levels.

Now we are sending targets for the surge level and all the levels below that.  This is because it is apparently easier to build a DFP report if we target multiple surge levels.
