### PR TITLE
Use a hack to make sure that formstack resizes appropriately

### DIFF
--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -484,7 +484,11 @@ a {
                 document.getElementsByTagName('html')[0].className += ' iframed--overflow-hidden';
 
                 // Update iframe height
+                // This should really use http://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js
+                // but it isn't available over SSL at the moment.
+                self.sendHeight();
                 window.addEventListener('resize', self.sendHeight, false);
+                setInterval(self.sendHeight, 500);
 
                 dom.$form.className = dom.$form.className.replace('is-hidden', '');
 


### PR DESCRIPTION
This is a hack to make sure that formstack forms resize properly.

We should really use the script from interactives at http://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js but this is not available over SSL (not with a CDN anyhow) and formstack forms are all SSL. As a result I'm just grabbing the key techniques they are using in that file until such a time that they do have HTTPS.
