### PR TITLE
Add detect.isBreakpoint method

### DIFF
--- a/common/app/assets/javascripts/bootstraps/football.js
+++ b/common/app/assets/javascripts/bootstraps/football.js
@@ -160,7 +160,7 @@ define([
 
                     if(!/^\s+$/.test(scoreBoard.template)) {
                         scoreBoard.endpoint = endpoint;
-                        scoreBoard.updateEvery = /desktop|wide/.test(detect.getBreakpoint()) ? 30 : 60;
+                        scoreBoard.updateEvery = detect.isBreakpoint({ min: 'desktop' }) ? 30 : 60;
                         scoreBoard.autoupdated = match.isLive;
 
                         scoreBoard.render(scoreContainer);

--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -154,7 +154,7 @@ define([
                 $('.js-live-blog__timeline li:first-child .timeline__title').text('Latest post');
                 $('.js-live-blog__timeline li:last-child .timeline__title').text('Opening post');
 
-                if (/desktop|wide/.test(detect.getBreakpoint()) && config.page.keywordIds.indexOf('football/football') < 0) {
+                if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0) {
                     var topMarker = qwery('.js-top-marker')[0];
                     affix = new Affix({
                         element: qwery('.js-live-blog__timeline-container')[0],
@@ -171,7 +171,7 @@ define([
 
             if (config.page.isLive) {
 
-                var timerDelay = /desktop|wide/.test(detect.getBreakpoint()) ? 30000 : 60000;
+                var timerDelay = detect.isBreakpoint({ min: 'desktop' }) ? 30000 : 60000;
                 autoUpdate = new AutoUpdate({
                     path: getUpdatePath,
                     delay: timerDelay,

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -40,7 +40,7 @@ define([
     raven,
     preferences
 ) {
-    var isDesktop = /desktop|wide/.test(detect.getBreakpoint()),
+    var isDesktop = detect.isBreakpoint({ min: 'desktop' }),
         QUARTILES = [25, 50, 75],
         // Advert and content events used by analytics. The expected order of bean events is:
         EVENTS = [
@@ -358,8 +358,10 @@ define([
                                     modules.bindContentEvents(player);
                                 }
 
-                                if (bonzo(el).attr('data-show-end-slate') === 'true' &&
-                                    /desktop|wide/.test(detect.getBreakpoint())) {
+                                if (
+                                    bonzo(el).attr('data-show-end-slate') === 'true' &&
+                                    detect.isBreakpoint({ min: 'desktop' })
+                                ) {
                                     modules.initEndSlate(player, bonzo(el).attr('data-end-slate'));
                                 }
                             } else {

--- a/common/app/assets/javascripts/modules/analytics/clickstream.js
+++ b/common/app/assets/javascripts/modules/analytics/clickstream.js
@@ -1,13 +1,11 @@
 define([
     'bean',
     'lodash/collections/map',
-    'common/utils/detect',
     'common/utils/mediator',
     'common/modules/experiments/ab'
 ], function (
     bean,
     map,
-    detect,
     mediator,
     ab
 ) {

--- a/common/app/assets/javascripts/modules/commercial/article-body-adverts.js
+++ b/common/app/assets/javascripts/modules/commercial/article-body-adverts.js
@@ -43,7 +43,7 @@ define([
 
             var breakpoint  = detect.getBreakpoint(),
                 rules = {
-                    minAbove: (/mobile|tablet/).test(breakpoint) ? 300 : 700,
+                    minAbove: detect.isBreakpoint({ max: 'tablet' }) ? 300 : 700,
                     minBelow: 300,
                     selectors: {
                         ' > h2': {minAbove: breakpoint === 'mobile' ? 20 : 0, minBelow: 250},
@@ -58,7 +58,7 @@ define([
             }
             insertAdAtP(spacefinder.getParaWithSpace(rules));
 
-            if (breakpoint === 'mobile' || ((/wide|desktop|tablet/).test(breakpoint) && (config.innerWidth || window.innerWidth) < 900)) {
+            if (breakpoint === 'mobile' || (detect.isBreakpoint({ min: 'tablet' }) && (config.innerWidth || window.innerWidth) < 900)) {
                 insertAdAtP(spacefinder.getParaWithSpace(rules));
             }
         };

--- a/common/app/assets/javascripts/modules/navigation/profile.js
+++ b/common/app/assets/javascripts/modules/navigation/profile.js
@@ -4,7 +4,6 @@ define([
     'common/utils/ajax',
     'bonzo',
     'bean',
-    'common/utils/detect',
     'common/modules/identity/api'
 ], function(
     assign,
@@ -12,7 +11,6 @@ define([
     ajax,
     bonzo,
     bean,
-    detect,
     Id
 ) {
 

--- a/common/app/assets/javascripts/utils/detect.js
+++ b/common/app/assets/javascripts/utils/detect.js
@@ -8,10 +8,18 @@
 
 define([
     'lodash/arrays/findIndex',
+    'lodash/arrays/first',
+    'lodash/arrays/last',
+    'lodash/arrays/rest',
+    'lodash/objects/defaults',
     'common/utils/_',
     'common/utils/mediator'
 ], function (
     findIndex,
+    first,
+    last,
+    rest,
+    defaults,
     _,
     mediator
 ) {
@@ -230,6 +238,26 @@ define([
         return breakpoint;
     }
 
+    function isBreakpoint(criteria) {
+        var c = defaults(
+                criteria,
+                {
+                    min: first(breakpoints).name,
+                    max: last(breakpoints).name
+                }
+            ),
+            currentBreakpoint = getBreakpoint(true);
+        return _(breakpoints)
+            .rest(function (breakpoint) {
+                return breakpoint.name !== c.min;
+            })
+            .initial(function (breakpoint) {
+                return breakpoint.name !== c.max;
+            })
+            .pluck('name')
+            .contains(currentBreakpoint);
+    }
+
     // Page Visibility
     function initPageVisibility() {
         // Taken from http://stackoverflow.com/a/1060034
@@ -294,6 +322,7 @@ define([
         hasPushStateSupport: hasPushStateSupport,
         getOrientation: getOrientation,
         getBreakpoint: getBreakpoint,
+        isBreakpoint: isBreakpoint,
         initPageVisibility: initPageVisibility,
         pageVisible: pageVisible,
         hasWebSocket: hasWebSocket,

--- a/common/test/assets/javascripts/spec/utils/detect.spec.js
+++ b/common/test/assets/javascripts/spec/utils/detect.spec.js
@@ -102,6 +102,50 @@ define([
 
         });
 
+        describe('isBreakpoint', function () {
+
+            beforeEach(function () {
+                $style.html('body:after { content: "rightCol"; }');
+            });
+
+            it('should return true if breakpoint is at the given min breakpoint', function () {
+                expect(detect.isBreakpoint({ min: 'rightCol' })).toBe(true);
+            });
+
+            it('should return true if breakpoint is greater than the given min breakpoint', function () {
+                expect(detect.isBreakpoint({ min: 'tablet' })).toBe(true);
+            });
+
+            it('should return false if breakpoint is less than the given min breakpoint', function () {
+                expect(detect.isBreakpoint({ min: 'desktop' })).toBe(false);
+            });
+
+            it('should return true if breakpoint is at the given max breakpoint', function () {
+                expect(detect.isBreakpoint({ max: 'rightCol' })).toBe(true);
+            });
+
+            it('should return true if breakpoint is less than the given max breakpoint', function () {
+                expect(detect.isBreakpoint({ max: 'desktop' })).toBe(true);
+            });
+
+            it('should return false if breakpoint is greater than the given max breakpoint', function () {
+                expect(detect.isBreakpoint({ max: 'tablet' })).toBe(false);
+            });
+
+            it('should return true if breakpoint is at the given min and max breakpoint', function () {
+                expect(detect.isBreakpoint({ min: 'rightCol', max: 'rightCol' })).toBe(true);
+            });
+
+            it('should return true if breakpoint is within the given min and max breakpoint', function () {
+                expect(detect.isBreakpoint({ min: 'tablet', max: 'desktop' })).toBe(true);
+            });
+
+            it('should return false if breakpoint is without the given min and max breakpoint', function () {
+                expect(detect.isBreakpoint({ min: 'mobile', max: 'tablet' })).toBe(false);
+            });
+
+        });
+
     });
 
     describe("Connection speed", function() {


### PR DESCRIPTION
Instead of doing something like this

```
/desktop|wide/.test(detect.getBreakpoint());
```

can now do this

```
detect.isBreakpoint({ min: 'desktop' });
```

Another step towards allowing us to add tweakpoints/new breakpoints to our detect object
