### PR TITLE
Fix visual ordering and appearnce of hl4-q-q

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_slices.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_slices.scss
@@ -65,3 +65,9 @@ Hence why a greater depth of selector specificity is needed.
         }
     }
 }
+
+.facia-slice--h14-q-q {
+    @if $browser-supports-flexbox {
+        @include flex-direction(row-reverse);
+    }
+}

--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -351,31 +351,31 @@ case object QuarterQuarterHl3 extends Slice {
  * |_________________|        |        |
  * |_________________|________|________|
  */
+
+/*
+* The order of this sequence is important.
+* We use flex-direction(row-reverse) to maintain DOM hierarchy whilst having correct visual ordering.
+* */
 case object Hl4QuarterQuarter extends Slice {
   val layout = SliceLayout(
     cssClassName = "h14-q-q",
     columns = Seq(
       Rows(
         colSpan = 2,
+        columns = 2,
+        rows = 1,
+        ItemClasses(
+          mobile = "list-media",
+          desktop = "standard"
+        )
+      ),
+      Rows(
+        colSpan = 2,
         columns = 1,
         rows = 4,
         ItemClasses(
           mobile = "list",
-          desktop = "list"
-        )
-      ),
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = "list-media",
-          desktop = "standard"
-        )
-      ),
-      SingleItem(
-        colSpan = 1,
-        ItemClasses(
-          mobile = "list-media",
-          desktop = "standard"
+          desktop = "list-media"
         )
       )
     )
@@ -388,6 +388,10 @@ case object Hl4QuarterQuarter extends Slice {
  * |_###_____________|#################|
  * |_###_____________|_________________|
  */
+/*
+* The order of this sequence is important.
+* We use flex-direction(row-reverse) to maintain DOM hierarchy whilst having correct visual ordering.
+* */
 case object Hl4Half extends Slice {
   val layout = SliceLayout(
     cssClassName = "hl4-h",


### PR DESCRIPTION
This slice was incorrectly spec'd
- Change the list items to use `list-media` pattern on desktop.
- Reverse visual using `row-reverse`
- Leave comment about weirdness
### Desktop

![google chrome](https://cloud.githubusercontent.com/assets/80089/4402842/db6b9d50-449b-11e4-8c4d-f878ecf28d39.png)
### Mobile

![google chrome](https://cloud.githubusercontent.com/assets/80089/4402844/de8ef61c-449b-11e4-9e3f-8565bd002fe6.png)

/cc @robertberry @sndrs @kungpochicken 
