### PR TITLE
Fix formstack iframe sizing

### DIFF
--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -476,7 +476,7 @@ a {
                 self.populateHiddenFields(user);
 
                 // Events
-                window.addEventListener('unload', self.unload, false)
+                window.addEventListener('unload', self.unload, false);
                 dom.$form.addEventListener('submit', self.submit, false);
 
                 // Display
@@ -484,7 +484,7 @@ a {
                 document.getElementsByTagName('html')[0].className += ' iframed--overflow-hidden';
 
                 // Update iframe height
-                self.sendHeight();
+                window.addEventListener('resize', self.sendHeight, false);
 
                 dom.$form.className = dom.$form.className.replace('is-hidden', '');
 


### PR DESCRIPTION
At the moment formstack forms are often sized incorrectly, hiding the submission button. This is because the iframe content isn't completely fixed when we last send a message to size the iframe.

This PR adds a resize listener so that it correctly sizes and is also responsive.
