### PR TITLE
Url decoding now understands not to mess with combiner pages.

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -14,7 +14,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   })
 
   def isEncoded(path: String): Option[String] = {
-    val decodedPath = URLDecoder.decode(path, "UTF-8")
+    val decodedPath = URLDecoder.decode(path, "UTF-8").replace(" ", "+") // the + is for combiner pages
     if (decodedPath != path) Some(decodedPath) else None
   } 
 

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -34,6 +34,11 @@ class ArchiveControllerTest extends FlatSpec with Matchers {
     controllers.ArchiveController.isEncoded("foo") should be (None)
   }
 
+  it should "decode spaces as +" in Fake {
+    controllers.ArchiveController.isEncoded("foo%20foo") should be (Some("foo+foo"))
+    controllers.ArchiveController.isEncoded("foo+foo") should be (None)
+  }
+
   it should "test a string contains an old gallery" in Fake {
     controllers.ArchiveController.isGallery("arts/gallery/0,") should be (Some("arts/pictures/0,"))
   }


### PR DESCRIPTION
Surprisingly this caused a massive redirect loop in a battle with a bot and caused this mass of hits...

![oops](https://cloud.githubusercontent.com/assets/76709/4078952/b7588c10-2ed0-11e4-8ef6-d372a71ef1bf.png)
