### PR TITLE
No FastClick for FF

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -102,6 +102,7 @@ define([
     var modules = {
 
         initFastClick: function() {
+            // broken in ff, so ignoring for now - https://github.com/ftlabs/fastclick/issues/292
             if (window.navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
                 new FastClick(document.body);
             }

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -102,10 +102,7 @@ define([
     var modules = {
 
         initFastClick: function() {
-            // broken in ff, so ignoring for now - https://github.com/ftlabs/fastclick/issues/292
-            if (window.navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
-                new FastClick(document.body);
-            }
+            new FastClick(document.body);
         },
 
         initialiseFauxBlockLink: function(context){

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -102,7 +102,9 @@ define([
     var modules = {
 
         initFastClick: function() {
-            new FastClick(document.body);
+            if (window.navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
+                new FastClick(document.body);
+            }
         },
 
         initialiseFauxBlockLink: function(context){

--- a/common/app/assets/javascripts/bower.json
+++ b/common/app/assets/javascripts/bower.json
@@ -10,7 +10,7 @@
     "bonzo": "~2.0.0",
     "curl": "~0.8.9",
     "qwery": "3.4.2",
-    "reqwest": "git://github.com/guardian/reqwest.git",
+    "reqwest": "guardian/reqwest#master",
     "enhancer": "0.1.1",
     "videojs": "guardian/video.js#21f2d3c150b3573337030758f7dfb634f6798052",
     "videojs-contrib-ads": "guardian/videojs-contrib-ads#099c752aa8c7d849290be49276ac568852b6ba28",
@@ -19,7 +19,7 @@
     "socket.io-client": "1.0.6",
     "raven-js": "~1.1.16",
     "videojs-playlist-audio": "*",
-    "fastclick": "~1.0.3"
+    "fastclick": "guardian/fastclick#master"
   },
   "resolutions": {
     "videojs": "21f2d3c150b3573337030758f7dfb634f6798052",

--- a/common/app/assets/javascripts/components/fastclick/fastclick.js
+++ b/common/app/assets/javascripts/components/fastclick/fastclick.js
@@ -94,6 +94,13 @@ function FastClick(layer, options) {
 	 */
 	this.tapDelay = options.tapDelay || 200;
 
+	/**
+	 * The maximum time for a tap
+	 *
+	 * @type number
+	 */
+	this.tapTimeout = options.tapTimeout || 700;
+
 	if (FastClick.notNeeded(layer)) {
 		return;
 	}
@@ -525,6 +532,10 @@ FastClick.prototype.onTouchEnd = function(event) {
 	// Prevent phantom clicks on fast double-tap (issue #36)
 	if ((event.timeStamp - this.lastClickTime) < this.tapDelay) {
 		this.cancelNextClick = true;
+		return true;
+	}
+
+	if ((event.timeStamp - this.trackingClickStart) > this.tapTimeout) {
 		return true;
 	}
 


### PR DESCRIPTION
It breaks 'Open in New Tab' functionality, which is a greater UI fail than 300ms delay (and FF is heading towards not having the delay anyways - https://bugzilla.mozilla.org/show_bug.cgi?id=941995)
