### PR TITLE
Add vcs revision to Sentry events

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -212,7 +212,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   object witness {
     lazy val witnessApiRoot = configuration.getMandatoryStringProperty("witness.apiRoot")
   }
-  
+
   object commercial {
     lazy val dfpAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfpAdUnitRoot")
     lazy val dfpAccountId = configuration.getMandatoryStringProperty("guardian.page.dfpAccountId")
@@ -390,5 +390,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
 object ManifestData {
   lazy val build = ManifestFile.asKeyValuePairs.getOrElse("Build", "DEV").dequote.trim
+  lazy val revision = ManifestFile.asKeyValuePairs.getOrElse("Revision", "DEV").dequote.trim
 }
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -46,7 +46,7 @@ trait MetaData extends Tags {
     ("section", JsString(section)),
     ("webTitle", JsString(webTitle)),
     ("buildNumber", JsString(buildNumber)),
-    ("revisionNumber", JsString(revision)),
+    ("revisionNumber", JsString(revision.take(7))),
     ("analyticsName", JsString(analyticsName)),
     ("blockVideoAds", JsBoolean(false)),
     ("isFront", JsBoolean(isFront)),

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -27,6 +27,7 @@ trait MetaData extends Tags {
   // Basically it helps us understand the impact of changes and needs
   // to be an integral part of each page
   def buildNumber: String = ManifestData.build
+  def revision: String = ManifestData.revision
 
   //must be one of... http://schema.org/docs/schemas.html
   def schemaType: Option[String] = None
@@ -45,6 +46,7 @@ trait MetaData extends Tags {
     ("section", JsString(section)),
     ("webTitle", JsString(webTitle)),
     ("buildNumber", JsString(buildNumber)),
+    ("revisionNumber", JsString(revision)),
     ("analyticsName", JsString(analyticsName)),
     ("blockVideoAds", JsBoolean(false)),
     ("isFront", JsBoolean(isFront)),

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -140,9 +140,11 @@
                     tags: {
                         edition: config.page.edition,
                         contentType: config.page.contentType,
-                        buildNumber: config.page.buildNumber
+                        revisionNumber: config.page.revisionNumber
                     },
                     dataCallback: function(data) {
+                        var appUrl = /\/[a-z\/]*\/([a-z0-9]*\/)[\da-z\.-]+$/.exec(data.culprit);
+                        data.culprit = (appUrl.length) ? data.culprit.replace(appUrl[1], '') : data.culprit;
                         data.tags.origin = (/j.ophan.co.uk/.test(data.culprit)) ? 'ophan' : 'app';
                         return data;
                     },

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -143,8 +143,7 @@
                         revisionNumber: config.page.revisionNumber
                     },
                     dataCallback: function(data) {
-                        var appUrl = /\/[a-z\/]*\/([a-z0-9]*\/)[\da-z\.-]+$/.exec(data.culprit);
-                        data.culprit = (appUrl.length) ? data.culprit.replace(appUrl[1], '') : data.culprit;
+                        data.culprit = data.culprit.replace(/\/[a-z\d]{32}(\/[^\/]+)$/, '$1');
                         data.tags.origin = (/j.ophan.co.uk/.test(data.culprit)) ? 'ophan' : 'app';
                         return data;
                     },


### PR DESCRIPTION
We have found that the build number is not a useful metric to cut the Sentry data by, as the JavaScript files are related to Common and not specific applications. Therefore, we have chosen to use the vcs revision number from the CI build instead which will group changes back to the Git SHA instead.

This PR also scrubs the md5 hash from the culprit JS file before sending it back to Sentry to avoid the same error being reported as a new unique by different builds.

/cc @rich-nguyen @ironsidevsquincy @mattosborn 
