### PR TITLE
Synchronise aria attributes when using liveblog dropdowns

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -60,7 +60,7 @@
                     @if(article.hasKeyEvents) {
                         <div class="blog__timeline blog__dropdown js-live-blog__key-events">
                             <div class="blog__timeline-container js-live-blog__timeline-container" data-component="timeline">
-                                @fragments.dropdown("Key events", Some("key-events"), article.section != "football") {
+                                @fragments.dropdown("Key events", Some("key-events"), false) {
                                     <ul class="timeline js-live-blog__timeline u-unstyled"></ul>
                                 }
                             </div>

--- a/common/app/assets/javascripts/bootstraps/liveblog.js
+++ b/common/app/assets/javascripts/bootstraps/liveblog.js
@@ -15,6 +15,7 @@ define([
     'common/modules/experiments/affix',
     'common/modules/live/filter',
     'common/modules/ui/autoupdate',
+    'common/modules/ui/dropdowns',
     'common/modules/ui/message',
     'common/modules/ui/notification-counter',
     'common/bootstraps/article',
@@ -36,6 +37,7 @@ define([
     Affix,
     LiveFilter,
     AutoUpdate,
+    dropdowns,
     Message,
     NotificationCounter,
     article,
@@ -151,6 +153,9 @@ define([
                 var timelineHTML = getTimelineHTML(allEvents);
 
                 $('.js-live-blog__timeline').append(timelineHTML);
+                var dropdown = $('.js-live-blog__timeline-container .dropdown');
+                dropdown.addClass('dropdown--active');
+                dropdowns.updateAria(dropdown);
 
                 if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0) {
                     var topMarker = qwery('.js-top-marker')[0];

--- a/common/app/assets/javascripts/modules/ui/dropdowns.js
+++ b/common/app/assets/javascripts/modules/ui/dropdowns.js
@@ -13,26 +13,31 @@ define([
         content: '.dropdown__content'
     };
     function init() {
-
-        function ancestor(el, c) {
-            if (!el.parentNode || bonzo(el.parentNode).hasClass(c.substring(1))) {
-                return el.parentNode;
-            } else {
-                ancestor(el.parentNode, c);
-            }
+        bean.on(document.body, 'click', s.button, function(e){
+            var $container = bonzo(ancestor(e.currentTarget, s.container))
+            $container.toggleClass('dropdown--active');
+            updateAria($container);
+        });
+    }
+    function ancestor(el, c) {
+        if (!el.parentNode || bonzo(el.parentNode).hasClass(c.substring(1))) {
+            return el.parentNode;
+        } else {
+            ancestor(el.parentNode, c);
         }
-        bean.on(document.body, 'click', s.button, function(e) {
-            bonzo(ancestor(e.currentTarget, s.container))
-                .toggleClass('dropdown--active')
-                .each(function(d) {
-                    var v = bonzo(d).hasClass('dropdown--active');
-                    $(s.content, d).attr('aria-hidden', !v);
-                    $(s.content, d).attr('aria-expanded', v);
-                });
+    }
+
+    function updateAria($container) {
+        $container.each(function(d) {
+            var v = bonzo(d).hasClass('dropdown--active');
+            $(s.content, d).attr('aria-hidden', !v);
+            $(s.button, d).attr('aria-expanded', v);
+            $(s.content, d).attr('aria-expanded', v);
         });
     }
 
     return {
-        init: init
+        init: init,
+        updateAria: updateAria
     };
 });

--- a/common/app/assets/javascripts/modules/ui/dropdowns.js
+++ b/common/app/assets/javascripts/modules/ui/dropdowns.js
@@ -14,7 +14,7 @@ define([
     };
     function init() {
         bean.on(document.body, 'click', s.button, function(e){
-            var $container = bonzo(ancestor(e.currentTarget, s.container))
+            var $container = bonzo(ancestor(e.currentTarget, s.container));
             $container.toggleClass('dropdown--active');
             updateAria($container);
         });

--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -5,8 +5,8 @@
     <button class="dropdown__button u-button-reset js-dropdown-button"
             type="button"
             data-link-name="Show dropdown: @name"
-            aria-haspopup="true"
-            aria-controls="@hash">
+            aria-controls="@hash"
+            aria-expanded="@{isActive.toString}">
         <span class="dropdown__label">@name</span>
         <span class="control modern-visible">
             <i class="i i-arrow-down-white-mask tone-background"></i>
@@ -14,16 +14,14 @@
     </button>
 
     <label class="dropdown__toggle-label modern-hidden"
-           aria-haspopup="true"
            aria-controls="@hash"
            for="@{hash}__label">Show</label>
     <input class="dropdown__toggle modern-hidden"
-            aria-haspopup="true"
             aria-controls="@hash"
             type="checkbox"
             id="@{hash}__label" />
 
-    <div id="@hash" class="dropdown__content" aria-hidden="true" aria-expanded="false">
+    <div id="@hash" class="dropdown__content" aria-hidden="@{!isActive.toString}" aria-expanded="@{isActive.toString}">
         @content
     </div>
 </div>


### PR DESCRIPTION
This solves the following issues:
1. The live blog content was being aria-hidden by default.
2. Dropdown buttons were marked in aria as pop-up, but they are not pop-up.
3. Order by control was being aria-hidden.
