### PR TITLE
Fix position of show comments icon

### DIFF
--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -173,6 +173,7 @@ $avatarSize: 44px;
 
     .i-show-all-comments {
         position: absolute;
+        top: 0;
         left: 0;
     }
     .i-arrow-blue-down {


### PR DESCRIPTION
I broke this:

![screen shot 2014-08-22 at 17 32 04](https://cloud.githubusercontent.com/assets/813383/4013832/7c485232-2a1a-11e4-931b-9a87f7a3d8c0.png)

So I fixed it:

![screen shot 2014-08-22 at 17 35 24](https://cloud.githubusercontent.com/assets/813383/4013839/87826e80-2a1a-11e4-9a7e-0b7bf11def10.png)

Sorry!
