### PR TITLE
Article titles fix: section name instead of section id

### DIFF
--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -9,7 +9,7 @@ object Title {
 
   def apply(page: MetaData)(implicit request: RequestHeader): Html = Html{
     val title = page match {
-      case c: Content => s"${c.webTitle}${pagination(page)}${getSectionConsideringWebtitle(c.webTitle, Option(page.section))}"
+      case c: Content => s"${c.webTitle}${pagination(c)}${getSectionConsideringWebtitle(c.webTitle, Option(c.sectionName))}"
       case t: Tag     => s"${t.webTitle}${pagination(page)}${getSectionConsideringWebtitle(t.webTitle, Option(page.section))}"
       case _          => page.title.filter(_.nonEmpty).getOrElse(s"${page.webTitle}${pagination(page)}${getSectionConsideringWebtitle(page.webTitle, Option(page.section))}")
     }


### PR DESCRIPTION
### before

![screen shot 2014-09-01 at 16 11 08](https://cloud.githubusercontent.com/assets/1492162/4109884/f1914f26-31ea-11e4-82ab-1ed6c1425bac.png)
![screen shot 2014-09-01 at 16 10 37](https://cloud.githubusercontent.com/assets/1492162/4109883/f190c2f4-31ea-11e4-933f-ac7f475ccea4.png)
### after

![screen shot 2014-09-01 at 16 11 23](https://cloud.githubusercontent.com/assets/1492162/4109881/f18756d8-31ea-11e4-9cf3-91436a64357b.png)
![screen shot 2014-09-01 at 16 10 57](https://cloud.githubusercontent.com/assets/1492162/4109882/f18f1c4c-31ea-11e4-801c-50c9c6e52860.png)
