### PR TITLE
video page fixes

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -81,7 +81,7 @@
                 </ul>
                 <div class="tag-wrapper tag-wrapper--break-at-leftcol" data-link-name="keywords">
                     @if(gallery.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                        <h2 class="social__head hide-until-leftcol">Topics</h2>
+                        <h2 class="social__head">Topics</h2>
                         @fragments.keywordList(gallery.keywords, tone = "media")
                     }
                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-component="share">

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -79,7 +79,7 @@
                         }
                     }
                 </ul>
-                <div class="tag-wrapper tag-wrapper--break-at-leftCol">
+                <div class="tag-wrapper tag-wrapper--break-at-leftcol">
                     @if(gallery.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
                             <h2 class="social__head u-h--up-to-left-col">Topics</h2>

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -82,12 +82,12 @@
                 <div class="tag-wrapper tag-wrapper--break-at-leftcol">
                     @if(gallery.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                            <h2 class="social__head u-h--up-to-left-col">Topics</h2>
+                            <h2 class="social__head hide-until-leftcol">Topics</h2>
                             @fragments.keywordList(gallery.keywords, tone = "media")
                         </div>
                     }
                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-component="share">
-                        <h2 class="social__head u-h--up-to-left-col">Share this article</h2>
+                        <h2 class="social__head hide-until-leftcol">Share this article</h2>
                         @fragments.social(gallery, iconModifier = "white")
                     </div>
                 </div>

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -79,7 +79,7 @@
                         }
                     }
                 </ul>
-                <div class="tag-wrapper">
+                <div class="tag-wrapper tag-wrapper--break-at-leftCol">
                     @if(gallery.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
                             <h2 class="social__head u-h--up-to-left-col">Topics</h2>

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -79,12 +79,10 @@
                         }
                     }
                 </ul>
-                <div class="tag-wrapper tag-wrapper--break-at-leftcol">
+                <div class="tag-wrapper tag-wrapper--break-at-leftcol" data-link-name="keywords">
                     @if(gallery.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                        <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                            <h2 class="social__head hide-until-leftcol">Topics</h2>
-                            @fragments.keywordList(gallery.keywords, tone = "media")
-                        </div>
+                        <h2 class="social__head hide-until-leftcol">Topics</h2>
+                        @fragments.keywordList(gallery.keywords, tone = "media")
                     }
                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-component="share">
                         <h2 class="social__head hide-until-leftcol">Share this article</h2>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -89,7 +89,7 @@
                             <div class="tag-wrapper tag-wrapper--break-at-wide">
                                 @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
                                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                                        <h2 class="social__head hide-until-leftcol">Topics</h2>
+                                        <h2 class="social__head hide-until-wide">Topics</h2>
                                         @fragments.keywordList(media.keywords, tone = "media")
                                     </div>
                                 }

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -89,7 +89,7 @@
                             <div class="tag-wrapper tag-wrapper--break-at-wide">
                                 @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
                                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                                        <h2 class="social__head u-h--up-to-left-col">Topics</h2>
+                                        <h2 class="social__head hide-until-leftcol">Topics</h2>
                                         @fragments.keywordList(media.keywords, tone = "media")
                                     </div>
                                 }

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -86,7 +86,7 @@
                             }
                             @fragments.contentMeta(media)
 
-                            <div class="tag-wrapper">
+                            <div class="tag-wrapper tag-wrapper--break-at-wide">
                                 @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
                                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
                                         <h2 class="social__head u-h--up-to-left-col">Topics</h2>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -87,10 +87,10 @@
                             @fragments.contentMeta(media)
 
                             @defining(media match {
-                                case v: Video => v.standfirst.getOrElse("");
-                                case a: Audio => a.body
-                            }) { body =>
-                                <div class="tag-wrapper @if(body.length > 300) { tag-wrapper--break-at-wide }" data-link-name="keywords">
+                                case v: Video => v.standfirst.getOrElse("").length > 350
+                                case a: Audio => a.body.length > 800
+                            }) { breakIntoLeftCol =>
+                                <div class="tag-wrapper @if(breakIntoLeftCol) { tag-wrapper--break-at-wide }" data-link-name="keywords">
                                 @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
                                     <h2 class="social__head">Topics</h2>
                                     @fragments.keywordList(media.keywords, tone = "media")

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -13,7 +13,7 @@
 
             <div class="gs-container">
                 <div class="content__main-column content__main-column--media content__main-column--@mediaType">
-                    <div class="video-body">
+                    <div class="media-body">
 
                         @media match {
                             case audio: Audio if audio.mainAudio.exists(_.imageCrops.nonEmpty) => {

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -86,14 +86,17 @@
                             }
                             @fragments.contentMeta(media)
 
-                            <div class="tag-wrapper tag-wrapper--break-at-wide">
+                            @defining(media match {
+                                case v: Video => v.standfirst.getOrElse("");
+                                case a: Audio => a.body
+                            }) { body =>
+                                <div class="tag-wrapper @if(body.length > 300) { tag-wrapper--break-at-wide }" data-link-name="keywords">
                                 @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                                    <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                                        <h2 class="social__head hide-until-wide">Topics</h2>
-                                        @fragments.keywordList(media.keywords, tone = "media")
-                                    </div>
+                                    <h2 class="social__head">Topics</h2>
+                                    @fragments.keywordList(media.keywords, tone = "media")
                                 }
-                            </div>
+                                </div>
+                            }
 
                             <div class="social-wrapper social-wrapper--bottom" data-component="share">
                                 @fragments.social(media, iconModifier = "white")

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -13,98 +13,94 @@
 
             <div class="gs-container">
                 <div class="content__main-column content__main-column--media content__main-column--@mediaType">
+                    <div class="video-body">
 
-                    @media match {
-                        case audio: Audio if audio.mainAudio.exists(_.imageCrops.nonEmpty) => {
-                            @fragments.img(media.mainAudio, false, false)
-                        }
-                        case _ => { }
-                    }
-
-                    <div class="media-primary player">
                         @media match {
-                            case audio: Audio => {
-                                <figure itemprop="audio" itemscope itemtype="http://schema.org/AudioObject" data-component="main audio">
-                                @audio.mainAudio.map { audioElement =>
-                                    @fragments.media.audio(AudioPlayer(
-                                        audio,
-                                        audioElement,
-                                        audio.headline,
-                                        autoPlay = true
-                                    ))
-                                }
-                                </figure>
+                            case audio: Audio if audio.mainAudio.exists(_.imageCrops.nonEmpty) => {
+                                @fragments.img(media.mainAudio, false, false)
                             }
-                            case video: Video => {
-                                <figure itemprop="video" itemscope itemtype="http://schema.org/VideoObject" data-component="main video">
-                                    <meta itemprop="name" content="@Html(video.headline)"/>
-                                    <meta itemprop="headline" content="@Html(video.headline)"/>
-                                    <meta itemprop="url" content="@video.url"/>
-                                    @video.trailText.map{ t =>
-                                        <meta itemprop="description" content="@StripHtmlTags(t)" />
-                                        <meta itemprop="about" content="@StripHtmlTags(t)" />
-                                    }
+                            case _ => { }
+                        }
 
-                                    <meta itemprop="datePublished" content="@video.webPublicationDate.toString("yyyy-MM-dd")" />
-                                    <meta itemprop="name" content="@video.webTitle" />
-                                    <meta itemprop="uploadDate" content="@video.webPublicationDate.toString("yyyy-MM-dd")" />
-                                    @video.mainVideo.map { mv =>
-                                        <meta itemprop="duration" content="@mv.ISOduration" />
-                                        <meta itemprop="height" content="@mv.height" />
-                                        <meta itemprop="width" content="@mv.width" />
-                                    }
-                                    <meta itemprop="requiresSubscription" content="no" />
-                                    <meta itemprop="image" content="@video.openGraphImage" />
-                                    @video.thumbnail.map{ img => <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img)" /> }
-                                    @video.mainVideo.map { videoElement =>
-                                        @fragments.media.video(VideoPlayer(
-                                            videoElement,
-                                            Video640,
-                                            video.headline,
-                                            autoPlay = true,
-                                            showControlsAtStart = true,
-                                            endSlatePath = video.endSlatePath,
-                                            None
+                        <div class="media-primary player">
+                            @media match {
+                                case audio: Audio => {
+                                    <figure itemprop="audio" itemscope itemtype="http://schema.org/AudioObject" data-component="main audio">
+                                    @audio.mainAudio.map { audioElement =>
+                                        @fragments.media.audio(AudioPlayer(
+                                            audio,
+                                            audioElement,
+                                            audio.headline,
+                                            autoPlay = true
                                         ))
                                     }
-                                </figure>
-                            }
-                        }
-                    </div>
+                                    </figure>
+                                }
+                                case video: Video => {
+                                    <figure itemprop="video" itemscope itemtype="http://schema.org/VideoObject" data-component="main video">
+                                        <meta itemprop="name" content="@Html(video.headline)"/>
+                                        <meta itemprop="headline" content="@Html(video.headline)"/>
+                                        <meta itemprop="url" content="@video.url"/>
+                                        @video.trailText.map{ t =>
+                                            <meta itemprop="description" content="@StripHtmlTags(t)" />
+                                            <meta itemprop="about" content="@StripHtmlTags(t)" />
+                                        }
 
-                    <div class="content__main-column__body" data-component="body">
-                        @media match {
-                            case v: Video => {
-                                <div class="video-standfirst">
-                                    @fragments.standfirst(v)
-                                </div>
-                            }
-                            case a: Audio => {
-                                <div class="from-content-api">
-                                    @Html(a.body)
-                                </div>
-                            }
-                        }
-                        <div class="tag-wrapper u-h--up-to-left-col">
-                            @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                                <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                                    <h2 class="social__head u-h--up-to-left-col">Topics</h2>
-                                    @fragments.keywordList(media.keywords, tone = "media")
-                                </div>
+                                        <meta itemprop="datePublished" content="@video.webPublicationDate.toString("yyyy-MM-dd")" />
+                                        <meta itemprop="name" content="@video.webTitle" />
+                                        <meta itemprop="uploadDate" content="@video.webPublicationDate.toString("yyyy-MM-dd")" />
+                                        @video.mainVideo.map { mv =>
+                                            <meta itemprop="duration" content="@mv.ISOduration" />
+                                            <meta itemprop="height" content="@mv.height" />
+                                            <meta itemprop="width" content="@mv.width" />
+                                        }
+                                        <meta itemprop="requiresSubscription" content="no" />
+                                        <meta itemprop="image" content="@video.openGraphImage" />
+                                        @video.thumbnail.map{ img => <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img)" /> }
+                                        @video.mainVideo.map { videoElement =>
+                                            @fragments.media.video(VideoPlayer(
+                                                videoElement,
+                                                Video640,
+                                                video.headline,
+                                                autoPlay = true,
+                                                showControlsAtStart = true,
+                                                endSlatePath = video.endSlatePath,
+                                                None
+                                            ))
+                                        }
+                                    </figure>
+                                }
                             }
                         </div>
-                    </div>
-                    @fragments.contentMeta(media)
-                    <div class="tag-wrapper hide-from-left-col">
-                        @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                            <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                                <h2 class="social__head u-h--up-to-left-col">Topics</h2>
-                                @fragments.keywordList(media.keywords, tone = "media")
+
+                        <div class="content__main-column__body" data-component="body">
+                            @media match {
+                                case v: Video => {
+                                    @fragments.standfirst(v)
+                                }
+                                case a: Audio => {
+                                    <div class="from-content-api">
+                                        @Html(a.body)
+                                    </div>
+                                }
+                            }
+                            @fragments.contentMeta(media)
+
+                            <div class="tag-wrapper">
+                                @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
+                                    <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
+                                        <h2 class="social__head u-h--up-to-left-col">Topics</h2>
+                                        @fragments.keywordList(media.keywords, tone = "media")
+                                    </div>
+                                }
                             </div>
-                        }
-                    </div>
-                    <div class="social-wrapper social-wrapper--bottom" data-component="share">
-                        @fragments.social(media, iconModifier = "white")
+
+                            <div class="social-wrapper social-wrapper--bottom" data-component="share">
+                                @fragments.social(media, iconModifier = "white")
+                            </div>
+
+                        </div>
+
                     </div>
 
                 </div>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -39,7 +39,7 @@
 
                 <div class="tag-wrapper tag-wrapper--break-at-leftcol" data-link-name="keywords">
                     @if(article.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                        <h2 class="social__head hide-until-leftcol">Topics</h2>
+                        <h2 class="social__head">Topics</h2>
                         @fragments.keywordList(article.keywords, tone = article.visualTone)
                     }
                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-component="share">

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -37,7 +37,7 @@
                 </div>
 
 
-                <div class="tag-wrapper">
+                <div class="tag-wrapper tag-wrapper--break-at-leftCol">
                     @if(article.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
                             <h2 class="social__head u-h--up-to-left-col">Topics</h2>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -37,7 +37,7 @@
                 </div>
 
 
-                <div class="tag-wrapper tag-wrapper--break-at-leftCol">
+                <div class="tag-wrapper tag-wrapper--break-at-leftcol">
                     @if(article.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
                             <h2 class="social__head u-h--up-to-left-col">Topics</h2>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -37,12 +37,10 @@
                 </div>
 
 
-                <div class="tag-wrapper tag-wrapper--break-at-leftcol">
+                <div class="tag-wrapper tag-wrapper--break-at-leftcol" data-link-name="keywords">
                     @if(article.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                        <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                            <h2 class="social__head hide-until-leftcol">Topics</h2>
-                            @fragments.keywordList(article.keywords, tone = article.visualTone)
-                        </div>
+                        <h2 class="social__head hide-until-leftcol">Topics</h2>
+                        @fragments.keywordList(article.keywords, tone = article.visualTone)
                     }
                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-component="share">
                         <h2 class="social__head hide-until-leftcol">Share this article</h2>

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -40,12 +40,12 @@
                 <div class="tag-wrapper tag-wrapper--break-at-leftcol">
                     @if(article.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-link-name="keywords">
-                            <h2 class="social__head u-h--up-to-left-col">Topics</h2>
+                            <h2 class="social__head hide-until-leftcol">Topics</h2>
                             @fragments.keywordList(article.keywords, tone = article.visualTone)
                         </div>
                     }
                     <div class="social-wrapper social-wrapper--aside social-wrapper--tags" data-component="share">
-                        <h2 class="social__head u-h--up-to-left-col">Share this article</h2>
+                        <h2 class="social__head hide-until-leftcol">Share this article</h2>
                         @fragments.social(article)
                     </div>
                 </div>

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -18,8 +18,14 @@
     }
 }
 
-.hide-from-left-col {
-    @include mq($from: leftCol) {
+.u-h--up-to-wide {
+    @include mq($until: wide) {
+        @include u-h;
+    }
+}
+
+.u-h--from-wide {
+    @include mq($from: wide) {
         @include u-h;
     }
 }

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -6,26 +6,14 @@
     @include u-h;
 }
 
-.u-h--up-to-right-col {
+.hide-until-rightcol {
     @include mq($until: rightCol) {
         @include u-h;
     }
 }
 
-.u-h--up-to-left-col {
+.hide-until-leftcol {
     @include mq($until: leftCol) {
-        @include u-h;
-    }
-}
-
-.u-h--up-to-wide {
-    @include mq($until: wide) {
-        @include u-h;
-    }
-}
-
-.u-h--from-wide {
-    @include mq($from: wide) {
         @include u-h;
     }
 }

--- a/common/app/assets/stylesheets/base/_helpers.scss
+++ b/common/app/assets/stylesheets/base/_helpers.scss
@@ -18,6 +18,12 @@
     }
 }
 
+.hide-until-wide {
+    @include mq($until: wide) {
+        @include u-h;
+    }
+}
+
 .is-hidden,
 [hidden] {
     display: none !important;

--- a/common/app/assets/stylesheets/module/_tabs.scss
+++ b/common/app/assets/stylesheets/module/_tabs.scss
@@ -9,10 +9,10 @@ category: Common
 <div class="tabs u-cf">
     <ol class="tabs__container" role="tablist">
         <li class="tabs__tab tabs__tab--selected" role="tab" id="tabs-example-1-tab" aria-selected="true" aria-controls="tabs-example-1">
-            <a href="#tabs-example-1"><span class="u-h--up-to-right-col">Popular in </span>World news</a>
+            <a href="#tabs-example-1"><span class="hide-until-rightcol">Popular in </span>World news</a>
         </li>
         <li class="tabs__tab" role="tab" id="tabs-example-2-tab" aria-controls="tabs-example-2">
-            <a href="#tabs-example-2"><span class="u-h--up-to-right-col">Popular in </span>The Guardian</a>
+            <a href="#tabs-example-2"><span class="hide-until-rightcol">Popular in </span>The Guardian</a>
         </li>
     </ol>
     <div class="tabs__content">

--- a/common/app/assets/stylesheets/module/_tag-list.scss
+++ b/common/app/assets/stylesheets/module/_tag-list.scss
@@ -12,7 +12,7 @@
     }
 }
 
-.tag-wrapper--break-at-leftCol {
+.tag-wrapper--break-at-leftcol {
     @include mq(leftCol) {
         width: $left-column;
         position: absolute;

--- a/common/app/assets/stylesheets/module/_tag-list.scss
+++ b/common/app/assets/stylesheets/module/_tag-list.scss
@@ -1,6 +1,13 @@
 .tag-wrapper {
     width: 100%;
 
+    @include mq(leftCol) {
+        margin-top: $gs-baseline*2;
+        padding-top: $gs-baseline;
+        border-top: 1px dotted $c-neutral4;
+    }
+
+
     .content--article & {
         margin-bottom: $gs-baseline/2;
     }
@@ -10,10 +17,15 @@
             padding-bottom: $gs-baseline*4;
         }
     }
+    .social__head {
+        display: none;
+    }
 }
 
 .tag-wrapper--break-at-leftcol {
     @include mq(leftCol) {
+        padding-top: 0;
+        margin-top: 0;
         width: $left-column;
         position: absolute;
         bottom: 0;
@@ -21,6 +33,10 @@
 
         .content__main-column--media & {
             bottom: -($gs-baseline/4);
+        }
+
+        .social__head {
+            display: block;
         }
     }
 
@@ -32,10 +48,15 @@
 
 .tag-wrapper--break-at-wide {
     @include mq(wide) {
+        padding-top: 0;
         width: $left-column-wide;
         position: absolute;
         bottom: 0;
         left: -$left-column-wide - $gs-gutter;
+
+        .social__head {
+            display: block;
+        }
 
         .content__main-column--media & {
             bottom: -($gs-baseline/4);

--- a/common/app/assets/stylesheets/module/_tag-list.scss
+++ b/common/app/assets/stylesheets/module/_tag-list.scss
@@ -10,7 +10,9 @@
             padding-bottom: $gs-baseline*4;
         }
     }
+}
 
+.tag-wrapper--break-at-leftCol {
     @include mq(leftCol) {
         width: $left-column;
         position: absolute;
@@ -25,6 +27,19 @@
     @include mq(wide) {
         width: $left-column-wide;
         left: -$left-column-wide - $gs-gutter;
+    }
+}
+
+.tag-wrapper--break-at-wide {
+    @include mq(wide) {
+        width: $left-column-wide;
+        position: absolute;
+        bottom: 0;
+        left: -$left-column-wide - $gs-gutter;
+
+        .content__main-column--media & {
+            bottom: -($gs-baseline/4);
+        }
     }
 }
 

--- a/common/app/assets/stylesheets/module/content/_media-player.scss
+++ b/common/app/assets/stylesheets/module/content/_media-player.scss
@@ -32,9 +32,6 @@ $vjs-progress-inset-bottom: 4px;
         border-right: $gs-gutter/2 solid transparent;
     }
 }
-.video-standfirst {
-    margin-bottom: ($gs-baseline/3)*4;
-}
 
 .element-video {
     position: relative;

--- a/common/app/assets/stylesheets/module/content/_media.global.scss
+++ b/common/app/assets/stylesheets/module/content/_media.global.scss
@@ -5,6 +5,7 @@
     .social-wrapper--aside,
     .content__meta-container,
     .ad-slot--paid-for-badge--article,
+    .tag-wrapper,
     .commentcount {
         border-color: $c-neutral2;
     }

--- a/common/app/assets/stylesheets/module/content/_media.global.scss
+++ b/common/app/assets/stylesheets/module/content/_media.global.scss
@@ -83,12 +83,11 @@
         max-width: none;
     }
 
-    $video-most-viewed-container: 525px;
     $audio-most-viewed-container: 358px;
 
     .content__main-column--video {
         @include mq(rightCol) {
-            min-height: $video-most-viewed-container;
+            min-height: gs-height(12);
         }
     }
     .content__main-column--audio {
@@ -111,7 +110,7 @@
     }
     .content__secondary-column--video {
         @include mq(rightCol) {
-            height: $video-most-viewed-container;
+            height: auto;
         }
     }
     .content__secondary-column--audio {

--- a/common/app/assets/stylesheets/module/content/_media.head.scss
+++ b/common/app/assets/stylesheets/module/content/_media.head.scss
@@ -73,6 +73,6 @@
     }
 }
 
-.video-body {
+.media-body {
     position: relative;
 }

--- a/common/app/assets/stylesheets/module/content/_media.head.scss
+++ b/common/app/assets/stylesheets/module/content/_media.head.scss
@@ -14,11 +14,6 @@
     max-width: gs-span(8);
 }
 
-.content__main-column--media .content__main-column__body {
-    position: relative;
-}
-
-
 .content--media {
     background-color: $c-neutral1;
     color: $c-neutral7;
@@ -76,4 +71,8 @@
             }
         }
     }
+}
+
+.video-body {
+    position: relative;
 }

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -13,7 +13,7 @@
                 <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
                     @popular.zipWithRowInfo.map{ case (section, info) =>
                         <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">
-                            <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h--up-to-right-col">Popular in </span>@Html(section.heading)</a>
+                            <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="hide-until-rightcol">Popular in </span>@Html(section.heading)</a>
                         </li>
                     }
                 </ol>


### PR DESCRIPTION
## Changes
- Auto height for popular video container
- Only break tags into left column at the wide breakpoint on media page
- Removed the second tag container in the media page HTML (can do the same with one)
## Fixes
- Fixes popular video container getting cut off:

![image](https://cloud.githubusercontent.com/assets/960919/4322570/ba5ff87e-3f49-11e4-80be-6dd126c92748.png)
- Partial fix for tags colliding with long bylines:

![image](https://cloud.githubusercontent.com/assets/960919/4322583/cde6bc20-3f49-11e4-8abf-fb352de5cd41.png)

// @Jholder112233 
