### PR TITLE
Do not deduplicate items in dynamic containers

### DIFF
--- a/common/app/layout/ContainerLayout.scala
+++ b/common/app/layout/ContainerLayout.scala
@@ -29,14 +29,17 @@ object ContainerLayout extends implicits.Collections {
 
   def apply(containerDefinition: ContainerDefinition,
             collection: Collection,
-            templateDeduping: TemplateDeduping): ContainerLayout = {
+            maybeTemplateDeduping: Option[TemplateDeduping]): ContainerLayout = {
     /** TODO move this to earlier in the process, so that we can make the de-duping a functional transformation */
     val items = collection.items
-    val numItems = containerDefinition.slices.flatMap(_.layout.columns.map(_.numItems)).sum
-    val unusedTrailsForThisSlice = templateDeduping(numItems, items).take(numItems)
-    val dedupedPrioritisedTrails = (unusedTrailsForThisSlice ++ items).distinctBy(_.url)
 
-    apply(containerDefinition.slices, dedupedPrioritisedTrails, containerDefinition.mobileShowMore)
+    val trails = maybeTemplateDeduping map { templateDeduping =>
+      val numItems = containerDefinition.slices.flatMap(_.layout.columns.map(_.numItems)).sum
+      val unusedTrailsForThisSlice = templateDeduping(numItems, items).take(numItems)
+      (unusedTrailsForThisSlice ++ items).distinctBy(_.url)
+    } getOrElse items
+
+    apply(containerDefinition.slices, trails, containerDefinition.mobileShowMore)
   }
 }
 

--- a/common/test/slices/DedupingTest.scala
+++ b/common/test/slices/DedupingTest.scala
@@ -18,7 +18,7 @@ class DedupingTest extends FlatSpec with Matchers {
     val ContainerLayout(slices, unusedCards) = ContainerLayout(
       containerFixture,
       Collection(rawTrails.toSeq),
-      deduping
+      Some(deduping)
     )
 
     val usedTrails = slices.flatMap(_.columns.flatMap(_.cards.map(_.item)))
@@ -46,7 +46,7 @@ class DedupingTest extends FlatSpec with Matchers {
     val ContainerLayout(slices, unusedCards) = ContainerLayout(
       containerFixture,
       Collection(rawTrails.toSeq),
-      deduping
+      Some(deduping)
     )
 
     val usedTrails = slices.flatMap(_.columns.flatMap(_.cards.map(_.item)))

--- a/facia/app/views/fragments/frontCollection.scala.html
+++ b/facia/app/views/fragments/frontCollection.scala.html
@@ -25,11 +25,11 @@
         case Some("prototype/quichelorraine")   => { @containers.quichelorraine(collection, QuicheLorraineContainer(), index)(request, templateDeduping, config) }
         case Some("prototype/raclette")         => { @containers.raclette(collection, RacletteContainer(), index)(request, templateDeduping, config) }
         case Some("comment/comment-and-debate") => { @containers.commentanddebate(collection, CommentAndDebateContainer(), index)(request, templateDeduping, config) }
-        case FixedContainers(containerDefinition) => { @containers.facia_cards.container(collection, ContainerLayout(containerDefinition, collection, templateDeduping), index)(request, templateDeduping, config) }
+        case FixedContainers(containerDefinition) => { @containers.facia_cards.container(collection, ContainerLayout(containerDefinition, collection, Some(templateDeduping)), index)(request, templateDeduping, config) }
         case collectionType => {
             @DynamicContainers(collectionType, collection.items) match {
                 case Some(containerDefinition) => {
-                    @containers.facia_cards.container(collection, ContainerLayout(containerDefinition, collection, templateDeduping), index)(request, templateDeduping, config)
+                    @containers.facia_cards.container(collection, ContainerLayout(containerDefinition, collection, None), index)(request, templateDeduping, config)
                 }
 
                 case None => {


### PR DESCRIPTION
As the items put into the container determine its layout, deduplicating it is quite confusing.

Also, it's very tricky for us to be able to do this until we move to a more comprehensive de-duplication algorithm up front for a front, as the number of cards consumed by the dynamic container is determined by the cards that are fed in and what groups & boosting they have. We ought to move to an algorithm like this anyway (as the current one is mutable and nasty) but it'll only be easy to do so once we move everything over to the new-style containers, which have metadata about how many items they consume baked into the Scala data-structure.

CC @gklopper @janua 
