### PR TITLE
Fixes components overlapping content on articles at tablet breakpoint

### DIFF
--- a/common/app/assets/stylesheets/base/_normalize.scss
+++ b/common/app/assets/stylesheets/base/_normalize.scss
@@ -183,7 +183,7 @@ svg:not(:root) {
  */
 
 figure {
-    margin: 1em 40px;
+    margin: 1em 0;
 }
 
 /**

--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -52,8 +52,7 @@
         .content__article-body {
             padding-right: gs-span(1) + $gs-gutter;
 
-            .element,
-            .img--extended,
+            .img--landscape,
             .ad-slot {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
             }

--- a/common/app/assets/stylesheets/module/content/_media.global.scss
+++ b/common/app/assets/stylesheets/module/content/_media.global.scss
@@ -111,8 +111,8 @@
             display: block;
             position: relative;
             width: 100%;
-            max-width: gs-span(8);
-            margin: auto;
+            max-width: gs-span(9);
+            margin: $gs-baseline*2 auto 0;
         }
         @include mq(rightCol) {
             padding-left: $gs-gutter/2;


### PR DESCRIPTION
- Tighter scope for which elements we pull into the right-hand gutter on article pages
- Increases max-width for related content container on video pages
- Changes baseline metrics of <figure> in normalise.scss (causes more problems than it solves)
