### PR TITLE
Consistent headline size across articles and live blogs

### DIFF
--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -169,7 +169,6 @@
 .content__headline {
     @include fs-headline(5);
     padding-bottom: $gs-baseline*2;
-    padding-top: $gs-baseline/2;
 
     @include mq(mobileLandscape) {
         @include fs-headline(7, true);

--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -175,10 +175,7 @@
         @include fs-headline(7, true);
     }
     @include mq(tablet) {
-        @include fs-headline(8, true);
         padding-bottom: $gs-row-height;
-        padding-top: $gs-baseline/6;
-        border-top: 0;
     }
     a {
         &,

--- a/common/app/assets/stylesheets/module/content/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/content/_live-blog.scss
@@ -807,20 +807,10 @@ $timeline-width: 14px;
     background-color: $c-neutral8;
 
     .content__headline {
-        padding-bottom: $gs-baseline*3;
         color: $c-neutral1;
-        @include fs-headline(5);
-
-        @include mq(tablet) {
-            @include fs-headline(6, true);
-        }
-        @include mq(rightCol) {
-            padding-bottom: $gs-row-height + ($gs-baseline * 2);
-        }
     }
 
     &.tone-live .content__head--tonal .content__section {
-
         @include mq(rightCol) {
             float: left;
             width: gs-span(3);

--- a/common/app/assets/stylesheets/module/football/_match-summary.scss
+++ b/common/app/assets/stylesheets/module/football/_match-summary.scss
@@ -14,19 +14,28 @@ $football-crest--large: 60px;
 }
 
 .match-summary__teams {
+    padding-top: $gs-baseline;
     position: relative;
-    padding: $gs-baseline/2 0 0;
-    border-top: 1px dotted $c-neutral2;
+    border-top: 1px dotted $c-neutral5;
     font-size: 0;
+
+    @include mq(tablet) {
+        padding-top: 0;
+    }
 }
+
 .match-summary__team {
-    margin-bottom: $gs-baseline*2;
+    margin-bottom: $gs-baseline;
 }
 
 .team__info {
     position: relative;
     margin-left: $gs-gutter/2 + $football-crest--small;
-    @include fs-headline(6);
+    @include fs-headline(5);
+
+    @include mq(mobileLandscape) {
+        @include fs-headline(7, true);
+    }
 }
 
 .team__heading {
@@ -80,7 +89,8 @@ $football-crest--large: 60px;
 }
 
 .team__scorers {
-    @include fs-data(5);
+    @include fs-textSans(3);
+    color: $c-neutral2;
 }
 
 .match-summary--report .team__scorers dd {
@@ -166,7 +176,7 @@ $football-crest--large: 60px;
 }
 
 .match-info {
-    @include fs-data(3);
+    @include fs-textSans(1);
     padding-left: $gs-gutter/2;
     display: inline-block;
     vertical-align: middle;
@@ -296,9 +306,6 @@ $football-crest--large: 60px;
 
     .match-summary__status {
         display: none;
-    }
-    .match-summary__team {
-        margin-bottom: $gs-baseline;
     }
     .match-info {
         padding: $gs-gutter/2 0;


### PR DESCRIPTION
…also tweaks typography on football score headlines. Previously headline sizes differed across live blogs and articles. Headlines are now always 28/32 (`fs-headline(5)`) until the mobileLandscape breakpoint, to which they increase to 36/40 (`fs-headline(7)`). Example of score heading tweaks:

Before:
![screen shot 2014-09-22 at 17 52 38](https://cloud.githubusercontent.com/assets/813383/4360238/aad439c8-4279-11e4-85c4-4e62dd1d0474.png)

After:
![screen shot 2014-09-22 at 17 52 28](https://cloud.githubusercontent.com/assets/813383/4360240/b32058b4-4279-11e4-83d9-79e28c15bd10.png)
