### PR TITLE
super high compoennt title visible on tablet & lower

### DIFF
--- a/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_commercial-component.scss
@@ -158,13 +158,7 @@ $commercial-cta-diameter: (
         padding: $gs-baseline $gs-gutter/2;
         
         .commercial__title {
-            display: none;
             float: none;
-        }
-        @include mq(tablet) {
-            .commercial__title {
-                display: block;
-            }
         }
         @include mq(leftCol, wide) {
             .i-bookshop-logo--bookshop {


### PR DESCRIPTION
Shows the title of the component at less than tablet as requested by commercial.
