### PR TITLE
Extend column dividers past list items in facia cards

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -12,6 +12,11 @@ $fc-item-gutter: $gs-gutter / 3;
     .facia-slice__item {
         @include flex-display;
         padding-bottom: 0;
+
+        &.l-list__item {
+            margin-bottom: 0;
+            padding-bottom: $gs-baseline;
+        }
     }
 }
 
@@ -278,7 +283,7 @@ $fc-item-gutter: $gs-gutter / 3;
             &.l-list--rows-#{$row} {
                 .l-list__item:nth-last-child(-n+#{$column}) {
                     @include mq(tablet) {
-                        margin-bottom: 0;
+                        padding-bottom: 0;
                     }
                 }
             }

--- a/common/app/assets/stylesheets/module/facia-cards/_linkslist.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_linkslist.scss
@@ -23,6 +23,16 @@
                         border: 0;
                     }
                 }
+
+                &:nth-child(2n+1):nth-last-child(-n+4),
+                &:nth-child(2n+2):nth-last-child(-n+3) {
+                    padding-bottom: 0;
+                }
+
+                &:nth-child(2n+1):nth-last-child(-n+2),
+                &:nth-child(2n+2):last-child {
+                    padding-top: $gs-baseline;
+                }
             }
 
             @include mq(desktop) {
@@ -35,10 +45,18 @@
                         border: 0;
                     }
                 }
-            }
 
-            &:last-child {
-                margin-bottom: $gs-baseline;
+                &:nth-child(3n+1):nth-last-child(-n+6),
+                &:nth-child(3n+2):nth-last-child(-n+5),
+                &:nth-child(3n+3):nth-last-child(-n+4) {
+                    padding-bottom: 0;
+                }
+
+                &:nth-child(3n+1):nth-last-child(-n+3),
+                &:nth-child(3n+2):nth-last-child(-n+2),
+                &:nth-child(3n+3):last-child {
+                    padding-top: $gs-baseline;
+                }
             }
         }
 


### PR DESCRIPTION
![screen shot 2014-09-24 at 14 31 43](https://cloud.githubusercontent.com/assets/867233/4388819/331db90a-43ef-11e4-852e-c8b144a58685.png)
![screen shot 2014-09-24 at 14 31 24](https://cloud.githubusercontent.com/assets/867233/4388822/368d9560-43ef-11e4-851a-ff552737c68a.png)

TODO - horizontal dividers (requires show more rejig)
