### PR TITLE
Add Facia signposting override for editorally curated index pages

### DIFF
--- a/applications/app/Global.scala
+++ b/applications/app/Global.scala
@@ -1,28 +1,21 @@
 import common.{ContentApiMetrics, CloudWatchApplicationMetrics}
-import conf.{Configuration, Filters}
+import conf.Filters
 import dev.DevParametersLifecycle
 import dfp.DfpAgentLifecycle
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
-import play.api.Application
 import play.api.mvc.WithFilters
-import services.{ContributorAlphaIndexAutoRefresh, KeywordSectionIndexAutoRefresh, KeywordAlphaIndexAutoRefresh}
+import services.IndexListingsLifecycle
 
 object Global extends WithFilters(Filters.common: _*)
-                      with DevParametersLifecycle
-                      with CloudWatchApplicationMetrics
-                      with DfpAgentLifecycle
-                      with SurgingContentAgentLifecycle{
+  with DevParametersLifecycle
+  with CloudWatchApplicationMetrics
+  with DfpAgentLifecycle
+  with SurgingContentAgentLifecycle
+  with IndexListingsLifecycle {
   override lazy val applicationName = "frontend-applications"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
     ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric
   )
-
-  override def onStart(app: Application): Unit = {
-    super.onStart(app)
-    KeywordSectionIndexAutoRefresh.start()
-    KeywordAlphaIndexAutoRefresh.start()
-    ContributorAlphaIndexAutoRefresh.start()
-  }
 }

--- a/applications/app/model/TagIndexPageMetadata.scala
+++ b/applications/app/model/TagIndexPageMetadata.scala
@@ -1,29 +1,5 @@
 package model
 
-import common.{SectionLink, NavItem}
-import services.{KeywordAlphaIndexAutoRefresh, ContributorAlphaIndexAutoRefresh}
-
-object IndexNav {
-  private def tagIndexSignposting(tagType: String, navTitle: String)(get: => Option[TagIndexListings]) = {
-    val sectionRoot = SectionLink(tagType, tagType, navTitle, s"/index/$tagType")
-
-    get match {
-      case Some(listings) => NavItem(
-        sectionRoot,
-        listings.pages map { page =>
-          SectionLink(tagType, page.title.toLowerCase, page.title, s"/index/$tagType/${page.id}")
-        }
-      )
-
-      case None => NavItem(sectionRoot, Nil)
-    }
-  }
-
-  val contributorsAlpha = tagIndexSignposting("contributors", "Contributors")(ContributorAlphaIndexAutoRefresh.get)
-
-  val keywordsAlpha = tagIndexSignposting("subjects", "Subjects")(KeywordAlphaIndexAutoRefresh.get)
-}
-
 trait TagIndexPageMetaData extends MetaData {
   val page: String
 

--- a/common/app/model/IndexNav.scala
+++ b/common/app/model/IndexNav.scala
@@ -1,0 +1,25 @@
+package model
+
+import common.{NavItem, SectionLink}
+import services.{KeywordAlphaIndexAutoRefresh, ContributorAlphaIndexAutoRefresh}
+
+object IndexNav {
+  private def tagIndexSignposting(tagType: String, navTitle: String)(get: => Option[TagIndexListings]) = {
+    val sectionRoot = SectionLink(tagType, tagType, navTitle, s"/index/$tagType")
+
+    get match {
+      case Some(listings) => NavItem(
+        sectionRoot,
+        listings.pages map { page =>
+          SectionLink(tagType, page.title.toLowerCase, page.title, s"/index/$tagType/${page.id}")
+        }
+      )
+
+      case None => NavItem(sectionRoot, Nil)
+    }
+  }
+
+  val contributorsAlpha = tagIndexSignposting("contributors", "Contributors")(ContributorAlphaIndexAutoRefresh.get)
+
+  val keywordsAlpha = tagIndexSignposting("subjects", "Subjects")(KeywordAlphaIndexAutoRefresh.get)
+}

--- a/common/app/services/indexAutoRefreshes.scala
+++ b/common/app/services/indexAutoRefreshes.scala
@@ -2,11 +2,22 @@ package services
 
 import common.AutoRefresh
 import model.TagIndexListings
+import play.api.{Application, GlobalSettings}
 
-import scala.concurrent.{Future, blocking}
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Future, blocking}
 import scala.language.postfixOps
+
+trait IndexListingsLifecycle extends GlobalSettings {
+  override def onStart(app: Application): Unit = {
+    super.onStart(app)
+
+    KeywordSectionIndexAutoRefresh.start()
+    KeywordAlphaIndexAutoRefresh.start()
+    ContributorAlphaIndexAutoRefresh.start()
+  }
+}
 
 object KeywordSectionIndexAutoRefresh extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes) {
   override protected def refresh(): Future[TagIndexListings] = Future {

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -7,16 +7,17 @@ import ophan.SurgingContentAgentLifecycle
 import play.Play
 import play.api.libs.json.Json
 import play.api.mvc.WithFilters
-import services.{ConfigAgent, ConfigAgentDefaults, ConfigAgentLifecycle}
+import services.{IndexListingsLifecycle, ConfigAgent, ConfigAgentDefaults, ConfigAgentLifecycle}
 import play.api.Application
 
 
 object Global extends WithFilters(Filters.common: _*)
-with ConfigAgentLifecycle
-with DevParametersLifecycle
-with CloudWatchApplicationMetrics
-with DfpAgentLifecycle
-with SurgingContentAgentLifecycle {
+  with ConfigAgentLifecycle
+  with DevParametersLifecycle
+  with CloudWatchApplicationMetrics
+  with DfpAgentLifecycle
+  with SurgingContentAgentLifecycle
+  with IndexListingsLifecycle {
   override lazy val applicationName = "frontend-facia"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -1,6 +1,6 @@
 package model
 
-import common.Edition
+import common.{NavItem, Edition}
 import dfp.DfpAgent
 import play.api.libs.json.{JsString, JsValue}
 
@@ -33,6 +33,8 @@ case class FaciaPage(id: String,
   override def hasPageSkin(edition: Edition) = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 
   def allItems = collections.map(_._2).flatMap(_.items).distinct
+
+  override def customSignPosting: Option[NavItem] = FaciaSignpostingOverrides(id)
 }
 
 object FaciaPage {

--- a/facia/app/model/FaciaSignpostingOverrides.scala
+++ b/facia/app/model/FaciaSignpostingOverrides.scala
@@ -1,0 +1,16 @@
+package model
+
+/** Custom overrides for the sign posting logic on Facia pages.
+  *
+  * This is currently used for the top level index listings, which are editorially curated using Facia tool, so that we
+  * can display foremost our most popular contributors & subjects.
+  *
+  * For the nav, we list the full A-Z pages available.
+  */
+object FaciaSignpostingOverrides {
+  def apply(id: String) = id match {
+    case "index/contributors" => Some(IndexNav.contributorsAlpha)
+    case "index/subjects" => Some(IndexNav.keywordsAlpha)
+    case _ => None
+  }
+}


### PR DESCRIPTION
This will allow the editors to curate a list of our most popular contributors and subjects through Facia tool, which will have the full a-z index pages in the nav.

![screen shot 2014-09-04 at 11 50 51](https://cloud.githubusercontent.com/assets/1001642/4148146/72f9346a-3421-11e4-9120-62e1d7bf8d41.png)
