### PR TITLE
videojs updates

### DIFF
--- a/common/app/assets/javascripts/bower.json
+++ b/common/app/assets/javascripts/bower.json
@@ -13,8 +13,8 @@
     "reqwest": "git://github.com/guardian/reqwest.git",
     "enhancer": "0.1.1",
     "videojs": "guardian/video.js#21f2d3c150b3573337030758f7dfb634f6798052",
-    "videojs-contrib-ads": "guardian/videojs-contrib-ads#099c752aa8c7d849290be49276ac568852b6ba28",
-    "videojs-vast": "guardian/videojs-vast-plugin#6b7b526ceb1ee5223db48a965b16be36b153e038",
+    "videojs-contrib-ads": "guardian/videojs-contrib-ads#e477f283d4cdf5f720f95e458451a027143d52bf",
+    "videojs-vast": "theonion/videojs-vast-plugin#4b2185024e112242aa46e11bd1ddcf561fc27bbe",
     "videojs-persistvolume": "~0.1.0",
     "socket.io-client": "1.0.6",
     "raven-js": "~1.1.16",
@@ -23,7 +23,7 @@
   },
   "resolutions": {
     "videojs": "21f2d3c150b3573337030758f7dfb634f6798052",
-    "videojs-contrib-ads": "099c752aa8c7d849290be49276ac568852b6ba28"
+    "videojs-contrib-ads": "e477f283d4cdf5f720f95e458451a027143d52bf"
   },
   "install": {
     "path": "components",

--- a/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
+++ b/common/app/assets/javascripts/components/videojs-vast/videojs.vast.js
@@ -192,16 +192,7 @@
         }
       };
 
-      player.one('error', player.vast.onError);
       player.one("ended", player.vast.tearDown);
-    };
-
-    player.vast.removeSafariAdBlockStyles = function() {
-        player.el().querySelector('.vjs-tech').setAttribute('style', '');
-    };
-
-    player.vast.onError = function() {
-        player.vast.removeSafariAdBlockStyles();
     };
 
     player.vast.tearDown = function() {
@@ -209,7 +200,6 @@
       player.vast.blocker.parentNode.removeChild(player.vast.blocker);
       player.off('timeupdate', player.vast.timeupdate);
       player.off('ended', player.vast.tearDown);
-      player.off('error', player.vast.onError);
       player.ads.endLinearAdMode();
       if (player.vast.showControls ) {
         player.controls(true);


### PR DESCRIPTION
Switching videojs-vast back to main repo (theonion/videojs-vast-plugin) and moving the adblock style fix to the videojs-contrib-ads plugin as it seems like a more suitable place for it.

Opened up two PRs for the fixes in our fork of videojs-contrib-ads:
https://github.com/videojs/videojs-contrib-ads/pull/37
https://github.com/videojs/videojs-contrib-ads/pull/38
