### PR TITLE
Scale initial images in galleries

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -20,26 +20,29 @@
 
                                     @ImgSrc.imager(gallery.imageContainer(row.rowNum-1), GalleryUpgradedImage).map { imgSrc =>
 
-                                        <a  class="gallery2__img-container js-gallerythumbs js-delayed-image-upgrade"
-                                            href="@LinkTo{@gallery.url?index=@row.rowNum}"
-                                            data-src="@imgSrc"
-                                            data-link-name="Launch Gallery Lightbox" data-is-ajax>
+                                        @GalleryInitialImage.bestFor(gallery.imageContainer(row.rowNum-1)).map { url =>
 
-                                            @GalleryInitialImage.bestFor(gallery.imageContainer(row.rowNum-1)).map { url =>
+                                            <a class="gallery2__img-container js-gallerythumbs js-delayed-image-upgrade @if(image.width >= image.height) {gallery2__img-container--landscape} else {gallery2__img-container--portrait}"
+                                                href="@LinkTo{@gallery.url?index=@row.rowNum}"
+                                                data-src="@imgSrc"
+                                                data-link-name="Launch Gallery Lightbox" data-is-ajax>
 
-                                                <img class="gallery2__img js-gallery-img responsive-img @if(image.width >= image.height) {gallery2__img--landscape} else {gallery2__img--portrait}"
+                                                <img class="gallery2__img js-gallery-img gallery2__img-initial @if(image.width >= image.height) {gallery2__img--landscape} else {gallery2__img--portrait}"
                                                     src="@url"
                                                     alt="@image.altText.getOrElse("")"
                                                     itemprop="contentUrl" />
 
-                                            }
+                                                <img class="gallery2__img js-gallery-img responsive-img u-h @if(image.width >= image.height) {gallery2__img--landscape} else {gallery2__img--portrait}"
+                                                    alt="@image.altText.getOrElse("")"
+                                                    itemprop="contentUrl" />
 
-                                            <span class="gallery2__fullscreen">
-                                                <i class="i i-expand-white"></i>
-                                                <i class="i i-expand-black"></i>
-                                            </span>
+                                                <span class="gallery2__fullscreen">
+                                                    <i class="i i-expand-white"></i>
+                                                    <i class="i i-expand-black"></i>
+                                                </span>
 
-                                        </a>
+                                            </a>
+                                        }
                                     }
 
                                     <div class="gallery2__figcaption">

--- a/common/app/assets/javascripts/bootstraps/gallery.js
+++ b/common/app/assets/javascripts/bootstraps/gallery.js
@@ -4,16 +4,20 @@ define([
     'common/utils/config',
     'common/modules/component',
     'common/modules/gallery/lightbox',
+    'lodash/collections/forEach',
     'bonzo',
-    'qwery'
+    'qwery',
+    'bean'
 ], function(
     mediator,
     $,
     config,
     Component,
     LightboxGallery,
+    forEach,
     bonzo,
-    qwery
+    qwery,
+    bean
 ) {
 
     var verticallyResponsiveImages = function() {
@@ -23,8 +27,12 @@ define([
                 var $imgs = $('.js-gallery-img'),
                     min = 300, // stops images getting too small
                     max = $imgs.parent().dim().width, // portrait images shouldn't be taller than landscapes are wide
-                    maxHeight = Math.max(min, Math.min(max, window.innerHeight * 0.9));
-                $imgs.css('max-height', maxHeight);
+                    height = Math.max(min, Math.min(max, window.innerHeight * 0.9));
+                $imgs.css('max-height', height);
+
+                // Portrait containers use padding-bottom to set the height of the container prior to upgrading.
+                // This needs to be synchronised with the new image height.
+                $('.gallery2__img-container--portrait').css('padding-bottom', height);
             }
         };
 
@@ -57,6 +65,13 @@ define([
         LightboxGallery.init();
         verticallyResponsiveImages();
         $('.js-delayed-image-upgrade').removeClass('js-delayed-image-upgrade').addClass('js-image-upgrade');
+
+        forEach(qwery('.js-gallery-img.responsive-img'), function(responsiveImage) {
+            bean.one(responsiveImage , 'load', function(e) {
+                bonzo(e.currentTarget).removeClass('u-h').previous().hide();
+            });
+        });
+
         mediator.emit('ui:images:upgrade', $('.gallery2')[0]);
 
         mediator.emit('page:gallery:ready', config);

--- a/common/app/assets/stylesheets/module/content/_gallery.scss
+++ b/common/app/assets/stylesheets/module/content/_gallery.scss
@@ -122,6 +122,21 @@
     max-height: 700px;
 }
 
+.gallery2__img-initial.gallery2__img--landscape {
+    width: 100%;
+}
+
+.gallery2__img-container--portrait {
+    @include fix-aspect-ratio(1, 1);
+}
+
+.gallery2__img--portrait {
+    position: absolute;
+    height: 100%;
+    left: 0;
+    right: 0;
+}
+
 .gallery2__fullscreen {
     @include border-radius(50%);
     top: 0;


### PR DESCRIPTION
The gallery list view has low fi images that are much smaller than their upgraded counterparts. We can scale the initial images to reduce the pop-in effect of upgrading. Portraits use a responsive-ratio-like style to take a height according to the width. Landscapes initially style with 100% width.

![screen shot 2014-09-16 at 13 02 10](https://cloud.githubusercontent.com/assets/4549425/4286850/096990e8-3d9b-11e4-8034-16e794a8d823.png)
