### PR TITLE
Refuse to press fronts if Content API is returning empty back fills

### DIFF
--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -53,6 +53,9 @@ case class Collection(curated: Seq[Content],
                       updatedBy: Option[String],
                       updatedEmail: Option[String]) extends implicits.Collections with CollectionItems {
   override lazy val items: Seq[Content] = (curated ++ editorsPicks ++ mostViewed ++ results).distinctBy(_.url)
+
+  def isBackFillEmpty =
+    (editorsPicks ++ mostViewed ++ results).isEmpty
 }
 
 object Collection {

--- a/facia-press/app/frontpress/FrontPress.scala
+++ b/facia-press/app/frontpress/FrontPress.scala
@@ -40,8 +40,12 @@ trait FrontPress extends Logging {
     }
 
   def generateJson(id: String, seoData: SeoData, collections: Iterable[(Config, Collection)]): Try[JsObject] = {
-    if (collections.flatMap(_._2.items).isEmpty) {
-      val errorMessage = s"Tried to generate pressed JSON for front $id but all collections were empty - aborting!"
+    val collectionsWithBackFills = collections.toList collect {
+      case (config, collection) if config.contentApiQuery.isDefined => collection
+    }
+
+    if (collectionsWithBackFills.nonEmpty && collectionsWithBackFills.forall(_.isBackFillEmpty)) {
+      val errorMessage = s"Tried to generate pressed JSON for front $id but all back fills were empty - aborting!"
       log.error(errorMessage)
       Failure(new RuntimeException(errorMessage))
     } else {

--- a/facia-press/test/frontpress/FrontPressTest.scala
+++ b/facia-press/test/frontpress/FrontPressTest.scala
@@ -1,0 +1,69 @@
+package frontpress
+
+import model._
+import Config.emptyConfig
+import org.scalatest.{TryValues, Matchers, FlatSpec}
+import com.gu.openplatform.contentapi.model.{Asset, Content => ApiContent, Element => ApiElement, Tag => ApiTag}
+
+class FrontPressTest extends FlatSpec with Matchers with TryValues {
+  val seoDataFixture = SeoData(
+    "",
+    "",
+    "",
+    None,
+    None
+  )
+
+  val configWithBackFill = emptyConfig.copy(contentApiQuery = Some(""))
+
+  val emptyCollection = Collection(
+    Nil
+  )
+
+  val itemFixture = Content(ApiContentWithMeta(
+    ApiContent(
+      "",
+      None,
+      None,
+      None,
+      "",
+      "",
+      "",
+      None,
+      Nil,
+      Nil,
+      Nil,
+      None
+    )
+  ))
+
+  "generateJson" should "return an error if there are back fills and they are all empty" in {
+    FrontPress.generateJson("", seoDataFixture, List(
+      configWithBackFill -> emptyCollection
+    )).failure.exception.getMessage should include("back fills were empty")
+  }
+
+  it should "not return an error if there are no back fills" in {
+    FrontPress.generateJson("", seoDataFixture, List(
+      emptyConfig -> emptyCollection
+    )) should be a 'success
+  }
+
+  it should "not return an error if there are back fills and at least one has an item in results" in {
+    FrontPress.generateJson("", seoDataFixture, List(
+      configWithBackFill -> emptyCollection.copy(results = Seq(itemFixture))
+    )) should be a 'success
+  }
+
+  it should "not return an error if there are back fills and at least one has an item in most viewed" in {
+    FrontPress.generateJson("", seoDataFixture, List(
+      configWithBackFill -> emptyCollection.copy(mostViewed = Seq(itemFixture))
+    )) should be a 'success
+  }
+
+  it should "not return an error if there are back fills and at least one has an item in editor's picks" in {
+    FrontPress.generateJson("", seoDataFixture, List(
+      configWithBackFill -> emptyCollection.copy(editorsPicks = Seq(itemFixture))
+    )) should be a 'success
+  }
+}


### PR DESCRIPTION
It used to fail to press fronts if they were empty, but this is sometimes a valid scenario (breaking news for instance!)
