### PR TITLE
Correct badge size for dark backgrounded articles

### DIFF
--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -5,7 +5,7 @@
     @defining((
         content match { case c if c.isSponsored => {"spbadge"} case _ => {"adbadge"} },
         content match { case _: LiveBlog => {"live-blog"} case _ => {"article"} },
-        content match { case _: Media => "141" case _ => "140" }
+        content match { case _: Media | _: Gallery => "141" case _ => "140" }
     )) { case (name, badgeType, adSlotWidth) =>
         @fragments.commercial.adSlot(
             name,


### PR DESCRIPTION
So a more appropriate logo image can be used for the dark bg
### Before

![screen shot 2014-09-02 at 10 37 39](https://cloud.githubusercontent.com/assets/74132/4116432/fabcf0ec-3284-11e4-8140-3355c34c8a49.png)
### After

![screen shot 2014-09-02 at 10 37 48](https://cloud.githubusercontent.com/assets/74132/4116434/fe9aa83a-3284-11e4-9a3e-310c48aace82.png)
