### PR TITLE
remove opening and closeing events from key events panel

### DIFF
--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -48,17 +48,6 @@ define([
         return qwery('.is-key-event').slice(0, 7);
     }
 
-    function getBlocks() {
-        return qwery('.block');
-    }
-
-    function getFirstBlock() {
-        return getBlocks().shift();
-    }
-
-    function getLastBlock() {
-        return getBlocks().pop();
-    }
 
     function createScrollTransitions (){
 

--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -121,10 +121,6 @@ define([
         return recursiveRender(events, '');
     }
 
-    function wrapWithFirstAndLast(html) {
-        return createKeyEventHTML(getFirstBlock()) + html + createKeyEventHTML(getLastBlock());
-    }
-
     function getUpdatePath() {
         var blocks = qwery('.js-liveblog-body .block'),
             newestBlock = null;
@@ -154,11 +150,9 @@ define([
         createTimeline: function() {
             var allEvents = getKeyEvents();
             if(allEvents.length > 0) {
-                var timelineHTML = wrapWithFirstAndLast(getTimelineHTML(allEvents));
+                var timelineHTML = getTimelineHTML(allEvents);
 
                 $('.js-live-blog__timeline').append(timelineHTML);
-                $('.js-live-blog__timeline li:first-child .timeline__title').text('Latest post');
-                $('.js-live-blog__timeline li:last-child .timeline__title').text('Opening post');
 
                 if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0) {
                     var topMarker = qwery('.js-top-marker')[0];


### PR DESCRIPTION
Remove 'Latest Post' and 'Opening post' from live blog key events panel ( The two events indicated in the before ) 

Before:
![with-latest](https://cloud.githubusercontent.com/assets/986155/4355921/e91ddac6-4252-11e4-80c1-e5ece3439e95.png)

After:

![no-latest](https://cloud.githubusercontent.com/assets/986155/4355913/c53d7a94-4252-11e4-8ad3-1ddaa52d9b65.png)
