### PR TITLE
Stop requesting snaps in getArticles

### DIFF
--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -136,7 +136,7 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
   }
 
   def getArticles(collectionItems: Seq[CollectionItem], edition: Edition): Future[Seq[Content]] = {
-    batchGetContentApiItems(collectionItems ++ collectionItems.flatMap(retrieveSupportingLinks), edition) map { items =>
+    batchGetContentApiItems((collectionItems ++ collectionItems.flatMap(retrieveSupportingLinks)).filterNot(_.isSnap), edition) map { items =>
       collectionItems flatMap { collectionItem =>
         val supporting = retrieveSupportingLinks(collectionItem).flatMap({ collectionItem =>
           items.get(collectionItem) map { item =>


### PR DESCRIPTION
Our `content-api` `404`s have increased significantly since #5894 because we are now requesting `Snap` ids.

This stops requesting the Snap IDs from the content API.

@robertberry @stephanfowler 
