### PR TITLE
Add media service to image rewriting

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -99,18 +99,25 @@ object Profile {
 
 object ImgSrc {
 
-  def imageHost(host: String) = Configuration.images.path + host.stripSuffix(".guim.co.uk")
-  def imageHosts = Seq("static.guim.co.uk", "media.guim.co.uk")
+  private val imageHost = Configuration.images.path
+
+  private val hostPrefixMapping = Map(
+    "static.guim.co.uk" -> "static",
+    "media.guim.co.uk" -> "media"
+  )
+
+  private def isSupportedImage(uri: URI) =
+    hostPrefixMapping.isDefinedAt(uri.getHost) && !uri.getPath.toLowerCase.endsWith(".gif")
 
   def apply(url: String, imageType: ElementProfile): String = {
     val uri = new URI(url.trim)
-    val isSupportedImage = imageHosts.exists(h => h == uri.getHost) && !uri.getPath.toLowerCase.endsWith(".gif")
-    val host = imageHost(uri.getHost)
 
-    if (ImageServerSwitch.isSwitchedOn && isSupportedImage)
-      s"$host${imageType.resizeString}${uri.getPath}"
-    else
+    if (ImageServerSwitch.isSwitchedOn && isSupportedImage(uri)) {
+      val hostWithPathPrefix = s"$imageHost${hostPrefixMapping(uri.getHost)}"
+      s"$hostWithPathPrefix${imageType.resizeString}${uri.getPath}"
+    } else {
       url
+    }
   }
 
   object Imager extends Profile(None, None) {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -99,15 +99,16 @@ object Profile {
 
 object ImgSrc {
 
-  def imageHost = Configuration.images.path
+  def imageHost(host: String) = Configuration.images.path + host.stripSuffix(".guim.co.uk")
+  def imageHosts = Seq("static.guim.co.uk", "media.guim.co.uk")
 
   def apply(url: String, imageType: ElementProfile): String = {
     val uri = new URI(url.trim)
-
-    val isSupportedImage = uri.getHost == "static.guim.co.uk" && !uri.getPath.toLowerCase.endsWith(".gif")
+    val isSupportedImage = imageHosts.exists(h => h == uri.getHost) && !uri.getPath.toLowerCase.endsWith(".gif")
+    val host = imageHost(uri.getHost)
 
     if (ImageServerSwitch.isSwitchedOn && isSupportedImage)
-      s"$imageHost${imageType.resizeString}${uri.getPath}"
+      s"$host${imageType.resizeString}${uri.getPath}"
     else
       url
   }

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -106,18 +106,16 @@ object ImgSrc {
     "media.guim.co.uk" -> "media"
   )
 
-  private def isSupportedImage(uri: URI) =
-    hostPrefixMapping.isDefinedAt(uri.getHost) && !uri.getPath.toLowerCase.endsWith(".gif")
-
   def apply(url: String, imageType: ElementProfile): String = {
     val uri = new URI(url.trim)
+    val isSupportedImage = !uri.getPath.toLowerCase.endsWith(".gif")
 
-    if (ImageServerSwitch.isSwitchedOn && isSupportedImage(uri)) {
-      val hostWithPathPrefix = s"$imageHost${hostPrefixMapping(uri.getHost)}"
-      s"$hostWithPathPrefix${imageType.resizeString}${uri.getPath}"
-    } else {
-      url
-    }
+    hostPrefixMapping.get(uri.getHost)
+      .filter(_ => isSupportedImage)
+      .filter(_ => ImageServerSwitch.isSwitchedOn)
+      .map(pathPrefix =>
+        s"$imageHost$pathPrefix${imageType.resizeString}${uri.getPath}"
+      ).getOrElse(url)
   }
 
   object Imager extends Profile(None, None) {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -113,7 +113,7 @@ object ImgSrc {
     hostPrefixMapping.get(uri.getHost)
       .filter(_ => isSupportedImage)
       .filter(_ => ImageServerSwitch.isSwitchedOn)
-      .map(pathPrefix =>
+      .map( pathPrefix =>
         s"$imageHost$pathPrefix${imageType.resizeString}${uri.getPath}"
       ).getOrElse(url)
   }

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -114,7 +114,7 @@ object ImgSrc {
       .filter(_ => isSupportedImage)
       .filter(_ => ImageServerSwitch.isSwitchedOn)
       .map( pathPrefix =>
-        s"$imageHost$pathPrefix${imageType.resizeString}${uri.getPath}"
+        s"$imageHost/$pathPrefix${imageType.resizeString}${uri.getPath}"
       ).getOrElse(url)
   }
 

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -35,12 +35,12 @@ class ImgSrcTest extends FlatSpec with Matchers  {
 
   "ImgSrc" should "convert the URL of a static image to the resizing endpoint with a /static prefix" in {
     ImageServerSwitch.switchOn()
-      GalleryLargeTrail.bestFor(image) should be (Some(s"${imageHost}static/w-480/h-288/q-95/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"))
+      GalleryLargeTrail.bestFor(image) should be (Some(s"${imageHost}/static/w-480/h-288/q-95/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"))
   }
 
   it should "convert the URL of a media service to the resizing endpoint with a /media prefix" in {
     ImageServerSwitch.switchOn()
-      GalleryLargeTrail.bestFor(mediaImage) should be (Some(s"${imageHost}media/w-480/h-288/q-95/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg"))
+      GalleryLargeTrail.bestFor(mediaImage) should be (Some(s"${imageHost}/media/w-480/h-288/q-95/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg"))
   }
 
   it should "not convert the URL of the image if it is disabled" in {

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -23,9 +23,24 @@ class ImgSrcTest extends FlatSpec with Matchers  {
 
   val image = ImageContainer(Seq(imageAsset), null, imageAsset.index) // yep null, sorry but the tests don't need it
 
-  "ImgSrc" should "convert the URL of the image to the resizing endpoint" in {
+  val mediaImageAsset = ImageAsset(Asset(
+    "image",
+    Some("image/jpeg"),
+    Some("http://media.guim.co.uk/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg"),
+    Map.empty[String, String]
+  ), 1)
+
+  val mediaImage = ImageContainer(Seq(mediaImageAsset), null, mediaImageAsset.index)
+
+
+  "ImgSrc" should "convert the URL of a static image to the resizing endpoint with a /static prefix" in {
     ImageServerSwitch.switchOn()
-      GalleryLargeTrail.bestFor(image) should be (Some(s"$imageHost/w-480/h-288/q-95/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"))
+      GalleryLargeTrail.bestFor(image) should be (Some(s"${imageHost}static/w-480/h-288/q-95/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"))
+  }
+
+  it should "convert the URL of a media service to the resizing endpoint with a /media prefix" in {
+    ImageServerSwitch.switchOn()
+      GalleryLargeTrail.bestFor(mediaImage) should be (Some(s"${imageHost}media/w-480/h-288/q-95/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg"))
   }
 
   it should "not convert the URL of the image if it is disabled" in {


### PR DESCRIPTION
Waiting on a NGINX config change for this to go through.
Images from the media service need to be rewritten with `/media` prefixed as discussed with @phamann.

![Cameras](http://gifshost.com/012012/1327341659_lightning_caught_on_camera.gif)
