### PR TITLE
Move loading of dfp after tags

### DIFF
--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -446,9 +446,11 @@ define([
             .valueOf();
 
         if (adSlots.length > 0) {
-            // if we don't already have googletag, create command queue (assumes it's loaded further up the chain)
+            // if we don't already have googletag, create command queue and load it async
             if (!window.googletag) {
                 window.googletag = { cmd: [] };
+                // load the library asynchronously
+                require(['googletag']);
             }
 
             window.googletag.cmd.push(setListeners);

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -169,7 +169,7 @@
                 images.listen();
 
                 if (config.switches.commercial) {
-                    require(['bootstraps/commercial', 'js!googletag'], function(commercial) {
+                    require(['bootstraps/commercial'], function(commercial) {
                         commercial.init();
                     });
                 }


### PR DESCRIPTION
Basically reverting https://github.com/guardian/frontend/commit/2801b83152222ddb2ce6f45ada238853b94e90c8

Gives tags a chance to load before DFP
