### PR TITLE
gallery lightbox crop fixes

### DIFF
--- a/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
+++ b/common/app/assets/stylesheets/module/content/_gallery-lightbox.scss
@@ -23,7 +23,7 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
 
     @include mq($gallery-lightbox-sidebar-breakpoint) {
         .gallery-lightbox__item--img {
-            padding-right: $gallery-lightbox-info-width-desktop;
+            padding-right: $gallery-lightbox-sidebar-width + $gallery-lightbox-info-width-desktop;
         }
 
         .gallery-lightbox__info {

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -37,10 +37,10 @@ trait ImageContainer extends Element {
   // The image crop with the largest width.
   lazy val largestImage: Option[ImageAsset] = imageCrops.headOption
 
-  // almost all images with a width of 2048 and 1024 have been auto-cropped to a 4:3 aspect. except for portrait
-  // images that are scaled to this width by chance (rare edge case with no nasty side effects). this is a temporary
-  // solution until the new media service is in use and we can properly distinguish crops by their intended usage
-  lazy val largestEditorialCrop: Option[ImageAsset] = imageCrops.find(img => img.width != 2048 && img.width != 1024)
+  // all landscape images with a width of 1024 or 2048 have been auto-cropped to 4:3. portrait images are never
+  // auto-cropped.. this is a temporary solution until the new media service is in use and we can properly
+  // distinguish crops by their intended usage
+  lazy val largestEditorialCrop: Option[ImageAsset] = imageCrops.find(img => img.width < img.height || (img.width != 2048 && img.width != 1024))
 }
 
 object ImageContainer {

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -36,6 +36,11 @@ trait ImageContainer extends Element {
 
   // The image crop with the largest width.
   lazy val largestImage: Option[ImageAsset] = imageCrops.headOption
+
+  // almost all images with a width of 2048 and 1024 have been auto-cropped to a 4:3 aspect. except for portrait
+  // images that are scaled to this width by chance (rare edge case with no nasty side effects). this is a temporary
+  // solution until the new media service is in use and we can properly distinguish crops by their intended usage
+  lazy val largestEditorialCrop: Option[ImageAsset] = imageCrops.find(img => img.width != 2048 && img.width != 1024)
 }
 
 object ImageContainer {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -552,6 +552,8 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
   lazy val galleryImages: Seq[ImageElement] = images.filter(_.isGallery)
   lazy val largestCrops: Seq[ImageAsset] = galleryImages.flatMap(_.largestImage)
 
+  lazy val largestEditorialCrops: Seq[ImageAsset] = galleryImages.flatMap(_.largestEditorialCrop)
+
   override def cards: List[(String, String)] = super.cards ++ Seq(
     "twitter:card" -> "gallery",
     "twitter:title" -> linkText
@@ -562,7 +564,7 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
   lazy val lightbox: JsObject = {
     val imageContainers = galleryImages.filter(_.isGallery)
     val imageJson = imageContainers.map{ imgContainer =>
-      imgContainer.largestImage.map { img =>
+      imgContainer.largestEditorialCrop.map { img =>
         JsObject(Seq(
           "caption" -> JsString(img.caption.getOrElse("")),
           "credit" -> JsString(img.credit.getOrElse("")),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -552,8 +552,6 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
   lazy val galleryImages: Seq[ImageElement] = images.filter(_.isGallery)
   lazy val largestCrops: Seq[ImageAsset] = galleryImages.flatMap(_.largestImage)
 
-  lazy val largestEditorialCrops: Seq[ImageAsset] = galleryImages.flatMap(_.largestEditorialCrop)
-
   override def cards: List[(String, String)] = super.cards ++ Seq(
     "twitter:card" -> "gallery",
     "twitter:title" -> linkText


### PR DESCRIPTION
- Temporary fix to stop the gallery lightbox picking the auto-cropped 4:3 aspect images (this can be replaced when the new media service comes in)
- Fix for the caption info panel overlapping the lightbox image at desktop breakpoint

![image](https://s3.amazonaws.com/giphymedia/media/85hqFWqODN8Mo/200.gif)

// @jamesgorrie @theefer 
