### PR TITLE
Delete Facia Tool check if has pressed switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -333,11 +333,6 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val ToolCheckPressLastmodified = Switch("Facia", "facia-tool-check-press-lastmodified",
-    "If this switch is on facia tool will alert the user if a front is not pressed withing 10 secs of an edit/publish",
-    safeState = Off, sellByDate = never
-  )
-
   val ToolSnaps = Switch("Facia", "facia-tool-snaps",
     "If this is switched on then snaps can be created by dragging arbitrary links into the tool",
     safeState = Off, sellByDate = never
@@ -413,7 +408,6 @@ object Switches extends Collections {
     IdentityAvatarUploadSwitch,
     ToolDisable,
     ToolConfigurationDisable,
-    ToolCheckPressLastmodified,
     ToolSnaps,
     ToolImageOverride,
     ToolSparklines,

--- a/facia-tool/public/javascripts/models/collections/main.js
+++ b/facia-tool/public/javascripts/models/collections/main.js
@@ -112,7 +112,7 @@ define([
         model.deferredDetectPressFailure = _.debounce(function () {
             var count;
 
-            if (model.switches()['facia-tool-check-press-lastmodified'] && model.front()) {
+            if (model.front()) {
                 model.statusPressFailure(false);
 
                 count = ++model.detectPressFailureCount;


### PR DESCRIPTION
We always want the tool to alert editors if the update has failed, so there's no need for a feature switch for this.
