### PR TITLE
Change critical CSS conditional logic

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -89,8 +89,8 @@ object Switches extends Collections {
     safeState = On, sellByDate = never
   )
 
-  val CssFromStorageSwitch = Switch("Performance", "css-from-storage",
-    "If this switch is on CSS will be cached in users localStorage and read from there on subsequent requests.",
+  val InlineCriticalCss = Switch("Performance", "inline-critical-css",
+    "If this switch is on critical CSS will be inlined into the head of the document.",
     safeState = On, sellByDate = never
   )
 
@@ -377,7 +377,7 @@ object Switches extends Collections {
     SearchSwitch,
     ReleaseMessageSwitch,
     IdentityProfileNavigationSwitch,
-    CssFromStorageSwitch,
+    InlineCriticalCss,
     FacebookAutoSigninSwitch,
     IdentityFormstackSwitch,
     IdentityAvatarUploadSwitch,

--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -19,7 +19,7 @@
   - Include IE Mobile [|(IEMobile)]
 *@
 <!--[if (gt IE 9)|(IEMobile)]><!-->
-@if(play.Play.isDev()) {
+@if(play.Play.isDev() || !InlineCriticalCss.isSwitchedOn) {
     <link rel="stylesheet" data-reload="head@projectName.map("." + _).getOrElse(".default")" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse(".default") + ".css")" />
 } else {
     <style>

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -96,7 +96,7 @@
             loadFontsFromStorage();
         }
 
-        @if(CssFromStorageSwitch.isSwitchedOn && !play.Play.isDev()) {
+        @if(InlineCriticalCss.isSwitchedOn && !play.Play.isDev()) {
             function loadCssFromStorage() {
                 var c = localStorage.getItem('gu.css.@Static("stylesheets/global.css").md5Key'), s, head;
                 if(c) {

--- a/common/app/views/fragments/loadCss.scala.html
+++ b/common/app/views/fragments/loadCss.scala.html
@@ -1,7 +1,7 @@
 @()(implicit request: RequestHeader)
 @import conf.Switches._
 
-@if(CssFromStorageSwitch.isSwitchedOn && !play.Play.isDev()) {
+@if(InlineCriticalCss.isSwitchedOn && !play.Play.isDev()) {
     @*
       - Include any browser [<!-->]
       - Exclude IE < 10 [(gt IE 9)]


### PR DESCRIPTION
I'm updating my slides for [CSSConf](http://2014.cssconf.eu/) this week, and needed the ability to turn off CSS being inlined into the `<head>` of the document to generate a speed comparison. We current disable it by default in `Play.isDev()` mode but cannot in production. Therefore, this PR does two things:
- Rename the switch to be more explicit of its intentions
- Add the switch to the conditional logic surrounding the inline process.

This will enable me to turn off the switch in CODE and use webpagetest.org to generate this [timeline video](https://speakerdeck.com/patrickhamann/css-and-the-critical-path-cssconf-may-2014?slide=32) again.
