### PR TITLE
Make smart app banner a permanent feature

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -362,7 +362,7 @@ define([
             new MoreTags().init();
         },
 
-        showSmartBanner: function(config) {
+        showSmartBanner: function() {
             smartAppBanner.init();
         },
 

--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -363,9 +363,7 @@ define([
         },
 
         showSmartBanner: function(config) {
-            if(config.switches.smartBanner) {
-                smartAppBanner.init();
-            }
+            smartAppBanner.init();
         },
 
         initDiscussion: function() {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -138,7 +138,7 @@ object Switches extends Collections {
 
   val SmartBannerSwitch = Switch("Commercial", "smart-banner",
     "Display smart app banner onboarding message to iOS and Android users",
-    safeState = Off, sellByDate = new LocalDate(2014, 8, 31)
+    safeState = Off, sellByDate = never
   )
 
   val AudienceScienceSwitch = Switch("Commercial", "audience-science",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -136,11 +136,6 @@ object Switches extends Collections {
     safeState = On, sellByDate = never
   )
 
-  val SmartBannerSwitch = Switch("Commercial", "smart-banner",
-    "Display smart app banner onboarding message to iOS and Android users",
-    safeState = Off, sellByDate = never
-  )
-
   val AudienceScienceSwitch = Switch("Commercial", "audience-science",
     "If this switch is on, Audience Science segments will be used to target ads.",
     safeState = Off, sellByDate = new LocalDate(2014, 11, 1))
@@ -456,7 +451,6 @@ object Switches extends Collections {
     MemcachedFallbackSwitch,
     IncludeBuildNumberInMemcachedKey,
     GeoMostPopular,
-    SmartBannerSwitch,
     SeoEscapeFootballJsonPathLikeValuesSwitch,
     FaciaToolCachedContentApiSwitch,
     FaciaToolCachedZippingContentApiSwitch,


### PR DESCRIPTION
I don't like making features permanent, but after a long discussion with Tom Grinstead, this is here to stay. It is the apps most successful marketing in terms of conversion rate.

He would also like to discuss other targeting option in the future.
