### PR TITLE
Tweaks margins/paddings in container_meta

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_tag-meta.scss
+++ b/common/app/assets/stylesheets/module/facia/_tag-meta.scss
@@ -1,4 +1,7 @@
 .container__meta {
+    @include mq(tablet) {
+        margin-bottom: $gs-baseline;
+    }
     .container__meta__label {
         @include fs-header(3);
         line-height: get-line-height(header, 2) !important;
@@ -8,18 +11,18 @@
         margin: 0;
     }
     .container__meta__title {
+        padding-bottom: $gs-baseline/3;
+        line-height: get-line-height(header, 2) !important;
+        @include fs-header(3);
+
         @include mq($until: tablet) {
             padding: $gs-baseline/4 0 $gs-baseline/3;
         }
-        @include fs-header(3);
-        line-height: get-line-height(header, 2) !important;
-
         a {
             color: inherit;
         }
     }
     .container__meta__item {
-        padding: $gs-baseline/3 0 $gs-baseline;
         margin: 0;
         @include fs-headline(2);
         color: $c-neutral2;


### PR DESCRIPTION
Made them consistent with `container__title` so badges line up correctly
### Before

![screen shot 2014-09-24 at 13 07 41](https://cloud.githubusercontent.com/assets/74132/4387867/6997c55e-43e3-11e4-87fb-de1eac7f45f7.png)
## After

![screen shot 2014-09-24 at 13 07 45](https://cloud.githubusercontent.com/assets/74132/4387868/6d41cca4-43e3-11e4-9768-76e5f0e48e63.png)
