### PR TITLE
Fix sbt warnings

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val chargebee = "org.json" % "org.json" % "chargebee-1.0"
   val commonsCodec = "commons-codec" % "commons-codec" % "1.6"
   val commonsHttpClient = "commons-httpclient" % "commons-httpclient" % "3.1"
+  val commonsIo = "commons-io" % "commons-io" % "2.4"
   val contentApiClient = "com.gu" %% "content-api-client" % "2.19"
   val cucumberJava = "info.cukes" % "cucumber-java" % cucumberVersion
   val cucumberJUnit = "info.cukes" % "cucumber-junit" % cucumberVersion
@@ -39,6 +40,7 @@ object Dependencies {
   val mezaConfig = "hu.meza.tools" % "config" % "1.0.1"
   val mezaGaLib = "hu.meza.tools" % "galib" % "1.0.2"
   val mezaHttpClientWrapper = "hu.meza.tools" % "http-client-wrapper" % "0.1.9"
+  val mockito = "org.mockito" % "mockito-all" % "1.9.5" % Test
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "1.2.0"
   val openCsv = "net.sf.opencsv" % "opencsv" % "2.3"
   val paClient = "com.gu" %% "pa-client" % "5.0.1-NG"
@@ -50,6 +52,7 @@ object Dependencies {
   val romeModules = "org.rometools" % "rome-modules" % "1.0"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.5" % "test"
   val scalajTime = "org.scalaj" % "scalaj-time_2.10.2" % "0.7"
+  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.1" % Test
   val seeGuice = "com.tzavellas" % "sse-guice" % "0.7.1"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % seleniumVersion
   val seleniumServer = "org.seleniumhq.selenium" % "selenium-server" % seleniumVersion

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -6,6 +6,7 @@ import sbt.Keys._
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.typesafe.sbt.SbtNativePackager._
 import play.twirl.sbt.Import._
+import Dependencies._
 
 trait Prototypes {
   val version = "1-SNAPSHOT"
@@ -65,8 +66,6 @@ trait Prototypes {
     )
   )
 
-  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.1" % Test
-
   val frontendTestSettings = Seq(
     // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
     testOptions in Test := Nil,
@@ -79,7 +78,7 @@ trait Prototypes {
 
     libraryDependencies ++= Seq(
       scalaTest,
-      "org.mockito" % "mockito-all" % "1.9.5" % Test
+      mockito
     ),
 
     // These settings are needed for forking, which in turn is needed for concurrent restrictions.
@@ -99,7 +98,7 @@ trait Prototypes {
     .settings(VersionInfo.settings:_*)
     .settings(
       libraryDependencies ++= Seq(
-        "commons-io" % "commons-io" % "2.4"
+        commonsIo
       )
     )
     .settings(name in Universal := applicationName)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.5


### PR DESCRIPTION
By rolling back to `0.13.5`.

@rtyley It was kicking up loads of warnings, and I'm not sure why, and don't have time to debug it. We'll upgrade SBT when we upgrade to Scala 2.11.2, which @gklopper is working on.
