### PR TITLE
Fix for gallery series tags on gallery endslate

### DIFF
--- a/common/app/assets/stylesheets/module/_submeta.scss
+++ b/common/app/assets/stylesheets/module/_submeta.scss
@@ -26,6 +26,10 @@
         }
     }
 
+    .gallery-lightbox__item--endslate & {
+        display: none;
+    }
+
     .submeta {
         border-top: 0;
     }

--- a/common/app/assets/stylesheets/module/_tag-list.scss
+++ b/common/app/assets/stylesheets/module/_tag-list.scss
@@ -32,6 +32,6 @@
     display: inline-block;
 }
 
-.button-more { //fix for IE8/9 bug
+.more-tags { //fix for IE8/9 bug
     display: inline;
 }

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -23,7 +23,7 @@
 
                 @if(hiddenKeywords.nonEmpty) {
 
-                    <li class="inline-list__item js-more-tags modern-hidden">
+                    <li class="inline-list__item js-more-tags more-tags modern-hidden">
                         <button class="u-button-reset js-more-tags__link button button--small button--tag button--tone-@tone-variant button--more"
                            data-link-name="more-tags">More…</button>
                     </li>


### PR DESCRIPTION
Hides the 'more photography' div on the lightbox endslate to avoid clashes
