### PR TITLE
Refresh ads only if needed

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -350,7 +350,7 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
         And("the placeholder has the correct data attributes")
         adPlaceholder.getAttribute("data-name") should be("top-above-nav")
         adPlaceholder.getAttribute("data-tablet") should be("728,90")
-        adPlaceholder.getAttribute("data-rightCol") should be("728,90|940,230|900,250")
+        adPlaceholder.getAttribute("data-right-col") should be("728,90|940,230|900,250")
         adPlaceholder.getAttribute("data-wide") should be("728,90|940,230|900,250|970,250")
 
         And("the placeholder has the correct class name")

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -349,8 +349,8 @@ class ArticleFeatureTest extends FeatureSpec with GivenWhenThen with Matchers {
 
         And("the placeholder has the correct data attributes")
         adPlaceholder.getAttribute("data-name") should be("top-above-nav")
-        adPlaceholder.getAttribute("data-tabletportrait") should be("728,90")
-        adPlaceholder.getAttribute("data-tabletlandscape") should be("728,90|940,230|900,250")
+        adPlaceholder.getAttribute("data-tablet") should be("728,90")
+        adPlaceholder.getAttribute("data-rightCol") should be("728,90|940,230|900,250")
         adPlaceholder.getAttribute("data-wide") should be("728,90|940,230|900,250|970,250")
 
         And("the placeholder has the correct class name")

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -198,15 +198,35 @@ define([
 
             }
         },
-        shouldSlotRefresh = function () {
-            return true;
+        breakpointNameToAttribute = function (breakpointName) {
+            return breakpointName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+        },
+        getSlotsBreakpoint = function (breakpoint, slotBreakpoints) {
+            return _(detect.breakpoints)
+                .initial(function (breakpointInfo) {
+                    return breakpointInfo.name !== breakpoint;
+                })
+                .intersection(slotBreakpoints)
+                .last()
+                .valueOf();
+        },
+        shouldSlotRefresh = function (slotInfo, breakpoint, previousBreakpoint) {
+            // get the slots breakpoints
+            var slotBreakpoints = _(detect.breakpoints)
+                .filter(function (breakpointInfo) {
+                    return slotInfo.$adSlot.data(breakpointNameToAttribute(breakpointInfo.name));
+                })
+                .valueOf();
+            // have we changed breakpoints
+            return getSlotsBreakpoint(previousBreakpoint, slotBreakpoints) !==
+                getSlotsBreakpoint(breakpoint, slotBreakpoints);
         },
         refresh = function (breakpoint, previousBreakpoint) {
             googletag.pubads().refresh(
                 _(slotsToRefresh)
                     // only refresh if the slot needs to
-                    .filter(function (slot) {
-                        return shouldSlotRefresh(slot, breakpoint, previousBreakpoint);
+                    .filter(function (slotInfo) {
+                        return shouldSlotRefresh(slotInfo, breakpoint, previousBreakpoint);
                     })
                     .map(function (slotInfo) {
                         return slotInfo.slot;
@@ -240,7 +260,7 @@ define([
 
             forEach(detect.breakpoints, function (breakpointInfo) {
                 // turn breakpoint name into attribute style (lowercase, hyphenated)
-                var attr  = slot.data(breakpointInfo.name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase());
+                var attr  = slot.data(breakpointNameToAttribute(breakpointInfo.name));
                 if (attr) {
                     mapping.addSize([breakpointInfo.width, 0], createSizeMapping(attr));
                 }

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -209,10 +209,7 @@ define([
 
             }
         },
-        refresh = function(breakpoint, previousBreakpoint) {
-            console.info('#############################################');
-            console.info('WAS: ' + previousBreakpoint);
-            console.info('IS: ' + breakpoint);
+        refresh = function () {
             googletag.pubads().refresh(slotsToRefresh.map(function (slotInfo) { return slotInfo.slot; }));
         },
         /** A breakpoint can have various sizes assigned to it. You can assign either on

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -88,10 +88,12 @@ define([
         // These should match the widths inside _vars.scss
         breakpoints = {
             mobile: 0,
-            mobileLandscape: 480,
+            'mobile-landscape': 480,
             tablet: 740,
-            rightCol: 900,
+            'right-col': 900,
             desktop: 980,
+            'left-col': 1060,
+            'facia-left-col': 1140,
             wide: 1300
         },
         breakoutHash = {
@@ -101,7 +103,7 @@ define([
         adSlotDefinitions = {
             right: {
                 sizeMappings: {
-                    rightCol: '300,250|300,600'
+                    'right-col': '300,250|300,600'
                 }
             },
             im: {
@@ -114,14 +116,14 @@ define([
             inline1: {
                 sizeMappings: {
                     mobile: '300,50',
-                    mobileLandscape: '300,50|320,50',
+                    'mobile-landscape': '300,50|320,50',
                     tablet: '300,250'
                 }
             },
             inline2: {
                 sizeMappings: {
                     mobile: '300,50',
-                    mobileLandscape: '300,50|320,50',
+                    'mobile-landscape': '300,50|320,50',
                     tablet: '300,250'
                 }
             },
@@ -208,6 +210,9 @@ define([
             }
         },
         refresh = function(breakpoint, previousBreakpoint) {
+            console.info('#############################################');
+            console.info('WAS: ' + previousBreakpoint);
+            console.info('IS: ' + breakpoint);
             googletag.pubads().refresh(slotsToRefresh.map(function (slotInfo) { return slotInfo.slot; }));
         },
         /** A breakpoint can have various sizes assigned to it. You can assign either on
@@ -235,11 +240,9 @@ define([
             var mapping = googletag.sizeMapping();
 
             for (var breakpoint in breakpoints) {
-                var attr  = slot.data(breakpoint),
-                    width = breakpoints[breakpoint];
-
+                var attr  = slot.data(breakpoint);
                 if (attr) {
-                    mapping.addSize([width, 0], createSizeMapping(attr));
+                    mapping.addSize([breakpoints[breakpoint], 0], createSizeMapping(attr));
                 }
             }
 
@@ -404,7 +407,7 @@ define([
             googletag.display(adSlots.shift().attr('id'));
         },
         postDisplay = function() {
-            var hasBreakpointChanged = detect.hasCrossedBreakpoint();
+            var hasBreakpointChanged = detect.hasCrossedBreakpoint(true);
             mediator.on('window:resize',
                 debounce(function () {
                     // refresh on resize

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -218,8 +218,8 @@ define([
                 })
                 .valueOf();
             // have we changed breakpoints
-            return getSlotsBreakpoint(previousBreakpoint, slotBreakpoints) !==
-                getSlotsBreakpoint(breakpoint, slotBreakpoints);
+            var slotBreakpoint = getSlotsBreakpoint(breakpoint, slotBreakpoints);
+            return slotBreakpoint && getSlotsBreakpoint(previousBreakpoint, slotBreakpoints) !== slotBreakpoint;
         },
         refresh = function (breakpoint, previousBreakpoint) {
             googletag.pubads().refresh(

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -198,7 +198,7 @@ define([
 
             }
         },
-        shouldSlotRefresh = function (slot, breakpoint, previousBreakpoint) {
+        shouldSlotRefresh = function () {
             return true;
         },
         refresh = function (breakpoint, previousBreakpoint) {
@@ -206,7 +206,7 @@ define([
                 _(slotsToRefresh)
                     // only refresh if the slot needs to
                     .filter(function (slot) {
-                        return shouldSlotRefresh(slot, breakpoint, previousBreakpoint)
+                        return shouldSlotRefresh(slot, breakpoint, previousBreakpoint);
                     })
                     .map(function (slotInfo) {
                         return slotInfo.slot;

--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -88,9 +88,9 @@ define([
         // These should match the widths inside _vars.scss
         breakpoints = {
             mobile: 0,
-            mobilelandscape: 480,
-            tabletportrait: 740,
-            tabletlandscape: 900,
+            mobileLandscape: 480,
+            tablet: 740,
+            rightCol: 900,
             desktop: 980,
             wide: 1300
         },
@@ -101,7 +101,7 @@ define([
         adSlotDefinitions = {
             right: {
                 sizeMappings: {
-                    tabletlandscape: '300,250|300,600'
+                    rightCol: '300,250|300,600'
                 }
             },
             im: {
@@ -114,15 +114,15 @@ define([
             inline1: {
                 sizeMappings: {
                     mobile: '300,50',
-                    mobilelandscape: '300,50|320,50',
-                    tabletportrait: '300,250'
+                    mobileLandscape: '300,50|320,50',
+                    tablet: '300,250'
                 }
             },
             inline2: {
                 sizeMappings: {
                     mobile: '300,50',
-                    mobilelandscape: '300,50|320,50',
-                    tabletportrait: '300,250'
+                    mobileLandscape: '300,50|320,50',
+                    tablet: '300,250'
                 }
             },
             'merchandising-high': {
@@ -207,8 +207,8 @@ define([
 
             }
         },
-        refresh = function() {
-            googletag.pubads().refresh(slotsToRefresh);
+        refresh = function(breakpoint, previousBreakpoint) {
+            googletag.pubads().refresh(slotsToRefresh.map(function (slotInfo) { return slotInfo.slot; }));
         },
         /** A breakpoint can have various sizes assigned to it. You can assign either on
          * set of sizes or multiple.
@@ -389,7 +389,10 @@ define([
                 // Add to the array of ads to be refreshed (when the breakpoint changes)
                 // only if it's `data-refresh` attribute isn't set to false.
                 if ($adSlot.data('refresh') !== false) {
-                    slotsToRefresh.push(slot);
+                    slotsToRefresh.push({
+                        $adSlot: $adSlot,
+                        slot: slot
+                    });
                 }
             });
         },

--- a/common/app/assets/javascripts/utils/detect.js
+++ b/common/app/assets/javascripts/utils/detect.js
@@ -27,11 +27,13 @@ define([
         breakpoints = [
             {
                 name: 'mobile',
-                isTweakpoint: false
+                isTweakpoint: false,
+                width: 0
             },
             {
                 name: 'mobileLandscape',
-                isTweakpoint: true
+                isTweakpoint: true,
+                width: 480
             },
             {
                 name: 'phablet',
@@ -39,27 +41,33 @@ define([
             },
             {
                 name: 'tablet',
-                isTweakpoint: false
+                isTweakpoint: false,
+                width: 740
             },
             {
                 name: 'rightCol',
-                isTweakpoint: true
+                isTweakpoint: true,
+                width: 900
             },
             {
                 name: 'desktop',
-                isTweakpoint: false
+                isTweakpoint: false,
+                width: 980
             },
             {
                 name: 'leftCol',
-                isTweakpoint: true
+                isTweakpoint: true,
+                width: 1060
             },
             {
                 name: 'faciaLeftCol',
-                isTweakpoint: true
+                isTweakpoint: true,
+                width: 1140
             },
             {
                 name: 'wide',
-                isTweakpoint: false
+                isTweakpoint: false,
+                width: 1300
             }
         ];
 
@@ -297,7 +305,8 @@ define([
         initPageVisibility: initPageVisibility,
         pageVisible: pageVisible,
         hasWebSocket: hasWebSocket,
-        getPageSpeed: getPageSpeed
+        getPageSpeed: getPageSpeed,
+        breakpoints: breakpoints
     };
 
 });

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -4,5 +4,5 @@
         case _: Article => {article}
         case _          => {facia}
     }-layout">
-    @fragments.commercial.standardAd("top-above-nav", Seq("top-banner-ad"), Map("tabletportrait" -> Seq("728,90"), "tabletlandscape" -> Seq("728,90", "940,230", "900,250"), "wide" -> Seq("728,90", "940,230", "900,250", "970,250")))
+    @fragments.commercial.standardAd("top-above-nav", Seq("top-banner-ad"), Map("tablet" -> Seq("728,90"), "rightCol" -> Seq("728,90", "940,230", "900,250"), "wide" -> Seq("728,90", "940,230", "900,250", "970,250")))
 </div>

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -4,5 +4,5 @@
         case _: Article => {article}
         case _          => {facia}
     }-layout">
-    @fragments.commercial.standardAd("top-above-nav", Seq("top-banner-ad"), Map("tablet" -> Seq("728,90"), "rightCol" -> Seq("728,90", "940,230", "900,250"), "wide" -> Seq("728,90", "940,230", "900,250", "970,250")))
+    @fragments.commercial.standardAd("top-above-nav", Seq("top-banner-ad"), Map("tablet" -> Seq("728,90"), "right-col" -> Seq("728,90", "940,230", "900,250"), "wide" -> Seq("728,90", "940,230", "900,250", "970,250")))
 </div>

--- a/common/test/assets/javascripts/spec/commercial/article-aside-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/article-aside-adverts.spec.js
@@ -74,7 +74,7 @@ define([
 
         it('should have the correct size mappings', function() {
             articleAsideAdverts.init(config);
-            expect($('.ad-slot', fixture).data('tabletlandscape')).toBe('300,250|300,600');
+            expect($('.ad-slot', fixture).data('rightCol')).toBe('300,250|300,600');
         });
 
         it('should not add ad slot to hidden column', function() {

--- a/common/test/assets/javascripts/spec/commercial/article-aside-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/article-aside-adverts.spec.js
@@ -74,7 +74,7 @@ define([
 
         it('should have the correct size mappings', function() {
             articleAsideAdverts.init(config);
-            expect($('.ad-slot', fixture).data('rightCol')).toBe('300,250|300,600');
+            expect($('.ad-slot', fixture).data('right-col')).toBe('300,250|300,600');
         });
 
         it('should not add ad slot to hidden column', function() {

--- a/common/test/assets/javascripts/spec/commercial/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/dfp.spec.js
@@ -242,7 +242,7 @@ define([
                     name: 'right',
                     type: 'mpu-banner-ad',
                     html: '<div id="dfp-ad--right" class="ad-slot ad-slot--dfp ad-slot--right ad-slot--mpu-banner-ad" ' +
-                        'data-link-name="ad slot right" data-test-id="ad-slot-right" data-name="right" data-rightCol="300,250|300,600"></div>'
+                        'data-link-name="ad slot right" data-test-id="ad-slot-right" data-name="right" data-right-col="300,250|300,600"></div>'
                 },
                 {
                     name: 'im',
@@ -256,14 +256,14 @@ define([
                     type: 'inline',
                     html: '<div id="dfp-ad--inline1" class="ad-slot ad-slot--dfp ad-slot--inline1 ad-slot--inline" ' +
                         'data-link-name="ad slot inline1" data-test-id="ad-slot-inline1" data-name="inline1" data-mobile="300,50" ' +
-                        'data-mobileLandscape="300,50|320,50" data-tablet="300,250"></div>'
+                        'data-mobile-landscape="300,50|320,50" data-tablet="300,250"></div>'
                 },
                 {
                     name: 'inline2',
                     type: 'inline',
                     html: '<div id="dfp-ad--inline2" class="ad-slot ad-slot--dfp ad-slot--inline2 ad-slot--inline" ' +
                         'data-link-name="ad slot inline2" data-test-id="ad-slot-inline2" data-name="inline2" data-mobile="300,50" ' +
-                        'data-mobileLandscape="300,50|320,50" data-tablet="300,250"></div>'
+                        'data-mobile-landscape="300,50|320,50" data-tablet="300,250"></div>'
                 },
                 {
                     name: 'merchandising-high',

--- a/common/test/assets/javascripts/spec/commercial/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/dfp.spec.js
@@ -222,7 +222,7 @@ define([
                 return googletag.pubads().refresh.called;
             });
             runs(function() {
-                expect(googletag.pubads().refresh.firstCall.args[0].length).toBe(3);
+                expect(googletag.pubads().refresh.firstCall.args[0].length).toBe(2);
             })
         });
 

--- a/common/test/assets/javascripts/spec/commercial/dfp.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/dfp.spec.js
@@ -25,8 +25,8 @@ define([
                 fixtures: [
                     '<div id="dfp-ad-html-slot" class="ad-slot--dfp" data-name="html-slot" data-mobile="300,50"></div>\
                     <div id="dfp-ad-script-slot" class="ad-slot--dfp" data-name="script-slot" data-mobile="300,50|320,50" data-refresh="false"></div>\
-                    <div id="dfp-ad-already-labelled" class="ad-slot--dfp ad-label--showing" data-name="already-labelled" data-mobile="300,50|320,50"  data-tabletportrait="728,90"></div>\
-                    <div id="dfp-ad-dont-label" class="ad-slot--dfp" data-label="false" data-name="dont-label" data-mobile="300,50|320,50"  data-tabletportrait="728,90" data-desktop="728,90|900,250|970,250"></div>'
+                    <div id="dfp-ad-already-labelled" class="ad-slot--dfp ad-label--showing" data-name="already-labelled" data-mobile="300,50|320,50"  data-tablet="728,90"></div>\
+                    <div id="dfp-ad-dont-label" class="ad-slot--dfp" data-label="false" data-name="dont-label" data-mobile="300,50|320,50"  data-tablet="728,90" data-desktop="728,90|900,250|970,250"></div>'
                 ]
             },
             makeFakeEvent = function(id, isEmpty) {
@@ -242,7 +242,7 @@ define([
                     name: 'right',
                     type: 'mpu-banner-ad',
                     html: '<div id="dfp-ad--right" class="ad-slot ad-slot--dfp ad-slot--right ad-slot--mpu-banner-ad" ' +
-                        'data-link-name="ad slot right" data-test-id="ad-slot-right" data-name="right" data-tabletlandscape="300,250|300,600"></div>'
+                        'data-link-name="ad slot right" data-test-id="ad-slot-right" data-name="right" data-rightCol="300,250|300,600"></div>'
                 },
                 {
                     name: 'im',
@@ -256,14 +256,14 @@ define([
                     type: 'inline',
                     html: '<div id="dfp-ad--inline1" class="ad-slot ad-slot--dfp ad-slot--inline1 ad-slot--inline" ' +
                         'data-link-name="ad slot inline1" data-test-id="ad-slot-inline1" data-name="inline1" data-mobile="300,50" ' +
-                        'data-mobilelandscape="300,50|320,50" data-tabletportrait="300,250"></div>'
+                        'data-mobileLandscape="300,50|320,50" data-tablet="300,250"></div>'
                 },
                 {
                     name: 'inline2',
                     type: 'inline',
                     html: '<div id="dfp-ad--inline2" class="ad-slot ad-slot--dfp ad-slot--inline2 ad-slot--inline" ' +
                         'data-link-name="ad slot inline2" data-test-id="ad-slot-inline2" data-name="inline2" data-mobile="300,50" ' +
-                        'data-mobilelandscape="300,50|320,50" data-tabletportrait="300,250"></div>'
+                        'data-mobileLandscape="300,50|320,50" data-tablet="300,250"></div>'
                 },
                 {
                     name: 'merchandising-high',

--- a/common/test/assets/javascripts/spec/commercial/slice-adverts.spec.js
+++ b/common/test/assets/javascripts/spec/commercial/slice-adverts.spec.js
@@ -72,7 +72,7 @@ define([
                 .map(function(slot) { return $(slot); })
                 .forEach(function($adSlot) {
                     expect($adSlot.data('mobile')).toEqual('300,50');
-                    expect($adSlot.data('tabletportrait')).toEqual('300,250');
+                    expect($adSlot.data('tablet')).toEqual('300,250');
                 });
         });
 

--- a/common/test/assets/javascripts/spec/utils/detect.spec.js
+++ b/common/test/assets/javascripts/spec/utils/detect.spec.js
@@ -66,6 +66,9 @@ define([
                 $style.html('body:after { content: "mobile"; }');
                 hasBreakpointChanged(callback);
                 expect(callback).toHaveBeenCalledWith('mobile', 'desktop');
+                $style.html('body:after { content: "tablet"; }');
+                hasBreakpointChanged(callback);
+                expect(callback).toHaveBeenCalledWith('tablet', 'mobile');
             });
 
             it('should not fire if no breakpoint crossed', function(){


### PR DESCRIPTION
Previously we were refreshing ads at every change in breakpoint, regardless of whether the ad needed to be refresh

Now we only refresh ads if they need to be refreshed, i.e. if it's a change in breakpoint that the ad slot cares about
