### PR TITLE
Fix facia video

### DIFF
--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -38,14 +38,16 @@
                             endSlatePath,
                             Some(false)
                         )) { player =>
-                            <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
-                                <div class="fc-item__video-container">
+
+                            @if(Seq("half", "three", "full", "mega-full").exists(size => modifierClasses.contains(size))) {
+                                <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
+                                    <div class="fc-item__video-container">
                                     @video(player)
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="fc-item__video-fallback">
+                            } else {
                                 @image(trail, inlineImage = containerIndex == 0 && index < 4)
-                            </div>
+                            }
                         }
                     }
 

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -39,6 +39,7 @@
                             Some(false)
                         )) { player =>
 
+                            @* TODO: This is a temporary HACK until Rob Berry can clean up. *@
                             @if(Seq("half", "three", "full", "mega-full").exists(size => modifierClasses.contains(size))) {
                                 <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
                                     <div class="fc-item__video-container">


### PR DESCRIPTION
It seems video JS doesn't like instantiating lots of video player instances even if they are hidden.

This is a temporary hack to ensure we only print out the video element if it is a large item.

TODO: this should be abstracted into the Card or Slice model, but needs to ship this afternoon as is broken in PROD.

/cc @robertberry @sndrs @kungpochicken 
