### PR TITLE
Automatically set fronts' editorial type in facia-tool

### DIFF
--- a/facia-press/app/frontpress/FrontPress.scala
+++ b/facia-press/app/frontpress/FrontPress.scala
@@ -39,6 +39,13 @@ trait FrontPress extends Logging {
       json
     }
 
+  def generateJson(id: String, futureFront: Future[Iterable[(Config, Collection)]]): Future[JsObject] = {
+    for {
+      seoData <- SeoData.getSeoData(id)
+      front <- futureFront
+    } yield generateJson(id, seoData, front).get
+  }
+
   def generateJson(id: String, seoData: SeoData, collections: Iterable[(Config, Collection)]): Try[JsObject] = {
     val collectionsWithBackFills = collections.toList collect {
       case (config, collection) if config.contentApiQuery.isDefined => collection
@@ -57,19 +64,9 @@ trait FrontPress extends Logging {
     }
   }
 
-  def generateLiveJson(id: String): Future[JsObject] = {
-    for {
-      seoData <- SeoData.getSeoData(id)
-      front <- retrieveFrontByPath(id)
-    } yield generateJson(id, seoData, front).get
-  }
+  def generateLiveJson(id: String): Future[JsObject] = generateJson(id, retrieveFrontByPath(id))
 
-  def generateDraftJson(id: String): Future[JsObject] = {
-    for {
-      seoData <- SeoData.getSeoData(id)
-      front <- retrieveDraftFrontByPath(id)
-    } yield generateJson(id, seoData, front).get
-  }
+  def generateDraftJson(id: String): Future[JsObject] = generateJson(id, retrieveDraftFrontByPath(id))
 }
 
 object FrontPress extends FrontPress

--- a/facia-tool/app/services/FaciaPress.scala
+++ b/facia-tool/app/services/FaciaPress.scala
@@ -7,7 +7,6 @@ import common.FaciaToolMetrics.{EnqueuePressFailure, EnqueuePressSuccess}
 import common.{ExecutionContexts, JsonMessageQueue, Logging}
 import common.SQSQueues._
 import conf.Configuration
-import conf.Switches._
 import scala.concurrent.Future
 import scala.util.{Success, Failure}
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -177,7 +177,7 @@
                             attr: {placeholder: placeholders.webTitle},
                             value: props.webTitle"/>
 
-                        <label>SEO title</label>
+                        <label>Meta title</label>
                         <textarea data-bind="
                             attr: {placeholder: placeholders.title},
                             value: props.title"></textarea>
@@ -206,14 +206,6 @@
                         <span class="radio-label">editorial</span>
                         <input type="radio" name="group02" value="commercial" data-bind="checked: props.priority" />
                         <span class="radio-label">commercial</span>
-
-                        <label>Editorial type</label>
-                        <input type="radio" name="group03" data-bind="checkedValue: undefined, checked: props.editorialType" />
-                        <span class="radio-label">keyword</span>
-                        <input type="radio" name="group03" value="series" data-bind="checked: props.editorialType" />
-                        <span class="radio-label">series</span>
-                        <input type="radio" name="group03" value="contributor" data-bind="checked: props.editorialType" />
-                        <span class="radio-label">contributor</span>
 
                         <div class="tools">
                             <span class="tool" data-bind="click: saveProps">Save metadata</span>

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -81,8 +81,8 @@ define([
             }
         }, this);
 
-        this.capiProps.type.subscribe(function (x) {
-            this.props.editorialType(x);
+        this.capiProps.type.subscribe(function (type) {
+            this.props.editorialType(type);
         }, this);
 
         this.provisionalImageUrl = ko.observable();
@@ -159,7 +159,6 @@ define([
 
         if(checkUniqueness && _.filter(vars.model.fronts(), function(front) { return front.id() === self.id(); }).length > 1) {
             this.id(undefined);
-            return;
         }
     };
 
@@ -173,15 +172,18 @@ define([
     };
 
     Front.prototype.openProps = function() {
-        var self = this;
-
         this.state.isOpenProps(true);
         this.collections.items().map(function(collection) { collection.close(); });
 
-        contentApi.fetchMetaForPath(this.id())
-        .done(function(meta) {
+        this.loadCapiProps();
+    };
+
+    Front.prototype.loadCapiProps = function(){
+        var self = this;
+        contentApi.fetchMetaForPath(self.id())
+        .done(function (meta) {
             meta = meta || {};
-            _.each(self.capiProps, function(val, key) {
+            _.each(self.capiProps, function (val, key) {
                 val(meta[key]);
             });
         });
@@ -199,6 +201,11 @@ define([
         collection.parents.push(this);
         this.collections.items.push(collection);
         vars.model.collections.unshift(collection);
+
+        var isNewFront = this.collections.items().length === 1;
+        if(isNewFront){
+            this.loadCapiProps();
+        }
     };
 
     Front.prototype._depopulateCollection = function(collection) {

--- a/facia-tool/public/javascripts/models/config/front.js
+++ b/facia-tool/public/javascripts/models/config/front.js
@@ -49,7 +49,8 @@ define([
         this.capiProps = asObservableProps([
             'section',
             'webTitle',
-            'description']);
+            'description',
+            'type']);
 
         this.state = asObservableProps([
             'isOpen',
@@ -78,6 +79,10 @@ define([
             if (this.id()) {
                 this.setOpen(true);
             }
+        }, this);
+
+        this.capiProps.type.subscribe(function (x) {
+            this.props.editorialType(x);
         }, this);
 
         this.provisionalImageUrl = ko.observable();

--- a/facia-tool/public/javascripts/modules/content-api.js
+++ b/facia-tool/public/javascripts/modules/content-api.js
@@ -185,6 +185,7 @@ function (
                 .filter(function(obj) { return _.isObject(obj); })
                 .reduce(function(m, obj) {
                     m.section = m.section || _.last((obj.id || obj.sectionId).split('/'));
+                    m.type = m.type || obj.type;
                     m.webTitle = m.webTitle || obj.webTitle;
                     m.description = m.description || obj.description; // upcoming in Capi, at time of writing
                     m.title = m.title || obj.title;                   // this may never be added to Capi, or may under another name

--- a/facia-tool/public/javascripts/utils/validate-image-src.js
+++ b/facia-tool/public/javascripts/utils/validate-image-src.js
@@ -10,7 +10,7 @@ define([
      * @param criteria. validation criteria object. defines: maxWidth, minWidth, widthAspectRatio, heightAspectRatio
      * @returns jQuery.Deferred object: rejects with (error) OR resolves with (width, height)
      */
-    var validateImageSrc = function(src, criteria) {
+    function validateImageSrc(src, criteria) {
         var defer = $.Deferred(),
             img,
             defaultCriteria = {
@@ -54,7 +54,7 @@ define([
         }
 
         return defer.promise();
-    };
+    }
 
     return validateImageSrc;
 });


### PR DESCRIPTION
Editorial type represents the Tag type when a Front is created with the same URI and it's used to tweak the UI.

This can be inferred automatically upon creating the Front.

![](http://media2.giphy.com/media/Msh39uPhPKda/200.gif)
