### PR TITLE
Commercial single dfp fix

### DIFF
--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -283,7 +283,7 @@
             top: 0;
             width: gs-span(3) + $gs-gutter/2;
             padding: $gs-baseline 0;
-            left: gs-span(11) + ($gs-gutter/2);
+            left: gs-span(11) + ($gs-gutter*1.5);
         }
         .commercial__footer-inner {
             height: 100%;

--- a/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
+++ b/common/app/assets/stylesheets/module/commercial/_dfp-component.scss
@@ -299,7 +299,7 @@
     }
     @include mq(wide) {
         .commercial__footer {
-            left: gs-span(12) + ($gs-gutter/2);
+            left: gs-span(12) + ($gs-gutter*1.5);
             .has-page-skin & {
                 right: 0;
                 left: auto;

--- a/common/app/assets/stylesheets/module/commercial/_soulmates.scss
+++ b/common/app/assets/stylesheets/module/commercial/_soulmates.scss
@@ -11,6 +11,7 @@
         .svg & {
             background-size: cover;
         }
+        background-repeat: none;
     }
     .commercial__explainer {
         color: $c-soulmates-high;


### PR DESCRIPTION
This corrects the positioning of the component footer on widest breakpoints.

Before;
![screen shot 2014-09-16 at 11 02 00](https://cloud.githubusercontent.com/assets/1303616/4285602/9dd74b2a-3d88-11e4-9f84-fa57a6ffb4a0.png)

After;
![screen shot 2014-09-16 at 11 02 17](https://cloud.githubusercontent.com/assets/1303616/4285606/a500e28a-3d88-11e4-8e59-ffb6b03ac943.png)

Also adds background-repeat: none to Soulmates background graphic.
