### PR TITLE
Ensure the image inside mega-full item is correctly cropped

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--mega-full.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--mega-full.scss
@@ -25,6 +25,11 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
         padding-bottom: 40%;
     }
 
+    .responsive-img {
+        top: -25%;
+        height: auto;
+    }
+
     .fc-item__title,
     .fc-item__byline {
         @include fs-headline(4, true);


### PR DESCRIPTION
It was previously being squashed into the space rather than a center crop.
#### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/4403329/752d6464-44a1-11e4-9872-106f4def580d.png)
#### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/4403332/77c4a4f8-44a1-11e4-84e1-95a48ed986ef.png)

/cc @sndrs @robertberry @kungpochicken 
