### PR TITLE
Fix facia IE bugs

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -208,7 +208,7 @@ $fc-item-gutter: $gs-gutter / 3;
         .l-row--items-#{$column} {
             .l-row__item--span-#{$span} {
                 @include flex($span);
-                width: (100% / $column) * $span
+                width: (100% / $column) * $span;
             }
         }
     }

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -17,11 +17,9 @@ $fc-item-gutter: $gs-gutter / 3;
     @include box-sizing(border-box);
     display: block;
     @include clearfix;
-
     padding-bottom: $gs-baseline * 2.5;
     margin-left: $gs-gutter * .5;
     margin-right: $gs-gutter * .5;
-
     background-color: #ffffff;
     position: relative;
 
@@ -192,6 +190,7 @@ $fc-item-gutter: $gs-gutter / 3;
 }
 
 .l-list__item {
+    float: left;
 
     &:last-child {
         margin-bottom: 0;

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -9,20 +9,20 @@ $fc-item-gutter: $gs-gutter / 3;
     .facia-slice__item {
         @include flex-display;
         padding-bottom: 0;
-
-        @if not $browser-supports-flexbox {
-            width: 25%;
-        }
     }
 }
 
 .fc-item {
     @include flex(1);
+    @include box-sizing(border-box);
+    display: block;
+    @include clearfix;
+
     padding-bottom: $gs-baseline * 2.5;
     margin-left: $gs-gutter * .5;
     margin-right: $gs-gutter * .5;
+
     background-color: #ffffff;
-    display: block;
     position: relative;
 
     .stars {
@@ -183,7 +183,7 @@ $fc-item-gutter: $gs-gutter / 3;
 
 
 .l-list {
-    float: left;
+    width: 100%;
 
     .has-flex-wrap & {
         @include flex-display;
@@ -192,7 +192,6 @@ $fc-item-gutter: $gs-gutter / 3;
 }
 
 .l-list__item {
-    float: left;
 
     &:last-child {
         margin-bottom: 0;
@@ -204,10 +203,19 @@ $fc-item-gutter: $gs-gutter / 3;
     }
 }
 
-@for $column from 1 through 4 {
-    .l-row__item--span-#{$column} {
-        @include flex(#{$column});
+// We only need this functionality for 3 & 4 column rows.
+@for $column from 3 through 4 {
+    @for $span from 1 through $column {
+        .l-row--items-#{$column} {
+            .l-row__item--span-#{$span} {
+                @include flex($span);
+                width: (100% / $column) * $span
+            }
+        }
     }
+}
+
+@for $column from 1 through 4 {
 
     .l-list--columns-#{$column} {
         .l-list__item {

--- a/common/app/layout/Column.scala
+++ b/common/app/layout/Column.scala
@@ -6,7 +6,7 @@ case class ItemClasses(mobile: String, desktop: String) {
 }
 case class SliceLayout(cssClassName: String, columns: Seq[Column])
 
-sealed trait  Column {
+sealed trait Column {
   def numItems: Int
 }
 
@@ -44,5 +44,14 @@ object SliceWithCards {
   }
 }
 
-case class SliceWithCards(cssClassName: String, columns: Seq[ColumnAndCards])
+case class SliceWithCards(cssClassName: String, columns: Seq[ColumnAndCards]) {
+  def numberOfColumns = (columns map { columnAndCards: ColumnAndCards =>
+    columnAndCards.column match {
+      case Rows(_, cols, _, _) => cols
+      case _ => 1
+    }
+  }).sum
+}
+
+
 case class ColumnAndCards(column: Column, cards: Seq[Card])

--- a/common/app/views/fragments/containers/slice.scala.html
+++ b/common/app/views/fragments/containers/slice.scala.html
@@ -34,7 +34,7 @@
                 </div>
                 <div class="container__body container--rolled-up-hide">
                     <div class="facia-slice-wrapper">
-                        <ul class="u-unstyled l-row l-row--items-@slice.columns.size facia-slice">
+                        <ul class="u-unstyled l-row l-row--items-@slice.numberOfColumns facia-slice">
                         @for(ColumnAndCards(column, cards) <- slice.columns) {
 
                             @column match {

--- a/common/app/views/fragments/items/facia_cards/standard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/standard.scala.html
@@ -8,7 +8,7 @@
 
 @defining((card.item, card.index)) { case (trail, index) =>
 
-<li class="@GetClasses.forCollectionItem(trail) @if(isList){ l-list__item }">
+<li class="@GetClasses.forCollectionItem(trail) l-row__item--span-1 @if(isList){ l-list__item }">
 
     @defining((trail.visualTone, containerIndex == 0)) { case (tone, isFirstContainer) =>
         <div


### PR DESCRIPTION
- Ensure `.l-list` items display full width on IE9
- Ensure `.l-row__item--span-3` takes up correct width on IE9
- Fix float collapsing issue with `.l-list` on IE10
### Before

![littlesnapper](https://cloud.githubusercontent.com/assets/80089/4358415/1dba8a88-426a-11e4-981f-70efb5834168.jpg)
### After

![littlesnapper 2](https://cloud.githubusercontent.com/assets/80089/4358417/22c3b77a-426a-11e4-8416-beb704f46553.jpg)

/cc @sndrs 
