### PR TITLE
Delete Facia Tool Configuration disable switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -328,11 +328,6 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val ToolConfigurationDisable = Switch("Facia", "facia-tool-configuration-disable",
-    "If this is switched on then the fronts configuration tool is disabled",
-    safeState = Off, sellByDate = never
-  )
-
   val ToolSnaps = Switch("Facia", "facia-tool-snaps",
     "If this is switched on then snaps can be created by dragging arbitrary links into the tool",
     safeState = Off, sellByDate = never
@@ -407,7 +402,6 @@ object Switches extends Collections {
     IdentityFormstackSwitch,
     IdentityAvatarUploadSwitch,
     ToolDisable,
-    ToolConfigurationDisable,
     ToolSnaps,
     ToolImageOverride,
     ToolSparklines,

--- a/facia-tool/public/javascripts/models/config/main.js
+++ b/facia-tool/public/javascripts/models/config/main.js
@@ -101,10 +101,6 @@ define([
 
         function bootstrap(opts) {
             return fetchSettings(function (config, switches) {
-                if (switches['facia-tool-configuration-disable']) {
-                    terminate('The configuration tool has been switched off.', '/');
-                    return;
-                }
                 model.switches(switches);
 
                 if (opts.force || !_.isEqual(config, vars.state.config)) {


### PR DESCRIPTION
We don't need this switch as we have a tool-wide disable.
