### PR TITLE
Use new slice names

### DIFF
--- a/facia/app/slices/DynamicContainer.scala
+++ b/facia/app/slices/DynamicContainer.scala
@@ -21,18 +21,18 @@ private [slices] trait DynamicContainer {
     val veryBigs = byGroup.getOrElse(2, Seq.empty)
 
     if (huges.length > 0) {
-      Some((Godzilla, stories.drop(1)))
+      Some((MegaFull, stories.drop(1)))
     } else if (veryBigs.length == 1) {
-      Some((Mechagodzilla, stories.drop(1)))
+      Some((Full, stories.drop(1)))
     } else if (veryBigs.length >= 2) {
       val storiesInSlice = veryBigs.take(2)
 
       if (storiesInSlice.map(_.isBoosted).distinct.length == 1) {
-        Some((Negadon, stories.drop(2)))
+        Some((HalfHalf, stories.drop(2)))
       } else if (storiesInSlice(0).isBoosted) {
-        Some((Rodan, stories.drop(2)))
+        Some((ThreeQuarterQuarter, stories.drop(2)))
       } else {
-        Some((Pulgasari, stories.drop(2)))
+        Some((QuarterThreeQuarter, stories.drop(2)))
       }
     } else {
       None

--- a/facia/app/slices/DynamicFast.scala
+++ b/facia/app/slices/DynamicFast.scala
@@ -11,18 +11,18 @@ object DynamicFast extends DynamicContainer {
     } else {
       Some(
         if (stories.forall(_.group == 0)) {
-          Mothra
+          QlQlQlQl
         } else if (isFirstBoosted) {
           bigs.length match {
-            case 1 => Ghidorah
-            case _ => Anguirus
+            case 1 => HalfQl4Ql4
+            case _ => HalfQuarterQl2Ql3
           }
         } else {
           bigs.length match {
-            case 1 => Reptilicus
-            case 2 => Gappa
-            case 3 => Daimajin
-            case _ => Ultraman
+            case 1 => QuarterQlQlQl
+            case 2 => QuarterQuarterQlQl
+            case 3 => QuarterQuarterQuarterQl
+            case _ => QuarterQuarterQuarterQuarter
           }
         }
       )

--- a/facia/app/slices/DynamicSlow.scala
+++ b/facia/app/slices/DynamicSlow.scala
@@ -8,11 +8,11 @@ object DynamicSlow extends DynamicContainer {
       None
     } else {
       Some(if (bigs.length == 0) {
-        Minilla
+        Hl4Hl4
       } else if (bigs.length == 1) {
-        Gigan
+        Hl4Half
       } else {
-        Destoroyah
+        Hl4QuarterQuarter
       })
     }
   }

--- a/facia/app/slices/Slice.scala
+++ b/facia/app/slices/Slice.scala
@@ -8,35 +8,35 @@ sealed trait Slice
  * |________|________|________|________|
  * |________|________|________|________|
  */
-case object Mothra extends Slice
+case object QlQlQlQl extends Slice
 
 /* .________.________.________.________.
  * |########|________|________|________|
  * |########|________|________|________|
  * |________|________|________|________|
  */
-case object Reptilicus extends Slice
+case object QuarterQlQlQl extends Slice
 
 /* .________.________.________.________.
  * |########|########|________|________|
  * |########|########|________|________|
  * |________|________|________|________|
  */
-case object Gappa extends Slice
+case object QuarterQuarterQlQl extends Slice
 
 /* .________.________.________.________.
  * |########|########|########|________|
  * |########|########|########|________|
  * |________|________|________|________|
  */
-case object Daimajin extends Slice
+case object QuarterQuarterQuarterQl extends Slice
 
 /* .________.________.________.________.
  * |########|########|########|########|
  * |########|########|########|########|
  * |________|________|________|________|
  */
-case object Ultraman extends Slice
+case object QuarterQuarterQuarterQuarter extends Slice
 
 /* ._________________.________.________.
  * |#################|________|________|
@@ -44,7 +44,7 @@ case object Ultraman extends Slice
  * |#################|________|________|
  * |_________________|________|________|
  */
-case object Ghidorah extends Slice
+case object HalfQl4Ql4 extends Slice
 
 /* .________.________.________.________.
  * |#################|########|________|
@@ -52,7 +52,7 @@ case object Ghidorah extends Slice
  * |#################|________|________|
  * |_________________|________|________|
  */
-case object Anguirus extends Slice
+case object HalfQuarterQl2Ql3 extends Slice
 
 /* ._________________._________________.
  * |_________________|_________________|
@@ -60,7 +60,7 @@ case object Anguirus extends Slice
  * |_________________|_________________|
  * |_________________|_________________|
  */
-case object Minilla extends Slice
+case object Hl4Hl4 extends Slice
 
 /* ._________________.________.________.
  * |_________________|########|########|
@@ -68,7 +68,7 @@ case object Minilla extends Slice
  * |_________________|        |        |
  * |_________________|________|________|
  */
-case object Destoroyah extends Slice
+case object Hl4QuarterQuarter extends Slice
 
 /* ._________________._________________.
  * |_________________|#################|
@@ -76,7 +76,7 @@ case object Destoroyah extends Slice
  * |_________________|#################|
  * |_________________|_________________|
  */
-case object Gigan extends Slice
+case object Hl4Half extends Slice
 
 /* .__________________________.________.
  * |        ##################|########|
@@ -85,7 +85,7 @@ case object Gigan extends Slice
  * |        ##################|        |
  * `--------------------------'--------'
  */
-case object Rodan extends Slice
+case object ThreeQuarterQuarter extends Slice
 
 /* .________.__________________________.
  * |########|##################        |
@@ -94,7 +94,7 @@ case object Rodan extends Slice
  * |        |##################        |
  * `--------'--------------------------'
  */
-case object Pulgasari extends Slice
+case object QuarterThreeQuarter extends Slice
 
 /* ._________________._________________.
  * |#################|#################|
@@ -103,7 +103,7 @@ case object Pulgasari extends Slice
  * |                 |                 |
  * `-----------------'-----------------'
  */
-case object Negadon extends Slice
+case object HalfHalf extends Slice
 
 /* .___________________________________.
  * |         ##########################|
@@ -112,7 +112,7 @@ case object Negadon extends Slice
  * |         ##########################|
  * `-----------------------------------'
  */
-case object Mechagodzilla extends Slice
+case object Full extends Slice
 
 /* .___________________________________.
  * |###################################|
@@ -121,4 +121,4 @@ case object Mechagodzilla extends Slice
  * |                                   |
  * `-----------------------------------'
  */
-case object Godzilla extends Slice
+case object MegaFull extends Slice

--- a/facia/app/slices/Slice.scala
+++ b/facia/app/slices/Slice.scala
@@ -112,7 +112,7 @@ case object HalfHalf extends Slice
  * |         ##########################|
  * `-----------------------------------'
  */
-case object Full extends Slice
+case object FullThreeQuarterImage extends Slice
 
 /* .___________________________________.
  * |###################################|
@@ -121,4 +121,4 @@ case object Full extends Slice
  * |                                   |
  * `-----------------------------------'
  */
-case object MegaFull extends Slice
+case object Full extends Slice

--- a/facia/test/slices/DynamicContainerTest.scala
+++ b/facia/test/slices/DynamicContainerTest.scala
@@ -72,44 +72,44 @@ trait DynamicContainerTest extends FlatSpec with Matchers with GeneratorDrivenPr
     }
   }
 
-  it should "for 0 huge and n >= 2 very big, with 1st boosted, return Rodan as the optional 1st slice" in {
+  it should "for 0 huge and n >= 2 very big, with 1st boosted, return ThreeQuarterQuarter as the optional 1st slice" in {
     forAll(storySeqGen(2)) { stories: Seq[Story] =>
       slicesFor(
         Story(2, isBoosted = true) +: Story.unboosted(2) +: stories
-      ).value.headOption.value shouldEqual Rodan
+      ).value.headOption.value shouldEqual ThreeQuarterQuarter
     }
   }
 
-  it should "for 0 huge and n >= 2 very big, with 2nd boosted, return Pulgasari as the optional 1st slice" in {
+  it should "for 0 huge and n >= 2 very big, with 2nd boosted, return QuarterThreeQuarter as the optional 1st slice" in {
     forAll(storySeqGen(1)) { stories: Seq[Story] =>
       slicesFor(
         Story.unboosted(2) +: Story(2, isBoosted = true) +: stories
-      ).value.headOption.value shouldEqual Pulgasari
+      ).value.headOption.value shouldEqual QuarterThreeQuarter
     }
   }
 
-  it should "for 0 huge and n >= 2 very big, without boosting, return Negadon as the optional 1st slice" in {
+  it should "for 0 huge and n >= 2 very big, without boosting, return HalfHalf as the optional 1st slice" in {
     forAll(storySeqGen(2)) { stories: Seq[Story] =>
-      slicesFor(Seq.fill(2)(Story.unboosted(2)) ++ stories).value.headOption.value shouldEqual Negadon
+      slicesFor(Seq.fill(2)(Story.unboosted(2)) ++ stories).value.headOption.value shouldEqual HalfHalf
     }
   }
 
-  it should "for 0 huge and n >= 2 very big, with first 2 boosted, return Negadon as the optional 1st slice" in {
+  it should "for 0 huge and n >= 2 very big, with first 2 boosted, return HalfHalf as the optional 1st slice" in {
     forAll(storySeqGen(2)) { stories: Seq[Story] =>
-      slicesFor(Seq.fill(2)(Story(2, isBoosted = true)) ++ stories).value.headOption.value shouldEqual Negadon
+      slicesFor(Seq.fill(2)(Story(2, isBoosted = true)) ++ stories).value.headOption.value shouldEqual HalfHalf
     }
   }
 
-  it should "for 0 huge and one very big, return Mechagodzilla as the optional first slice" in {
+  it should "for 0 huge and one very big, return Full as the optional first slice" in {
     forAll { stories: Seq[Story] =>
-      slicesFor(Story.unboosted(2) +: stories.dropWhile(_.group >= 2)).value.headOption.value shouldEqual Mechagodzilla
+      slicesFor(Story.unboosted(2) +: stories.dropWhile(_.group >= 2)).value.headOption.value shouldEqual Full
     }
   }
 
-  it should "for any number of huge stories >= 1, return Godzilla as the optional first slice" in {
+  it should "for any number of huge stories >= 1, return MegaFull as the optional first slice" in {
     forAll { stories: Seq[Story] =>
       whenever(stories.headOption.exists(_.group == 3)) {
-        slicesFor(stories).value.headOption.value shouldEqual Godzilla
+        slicesFor(stories).value.headOption.value shouldEqual MegaFull
       }
     }
   }

--- a/facia/test/slices/DynamicFastTest.scala
+++ b/facia/test/slices/DynamicFastTest.scala
@@ -6,26 +6,26 @@ import org.scalatest.OptionValues._
 class DynamicFastTest extends DynamicContainerTest {
   override val slicesFor: (Seq[Story]) => Option[Seq[Slice]] = DynamicFast.slicesFor
 
-  it should "for n standard (0) items return Mothra" in {
+  it should "for n standard (0) items return QlQlQlQl" in {
     forAll(Gen.choose(1, 20)) { n: Int =>
       slicesFor(Seq.fill(n)(0).map(Story.unboosted)).value shouldEqual Seq(
-        Mothra
+        QlQlQlQl
       )
     }
   }
 
-  it should "for one big unboosted item and n standard return Reptilicus" in {
+  it should "for one big unboosted item and n standard return QuarterQlQlQl" in {
     forAll(Gen.choose(0, 20)) { n: Int =>
       slicesFor((1 +: Seq.fill(n)(0)).map(Story.unboosted)).value shouldEqual Seq(
-        Reptilicus
+        QuarterQlQlQl
       )
     }
   }
 
-  it should "for two big unboosted items and m standard return Gappa" in {
+  it should "for two big unboosted items and m standard return QuarterQuarterQlQl" in {
     forAll(Gen.choose(0, 20)) { m: Int =>
       slicesFor((Seq.fill(2)(1) ++ Seq.fill(m)(0)).map(Story.unboosted)).value shouldEqual Seq(
-        Gappa
+        QuarterQuarterQlQl
       )
     }
   }
@@ -33,33 +33,33 @@ class DynamicFastTest extends DynamicContainerTest {
   it should "for three big unboosted items and m standard return Daimaijin" in {
     forAll(Gen.choose(0, 20)) { m: Int =>
       slicesFor((Seq.fill(3)(1) ++ Seq.fill(m)(0)).map(Story.unboosted)).value shouldEqual Seq(
-        Daimajin
+        QuarterQuarterQuarterQl
       )
     }
   }
 
-  it should "for n > 3 big unboosted items and m standard return Ultraman" in {
+  it should "for n > 3 big unboosted items and m standard return QuarterQuarterQuarterQuarter" in {
     forAll(Gen.choose(4, 20), Gen.choose(0, 20)) { (n: Int, m: Int) =>
       slicesFor((Seq.fill(n)(1) ++ Seq.fill(m)(0)).map(Story.unboosted)).value shouldEqual Seq(
-        Ultraman
+        QuarterQuarterQuarterQuarter
       )
     }
   }
 
-  it should "for one big boosted item and n standard return Ghidorah" in {
+  it should "for one big boosted item and n standard return HalfQl4Ql4" in {
     forAll(Gen.choose(1, 20)) { n: Int =>
       slicesFor(Story(1, isBoosted = true) +: Seq.fill(n)(Story.unboosted(0))).value shouldEqual Seq(
-        Ghidorah
+        HalfQl4Ql4
       )
     }
   }
 
-  it should "for one big boosted, n >= 1 big, and m standards, return Anguirus" in {
+  it should "for one big boosted, n >= 1 big, and m standards, return HalfQuarterQl2Ql3" in {
     forAll(Gen.choose(1, 20), Gen.choose(1, 20)) { (m: Int, n: Int) =>
       slicesFor(
         Story(1, isBoosted = true) +:
           (Seq.fill(m)(Story.unboosted(1)) ++
-            Seq.fill(n)(Story.unboosted(0)))).value shouldEqual Seq(Anguirus)
+            Seq.fill(n)(Story.unboosted(0)))).value shouldEqual Seq(HalfQuarterQl2Ql3)
     }
   }
 }

--- a/facia/test/slices/DynamicSlowTest.scala
+++ b/facia/test/slices/DynamicSlowTest.scala
@@ -8,26 +8,26 @@ import common.Seqs._
 class DynamicSlowTest extends DynamicContainerTest {
   override val slicesFor: (Seq[Story]) => Option[Seq[Slice]] = DynamicSlow.slicesFor
 
-  it should "for only standard items return Minilla" in {
+  it should "for only standard items return Hl4Hl4" in {
     forAll(storySeqGen(0)) { stories: Seq[Story] =>
       whenever(stories.nonEmpty) {
-        slicesFor(stories).value.headOption.value shouldEqual Minilla
+        slicesFor(stories).value.headOption.value shouldEqual Hl4Hl4
       }
     }
   }
 
-  it should "for a single big and n standards, return Gigan" in {
+  it should "for a single big and n standards, return Hl4Half" in {
     forAll(storySeqGen(0), arbitrary[Boolean]) { (stories: Seq[Story], isBoosted: Boolean) =>
-      slicesFor(Story(1, isBoosted) +: stories).value.headOption.value shouldEqual Gigan
+      slicesFor(Story(1, isBoosted) +: stories).value.headOption.value shouldEqual Hl4Half
     }
   }
 
-  it should "for n > 1 bigs and m standards, return Destoroyah" in {
+  it should "for n > 1 bigs and m standards, return Hl4QuarterQuarter" in {
     forAll(storySeqGen(1)) { stories: Seq[Story] =>
       val bigs = stories.countWhile(_.group == 1)
 
       whenever(bigs > 1) {
-        slicesFor(stories).value.headOption.value shouldEqual Destoroyah
+        slicesFor(stories).value.headOption.value shouldEqual Hl4QuarterQuarter
       }
     }
   }


### PR DESCRIPTION
Replaces the slice names with something truly monstrous

@sammorrisdesign @kungpochicken I ended up doing full item names as words, because `QlQlQlQl` and `QQlQlQl` were kind of hard to differentiate ... not sure if this is just stupid though, so happy to go for whatever.
