### PR TITLE
use bundle when compiling sass

### DIFF
--- a/grunt-configs/sass.js
+++ b/grunt-configs/sass.js
@@ -6,7 +6,8 @@ module.exports = function(grunt, options) {
             style: 'compressed',
             sourcemap: options.isDev,
             noCache: true,
-            quiet: options.isDev ? false : true
+            quiet: options.isDev ? false : true,
+            bundleExec: true
         },
         compileStyleguide: {
             files: [{


### PR DESCRIPTION
this way we actually compile sass with version specified in the gem file :gem: :file_folder:  
