### PR TITLE
The horror ... the horror ...

### DIFF
--- a/admin/app/model/abtests/AbTestJob.scala
+++ b/admin/app/model/abtests/AbTestJob.scala
@@ -2,7 +2,7 @@ package model.abtests
 
 import common.{ExecutionContexts, Logging}
 import tools.CloudWatch
-import views.support.JavaScriptVariableName
+import views.support.CamelCase
 
 import scala.collection.JavaConverters._
 
@@ -16,7 +16,7 @@ object AbTestJob extends Logging with ExecutionContexts {
       val tests = result.getMetrics.asScala.map(_.getMetricName.split("-").toList).collect {
                     case test :: variant => (test, variant.mkString("-")) }.groupBy(_._1)
 
-      val switches = conf.Switches.all.filter(_.name.startsWith("ab-")).map(switch => JavaScriptVariableName(switch.name))
+      val switches = conf.Switches.all.filter(_.name.startsWith("ab-")).map(switch => CamelCase.fromHyphenated(switch.name))
 
       val testVariants = switches.foldLeft(Map.empty[String, Seq[String]]) ( (acc, switch ) => {
         if (tests.isDefinedAt(switch)) {

--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -1,5 +1,7 @@
 @(env: String, charts: Seq[tools.LineChart])
 
+@import views.support.CamelCase
+
 @chartJson(chart: tools.LineChart) = {
     '@chart.name': {
         data: @Html(chart.asDataset),
@@ -33,7 +35,7 @@
         };
         window.abSwitches = {
             @conf.Switches.all.filter(_.group == "A/B Tests").map{ s =>
-                "@JavaScriptVariableName(s.name)": @s.isSwitchedOn,
+                "@CamelCase.fromHyphenated(s.name)": @s.isSwitchedOn,
             }
         }
     </script>

--- a/article/test/AnalyticsFeatureTest.scala
+++ b/article/test/AnalyticsFeatureTest.scala
@@ -11,7 +11,7 @@ class AnalyticsFeatureTest extends FeatureSpec with GivenWhenThen with Matchers 
 
   feature("Analytics") {
 
-    // Feature 
+    // Feature
 
     info("In order understand how people are using the website and provide data for auditing")
     info("As a product manager")
@@ -43,7 +43,7 @@ class AnalyticsFeatureTest extends FeatureSpec with GivenWhenThen with Matchers 
       HtmlUnit("/sport/2012/jun/12/london-2012-olympic-opening-ceremony") { browser =>
         import browser._
         Then("all links on the page should be decorated with the Omniture meta-data attribute")
-        val anchorsWithNoDataLink = find("a").filter(hasNoLinkName(_))
+        val anchorsWithNoDataLink = find("a").filter(hasNoLinkName)
         anchorsWithNoDataLink should have length (0)
       }
 

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 
 class ArticleControllerTest extends FlatSpec with Matchers {
-  
+
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
   val liveBlogUrl = "global/middle-east-live/2013/sep/09/syria-crisis-russia-kerry-us-live"
   val sudokuUrl = "lifeandstyle/2013/sep/09/sudoku-2599-easy"
@@ -25,8 +25,8 @@ class ArticleControllerTest extends FlatSpec with Matchers {
   it should "count in body links" in Fake {
     val result = controllers.ArticleController.renderArticle(liveBlogUrl)(TestRequest(liveBlogUrl))
     val body = contentAsString(result)
-    body should include(""""inBodyInternalLinkCount": "38"""")
-    body should include(""""inBodyExternalLinkCount": "42"""")
+    body should include(""""inBodyInternalLinkCount":38""")
+    body should include(""""inBodyExternalLinkCount":42""")
   }
 
   it should "200 when content type is sudoku" in Fake {
@@ -58,7 +58,7 @@ class ArticleControllerTest extends FlatSpec with Matchers {
   it should "return JSON when .json format is supplied" in Fake {
     val fakeRequest = FakeRequest("GET", s"${articleUrl}.json")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-      
+
     val result = controllers.ArticleController.renderArticle(articleUrl)(fakeRequest)
     status(result) should be(200)
     contentType(result).get should be("application/json")

--- a/commercial/app/controllers/commercial/CreativeTestPage.scala
+++ b/commercial/app/controllers/commercial/CreativeTestPage.scala
@@ -1,6 +1,7 @@
 package controllers.commercial
 
 import model.{GuardianContentTypes, NoCache, Cached}
+import play.api.libs.json.{JsString, JsValue}
 import play.api.mvc._
 import conf.Configuration
 
@@ -16,12 +17,12 @@ object TestPage extends model.MetaData  {
 
   override lazy val isFront = true
 
-  override lazy val metaData: Map[String, Any] = super.metaData ++ faciaPageMetaData
-  lazy val faciaPageMetaData: Map[String, Any] = newMetaData
+  override lazy val metaData: Map[String, JsValue] = super.metaData ++ faciaPageMetaData
+  lazy val faciaPageMetaData: Map[String, JsValue] = newMetaData
 
-  lazy val newMetaData: Map[String, Any] = Map(
-    "keywords" -> webTitle.capitalize,
-    "content-type" -> contentType
+  lazy val newMetaData: Map[String, JsValue] = Map(
+    "keywords" -> JsString(webTitle.capitalize),
+    "contentType" -> JsString(contentType)
   )
 
   val isNetworkFront: Boolean = false

--- a/common/app/common/Maps.scala
+++ b/common/app/common/Maps.scala
@@ -4,4 +4,12 @@ object Maps {
   /** Insert k -> v into map, resolving collisions with f */
   def insertWith[A, B](map: Map[A, B], k: A, v: B)(f: (B, B) => B) =
     map + (k -> map.get(k).map(f.curried(v)).getOrElse(v))
+
+  implicit class RichMap[A, B](map: Map[A, B]) {
+    /** Obviously, if you get a collision, you're going to lose a pair */
+    def mapKeys[C](f: A => C) =
+      (map.toSeq map {
+        case (k, v) => (f(k), v)
+      }).toMap
+  }
 }

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -3,6 +3,7 @@ package common
 import com.gu.openplatform.contentapi.ApiError
 import conf.Switch
 import play.api.Logger
+import play.api.libs.json.{JsString, JsObject}
 import play.api.mvc.{ Result, RequestHeader }
 import play.twirl.api.Html
 import model.{NoCache, Cached}
@@ -58,5 +59,22 @@ object Reference {
   def apply(s: String) = {
     val parts = s.split("/")
     parts(0) -> parts.drop(1).mkString("/")
+  }
+
+  def toJavaScript(s: String) = {
+    val (k, v) = apply(s)
+
+    /** Yeah ... so ... in the JavaScript references are represented like this:
+      *
+      * "references":[{"esaFootballTeam":"/football/team/48"},{"optaFootballTournament":"5/2012"}57"} ... ]
+      *
+      * See for example the source of
+      * http://www.theguardian.com/football/live/2014/aug/20/maribor-v-celtic-champions-league-play-off-live-report
+      *
+      * Seems pretty STRANGE.
+      *
+      * TODO: figure out if this is actually being used. If so, refactor it.
+      */
+    JsObject(Seq(k -> JsString(v)))
   }
 }

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -3,7 +3,6 @@ package model
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.libs.json.Json.toJson
-import views.support.JavaScriptVariableName
 
 trait Formats extends implicits.Dates {
   implicit val imageFormat: Writes[ImageAsset] = new Writes[ImageAsset] {
@@ -36,14 +35,6 @@ trait Formats extends implicits.Dates {
   }
 
   implicit val metaDataFormat: Writes[MetaData] = new Writes[MetaData] {
-    def writes(item: MetaData): JsValue = toJson(
-      item.metaData map {
-        case (key, value) => JavaScriptVariableName(key) -> value
-      } mapValues {
-        case date: DateTime => toJson(date)
-        case string: String => toJson(string)
-        case boolean: Boolean => toJson(boolean)
-      }
-    )
+    def writes(item: MetaData): JsValue = toJson(item.metaData)
   }
 }

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -3,6 +3,7 @@ package model
 import com.gu.openplatform.contentapi.model.{ Section => ApiSection }
 import common.{Edition, Pagination}
 import dfp.DfpAgent
+import play.api.libs.json.{JsString, JsValue}
 
 case class Section(private val delegate: ApiSection, override val pagination: Option[Pagination] = None)
   extends MetaData with AdSuffixHandlingForFronts {
@@ -21,9 +22,9 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
 
   override lazy val rssPath = Some(s"/$id/rss")
 
-  override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-    "keywords" -> webTitle,
-    "content-type" -> "Section"
+  override lazy val metaData: Map[String, JsValue] = super.metaData ++ Map(
+    "keywords" -> JsString(webTitle),
+    "content-type" -> JsString("Section")
   )
 
   override def isSponsored = DfpAgent.isSponsored(this.id)

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -3,6 +3,7 @@ package model
 import com.gu.openplatform.contentapi.model.{ Tag => ApiTag }
 import common.Pagination
 import common.Reference
+import play.api.libs.json.{JsArray, JsString, JsValue}
 import views.support.{Contributor, ImgSrc, Item140}
 
 case class Tag(private val delegate: ApiTag, override val pagination: Option[Pagination] = None) extends MetaData with AdSuffixHandlingForFronts {
@@ -49,12 +50,14 @@ case class Tag(private val delegate: ApiTag, override val pagination: Option[Pag
   lazy val tagWithoutSection = id.split("/")(1) // used for football nav
 
   override lazy val analyticsName = s"GFE:$section:$name"
-  
+
   override lazy val rssPath = Some(s"/$id/rss")
 
-  override lazy val metaData: Map[String, Any] = super.metaData ++ Map(
-    "keywords" -> name,
-    "keywordIds" -> id,
-    "content-type" -> "Tag"
-  ) ++ Map("references" -> delegate.references.map(r => Reference(r.id)))
+  override lazy val metaData: Map[String, JsValue] = super.metaData ++ Map(
+    "keywords" -> JsString(name),
+    "keywordIds" -> JsString(id),
+    "content-type" -> JsString("Tag")
+  ) ++ Map(
+    "references" -> JsArray(delegate.references.toSeq.map(ref => Reference.toJavaScript(ref.id)))
+  )
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -3,6 +3,7 @@ package model
 import common.{NavItem, Edition, ManifestData, Pagination}
 import conf.Configuration
 import dfp.DfpAgent
+import play.api.libs.json.{JsBoolean, JsValue, JsString}
 
 trait MetaData extends Tags {
   def id: String
@@ -39,17 +40,17 @@ trait MetaData extends Tags {
 
   def isSurging: Seq[Int] = Seq(0)
 
-  def metaData: Map[String, Any] = Map(
-    ("page-id", id),
-    ("section", section),
-    ("web-title", webTitle),
-    ("build-number", buildNumber),
-    ("analytics-name", analyticsName),
-    ("blockVideoAds", false),
-    ("is-front", isFront),
-    ("ad-unit", s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitRoot}/$adUnitSuffix/ng"),
-    ("is-surging", isSurging.mkString(",")),
-    ("has-classic-version", hasClassicVersion)
+  def metaData: Map[String, JsValue] = Map(
+    ("pageId", JsString(id)),
+    ("section", JsString(section)),
+    ("webTitle", JsString(webTitle)),
+    ("buildNumber", JsString(buildNumber)),
+    ("analyticsName", JsString(analyticsName)),
+    ("blockVideoAds", JsBoolean(false)),
+    ("isFront", JsBoolean(isFront)),
+    ("adUnit", JsString(s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitRoot}/$adUnitSuffix/ng")),
+    ("isSurging", JsString(isSurging.mkString(","))),
+    ("hasClassicVersion", JsBoolean(hasClassicVersion))
   )
 
   def openGraph: Map[String, Any] = Map(

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -3,7 +3,7 @@
 <meta charset="utf-8" />
 <title>@views.support.Title(metaData)</title>
 
-@fragments.metaDataCritical(metaData)
+@fragments.metaDataCritical()
 
 @fragments.javaScriptFirstSteps(metaData, curlPaths)
 

--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -1,41 +1,18 @@
 @(item: model.MetaData)(implicit request: RequestHeader)
-@import conf.Configuration
-@import views.support.MetadataJson
-@import views.support.JavaScriptVariableName
+
 @import common.Edition
 @import dev.HttpSwitch
-@import org.joda.time.DateTime
+@import views.support.{JavaScriptPage, CamelCase}
+@import play.api.libs.json.Json
 
 @defining(Edition(request)) { edition =>
 {
-    "page": {
-        @{Html(item.metaData.map{ data => MetadataJson(data) }.mkString(","))},
-        @{Html((Configuration.javascript.config ++ Configuration.javascript.pageData).map{ case (key, value) =>
-            s""""${JavaScriptVariableName(key.split('.').last)}":"${value}""""}.mkString(",")
-        )},
-        "edition": "@edition.id",
-        "ajaxUrl": "@Configuration.ajax.url",
-        "isDev": @play.Play.isDev(),
-        "oasHost": "oas.theguardian.com",
-        "oasUrl": "@Configuration.oas.url",
-        "oasSiteIdHost": "www.theguardian-alpha.com",
-        "dfpHost": "pubads.g.doubleclick.net",
-        "idUrl": "@Configuration.id.url",
-        "beaconUrl": "@Configuration.debug.beaconUrl",
-        "renderTime": "@{(new DateTime).toISODateTimeNoMillisString}",
-        "isSSL": @Configuration.environment.secure,
-        "assetsPath": "@Configuration.assets.path",
-        "hasPageSkin": @item.hasPageSkin(edition),
-        "shouldHideAdverts": @item match {
-            case c: model.Content if c.shouldHideAdverts => {true}
-            case _                                       => {false}
-        }
-    },
+    "page": @Html(Json.stringify(JavaScriptPage(item, request).get)),
     "switches" : { @{Html(conf.Switches.all.map{ switch =>
             if(conf.Switches.httpSwitches.contains(switch))
-                s""""${JavaScriptVariableName(switch.name)}":${HttpSwitch(switch).isSwitchedOn}"""
+                s""""${CamelCase.fromHyphenated(switch.name)}":${HttpSwitch(switch).isSwitchedOn}"""
             else
-                s""""${JavaScriptVariableName(switch.name)}":${switch.isSwitchedOn}"""
+                s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""
         }.mkString(","))}
     },
     "modules": { }

--- a/common/app/views/fragments/metaDataCritical.scala.html
+++ b/common/app/views/fragments/metaDataCritical.scala.html
@@ -1,4 +1,4 @@
-@(item: model.MetaData)(implicit request: RequestHeader)
+@()(implicit request: RequestHeader)
 @import conf.Configuration
 @import common.AnalyticsHost
 

--- a/common/app/views/support/CamelCase.scala
+++ b/common/app/views/support/CamelCase.scala
@@ -1,0 +1,10 @@
+package views.support
+
+object CamelCase {
+  def fromHyphenated(s: String) =
+    s.split("-").toList match {
+      case first :: rest =>
+        first + rest.map(_.capitalize).mkString("")
+      case Nil => ""
+    }
+}

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -1,0 +1,43 @@
+package views.support
+
+import common.Edition
+import common.Maps.RichMap
+import conf.Configuration
+import model.{Content, MetaData}
+import org.joda.time.DateTime
+import play.api.Play
+import play.api.Play.current
+import play.api.libs.json.{JsBoolean, JsString, Json}
+import play.api.mvc.RequestHeader
+
+case class JavaScriptPage(metaData: MetaData, request: RequestHeader) {
+  def get = {
+    val edition = Edition(request)
+
+    val pageData = Configuration.javascript.pageData mapKeys { key =>
+      CamelCase.fromHyphenated(key.split('.').lastOption.getOrElse(""))
+    }
+
+    val config = (Configuration.javascript.config ++ pageData).mapValues(JsString.apply)
+
+    Json.toJson(metaData.metaData ++ config ++ Map(
+      ("edition", JsString(edition.id)),
+      ("ajaxUrl", JsString(Configuration.ajax.url)),
+      ("isDev", JsBoolean(Play.isDev)),
+      ("oasHost", JsString("oas.theguardian.com")),
+      ("oasUrl", JsString(Configuration.oas.url)),
+      ("oasSiteIdHost", JsString("www.theguardian-alpha.com")),
+      ("dfpHost", JsString("pubads.g.doubleclick.net")),
+      ("idUrl", JsString(Configuration.id.url)),
+      ("beaconUrl", JsString(Configuration.debug.beaconUrl)),
+      ("renderTime", JsString(DateTime.now.toISODateTimeNoMillisString)),
+      ("isSSL", JsBoolean(Configuration.environment.secure)),
+      ("assetsPath", JsString(Configuration.assets.path)),
+      ("hasPageSkin", JsBoolean(metaData.hasPageSkin(edition))),
+      ("shouldHideAdverts", JsBoolean(metaData match {
+        case c: Content if c.shouldHideAdverts => true
+        case _ => false
+      }))
+    ))
+  }
+}

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -13,7 +13,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{ Element, Document }
 import org.jsoup.safety.{ Whitelist, Cleaner }
 import play.api.libs.json.Json._
-import play.api.libs.json.Writes
+import play.api.libs.json.{Json, JsValue, JsString, Writes}
 import play.api.mvc.RequestHeader
 import play.api.mvc.Result
 import play.twirl.api.Html
@@ -137,21 +137,6 @@ case class PreviousAndNext(prev: Option[String], next: Option[String]) {
   val isDefined: Boolean = prev.isDefined || next.isDefined
 }
 
-object MetadataJson {
-
-  def apply(data: (String, Any)): String = data match {
-    // thank you erasure
-    case (key, value) if value.isInstanceOf[Map[_, _]] =>
-      val valueJson = value.asInstanceOf[Map[String, Any]].map(MetadataJson(_)).mkString(",")
-      s""""$key": {$valueJson}"""
-    case (key, value) if value.isInstanceOf[Seq[_]] =>
-      val valueJson = value.asInstanceOf[Seq[(String, Any)]].map(v => s"{${MetadataJson(v)}}").mkString(",")
-      s""""$key": [${valueJson}]""".format(key, valueJson)
-    case (key, value) =>
-      s""""${JavaScriptVariableName(key)}": ${JavaScriptValue(value)}"""
-  }
-}
-
 object JSON {
   //we wrap the result in an Html so that play does not escape it as html
   //after we have gone to the trouble of escaping it as Javascript
@@ -172,21 +157,6 @@ object RemoveOuterParaHtml {
       Html(fragment.html.drop(3).dropRight(4))
     }
   }
-}
-
-object JavaScriptValue {
-  def apply(value: Any) = value match {
-    case b: Boolean => b
-    case s => s""""${s.toString.trim.replace(""""""", """\"""")}""""
-  }
-}
-
-object JavaScriptVariableName {
-  def apply(s: String): String = {
-    val parts = s.split("-").toList
-    (parts.headOption.toList ::: parts.tail.map(firstLetterUppercase )).mkString
-  }
-  private def firstLetterUppercase(s: String) = s.head.toUpper + s.tail
 }
 
 case class RowInfo(rowNum: Int, isLast: Boolean = false) {
@@ -609,15 +579,18 @@ object ContributorLinks {
 object OmnitureAnalyticsData {
   def apply(page: MetaData, jsSupport: String, path: String)(implicit request: RequestHeader): Html = {
 
-    val data = page.metaData.map { case (key, value) => key -> value.toString }
-    val pageCode = data.get("page-code").getOrElse("")
-    val contentType = data.get("content-type").getOrElse("")
-    val section = data.get("section").getOrElse("")
+    val data = page.metaData map {
+      case (key, JsString(s)) => key -> s
+      case (key, jValue: JsValue) => key -> Json.stringify(jValue)
+    }
+    val pageCode = data.getOrElse("pageCode", "")
+    val contentType = data.getOrElse("contentType", "")
+    val section = data.getOrElse("section", "")
     val platform = "frontend"
-    val publication = data.get("publication").getOrElse("")
-    val omnitureEvent = data.get("omnitureEvent").getOrElse("")
-    val registrationType = data.get("registrationType").getOrElse("")
-    val omnitureErrorMessage = data.get("omnitureErrorMessage").getOrElse("")
+    val publication = data.getOrElse("publication", "")
+    val omnitureEvent = data.getOrElse("omnitureEvent", "")
+    val registrationType = data.getOrElse("registrationType", "")
+    val omnitureErrorMessage = data.getOrElse("omnitureErrorMessage", "")
 
     val isContent = page match {
       case c: Content => true
@@ -634,19 +607,19 @@ object OmnitureAnalyticsData {
       ("c3", publication),
       ("ch", section),
       ("c9", section),
-      ("c4", data.get("keywords").getOrElse("")),
-      ("c6", data.get("author").getOrElse("")),
+      ("c4", data.getOrElse("keywords", "")),
+      ("c6", data.getOrElse("author", "")),
       ("c8", pageCode),
       ("v8", pageCode),
       ("c9", contentType),
-      ("c10", data.get("tones").getOrElse("")),
+      ("c10", data.getOrElse("tones", "")),
       ("c11", section),
-      ("c13", data.get("series").getOrElse("")),
-      ("c25", data.get("blogs").getOrElse("")),
-      ("c14", data("build-number")),
+      ("c13", data.getOrElse("series", "")),
+      ("c25", data.getOrElse("blogs", "")),
+      ("c14", data("buildNumber")),
       ("c19", platform),
       ("v19", platform),
-      ("v67", "nextgen-served"),
+      ("v67", "nextgenServed"),
       ("c30", if (isContent) "content" else "non-content"),
       ("c56", jsSupport),
       ("event", omnitureEvent),

--- a/common/test/views/support/CamelCaseTest.scala
+++ b/common/test/views/support/CamelCaseTest.scala
@@ -1,0 +1,13 @@
+package views.support
+
+import CamelCase.fromHyphenated
+import org.scalatest.{Matchers, FlatSpec}
+
+class CamelCaseTest extends FlatSpec with Matchers {
+  "fromHyphenated" should "create a camel case string" in {
+    fromHyphenated("once-upon-a-time") shouldEqual "onceUponATime"
+    fromHyphenated("hello-world") shouldEqual "helloWorld"
+    fromHyphenated("monad") shouldEqual "monad"
+    fromHyphenated("") shouldEqual ""
+  }
+}

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -50,12 +50,6 @@ class TemplatesTest extends FlatSpec with Matchers {
     Tag(tag("Article")).pluralName should be("Articles")
   }
 
-  "javaScriptVariableName" should "create a sensible Javascript name" in {
-
-    JavaScriptVariableName("web-publication-date") should be("webPublicationDate")
-    JavaScriptVariableName("series") should be("series")
-  }
-
   "PictureCleaner" should "correctly format inline pictures" in {
 
     val body = XML.loadString(withJsoup(bodyTextWithInlineElements)(PictureCleaner(bodyImages)).body.trim)
@@ -110,7 +104,7 @@ class TemplatesTest extends FlatSpec with Matchers {
     (link \ "@href").text should be (s"${Configuration.site.host}/section/2011/jan/01/words-for-url")
 
   }
-  
+
   "InBodyLinkCleanerForR1" should "clean links" in {
 
     // i. www
@@ -133,8 +127,8 @@ class TemplatesTest extends FlatSpec with Matchers {
         val bodyAbsolute = XML.loadString(withJsoup(s"""<a href="${key}">foo</a>""")(InBodyLinkCleanerForR1("")).body.trim)
         (bodyAbsolute \ "@href").text should be (value)
     }
-    
-    // iii. relative to the old subdomain 
+
+    // iii. relative to the old subdomain
     val bodyAbsolute = XML.loadString(withJsoup(s"""<a href="/path/to/foo">foo</a>""")(InBodyLinkCleanerForR1("/arts")).body.trim)
     (bodyAbsolute \ "@href").text should be ("/arts/path/to/foo")
 

--- a/diagnostics/app/model/diagnostics/abtests/Metric.scala
+++ b/diagnostics/app/model/diagnostics/abtests/Metric.scala
@@ -1,7 +1,7 @@
 package model.diagnostics.abtests
 
 import common.Logging
-import views.support.JavaScriptVariableName
+import views.support.CamelCase
 import conf.Switches.{all => AllSwitches}
 
 import com.google.common.util.concurrent.AtomicDouble
@@ -14,7 +14,7 @@ object Metric extends Logging {
   private val sessions   = Wrappers.JConcurrentMapWrapper(new ConcurrentHashMap[String, AtomicDouble]())
 
   private lazy val abTests: Seq[String] = {
-    AllSwitches.filter {_.name.startsWith("ab-")} map {switch => JavaScriptVariableName(switch.name)}
+    AllSwitches filter { _.name.startsWith("ab-") } map { switch => CamelCase.fromHyphenated(switch.name) }
   }
 
   def incrementPageView(test: String, variant: String) {

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -2,6 +2,7 @@ package model
 
 import common.Edition
 import dfp.DfpAgent
+import play.api.libs.json.{JsString, JsValue}
 
 case class FaciaPage(
                       id: String,
@@ -17,12 +18,12 @@ case class FaciaPage(
 
   override lazy val isFront = true
 
-  override lazy val metaData: Map[String, Any] = super.metaData ++ faciaPageMetaData
-  lazy val faciaPageMetaData: Map[String, Any] = newMetaData
+  override lazy val metaData: Map[String, JsValue] = super.metaData ++ faciaPageMetaData
+  lazy val faciaPageMetaData: Map[String, JsValue] = newMetaData
 
-  lazy val newMetaData: Map[String, Any] = Map(
-    "keywords" -> webTitle.capitalize,
-    "content-type" -> contentType
+  lazy val newMetaData: Map[String, JsValue] = Map(
+    "keywords" -> JsString(webTitle.capitalize),
+    "contentType" -> JsString(contentType)
   )
 
   val isNetworkFront: Boolean = Edition.all.exists(edition => id.toLowerCase.endsWith(edition.id.toLowerCase))

--- a/identity/app/model/IdentityPage.scala
+++ b/identity/app/model/IdentityPage.scala
@@ -1,11 +1,13 @@
 package model
 
+import play.api.libs.json.{JsBoolean, JsValue}
 import tracking.Omniture
 
-class IdentityPage(id: String, webTitle: String, analyticsName: String, overridenMetadata: Option[Map[String, Any]] = None)
+class IdentityPage(id: String, webTitle: String, analyticsName: String, overridenMetadata: Option[Map[String, JsValue]] = None)
   extends Page(id, "identity", webTitle, analyticsName) {
 
-  override def metaData: Map[String, Any] = overridenMetadata.getOrElse(super.metaData + ("blockVideoAds" -> true))
+  override def metaData: Map[String, JsValue] =
+    overridenMetadata.getOrElse(super.metaData + ("blockVideoAds" -> JsBoolean(true)))
 }
 object IdentityPage {
   def apply(id: String, webTitle: String, analyticsName: String): IdentityPage with Omniture = {

--- a/identity/app/tracking/Omniture.scala
+++ b/identity/app/tracking/Omniture.scala
@@ -1,5 +1,6 @@
 package tracking
 
+import play.api.libs.json.{JsString, JsValue}
 import services.IdentityRequest
 import model.IdentityPage
 
@@ -8,65 +9,66 @@ trait Omniture {
   val id: String
   val webTitle: String
   val analyticsName: String
-  def metaData: Map[String, Any]
+  def metaData: Map[String, JsValue]
 
-  private def addMetadata(values: (String, Any)*) = {
-    metaData ++ values
-  }
+  def metaDataFor(
+    returnUrl: Option[String],
+    registrationType: Option[String] = None,
+    omnitureEvent: Option[String] = None
+  ) = metaData ++ Seq(
+    Some("contentType" -> JsString("userid")), // For the no js omniture tracking
+    returnUrl.map("returnUrl" -> JsString(_)),
+    registrationType.map("registrationType" -> JsString(_)),
+    omnitureEvent.map("omnitureEvent" -> JsString(_))
+  ).flatten
 
   def registrationStart(idRequest: IdentityRequest): IdentityPage with TrackingParams = {
-    val newMetadata = addMetadata(
-      "returnUrl" -> idRequest.returnUrl,
-      "content-type" -> "userid", // For the no js omniture tracking
-      "registrationType" -> "basicIdentity:Anewreg::theguardian",
-      "omnitureEvent" -> "event30"
+    val newMetadata = metaDataFor(
+      idRequest.returnUrl,
+      Some("basicIdentity:Anewreg::theguardian"),
+      Some("event30")
     )
     new IdentityPage(id, webTitle, analyticsName, Some(newMetadata)) with TrackingParams
   }
 
   def registrationError(idRequest: IdentityRequest): IdentityPage with TrackingParams = {
-    val newMetadata = addMetadata(
-      "returnUrl" -> idRequest.returnUrl,
-      "content-type" -> "userid", // For the no js omniture tracking
-      "registrationType" -> "basicIdentity:Anewreg::theguardian",
-      "omnitureEvent" -> "event33"
+    val newMetadata = metaDataFor(
+      idRequest.returnUrl,
+      Some("basicIdentity:Anewreg::theguardian"),
+      Some("event33")
     )
     new IdentityPage(id, webTitle, analyticsName, Some(newMetadata)) with TrackingParams
   }
 
   def signinAuthenticationError(idRequest: IdentityRequest) : IdentityPage with TrackingParams = {
-    val newMetadata = addMetadata(
-      "returnUrl" -> idRequest.returnUrl,
-      "content-type" -> "userid", // For the no js omniture tracking
-      "omnitureEvent" -> "event34",
-      "omnitureErrorMessage" -> "Authentication failed"
+    val newMetadata = metaDataFor(
+      idRequest.returnUrl,
+      Some("Authentication failed"),
+      Some("event34")
     )
     new IdentityPage(id, webTitle, analyticsName, Some(newMetadata)) with TrackingParams
   }
 
   def signinValidationError(idRequest: IdentityRequest) : IdentityPage with TrackingParams = {
-    val newMetadata = addMetadata(
-      "returnUrl" -> idRequest.returnUrl,
-      "content-type" -> "userid", // For the no js omniture tracking
-      "omnitureEvent" -> "event34",
-      "omnitureErrorMessage" -> "Validation failed"
+    val newMetadata = metaDataFor(
+      idRequest.returnUrl,
+      Some("Validation failed"),
+      Some("event34")
     )
     new IdentityPage(id, webTitle, analyticsName, Some(newMetadata)) with TrackingParams
   }
 
   def accountEdited(idRequest: IdentityRequest) : IdentityPage with TrackingParams = {
-    val newMetadata = addMetadata(
-      "returnUrl" -> idRequest.returnUrl,
-      "content-type" -> "userid", // For the no js omniture tracking
-      "omnitureEvent" -> "event35"
+    val newMetadata = metaDataFor(
+      idRequest.returnUrl,
+      omnitureEvent = Some("event35")
     )
     new IdentityPage(id, webTitle, analyticsName, Some(newMetadata)) with TrackingParams
   }
 
   def tracking(idRequest: IdentityRequest) : IdentityPage with TrackingParams = {
-    val newMetadata = addMetadata(
-      "returnUrl" -> idRequest.returnUrl,
-      "content-type" -> "userid" // For the no js omniture tracking
+    val newMetadata = metaDataFor(
+      idRequest.returnUrl
     )
     new IdentityPage(id, webTitle, analyticsName, Some(newMetadata)) with TrackingParams
   }

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -4,6 +4,7 @@ import common._
 import model.TeamMap.findTeamIdByUrlName
 import model._
 import conf._
+import play.api.libs.json._
 import play.api.mvc.{ Controller, Action }
 import pa.FootballMatch
 import org.joda.time.format.DateTimeFormat
@@ -25,14 +26,14 @@ case class MatchPage(theMatch: FootballMatch, lineUp: LineUp) extends MetaData w
 
   override val hasClassicVersion = false
 
-  override lazy val metaData: Map[String, Any] = super.metaData + (
-    "footballMatch" -> Map(
-      "id" -> theMatch.id,
-      "dateInMillis" -> theMatch.date.getMillis,
-      "homeTeam" -> theMatch.homeTeam.id,
-      "awayTeam" -> theMatch.awayTeam.id,
-      "isLive" -> theMatch.isLive
-    )
+  override lazy val metaData: Map[String, JsValue] = super.metaData + (
+    "footballMatch" -> JsObject(Seq(
+      "id" -> JsString(theMatch.id),
+      "dateInMillis" -> JsNumber(theMatch.date.getMillis),
+      "homeTeam" -> JsString(theMatch.homeTeam.id),
+      "awayTeam" -> JsString(theMatch.awayTeam.id),
+      "isLive" -> JsBoolean(theMatch.isLive)
+    ))
   )
 }
 


### PR DESCRIPTION
Refactors `MetaData.metaData` so that it is no longer a `Map[String, Any]`.

@gklopper led me down this rabbit hole ... 

There's a few other `Map[String, Any]` that we should look at, but they should be simpler to refactor, as it looks like they just ought to be `Map[String, String]`. (see `MetaData.openGraph` and `MetaData.cards`).
