### PR TITLE
Fix Sentry's 'contains' errors

### DIFF
--- a/common/app/assets/javascripts/modules/charts/doughnut.js
+++ b/common/app/assets/javascripts/modules/charts/doughnut.js
@@ -15,8 +15,10 @@ define([
      * @param {string} type
      * @return {Bonzo}
      */
-    function svgEl(type) {
-        return $.create(document.createElementNS('http://www.w3.org/2000/svg', type));
+    function svgEl(type, elClass) {
+        var $el = $.create(document.createElementNS('http://www.w3.org/2000/svg', type));
+        $el.className += (elClass ? ' ' + elClass : '');
+        return $el;
     }
 
     /**
@@ -51,9 +53,8 @@ define([
                 x: w/2,
                 y: h/2
             },
-            $svg = $.create('<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg>')
-                .attr({ width: w, height: h, viewbox: '0 0 '+ [w, h].join(' ') })
-                .addClass('chart chart--doughnut');
+            $svg = $.create('<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="chart chart--doughnut"></svg>')
+                .attr({ width: w, height: h, viewbox: '0 0 '+ [w, h].join(' ') });
 
         // Segments
         var segmentAngle, endRadius, arc, outer, inner, r, a, d, $g, $t,
@@ -101,29 +102,25 @@ define([
                 'A', cutoutRadius, cutoutRadius, 0, arc, 0, inner.end.x, inner.end.y,
                 'Z'
             ];
-            $g = svgEl('g')
-                .addClass('chart__arc')
+            $g = svgEl('g', 'chart__arc')
                 .append(svgEl('path').attr({
                     'd': d.join(' '),
                     'fill': datum.color
                 }));
 
             // labels
-            $t = svgEl('text');
+            $t = svgEl('text', 'chart__label');
             if (o.showValues) {
-                $t.append(svgEl('tspan')
+                $t.append(svgEl('tspan', 'chart__label-text')
                     .text(datum.label)
-                    .attr({ x: 0, dy: '0' })
-                    .addClass('chart__label-text'))
-                 .append(svgEl('tspan')
+                    .attr({ x: 0, dy: '0' }))
+                 .append(svgEl('tspan', 'chart__label-value')
                     .text(datum.value)
-                    .attr({ x: 0, dy: '1em' })
-                    .addClass('chart__label-value'));
+                    .attr({ x: 0, dy: '1em' }));
             } else {
                 $t.text(datum.label);
             }
             $t.attr({ transform: translate([(Math.cos(a)*r)+center.x, (Math.sin(a)*r)+center.y]) })
-                .addClass('chart__label')
                 .appendTo($g);
 
             $g.appendTo($svg);
@@ -131,9 +128,8 @@ define([
         });
 
         // Unit of measurement
-        return $svg.append(svgEl('text')
+        return $svg.append(svgEl('text', 'chart__unit')
             .text(o.unit)
-            .addClass('chart__unit')
             .attr({
                 transform: translate(c),
                 dy: '0.4em'

--- a/common/app/assets/javascripts/modules/charts/table-doughnut.js
+++ b/common/app/assets/javascripts/modules/charts/table-doughnut.js
@@ -26,11 +26,13 @@ TableDoughnut.prototype.render = function(el) {
         });
 
     bonzo(el).addClass('u-h');
-    return new Doughnut(data, {
+    var $doughnut = new Doughnut(data, {
         showValues: el.getAttribute('data-chart-show-values') === 'true',
         unit: el.getAttribute('data-chart-unit'),
         width: width
-    }).addClass(el.getAttribute('data-chart-class')).insertAfter(el);
+    });
+    $doughnut[0].className += ' ' + el.getAttribute('data-chart-class');
+    return $doughnut.insertAfter(el);
 };
 
 return TableDoughnut;


### PR DESCRIPTION
Fixes http://frontend.errors.guim.co.uk/guardian/frontend/group/229/

IE doesn't have a `classList` property on SVG elements. Bonzo uses this this property when working with classes.
Solution, when working with SVGs, don't use `addClass` et al, do it manually

cc: @jamesgorrie, @phamann 
