### PR TITLE
Container top borders always full width

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_mixins.scss
+++ b/common/app/assets/stylesheets/module/facia/_mixins.scss
@@ -42,6 +42,10 @@ $mq-breakpoints: mq-add-breakpoint(containerWidestMobile, $mobile-max-container-
             width: $container-width;
         }
     }
+    @include mq(tablet) {
+        padding-left: $gs-gutter;
+        padding-right: $gs-gutter;
+    }
 }
 
 @mixin facia-container--layout-front {


### PR DESCRIPTION
Before:
![screen shot 2014-09-26 at 13 33 43](https://cloud.githubusercontent.com/assets/813383/4420459/71be6110-4579-11e4-8c91-e3ef7de95361.png)

After:
![screen shot 2014-09-26 at 13 33 22](https://cloud.githubusercontent.com/assets/813383/4420462/7855ee9e-4579-11e4-841c-e047d6066b1d.png)
