### PR TITLE
Fix ASG issue

### DIFF
--- a/common/test/assets/javascripts/spec/commercial/tags/audience-science-gateway.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/tags/audience-science-gateway.spec.js
@@ -1,0 +1,68 @@
+define([
+    'common/utils/storage',
+    'common/modules/commercial/tags/audience-science-gateway'
+], function(
+    storage,
+    audienceScienceGateway
+) {
+
+    describe('Audience Science Gateway', function () {
+
+        it('should be able to get segments', function () {
+            var section = 'news';
+            audienceScienceGateway._init({
+                page: { section: section },
+                switches: { audienceScienceGateway: true }
+            });
+            var stored = {},
+                storedValue = {
+                    Y1C40a: {
+                        'default': {
+                            key: 'sct-76-qHDJGkNzOZB198Rq0V98'
+                        },
+                        data: {
+                            'STPG-li383': {
+                                key: 'sct-76-qHDJGkNzOZB198Rq0V98'
+                            }
+                        },
+                        blob: 'CjRjMmMyOTQ1OC0yZDhmLTRlMGMtYTY1Ni04NjcxZTJmOWRmMzctMTQwODYyODU1MjA2Ny0y'
+                    },
+                    c7Zrhu: {
+                        'default': {
+                            key: 'k_1zMBS3xPySFDHSOzVC3M3um3A'
+                        },
+                        data: {
+                            'STPG-li436': {
+                                key: 'k_1zMBS3xPySFDHSOzVC3M3um3A'
+                            }
+                        },
+                        blob: 'CjQ3YmM2YjgzZC02ZTk4LTQ3MjEtYTVmZC05ZGJiYzcwZmQyOWItMTQwODYzMjE4NTI4MS0w'
+                    }
+                };
+            stored[section] = storedValue;
+            storage.local.set('gu.ads.audsci-gateway', stored);
+            expect(audienceScienceGateway.getSegments()).toEqual({
+                pq_Y1C40a: 'T',
+                pq_c7Zrhu: 'T'
+            });
+        });
+
+        it('should return empty object if no segments', function () {
+            audienceScienceGateway._init({
+                page: { section: 'news' },
+                switches: { audienceScienceGateway: true }
+            });
+            storage.local.set('gu.ads.audsci-gateway', {});
+            expect(audienceScienceGateway.getSegments()).toEqual({});
+        });
+
+        it('should return empty object if switch is off', function () {
+            audienceScienceGateway._init({
+                switches: { audienceScienceGateway: false }
+            });
+            expect(audienceScienceGateway.getSegments()).toEqual({});
+        });
+
+    });
+
+});


### PR DESCRIPTION
Due to us not wanting to hold up the call to DFP, we store the Audience Science Gateway response locally and use it on the next request. However, ASG also loads some variables into the global space, which might not be there on the next request. So this stores those vars locally as well. 
In summary, really horrible
