### PR TITLE
Record the Match Day feed for auditing.

### DIFF
--- a/admin/app/football/feed/MatchDayRecorder.scala
+++ b/admin/app/football/feed/MatchDayRecorder.scala
@@ -1,0 +1,41 @@
+package football.feed
+
+import common.{Edition, ExecutionContexts, Logging}
+import conf.Switches
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+import play.api.libs.ws.WS
+import services.S3
+
+import scala.concurrent.ExecutionContext
+import play.api.Play.current
+
+object MatchDayRecorder extends ExecutionContexts with Logging {
+
+  private val feedDateFormat = DateTimeFormat.forPattern("yyyyMMdd").withZone(Edition.defaultEdition.timezone)
+  private val fileDateFormat = DateTimeFormat.forPattern("yyyy/MM/dd/HH-mm-ss").withZone(Edition.defaultEdition.timezone)
+
+  override implicit lazy val executionContext: ExecutionContext = feedsRecorderExecutionContext
+
+  import conf.Configuration.pa
+
+  def record(): Unit = if (Switches.FootballFeedRecorderSwitch.isSwitchedOn) {
+
+    val now = DateTime.now
+    val feedUrl = s"${pa.host}/api/football/competitions/matchDay/${pa.apiKey}/${now.toString(feedDateFormat)}"
+    val fileName = s"football-feeds/match-day/${now.toString(fileDateFormat)}.xml"
+    val result = WS.url(feedUrl).get()
+
+    result.onFailure {
+      case t: Throwable => log.info("match day recorder failed", t)
+    }
+
+    result.foreach { response =>
+      if (response.status != 200) {
+        log.info(s"match day recorder failed with status ${response.status} ${response.statusText}")
+      } else {
+        S3.putPrivate(fileName, response.body, "text/xml")
+      }
+    }
+  }
+}

--- a/admin/app/football/feed/MatchDayRecorder.scala
+++ b/admin/app/football/feed/MatchDayRecorder.scala
@@ -27,12 +27,12 @@ object MatchDayRecorder extends ExecutionContexts with Logging {
     val result = WS.url(feedUrl).get()
 
     result.onFailure {
-      case t: Throwable => log.info("match day recorder failed", t)
+      case t: Throwable => log.info(s"match day recorder failed $feedUrl", t)
     }
 
     result.foreach { response =>
       if (response.status != 200) {
-        log.info(s"match day recorder failed with status ${response.status} ${response.statusText}")
+        log.info(s"match day recorder failed with status ${response.status} ${response.statusText} $feedUrl")
       } else {
         S3.putPrivate(fileName, response.body, "text/xml")
       }

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -2,6 +2,7 @@ package model
 
 import commercial.TravelOffersCacheJob
 import conf.Configuration
+import football.feed.MatchDayRecorder
 import play.api.GlobalSettings
 import tools.{LoadBalancer, CloudWatch}
 import common.{AkkaAsync, Jobs}
@@ -50,6 +51,15 @@ trait AdminLifecycle extends GlobalSettings {
     Jobs.schedule("OmnitureReportJob", "0 */5 * * * ?") {
       OmnitureReportJob.run()
     }
+
+    Jobs.schedule("MatchDayRecorderJob", "0 * * * * ?") {
+      MatchDayRecorder.record()
+    }
+
+    AkkaAsync{
+      MatchDayRecorder.record()
+    }
+
   }
 
   private def descheduleJobs() {
@@ -62,6 +72,7 @@ trait AdminLifecycle extends GlobalSettings {
     Jobs.deschedule("TravelOffersCacheJob")
     Jobs.deschedule("RebuildIndexJob")
     Jobs.deschedule("OmnitureReportJob")
+    Jobs.deschedule("MatchDayRecorderJob")
   }
 
   override def onStart(app: play.api.Application) {

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -55,11 +55,6 @@ trait AdminLifecycle extends GlobalSettings {
     Jobs.schedule("MatchDayRecorderJob", "0 * * * * ?") {
       MatchDayRecorder.record()
     }
-
-    AkkaAsync{
-      MatchDayRecorder.record()
-    }
-
   }
 
   private def descheduleJobs() {

--- a/admin/conf/application.conf
+++ b/admin/conf/application.conf
@@ -42,6 +42,12 @@ play {
           parallelism-max = 1
         }
       }
+      feed-recorder = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 1
+        }
+      }
       memcached = {
         fork-join-executor {
           parallelism-factor = 1.0

--- a/common/app/common/akka.scala
+++ b/common/app/common/akka.scala
@@ -12,6 +12,7 @@ trait ExecutionContexts {
   implicit lazy val executionContext: ExecutionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
   lazy val actorSystem: ActorSystem = PlayAkka.system
   lazy val memcachedExecutionContext: ExecutionContext = PlayAkka.system.dispatchers.lookup("play.akka.actor.memcached")
+  lazy val feedsRecorderExecutionContext: ExecutionContext = PlayAkka.system.dispatchers.lookup("play.akka.actor.feed-recorder")
 }
 
 object AkkaAgent extends ExecutionContexts{

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -358,6 +358,10 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
+  val FootballFeedRecorderSwitch = Switch("Feature", "football-feed-recorder",
+    "If switched on then football matchday feeds will be recorded every minute",
+    safeState = Off, sellByDate = new LocalDate(2014, 9, 30))
+
   val all: List[Switch] = List(
     AutoRefreshSwitch,
     DoubleCacheTimesSwitch,
@@ -419,7 +423,8 @@ object Switches extends Collections {
     EnhancedMediaPlayerSwitch,
     BreakingNewsSwitch,
     ChildrensBooksSwitch,
-    MetricsSwitch
+    MetricsSwitch,
+    FootballFeedRecorderSwitch
   )
 
   val httpSwitches: List[Switch] = List(


### PR DESCRIPTION
This records the raw feed every minute so we can see if any scores were seriously out of date due to stale data in the feeds.

![football-feed](https://cloud.githubusercontent.com/assets/76709/4163688/8bb21d9a-34ea-11e4-8d7b-901c297362ee.png)
