### PR TITLE
Tidy up the switchboard

### DIFF
--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -4,6 +4,12 @@
 <link href="@routes.Assets.at("css/switchboard.css")" rel="stylesheet">
 <link href="@routes.Assets.at("css/radiator.css")" rel="stylesheet">
 @if(flash.get("error").isDefined) { <h1 style="color:#bd362f">@flash.get("error").get</h1> }
+<p>
+    <blockquote>
+        <em>"Death by switches."</em>
+        <footer>Nick Haley</footer>
+    </blockquote>
+</p>
 <div class="row-fluid">
     <form id="switchboard" action="/dev/switchboard" method="POST">
         <input type="hidden" name="lastModified" value="@lastModified" />
@@ -11,20 +17,16 @@
             <h4>@group</h4>
             <div class="well">
                 @switches.map { switch =>
-                    <div class="row-fluid">
-                        <fieldset>
-                            <legend>
-                                <input class="status" id="switch-@switch.name" name="@switch.name" type="checkbox" @if(switch.isSwitchedOn) { checked="checked" }/>
-                                <label for="switch-@switch.name"@if(switch.expiresSoon){ class="Expiring expiry-days-@switch.daysToExpiry"}>@switch.name</label>
-                                <small>- @switch.description</small>
-                                <small>Expires in <strong>@switch.daysToExpiry</strong> days.</small>
-                            </legend>
-                        </fieldset>
+                    <div class="checkbox">
+                        <label for="switch-@switch.name"@if(switch.expiresSoon){ class="Expiring expiry-days-@switch.daysToExpiry"}>
+                            <input id="switch-@switch.name" name="@switch.name" type="checkbox" @if(switch.isSwitchedOn) { checked="checked" }/>
+                            <strong>@switch.name</strong>
+                        </label>
+                        <span> - @switch.description<strong> @switch.daysToExpiry</strong> days left</span>
                     </div>
                 }
             </div>
         }
-
         <input class="btn btn-large btn-success" type="submit" value="Save">
     </form>
 </div>

--- a/admin/public/css/switchboard.css
+++ b/admin/public/css/switchboard.css
@@ -29,19 +29,8 @@ input.invalid {
     background-color: #F2DEDE;
 }
 
-fieldset,
-input[type=text] {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-}
-
 input[type=text] {
     height: inherit;
-}
-
-fieldset#controls {
-    margin-top: 30px;
-    position: relative;
 }
 
 #clear-frontend {
@@ -49,21 +38,11 @@ fieldset#controls {
     right: 0;
 }
 
-input[type=checkbox].status {
-    width: 33px;
-    height: 33px;
-    float: left;
-    margin-right: 10px;
-}
-
-#switchboard label {
-    display: inline;
-    font-size: 20px;
-}
-
 #switchboard label:hover {
     color: #699;
     cursor: pointer;
 }
 
-
+#switchboard .checkbox:nth-child(odd) {
+    background-color: #E9E9E9;
+}

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -44,236 +44,233 @@ object Switches extends Collections {
 
   private lazy val never = new LocalDate(2100, 1, 1)
 
-  // Load Switches
+  // Performance
 
-  val MemcachedSwitch = Switch("Performance Switches", "memcached-action",
+  val MemcachedSwitch = Switch("Performance", "memcached-action",
     "If this switch is switched on then the MemcacheAction will be operational",
     safeState = On,
     sellByDate = never
   )
 
-  val MemcachedFallbackSwitch = Switch("Performance Switches", "memcached-fallback",
+  val MemcachedFallbackSwitch = Switch("Performance", "memcached-fallback",
     "If this switch is switched on then the MemcachedFallback will be operational",
     safeState = Off,
     sellByDate = never
   )
 
-  val IncludeBuildNumberInMemcachedKey = Switch("Performance Switches", "memcached-build-number",
+  val IncludeBuildNumberInMemcachedKey = Switch("Performance", "memcached-build-number",
     "If this switch is switched on then the MemcacheFilter will include the build number in the cache key",
     safeState = Off,
     sellByDate = never
   )
 
-  val AutoRefreshSwitch = Switch("Performance Switches", "auto-refresh",
+  val AutoRefreshSwitch = Switch("Performance", "auto-refresh",
     "Enables auto refresh in pages such as live blogs and live scores. Turn off to help handle exceptional load.",
     safeState = Off, sellByDate = never
   )
 
-  val DoubleCacheTimesSwitch = Switch("Performance Switches", "double-cache-times",
+  val DoubleCacheTimesSwitch = Switch("Performance", "double-cache-times",
     "Doubles the cache time of every endpoint. Turn on to help handle exceptional load.",
     safeState = On, sellByDate = never
   )
 
-  val RelatedContentSwitch = Switch("Performance Switches", "related-content",
+  val RelatedContentSwitch = Switch("Performance", "related-content",
     "If this switch is turned on then related content will show. Turn off to help handle exceptional load.",
     safeState = On, sellByDate = never
   )
 
-  val AjaxRelatedContentSwitch = Switch("Performance Switches", "ajax-related-content",
+  val AjaxRelatedContentSwitch = Switch("Performance", "ajax-related-content",
     "If this switch is turned on then related be loaded via ajax and not inline. Also requires related-content switch to be on.",
     safeState = On, sellByDate = never
   )
 
-  val CssFromStorageSwitch = Switch("Performance Switches", "css-from-storage",
+  val CssFromStorageSwitch = Switch("Performance", "css-from-storage",
     "If this switch is on CSS will be cached in users localStorage and read from there on subsequent requests.",
     safeState = On, sellByDate = never
   )
 
-  val ShowAllArticleEmbedsSwitch = Switch("Performance Switches", "show-all-embeds",
+  val ShowAllArticleEmbedsSwitch = Switch("Performance", "show-all-embeds",
     "If switched on then all embeds will be shown inside article bodies",
     safeState = On, sellByDate = never
   )
 
-  val DiscussionSwitch = Switch("Performance Switches", "discussion",
+  val DiscussionSwitch = Switch("Performance", "discussion",
     "If this switch is on, comments are displayed on articles. Turn this off if the Discussion API is blowing up.",
     safeState = Off, sellByDate = never
   )
 
-  val OpenCtaSwitch = Switch("Performance Switches", "open-cta",
+  val OpenCtaSwitch = Switch("Performance", "open-cta",
     "If this switch is on, will see a CTA to comments on the right hand side. Turn this off if the Open API is blowing up.",
     safeState = Off, sellByDate = never
   )
 
-  // Advertising Switches
+  val ImageServerSwitch = Switch("Performance", "image-server",
+    "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
+    safeState = On, sellByDate = never
+  )
 
-  val CommercialSwitch = Switch("Advertising", "commercial",
+  // Commercial
+
+  val CommercialSwitch = Switch("Commercial", "commercial",
     "Kill switch for all commercial JS.",
     safeState = On, sellByDate = never
   )
 
-  val StandardAdvertsSwitch = Switch("Advertising", "standard-adverts",
+  val StandardAdvertsSwitch = Switch("Commercial", "standard-adverts",
     "Display 'standard' adverts, e.g. top banner ads, inline ads, MPUs, etc.",
     safeState = On, sellByDate = never
   )
 
-  val CommercialComponentsSwitch = Switch("Advertising", "commercial-components",
+  val CommercialComponentsSwitch = Switch("Commercial", "commercial-components",
     "Display commercial components, e.g. jobs, soulmates.",
     safeState = On, sellByDate = never
   )
 
-  val VideoAdvertsSwitch = Switch("Advertising", "video-adverts",
+  val VideoAdvertsSwitch = Switch("Commercial", "video-adverts",
     "Show adverts on videos.",
     safeState = On, sellByDate = never
   )
 
-  val SponsoredSwitch = Switch("Advertising", "sponsored",
+  val SponsoredSwitch = Switch("Commercial", "sponsored",
     "Show sponsored badges, logos, etc.",
     safeState = On, sellByDate = never
   )
 
-  val SmartBannerSwitch = Switch("Advertising", "smart-banner",
+  val SmartBannerSwitch = Switch("Commercial", "smart-banner",
     "Display smart app banner onboarding message to iOS and Android users",
     safeState = Off, sellByDate = new LocalDate(2014, 8, 31)
   )
 
-  // Commercial Tags
-
-  val AudienceScienceSwitch = Switch("Commercial Tags", "audience-science",
+  val AudienceScienceSwitch = Switch("Commercial", "audience-science",
     "If this switch is on, Audience Science segments will be used to target ads.",
     safeState = Off, sellByDate = new LocalDate(2014, 11, 1))
 
-  val AudienceScienceGatewaySwitch = Switch("Commercial Tags", "audience-science-gateway",
+  val AudienceScienceGatewaySwitch = Switch("Commercial", "audience-science-gateway",
     "If this switch is on, Audience Science Gateway segments will be used to target ads.",
     safeState = Off, sellByDate = new LocalDate(2014, 11, 1))
 
-  val CriteoSwitch = Switch("Commercial Tags", "criteo",
+  val CriteoSwitch = Switch("Commercial", "criteo",
     "If this switch is on, Criteo segments will be used to target ads.",
     safeState = Off, sellByDate = new LocalDate(2014, 11, 1))
 
-  val EffectiveMeasureSwitch = Switch("Commercial Tags", "effective-measure",
+  val EffectiveMeasureSwitch = Switch("Commercial", "effective-measure",
     "Enable the Effective Measure audience segment tracking.",
     safeState = Off, sellByDate = never)
 
-  val ImrWorldwideSwitch = Switch("Commercial Tags", "imr-worldwide",
+  val ImrWorldwideSwitch = Switch("Commercial", "imr-worldwide",
     "Enable the IMR Worldwide audience segment tracking.",
     safeState = Off, sellByDate = never)
 
-  val MediaMathSwitch = Switch("Commercial Tags", "media-math",
+  val MediaMathSwitch = Switch("Commercial", "media-math",
     "Enable Media Math audience segment tracking",
     safeState = Off, sellByDate = never)
 
-  val RemarketingSwitch = Switch("Commercial Tags", "remarketing",
+  val RemarketingSwitch = Switch("Commercial", "remarketing",
     "Enable Remarketing tracking",
     safeState = Off, sellByDate = never)
 
-  // Content Recommendation
-
-  val OutbrainSwitch = Switch("Content Recommendation", "outbrain",
-    "Enable the Outbrain content recommendation widget.",
-    safeState = Off, sellByDate = never)
-
-
-  // We don't foresee this service being switched off
-  val ForeseeSwitch = Switch("Performance Switches", "foresee",
-    "Enable Foresee surveys for a sample of our audience",
-    safeState = Off, sellByDate = never)
-
-  // Commercial Feeds
-
-  val TravelOffersFeedSwitch = Switch("Performance Switches", "gu-travel-offers",
+  val TravelOffersFeedSwitch = Switch("Commercial", "gu-travel-offers",
     "If this switch is on, commercial components will be fed by travel offer feed.",
     safeState = Off, sellByDate = never)
 
-  val JobFeedSwitch = Switch("Performance Switches", "gu-jobs",
+  val JobFeedSwitch = Switch("Commercial", "gu-jobs",
     "If this switch is on, commercial components will be fed by job feed.",
     safeState = Off, sellByDate = never)
 
-  val MasterclassFeedSwitch = Switch("Performance Switches", "gu-masterclasses",
+  val MasterclassFeedSwitch = Switch("Commercial", "gu-masterclasses",
     "If this switch is on, commercial components will be fed by masterclass feed.",
     safeState = Off, sellByDate = never)
 
-  val SoulmatesFeedSwitch = Switch("Performance Switches", "gu-soulmates",
+  val SoulmatesFeedSwitch = Switch("Commercial", "gu-soulmates",
     "If this switch is on, commercial components will be fed by soulmates feed.",
     safeState = Off, sellByDate = never)
 
-  val MoneysupermarketFeedsSwitch = Switch("Performance Switches", "moneysupermarket",
+  val MoneysupermarketFeedsSwitch = Switch("Commercial", "moneysupermarket",
     "If this switch is on, commercial components will be fed by Moneysupermarket feeds.",
     safeState = Off, sellByDate = never)
 
-  val LCMortgageFeedSwitch = Switch("Performance Switches", "lc-mortgages",
+  val LCMortgageFeedSwitch = Switch("Commercial", "lc-mortgages",
     "If this switch is on, commercial components will be fed by London & Country mortgage feed.",
     safeState = Off, sellByDate = never)
 
-  val GuBookshopFeedsSwitch = Switch("Performance Switches", "gu-bookshop",
+  val GuBookshopFeedsSwitch = Switch("Commercial", "gu-bookshop",
     "If this switch is on, commercial components will be fed by the Guardian Bookshop feed.",
     safeState = Off, sellByDate = never)
 
 
-  // Analytics Switches
+  // Monitoring
 
-  val OphanSwitch = Switch("Analytics", "ophan",
+  val OphanSwitch = Switch("Monitoring", "ophan",
     "Enables the new Ophan tracking javascript",
     safeState = On, never
   )
 
-  val DiagnosticsLogging = Switch("Diagnostics", "enable-diagnostics-logging",
+  val DiagnosticsLogging = Switch("Monitoring", "enable-diagnostics-logging",
     "If this switch is on, then js error reports and requests sent to the Diagnostics servers will be logged.",
     safeState = On, never
   )
 
-  val MetricsSwitch = Switch("Diagnostics", "enable-metrics-non-prod",
+  val MetricsSwitch = Switch("Monitoring", "enable-metrics-non-prod",
     "If this switch is on, then metrics will be pushed to cloudwatch on DEV and CODE",
     safeState = Off, never
   )
 
-  val ScrollDepthSwitch = Switch("Analytics", "scroll-depth",
+  val ScrollDepthSwitch = Switch("Monitoring", "scroll-depth",
     "Enables tracking and measurement of scroll depth",
     safeState = Off, never
   )
 
-  // Feature Switches
+  // Features
 
-  val ReleaseMessageSwitch = Switch("Feature Switches", "release-message",
+  val OutbrainSwitch = Switch("Feature", "outbrain",
+    "Enable the Outbrain content recommendation widget.",
+    safeState = Off, sellByDate = never)
+
+  val ForeseeSwitch = Switch("Feature", "foresee",
+    "Enable Foresee surveys for a sample of our audience",
+    safeState = Off, sellByDate = never)
+
+  val ReleaseMessageSwitch = Switch("Feature", "release-message",
     "If this is switched on users will be messaged that they are inside the beta release",
     safeState = Off, sellByDate = new LocalDate(2014, 8, 31)
   )
 
-  val GeoMostPopular = Switch("Feature Switches", "geo-most-popular",
+  val GeoMostPopular = Switch("Feature", "geo-most-popular",
     "If this is switched on users then 'most popular' will be upgraded to geo targeted",
     safeState = On, sellByDate = never
   )
 
-  val FontSwitch = Switch("Feature Switches", "web-fonts",
+  val FontSwitch = Switch("Feature", "web-fonts",
     "If this is switched on then the custom Guardian web font will load.",
     safeState = On, sellByDate = never
   )
 
-  val SearchSwitch = Switch("Feature Switches", "google-search",
+  val SearchSwitch = Switch("Feature", "google-search",
     "If this switch is turned on then Google search is added to the sections nav.",
     safeState = Off, sellByDate = never
   )
 
-  val IdentityProfileNavigationSwitch = Switch("Feature Switches", "id-profile-navigation",
+  val IdentityProfileNavigationSwitch = Switch("Feature", "id-profile-navigation",
     "If this switch is on you will see the link in the topbar taking you through to the users profile or sign in..",
     safeState = On, sellByDate = never
   )
 
-  val FacebookAutoSigninSwitch = Switch("Feature Switches", "facebook-autosignin",
+  val FacebookAutoSigninSwitch = Switch("Feature", "facebook-autosignin",
     "If this switch is on then users who have previously authorized the guardian app in facebook and who have not recently signed out are automatically signed in.",
     safeState = Off, sellByDate = never
   )
 
-  val IdentityFormstackSwitch = Switch("Feature Switches", "id-formstack",
+  val IdentityFormstackSwitch = Switch("Feature", "id-formstack",
     "If this switch is on, formstack forms will be available",
     safeState = Off, sellByDate = never
   )
 
-  val IdentityAvatarUploadSwitch = Switch("Feature Switches", "id-avatar-upload",
+  val IdentityAvatarUploadSwitch = Switch("Feature", "id-avatar-upload",
     "If this switch is on, users can upload avatars on their profile page",
     safeState = Off, sellByDate = never
   )
 
-  val IndiaRegionSwitch = Switch("Feature Switches", "india-region",
+  val IndiaRegionSwitch = Switch("Feature", "india-region",
     "If this switch is switched on then the India region will be enabled",
     safeState = Off,
     // I know this is far away, but this will lie dormant for a while (other than testing) while
@@ -281,24 +278,40 @@ object Switches extends Collections {
     sellByDate = new LocalDate(2014, 10, 30)
   )
 
-  val EnhanceTweetsSwitch = Switch("Feature Switches", "enhance-tweets",
+  val EnhanceTweetsSwitch = Switch("Feature", "enhance-tweets",
     "If this switch is turned on then embedded tweets will be enhanced using Twitter's widgets.",
     safeState = Off, sellByDate = never
   )
 
-  val SentimentalCommentsSwitch = Switch("Feature Switches", "sentimental-comments",
+  val SentimentalCommentsSwitch = Switch("Feature", "sentimental-comments",
     "When this switch is on, you will be able to put sentiment into your comments.",
     safeState = Off, sellByDate = new LocalDate(2014, 9, 1)
   )
 
-  val EnhancedMediaPlayerSwitch = Switch("Feature Switches", "enhanced-media-player",
+  val EnhancedMediaPlayerSwitch = Switch("Feature", "enhanced-media-player",
     "If this is switched on then videos are enhanced using our JavaScript player",
     safeState = On, sellByDate = never
   )
 
-  val BreakingNewsSwitch = Switch("Feature Switches", "breaking-news",
+  val BreakingNewsSwitch = Switch("Feature", "breaking-news",
     "If this is switched on then the breaking news feed is requested and articles are displayed",
     safeState = Off, sellByDate = new LocalDate(2014, 9, 30)
+  )
+
+  // actually just here to make us remove this in the future
+  val GuShiftCookieSwitch = Switch("Feature", "gu-shift-cookie",
+    "If switched on, the GU_SHIFT cookie will be updated when users opt into or out of Next Gen",
+    safeState = On, sellByDate = new LocalDate(2014, 9, 30)
+  )
+
+  val ChildrensBooksSwitch = Switch("Feature", "childrens-books-hide-popular",
+    "If switched on, video pages in the childrens books section will not show popular videos",
+    safeState = On, sellByDate = new LocalDate(2014, 9, 8)
+  )
+
+  val SeoOptimisedContentImageSwitch = Switch("Feature", "seo-optimised-article-image",
+    "If this switch is on images then articles will get a 460px on static.guim.co.uk image as the low-res version.",
+    safeState = On, sellByDate = new LocalDate(2014, 8, 30)
   )
 
   // A/B Tests
@@ -308,115 +321,76 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  // Dummy Switches
+  // Facia
 
-  val IntegrationTestSwitch = Switch("Unwired Test Switch", "integration-test-switch",
-    "Switch that is only used while running tests. You never need to change this switch.",
-    safeState = Off, sellByDate = never
-  )
-
-  val NeverExpiredSwitch = Switch("Unwired Test Switch", "never-expired-switch",
-    "Switch that is only used while running tests. You never need to change this switch.",
-    safeState = On, sellByDate = never
-  )
-
-  val AlwaysExpiredSwitch = Switch("Unwired Test Switch", "always-expired",
-    "Switch that is only used while running tests. You never need to change this switch.",
-    safeState = On, new LocalDate().minusDays(1)
-  )
-
-  // Facia Tool Switches
-
-  val ToolDisable = Switch("Facia Tool", "facia-tool-disable",
+  val ToolDisable = Switch("Facia", "facia-tool-disable",
     "If this is switched on then the fronts tool is disabled",
     safeState = Off, sellByDate = never
   )
 
-  val ToolConfigurationDisable = Switch("Facia Tool", "facia-tool-configuration-disable",
+  val ToolConfigurationDisable = Switch("Facia", "facia-tool-configuration-disable",
     "If this is switched on then the fronts configuration tool is disabled",
     safeState = Off, sellByDate = never
   )
 
-  val ToolCheckPressLastmodified = Switch("Facia Tool", "facia-tool-check-press-lastmodified",
+  val ToolCheckPressLastmodified = Switch("Facia", "facia-tool-check-press-lastmodified",
     "If this switch is on facia tool will alert the user if a front is not pressed withing 10 secs of an edit/publish",
     safeState = Off, sellByDate = never
   )
 
-  val ToolSnaps = Switch("Facia Tool", "facia-tool-snaps",
+  val ToolSnaps = Switch("Facia", "facia-tool-snaps",
     "If this is switched on then snaps can be created by dragging arbitrary links into the tool",
     safeState = Off, sellByDate = never
   )
 
-  val ToolImageOverride = Switch("Facia Tool", "facia-tool-image-override",
+  val ToolImageOverride = Switch("Facia", "facia-tool-image-override",
     "If this is switched on then images can be overridden in the fronts tool",
     safeState = Off, sellByDate = never
   )
 
-  val ToolSparklines = Switch("Facia Tool", "facia-tool-sparklines",
+  val ToolSparklines = Switch("Facia", "facia-tool-sparklines",
     "If this is switched on then the fronts tool renders images from sparklines.ophan.co.uk",
     safeState = Off, sellByDate = never
   )
 
-  val ContentApiPutSwitch = Switch("Facia Tool", "facia-tool-contentapi-put",
+  val ContentApiPutSwitch = Switch("Facia", "facia-tool-contentapi-put",
     "If this switch is on facia tool will PUT all collection changes to content api",
     safeState = Off, sellByDate = never
   )
 
-  val FaciaToolPressSwitch = Switch("Front Press Switches", "facia-tool-press-front",
+  val FaciaToolPressSwitch = Switch("Facia", "facia-tool-press-front",
     "If this switch is on facia tool will press fronts on each change",
     safeState = Off, sellByDate = never
   )
 
-  val FaciaToolDraftPressSwitch = Switch("Front Press Switches", "facia-tool-press-draft-front",
+  val FaciaToolDraftPressSwitch = Switch("Facia", "facia-tool-press-draft-front",
     "If this switch is on facia tool will press draft fronts on each change",
     safeState = Off, sellByDate = never
   )
 
-  val FaciaToolDraftContent = Switch("Front Press Switches", "facia-tool-draft-content",
+  val FaciaToolDraftContent = Switch("Facia", "facia-tool-draft-content",
     "If this switch is on facia tool will offer draft content to editors, and press draft fronts from draft content ",
     safeState = Off, sellByDate = never
   )
 
-  val FaciaToolCachedContentApiSwitch = Switch("Front Press Switches", "facia-tool-cached-capi-requests",
+  val FaciaToolCachedContentApiSwitch = Switch("Facia", "facia-tool-cached-capi-requests",
     "If this switch is on facia tool will cache responses from the content API and use them on failure",
     safeState = On, sellByDate = never
   )
 
-  val FaciaToolCachedZippingContentApiSwitch = Switch("Front Press Switches", "facia-tool-zipcached-capi-requests",
+  val FaciaToolCachedZippingContentApiSwitch = Switch("Facia", "facia-tool-zipcached-capi-requests",
     "If this switch is on facia tool will zip cache responses from the content API and use them on failure",
     safeState = On, sellByDate = never
   )
 
-  // Front Press Switches
-  val FrontPressJobSwitch = Switch("Front Press Switches", "front-press-job-switch",
+  val FrontPressJobSwitch = Switch("Facia", "front-press-job-switch",
     "If this switch is on then the jobs to push and pull from SQS will run",
     safeState = Off, sellByDate = never
   )
 
-  val FaciaToolContainerTagsSwitch = Switch("Facia Tool", "facia-tool-tags",
+  val FaciaToolContainerTagsSwitch = Switch("Facia", "facia-tool-tags",
     "If this switch is on the container configuration will allow articles to show their tags or sections",
     safeState = Off, sellByDate = new LocalDate(2014, 9, 2)
-  )
-
-  val ImageServerSwitch = Switch("Image Server", "image-server",
-    "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
-    safeState = On, sellByDate = never // this is a performance related switch, not a feature switch
-  )
-
-  val SeoOptimisedContentImageSwitch = Switch("Image Server", "seo-optimised-article-image",
-    "If this switch is on images then articles will get a 460px on static.guim.co.uk image as the low-res version.",
-    safeState = On, sellByDate = new LocalDate(2014, 8, 30)
-  )
-
-  // actually just here to make us remove this in the future
-  val GuShiftCookieSwitch = Switch("Feature Switches", "gu-shift-cookie",
-    "If switched on, the GU_SHIFT cookie will be updated when users opt into or out of Next Gen",
-    safeState = On, sellByDate = new LocalDate(2014, 9, 30)
-  )
-
-  val ChildrensBooksSwitch = Switch("Feature Switches", "childrens-books-hide-popular",
-    "If switched on, video pages in the childrens books section will not show popular videos",
-    safeState = On, sellByDate = new LocalDate(2014, 9, 8)
   )
 
   val all: List[Switch] = List(
@@ -437,7 +411,6 @@ object Switches extends Collections {
     FontSwitch,
     SearchSwitch,
     ReleaseMessageSwitch,
-    IntegrationTestSwitch,
     IdentityProfileNavigationSwitch,
     CssFromStorageSwitch,
     FacebookAutoSigninSwitch,

--- a/common/test/conf/SwitchesTest.scala
+++ b/common/test/conf/SwitchesTest.scala
@@ -27,13 +27,4 @@ class SwitchesTest extends FlatSpec with Matchers {
       case Switch(_, id, _, _, sellByDate) => assert(sellByDate.isAfter(new LocalDate()), id)
     }
   }
-
-  it should "Check a switch is on if set to expire in the future" in {
-    assert(Switches.NeverExpiredSwitch.isSwitchedOn)
-  }
-  
-  it should "Check a switch expires once it's sell by date has past" in {
-    assert(Switches.AlwaysExpiredSwitch.isSwitchedOff)
-  }
-  
 }


### PR DESCRIPTION
Just making the switches easier to read.

Uses coarser switch categories so we can see fewer wells.

![screen shot 2014-08-21 at 15 22 19](https://cloud.githubusercontent.com/assets/4549425/3997345/b155a010-293e-11e4-95bc-c257d3536574.png)
