### PR TITLE
Reduce Sentry sample size to 10%

### DIFF
--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -147,7 +147,7 @@
                         return data;
                     },
                     shouldSendCallback: function(data) {
-                        return Math.random() < 0.4 && guardian.config.switches.enableDiagnosticsLogging;
+                        return Math.random() < 0.1 && guardian.config.switches.enableDiagnosticsLogging;
                     }
                 }
             ).install();

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -147,7 +147,7 @@
                         return data;
                     },
                     shouldSendCallback: function(data) {
-                        return Math.random() < 0.1 && guardian.config.switches.enableDiagnosticsLogging;
+                        return Math.random() < 0.2 && guardian.config.switches.enableDiagnosticsLogging;
                     }
                 }
             ).install();


### PR DESCRIPTION
We noticed that the Sentry interface got very sluggish and the instance was running at 80-90% CPU. This is due to the increased amount of events we were sending after @ironsidevsquincy merged #5698.

I have since doubled the ASG instance size to 2, and now the instances are running at 40%, but until we can discuss with someone the health of the RDS database instance I want to reduce the load.

This PR simply decreases the sample size back down to 10% in the interim.

/cc @ironsidevsquincy @rich-nguyen 
