### PR TITLE
Facia-Cards tone refactor

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_container.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_container.scss
@@ -1,7 +1,6 @@
 .fc-container {
     padding-bottom: $gs-baseline;
     margin-bottom: 0;
-    background-color: $c-neutral7;
 
     @include mq(tablet) {
         padding-bottom: $gs-baseline * 2;

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -130,7 +130,7 @@ $fc-item-gutter: $gs-gutter / 3;
 }
 
 .fc-item__timestamp {
-    display: none;
+    // display: none;
 }
 
 .fc-trail__count--inline-template {

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -123,7 +123,7 @@ $fc-item-gutter: $gs-gutter / 3;
 }
 
 .fc-item__timestamp {
-    // display: none;
+    display: none;
 }
 
 .fc-trail__count--inline-template {

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -77,13 +77,6 @@ $fc-item-gutter: $gs-gutter / 3;
     position: relative;
 }
 
-.fc-item__header,
-.fc-item__standfirst,
-.fc-item__meta {
-    padding-left: $fc-item-gutter;
-    padding-right: $fc-item-gutter;
-}
-
 .fc-item__live-indicator {
     background-color: #ffffff;
     color: $c-live;

--- a/common/app/assets/stylesheets/module/facia-cards/_tones.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones.scss
@@ -1,123 +1,15 @@
-.tone-news {
-    .fc-item__kicker {
-        color: $c-analysisAccent;
-    }
-
-    &.fc-item--has-image:before {
-        background-color: $c-neutral5;
-    }
-
-    &.fc-item--list-mobile .fc-item__container {
-        @include mq($until: tablet) {
-            border-top: 1px solid $c-newsAccent;
-        }
-    }
-
-    &.fc-item--list-tablet .fc-item__container {
-        @include mq(tablet) {
-            border-top: 1px solid $c-newsAccent;
-        }
-    }
-}
-
-.tone-live {
-    &.fc-item {
-        background-color: $c-live;
-
-        &,
-        & a {
-            color: #ffffff;
-        }
-    }
-
-    a.fc-item__kicker {
-        color: $c-liveMute;
-    }
-
+%tone-background {
+    .fc-item__header,
+    .fc-item__standfirst,
     .fc-item__meta {
-        &,
-        & a {
-            color: $c-liveMute;
-        }
+        padding-left: $fc-item-gutter;
+        padding-right: $fc-item-gutter;
     }
 }
 
-.tone-comment {
-    &.fc-item {
-        background-color: $c-commentBackground;
-    }
-
-    .fc-item__kicker {
-        color: $c-commentDefault;
-    }
-
-    .fc-item__meta {
-        background-color: fade-out($c-commentBackground, .5);
-    }
-}
-
-.tone-feature {
-    &.fc-item {
-        background-color: $c-featureDefault;
-
-        &,
-        & a,
-        & .fc-item__standfirst {
-            color: #ffffff;
-        }
-    }
-
-    .fc-item__kicker {
-        color: $c-featureMute !important;
-    }
-
-    .fc-item__title .i {
-        display: inline-block;
-        height: .9em;
-        width: 1em;
-        background-position: center;
-    }
-
-    .fc-item__meta {
-        &,
-        & a {
-            color: $c-featureMute;
-        }
-    }
-}
-
-.tone-analysis {
-    &.fc-item {
-        background-color: $c-analysisBackground;
-    }
-
-    .fc-item__kicker {
-        color: $c-analysisAccent;
-    }
-}
-
-.tone-media {
-    &.fc-item {
-        background-color: $c-neutral1;
-
-        &,
-        & a {
-            color: #ffffff;
-        }
-    }
-
-    .fc-item__kicker {
-        color: $c-mediaDefault;
-    }
-
-    &.fc-item--has-image:before {
-        background-color: fade-out(#000000, .75);
-    }
-
-    .fc-item__meta {
-        &,
-        & a {
-            color: $c-neutral2;
-        }
-    }
-}
+@import 'item-tones/tone-news';
+@import 'item-tones/tone-live';
+@import 'item-tones/tone-comment';
+@import 'item-tones/tone-feature';
+@import 'item-tones/tone-analysis';
+@import 'item-tones/tone-media';

--- a/common/app/assets/stylesheets/module/facia-cards/_tones.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_tones.scss
@@ -6,6 +6,18 @@
     &.fc-item--has-image:before {
         background-color: $c-neutral5;
     }
+
+    &.fc-item--list-mobile .fc-item__container {
+        @include mq($until: tablet) {
+            border-top: 1px solid $c-newsAccent;
+        }
+    }
+
+    &.fc-item--list-tablet .fc-item__container {
+        @include mq(tablet) {
+            border-top: 1px solid $c-newsAccent;
+        }
+    }
 }
 
 .tone-live {

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list.scss
@@ -23,7 +23,6 @@ x x x x x x x x x x x x x x x x x x x x x x x x
 
     .fc-item__header {
         margin-bottom: 0;
-        padding-left: $fc-item-gutter;
         padding-bottom: $gs-baseline * 1.666;
     }
 

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
@@ -1,0 +1,11 @@
+.tone-analysis {
+    @extend %tone-background;
+
+    &.fc-item {
+        background-color: $c-analysisBackground;
+    }
+
+    .fc-item__kicker {
+        color: $c-analysisAccent;
+    }
+}

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -1,0 +1,15 @@
+.tone-comment {
+    @extend %tone-background;
+
+    &.fc-item {
+        background-color: $c-commentBackground;
+    }
+
+    .fc-item__kicker {
+        color: $c-commentDefault;
+    }
+
+    .fc-item__meta {
+        background-color: fade-out($c-commentBackground, .5);
+    }
+}

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -1,0 +1,31 @@
+.tone-feature {
+    @extend %tone-background;
+
+    &.fc-item {
+        background-color: $c-featureDefault;
+
+        &,
+        & a,
+        & .fc-item__standfirst {
+            color: #ffffff;
+        }
+    }
+
+    .fc-item__kicker {
+        color: $c-featureMute !important;
+    }
+
+    .fc-item__title .i {
+        display: inline-block;
+        height: .9em;
+        width: 1em;
+        background-position: center;
+    }
+
+    .fc-item__meta {
+        &,
+        & a {
+            color: $c-featureMute;
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -1,0 +1,23 @@
+.tone-live {
+    @extend %tone-background;
+
+    &.fc-item {
+        background-color: $c-live;
+
+        &,
+        & a {
+            color: #ffffff;
+        }
+    }
+
+    a.fc-item__kicker {
+        color: $c-liveMute;
+    }
+
+    .fc-item__meta {
+        &,
+        & a {
+            color: $c-liveMute;
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -1,0 +1,27 @@
+.tone-media {
+    @extend %tone-background;
+
+    &.fc-item {
+        background-color: $c-neutral1;
+
+        &,
+        & a {
+            color: #ffffff;
+        }
+    }
+
+    .fc-item__kicker {
+        color: $c-mediaDefault;
+    }
+
+    &.fc-item--has-image:before {
+        background-color: fade-out(#000000, .75);
+    }
+
+    .fc-item__meta {
+        &,
+        & a {
+            color: $c-neutral2;
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -9,13 +9,13 @@
 
     &.fc-item--list-mobile .fc-item__container {
         @include mq($until: tablet) {
-            border-top: 1px solid $c-newsAccent;
+            @include box-shadow(inset 0 1px $c-newsAccent);
         }
     }
 
     &.fc-item--list-tablet .fc-item__container {
         @include mq(tablet) {
-            border-top: 1px solid $c-newsAccent;
+            @include box-shadow(inset 0 1px $c-newsAccent);
         }
     }
 

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -39,7 +39,8 @@
         }
     }
 
-    &.fc-item--list-media-mobile {
+    &.fc-item--list-media-mobile,
+    &.fc-item--list-media-large-mobile {
         .fc-item__header,
         .fc-item__standfirst,
         .fc-item__meta {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -1,0 +1,63 @@
+.tone-news {
+    .fc-item__kicker {
+        color: $c-analysisAccent;
+    }
+
+    &.fc-item--has-image:before {
+        background-color: $c-neutral5;
+    }
+
+    &.fc-item--list-mobile .fc-item__container {
+        @include mq($until: tablet) {
+            border-top: 1px solid $c-newsAccent;
+        }
+    }
+
+    &.fc-item--list-tablet .fc-item__container {
+        @include mq(tablet) {
+            border-top: 1px solid $c-newsAccent;
+        }
+    }
+
+    &.fc-item--list-media-mobile,
+    &.fc-item--list-media-large-mobile {
+        .fc-item__title {
+            @include mq($until: tablet) {
+                padding-top: 0;
+            }
+        }
+    }
+
+    &.fc-item--list-media-tablet,
+    &.fc-item--three-quarters-tablet,
+    &.fc-item--full-tablet,
+    &.fc-item--mega-full-tablet {
+        .fc-item__title {
+            @include mq(tablet) {
+                padding-top: 0;
+            }
+        }
+    }
+
+    &.fc-item--list-media-mobile {
+        .fc-item__header,
+        .fc-item__standfirst,
+        .fc-item__meta {
+            @include mq($until: tablet) {
+                padding-left: $fc-item-gutter;
+                padding-right: $fc-item-gutter;
+            }
+        }
+    }
+
+    &.fc-item--list-media-tablet {
+        .fc-item__header,
+        .fc-item__standfirst,
+        .fc-item__meta {
+            @include mq(tablet) {
+                padding-left: $fc-item-gutter;
+                padding-right: $fc-item-gutter;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Move tones to separate partials as it's getting out of hand. This also includes the new style work that removes the card styling on tone-news.

![screen shot 2014-09-25 at 13 04 00](https://cloud.githubusercontent.com/assets/1607666/4404036/2b05c6dc-44ac-11e4-80a0-edc7060941d3.png)
