### PR TITLE
facia tool: fake contentEditable

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -122,32 +122,26 @@
     <script type="text/html" id="template_editor">
         <!-- ko if: type === 'text' && visible() -->
             <div class="editor">
-                <a data-bind="
-                    attr: {
-                        class: 'element element__' + key,
-                        title: label
-                    },
+                <textarea data-bind="
                     click: open,
-                    css: {empty: !overrideOrVal()},
-                    html: overrideOrVal() || label + '...'"></a>
+                    clickBubble: false,
+                    hasFocus: hasFocus,
+                    attr: {
+                        class: 'element__' + key + (hasFocus() ? ' active' : ''),
+                        placeholder: field() || label + '...'
+                    },
+                    autoResize: true,
+                    tabbableFormField: true,
+                    valueUpdate: 'afterkeydown',
+                    value: overrideOrVal"></textarea>
 
-                <!-- ko if: meta === $root.uiOpenElement() -->
-                        <textarea data-bind="
-                            hasFocus: true,
-                            attr: {
-                                class: 'editor__' + key + ' element__' + key,
-                                placeholder: field() || label + '...'
-                            },
-                            autoResize: true,
-                            tabbableFormField: true,
-                            valueUpdate: 'afterkeydown',
-                            value: overrideOrVal"></textarea>
-                        <span class="editor__length" data-bind="
-                            css: {'editor__length--alert': lengthAlert},
-                            text: length"></span>
-                        <a class="editor__revert" data-bind="
-                            visible: meta,
-                            click: revert"><i class="icon-fast-backward"></i></a>
+                <!-- ko if: hasFocus() -->
+                    <span class="editor__length" data-bind="
+                        css: {'editor__length--alert': lengthAlert},
+                        text: length"></span>
+                    <a class="editor__revert" data-bind="
+                        visible: meta,
+                        click: revert"><i class="icon-fast-backward"></i></a>
                 <!-- /ko -->
             </div>
         <!-- /ko -->
@@ -155,6 +149,7 @@
         <!-- ko if: type === 'boolean' -->
             <span data-bind="
                 click: toggle,
+                clickBubble: false,
                 attr: {class: 'editor--boolean editor--boolean--' + key},
                 css: {selected: meta},
                 visible: visible">

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -120,7 +120,7 @@
     <!-- templates -->
 
     <script type="text/html" id="template_editor">
-        <!-- ko if: type === 'text' && visible() -->
+        <!-- ko if: type === 'text' && displayEditor() -->
             <div class="editor">
                 <textarea data-bind="
                     click: open,
@@ -146,13 +146,12 @@
             </div>
         <!-- /ko -->
 
-        <!-- ko if: type === 'boolean' -->
+        <!-- ko if: type === 'boolean' && displayEditor() -->
             <span data-bind="
                 click: toggle,
                 clickBubble: false,
                 attr: {class: 'editor--boolean editor--boolean--' + key},
-                css: {selected: meta},
-                visible: visible">
+                css: {selected: meta}">
                 <a class="editor--boolean__label" data-bind="
                     text: label"></a>
                 <span class="editor--boolean__state"><span data-bind="visible: meta">&#10004;</span></span>
@@ -161,14 +160,13 @@
     </script>
 
     <script type="text/html" id="template_editor_boolean_states">
-        <!-- ko if: type === 'boolean' && meta() -->
+        <!-- ko if: type === 'boolean' && meta() && displayValue() -->
             <span class="editor--boolean  selected">
                 <span class="editor--boolean__label" data-bind="text: label"></span>
                 <span class="editor--boolean__state">&#10004;</span>
             </span>
         <!-- /ko -->
     </script>
-
 
     <script type="text/html" id="template_collection">
         <div class="collection">

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -120,42 +120,44 @@
     <!-- templates -->
 
     <script type="text/html" id="template_editor">
-        <!-- ko if: type === 'text' && displayEditor() -->
-            <div class="editor">
-                <textarea data-bind="
-                    click: open,
+        <!-- ko if: displayEditor -->
+            <!-- ko if: type === 'text' -->
+                <div class="editor">
+                    <textarea data-bind="
+                        click: open,
+                        clickBubble: false,
+                        hasFocus: hasFocus,
+                        attr: {
+                            class: 'element__' + key + (hasFocus() ? ' active' : ''),
+                            placeholder: field() || label + '...'
+                        },
+                        autoResize: true,
+                        tabbableFormField: true,
+                        valueUpdate: 'afterkeydown',
+                        value: overrideOrVal"></textarea>
+
+                    <!-- ko if: hasFocus() -->
+                        <span class="editor__length" data-bind="
+                            css: {'editor__length--alert': lengthAlert},
+                            text: length"></span>
+                        <a class="editor__revert" data-bind="
+                            visible: meta,
+                            click: revert"><i class="icon-fast-backward"></i></a>
+                    <!-- /ko -->
+                </div>
+            <!-- /ko -->
+
+            <!-- ko if: type === 'boolean' -->
+                <span data-bind="
+                    click: toggle,
                     clickBubble: false,
-                    hasFocus: hasFocus,
-                    attr: {
-                        class: 'element__' + key + (hasFocus() ? ' active' : ''),
-                        placeholder: field() || label + '...'
-                    },
-                    autoResize: true,
-                    tabbableFormField: true,
-                    valueUpdate: 'afterkeydown',
-                    value: overrideOrVal"></textarea>
-
-                <!-- ko if: hasFocus() -->
-                    <span class="editor__length" data-bind="
-                        css: {'editor__length--alert': lengthAlert},
-                        text: length"></span>
-                    <a class="editor__revert" data-bind="
-                        visible: meta,
-                        click: revert"><i class="icon-fast-backward"></i></a>
-                <!-- /ko -->
-            </div>
-        <!-- /ko -->
-
-        <!-- ko if: type === 'boolean' && displayEditor() -->
-            <span data-bind="
-                click: toggle,
-                clickBubble: false,
-                attr: {class: 'editor--boolean editor--boolean--' + key},
-                css: {selected: meta}">
-                <a class="editor--boolean__label" data-bind="
-                    text: label"></a>
-                <span class="editor--boolean__state"><span data-bind="visible: meta">&#10004;</span></span>
-            </span>
+                    attr: {class: 'editor--boolean editor--boolean--' + key},
+                    css: {selected: meta}">
+                    <a class="editor--boolean__label" data-bind="
+                        text: label"></a>
+                    <span class="editor--boolean__state"><span data-bind="visible: meta">&#10004;</span></span>
+                </span>
+            <!-- /ko -->
         <!-- /ko -->
     </script>
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -545,7 +545,7 @@ input[type="text"] {
     line-height: 16px;
     -webkit-border-radius: 4px;
     -moz-border-radius: 4px;
-    border-radius: 4px;
+    border-radius: 2px;
     border: 1px solid #cccccc;
     background-color: #ffffff;
 }

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -400,36 +400,6 @@ h1 {
     font-size: 12px;
 }
 
-.element {
-    display: inline-block;
-    margin: 3px 0;
-    width: 100%;
-}
-
-.element,
-.element a {
-    color: #999999;
-    cursor: pointer;
-    text-decoration: none;
-}
-
-.element:hover {
-    color: #000000;
-}
-
-.element__headline a,
-.element__headline {
-    color: #000000;
-    font-size: 16px;
-    line-height: 16px;
-}
-
-.element__trailText a,
-.element__trailText {
-    color: #666666;
-}
-
-
 .article__ammends {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -548,6 +518,7 @@ h1 {
 }
 
 .supporting .editor--boolean,
+.supporting .article__ammends,
 .supporting .element__trailText,
 .supporting .element__byline,
 .supporting .element__imageSrc,
@@ -607,15 +578,18 @@ select {
 }
 
 .editor textarea {
-    position: absolute;
-    top: 0;
-    left: 0;
-    min-height: 18px;
     width: 100%;
-    padding: 1px 0 1px 2px;
+    padding: 0 2px;
     border: 0;
-    margin: 2px 0 -1px -2px;
+    margin: 3px 0 -1px -2px;
     z-index: 10;
+    color: #999999;
+    background: #dddddd;
+}
+
+.editor textarea.active {
+    background: #fafafa;
+    color: #000000;
 }
 
 .editor__revert,
@@ -658,6 +632,35 @@ select {
 .editor--boolean__state {
     display: inline-block;
     width: 15px;
+}
+
+.element {
+    display: inline-block;
+    margin: 3px 0;
+    width: 100%;
+}
+
+.element,
+.element a {
+    color: #999999;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.element:hover {
+    color: #000000;
+}
+
+.element__headline a,
+.element__headline {
+    color: #000000 !important;
+    font-size: 16px;
+    line-height: 16px;
+}
+
+.element__trailText a,
+.element__trailText {
+    color: #666666 !important;
 }
 
 button {

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -120,6 +120,7 @@ define([
                     editable: true,
                     singleton: 'images',
                     label: 'replace image',
+                    displayIf: 'imageSrc',
                     type: 'boolean'
                 },
                 {
@@ -275,20 +276,29 @@ define([
 
             return {
                 key:    key,
+
                 label:  opts.label,
+
                 type:   opts.type,
 
                 meta:   meta,
+
                 field:  field,
+
                 revert: function() { meta(undefined); },
+
                 open:   function() { mediator.emit('ui:open', meta); },
 
                 hasFocus: ko.computed(function() {
                     return meta === vars.model.uiOpenElement();
                 }, self),
 
-                visible: ko.computed(function() {
+                displayEditor: ko.computed(function() {
                     return opts.requires ? _.some(all, function(editor) { return editor.key === opts.requires && self.meta[editor.key](); }) : true;
+                }, self),
+
+                displayValue: ko.computed(function() {
+                    return opts.displayIf ? _.some(all, function(editor) { return editor.key === opts.displayIf && self.meta[editor.key](); }) : true;
                 }, self),
 
                 toggle: function() {
@@ -545,7 +555,7 @@ define([
                     if (keyCode === 9) {
                         e.preventDefault();
                         formField = bindingContext.$rawData;
-                        formFields = _.filter(bindingContext.$parent.editors(), function(ed) { return ed.type === "text" && ed.visible(); });
+                        formFields = _.filter(bindingContext.$parent.editors(), function(ed) { return ed.type === "text" && ed.displayEditor(); });
                         nextIndex = mod(formFields.indexOf(formField) + (e.shiftKey ? -1 : 1), formFields.length);
                         mediator.emit('ui:open', formFields[nextIndex].meta);
                     }

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -281,7 +281,11 @@ define([
                 meta:   meta,
                 field:  field,
                 revert: function() { meta(undefined); },
-                open:   function() { mediator.emit('ui:open', meta); },
+                open:   function() { mediator.emit('ui:open', meta); return false; },
+
+                hasFocus: ko.computed(function() {
+                    return meta === vars.model.uiOpenElement();
+                }, self),
 
                 visible: ko.computed(function() {
                     return opts.requires ? _.some(all, function(editor) { return editor.key === opts.requires && self.meta[editor.key](); }) : true;
@@ -301,7 +305,7 @@ define([
                    _.chain(all)
                     .filter(function(editor) { return editor.requires === key; })
                     .first(1)
-                    .each(function(editor) { mediator.emit('ui:open', self.meta[editor.key]); })
+                    .each(function(editor) { mediator.emit('ui:open', self.meta[editor.key]); });
                 },
 
                 length: ko.computed(function() {
@@ -317,7 +321,7 @@ define([
                         return meta() || field();
                     },
                     write: function(value) {
-                        meta(value.replace(rxScriptStriper, ''));
+                        meta(value === field() ? undefined : value.replace(rxScriptStriper, ''));
                     },
                     owner: self
                 })
@@ -497,6 +501,8 @@ define([
             if (!this.state.isOpen()) {
                  this.state.isOpen(true);
                  mediator.emit('ui:open', this.meta.headline);
+            } else {
+                 mediator.emit('ui:open', undefined);
             }
         };
 

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -281,7 +281,7 @@ define([
                 meta:   meta,
                 field:  field,
                 revert: function() { meta(undefined); },
-                open:   function() { mediator.emit('ui:open', meta); return false; },
+                open:   function() { mediator.emit('ui:open', meta); },
 
                 hasFocus: ko.computed(function() {
                     return meta === vars.model.uiOpenElement();

--- a/facia-tool/public/js/models/collections/main.js
+++ b/facia-tool/public/js/models/collections/main.js
@@ -322,7 +322,7 @@ define([
                 updateScrollables();
                 window.onresize = updateScrollables;
 
-                //startCollectionsPoller();
+                startCollectionsPoller();
                 startSparksPoller();
                 startRelativeTimesPoller();
 


### PR DESCRIPTION
Use de-styled textareas for editable elements; make the focused one white. Bingo. 

![fronts-tool](https://cloud.githubusercontent.com/assets/1147913/4423948/ca170c84-4599-11e4-9186-d23090973c8e.png)

Also hides option indicators that have no effect (ie. imageHide, when there's no actual imageSrc)
