### PR TITLE
adding background colour to facia-container when page-skins are present

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_facia-container.scss
+++ b/common/app/assets/stylesheets/module/facia/_facia-container.scss
@@ -1,3 +1,7 @@
 .facia-container {
     @include clearfix;
 }
+
+.has-page-skin .facia-container--layout-front {
+    background-color: #ffffff;
+}


### PR DESCRIPTION
This fixes a problem where page-skins that work on R2 sometimes look wrong on NGW, it sets the background of facia-container--layout-front to white if there is a page-skin present. Coloured containers are un-effected by this.

Before;
![screen shot 2014-09-15 at 14 16 50](https://cloud.githubusercontent.com/assets/1303616/4271679/097dc218-3cdb-11e4-84cb-5b8fe6786989.png)

After;
![screen shot 2014-09-15 at 14 16 42](https://cloud.githubusercontent.com/assets/1303616/4271682/116cf17e-3cdb-11e4-8003-d4ecfc844a5c.png)
