### PR TITLE
fix for rendering inconsistencies

### DIFF
--- a/common/app/assets/stylesheets/_extends-only.scss
+++ b/common/app/assets/stylesheets/_extends-only.scss
@@ -31,7 +31,6 @@
 %icon-holder-circle {
     position: relative;
     display: block;
-    overflow: hidden;
     width: 30px;
     height: 30px;
     border: 1px solid $c-neutral1;


### PR DESCRIPTION
fix for circles getting cropped at some screen widths when transform animations are used in the banner ad

![image](https://cloud.githubusercontent.com/assets/960919/4357065/3218e322-425f-11e4-8aa7-fd8b9a4da772.png)

![image](http://media.giphy.com/media/LZaNrkOLxI5Yk/giphy.gif)

// @austinh7 
