### PR TITLE
Fix missing image from Open Graph

### DIFF
--- a/admin/app/jobs/RebuildIndexJob.scala
+++ b/admin/app/jobs/RebuildIndexJob.scala
@@ -40,16 +40,15 @@ object RebuildIndexJob extends ExecutionContexts with Logging {
 
     /** Subjects are indexed both alphabetically and by their parent section */
     (keywords andThen series).run(Enumeratee.zip(bySection, byWebTitle)) map { case (sectionMap, alphaMap) =>
-        blocking {
-          saveToS3("keywords", toPages(alphaMap)(alphaTitle))
-          saveToS3("keywords_by_section", toPages(sectionMap)(ValidSections(_)))
-        }
+      blocking {
+        saveToS3("keywords", toPages(alphaMap)(alphaTitle))
+        saveToS3("keywords_by_section", toPages(sectionMap)(ValidSections(_)))
+      }
     }
   }
 
   def rebuildContributorIndex() = {
-    ContentApiTagsEnumerator.enumerateTagTypeFiltered("contributor")
-      .run(byWebTitle) map { alphaMap =>
+    ContentApiTagsEnumerator.enumerateTagTypeFiltered("contributor").run(byWebTitle) map { alphaMap =>
       blocking {
         saveToS3("contributors", toPages(alphaMap)(alphaTitle))
       }
@@ -59,8 +58,7 @@ object RebuildIndexJob extends ExecutionContexts with Logging {
   implicit class RichFuture[A](future: Future[A]) {
     def withErrorLogging = {
       future onFailure {
-        case throwable: Throwable =>
-          log.error("Error rebuilding index", throwable)
+        case throwable: Throwable => log.error("Error rebuilding index", throwable)
       }
 
       future

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -66,7 +66,7 @@ case class Tag(private val delegate: ApiTag, override val pagination: Option[Pag
 
   override def openGraph: Map[String, String] = super.openGraph ++
     Map("og:title" -> webTitle) ++
-    openGraphDescription.map { s => Map("og:description" -> s)}.getOrElse(Map())
+    openGraphDescription.map { s => Map("og:description" -> s) }.getOrElse(Map()) ++
     openGraphImage.map { s => Map("og:image" -> s)}.getOrElse(Map())
 
   override def cards: List[(String, String)] = super.cards ++

--- a/common/app/model/TagIndexPage.scala
+++ b/common/app/model/TagIndexPage.scala
@@ -85,8 +85,8 @@ case class TagIndexPage(
     Maps.insertWith(acc, tag.webTitle, 1) { _ + _ }
   }
 
-  def hasDuplicateWebTitle(tagDefiniton: TagDefinition) =
-    countsByWebTitle.get(tagDefiniton.webTitle).exists(_ > 1)
+  def hasDuplicateWebTitle(tagDefinition: TagDefinition) =
+    countsByWebTitle.get(tagDefinition.webTitle).exists(_ > 1)
 
   def indexTitle(tagDefinition: TagDefinition) =
     tagDefinition.webTitle + (if (hasDuplicateWebTitle(tagDefinition))


### PR DESCRIPTION
``` scala
 override def openGraph: Map[String, String] = super.openGraph ++
    Map("og:title" -> webTitle) ++
    openGraphDescription.map { s => Map("og:description" -> s) }.getOrElse(Map()) // <-- OH NO
    openGraphImage.map { s => Map("og:image" -> s)}.getOrElse(Map())
```

Because the `++` was missing there, it wasn't actually appending the image to the open graph data.

This manifested itself as a bizarre error on the admin box when rebuilding indexes. As that line wasn't part of the method definition it was invoked when the `Tag` object was initialised. One of the contributor tags contains crap data for the image url (thanks R2, for validating things like this!) -- i.e., it contains spaces, and this is passed through into the Java `Url` constructor somewhere further down the line, without anybody bothering to catch the exception it throws when something doesn't look like an url ...

So, yeah.

Also some unnecessary style changes that happened while I was investigating :angel: 
