### PR TITLE
Add FF OS tracking onto platform var

### DIFF
--- a/common/app/assets/javascripts/modules/analytics/omniture.js
+++ b/common/app/assets/javascripts/modules/analytics/omniture.js
@@ -166,7 +166,7 @@ define([
 
             s.prop14    = config.page.buildNumber || '';
 
-            var platform = 'frontend';
+            var platform = !(navigator.mozApps && !window.locationbar.visible) ? 'frontend' : 'firefoxosapp';
             s.prop19     = platform;
             s.eVar19     = platform;
 


### PR DESCRIPTION
We are going to be running a test to see how much traffic will come from Firefox OS.
The tricky bit is knowing if someone is coming from the browser in FF OS or the app ([they have the same user agent string](https://developer.mozilla.org/en-US/docs/Web/HTTP/Gecko_user_agent_string_reference)).

After talking to @rich-nguyen, the apps team, and the Omniture team, this seemed like the most sensible approach.

![Making tracks](http://28.media.tumblr.com/tumblr_lzz4ew0O3R1r9xjxoo1_500.gif)
