### PR TITLE
Show annual/monthly depending on subscription type

### DIFF
--- a/identity/app/assets/javascripts/membership/membership-tab.js
+++ b/identity/app/assets/javascripts/membership/membership-tab.js
@@ -53,6 +53,7 @@ define([
         ANIM_CLOSED: 'membership-tab__change-cc-form-cont--closed',
         NOTIFICATION_TIER_CURRENT: 'js-mem-tier-current',
         NOTIFICATION_TIER_TARGET: 'js-mem-tier-target',
+        NOTIFICATION_INTERVAL: 'js-mem-current-interval',
         NOTIFICATION_PERIOD_START: 'js-mem-current-period-start',
         NOTIFICATION_PERIOD_END: 'js-mem-current-period-end',
         NOTIFICATION_CANCEL: 'js-mem-cancel-tier',
@@ -176,6 +177,7 @@ define([
         $(rootElement,this.context).removeClass('is-hidden');
         $(this.getClass('NOTIFICATION_TIER_CURRENT'), rootElement).html(resp.tier);
         $(this.getClass('NOTIFICATION_TIER_TARGET'), rootElement).html('Friend');
+        $(this.getClass('NOTIFICATION_INTERVAL'), rootElement).html(subscriptionDates.interval);
         $(this.getClass('NOTIFICATION_PERIOD_START'), rootElement).html(subscriptionDates.currentPeriodStart);
         $(this.getClass('NOTIFICATION_PERIOD_END'), rootElement).html(subscriptionDates.currentPeriodEnd);
         $(this.getClass('NOTIFICATION_NEW_START'), rootElement).html(subscriptionNewStartDate);

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -37,7 +37,7 @@
                             <span class="change-summary__data js-mem-current-period-end"></span>
                         </li>
                         <li class="change-summery__item">
-                            <span class="change-summary__label">Monthly payment</span>
+                            <span class="change-summary__label"><span class="js-mem-current-interval"></span> payment</span>
                             <span class="membership-tab__currency">£</span><span class="change-summary__data js-membership-payment-cost"></span>
                         </li>
                         <li class="change-summery__item">


### PR DESCRIPTION
When a user downgraded their subscription, it was incorrectly always showing "Monthly" even if they were downgrading from an annual plan.
