### PR TITLE
move comment counts from <i> to :before

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -57,8 +57,8 @@
         bottom: $gs-baseline / 3;
     }
 
-    .item__timestamp {
-        padding-left: 0;
+    .trail__count a {
+        padding: 0;
     }
 
     .item--has-cutout {

--- a/common/app/assets/stylesheets/module/facia-cards/_tones-images.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones-images.scss
@@ -1,41 +1,69 @@
-%facia-card-media-icon {
-    content: '';
-    margin: 0;
-}
-
 .container--facia-cards {
-    .item__timestamp:before {
-        @include icon(clock-light-grey, false);
-        @extend %facia-card-media-icon;
-        top: 1px;
-        position: relative;
-        height: 11px;
-        width: 11px;
-        margin-right: 2px;
+    .item__timestamp {
+        padding-left: 0;
+
+        &:before {
+            @include icon(clock-light-grey, false);
+            content: '';
+            margin: 0;
+            top: 1px;
+            position: relative;
+            height: 11px;
+            width: 11px;
+            margin-right: 2px;
+        }
+    }
+
+    .item__title:before {
+        content: '';
+        margin: 0;
+    }
+
+    .trail__count {
+        &:before {
+            @include icon(comment-light-grey, false);
+            width: 16px;
+            height: 16px;
+            content: '';
+            position: relative;
+            top: 3px;
+            float: left;
+            margin-right: 1px;
+        }
     }
 
     .tone-media {
         .item__timestamp:before {
             @include icon(clock-yellow, false);
         }
+
+        .trail__count:before {
+            @include icon(comment-yellow, false);
+        }
     }
 
     .item--video {
         .item__title:before {
             @include icon(video-icon, false);
-            @extend %facia-card-media-icon;
             height: .75em;
             width: 1.2em;
             margin-right: 2px;
+        }
+
+        .trail__count:before {
+            @include icon(comment-yellow, false);
         }
     }
 
     .item--gallery {
         .item__title:before {
             @include icon(camera-yellow-large, false);
-            @extend %facia-card-media-icon;
             height: .75em;
             width: 1.2em;
+        }
+
+        .trail__count:before {
+            @include icon(comment-yellow, false);
         }
     }
 
@@ -43,18 +71,25 @@
         .item__timestamp:before {
             @include icon(clock-light-pink, false);
         }
+
+        .trail__count:before {
+            @include icon(comment-light-pink, false);
+        }
     }
 
     .tone-feature {
         .item__timestamp:before {
             @include icon(clock-light-pink, false);
         }
+
+        .trail__count:before {
+            @include icon(comment-light-pink, false);
+        }
     }
 
     .tone-comment {
         .item__title:before {
             @include icon(quote-grey, false);
-            @extend %facia-card-media-icon;
             height: .8em;
             width: 1em;
         }

--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -16,7 +16,6 @@
 
     <span class="trail__count trail__count--commentcount trail__count--inline-template js-item__inline-comment-template">
         <a href="@LinkTo(trail)#comments" data-link-name="Comment count">
-            <i class="i @TrailCssClasses.commentCountClass(trail)"></i>
             <span class="js-item__comment-count"></span> <span class="u-h js-item__comment-or-comments"></span>
         </a>
     </span>


### PR DESCRIPTION
and refactor title :befores a bit.

Ensures comment icons align better at smaller breakpoints

![screen shot 2014-09-17 at 11 17 33](https://cloud.githubusercontent.com/assets/867233/4301879/e8c1f51a-3e53-11e4-837a-f3a45546c38f.png) 
vs 
![screen shot 2014-09-17 at 11 17 55](https://cloud.githubusercontent.com/assets/867233/4301882/f13ffb2e-3e53-11e4-84a4-91c85d510711.png)
