### PR TITLE
Add Line Item Links to Sponsored Tags

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -76,24 +76,6 @@ object DfpDataCacheJob extends ExecutionContexts {
     }
   }
 
-  private implicit val sponsorshipWrites = new Writes[Sponsorship] {
-    def writes(sponsorship: Sponsorship): JsValue = {
-      Json.obj(
-        "sponsor" -> sponsorship.sponsor,
-        "tags" -> sponsorship.tags
-      )
-    }
-  }
-
-  private implicit val sponsorshipReportWrites = new Writes[SponsorshipReport] {
-    def writes(sponsorshipReport: SponsorshipReport): JsValue = {
-      Json.obj(
-        "updatedTimeStamp" -> sponsorshipReport.updatedTimeStamp,
-        "sponsorships" -> sponsorshipReport.sponsorships
-      )
-    }
-  }
-
   private implicit val pageSkinSponsorshipReportWrites = new Writes[PageSkinSponsorshipReport] {
     def writes(report: PageSkinSponsorshipReport): JsValue = {
       Json.obj(

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -8,7 +8,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
     lineItems.withFilter { lineItem =>
       lineItem.sponsoredTags.nonEmpty && lineItem.isCurrent
     }.map { lineItem =>
-      Sponsorship(lineItem.sponsoredTags, lineItem.sponsor)
+      Sponsorship(lineItem.sponsoredTags, lineItem.sponsor, lineItem.id)
     }.distinct
   }
 
@@ -16,7 +16,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
     lineItems.withFilter { lineItem =>
       lineItem.advertisementFeatureTags.nonEmpty && lineItem.isCurrent
     }.map { lineItem =>
-      Sponsorship(lineItem.advertisementFeatureTags, lineItem.sponsor)
+      Sponsorship(lineItem.advertisementFeatureTags, lineItem.sponsor, lineItem.id)
     }.distinct
   }
 

--- a/admin/app/views/commercial/sponsorships.scala.html
+++ b/admin/app/views/commercial/sponsorships.scala.html
@@ -1,4 +1,11 @@
 @(env: String, sponsoredTags: dfp.SponsorshipReport, advertisementTags: dfp.SponsorshipReport)
+@import tools.DfpLink
+
+@listItem(sponsorship: dfp.Sponsorship) = {
+    <li style="padding-bottom:12px">@{sponsorship.tags.mkString(", ")} (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
+        @{sponsorship.sponsor.map(sponsor => <br /> <small>[sponsored by <b>{sponsor}</b>]</small>)} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    </li>
+}
 
 @admin_main("Commercial", env, isAuthed = true, hasCharts = true) {
 
@@ -10,24 +17,14 @@
 <h3>Sponsored Tags</h3>
 <p>Last updated: @sponsoredTags.updatedTimeStamp</p>
 <ol>
-    @for(sponsorship <- sponsoredTags.sponsorships) {
-    <li>@{sponsorship.tags.mkString(", ")}@{sponsorship.sponsor.map(sponsor =>
-        <small>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[sponsored by <b>{sponsor}</b>]</small>
-        )}
-    </li>
-    }
+    @for(sponsorship <- sponsoredTags.sponsorships){@listItem(sponsorship)}
 </ol>
 
 <h3>Advertisement Feature Tags</h3>
 <p>Last updated: @advertisementTags.updatedTimeStamp</p>
 
 <ol>
-    @for(sponsorship <- advertisementTags.sponsorships) {
-    <li>@{sponsorship.tags.mkString(", ")}@{sponsorship.sponsor.map(sponsor =>
-        <small>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[sponsored by <b>{sponsor}</b>]</small>
-        )}
-    </li>
-    }
+    @for(sponsorship <- advertisementTags.sponsorships) {@listItem(sponsorship)}
 </ol>
 
 <h3><a name="criteria">Criteria:</a></h3>

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -233,7 +233,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
     private lazy val dfpRoot = s"${environment.stage.toUpperCase}/commercial/dfp"
     lazy val dfpSponsoredTagsDataKey = s"$dfpRoot/sponsored-tags-v3.json"
-    lazy val dfpAdvertisementFeatureTagsDataKey = s"$dfpRoot/advertisement-feature-tags-v2.json"
+    lazy val dfpAdvertisementFeatureTagsDataKey = s"$dfpRoot/advertisement-feature-tags-v3.json"
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v5.json"
     lazy val dfpLineItemsKey = s"$dfpRoot/lineitems.json"

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -232,7 +232,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val traveloffers_url = configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
 
     private lazy val dfpRoot = s"${environment.stage.toUpperCase}/commercial/dfp"
-    lazy val dfpSponsoredTagsDataKey = s"$dfpRoot/sponsored-tags-v2.json"
+    lazy val dfpSponsoredTagsDataKey = s"$dfpRoot/sponsored-tags-v3.json"
     lazy val dfpAdvertisementFeatureTagsDataKey = s"$dfpRoot/advertisement-feature-tags-v2.json"
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v5.json"

--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -4,13 +4,27 @@ import common.Logging
 import model.Tag
 import play.api.libs.json._
 
+
 object Sponsorship {
+
+  implicit val sponsorshipWrites = new Writes[Sponsorship] {
+    def writes(sponsorship: Sponsorship): JsValue = {
+      Json.obj(
+        "sponsor" -> sponsorship.sponsor,
+        "tags" -> sponsorship.tags,
+        "lineItemId" -> sponsorship.lineItemId
+      )
+    }
+  }
+
   implicit val jsonReads = Json.reads[Sponsorship]
+
 }
 
-case class Sponsorship(tags: Seq[String], sponsor: Option[String]) {
+case class Sponsorship(tags: Seq[String], sponsor: Option[String], lineItemId: Long) {
   def hasTag(tagId: String): Boolean = tags contains tagId.split('/').last
 }
+
 
 object InlineMerchandisingTagSet {
   implicit val jsonReads = Json.reads[InlineMerchandisingTagSet]
@@ -30,8 +44,20 @@ case class InlineMerchandisingTagSet(keywords: Set[String] = Set.empty, series: 
   def nonEmpty: Boolean = keywords.nonEmpty || series.nonEmpty || contributors.nonEmpty
 }
 
+
 object SponsorshipReport {
+
+  implicit val sponsorshipReportWrites = new Writes[SponsorshipReport] {
+    def writes(sponsorshipReport: SponsorshipReport): JsValue = {
+      Json.obj(
+        "updatedTimeStamp" -> sponsorshipReport.updatedTimeStamp,
+        "sponsorships" -> sponsorshipReport.sponsorships
+      )
+    }
+  }
+
   implicit val jsonReads = Json.reads[SponsorshipReport]
+
 }
 
 case class SponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[Sponsorship])
@@ -47,6 +73,7 @@ object SponsorshipReportParser extends Logging {
     }
   }
 }
+
 
 object InlineMerchandisingTargetedTagsReport {
   implicit val jsonReads = Json.reads[InlineMerchandisingTargetedTagsReport]

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -36,14 +36,14 @@ class DfpAgentTest extends FlatSpec with Matchers {
 
   private object testDfpAgent extends DfpAgent {
     override protected def sponsorships: Seq[Sponsorship] = Seq(
-      Sponsorship(Seq("spon-page"), Some("spon")),
-      Sponsorship(Seq("media"), None),
-      Sponsorship(Seq("healthyliving"), Some("Squeegee"))
+      Sponsorship(Seq("spon-page"), Some("spon"), 1),
+      Sponsorship(Seq("media"), None, 2),
+      Sponsorship(Seq("healthyliving"), Some("Squeegee"), 3)
     )
 
     override protected def advertisementFeatureSponsorships: Seq[Sponsorship] = Seq(
-      Sponsorship(Seq("ad-feature"), Some("spon2")),
-      Sponsorship(Seq("film"), None)
+      Sponsorship(Seq("ad-feature"), Some("spon2"), 4),
+      Sponsorship(Seq("film"), None, 5)
     )
 
     override protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = examplePageSponsorships

--- a/common/test/dfp/SponsorshipReportTest.scala
+++ b/common/test/dfp/SponsorshipReportTest.scala
@@ -1,32 +1,35 @@
 package dfp
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
-import play.api.test.Helpers._
-import play.api.libs.json.{JsValue, Json}
+import org.scalatest.{FlatSpec, Matchers}
 
-class SponsorShipReportTest extends FlatSpec with Matchers {
+class SponsorshipReportTest extends FlatSpec with Matchers {
   val jsonString =
     """{"updatedTimeStamp":"Sun 20:14 22 June 2014",
-      |"sponsorships":
-      |[{"sponsor":"Unilever","tags":["live-better"]},{"sponsor":null,"tags":["secure-protect"]},{"sponsor":null,"tags":["world-cup-football","world-cup-2014"]},{"sponsor":null,"tags":["cricket"]},{"sponsor":null,"tags":["world-cup-show-2014"]}]
+      |"sponsorships":[
+      |{"sponsor":"Unilever","tags":["live-better"],"lineItemId":1},
+      |{"sponsor":null,"tags":["secure-protect"],"lineItemId":2},
+      |{"sponsor":null,"tags":["world-cup-football","world-cup-2014"],"lineItemId":3},
+      |{"sponsor":null,"tags":["cricket"],"lineItemId":4},
+      |{"sponsor":null,"tags":["world-cup-show-2014"],"lineItemId":5}
+      |]
     }""".stripMargin
 
   "SponsorshipReports object" should "be able to hydrate proper SponsorshipReports object" in {
     val result: Option[SponsorshipReport] = SponsorshipReportParser(jsonString)
-    result.isDefined shouldEqual(true)
+    result.isDefined shouldEqual true
     val report: SponsorshipReport = result.get
 
-    report.updatedTimeStamp shouldEqual("Sun 20:14 22 June 2014")
-    report.sponsorships.size shouldEqual(5)
+    report.updatedTimeStamp shouldEqual "Sun 20:14 22 June 2014"
+    report.sponsorships.size shouldEqual 5
     val liveBetter: Sponsorship = report.sponsorships(0)
     liveBetter.sponsor should equal(Some("Unilever"))
     liveBetter.tags should contain("live-better")
+    liveBetter.lineItemId shouldEqual 1
 
     val secureProtect: Sponsorship = report.sponsorships(1)
     secureProtect.sponsor should equal(None)
     secureProtect.tags should contain("secure-protect")
+    secureProtect.lineItemId shouldEqual 2
   }
-
 
 }


### PR DESCRIPTION
Sponsorship dashboard now shows link to line item for each sponsored tag:

![image](https://cloud.githubusercontent.com/assets/1722550/4302729/574e8c10-3e5d-11e4-99dd-0342a22b1663.png)
