### PR TITLE
removing top margin from commercial component

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -241,9 +241,6 @@
         display: block;
     }
 }
-.ad-slot--commercial-component {
-    margin-top: $gs-baseline;
-}
 
 /**
  * Badges


### PR DESCRIPTION
Removes the top margin from the bottom commercial component, looks much better when there is a dark container above.

Before;
![screen shot 2014-08-26 at 15 03 39](https://cloud.githubusercontent.com/assets/1303616/4045448/ee4f4cde-2d29-11e4-98ce-80210c4c9b08.png)

After;
![screen shot 2014-08-26 at 15 03 57](https://cloud.githubusercontent.com/assets/1303616/4045450/f4a3e9f0-2d29-11e4-97a9-1478ded65f01.png)
