### PR TITLE
iFrame breakout fix - check if `readyState` is not unknown

### DIFF
--- a/common/app/assets/javascripts/modules/commercial/dfp.js
+++ b/common/app/assets/javascripts/modules/commercial/dfp.js
@@ -426,7 +426,7 @@ define([
                 if (iFrame.readyState && iFrame.readyState !== 'complete') {
                     bean.on(iFrame, 'readystatechange', function (e) {
                         var updatedIFrame = e.srcElement;
-                        if (updatedIFrame.readyState === 'complete') {
+                        if (typeof updatedIFrame.readyState !== 'unknown' && updatedIFrame.readyState === 'complete') {
                             breakoutIFrame(updatedIFrame);
                             bean.off(updatedIFrame, 'readystatechange');
                         }


### PR DESCRIPTION
Fixes http://frontend.errors.gutools.co.uk/guardian/frontend/group/2367/

Fun fact, IE can return `unknown` as a `typeof` value if the ["object in question is on the other side of a COM+ bridge"](http://robertnyman.com/2005/12/21/what-is-typeof-unknown/#comment-8001). Who knew?
