### PR TITLE
Understand when the CDN has forced pages to Next Gen

### DIFF
--- a/common/app/assets/javascripts/bootstraps/common.js
+++ b/common/app/assets/javascripts/bootstraps/common.js
@@ -246,7 +246,7 @@ define([
 
             if (
                 config.switches.releaseMessage &&
-                config.page.hasClassicVersion &&
+                config.page.showClassicVersion &&
                 (detect.getBreakpoint() !== 'mobile')
             ) {
                 // force the visitor in to the alpha release for subsequent visits

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,14 +1,15 @@
-@(page: MetaData, showNav: Boolean=true)(implicit request: RequestHeader)
+@(page: model.MetaData, showNav: Boolean=true)(implicit request: RequestHeader)
+@import views.support.HasClassicVersion
 
 @import conf.Switches._
 @import org.joda.time.DateTime
 @import common.Edition
-@import common.editions._
+@import common.LinkTo
+@import common.editions.{Au, Uk, Us}
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
 
-    @if(ReleaseMessageSwitch.isSwitchedOn &&
-        page.hasClassicVersion) {
+    @if(ReleaseMessageSwitch.isSwitchedOn && HasClassicVersion(page)) {
         <div class="site-message--footer is-hidden js-footer-message" data-link-name="release message">
             <div class="gs-container">
                 <div class="site-message__inner">
@@ -80,7 +81,7 @@
             <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo("/help/privacy-policy")">privacy policy</a></li>
             <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo("/info/cookies")">cookie policy</a></li>
 
-        @if(page.hasClassicVersion) {
+        @if(HasClassicVersion(page)) {
             <li class="colophon__item hide-on-mobile">@fragments.mainSiteLink(page, label = "use current version")</li>
             <li class="colophon__item mobile-only">@fragments.mainSiteLink(page, label = "desktop site")</li>
         }

--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -7,7 +7,7 @@
 
 @defining(Edition(request)) { edition =>
 {
-    "page": @Html(Json.stringify(JavaScriptPage(item, request).get)),
+    "page": @Html(Json.stringify(JavaScriptPage(item).get)),
     "switches" : { @{Html(conf.Switches.all.map{ switch =>
             if(conf.Switches.httpSwitches.contains(switch))
                 s""""${CamelCase.fromHyphenated(switch.name)}":${HttpSwitch(switch).isSwitchedOn}"""

--- a/common/app/views/support/HasClassicVersion.scala
+++ b/common/app/views/support/HasClassicVersion.scala
@@ -1,0 +1,11 @@
+package views.support
+
+import model.MetaData
+import play.api.mvc.RequestHeader
+
+object HasClassicVersion {
+  def apply(page: MetaData)(implicit request: RequestHeader): Boolean = {
+    val forcedFromCdn = request.headers.get("X-GU-Next-Gen-Only").exists(_ == "true")
+    page.hasClassicVersion && !forcedFromCdn
+  }
+}

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -11,7 +11,8 @@ import play.api.Play.current
 import play.api.libs.json.{JsBoolean, JsString, Json}
 import play.api.mvc.RequestHeader
 
-case class JavaScriptPage(metaData: MetaData, request: RequestHeader) {
+case class JavaScriptPage(metaData: MetaData)(implicit request: RequestHeader) {
+
   def get = {
     val edition = Edition(request)
 
@@ -35,6 +36,7 @@ case class JavaScriptPage(metaData: MetaData, request: RequestHeader) {
       ("isSSL", JsBoolean(Configuration.environment.secure)),
       ("assetsPath", JsString(Configuration.assets.path)),
       ("hasPageSkin", JsBoolean(metaData.hasPageSkin(edition))),
+      ("showClassicVersion", JsBoolean(HasClassicVersion(metaData))),
       ("shouldHideAdverts", JsBoolean(metaData match {
         case c: Content if c.shouldHideAdverts => true
         case _ => false


### PR DESCRIPTION
In this case we do not want "classic version" links
