### PR TITLE
Fix bug in Facia Tool where main media video was not appearing as option

### DIFF
--- a/facia-tool/public/javascripts/models/collections/article.js
+++ b/facia-tool/public/javascripts/models/collections/article.js
@@ -196,6 +196,13 @@ define([
             };
         };
 
+        function mainMediaType(contentApiArticle) {
+            var mainElement = _.findWhere(contentApiArticle.elements || [], {
+                relation: 'main'
+            });
+            return mainElement && mainElement.type;
+        }
+
         Article.prototype.populate = function(opts, validate) {
             var missingProps;
 
@@ -203,7 +210,12 @@ define([
             populateObservables(this.meta,   opts.meta);
             populateObservables(this.fields, opts.fields);
             populateObservables(this.state,  opts.state);
-            opts.mainMediaType && this.mainMediaType(opts.mainMediaType);
+
+            var mainMedia = mainMediaType(opts);
+
+            if (mainMedia) {
+                this.mainMediaType(mainMedia);
+            }
 
             this.setRelativeTimes();
 

--- a/facia-tool/public/javascripts/models/collections/latest-articles.js
+++ b/facia-tool/public/javascripts/models/collections/latest-articles.js
@@ -109,7 +109,7 @@ define([
                 // If term contains slashes, assume it's an article id (and first convert it to a path)
                 if (self.isTermAnItem()) {
                     self.term(urlAbsPath(self.term()));
-                    url = vars.CONST.apiSearchBase + '/' + self.term() + '?show-fields=all&format=json';
+                    url = vars.CONST.apiSearchBase + '/' + self.term() + '?show-fields=all&show-elements=video&format=json';
                     propName = 'content';
                 } else {
                     url  = vars.CONST.apiSearchBase + '/search?show-fields=all&format=json';

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -134,15 +134,7 @@ function (
         });
     }
 
-    function mainMediaType(contentApiArticle) {
-        var mainElement = _.findWhere(contentApiArticle.elements || [], {
-            relation: 'main'
-        });
-        return mainElement && mainElement.type;
-    }
-
     function populate(article, contentApiArticle) {
-        contentApiArticle.mainMediaType = mainMediaType(contentApiArticle);
         article.populate(contentApiArticle, true);
     }
 


### PR DESCRIPTION
There was a query being made to Content API that didn't ask for the main media elements, which was one reason. The other was that the main media was only being attached in the module where I thought all the Content API queries were being made - that's now been moved to the entry point for population of attributes in the Article model, which should fix that ... 
