### PR TITLE
Footer links info and resources

### DIFF
--- a/article/test/SectionsNavigationFeatureTest.scala
+++ b/article/test/SectionsNavigationFeatureTest.scala
@@ -65,8 +65,8 @@ class SectionNavigationFeatureTest extends FeatureSpec with GivenWhenThen with M
         val contact = browser.find(".l-footer li a", withText().contains("contact"))
         contact.length should be > 0
 
-        And("a link to the about this page")
-        val about = browser.find(".l-footer li a", withText().contains("about this site"))
+        And("a link to the info and resources")
+        val about = browser.find(".l-footer li a", withText().contains("info and resources"))
         about.length should be > 0
       }
     }

--- a/article/test/SectionsNavigationFeatureTest.scala
+++ b/article/test/SectionsNavigationFeatureTest.scala
@@ -66,8 +66,12 @@ class SectionNavigationFeatureTest extends FeatureSpec with GivenWhenThen with M
         contact.length should be > 0
 
         And("a link to the info and resources")
-        val about = browser.find(".l-footer li a", withText().contains("info and resources"))
-        about.length should be > 0
+        val info = browser.find(".l-footer li a", withText().contains("info and resources"))
+        info.length should be > 0
+
+        And("a link to the complaints and corrections")
+        val complaints = browser.find(".l-footer li a", withText().contains("complaints & corrections"))
+        complaints.length should be > 0
       }
     }
 

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -73,6 +73,7 @@
             <li class="colophon__item"><a data-link-name="contact" href="@LinkTo("/help/contact-us")">contact us</a></li>
             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">securedrop</a></li>
             <li class="colophon__item"><a data-link-name="feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-beta-feedback">feedback</a></li>
+            <li class="colophon__item"><a data-link-name="complaints" href="http://www.theguardian.com/info/complaints-and-corrections">complaints &amp; corrections</a></li>
             <li class="colophon__item"><a data-link-name="terms" href="@LinkTo("/help/terms-of-service")">terms &amp; conditions</a></li>
             <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo("/help/privacy-policy")">privacy policy</a></li>
             <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo("/info/cookies")">cookie policy</a></li>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -69,7 +69,7 @@
         }
             <li class="colophon__item"><a data-link-name="all topics" href="http://www.theguardian.com/index/subjects/a">all topics</a></li>
             <li class="colophon__item"><a data-link-name="all contributors" href="http://www.theguardian.com/index/contributors/a">all contributors</a></li>
-            <li class="colophon__item"><a data-link-name="about" href="http://www.theguardian.com/info">about this site</a></li>
+            <li class="colophon__item"><a data-link-name="info" href="http://www.theguardian.com/info">info and resources</a></li>
             <li class="colophon__item"><a data-link-name="contact" href="@LinkTo("/help/contact-us")">contact us</a></li>
             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">securedrop</a></li>
             <li class="colophon__item"><a data-link-name="feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-beta-feedback">feedback</a></li>


### PR DESCRIPTION
Updates to footer links:

 'about this page' to 'info and resources'
New link 'complaints & corrections'
