### PR TITLE
Add use main media video option to facia tool

### DIFF
--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -1,0 +1,20 @@
+package model
+
+object FaciaDisplayElement {
+  def fromTrail(trail: Trail) = {
+    val mainVideo = trail.mainVideo
+
+    (trail, trail.mainVideo) match {
+      case (video: Video, Some(videoElement)) =>
+        InlineVideo(videoElement, video.webTitle, video.endSlatePath)
+      case (other: Content, Some(videoElement)) if other.showMainVideo =>
+        InlineVideo(videoElement, other.webTitle, EndSlateComponents.fromContent(other).toUriPath)
+      case _ => InlineImage
+    }
+  }
+}
+
+sealed trait FaciaDisplayElement
+
+case class InlineVideo(videoElement: VideoElement, title: String, endSlatePath: String) extends FaciaDisplayElement
+case object InlineImage extends FaciaDisplayElement

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -192,6 +192,9 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     height <- imageSrcHeight
   } yield ImageOverride.createElementWithOneAsset(src, width, height)
 
+  override lazy val showMainVideo: Boolean =
+    apiContent.metaData.get("showMainVideo").flatMap(_.asOpt[Boolean]).getOrElse(false)
+
   override lazy val adUnitSuffix: String = super.adUnitSuffix + "/" + contentType.toLowerCase
 }
 

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -40,4 +40,5 @@ trait FaciaFields {
   def imageSrcHeight: Option[String] = None
   def imageAdjust: String = "default"
   def isBreaking: Boolean = false
+  def showMainVideo: Boolean = false
 }

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -1,7 +1,7 @@
 @(trail: model.Trail, index: Int)(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
-@import model.{Video, VideoPlayer}
+@import model.{FaciaDisplayElement, InlineImage, InlineVideo, VideoPlayer}
 @import views.html.fragments.media.video
 @import views.support.{GetClasses, RemoveOuterParaHtml, SnapData, Video640}
 
@@ -13,22 +13,22 @@
 
     <div class="item__container">
         <div class="item__tonal-border tone-accent-border"></div>
-        @trail match {
-            case v: Video if v.mainVideo.isDefined => {
+        @FaciaDisplayElement.fromTrail(trail) match {
+            case InlineVideo(videoElement, title, endSlatePath) => {
                 <div class="item__media-wrapper item__media-wrapper--has-icon u-faux-block-link__promote">
                     <div class="item__video-container">
                         @video(VideoPlayer(
-                            v.mainVideo.get,
+                            videoElement,
                             Video640,
-                            v.webTitle,
+                            title,
                             autoPlay = false,
                             showControlsAtStart = false,
-                            v.endSlatePath
+                            endSlatePath
                         ))
                     </div>
                 </div>
             }
-            case _ => {
+            case InlineImage => {
                 @fragments.items.elements.image(trail, inlineImage = true, maxWidth = 940)
             }
         }

--- a/common/app/views/fragments/items/baguette.scala.html
+++ b/common/app/views/fragments/items/baguette.scala.html
@@ -1,9 +1,9 @@
-@(trail: model.Trail, index: Int)(implicit request: RequestHeader, config: Config)
+@(trail: model.Trail, index: Int)(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
 @import model.{Video, VideoPlayer}
 @import views.html.fragments.media.video
-@import views.support.{GetClasses, SnapData, Video640}
+@import views.support.{GetClasses, RemoveOuterParaHtml, SnapData, Video640}
 
 <div
     class="@GetClasses.forItem(trail, true) baguette u-faux-block-link"
@@ -34,7 +34,7 @@
         }
         @fragments.items.elements.title(trail, index, 0, showTag = false)
 
-        @trail match { case content:model.Content => @fragments.items.elements.starRating(content) }
+        @trail match { case content: model.Content => @fragments.items.elements.starRating(content) }
 
         @trail.trailText.map { text =>
             <div class="baguette__standfirst">@Html(text)</div>

--- a/common/app/views/fragments/items/fromage.scala.html
+++ b/common/app/views/fragments/items/fromage.scala.html
@@ -1,7 +1,7 @@
 @(trail: model.Trail, index: Int, imageAdjustOverride: Option[String] = None)(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
-@import model.Video
+@import model.{FaciaDisplayElement, InlineVideo, InlineImage}
 @import views.support.{GetClasses, ImgSrc, Item220, Item300, Item620, SnapData}
 
 @defining((trail.visualTone, imageAdjustOverride.getOrElse(trail.imageAdjust))) { case (tone, imageAdjust) =>
@@ -17,12 +17,12 @@
         @SnapData(trail)>
 
         <div class="fromage__container">
-            @trail match {
-                case v: Video if v.mainVideo.isDefined && imageAdjust == "boost" => {
-                    @fromageVideo(v.mainVideo.get, v.webTitle, true, v.endSlatePath)
+            @FaciaDisplayElement.fromTrail(trail) match {
+                case InlineVideo(videoElement, title, endSlatePath) if imageAdjust == "boost" => {
+                    @fromageVideo(videoElement, title, true, endSlatePath)
                 }
-                case _ => {
-                    @if(imageAdjust != Some("hide")) {
+                case InlineImage => {
+                    @if(imageAdjust != "hide") {
                         @trail.trailPicture(5,3).map{ imageContainer =>
                             @ImgSrc.imager(imageContainer, Item620).map { imgSrc =>
                                 <div class="fromage__media-wrapper fromage__media-wrapper--first">

--- a/common/app/views/fragments/items/standardVideo.scala.html
+++ b/common/app/views/fragments/items/standardVideo.scala.html
@@ -1,7 +1,7 @@
 @(trail: model.Trail, index: Int, containerIndex: Int, element: String = "li", forceTone: Option[String] = None, forcePlayable: Boolean = false)(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
-@import model.{Video, VideoPlayer}
+@import model.{VideoPlayer, FaciaDisplayElement, InlineVideo, InlineImage}
 @import views.html.fragments.media.video
 @import views.support.{GetClasses, ImgSrc, Video640, Item620, Item300, RemoveOuterParaHtml}
 
@@ -17,17 +17,17 @@
 
         <div class="item__container">
             <div class="item__tonal-border tone-accent-border"></div>
-            @trail match {
-                case videoItem: Video if videoItem.mainVideo.isDefined && (trail.imageAdjust == "boost" || forcePlayable) => {
+            @FaciaDisplayElement.fromTrail(trail) match {
+                case InlineVideo(videoElement, title, endSlatePath) if (trail.imageAdjust == "boost" || forcePlayable) => {
                     <div class="item__media-wrapper item__media-wrapper--has-icon u-faux-block-link__promote">
                         <div class="item__video-container">
                             @video(VideoPlayer(
-                                videoItem.mainVideo.get,
+                                videoElement,
                                 Video640,
-                                videoItem.webTitle,
+                                title,
                                 autoPlay = false,
                                 showControlsAtStart = false,
-                                videoItem.endSlatePath
+                                endSlatePath
                             ))
                         </div>
                     </div>

--- a/facia-press/app/frontpress/jsonModels.scala
+++ b/facia-press/app/frontpress/jsonModels.scala
@@ -62,21 +62,23 @@ object ItemMeta {
     href = content.apiContent.metaData.get("href"),
     snapType = content.apiContent.metaData.get("snapType"),
     snapCss = content.apiContent.metaData.get("snapCss"),
-    snapUri = content.apiContent.metaData.get("snapUri")
+    snapUri = content.apiContent.metaData.get("snapUri"),
+    showMainVideo = content.apiContent.metaData.get("showMainVideo")
   )
 }
 
 case class ItemMeta(
-  headline:     Option[JsValue],
-  trailText:    Option[JsValue],
-  group:        Option[JsValue],
-  imageAdjust:  Option[JsValue],
-  isBreaking:   Option[Boolean],
-  supporting:   Option[Seq[JsValue]],
-  href:         Option[JsValue],
-  snapType:     Option[JsValue],
-  snapCss:      Option[JsValue],
-  snapUri:      Option[JsValue]
+  headline:      Option[JsValue],
+  trailText:     Option[JsValue],
+  group:         Option[JsValue],
+  imageAdjust:   Option[JsValue],
+  isBreaking:    Option[Boolean],
+  supporting:    Option[Seq[JsValue]],
+  href:          Option[JsValue],
+  snapType:      Option[JsValue],
+  snapCss:       Option[JsValue],
+  snapUri:       Option[JsValue],
+  showMainVideo: Option[JsValue]
 )
 
 

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -37,7 +37,8 @@ case class Collection(
   groups: Option[List[String]],
   uneditable: Option[Boolean],
   showTags: Option[Boolean],
-  showSections: Option[Boolean]
+  showSections: Option[Boolean],
+  showMainVideo: Option[Boolean]
 )
 
 object Config {
@@ -128,8 +129,10 @@ trait UpdateActions extends Logging {
     "imageSrc",
     "imageSrcWidth",
     "imageSrcHeight",
-    "isBreaking")
-  
+    "isBreaking",
+    "showMainVideo"
+  )
+
   implicit val collectionMetaWrites = Json.writes[CollectionMetaUpdate]
   implicit val updateListWrite = Json.writes[UpdateList]
 

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -310,7 +310,12 @@
                             click: toggleImageAdjustHide,
                             text: meta.imageAdjust() === 'hide' ? 'hidden' : 'hide',
                             css: {selected: meta.imageAdjust() === 'hide'}"></a>
-
+                        &middot;
+                        Main media video
+                        <a data-bind="
+                            click: toggleShowMainVideo,
+                            text: meta.showMainVideo() ? 'overridden' : 'override',
+                            css: {selected: meta.videoId}"></a>
                         &middot;
                         Mark as
                         <a data-bind="

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -311,12 +311,12 @@
                             text: meta.imageAdjust() === 'hide' ? 'hidden' : 'hide',
                             css: {selected: meta.imageAdjust() === 'hide'}"></a>
                         &middot;
-                        Main media video
+                        <!-- ko if: mainMediaType() === 'video' -->
                         <a data-bind="
                             click: toggleShowMainVideo,
-                            text: meta.showMainVideo() ? 'overridden' : 'override',
-                            css: {selected: meta.videoId}"></a>
+                            css: {selected: meta.showMainVideo}">video</a>
                         &middot;
+                        <!-- /ko -->
                         Mark as
                         <a data-bind="
                             click: toggleIsBreaking,

--- a/facia-tool/public/javascripts/models/collections/article.js
+++ b/facia-tool/public/javascripts/models/collections/article.js
@@ -64,6 +64,7 @@ define([
                 'imageSrc',
                 'imageSrcWidth',
                 'imageSrcHeight',
+                'showMainVideo',
                 'isBreaking',
                 'group',
                 'snapType',
@@ -248,6 +249,11 @@ define([
 
         Article.prototype.toggleImageAdjustHide = function() {
             this.meta.imageAdjust(this.meta.imageAdjust() === 'hide' ? undefined : 'hide');
+            this._save();
+        };
+
+        Article.prototype.toggleShowMainVideo = function () {
+            this.meta.showMainVideo(!this.meta.showMainVideo());
             this._save();
         };
 

--- a/facia-tool/public/javascripts/models/collections/article.js
+++ b/facia-tool/public/javascripts/models/collections/article.js
@@ -203,7 +203,7 @@ define([
             populateObservables(this.meta,   opts.meta);
             populateObservables(this.fields, opts.fields);
             populateObservables(this.state,  opts.state);
-            opts["mainMediaType"] && this.mainMediaType(opts["mainMediaType"]);
+            opts.mainMediaType && this.mainMediaType(opts.mainMediaType);
 
             if (validate || opts.webUrl) {
                  missingProps = [

--- a/facia-tool/public/javascripts/models/collections/article.js
+++ b/facia-tool/public/javascripts/models/collections/article.js
@@ -45,6 +45,8 @@ define([
             this.frontPublicationDate = opts.frontPublicationDate;
             this.frontPublicationTime = ko.observable();
 
+            this.mainMediaType = ko.observable();
+
             this.props = asObservableProps([
                 'webUrl',
                 'webPublicationDate']);
@@ -201,6 +203,7 @@ define([
             populateObservables(this.meta,   opts.meta);
             populateObservables(this.fields, opts.fields);
             populateObservables(this.state,  opts.state);
+            opts["mainMediaType"] && this.mainMediaType(opts["mainMediaType"]);
 
             if (validate || opts.webUrl) {
                  missingProps = [

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -135,14 +135,14 @@ function (
     }
 
     function mainMediaType(contentApiArticle) {
-        var mainElement = _.findWhere(contentApiArticle["elements"] || [], {
-            relation: "main"
+        var mainElement = _.findWhere(contentApiArticle.elements || [], {
+            relation: 'main'
         });
-        return mainElement && mainElement["type"];
+        return mainElement && mainElement.type;
     }
 
     function populate(article, contentApiArticle) {
-        contentApiArticle["mainMediaType"] = mainMediaType(contentApiArticle);
+        contentApiArticle.mainMediaType = mainMediaType(contentApiArticle);
         article.populate(contentApiArticle, true);
     }
 

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -17,7 +17,7 @@ function (
     urlAbsPath,
     snap
 ){
-    var standardQueryParams = 'page-size=50&format=json&show-fields=all';
+    var standardQueryParams = 'page-size=50&format=json&show-fields=all&show-elements=video';
 
     function validateItem (item) {
         var defer = $.Deferred(),
@@ -134,8 +134,16 @@ function (
         });
     }
 
-    function populate(article, opts) {
-        article.populate(opts, true);
+    function mainMediaType(contentApiArticle) {
+        var mainElement = _.findWhere(contentApiArticle["elements"] || [], {
+            relation: "main"
+        });
+        return mainElement && mainElement["type"];
+    }
+
+    function populate(article, contentApiArticle) {
+        contentApiArticle["mainMediaType"] = mainMediaType(contentApiArticle);
+        article.populate(contentApiArticle, true);
     }
 
     function fetchContentByIds(ids) {

--- a/facia-tool/test/config/TransformationsSpec.scala
+++ b/facia-tool/test/config/TransformationsSpec.scala
@@ -13,7 +13,8 @@ class TransformationsSpec extends FlatSpec with ShouldMatchers {
     groups = Some(List("1", "2")),
     uneditable = Some(false),
     showTags = Some(true),
-    showSections = Some(false)
+    showSections = Some(false),
+    showMainVideo = None
   )
 
   val createCommandFixture = CreateFront(
@@ -27,6 +28,7 @@ class TransformationsSpec extends FlatSpec with ShouldMatchers {
   )
 
   val emptyCollectionFixture = Collection(
+    None,
     None,
     None,
     None,


### PR DESCRIPTION
Allows editors to set an inline video player to appear for an article if its main media is a video.

![screen shot 2014-08-21 at 11 13 44](https://cloud.githubusercontent.com/assets/1001642/3994557/eb31d5ec-291b-11e4-8802-d624a8822a4a.png)
