### PR TITLE
correct image ratios

### DIFF
--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -13,7 +13,9 @@
                     @for(item <- items) {
                         <li class="lineitem">
                             <a class="lineitem__link" href="@AdLink{@item.webUrl}" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle">
-                                <img class="lineitem__image" src="@item.mainPicture.map(_.largestImage.map(_.url))" />
+                                @item.mainPicture.map{ picture =>
+                                    @Item300.bestFor(picture).map{ url => <img src="@url" alt="" class="lineitem__image" /> }
+                                }
                                 <div class="lineitem__offer">
                                     <h4 class="lineitem__title">@item.webTitle</h4>
                                     <div class="item__meta">


### PR DESCRIPTION
This puts the right image size into the commercial content API component.

Before;
![screen shot 2014-08-21 at 10 45 03](https://cloud.githubusercontent.com/assets/1303616/3994289/13d41a04-2918-11e4-9cf6-63e365534c23.png)

After
![screen shot 2014-08-21 at 10 45 27](https://cloud.githubusercontent.com/assets/1303616/3994292/1c881c72-2918-11e4-885d-30d345760f00.png)
