### PR TITLE
Container config

### DIFF
--- a/common/app/layout/ContainerLayout.scala
+++ b/common/app/layout/ContainerLayout.scala
@@ -5,7 +5,7 @@ import slices.{ContainerDefinition, Slice}
 import views.support.TemplateDeduping
 
 object ContainerLayout extends implicits.Collections {
-  def apply(sliceDefinitions: Seq[Slice], items: Seq[Trail], nToShowOnMobile: Int = 6): ContainerLayout = {
+  def apply(sliceDefinitions: Seq[Slice], items: Seq[Trail], nToShowOnMobile: Int): ContainerLayout = {
     val cards = items.zipWithIndex map {
       case (trail, index) => Card(
         index,

--- a/common/app/layout/ContainerLayout.scala
+++ b/common/app/layout/ContainerLayout.scala
@@ -1,0 +1,43 @@
+package layout
+
+import model.{Collection, Trail}
+import slices.{ContainerDefinition, Slice}
+import views.support.TemplateDeduping
+
+object ContainerLayout extends implicits.Collections {
+  def apply(sliceDefinitions: Seq[Slice], items: Seq[Trail], nToShowOnMobile: Int = 6): ContainerLayout = {
+    val cards = items.zipWithIndex map {
+      case (trail, index) => Card(
+        index,
+        trail,
+        if (index >= nToShowOnMobile) Some(Mobile) else None
+      )
+    }
+
+    val ContainerLayout(slices, showMore) = sliceDefinitions.foldLeft(ContainerLayout(Seq.empty, cards)) {
+      case (s @ ContainerLayout(_, Nil), _) => s
+      case (ContainerLayout(slicesSoFar, cardsForUse), sliceDefinition) =>
+        val (slice, remainingCards) = SliceWithCards.fromItems(cards, sliceDefinition.layout)
+        ContainerLayout(slicesSoFar :+ slice, remainingCards)
+    }
+
+    ContainerLayout(slices, showMore.map(_.copy(hideUpTo = Some(Desktop))))
+  }
+
+  def apply(containerDefinition: ContainerDefinition,
+            collection: Collection,
+            templateDeduping: TemplateDeduping): ContainerLayout = {
+    /** TODO move this to earlier in the process, so that we can make the de-duping a functional transformation */
+    val items = collection.items
+    val numItems = containerDefinition.slices.flatMap(_.layout.columns.map(_.numItems)).sum
+    val unusedTrailsForThisSlice = templateDeduping(numItems, items).take(numItems)
+    val dedupedPrioritisedTrails = (unusedTrailsForThisSlice ++ items).distinctBy(_.url)
+
+    apply(containerDefinition.slices, dedupedPrioritisedTrails, containerDefinition.numberOfCardsForMobile)
+  }
+}
+
+case class ContainerLayout(
+  slices: Seq[SliceWithCards],
+  remainingCards: Seq[Card]
+)

--- a/common/app/slices/ContainerDefinition.scala
+++ b/common/app/slices/ContainerDefinition.scala
@@ -1,0 +1,15 @@
+package slices
+
+object ContainerDefinition {
+  val DefaultCards = 6
+
+  def ofSlices(slices: Slice*) = ContainerDefinition(
+    slices,
+    DefaultCards
+  )
+}
+
+case class ContainerDefinition(
+  slices: Seq[Slice],
+  numberOfCardsForMobile: Int
+)

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -1,0 +1,15 @@
+package slices
+
+object FixedContainers {
+  import ContainerDefinition.{ofSlices => slices}
+
+  val all: Map[String, ContainerDefinition] = Map(
+    "fixed/small/slow-IV" -> slices(QuarterQuarterQuarterQuarter),
+    "fixed/small/slow-V" -> slices(Hl4Half),
+    "fixed/small/fast-VIII" -> slices(QuarterQuarterQlQl),
+    "fixed/small/fast-X" -> slices(QuarterQlQlQl)
+  )
+
+  def unapply(collectionType: Option[String]): Option[ContainerDefinition] =
+    collectionType.flatMap(all.lift)
+}

--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -1,33 +1,10 @@
 package slices
 
 import layout._
-import model.{Collection, Trail}
-import views.support.TemplateDeduping
 
-sealed trait Slice extends implicits.Collections {
+sealed trait Slice {
   /** TODO: once we get rid of all the not-implementeds below, turn this into a val */
   def layout: SliceLayout
-
-  def apply(items: Seq[Trail], nToShowOnMobile: Int = 6)
-           (implicit templateDeduping: TemplateDeduping): (SliceWithCards, Seq[Card]) = {
-    val numItems = layout.columns.map(_.numItems).sum
-    val unusedTrailsForThisSlice = templateDeduping(numItems, items).take(numItems)
-    val dedupePrioritisedTrails = (unusedTrailsForThisSlice ++ items).distinctBy(_.url)
-    val cards = dedupePrioritisedTrails.zipWithIndex.map {
-      case (trail, index) => Card(
-        index,
-        trail,
-        if (index >= nToShowOnMobile) Some(Mobile) else None
-      )
-    }
-    val (slice, showMore) = SliceWithCards.fromItems(cards, layout)
-
-    (slice, showMore.map(_.copy(hideUpTo = Some(Desktop))))
-  }
-
-  def apply(collection: Collection)(implicit templateDeduping: TemplateDeduping): (SliceWithCards, Seq[Card]) = {
-    this(collection.items)
-  }
 }
 
 

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,0 +1,38 @@
+@(collection: model.Collection, containerLayout: layout.ContainerLayout, containerIndex: Int)(implicit request: RequestHeader, templateDeduping: views.support.TemplateDeduping, config: model.Config)
+
+@import views.support.GetClasses
+@import views.html.fragments.containers.facia_cards.{show_more, slice}
+@import model.FaciaComponentName
+@import common.LinkTo
+
+@defining((config.displayName.orElse(collection.displayName), config.href.orElse(collection.href))) { case (title, href) =>
+    <section id="@FaciaComponentName(config, collection)"
+             class="@GetClasses.forNewStyleContainer(config, containerIndex == 0, title.nonEmpty)"
+             data-link-name="@FaciaComponentName(config, collection)"
+             data-id="@config.id"
+             @config.sponsorshipKeyword.map { keyword =>
+                 data-keywords="@keyword"
+             }
+             data-component="@FaciaComponentName(config, collection)">
+        <div class="facia-container__inner">
+            <div class="container__header">
+            @title.map { title =>
+                <h2 class="container__title">
+                    @href.map { href =>
+                    <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
+                    }.getOrElse{
+                        <span class="container__title__label u-text-hyphenate">@Html(title)</span>
+                    }
+                </h2>
+            }
+            </div>
+            <div class="container__body container--rolled-up-hide js-container--fc-show-more">
+                @for(sliceWithCards <- containerLayout.slices) {
+                    @slice(sliceWithCards, containerIndex)
+                }
+
+                @show_more(containerLayout.remainingCards, containerIndex)
+            </div>
+        </div>
+    </section>
+}

--- a/common/app/views/fragments/containers/facia_cards/show_more.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/show_more.scala.html
@@ -11,11 +11,13 @@
  * TODO use the number of columns here
  *@
 @if(cards.nonEmpty) {
-    <div class="linkslist-container">
-        <ul class="linkslist u-unstyled l-list facia-slice">
-        @cards.map { card =>
-            @item(card, "l-list__item fc-item--list-mobile fc-item--list-tablet", containerIndex, isList = true)
-        }
-        </ul>
+    <div class="facia-slice-wrapper">
+        <div class="linkslist-container">
+            <ul class="linkslist u-unstyled l-list facia-slice">
+            @cards.map { card =>
+                @item(card, "l-list__item fc-item--list-mobile fc-item--list-tablet", containerIndex, isList = true)
+            }
+            </ul>
+        </div>
     </div>
 }

--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -1,72 +1,32 @@
-@(collection: model.Collection, sliceWithRemaining: (layout.SliceWithCards, Seq[layout.Card]), containerIndex: Int)(implicit request: RequestHeader, templateDeduping: views.support.TemplateDeduping, config: model.Config)
+@(slice: layout.SliceWithCards, containerIndex: Int)(implicit request: RequestHeader, config: model.Config)
 
-@import views.support.GetClasses
 @import layout.{ColumnAndCards, SingleItem, Rows}
-@import views.html.fragments.containers.facia_cards.show_more
 @import views.html.fragments.items.facia_cards.item
-@import model.FaciaComponentName
-@import common.LinkTo
 
-@defining(sliceWithRemaining){ case (slice, remainingCards) =>
-
-    @defining((config.displayName.orElse(collection.displayName), config.href.orElse(collection.href))) { case (title, href) =>
-
-        <section
-        id="@FaciaComponentName(config, collection)"
-        class="@GetClasses.forNewStyleContainer(config, containerIndex == 0, title.nonEmpty)"
-        data-link-name="@FaciaComponentName(config, collection)"
-        data-id="@config.id"
-        @config.sponsorshipKeyword.map { keyword =>
-            data-keywords="@keyword"
-        }
-        data-component="@FaciaComponentName(config, collection)">
-            <div class="facia-container__inner">
-                <div class="container__header">
-                @title.map { title =>
-                    <h2 class="container__title">
-                        @href.map { href =>
-                        <a class="container__title__label u-text-hyphenate" data-link-name="section heading" href="@LinkTo{/@href}">@Html(title)</a>
-                        }.getOrElse{
-                            <span class="container__title__label u-text-hyphenate">@Html(title)</span>
-                        }
-                    </h2>
+<div class="facia-slice-wrapper">
+    <ul class="u-unstyled l-row l-row--items-@slice.numberOfColumns facia-slice facia-slice--@slice.cssClassName">
+    @for(ColumnAndCards(column, cards) <- slice.columns) {
+        @column match {
+            case SingleItem(colSpan, itemClasses) => {
+                @cards.headOption.map { card =>
+                    @item(card, itemClasses.classes, containerIndex, false, colSpan)
                 }
-                </div>
-                <div class="container__body container--rolled-up-hide js-container--fc-show-more">
-                    <div class="facia-slice-wrapper">
-                        <ul class="u-unstyled l-row l-row--items-@slice.numberOfColumns facia-slice facia-slice--@slice.cssClassName">
-                        @for(ColumnAndCards(column, cards) <- slice.columns) {
+            }
 
-                            @column match {
-
-                                case SingleItem(colSpan, itemClasses) => {
-                                    @cards.headOption.map { card =>
-                                        @item(card, itemClasses.classes, containerIndex, false, colSpan)
-                                    }
-                                }
-
-                                case Rows(colSpan, columns, rows, itemClasses) => {
-                                    <li class="facia-slice__item l-row__item l-row__item--span-@colSpan">
-                                        <ul class="u-unstyled l-list l-list--columns-@columns l-list--rows-@rows">
-                                            @if(cards.nonEmpty) {
-                                                @cards.map{ card =>
-                                                    @item(card, itemClasses.classes, containerIndex, isList = true)
-                                                }
-                                            }
-                                        </ul>
-                                    </li>
-                                }
-
-                                case _ => { @* TODO *@ }
+            case Rows(colSpan, columns, rows, itemClasses) => {
+                <li class="facia-slice__item l-row__item l-row__item--span-@colSpan">
+                    <ul class="u-unstyled l-list l-list--columns-@columns l-list--rows-@rows">
+                        @if(cards.nonEmpty) {
+                            @cards.map{ card =>
+                                @item(card, itemClasses.classes, containerIndex, isList = true)
                             }
                         }
-                        </ul>
+                    </ul>
+                </li>
+            }
 
-                        @show_more(remainingCards, containerIndex)
-
-                    </div>
-                </div>
-            </div>
-        </section>
+            case _ => { @* TODO *@ }
+        }
     }
-}
+    </ul>
+</div>

--- a/common/test/slices/DedupingTest.scala
+++ b/common/test/slices/DedupingTest.scala
@@ -1,22 +1,27 @@
 package slices
 
-import model.Trail
-import org.joda.time.DateTime
+import layout.ContainerLayout
+import model.{ApiContentWithMeta, Content, Collection}
 import org.scalatest.{FlatSpec, Matchers}
 import views.support.TemplateDeduping
+import com.gu.openplatform.contentapi.model.{Content => ApiContent}
 
 class DedupingTest extends FlatSpec with Matchers {
+  val containerFixture = ContainerDefinition(Seq(QuarterQuarterQuarterQuarter), 6)
 
   "Slices" should "dedupe items" in {
-
     val rawTrails = stubTrails
 
     implicit val deduping = TemplateDeduping()
     deduping(rawTrails.take(2))
 
-    val (slice, unusedCards) = QuarterQuarterQuarterQuarter(rawTrails)
+    val ContainerLayout(slices, unusedCards) = ContainerLayout(
+      containerFixture,
+      Collection(rawTrails.toSeq),
+      deduping
+    )
 
-    val usedTrails = slice.columns.flatMap(_.cards.map(_.item))
+    val usedTrails = slices.flatMap(_.columns.flatMap(_.cards.map(_.item)))
 
     withClue("should ignore the duplicates and take the next available items") {
       usedTrails should be(rawTrails.drop(2).take(4))
@@ -32,36 +37,41 @@ class DedupingTest extends FlatSpec with Matchers {
   }
 
   they should "include deduped items if there are not enough unused items" in {
-
     val rawTrails = stubTrails
 
     implicit val deduping = TemplateDeduping()
 
     deduping(rawTrails)
 
-    val (slice, _) = QuarterQuarterQuarterQuarter(rawTrails)
+    val ContainerLayout(slices, unusedCards) = ContainerLayout(
+      containerFixture,
+      Collection(rawTrails.toSeq),
+      deduping
+    )
 
-    val usedTrails = slice.columns.flatMap(_.cards.map(_.item))
+    val usedTrails = slices.flatMap(_.columns.flatMap(_.cards.map(_.item)))
 
     withClue("should include deduped items") {
       usedTrails.map(_.url) should be (Seq("/item-1", "/item-2", "/item-3", "/item-4"))
     }
   }
 
-  private def stubTrails: Seq[Trail] = (1 to 20).map{ index =>
-    new Trail{
-
-      override def url: String = s"/item-$index"
-
-      override def isLive: Boolean = false
-      override def webPublicationDate: DateTime = DateTime.now
-      override def section: String = ""
-      override def trailText: Option[String] = None
-      override def sectionName: String = ""
-      override def linkText: String = ""
-      override def headline: String = ""
-      override def webUrl: String = ""
-      override def toString = url
-    }
+  private def stubTrails: Seq[Content] = (1 to 20) map { index =>
+    Content(ApiContentWithMeta(
+      ApiContent(
+        s"item-$index",
+        None,
+        None,
+        None,
+        "",
+        "",
+        "",
+        None,
+        Nil,
+        Nil,
+        Nil,
+        None
+      )
+    ))
   }
 }

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -1,9 +1,11 @@
 @(front: model.MetaData, block: (model.Config, model.Collection), collectionsSize: Int = 1, index: Int = 1)(implicit request: RequestHeader, templateDeduping: views.support.TemplateDeduping)
 
+@import layout.ContainerLayout
 @import views.support._
 @import views.html.fragments.containers
-@import slices._
-@import layout._
+@import slices.FixedContainers
+
+@* This nastiness will go once everything moves to the new Facia Cards pattern *@
 
 @defining(block){ case (config, collection) =>
     @config.collectionType match {
@@ -23,10 +25,7 @@
         case Some("prototype/quichelorraine")   => { @containers.quichelorraine(collection, QuicheLorraineContainer(), index)(request, templateDeduping, config) }
         case Some("prototype/raclette")         => { @containers.raclette(collection, RacletteContainer(), index)(request, templateDeduping, config) }
         case Some("comment/comment-and-debate") => { @containers.commentanddebate(collection, CommentAndDebateContainer(), index)(request, templateDeduping, config) }
-        case Some("fixed/small/slow-IV")        => { @containers.facia_cards.slice(collection, QuarterQuarterQuarterQuarter(collection), index)(request, templateDeduping, config) }
-        case Some("fixed/small/slow-V")         => { @containers.facia_cards.slice(collection, Hl4Half(collection), index)(request, templateDeduping, config) }
-        case Some("fixed/small/fast-VIII")      => { @containers.facia_cards.slice(collection, QuarterQuarterQlQl(collection), index)(request, templateDeduping, config) }
-        case Some("fixed/small/fast-X")         => { @containers.facia_cards.slice(collection, QuarterQlQlQl(collection), index)(request, templateDeduping, config) }
+        case FixedContainers(containerDefinition) => { @containers.facia_cards.container(collection, ContainerLayout(containerDefinition, collection, templateDeduping), index)(request, templateDeduping, config) }
         case _                                  => { @containers.special(collection, SpecialContainer(), index)(request, templateDeduping, config) }
     }
 }


### PR DESCRIPTION
@phamann @sndrs @gklopper 

Containers are now defined in a Scala config. This should allow us to easily add containers with multiple slices.

TODO: I'm going to make a separate pull request that will automatically write the fixed container IDs to the JavaScript file consumed by Facia Tool, so that we will no longer have to add them in both places.
