### PR TITLE
lightbox close/back fix

### DIFF
--- a/common/app/assets/javascripts/modules/gallery/lightbox.js
+++ b/common/app/assets/javascripts/modules/gallery/lightbox.js
@@ -123,7 +123,7 @@ define([
         }
 
         bean.on(window, 'popstate', function(event) {
-            if (event.state === null) {
+            if (!event.state) {
                 this.trigger('close');
             }
         }.bind(this));


### PR DESCRIPTION
chrome ios initial history state is undefined, not null
