### PR TITLE
removing space under button due to inline block

### DIFF
--- a/common/app/assets/stylesheets/base/_buttons.scss
+++ b/common/app/assets/stylesheets/base/_buttons.scss
@@ -177,6 +177,7 @@ category: Common
 }
 .button {
     display: inline-block;
+    vertical-align: top;
     width: auto;
     @include fs-textSans(2);
     font-weight: bold;


### PR DESCRIPTION
Ensures that there isn't extra spacing under a button

Before;
![screen shot 2014-09-02 at 15 24 47](https://cloud.githubusercontent.com/assets/1303616/4119699/ee9d0ee6-32ac-11e4-95ac-6a3b6fbbb9e1.png)

After;
![screen shot 2014-09-02 at 15 24 34](https://cloud.githubusercontent.com/assets/1303616/4119705/f47fba48-32ac-11e4-9178-8a5007dc0487.png)
