### PR TITLE
Remove seo football json path escape switch

### DIFF
--- a/common/app/common/RelativePathEscaper.scala
+++ b/common/app/common/RelativePathEscaper.scala
@@ -1,7 +1,5 @@
 package common
 
-import conf.Switches.SeoEscapeFootballJsonPathLikeValuesSwitch
-
 object RelativePathEscaper {
   def apply(unescaped: String) = {
     // We are getting Googlebot 404s because Google is incorrectly assessing paths in curl js & json config data
@@ -25,14 +23,10 @@ object RelativePathEscaper {
 
   def escapeLeadingSlashFootballPaths(unescaped: String) = {
     val leadingSlashFootballPathRegex = """["']?(\/football)(\/team|\/tournament)(\/\w+)['"]?""".r
-    if (SeoEscapeFootballJsonPathLikeValuesSwitch.isSwitchedOn) {
-      val footballMatches = leadingSlashFootballPathRegex.findAllIn(unescaped)
-      footballMatches.foldLeft(unescaped) {
-        case (result: String, matched: String) =>
-          result.replace(matched, matched.replace("/", "/\" + \""))
-      }
-    } else {
-      unescaped
+    val footballMatches = leadingSlashFootballPathRegex.findAllIn(unescaped)
+    footballMatches.foldLeft(unescaped) {
+      case (result: String, matched: String) =>
+        result.replace(matched, matched.replace("/", "/\" + \""))
     }
   }
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -304,11 +304,6 @@ object Switches extends Collections {
     safeState = On, sellByDate = new LocalDate(2014, 9, 8)
   )
 
-  val SeoEscapeFootballJsonPathLikeValuesSwitch = Switch("Feature", "seo-googlebot-escape-football-json-path-like-values",
-    "If switched ON, json football references that look like a path to googlebot are 'escaped'.",
-    safeState = Off, sellByDate = new LocalDate(2014, 9, 2)
-  )
-
   // A/B Tests
 
   val ABHighCommercialComponent = Switch("A/B Tests", "ab-high-commercial-component",
@@ -451,7 +446,6 @@ object Switches extends Collections {
     MemcachedFallbackSwitch,
     IncludeBuildNumberInMemcachedKey,
     GeoMostPopular,
-    SeoEscapeFootballJsonPathLikeValuesSwitch,
     FaciaToolCachedContentApiSwitch,
     FaciaToolCachedZippingContentApiSwitch,
     FaciaToolDraftPressSwitch,

--- a/common/test/common/RelativePathEscaperTest.scala
+++ b/common/test/common/RelativePathEscaperTest.scala
@@ -3,7 +3,6 @@ package common
 import conf.Static
 import org.scalatest.{Matchers, FlatSpec}
 import test.Fake
-import conf.Switches.SeoEscapeFootballJsonPathLikeValuesSwitch
 
 class RelativePathEscaperTest extends FlatSpec with Matchers {
   "RelativePathEscaper" should "escape javascript paths in Static.js.curl" in Fake{
@@ -11,22 +10,12 @@ class RelativePathEscaperTest extends FlatSpec with Matchers {
     val escapedCurlJs = RelativePathEscaper.escapeLeadingDotPaths(curlJs)
     escapedCurlJs should include ("[\"..\" + \"/\" + \"domReady\"]")
   }
-  it should "escape path-like json in football config references data when enabled" in Fake {
+  it should "escape path-like json in football config references data" in Fake {
     val jsonFootballRefs = "\"references\":[{\"paFootballTeam\":\"13\"},{\"esaFootballTeam\":\"/football/team/32\"},{\"paFootballCompetition\":\"101\"},{\"esaFootballTeam\":\"/football/team/9\"},{\"optaFootballTournament\":\"10/2012\"},{\"paFootballTeam\":\"28\"},{\"optaFootballTeam\":\"2\"},{\"esaFootballTournament\":\"/football/tournament/div1\"},{\"optaFootballTeam\":\"103\"}]"
-    SeoEscapeFootballJsonPathLikeValuesSwitch.switchOn()
     val escapedJson = RelativePathEscaper.escapeLeadingSlashFootballPaths(jsonFootballRefs)
     escapedJson should not include ("""":"/football/team/32"""")
     escapedJson should include (""":"/" + "football/" + "team/" + "32"""")
     escapedJson should not include ("""":"/football/tournament/div1"""")
     escapedJson should include (""":"/" + "football/" + "tournament/" + "div1"""")
-  }
-  it should "NOT escape path-like json in football config references data when DISABLED" in Fake {
-    val jsonFootballRefs = "\"references\":[{\"paFootballTeam\":\"13\"},{\"esaFootballTeam\":\"/football/team/32\"},{\"paFootballCompetition\":\"101\"},{\"esaFootballTeam\":\"/football/team/9\"},{\"optaFootballTournament\":\"10/2012\"},{\"paFootballTeam\":\"28\"},{\"optaFootballTeam\":\"2\"},{\"esaFootballTournament\":\"/football/tournament/div1\"},{\"optaFootballTeam\":\"103\"}]"
-    SeoEscapeFootballJsonPathLikeValuesSwitch.switchOff()
-    val escapedJson = RelativePathEscaper.escapeLeadingSlashFootballPaths(jsonFootballRefs)
-    escapedJson should include ("""":"/football/team/32"""")
-    escapedJson should not include (""":"/" + "football/" + "team/" + "32"""")
-    escapedJson should include ("""":"/football/tournament/div1"""")
-    escapedJson should not include (""":"/" + "football/" + "tournament/" + "div1"""")
   }
 }


### PR DESCRIPTION
We haven't had any complaints yet, and googlebot hasn't recorded any more of these 404 errors since the fix originally went in, so let's retire the switch?
