### PR TITLE
Fix front press order

### DIFF
--- a/facia-press/app/frontpress/FrontPress.scala
+++ b/facia-press/app/frontpress/FrontPress.scala
@@ -31,7 +31,7 @@ trait FrontPress extends Logging {
   def generateJson(id: String,
                    seoData: SeoData,
                    frontProperties: FrontProperties,
-                   collections: Iterable[(Config, Collection)]): Try[JsObject] = {
+                   collections: Seq[(Config, Collection)]): Try[JsObject] = {
     val collectionsWithBackFills = collections.toList collect {
       case (config, collection) if config.contentApiQuery.isDefined => collection
     }
@@ -53,7 +53,7 @@ trait FrontPress extends Logging {
     }
   }
 
-  private def retrieveCollectionsById(id: String, parseCollection: ParseCollection): Future[Iterable[(Config, Collection)]] = {
+  private def retrieveCollectionsById(id: String, parseCollection: ParseCollection): Future[Seq[(Config, Collection)]] = {
     val collectionIds: List[Config] = ConfigAgent.getConfigForId(id).getOrElse(Nil)
     val collections = collectionIds.map(config => parseCollection.getCollection(config.id, config, Uk).map((config, _)))
     Future.sequence(collections)

--- a/facia-press/app/frontpress/FrontPress.scala
+++ b/facia-press/app/frontpress/FrontPress.scala
@@ -53,10 +53,10 @@ trait FrontPress extends Logging {
     }
   }
 
-  private def retrieveCollectionsById(id: String, parseCollection: ParseCollection): Future[Map[Config, Collection]] = {
+  private def retrieveCollectionsById(id: String, parseCollection: ParseCollection): Future[Iterable[(Config, Collection)]] = {
     val collectionIds: List[Config] = ConfigAgent.getConfigForId(id).getOrElse(Nil)
     val collections = collectionIds.map(config => parseCollection.getCollection(config.id, config, Uk).map((config, _)))
-    Future.sequence(collections).map(_.toMap)
+    Future.sequence(collections)
   }
 
   private def generateJson(id: String, parseCollection: ParseCollection): Future[JsObject] =


### PR DESCRIPTION
#5921 completely broke the order of `FrontPress`ing by the arbitrary use of a `Map`.

It was then never tested on any of the environments, left in a broken state on `CODE` AND left undeployed to `PROD` all weekend.

This changes back to something that actually guarantees sequence. Before it was `Iterable` coming from a `List`, but now we are being more explicit by the use of `Seq`.

As discussed, we are probably going to need tests for this part of the code, as it is the heart of our fronts and if it went to `PROD` could have been quite bad.

@robertberry @tudorraul 
