### PR TITLE
Fix nested snaps

### DIFF
--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -138,13 +138,22 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
   def getArticles(collectionItems: Seq[CollectionItem], edition: Edition): Future[Seq[Content]] = {
     batchGetContentApiItems((collectionItems ++ collectionItems.flatMap(retrieveSupportingLinks)).filterNot(_.isSnap), edition) map { items =>
       collectionItems flatMap { collectionItem =>
-        val supporting = retrieveSupportingLinks(collectionItem).flatMap({ collectionItem =>
-          items.get(collectionItem) map { item =>
-            Content(
-              item,
+        val supporting: List[Content] = retrieveSupportingLinks(collectionItem).flatMap({ collectionItem =>
+          if (collectionItem.isSnap) {
+            Some(new Snap(
+              collectionItem.id,
               Nil,
-              collectionItem.metaData
-            )
+              collectionItem.webPublicationDate.getOrElse(DateTime.now),
+              collectionItem.metaData.getOrElse(Map.empty)
+            ))
+          } else {
+            items.get(collectionItem) map { item =>
+              Content(
+                item,
+                Nil,
+                collectionItem.metaData
+              )
+            }
           }
         })
 


### PR DESCRIPTION
Nested `Snaps` are broken, because the `supporting` value only got what was requested from the `Content API`.

@robertberry @stephanfowler 
