### PR TITLE
Ability to center top-banner ads

### DIFF
--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -62,6 +62,7 @@
         }
     }
     .ad-slot__label {
+        /* this is the minimum width of possible ads sizes */
         width: 728px;
         text-align: left;
         border-top: 0;

--- a/common/app/assets/stylesheets/module/_adslot.scss
+++ b/common/app/assets/stylesheets/module/_adslot.scss
@@ -53,6 +53,7 @@
         display: none;
         min-height: 90 + ($gs-row-height/2);
         padding-bottom: $gs-row-height/2;
+        text-align: center;
 
         @include mq(tablet) {
             .js-on & {
@@ -61,6 +62,7 @@
         }
     }
     .ad-slot__label {
+        width: 728px;
         text-align: left;
         border-top: 0;
         padding: 0;
@@ -71,25 +73,30 @@
         transform: translateZ(0);
         @include transition(height 1s cubic-bezier(0, 0, 0, .985));
     }
+}
+.top-banner-ad-container--non-center .ad-slot--top-banner-ad {
+    @include mq(leftCol) {
+        text-align: left;
+        margin: 0 auto;
+
+        .ad-slot__label {
+            margin: 0;
+        }
+    }
     @include mq(wide) {
         .has-page-skin & {
-            .ad-slot--top-banner-ad {
-                width: 970px;
-                padding-left: 0;
-                text-align: center;
-            }
+            width: auto !important;
+            padding-left: 0 !important;
+            text-align: center;
+
             .ad-slot__label {
-                width: 720px;
+                margin: 0 auto;
             }
         }
     }
 }
-.top-banner-ad-container--facia-layout .ad-slot--top-banner-ad {
-    @include mq(mobile, leftCol) {
-        text-align: center;
-    }
+.top-banner-ad-container--non-center.top-banner-ad-container--facia-layout .ad-slot--top-banner-ad {
     @include mq(leftCol) {
-        margin: 0 auto;
         width: gs-span(14) - ($left-column + $gs-gutter);
         padding-left: $left-column + $gs-gutter;
     }
@@ -97,33 +104,15 @@
         width: gs-span(16) - ($left-column-wide + $gs-gutter);
         padding-left: $left-column-wide + $gs-gutter;
     }
-    @include mq(tablet, leftCol) {
-        .ad-slot__label {
-            width: 728px;
-        }
-    }
 }
-.top-banner-ad-container--article-layout .ad-slot--top-banner-ad {
-    @include mq(mobile, rightCol) {
-        text-align: center;
-    }
-    @include mq(rightCol) {
-        margin: 0 0 0 $gs-gutter;
-    }
+.top-banner-ad-container--non-center.top-banner-ad-container--article-layout .ad-slot--top-banner-ad {
     @include mq(leftCol) {
-        margin: 0 auto;
         max-width: gs-span(14) + ($gs-gutter*2) - ($left-column + ($gs-gutter*2));
         padding-left: $left-column + ($gs-gutter*2);
     }
     @include mq(wide) {
         max-width: gs-span(16) + ($gs-gutter*2) - ($left-column-wide + ($gs-gutter*2));
         padding-left: $left-column-wide + ($gs-gutter*2);
-    }
-    @include mq(tablet, rightCol) {
-        .ad-slot__label {
-            width: 728px;
-            margin: 0 auto;
-        }
     }
 }
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -308,6 +308,10 @@ object Switches extends Collections {
     safeState = On, sellByDate = new LocalDate(2014, 9, 30)
   )
 
+  val CentreTopBannerAd = Switch("Feature", "centre-top-banner-ad",
+    "Center the top banner ad, allows more ad sizes to be used at smaller breakpoints.",
+    safeState = Off, sellByDate = new LocalDate(2014, 10, 4))
+
   // A/B Tests
 
   val ABHighCommercialComponent = Switch("A/B Tests", "ab-high-commercial-component",
@@ -417,7 +421,8 @@ object Switches extends Collections {
     EnhancedMediaPlayerSwitch,
     BreakingNewsSwitch,
     MetricsSwitch,
-    FootballFeedRecorderSwitch
+    FootballFeedRecorderSwitch,
+    CentreTopBannerAd
   )
 
   val httpSwitches: List[Switch] = List(

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -1,16 +1,24 @@
 @(metaData: model.MetaData)
+@import conf.Switches._
 
 <div class="top-banner-ad-container top-banner-ad-container--desktop top-banner-ad-container--@metaData match {
         case _: Article => {article}
         case _          => {facia}
-    }-layout">
-    @fragments.commercial.standardAd(
-        "top-above-nav",
-        Seq("top-banner-ad"),
-        Map(
-            "mobile" -> Seq("88,70", "728,90"),
-            "right-col" -> Seq("88,70", "728,90", "940,230", "900,250"),
-            "wide" -> Seq("88,70", "728,90", "940,230", "900,250", "970,250")
-        )
-    )
+    }-layout @if(CentreTopBannerAd.isSwitchedOff) {top-banner-ad-container--non-center}">
+    @defining(
+        if(CentreTopBannerAd.isSwitchedOff) {
+            Map(
+                "mobile" -> Seq("88,70", "728,90"),
+                "right-col" -> Seq("88,70", "728,90", "940,230", "900,250"),
+                "wide" -> Seq("88,70", "728,90", "940,230", "900,250", "970,250")
+            )
+        } else {
+            Map(
+                "mobile" -> Seq("88,70", "728,90"),
+                "desktop" -> Seq("88,70", "728,90", "940,230", "900,250", "970,250")
+            )
+        }
+    ) { sizeMappings =>
+        @fragments.commercial.standardAd("top-above-nav", Seq("top-banner-ad"), sizeMappings)
+    }
 </div>


### PR DESCRIPTION
Currently we line up the top banner ad with the left hand side of the content

This gives us less room to play with, i.e. we can't load in larger ads at smaller breakpoints -> limiting what inventory we can sell

I've styled up the top banner so it's centre-aligned, gives us more room to play with. Need to weight up the aesthetics with the commercial benefit

It's behind a switch

![screen shot 2014-09-17 at 17 56 41](https://cloud.githubusercontent.com/assets/74132/4307746/1248ec9e-3e8c-11e4-9260-d6e460bae265.png)
