### PR TITLE
Switch back the default for the football troubleshooter to Prem League

### DIFF
--- a/admin/app/views/footballTroubleshooter.scala.html
+++ b/admin/app/views/footballTroubleshooter.scala.html
@@ -5,7 +5,7 @@
 
 @admin_main("Football Troubleshooter", env, isAuthed = true) {
 
-@defining(Format(new DateTime(), "yyyyMMdd")){ today =>
+@defining((Format(DateTime.now(), "yyyyMMdd"), "Premier League", "100")){ case (today, competition, competitionId) =>
 
     <h1>Football Troubleshooter</h1>
 
@@ -43,28 +43,28 @@
 
     <p>Matches will first appear in the fixtures feed. We query each competition separately for all upcoming fixtures.</p>
 
-    <p>Here is the API call for all upcoming fixtures in the <strong>World Cup 2014</strong> (id 700). You can get other competition IDs
+    <p>Here is the API call for all upcoming fixtures in the <strong>@competition</strong> (id @competitionId). You can get other competition IDs
         from the Competitions feed above.</p>
 
-    <a href="@pa.host/api/football/competition/fixtures/@pa.apiKey/700">@pa.host/api/football/competition/fixtures/@pa.apiKey/<strong>700</strong></a>
+    <a href="@pa.host/api/football/competition/fixtures/@pa.apiKey/@competitionId">@pa.host/api/football/competition/fixtures/@pa.apiKey/<strong>@competitionId</strong></a>
 
     <h2>Results feed</h2>
 
     <p>Shows the results for completed matches. We query each competition separately for results.</p>
 
-    <p>Here is the API call for results in the <strong>World Cup 2014</strong> (id 700). You can get other competition IDs
-        from the Competitions feed above and the date format is <i>YYYYMMDD</i> (12 Jun is the start of the World Cup).</p>
+    <p>Here is the API call for results in the <strong>@competition</strong> (id @competitionId). You can get other competition IDs
+        from the Competitions feed above and the date format is <i>YYYYMMDD</i></p>
 
-    <a href="@pa.host/api/football/competition/results/@pa.apiKey/700/@Format(new LocalDate(2014, 6, 12), "yyyyMMdd")">@pa.host/api/football/competition/results/@pa.apiKey/<strong>700</strong>/<strong>@Format(new LocalDate(2014, 6, 12), "yyyyMMdd")</strong></a>
+    <a href="@pa.host/api/football/competition/results/@pa.apiKey/@competitionId/@Format(new LocalDate(2014, 6, 12), "yyyyMMdd")">@pa.host/api/football/competition/results/@pa.apiKey/<strong>@competitionId</strong>/<strong>@Format(new LocalDate(2014, 6, 12), "yyyyMMdd")</strong></a>
 
     <h2>League table</h2>
 
     <p>Shows all the stats we use to populate the league tables.</p>
 
-    <p>Here is the API call for the league table for <strong>World Cup 2014</strong> (id 700). You can get other competition IDs
+    <p>Here is the API call for the league table for <strong>@competition</strong> (id @competitionId). You can get other competition IDs
         from the Competitions feed above and the date format is <i>YYYYMMDD</i>.</p>
 
-    <a href="@pa.host/api/football/competition/leagueTable/@pa.apiKey/700/@today">@pa.host/api/football/competition/leagueTable/@pa.apiKey/<strong>700</strong>/<strong>@today</strong></a>
+    <a href="@pa.host/api/football/competition/leagueTable/@pa.apiKey/@competitionId/@today">@pa.host/api/football/competition/leagueTable/@pa.apiKey/<strong>@competitionId</strong>/<strong>@today</strong></a>
 
     <h2>Match stats</h2>
 

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -93,6 +93,7 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
   val competitionDefinitions = Seq(
     Competition("100", "/football/premierleague", "Premier League", "Premier League", "English", showInTeamsList = true, tableDividers = List(4, 5, 17)),
     Competition("500", "/football/championsleague", "Champions League", "Champions League", "European", tableDividers = List(2, 6, 21)),
+    Competition("501", "/football/champions-league-qualifying", "Champions League qualifying", "Champions League qual.", "European"),
     Competition("510", "/football/uefa-europa-league", "Europa League", "Europa League", "European", tableDividers = List(2)),
     Competition("300", "/football/fa-cup", "FA Cup", "FA Cup", "English"),
     Competition("301", "/football/capital-one-cup", "Capital One Cup", "Capital One Cup", "English"),


### PR DESCRIPTION
Was set to World Cup for the (wait for it...) World Cup.

It is much more useful as premier League now.

Also made it a bit easier to modify in the future.

Also added the "Champions League qualifying" competition
