### PR TITLE
Only try show lightbox if this is actually a gallery

### DIFF
--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -75,7 +75,7 @@ define([
 
             // Load gallery straight away if url contains a direct image link
             var urlParams = url.getUrlVars();
-            if (urlParams.index) {
+            if (urlParams.index && config.page.contentType === 'Gallery') {
                 this.loadGallery({
                     url: '/' + config.page.pageId,
                     startingImage: parseInt(urlParams.index, 10)


### PR DESCRIPTION
At the moment appending `?index=1` to any page other than a gallery will try fire off the lightbox only to error.

```
http://www.theguardian.com/sport/cycling?index=2&view=responsive
```

![gallery](https://cloud.githubusercontent.com/assets/76709/4197063/517707bc-37e2-11e4-9b75-8786a5860011.png)
