### PR TITLE
Add Guardian Egyptian Web Medium to project

### DIFF
--- a/common/app/assets/stylesheets/webfonts.scss
+++ b/common/app/assets/stylesheets/webfonts.scss
@@ -2,4 +2,28 @@ $guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
 
 @import './components/guss-webfonts/src/_webfonts.scss';
 
-@include guss-webfonts();
+@include guss-webfonts(
+    (
+        'Guardian Text Egyptian Web': (
+            (weight: 'regular',  style: 'normal'),
+            (weight: 'regular',  style: 'italic'),
+            (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
+            (weight: 'medium',   style: 'italic', use-as: (weight: 'bold', style: 'italic')),
+        ),
+        'Guardian Egyptian Web': (
+            (weight: 'light',    style: 'normal'),
+            (weight: 'regular',  style: 'normal'),
+            (weight: 'medium',   style: 'normal'),
+            (weight: 'semibold', style: 'normal', use-as: (weight: 'ultrablack', style: 'normal')),
+        ),
+        'Guardian Text Sans Web': (
+            (weight: 'regular',  style: 'normal'),
+            (weight: 'regular',  style: 'italic'),
+            (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
+            (weight: 'medium',   style: 'italic', use-as: (weight: 'bold', style: 'italic')),
+        ),
+        'Guardian Sans Web': (
+            (weight: 'regular',  style: 'normal'),
+        )
+    )
+);

--- a/common/app/assets/stylesheets/webfonts.scss
+++ b/common/app/assets/stylesheets/webfonts.scss
@@ -8,7 +8,6 @@ $guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
             (weight: 'regular',  style: 'normal'),
             (weight: 'regular',  style: 'italic'),
             (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
-            (weight: 'medium',   style: 'italic', use-as: (weight: 'bold', style: 'italic')),
         ),
         'Guardian Egyptian Web': (
             (weight: 'light',    style: 'normal'),
@@ -20,7 +19,6 @@ $guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
             (weight: 'regular',  style: 'normal'),
             (weight: 'regular',  style: 'italic'),
             (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
-            (weight: 'medium',   style: 'italic', use-as: (weight: 'bold', style: 'italic')),
         ),
         'Guardian Sans Web': (
             (weight: 'regular',  style: 'normal'),

--- a/grunt-configs/webfontjson.js
+++ b/grunt-configs/webfontjson.js
@@ -36,6 +36,12 @@ module.exports = function(grunt, options) {
                         file: options.webfontsDir + 'hinting-off_kerning-off/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff2',
                         format: 'woff'
                     },
+                    {
+                        'font-family': '"Guardian Egyptian Web"',
+                        'font-weight': '500',
+                        file: options.webfontsDir + 'hinting-off_kerning-off/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
+                        format: 'woff'
+                    },
                     // This weight contains only a certain set of chars
                     // since it is used only in one place (section names)
                     {
@@ -81,6 +87,12 @@ module.exports = function(grunt, options) {
                         file: options.webfontsDir + 'hinting-off_kerning-off/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff',
                         format: 'woff'
                     },
+                    {
+                        'font-family': '"Guardian Egyptian Web"',
+                        'font-weight': '500',
+                        file: options.webfontsDir + 'hinting-off_kerning-off/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff',
+                        format: 'woff'
+                    },
                     // This weight contains only a certain set of chars
                     // since it is used only in one place (section names)
                     {
@@ -124,6 +136,12 @@ module.exports = function(grunt, options) {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '400',
                         file: options.webfontsDir + 'hinting-off_kerning-off/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.ttf',
+                        format: 'ttf'
+                    },
+                    {
+                        'font-family': '"Guardian Egyptian Web"',
+                        'font-weight': '500',
+                        file: options.webfontsDir + 'hinting-off_kerning-off/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
                         format: 'ttf'
                     },
                     // This weight contains only a certain set of chars


### PR DESCRIPTION
Soon to be used on the new fronts.

I've also included a map of the actual fonts that we use in webfonts.scss. Before we weren't passing anything to guss-webfonts(), which meant that before IE9 was loading **all** the fonts.
