### PR TITLE
Refactor Facia Press cron queue to use JsonQueue

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -1,22 +1,24 @@
 package jobs
 
-import services.{S3FrontsApi, FrontPressNotification}
+import services.{FrontPath, CronUpdate, S3FrontsApi, FrontPressNotification}
 import play.api.libs.json.{JsValue, Json}
 import conf.Switches._
 import conf.Configuration
 
 object RefreshFrontsJob {
-
-  def getPaths: Option[Seq[String]] = {
+  def getCronUpdates: Option[Seq[CronUpdate]] = {
     S3FrontsApi.getMasterConfig
       .map(Json.parse)
       .flatMap { json => (json \ "fronts").asOpt[Map[String, JsValue]] }
-      .map(_.keys.toSeq)
+      .map(_.keys.toSeq.map(path => CronUpdate(FrontPath(path))))
   }
 
   def run(): Unit = {
     if (FrontPressJobSwitch.isSwitchedOn && Configuration.aws.frontPressSns.filter(_.nonEmpty).isDefined) {
-      getPaths map(_.map(FrontPressNotification.sendWithoutSubject))
+      for {
+        updates <- getCronUpdates
+        update <- updates
+      } FrontPressNotification.sendWithoutSubject(Json.stringify(Json.toJson(update)))
     }
   }
 }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -289,16 +289,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
         oauthCallback <- configuration.getStringProperty("faciatool.oauth.callback")
       } yield OAuthCredentials(oauthClientId, oauthSecret, oauthCallback)
 
-    //It's not possible to take a batch size above 10
-    lazy val pressJobBatchSize: Int =
-      Try(configuration.getStringProperty("faciapress.batch.size").get.toInt)
-        .filter(_ <= 10).getOrElse(10)
-
-    //Above 59 would probably break the cron expression
-    lazy val pressJobConsumeRateInSeconds: Int =
-      Try(configuration.getStringProperty("faciapress.rate.inseconds").get.toInt)
-        .filter(_ <= 59).filter(_ > 0).getOrElse(10)
-
     lazy val adminPressJobPushRateInMinutes: Int =
       Try(configuration.getStringProperty("admin.pressjob.push.rate.inminutes").get.toInt)
         .getOrElse(3)

--- a/common/app/services/faciaPressQueue.scala
+++ b/common/app/services/faciaPressQueue.scala
@@ -46,3 +46,9 @@ object PressJob {
 }
 
 case class PressJob(path: FrontPath, pressType: PressType, creationTime: DateTime = DateTime.now)
+
+object CronUpdate {
+  implicit val jsonFormat = Json.format[CronUpdate]
+}
+
+case class CronUpdate(path: FrontPath)

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -81,8 +81,6 @@ commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
 
 #Pressing
-faciapress.batch.size=2
-faciapress.rate.inseconds=5
 admin.pressjob.push.rate.inminutes=5
 
 #Facia-tool Oauth

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -76,8 +76,6 @@ commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
 
 # Pressing
-faciapress.batch.size=1
-faciapress.rate.inseconds=5
 admin.pressjob.push.rate.inminutes=5
 
 #Facia-tool Oauth

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -2,84 +2,59 @@ package frontpress
 
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
-import com.amazonaws.services.sqs.model._
 import common.FaciaPressMetrics.{FrontPressCronFailure, FrontPressCronSuccess}
 import common.SQSQueues._
-import common.{Edition, Logging}
+import common.{StopWatch, JsonMessageQueue, Edition}
 import conf.Configuration
 import conf.Switches.FrontPressJobSwitch
 import metrics.AllFrontsPressLatencyMetric
-import org.joda.time.DateTime
-import play.api.libs.concurrent.Akka
-import play.api.libs.json.Json
+import services.CronUpdate
 
-import scala.collection.JavaConversions._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-/** TODO convert this to use JsonQueueWorker
-  *
-  * (So as to a) reduce code, and b) allow us to use the various metrics it gives for health checks)
-  */
-object FrontPressCron extends Logging with implicits.Collections {
+object FrontPressCron extends JsonQueueWorker[CronUpdate] {
   val queueUrl: Option[String] = Configuration.faciatool.frontPressCronQueue
 
-  import play.api.Play.current
-  private lazy implicit val frontPressContext = Akka.system.dispatchers.lookup("play.akka.actor.front-press")
+  override val queue: JsonMessageQueue[CronUpdate] = (Configuration.faciatool.frontPressCronQueue map { queueUrl =>
+    val credentials = Configuration.aws.mandatoryCredentials
 
-  val batchSize: Int = Configuration.faciatool.pressJobBatchSize
-
-  def newClient: AmazonSQSAsyncClient = {
-    new AmazonSQSAsyncClient(Configuration.aws.mandatoryCredentials).withRegion(Region.getRegion(Regions.EU_WEST_1))
+    JsonMessageQueue[CronUpdate](
+      new AmazonSQSAsyncClient(credentials).withRegion(Region.getRegion(Regions.EU_WEST_1)),
+      queueUrl
+    )
+  }) getOrElse {
+    throw new RuntimeException("Required property 'frontpress.sqs.cron_queue_url' not set")
   }
 
-  def run(): Unit = {
-    for (queueUrl <- queueUrl) {
-      if (FrontPressJobSwitch.isSwitchedOn) {
-        val client = newClient
-        try {
-          val receiveMessageResult = client.receiveMessage(new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(batchSize))
-          Future.traverse(receiveMessageResult.getMessages.map(getConfigFromMessage).distinct) { path =>
-            val start = DateTime.now
-            val f = FrontPress.pressLiveByPathId(path)
-            f onComplete {
-              case Success(_) =>
+  override def process(message: common.Message[CronUpdate]): Future[Unit] = {
+    val path = message.get.path.get
 
-                if (Edition.all.map(_.id.toLowerCase).exists(_ == path))
-                  ToolPressQueueWorker.metricsByPath.get(path).foreach { metric =>
-                    metric.recordDuration(DateTime.now.getMillis - start.getMillis)
-                  }
-                else
-                  AllFrontsPressLatencyMetric.recordDuration(DateTime.now.getMillis - start.getMillis)
+    if (FrontPressJobSwitch.isSwitchedOn) {
+      log.info(s"Cron pressing path $path")
+      val stopWatch = new StopWatch
+      val pressFuture = FrontPress.pressLiveByPathId(path)
 
-                deleteMessage(receiveMessageResult, queueUrl)
-                FrontPressCronSuccess.increment()
-              case Failure(error) =>
-                deleteMessage(receiveMessageResult, queueUrl)
-                log.warn("Error updating collection via cron", error)
-                FrontPressCronFailure.increment()
+      pressFuture onComplete {
+        case Success(_) =>
+          if (Edition.all.map(_.id.toLowerCase).contains(path)) {
+            ToolPressQueueWorker.metricsByPath.get(path) foreach { metric =>
+              metric.recordDuration(stopWatch.elapsed)
             }
-            f
+          } else {
+            AllFrontsPressLatencyMetric.recordDuration(stopWatch.elapsed)
           }
-        } catch {
-          case error: Throwable =>
-            log.error("Error updating collection via cron", error)
-            FrontPressCronFailure.increment()
-        }
+
+          FrontPressCronSuccess.increment()
+        case Failure(error) =>
+          log.warn("Error updating collection via cron", error)
+          FrontPressCronFailure.increment()
       }
+
+      pressFuture.map(Function.const(()))
+    } else {
+      log.info(s"Ignoring message $message in Facia Press cron as cron is turned OFF")
+      Future.successful(())
     }
   }
-
-  def deleteMessage(receiveMessageResult: ReceiveMessageResult, queueUrl: String): DeleteMessageBatchResult = {
-    val client = newClient
-    client.deleteMessageBatch(
-      new DeleteMessageBatchRequest(
-        queueUrl,
-        receiveMessageResult.getMessages.map { msg => new DeleteMessageBatchRequestEntry(msg.getMessageId, msg.getReceiptHandle)}
-      )
-    )
-  }
-
-  def getConfigFromMessage(message: Message): String =
-    (Json.parse(message.getBody) \ "Message").as[String]
 }

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -14,7 +14,6 @@ import scala.util.{Failure, Success}
 
 object ToolPressQueueWorker extends JsonQueueWorker[PressJob] with Logging {
   override val queue = (Configuration.faciatool.frontPressToolQueue map { queueUrl =>
-
     val credentials = Configuration.aws.mandatoryCredentials
 
     JsonMessageQueue[PressJob](


### PR DESCRIPTION
This'll prevent the unbounded concurrency problem we've sometimes seen on the Facia Press boxes.

Also, it deletes more code than it adds, which is always a good thing. :heart: 
