### PR TITLE
Remove letters tone from comment mapping

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -258,7 +258,6 @@ object Tags {
 
   val commentMappings = Seq(
     "tone/comment",
-    "tone/letters",
     "tone/editorials"
   )
 


### PR DESCRIPTION
Seeing as the comment template is designed to highlight our personalities, it doesn't make sense for the letters tone to adapt to this style. This is at the request of editorial.

Before:
![screen shot 2014-09-19 at 11 19 46](https://cloud.githubusercontent.com/assets/1607666/4333924/fd4c8326-3fe6-11e4-868f-dbe446820518.png)

After:
![screen shot 2014-09-19 at 11 19 54](https://cloud.githubusercontent.com/assets/1607666/4333928/0a0455f8-3fe7-11e4-8373-d0c3a0adb94f.png)
