### PR TITLE
Social sharing image served from non-secure domain

### DIFF
--- a/facia/app/views/fragments/frontHead.scala.html
+++ b/facia/app/views/fragments/frontHead.scala.html
@@ -7,4 +7,4 @@
 
 @page.description.map { desc => <meta name="og:description" content="@desc" />}
 <meta name="og:title" content="@views.support.Title(page)" />
-<meta name="og:image" content="http://static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png" />
+<meta name="og:image" content="http://static.guim.co.uk/icons/social/og/gu-logo-fallback.png" />

--- a/facia/app/views/fragments/frontHead.scala.html
+++ b/facia/app/views/fragments/frontHead.scala.html
@@ -7,4 +7,4 @@
 
 @page.description.map { desc => <meta name="og:description" content="@desc" />}
 <meta name="og:title" content="@views.support.Title(page)" />
-<meta name="og:image" content="//static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png" />
+<meta name="og:image" content="http://static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png" />


### PR DESCRIPTION
Serving from `http://static.guim.co.uk` rather than `https://static-secure.guim.co.uk`

cc @gklopper 
