### PR TITLE
various gallery/lightbox fixes/tweaks

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -1,5 +1,5 @@
 @(gallery: model.Gallery, related: model.RelatedContent, index: Int)(implicit request: RequestHeader)
-<div class="l-side-margins l-side-margins--layout-content">
+<div class="l-side-margins l-side-margins--layout-content l-side-margins--media">
     <article class="content content--media content--gallery tone-@gallery.visualTone"
         itemprop="mainContentOfPage" itemscope itemtype="@gallery.schemaType" role="main">
 

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -86,7 +86,7 @@
         <div class="container container--popular">
             <div class="facia-container__inner">
                 <h2 class="container__title">
-                    <a class="most-viewed-no-js tone-colour" href="@LinkTo{"/gallery/most-viewed"}" data-link-name="Most viewed galleries">More galleries</a>
+                    <a class="most-viewed-no-js tone-colour" href="@LinkTo{/gallery/most-viewed}" data-link-name="Most viewed galleries">More galleries</a>
                 </h2>
             </div>
         </div>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -4,7 +4,7 @@
 @import views.support.{Video640, SeoOptimisedContentImage, StripHtmlTags}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }){ case (media, mediaType) =>
-<div class="l-side-margins l-side-margins--layout-content">
+<div class="l-side-margins l-side-margins--layout-content l-side-margins--media">
     <article class="content content--media content--media--@mediaType tone-@media.visualTone"
         itemprop="mainContentOfPage" itemscope itemtype="@media.schemaType" role="main">
         <div class="l-side-margins l-side-margins--media l-side-margins--layout-content">

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -384,6 +384,9 @@ define([
                     this.index = this.images.length;
                     this.state = 'image';
                 },
+                'reload': function() {
+                    this.reloadState = true;
+                },
                 'resize': function() {
                     this.swipeContainerWidth = this.$swipeContainer.dim().width;
                     this.translateContent(this.$slides.length, 0, 0);

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -11,7 +11,8 @@ define([
     'common/utils/fsm',
     'common/utils/detect',
     'common/modules/component',
-    'common/modules/ui/images'
+    'common/modules/ui/images',
+    'common/utils/template'
 ], function (
     _,
     bean,
@@ -25,7 +26,8 @@ define([
     FiniteStateMachine,
     detect,
     Component,
-    imagesModule
+    imagesModule,
+    template
 ) {
     function GalleryLightbox() {
 
@@ -36,10 +38,10 @@ define([
 
         // TEMPLATE
         function generateButtonHTML(label) {
-            var templ = '<div class="gallery-lightbox__btn gallery-lightbox__btn--{{label}} js-gallery-{{label}}">' +
+            var tmpl = '<div class="gallery-lightbox__btn gallery-lightbox__btn--{{label}} js-gallery-{{label}}">' +
                         '<button class="gallery-lightbox__btn-body"><i></i></button>' +
                     '</div>';
-            return templ.replace(/{{label}}/g, label);
+            return template(tmpl, {label: label});
         }
 
         this.endslateHTML =

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -37,7 +37,7 @@ define([
         // TEMPLATE
         function generateButtonHTML(label) {
             var templ = '<div class="gallery-lightbox__btn gallery-lightbox__btn--{{label}} js-gallery-{{label}}">' +
-                        '<div class="gallery-lightbox__btn-body"><i></i></div>' +
+                        '<button class="gallery-lightbox__btn-body"><i></i></button>' +
                     '</div>';
             return templ.replace(/{{label}}/g, label);
         }

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -349,7 +349,7 @@ define([
                 'reload': function() {
                     this.reloadState = true;
                 },
-                'toggle-info': function(e) {
+                'toggle-info': function() {
                     this.pulseButton(this.infoBtn);
                     this.$lightboxEl.toggleClass('gallery-lightbox--show-info');
                 },

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -38,9 +38,10 @@ define([
 
         // TEMPLATE
         function generateButtonHTML(label) {
-            var tmpl = '<div class="gallery-lightbox__btn gallery-lightbox__btn--{{label}} js-gallery-{{label}}">' +
-                        '<button class="gallery-lightbox__btn-body"><i></i></button>' +
-                    '</div>';
+            var tmpl =
+                '<div class="gallery-lightbox__btn gallery-lightbox__btn--{{label}} js-gallery-{{label}}">' +
+                    '<button class="gallery-lightbox__btn-body"><i></i>{{label}}</button>' +
+                '</div>';
             return template(tmpl, {label: label});
         }
 

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -57,7 +57,7 @@ define([
         this.imgElementHtml =
             '<li class="gallery-lightbox__item gallery-lightbox__item--img js-gallery-slide">' +
                 '<div class="gallery-lightbox__img-container"><img class="gallery-lightbox__img js-gallery-lightbox-img""></div>' +
-                '<div class="gallery-lightbox__info">' +
+                '<div class="gallery-lightbox__info js-gallery-lightbox-info">' +
                     '<div class="gallery-lightbox__progress gallery-lightbox__progress--info">' +
                         '<span class="gallery-lightbox__index">${index}</span>' +
                         '<span class="gallery-lightbox__progress-separator"></span>' +
@@ -108,6 +108,12 @@ define([
         this.handleKeyEvents = this._handleKeyEvents.bind(this); // bound for event handler
         this.toggleInfo = this.trigger.bind(this, 'toggle-info');
         this.resize = this.trigger.bind(this, 'resize');
+
+        this.stopPropagationOnMouseClick = function(e) {
+            if (detect.isBreakpoint({min: 'desktop'})) {
+                e.stop();
+            }
+        }.bind(this);
 
         if (detect.hasTouchScreen()) {
             this.disableHover();
@@ -297,14 +303,16 @@ define([
                 url.pushUrl({}, document.title, '/' + this.galleryJson.id + '?index=' + this.index, true);
 
                 // event bindings
-                bean.on(this.$contentEl[0], 'click', this.toggleInfo);
+                bean.on(this.$swipeContainer[0], 'click', '.js-gallery-content', this.toggleInfo);
+                bean.on(this.$contentEl[0], 'click', '.js-gallery-lightbox-info', this.stopPropagationOnMouseClick);
                 bean.on(window, 'resize', this.resize);
 
                 // meta
                 this.$indexEl.text(this.index);
             },
             leave: function() {
-                bean.off(this.$contentEl[0], 'click', this.toggleInfo);
+                bean.off(this.$swipeContainer[0], 'click', this.toggleInfo);
+                bean.off(this.$contentEl[0], 'click', this.stopPropagationOnMouseClick);
                 bean.off(window, 'resize', this.resize);
             },
             events: {
@@ -341,7 +349,7 @@ define([
                 'reload': function() {
                     this.reloadState = true;
                 },
-                'toggle-info': function() {
+                'toggle-info': function(e) {
                     this.pulseButton(this.infoBtn);
                     this.$lightboxEl.toggleClass('gallery-lightbox--show-info');
                 },

--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -445,9 +445,9 @@ define([
         } else if (e.keyCode === 39) { // right
             this.trigger('next');
         } else if (e.keyCode === 38) { // up
-            this.trigger('hide-info');
-        } else if (e.keyCode === 40) { // down
             this.trigger('show-info');
+        } else if (e.keyCode === 40) { // down
+            this.trigger('hide-info');
         } else if (e.keyCode === 27) { // esc
             this.close();
         } else if (e.keyCode === 73) { // 'i'

--- a/common/app/assets/stylesheets/layout/_side-margins.scss
+++ b/common/app/assets/stylesheets/layout/_side-margins.scss
@@ -74,7 +74,7 @@
     @include mq(desktop) {
         &:after,
         &:before {
-            background: rgba($c-neutral1, .3);
+            background: rgba(0, 0, 0, .05);
 
             .container__banding + .container__banding & {
                 background: rgba($c-neutral1, .15);

--- a/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
+++ b/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
@@ -280,8 +280,13 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
 .gallery-lightbox__btn-body {
     margin: auto;
     background: $c-gallery-lightbox-btn;
+    border: 0;
+    outline: none;
 
     @include transition(background-color .2s);
+    &:focus {
+        background-color: lighten($c-gallery-lightbox-btn, 8%);
+    }
 }
 
 .gallery-lightbox--hover .gallery-lightbox__btn:hover .gallery-lightbox__btn-body {

--- a/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
+++ b/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
@@ -42,6 +42,10 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
     .gallery-lightbox__btn--close {
         display: block;
     }
+
+    .gallery-lightbox__btn--info-button .gallery-lightbox__btn-body {
+        background-color: $c-gallery-lightbox-btn--active;
+    }
 }
 
 .gallery-lightbox--endslate {

--- a/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
+++ b/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
@@ -282,6 +282,7 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
     background: $c-gallery-lightbox-btn;
     border: 0;
     outline: none;
+    text-indent: -9999px;
 
     @include transition(background-color .2s);
     &:focus {

--- a/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
+++ b/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
@@ -34,7 +34,7 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
 
     @include mq(wide) {
         .gallery-lightbox__item--img {
-            padding-right: $gallery-lightbox-info-width-wide;
+            padding-right: $gallery-lightbox-sidebar-width + $gallery-lightbox-info-width-wide;
         }
     }
 

--- a/common/app/assets/stylesheets/module/content/_gallery.scss
+++ b/common/app/assets/stylesheets/module/content/_gallery.scss
@@ -162,6 +162,7 @@
 
 .content__main-column--gallery {
     margin-right: auto;
+    padding-bottom: $gs-baseline*2;
 }
 
 .content--gallery {

--- a/common/app/assets/stylesheets/module/content/_media.head.scss
+++ b/common/app/assets/stylesheets/module/content/_media.head.scss
@@ -1,4 +1,6 @@
 .content__main-column--media {
+    padding-bottom: $gs-baseline*2;
+
     @include mq(wide) {
         width: gs-span(9);
     }
@@ -15,7 +17,7 @@
 .content--media {
     background-color: $c-neutral1;
     color: $c-neutral7;
-    padding-bottom: $gs-baseline*2;
+    padding-bottom: 0;
 
     .content__section .tone-colour {
         color: $c-commentAccent;

--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -121,7 +121,7 @@ $mq-breakpoints: mq-add-breakpoint(containerWidestMobile, $mobile-max-container-
             @include facia-container__inner;
         }
         .container--dark-background .container__border {
-            border-color: lighten($c-neutral1, 16%);
+            border-color: colour(neutral-2);
         }
         @include mq(leftCol) {
             .container__title {

--- a/common/app/views/fragments/containers/gallery.scala.html
+++ b/common/app/views/fragments/containers/gallery.scala.html
@@ -21,7 +21,7 @@
                     <div class="container__banding">
                         <div class="l-side-margins l-side-margins--media l-side-margins--layout-@layoutType">
                             <div class="facia-container__inner">
-                                <div class="container__border tone-@style.tone tone-accent-border"></div>
+                                <div class="container__border tone-@style.tone"></div>
                                 <div class="@RenderClasses(Map(
                                     ("container__header", true),
                                     ("hide-on-mobile", (FaciaComponentName(config, collection) == "top-stories"))))">


### PR DESCRIPTION
A bunch of fixes and tweaks to gallery and lightbox:
- fixing nojs gallery most-viewed link
- darkening gallery most viewed onward container border color
- darkening media margin colour
- don't toggle info panel when clicking on the info panel itself in desktop
- reload endslate responsive images when it becomes visible
- keep info button highlighted while the panel is active
- switch up/down buttons (show/hide info)
- change controls to `<button>` elements #5952 
- change control focus style (now `lighten`ed when they have focus)

![image](http://media.giphy.com/media/KNEuNnTlppwcM/giphy.gif)
