### PR TITLE
Removed tonal colourings for tag lozenges 

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -41,7 +41,7 @@
                     @if(article.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="submeta" data-link-name="keywords">
                             <h2 class="submeta__head">Topics</h2>
-                            @fragments.keywordList(article.keywords, tone = article.visualTone)
+                            @fragments.keywordList(article.keywords)
                         </div>
                     }
                     <div class="submeta js-social--bottom" data-component="share">

--- a/common/app/assets/stylesheets/components/pasteup-buttons/src/_buttons.scss
+++ b/common/app/assets/stylesheets/components/pasteup-buttons/src/_buttons.scss
@@ -225,14 +225,14 @@ And with inline icons:
 .button--tone-live {
     @include button-colour(
         guss-colour(neutral-6, $pasteup-palette),
-        guss-colour(tone-news-1, $pasteup-palette),
+        guss-colour(neutral-1, $pasteup-palette),
         darken(guss-colour(neutral-6, $pasteup-palette), 10%)
     );
 }
 .button--tone-live-variant {
     @include button-colour(
         guss-colour(neutral-8, $pasteup-palette),
-        guss-colour(tone-news-1, $pasteup-palette),
+        guss-colour(neutral-1, $pasteup-palette),
         guss-colour(neutral-8, $pasteup-palette),
         darken(guss-colour(neutral-3, $pasteup-palette), 10%),
         guss-colour(neutral-3, $pasteup-palette)

--- a/common/app/assets/stylesheets/components/pasteup-buttons/src/_buttons.scss
+++ b/common/app/assets/stylesheets/components/pasteup-buttons/src/_buttons.scss
@@ -177,14 +177,14 @@ And with inline icons:
 .button--tone-news {
     @include button-colour(
         guss-colour(neutral-7, $pasteup-palette),
-        guss-colour(tone-news-1, $pasteup-palette),
+        guss-colour(neutral-1, $pasteup-palette),
         darken(guss-colour(neutral-7, $pasteup-palette), 10%)
     );
 }
 .button--tone-news-variant {
     @include button-colour(
         #ffffff,
-        guss-colour(tone-news-1, $pasteup-palette),
+        guss-colour(neutral-1, $pasteup-palette),
         #ffffff,
         darken(guss-colour(neutral-3, $pasteup-palette), 10%),
         guss-colour(neutral-5, $pasteup-palette)


### PR DESCRIPTION
The tag lozenges no longer have tonal colourings (e.g. no orange text on comment pieces).

![screen shot 2014-09-24 at 16 22 24](https://cloud.githubusercontent.com/assets/2236852/4390625/9b19461e-43fe-11e4-8b58-187dd79ca20c.png)
