### PR TITLE
Fix Page Skins Bug

### DIFF
--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -47,7 +47,7 @@ trait DfpAgent {
   def hasInlineMerchandise(tags: Seq[Tag]): Boolean = tags exists inlineMerchandisingTargetedTags.hasTag
 
   def isPageSkinned(adUnitWithoutRoot: String, edition: Edition): Boolean = {
-    if (adUnitWithoutRoot endsWith "front") {
+    if (isValidForNextGenPageSkin(adUnitWithoutRoot)) {
       val adUnitWithRoot: String = s"$dfpAdUnitRoot/$adUnitWithoutRoot"
 
       def targetsAdUnitAndMatchesTheEdition(sponsorship: PageSkinSponsorship) = {

--- a/common/app/dfp/PageSkinSponsorship.scala
+++ b/common/app/dfp/PageSkinSponsorship.scala
@@ -70,7 +70,7 @@ object PageSkinSponsorship {
 case class PageSkinSponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[PageSkinSponsorship]) {
 
   val (deliverableAndTestSponsorships, legacySponsorships) = sponsorships partition { sponsorship =>
-    sponsorship.adUnits.exists(adUnit => adUnit.endsWith("/front") || adUnit.endsWith("/front/ng")) && (!sponsorship.isR2Only)
+    sponsorship.adUnits.exists(isValidForNextGenPageSkin) && (!sponsorship.isR2Only)
   }
   val (testSponsorships, deliverableSponsorships) = deliverableAndTestSponsorships partition (_.targetsAdTest)
 }

--- a/common/app/dfp/package.scala
+++ b/common/app/dfp/package.scala
@@ -1,0 +1,5 @@
+package object dfp {
+
+  def isValidForNextGenPageSkin(adUnit: String): Boolean = adUnit.endsWith("/front") || adUnit.endsWith("/front/ng")
+
+}

--- a/common/app/model/AdSuffixHandlingForFronts.scala
+++ b/common/app/model/AdSuffixHandlingForFronts.scala
@@ -9,13 +9,13 @@ trait AdSuffixHandlingForFronts extends MetaData{
   }
 
   def extractAdUnitSuffixFrom(path: String) = {
-    val frontSuffixList = List("front")
+    val frontSuffixList = List("front", "ng")
     val tagPageSuffixList = List("subsection")
 
     path.split("/").toList match {
       case cc :: Nil  if supportedCountries contains cc => (cc :: frontSuffixList).mkString("/")
-      case cc :: bitsAfterTheEdition if (supportedCountries.contains(cc) &&
-        bitsAfterTheEdition == List(section))=> (section :: frontSuffixList).mkString("/")
+      case cc :: bitsAfterTheEdition if supportedCountries.contains(cc) &&
+        bitsAfterTheEdition == List(section) => (section :: frontSuffixList).mkString("/")
       case nonEditionalisedPath if nonEditionalisedPath == List(section) => (section :: frontSuffixList).mkString("/")
       case _  => (section :: tagPageSuffixList).mkString("/")
     }

--- a/common/test/model/AdSuffixHandlingForFrontsTest.scala
+++ b/common/test/model/AdSuffixHandlingForFrontsTest.scala
@@ -36,15 +36,15 @@ class AdSuffixHandlingForFrontsTest extends FlatSpec with Matchers  {
 
 
   "Editionalised Network Front pages" should "have editions in the ad unit suffix and end with 'front'" in {
-    NetworkFronts.extractAdUnitSuffixFrom("uk") should equal("uk/front")
+    NetworkFronts.extractAdUnitSuffixFrom("uk") should equal("uk/front/ng")
   }
 
   "Editionalised Section fronts" should "end with front, and do not have editions in the ad unit suffix" in {
-    SectionFront.extractAdUnitSuffixFrom("uk/business") should equal("business/front")
+    SectionFront.extractAdUnitSuffixFrom("uk/business") should equal("business/front/ng")
   }
 
   "Non-editionlised section fronts" should "end with 'front'" in {
-    SectionFront.extractAdUnitSuffixFrom("business") should equal("business/front")
+    SectionFront.extractAdUnitSuffixFrom("business") should equal("business/front/ng")
   }
 
   "Tag Fronts ad units" should "be the section, plus the word 'subsection'" in {


### PR DESCRIPTION
Fronts misidentified their ad units.  They had no 'ng' suffix.
So they weren't being targeted by DFP.
