### PR TITLE
fire resize when gallery lightbox closes

### DIFF
--- a/common/app/assets/javascripts/bootstraps/gallery.js
+++ b/common/app/assets/javascripts/bootstraps/gallery.js
@@ -1,7 +1,9 @@
 define([
-    'common/utils/mediator'
+    'common/utils/mediator',
+    'bean'
 ], function(
-    mediator
+    mediator,
+    bean
 ) {
 
     var ready = function (config, context) {
@@ -9,6 +11,9 @@ define([
             this.initialised = true;
         }
         mediator.emit('page:gallery:ready', config, context);
+        mediator.on('modules:overlay:hide', function() {
+            bean.fire(document, 'resize');
+        });
     };
 
     return {

--- a/common/app/assets/javascripts/bootstraps/gallery.js
+++ b/common/app/assets/javascripts/bootstraps/gallery.js
@@ -1,9 +1,7 @@
 define([
-    'common/utils/mediator',
-    'bean'
+    'common/utils/mediator'
 ], function(
-    mediator,
-    bean
+    mediator
 ) {
 
     var ready = function (config, context) {
@@ -11,9 +9,6 @@ define([
             this.initialised = true;
         }
         mediator.emit('page:gallery:ready', config, context);
-        mediator.on('modules:overlay:hide', function() {
-            bean.fire(document, 'resize');
-        });
     };
 
     return {

--- a/common/app/assets/javascripts/modules/ui/overlay.js
+++ b/common/app/assets/javascripts/modules/ui/overlay.js
@@ -72,6 +72,7 @@ define([
 
         this.node.style.display = 'none';
         mediator.emit('modules:overlay:hide', this);
+        mediator.emit('window:resize'); // trigger responsive image upgrade
     };
 
     Overlay.prototype.setBody = function(content) {


### PR DESCRIPTION
Resizing in lightbox mode breaks imager's responsive image loading (as the element containing the images is `display: none;`). Fire a resize when lightbox closes.
