### PR TITLE
Delete Facia Tool Image Override switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -343,11 +343,6 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val ToolImageOverride = Switch("Facia", "facia-tool-image-override",
-    "If this is switched on then images can be overridden in the fronts tool",
-    safeState = Off, sellByDate = never
-  )
-
   val ToolSparklines = Switch("Facia", "facia-tool-sparklines",
     "If this is switched on then the fronts tool renders images from sparklines.ophan.co.uk",
     safeState = Off, sellByDate = never
@@ -415,7 +410,6 @@ object Switches extends Collections {
     ToolConfigurationDisable,
     ToolCheckPressLastmodified,
     ToolSnaps,
-    ToolImageOverride,
     ToolSparklines,
     OphanSwitch,
     ScrollDepthSwitch,

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -294,13 +294,11 @@
                     <div class="misc__overrides">
                         Image
 
-                        <!-- ko if: $root.switches()['facia-tool-image-override'] -->
                         <a data-bind="
                             click: toggleOpenImage,
                             text: meta.imageSrc() ? 'replaced' : 'replace',
                             css: {selected: meta.imageSrc}"></a>
                         &middot;
-                        <!-- /ko -->
                         <a data-bind="
                             click: toggleImageAdjustBoost,
                             text: meta.imageAdjust() === 'boost' ? 'boosted' : 'boost',


### PR DESCRIPTION
This doesn't need to be behind a feature switch, we always want image override to be available.
