### PR TITLE
Tidy up dropdowns on live blogs

### DIFF
--- a/common/app/assets/stylesheets/_mixins.scss
+++ b/common/app/assets/stylesheets/_mixins.scss
@@ -140,28 +140,6 @@
     }
 }
 
-@mixin full-bleed($color) {
-    $bgWidth: 10000px;
-    background-color: $color;
-
-    &:before,
-    &:after {
-        @include box-sizing(border-box);
-        content: ' ';
-        background-color: $color;
-        position: absolute;
-        top: 0;
-        height: 100%;
-        width: $bgWidth;
-    }
-    &:before {
-        right: 100%;
-    }
-    &:after {
-        left: 100%;
-    }
-}
-
 @mixin video-play-button-size($size) {
     width: $size;
     height: $size;

--- a/common/app/assets/stylesheets/module/_dropdown.scss
+++ b/common/app/assets/stylesheets/module/_dropdown.scss
@@ -2,8 +2,7 @@
 // If you have other styles, but would like to maintain the functionality,
 // just apply .dropdown
 .dropdown-styled {
-    padding: ($gs-baseline/3)*2 0;
-    border-top: 1px solid $c-neutral5;
+    border-top: 1px solid $c-neutral4;
     position: relative;
 
     .dropdown__toggle,
@@ -24,6 +23,7 @@
     }
 
     .dropdown__button {
+        padding: $gs-baseline/2 0 $gs-baseline*1.5;
         color: $c-neutral1;
         text-align: left;
 
@@ -36,7 +36,6 @@
         .i {
             background-color: $c-neutral2;
             right: 0;
-            top: -$gs-baseline/2;
             position: absolute;
         }
     }
@@ -57,6 +56,7 @@
 .dropdown--active .dropdown__content {
     display: block;
 }
+
 .dropdown__content {
     display: none;
 }

--- a/common/app/assets/stylesheets/module/content/_content.scss
+++ b/common/app/assets/stylesheets/module/content/_content.scss
@@ -1,7 +1,7 @@
 .content {
     border-top: 1px solid #ffffff;
     padding-top: 0;
-    padding-bottom: $gs-baseline*3.5;
+    padding-bottom: $gs-baseline*3;
 
     &:after { // clearfix
         content: '';

--- a/common/app/assets/stylesheets/module/content/_live-blog.scss
+++ b/common/app/assets/stylesheets/module/content/_live-blog.scss
@@ -482,53 +482,23 @@ $block-padding-right: $gs-gutter;
    ========================================================================== */
 .dropdown--key-events,
 .dropdown--live-feed {
-    position: relative;
-    padding: 0;
-    z-index: 100;
-    border-top: 0;
-    border-bottom: 1px solid $c-neutral4;
-
     @include mq($until: rightCol) {
-        @include full-bleed(transparent);
-    }
-
-    .blog__timeline &,
-    &.dropdown--active,
-    .blog__main-column > & {
-        border-bottom: 0;
-    }
-
-    &:before,
-    &:after {
-        top: auto;
-        bottom: -1px;
-        border-bottom: 1px solid $c-neutral4;
-
-        .blog__timeline & {
-            border-bottom: 0;
-        }
-    }
-
-    &.dropdown--active,
-    .blog__main-column > & {
-        &:before,
-        &:after {
-            border-bottom: 0;
-        }
+        margin-right: $gs-gutter*-1;
+        margin-left: $gs-gutter*-1;
+        padding-right: $gs-gutter;
+        padding-left: $gs-gutter;
+        padding-top: $gs-baseline*4;
     }
 
     .dropdown__button {
-        padding: $gs-baseline/1.5 0;
-        border-top: 1px solid $c-neutral4;
-
-        &:before,
-        &:after {
-            top: -1px;
-            border-top: 1px solid $c-neutral4;
-        }
-
         @include mq($until: rightCol) {
-            @include full-bleed(#ffffff);
+            background-color: #ffffff;
+            padding-right: $gs-gutter;
+            padding-left: $gs-gutter;
+            position: absolute;
+            top: 0;
+            right: 0;
+            left: 0;
         }
 
         @include mq(rightCol) {
@@ -546,34 +516,17 @@ $block-padding-right: $gs-gutter;
         }
     }
 
-    & + & {
-        .dropdown__button {
-            border-top: 0;
-
-            &:before,
-            &:after {
-                border-top: 0;
-            }
-        }
-    }
-
     .dropdown__label {
-        @include fs-header(2);
-        line-height: 30px;
+        @include fs-header(3);
     }
 
     .dropdown__content {
         position: relative;
         margin: 0;
-        padding: $gs-baseline 0;
-
-        .blog__timeline & {
-            padding: 0 0 $gs-baseline;
-        }
 
         @include mq($until: rightCol) {
             background-color: $c-neutral8;
-            @include full-bleed($c-neutral8);
+            padding: $gs-baseline 0;
         }
 
         @include mq(rightCol) {
@@ -597,10 +550,6 @@ $timeline-width: 14px;
         .dropdown {
             border-top: 0;
         }
-    }
-
-    .meta__comment-count-timeline {
-        margin-top: -21px;
     }
 }
 
@@ -803,9 +752,6 @@ $timeline-width: 14px;
         .tabs__container--multiple {
             background-color: $c-neutral8;
         }
-        .after-header {
-            @include full-bleed($c-neutral8);
-        }
 
         .tabs__tab--selected .tab__link {
             background-color: $c-neutral8;
@@ -891,6 +837,10 @@ $timeline-width: 14px;
 }
 
 .content--liveblog {
+    @include mq($until: rightCol) {
+        padding-bottom: 0;
+    }
+    
     .content__standfirst,
     .blog__timeline,
     .content__secondary-column {

--- a/common/app/assets/stylesheets/module/content/_live-filter.scss
+++ b/common/app/assets/stylesheets/module/content/_live-filter.scss
@@ -1,6 +1,5 @@
 .live-toolbar {
     width: 100%;
-    margin-bottom: $gs-baseline;
     height: $gs-row-height + $gs-baseline;
 
     .is-live & {
@@ -9,10 +8,6 @@
 
     @include mq($until: tablet) {
         font-size: .875em;
-    }
-
-    @include mq(rightCol) {
-        border-top: 1px solid $c-neutral3;
     }
 }
 


### PR DESCRIPTION
Fixes a few issues/bugs on liveblog drop downs (up to desktop breakpoints), namely overlapping with page margins, padding around content and collapsed menu appearance. Picture: 

Open before:
![screen shot 2014-09-26 at 13 12 09](https://cloud.githubusercontent.com/assets/813383/4420245/bfd1f81a-4576-11e4-9b29-2842679444ec.png)

Open after:
![screen shot 2014-09-26 at 13 12 20](https://cloud.githubusercontent.com/assets/813383/4420248/ccdccea4-4576-11e4-83b4-149cd90500d5.png)

Closed before:
![screen shot 2014-09-26 at 13 12 30](https://cloud.githubusercontent.com/assets/813383/4420249/d21d1c20-4576-11e4-8d3b-6a106b4f56ca.png)

Closed after:
![screen shot 2014-09-26 at 13 12 44](https://cloud.githubusercontent.com/assets/813383/4420256/d77b77b6-4576-11e4-95dc-524400c3fe3c.png)

A second PR will be needed to fix borders on facia containers, so that they extend to the full width of the page, as they do above tablet breakpoint.

/cc @mattosborn 
