### PR TITLE
Add semi-transparent background for comment count overlap on comment cards

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -54,11 +54,13 @@
     }
 
     .item__meta {
-        bottom: $gs-baseline / 3;
+        padding-top: $gs-baseline / 3;
+        padding-bottom: $gs-baseline / 3;
     }
 
     .item__timestamp {
         padding-left: 0;
+        padding-right: 0;
     }
 
     .item--has-cutout {

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -58,8 +58,12 @@
         padding-bottom: $gs-baseline / 3;
     }
 
-    .trail__count a {
-        padding: 0;
+    .trail__count {
+        padding-left: $gs-baseline / 2;
+
+        a {
+            padding: 0;
+        }
     }
 
     .item__timestamp {

--- a/common/app/assets/stylesheets/module/facia-cards/_tones.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones.scss
@@ -30,6 +30,10 @@
         .item__kicker {
             color: $c-commentDefault;
         }
+
+        .item__meta {
+            background-color: fade-out($c-commentBackground, .5);
+        }
     }
 
     .tone-feature {


### PR DESCRIPTION
![screen shot 2014-09-17 at 11 48 35](https://cloud.githubusercontent.com/assets/1001642/4302269/56f3e210-3e58-11e4-9fe1-262676e751e6.png)

Interim solution while @sammorrisdesign thinks of something better.
