### PR TITLE
Changed navigation link 'observer' to 'the observer'

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -58,7 +58,7 @@ trait Navigation {
   val africa = SectionLink("world", "africa", "Africa", "/world/africa")
   val middleEast = SectionLink("world", "middle east", "Middle east", "/world/middleeast")
   val video = SectionLink("video", "video", "Video", "/video")
-  val observer = SectionLink("observer", "observer", "Observer", "/observer")
+  val observer = SectionLink("observer", "the observer", "The Observer", "/observer")
 
   val health = SectionLink("society", "health", "Health", "/society/health")
 


### PR DESCRIPTION
Just the change in navigation variables. Link to /observer is now saying 'the observer' instead of just 'observer'.
