### PR TITLE
Do not show video player on media-list items

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -77,6 +77,10 @@ $fc-item-gutter: $gs-gutter / 3;
     position: relative;
 }
 
+.fc-item__video-fallback {
+    display: none;
+}
+
 .fc-item__header,
 .fc-item__standfirst,
 .fc-item__meta {

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
@@ -55,4 +55,7 @@ Media list item. Looks a bit like this:
         margin-left: 0 - $image-width;
         width: $image-width;
     }
+
+    .fc-item__video-container { display: none; }
+    .fc-item__video-fallback { display: block; }
 }

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -29,19 +29,24 @@
             <div class="fc-item__container">
                 @FaciaDisplayElement.fromTrail(trail) match {
                     case InlineVideo(videoElement, title, endSlatePath) => {
-                        <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
-                            <div class="fc-item__video-container">
-                            @video(VideoPlayer(
-                                videoElement,
-                                Video640,
-                                title,
-                                autoPlay = false,
-                                showControlsAtStart = false,
-                                endSlatePath,
-                                Some(false)
-                            ))
+                        @defining(VideoPlayer(
+                            videoElement,
+                            Video640,
+                            title,
+                            autoPlay = false,
+                            showControlsAtStart = false,
+                            endSlatePath,
+                            Some(false)
+                        )) { player =>
+                            <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
+                                <div class="fc-item__video-container">
+                                    @video(player)
+                                </div>
                             </div>
-                        </div>
+                            <div class="fc-item__video-fallback">
+                                @image(trail, inlineImage = containerIndex == 0 && index < 4)
+                            </div>
+                        }
                     }
 
                     case _ => {


### PR DESCRIPTION
We are currently showing a tiny video player in facia list-media items. This fixes that by showing a fallback image instead and hiding the video element.

Need to do some performance testing to ensure all of our image and video combinations are not causing unnecessary HTTP requests.
#### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/4403792/6fd99ada-44a8-11e4-8e03-100c1f8bdeb8.png)
#### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/4403793/71072cd8-44a8-11e4-85fb-b0f68222449d.png)

 /cc @robertberry @sndrs @kungpochicken 
