### PR TITLE
Create a fallback for facia-cards images when headline is too long

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -38,6 +38,12 @@ $fc-item-gutter: $gs-gutter / 3;
     }
 }
 
+.fc-item--has-image {
+    &:before {
+        background-color: rgba($c-neutral1, .15);
+    }
+}
+
 .fc-item__media-wrapper,
 .fc-item__image-container {
     display: none;

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -23,6 +23,10 @@ $fc-item-gutter: $gs-gutter / 3;
     display: block;
     position: relative;
 
+    a {
+        color: $c-neutral1;
+    }
+
     .stars {
         margin-top: $gs-baseline * .25;
 
@@ -38,10 +42,8 @@ $fc-item-gutter: $gs-gutter / 3;
     }
 }
 
-.fc-item--has-image {
-    &:before {
-        background-color: rgba($c-neutral1, .15);
-    }
+.fc-item--has-image:before {
+    background-color: rgba($c-neutral1, .15);
 }
 
 .fc-item__media-wrapper,
@@ -99,6 +101,11 @@ $fc-item-gutter: $gs-gutter / 3;
     padding-top: $gs-baseline / 3;
     padding-bottom: $gs-baseline / 3;
     @include fs-textSans(1);
+
+    &,
+    & a {
+        color: $c-neutral2;
+    }
 }
 
 .fc-item__timestamp,

--- a/common/app/assets/stylesheets/module/facia-cards/_tones.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones.scss
@@ -24,6 +24,7 @@ a {
 .tone-live {
     &.fc-item {
         background-color: $c-live;
+
         &,
         & a {
             color: #ffffff;

--- a/common/app/assets/stylesheets/module/facia-cards/_tones.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones.scss
@@ -1,16 +1,3 @@
-// DEFAULTS
-.fc-item {
-    a {
-        color: $c-neutral1;
-    }
-}
-
-.fc-item__meta,
-.fc-item__meta a {
-    color: $c-neutral2;
-}
-
-// TONAL OVERRIDES
 .tone-news {
     .fc-item__kicker {
         color: $c-analysisAccent;

--- a/common/app/assets/stylesheets/module/facia-cards/_tones.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones.scss
@@ -1,6 +1,8 @@
 // DEFAULTS
-a {
-    color: $c-neutral1;
+.fc-item {
+    a {
+        color: $c-neutral1;
+    }
 }
 
 .fc-item__meta,
@@ -14,10 +16,8 @@ a {
         color: $c-analysisAccent;
     }
 
-    &.fc-item--has-image {
-        &:before {
-            background-color: $c-neutral5;
-        }
+    &.fc-item--has-image:before {
+        background-color: $c-neutral5;
     }
 }
 
@@ -111,10 +111,8 @@ a {
         color: $c-mediaDefault;
     }
 
-    &.fc-item--has-image {
-        &:before {
-            background-color: fade-out(#000000, .75);
-        }
+    &.fc-item--has-image:before {
+        background-color: fade-out(#000000, .75);
     }
 
     .fc-item__meta {

--- a/common/app/assets/stylesheets/module/facia-cards/_tones.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones.scss
@@ -13,6 +13,12 @@ a {
     .fc-item__kicker {
         color: $c-analysisAccent;
     }
+
+    &.fc-item--has-image {
+        &:before {
+            background-color: $c-neutral5;
+        }
+    }
 }
 
 .tone-live {
@@ -26,12 +32,6 @@ a {
 
     a.fc-item__kicker {
         color: $c-liveMute;
-    }
-
-    &.fc-item--has-image {
-        &:before {
-            background-color: fade-out(#ffffff, .5);
-        }
     }
 
     .fc-item__meta {
@@ -49,12 +49,6 @@ a {
 
     .fc-item__kicker {
         color: $c-commentDefault;
-    }
-
-    &.fc-item--has-image {
-        &:before {
-            background-color: fade-out(#ffffff, .5);
-        }
     }
 
     .fc-item__meta {
@@ -75,12 +69,6 @@ a {
 
     .fc-item__kicker {
         color: $c-featureMute !important;
-    }
-
-    &.fc-item--has-image {
-        &:before {
-            background-color: fade-out(#ffffff, .5);
-        }
     }
 
     .fc-item__title .i {
@@ -106,12 +94,6 @@ a {
     .fc-item__kicker {
         color: $c-analysisAccent;
     }
-
-    &.fc-item--has-image {
-        &:before {
-            background-color: fade-out(#ffffff, .5);
-        }
-    }
 }
 
 .tone-media {
@@ -130,7 +112,7 @@ a {
 
     &.fc-item--has-image {
         &:before {
-            background-color: fade-out(#ffffff, .5);
+            background-color: fade-out(#000000, .75);
         }
     }
 


### PR DESCRIPTION
Because I'm an idiot who didn't push something to our facia-cards-2.0 branch, this is in a separate PR.

This changes the colour behind the image dependant on tone. Which means when the headline is too long it looks like this...

![screen shot 2014-09-19 at 17 53 55](https://cloud.githubusercontent.com/assets/1607666/4338874/9a4786fe-401d-11e4-900b-115767353b3d.png)
