### PR TITLE
Update asset-monitor

### DIFF
--- a/grunt-configs/assetmonitor.js
+++ b/grunt-configs/assetmonitor.js
@@ -3,7 +3,8 @@ module.exports = function(grunt, options) {
         common: {
             src: [
                 options.staticTargetDir + 'javascripts/bootstraps/*.js',
-                options.staticTargetDir + 'stylesheets/*.css'
+                options.staticTargetDir + 'stylesheets/*.css',
+                '!' + options.staticTargetDir + 'stylesheets/*head.identity.css'
             ],
             options: {
                 credentials: options.propertiesFile

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "glob": "^4.0.2",
     "grunt": "^0.4.5",
     "grunt-asset-hash": "^0.1.2",
-    "grunt-asset-monitor": "~0.1.5",
+    "grunt-asset-monitor": "~0.2",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "~0.5",
     "grunt-contrib-copy": "~0.5.0",


### PR DESCRIPTION
Adds CSS metric monitoring

Needs to ignore `identity.css`, as css-parse fails with nested media query within a keyframe, e.g. https://github.com/guardian/frontend/blob/master/common/app/assets/stylesheets/module/identity/_identity.scss#L578
