### PR TITLE
Remove childrens book popular switch

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -427,7 +427,7 @@ define([
             if (!config.isMedia) {
                 return;
             }
-            if (config.page.section === 'childrens-books-site' && config.switches.childrensBooksHidePopular) {
+            if (config.page.section === 'childrens-books-site') {
                 $('.content__secondary-column--media').addClass('u-h');
             } else {
                 var mostViewed = new Component();

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -304,11 +304,6 @@ object Switches extends Collections {
     safeState = On, sellByDate = new LocalDate(2014, 9, 30)
   )
 
-  val ChildrensBooksSwitch = Switch("Feature", "childrens-books-hide-popular",
-    "If switched on, video pages in the childrens books section will not show popular videos",
-    safeState = On, sellByDate = new LocalDate(2014, 9, 8)
-  )
-
   // A/B Tests
 
   val ABHighCommercialComponent = Switch("A/B Tests", "ab-high-commercial-component",
@@ -422,7 +417,6 @@ object Switches extends Collections {
     ABSoulmatesLabelling,
     EnhancedMediaPlayerSwitch,
     BreakingNewsSwitch,
-    ChildrensBooksSwitch,
     MetricsSwitch,
     FootballFeedRecorderSwitch
   )


### PR DESCRIPTION
Remove switch, but keep the feature. It should always be on.
