### PR TITLE
Consider Platform When Inserting Pageskin Ad Slots

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -94,27 +94,6 @@ object DfpDataCacheJob extends ExecutionContexts {
     }
   }
 
-  private implicit val countryWrites = new Writes[Country] {
-    def writes(country: Country): JsValue = {
-      Json.obj(
-        "name" -> country.name,
-        "editionId" -> country.editionId
-      )
-    }
-  }
-
-  private implicit val pageSkinSponsorshipWrites = new Writes[PageSkinSponsorship] {
-    def writes(sponsorship: PageSkinSponsorship): JsValue = {
-      Json.obj(
-        "lineItem" -> sponsorship.lineItemName,
-        "lineItemId" -> sponsorship.lineItemId,
-        "adUnits" -> sponsorship.adUnits,
-        "countries" -> sponsorship.countries,
-        "isAdTest" -> sponsorship.targetsAdTest
-      )
-    }
-  }
-
   private implicit val pageSkinSponsorshipReportWrites = new Writes[PageSkinSponsorshipReport] {
     def writes(report: PageSkinSponsorshipReport): JsValue = {
       Json.obj(

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -36,8 +36,9 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
         adUnit.path mkString "/"
       }
       val countries = lineItem.targeting.geoTargets map (geoTarget => Country.fromName(geoTarget.name))
+      val isR2Only = lineItem.targeting.targetsR2Only
       val targetsAdTest = lineItem.targeting.hasAdTestTargetting
-      PageSkinSponsorship(lineItem.name, lineItem.id, paths, countries, targetsAdTest)
+      PageSkinSponsorship(lineItem.name, lineItem.id, paths, countries, isR2Only, targetsAdTest)
     }
   }
 }

--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -35,19 +35,23 @@
     </ol>
 
     <h3>Behind Test Cookie</h3>
-    <ol>
-    @for(sponsorship <- pageSkinnedAdUnits.testSponsorships) {
-        <li style="margin: 20px">@sponsorship.lineItemName (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
-            @if(sponsorship.countries.nonEmpty){<br />Editions: @for(country <- sponsorship.countries){@{country.editionId}<span style="font-size:75%">&nbsp;&nbsp;&nbsp;[deduced from country: @{country.name}]</span>}}
-        <br />Ad Units:
-        <ul>
-        @for(adUnit <- sponsorship.adUnits) {
-            <li>@SiteLink.adUnit(adUnit).map{link => <a href="@link">@adUnit</a>}.getOrElse{@adUnit}</li>
+    @if(pageSkinnedAdUnits.testSponsorships.isEmpty) {
+        <p>None</p>
+    } else {
+        <ol>
+        @for(sponsorship <- pageSkinnedAdUnits.testSponsorships) {
+            <li style="margin : 20px">@sponsorship.lineItemName (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
+                @if(sponsorship.countries.nonEmpty){<br />Editions: @for(country <- sponsorship.countries) {@{country.editionId} <span style="font-size : 75 %">&nbsp;&nbsp;&nbsp;[deduced from country: @{country.name}]</span>}}
+            <br />Ad Units:
+            <ul>
+            @for(adUnit <- sponsorship.adUnits) {
+                <li>@SiteLink.adUnit(adUnit).map { link => <a href="@link">@adUnit</a>}.getOrElse {@adUnit}</li>
+            }
+            </ul>
+            </li>
         }
-        </ul>
-        </li>
+        </ol>
     }
-    </ol>
 
     <h3>R2 Only</h3>
     <ol>

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -228,7 +228,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val dfpSponsoredTagsDataKey = s"$dfpRoot/sponsored-tags-v2.json"
     lazy val dfpAdvertisementFeatureTagsDataKey = s"$dfpRoot/advertisement-feature-tags-v2.json"
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
-    lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v4.json"
+    lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v5.json"
     lazy val dfpLineItemsKey = s"$dfpRoot/lineitems.json"
 
     lazy val travelOffersS3Key = s"${environment.stage.toUpperCase}/commercial/cache/traveloffers.xml"

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -52,7 +52,8 @@ trait DfpAgent {
 
       def targetsAdUnitAndMatchesTheEdition(sponsorship: PageSkinSponsorship) = {
         sponsorship.adUnits.contains(adUnitWithRoot) &&
-          (sponsorship.countries.isEmpty || sponsorship.countries.exists(_.editionId == edition.id))
+          (sponsorship.countries.isEmpty || sponsorship.countries.exists(_.editionId == edition.id)) &&
+          !sponsorship.isR2Only
       }
 
       if (isProd) {

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -5,8 +5,12 @@ import org.joda.time.DateTime
 case class CustomTarget(name: String, op: String, values: Seq[String]) {
 
   def isPositive(targetName: String) = name == targetName && op == "IS"
+  def isNegative(targetName: String) = name == targetName && op == "IS_NOT"
 
   def isSlot(value: String) = isPositive("slot") && values.contains(value)
+
+  def isPlatform(value: String) = isPositive("p") && values.contains(value)
+  def isNotPlatform(value: String) = isNegative("p") && values.contains(value)
 
   val isSponsoredSlot = isSlot("spbadge")
 
@@ -19,10 +23,13 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   val isKeywordTag = isPositive("k")
   val isSeriesTag = isPositive("se")
   val isContributorTag = isPositive("co")
+
+  val targetsR2Only: Boolean = isPlatform("r2") || isNotPlatform("ng")
 }
 
 
 case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
+
   def filterTags(tagCriteria: CustomTarget => Boolean)(bySlotType: CustomTarget => Boolean) = {
     if (targets exists bySlotType) {
       targets.filter(tagCriteria).flatMap(_.values).distinct
@@ -38,6 +45,8 @@ case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
   val inlineMerchandisingTargetedContributors = filterTags(tag => tag.isContributorTag)(_.isInlineMerchandisingSlot)
 
   val targetsAdTest = targets.exists(_.targetsAdTest)
+
+  val targetsR2Only: Boolean = targets exists (_.targetsR2Only)
 }
 
 
@@ -48,9 +57,10 @@ case class GuAdUnit(id: String, path: Seq[String])
 
 
 case class GuTargeting(adUnits: Seq[GuAdUnit], geoTargets: Seq[GeoTarget], customTargetSets: Seq[CustomTargetSet]) {
-  def hasAdTestTargetting = {
-    customTargetSets.exists(_.targetsAdTest)
-  }
+
+  def hasAdTestTargetting = customTargetSets.exists(_.targetsAdTest)
+
+  def targetsR2Only = customTargetSets exists (_.targetsR2Only)
 }
 
 

--- a/common/app/dfp/PageSkinSponsorship.scala
+++ b/common/app/dfp/PageSkinSponsorship.scala
@@ -1,17 +1,28 @@
 package dfp
 
-import common.editions
-import common.{Edition, Logging}
+import common.{Edition, Logging, editions}
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
-case class PageSkinSponsorship(lineItemName: String,
-                               lineItemId: Long,
-                               adUnits: Seq[String],
-                               countries: Seq[Country],
-                               targetsAdTest: Boolean)
 
 case class Country(name: String, editionId: String)
 
 object Country {
+
+  implicit val countryWrites = new Writes[Country] {
+    def writes(country: Country): JsValue = {
+      Json.obj(
+        "name" -> country.name,
+        "editionId" -> country.editionId
+      )
+    }
+  }
+
+  implicit val countryReads: Reads[Country] = (
+    (JsPath \ "name").read[String] and
+      (JsPath \ "editionId").read[String]
+    )(Country.apply _)
+
   def fromName(name: String) = {
     val edition = name match {
       case "United States" => editions.Us
@@ -22,32 +33,51 @@ object Country {
   }
 }
 
+
+case class PageSkinSponsorship(lineItemName: String,
+                               lineItemId: Long,
+                               adUnits: Seq[String],
+                               countries: Seq[Country],
+                               isR2Only: Boolean,
+                               targetsAdTest: Boolean)
+
+object PageSkinSponsorship {
+
+  implicit val pageSkinSponsorshipWrites = new Writes[PageSkinSponsorship] {
+    def writes(sponsorship: PageSkinSponsorship): JsValue = {
+      Json.obj(
+        "lineItem" -> sponsorship.lineItemName,
+        "lineItemId" -> sponsorship.lineItemId,
+        "adUnits" -> sponsorship.adUnits,
+        "countries" -> sponsorship.countries,
+        "isR2Only" -> sponsorship.isR2Only,
+        "isAdTest" -> sponsorship.targetsAdTest
+      )
+    }
+  }
+
+  implicit val pageskinSponsorShipReads: Reads[PageSkinSponsorship] = (
+    (JsPath \ "lineItem").read[String] and
+      (JsPath \ "lineItemId").read[Long] and
+      (JsPath \ "adUnits").read[Seq[String]] and
+      (JsPath \ "countries").read[Seq[Country]] and
+      (JsPath \ "isR2Only").read[Boolean] and
+      (JsPath \ "isAdTest").read[Boolean]
+    )(PageSkinSponsorship.apply _)
+}
+
+
 case class PageSkinSponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[PageSkinSponsorship]) {
 
-  val (deliverableAndTestSponsorships, legacySponsorships) = sponsorships partition {
-    _.adUnits.exists(adUnit => adUnit.endsWith("/front") || adUnit.endsWith("/front/ng"))
+  val (deliverableAndTestSponsorships, legacySponsorships) = sponsorships partition { sponsorship =>
+    sponsorship.adUnits.exists(adUnit => adUnit.endsWith("/front") || adUnit.endsWith("/front/ng")) && (!sponsorship.isR2Only)
   }
   val (testSponsorships, deliverableSponsorships) = deliverableAndTestSponsorships partition (_.targetsAdTest)
 }
 
 object PageSkinSponsorshipReportParser extends Logging {
-  import play.api.libs.functional.syntax._
-  import play.api.libs.json._
 
   def apply(jsonString: String) = {
-
-    implicit val countryReads: Reads[Country] = (
-      (JsPath \ "name").read[String] and
-        (JsPath \ "editionId").read[String]
-      )(Country.apply _)
-
-    implicit val pageskinSponsorShipReads: Reads[PageSkinSponsorship] = (
-      (JsPath \ "lineItem").read[String] and
-        (JsPath \ "lineItemId").read[Long] and
-        (JsPath \ "adUnits").read[Seq[String]] and
-        (JsPath \ "countries").read[Seq[Country]] and
-        (JsPath \ "isAdTest").read[Boolean]
-      )(PageSkinSponsorship.apply _)
 
     implicit val reportReads: Reads[PageSkinSponsorshipReport] = (
       (JsPath \ "updatedTimeStamp").read[String] and

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -14,22 +14,22 @@ class DfpAgentTest extends FlatSpec with Matchers {
       1234L,
       Seq(s"$dfpAdUnitRoot/business/front"),
       Seq(Country("United Kingdom", "UK")),
-      false),
+      false, false),
     PageSkinSponsorship("lineItemName2",
       12345L,
       Seq(s"$dfpAdUnitRoot/music/front"),
       Nil,
-      false),
+      false, false),
     PageSkinSponsorship("lineItemName3",
       123456L,
       Seq(s"$dfpAdUnitRoot/sport"),
       Nil,
-      false),
+      false, false),
     PageSkinSponsorship("lineItemName4",
       1234567L,
       Seq(s"$dfpAdUnitRoot/testSport/front"),
       Seq(Country("United Kingdom", "UK")),
-      true)
+      false, true)
   )
 
   private def toKeyword(tagId: String): Tag = Tag(ApiTag(id = tagId, `type` = "keyword", webTitle = "title", webUrl = "url", apiUrl = "url"))


### PR DESCRIPTION
Custom targeting has been set up on DFP line items that we are not honouring.  Specifically we are opening slots in NG for ads targeted only at R2.
