### PR TITLE
Minor header updates

### DIFF
--- a/common/app/assets/stylesheets/module/nav/_brand-bar.scss
+++ b/common/app/assets/stylesheets/module/nav/_brand-bar.scss
@@ -47,11 +47,21 @@
 }
 
 .brand-bar__item--action {
-    &:hover .control__icon-wrapper,
-    &:active .control__icon-wrapper,
-    &:focus .control__icon-wrapper,
-    &.is-active .control__icon-wrapper {
-        border-color: #ffffff;
+    &:active,
+    &:focus,
+    &.is-active {
+        .control__icon-wrapper {
+            border-color: #ffffff;
+        }
+    }
+    &:hover {
+        // stops controls icons staying hightlighted
+        // after closing a popup on mobile
+        @include mq(tablet) {
+            .control__icon-wrapper {
+                border-color: #ffffff;
+            }
+        }
     }
 }
 
@@ -67,12 +77,23 @@
     ));
 }
 
-.brand-bar__item--action:hover,
-.brand-bar__item--action:focus,
-.brand-bar__item--action:active {
-    &,
-    .control__info {
-        text-decoration: underline;
+.brand-bar__item--action {
+    &:focus,
+    &:active {
+        &,
+        .control__info {
+            text-decoration: underline;
+        }
+    }
+    &:hover {
+        &,
+        .control__info {
+            // stops links staying underlined
+            // after closing a popup on mobile
+            @include mq(tablet) {
+                text-decoration: underline;
+            }
+        }
     }
 }
 

--- a/common/app/assets/stylesheets/module/nav/_brand-bar.scss
+++ b/common/app/assets/stylesheets/module/nav/_brand-bar.scss
@@ -54,6 +54,7 @@
             border-color: #ffffff;
         }
     }
+
     &:hover {
         // stops controls icons staying hightlighted
         // after closing a popup on mobile
@@ -85,6 +86,7 @@
             text-decoration: underline;
         }
     }
+
     &:hover {
         &,
         .control__info {

--- a/common/app/assets/stylesheets/module/nav/_navigation.scss
+++ b/common/app/assets/stylesheets/module/nav/_navigation.scss
@@ -44,17 +44,6 @@ $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevels, mq-get-breakpoint
 $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevelsWithWideToggle, mq-get-breakpoint-width(navigationBreakOnTwoLevels) + gs-span(1) + $gs-gutter * 1.5);
 
 
-/* Meganav footer overrides (edition switcher and Guardian services)
-   ========================================================================== */
-
-.navigation__expandable {
-    .global-navigation__title--guardian-services {
-        background-color: $c-newsDefault;
-        border-top: 1px solid mix(guss-colour(guardian-brand), #ffffff, 93%);
-    }
-}
-
-
 /* Styles common to all states
    ========================================================================== */
 

--- a/common/app/views/fragments/nav/globalNavigation.scala.html
+++ b/common/app/views/fragments/nav/globalNavigation.scala.html
@@ -35,37 +35,6 @@
                         }
                     </li>
                 }
-                <li class="global-navigation__section">
-                    <span class="global-navigation__title global-navigation__title--guardian-services">from the guardian</span>
-                    <ul class="global-navigation__children">
-                    @if(Edition(request) == Uk){
-                        <li class="global-navigation__child">
-                            <a class="global-navigation__action" href="http://jobs.theguardian.com/?INTCMP=NGW_NAVBAR_UK_GU_JOBS" target="_blank" data-link-name="Jobs">jobs</a>
-                        </li>
-                        <li class="global-navigation__child">
-                            <a class="global-navigation__action" href="https://soulmates.theguardian.com/?INTCMP=NGW_NAVBAR_UK_GU_SOULMATES" target="_blank" data-link-name="Soulmates">soulmates</a>
-                        </li>
-                        <li class="global-navigation__child">
-                            <a class="global-navigation__action" href="http://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES" target="_blank" data-link-name="Masterclasses">masterclasses</a>
-                        </li>
-                    }
-                    @if(Edition(request) == Us){
-                        <li class="global-navigation__child">
-                            <a class="global-navigation__action" href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_US_GU_JOBS" target="_blank" data-link-name="Jobs">jobs</a>
-                        </li>
-                    }
-                    @if(Edition(request) == Au){
-                        <li class="global-navigation__child">
-                            <a class="global-navigation__action" data-link-name="Jobs"
-                               href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_US_GU_JOBS">jobs</a>
-                        </li>
-                        <li class="global-navigation__child">
-                            <a class="global-navigation__action" data-link-name="Masterclasses"
-                                href="http://www.theguardian.com/guardian-masterclasses/guardian-masterclasses-australia">masterclasses</a>
-                        </li>
-                    }
-                    </ul>
-                </li>
             </ul>
         </nav>
     }


### PR DESCRIPTION
- controls don’t have hover states applied below tablet bp, to prevent them ‘staying on’ after toggling a menu closed. not fool-proof but a least worst option…
- remove services from mega nav
