### PR TITLE
Optimise facia-cards for tablet and desktop

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -90,11 +90,15 @@ $fc-item-gutter: $gs-gutter / 4;
     padding: .1em .2em .05em;
 }
 
+.fc-item__title,
+.fc-item__byline {
+    @include fs-headline(2);
+    font-weight: 500;
+}
+
 .fc-item__title {
     padding-top: $gs-baseline / 3;
     padding-bottom: 0;
-    @include fs-headline(2);
-    font-weight: 500;
     word-wrap: break-word;
 }
 

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -92,7 +92,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__title,
 .fc-item__byline {
-    @include fs-headline(2);
+    @include fs-headline(3);
     font-weight: 500;
 }
 
@@ -181,6 +181,9 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item--list-media-tablet {
     @include mq(tablet) {
+        @include fc-item--list-media(4, 1);
+    }
+    @include mq(desktop) {
         @include fc-item--list-media;
     }
 }
@@ -213,7 +216,8 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-.fc-item--standard-tablet {
+.fc-item--standard-tablet,
+.fc-item--standard-quarter-tablet {
     @include mq(tablet) {
         @include fc-item--standard;
     }
@@ -254,7 +258,6 @@ $fc-item-gutter: $gs-gutter / 4;
         @include fc-item--mega-full;
     }
 }
-
 
 .l-list {
     width: 100%;

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -183,6 +183,7 @@ $fc-item-gutter: $gs-gutter / 4;
     @include mq(tablet) {
         @include fc-item--list-media(4, 1);
     }
+
     @include mq(desktop) {
         @include fc-item--list-media;
     }

--- a/common/app/assets/stylesheets/module/facia-cards/_slices.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_slices.scss
@@ -24,14 +24,6 @@ Hence why a greater depth of selector specificity is needed.
             }
         }
     }
-
-    .fc-item--list-media-tablet {
-        @include mq(tablet) {
-            .fc-item__title {
-                @include fs-headline(2, true);
-            }
-        }
-    }
 }
 
 .facia-slice--h-ql4-ql4 {
@@ -47,16 +39,16 @@ Hence why a greater depth of selector specificity is needed.
 .facia-slice--h-q-q {
     .fc-item--standard-tablet {
         .fc-item__standfirst {
-            @include mq(tablet) {
+            @include mq(desktop) {
                 display: block;
             }
         }
     }
 }
 
-.facia-slice--q-qqq,
-.facia-slice--qqq-q {
-    .fc-item--standard {
+.facia-slice--q-q-q-q {
+    .fc-item--standard-tablet,
+    .fc-item--standard-quarter-tablet {
         .fc-item__title,
         .fc-item__byline {
             @include mq(tablet, desktop) {
@@ -65,6 +57,24 @@ Hence why a greater depth of selector specificity is needed.
         }
     }
 }
+
+/*
+
+.facia-slice--h-q-q,
+.facia-slice--q-ql-ql-ql,
+.facia-slice--q-q-ql-ql,
+.facia-slice--q-q-q-ql {
+    .fc-item--standard-tablet,
+    .fc-item--standard-quarter-tablet {
+        .fc-item__title,
+        .fc-item__byline {
+            @include mq(tablet, desktop) {
+                @include fs-headline(2, true);
+            }
+        }
+    }
+}
+*/
 
 .facia-slice--h14-q-q {
     @if $browser-supports-flexbox {

--- a/common/app/assets/stylesheets/module/facia-cards/_slices.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_slices.scss
@@ -58,24 +58,6 @@ Hence why a greater depth of selector specificity is needed.
     }
 }
 
-/*
-
-.facia-slice--h-q-q,
-.facia-slice--q-ql-ql-ql,
-.facia-slice--q-q-ql-ql,
-.facia-slice--q-q-q-ql {
-    .fc-item--standard-tablet,
-    .fc-item--standard-quarter-tablet {
-        .fc-item__title,
-        .fc-item__byline {
-            @include mq(tablet, desktop) {
-                @include fs-headline(2, true);
-            }
-        }
-    }
-}
-*/
-
 .facia-slice--h14-q-q {
     @if $browser-supports-flexbox {
         @include flex-direction(row-reverse);

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--half.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--half.scss
@@ -27,7 +27,8 @@ x x x x x x x x x x x x x x x x x x
 
 
 @mixin fc-item--half {
-    .fc-item__title {
+    .fc-item__title,
+    .fc-item__byline {
         @include fs-headline(4, true);
     }
 

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--half.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--half.scss
@@ -30,6 +30,10 @@ x x x x x x x x x x x x x x x x x x
     .fc-item__title,
     .fc-item__byline {
         @include fs-headline(4, true);
+
+        @include mq(tablet, desktop) {
+            @include fs-headline(3, true);
+        }
     }
 
     .vjs-big-play-button > span {

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
@@ -41,7 +41,8 @@ Media list item. Looks a bit like this:
         padding-left: $fc-item-gutter;
     }
 
-    .fc-item__title {
+    .fc-item__title,
+    .fc-item__byline {
         @include fs-headline($headline-size, true);
     }
 

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
@@ -10,11 +10,8 @@ Media list item. Looks a bit like this:
 
  */
 
-@mixin fc-item--list-media ($text-lines-per-media-object: 4) {
+@mixin fc-item--list-media ($text-lines-per-media-object: 4, $headline-size: 2) {
     @include fc-item--list;
-
-    // values to set image height
-    $headline-size: 1;
 
     // calculate image width
     $media-ratio: 5 / 3;

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--list.scss
@@ -16,8 +16,8 @@ x x x x x x x x x x x x x x x x x x x x x x x x
 
     padding-bottom: 0;
 
-    .fc-item__byline,
-    .fc-item__title {
+    .fc-item__title,
+    .fc-item__byline {
         @include fs-headline($headline-size, true);
     }
 

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--standard.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--standard.scss
@@ -27,7 +27,6 @@ x x x x x x x x
 
 
 @mixin fc-item--standard {
-
     .fc-item__title,
     .fc-item__byline {
         @include mq(tablet, desktop) {

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--standard.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--standard.scss
@@ -26,4 +26,12 @@ x x x x x x x x
 */
 
 
-@mixin fc-item--standard {}
+@mixin fc-item--standard {
+
+    .fc-item__title,
+    .fc-item__byline {
+        @include mq(tablet, desktop) {
+            @include fs-headline(2, true);
+        }
+    }
+}

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--three-quarters.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--three-quarters.scss
@@ -87,7 +87,7 @@ Three quarter item. Looks like a wide standard, a bit like this:
         .fc-item__header,
         .fc-item__standfirst,
         .fc-item__byline {
-            width: gs-span(4.5);
+            width: gs-span(4) + $gs-gutter * 2;
 
             @include mq(desktop) {
                 width: gs-span(6) + $gs-gutter;
@@ -104,7 +104,7 @@ Three quarter item. Looks like a wide standard, a bit like this:
     }
 
     &.fc-item--has-cutout {
-        min-height: gs-height(4.5);
+        min-height: gs-height(4) + $gs-baseline * 3;
     }
 
     .vjs-big-play-button > span {

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--three-quarters.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--three-quarters.scss
@@ -45,7 +45,8 @@ Three quarter item. Looks like a wide standard, a bit like this:
         }
     }
 
-    .fc-item__title {
+    .fc-item__title,
+    .fc-item__byline {
         @include mq(desktop) {
             @include fs-headline(4, true);
         }

--- a/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--three-quarters.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-layouts/_fc-item--three-quarters.scss
@@ -87,16 +87,24 @@ Three quarter item. Looks like a wide standard, a bit like this:
         .fc-item__header,
         .fc-item__standfirst,
         .fc-item__byline {
-            width: 100%;
+            width: gs-span(4.5);
 
             @include mq(desktop) {
                 width: gs-span(6) + $gs-gutter;
             }
         }
+
+        .fc-item__standfirst {
+            display: block;
+            
+            @include mq(desktop) {
+                width: gs-span(5);
+            }
+        }
     }
 
     &.fc-item--has-cutout {
-        min-height: gs-height(6);
+        min-height: gs-height(4.5);
     }
 
     .vjs-big-play-button > span {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -13,7 +13,8 @@
         }
     }
 
-    &.fc-item--list-tablet .fc-item__container {
+    &.fc-item--list-tablet .fc-item__container,
+    &.fc-item--list-media-tablet .fc-item__container {
         @include mq(tablet) {
             @include box-shadow(inset 0 1px $c-newsAccent);
         }
@@ -28,7 +29,6 @@
         }
     }
 
-    &.fc-item--list-media-tablet,
     &.fc-item--three-quarters-tablet,
     &.fc-item--full-tablet,
     &.fc-item--mega-full-tablet {


### PR DESCRIPTION
Mainly font sizing tweaks for tablet and desktop. Also includes adding standfirsts to specific items and making sure that bylines and titles are styled in the same way.
