### PR TITLE
Added teamcity widget to radiator

### DIFF
--- a/admin/app/assets/javascripts/bootstraps/radiator.js
+++ b/admin/app/assets/javascripts/bootstraps/radiator.js
@@ -163,7 +163,18 @@ define([
                 var viewsPerSecond = Math.round(lastOphanEntry/60);
                 $('.pageviews-per-second').html('(' + viewsPerSecond + ' views/sec)');
             }
-        )
+        );
+
+        // "upgrade" build icons
+        $('.buildConfigurationName').each(function(build){
+            var icon = $('img', build);
+            var success = icon.attr('src').indexOf("success.png") >= 0;
+            var link = $('a', build);
+            var buildName = link[0].innerText;
+            var status = success ? 'success' : 'failure';
+            icon.replaceWith('<div title="' + buildName + '" class="' + status + '">' + buildName + '</div>');
+            link.remove();
+        });
     }
 
     return {

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -15,6 +15,15 @@
         <div class="cost"><strong>$@cost.max.toLong</strong> this month</div>
     </header>
 
+    <div class="">
+        <h2>Teamcity builds</h2>
+
+        @* to add another build just append another &buildTypeId=btXXXX *@
+
+        <script type="text/javascript" src="http://teamcity.guprod.gnm:8111/externalStatus.html?js=1&buildTypeId=bt1304">
+        </script>
+    </div>
+
     <div class="pingdom-wrapper">
         <h2>Pingdom <small>(external monitoring of our host names)</small></h2>
         <ul id="pingdom"></ul>

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -15,18 +15,18 @@
         <div class="cost"><strong>$@cost.max.toLong</strong> this month</div>
     </header>
 
-    <div class="">
-        <h2>Teamcity builds</h2>
-
-        @* to add another build just append another &buildTypeId=btXXXX *@
-
-        <script type="text/javascript" src="http://teamcity.guprod.gnm:8111/externalStatus.html?js=1&buildTypeId=bt1304">
-        </script>
-    </div>
-
     <div class="pingdom-wrapper">
         <h2>Pingdom <small>(external monitoring of our host names)</small></h2>
         <ul id="pingdom"></ul>
+    </div>
+
+    <div class="build-wrapper">
+        <h2>Teamcity builds</h2>
+        @*
+            To add another build just append another &buildTypeId=XXXXXX
+            Note, it will not show unless you enable the "External status widget" for the build in Teamcity
+        *@
+        <script type="text/javascript" src="http://teamcity.guprod.gnm:8111/externalStatus.html?js=1&buildTypeId=bt1304"></script>
     </div>
     
     <div class="expiring-wrapper">

--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -141,7 +141,9 @@ a {
         width: 100%;
     }
     
-    .pingdom-wrapper,
+    .pingdom-wrapper {
+        width: 100%;
+    }
     .expiring-wrapper {
         float: left;
         width: 50%;
@@ -154,11 +156,18 @@ a {
     }
 }
 
-/* Teamcity widget (we do not have control over these class names) */
+/* Teamcity widget */
+.build-wrapper {
+    float: left;
+    width: 50%;
+}
+
+/*(we do not have control over these class names) */
 .buildNumberDate, .buildResults, .tcTD_projectName {
     display: none;
 }
-.tcTable tr {
+
+.tcTable, .tcTable tr {
     display: inline-block;
 }
 
@@ -170,5 +179,23 @@ a {
     color: #999;
     text-decoration: none;
 }
+
+.buildConfigurationName .success {
+    background-color: #B8FAA0;
+    padding: 3px 3px 3px 3px;
+    margin-right: 5px;
+    width: 30px;
+    height: 30px;
+    font-size: 0;
+}
+
+.buildConfigurationName .failure {
+    background-color: red;
+    padding: 3px 3px 3px 3px;
+    margin-right: 5px;
+    height: 30px;
+    color: white;
+}
+
 
 

--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -154,3 +154,21 @@ a {
     }
 }
 
+/* Teamcity widget (we do not have control over these class names) */
+.buildNumberDate, .buildResults, .tcTD_projectName {
+    display: none;
+}
+.tcTable tr {
+    display: inline-block;
+}
+
+.buildTypeIcon {
+   width: 32px;
+}
+
+.buildConfigurationName a {
+    color: #999;
+    text-decoration: none;
+}
+
+


### PR DESCRIPTION
Adds the standard Teamcity build widget. I went with the widget instead of the API to avoid needing to configure and expose usernames and passwords.

~~I have just tweaked its style a bit mainly by hiding things.~~

~~The icon is a bit low res, might look into replacing it.~~

~~Screenshot will follow~~

![teamcity](https://cloud.githubusercontent.com/assets/76709/4177781/ee7d321e-365e-11e4-9d7c-eb19cdd976af.png)
