### PR TITLE
don’t add psuedo els to all headers in new item cards

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_tones-images.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones-images.scss
@@ -14,11 +14,6 @@
         }
     }
 
-    .item__title:before {
-        content: '';
-        margin: 0;
-    }
-
     .trail__count {
         &:before {
             @include icon(comment-light-grey, false);
@@ -45,6 +40,7 @@
     .item--video {
         .item__title:before {
             @include icon(video-icon, false);
+            content: '';
             height: .75em;
             width: 1.2em;
             margin-right: 2px;
@@ -58,6 +54,7 @@
     .item--gallery {
         .item__title:before {
             @include icon(camera-yellow-large, false);
+            content: '';
             height: .75em;
             width: 1.2em;
         }
@@ -90,6 +87,7 @@
     .tone-comment {
         .item__title:before {
             @include icon(quote-grey, false);
+            content: '';
             height: .8em;
             width: 1em;
         }


### PR DESCRIPTION
it should be like

![screen shot 2014-09-17 at 12 14 44](https://cloud.githubusercontent.com/assets/867233/4302623/f83c19dc-3e5b-11e4-8abf-3b784deadd76.png)

but they make it like

![screen shot 2014-09-17 at 12 15 16](https://cloud.githubusercontent.com/assets/867233/4302626/06faa60a-3e5c-11e4-8d4f-6480fd255392.png)
