### PR TITLE
Delete Facia Tool press draft front switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -363,11 +363,6 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val FaciaToolDraftPressSwitch = Switch("Facia", "facia-tool-press-draft-front",
-    "If this switch is on facia tool will press draft fronts on each change",
-    safeState = Off, sellByDate = never
-  )
-
   val FaciaToolDraftContent = Switch("Facia", "facia-tool-draft-content",
     "If this switch is on facia tool will offer draft content to editors, and press draft fronts from draft content ",
     safeState = Off, sellByDate = never
@@ -448,7 +443,6 @@ object Switches extends Collections {
     SeoEscapeFootballJsonPathLikeValuesSwitch,
     FaciaToolCachedContentApiSwitch,
     FaciaToolCachedZippingContentApiSwitch,
-    FaciaToolDraftPressSwitch,
     FaciaToolDraftContent,
     GuShiftCookieSwitch,
     ABHighCommercialComponent,

--- a/facia-tool/app/services/FaciaPress.scala
+++ b/facia-tool/app/services/FaciaPress.scala
@@ -64,7 +64,7 @@ object FaciaPress extends Logging with ExecutionContexts {
         }
 
       lazy val draftPress =
-        if (FaciaToolDraftPressSwitch.isSwitchedOn && pressCommand.draft) {
+        if (pressCommand.draft) {
           val fut = Future.traverse(paths)(path => FaciaPressQueue.enqueue(PressJob(FrontPath(path), Draft)))
           fut.onComplete {
             case Failure(error) =>


### PR DESCRIPTION
We always want to press draft fronts. No need for a feature switch.
