### PR TITLE
Fix the mystery of the disappearing gallery sublink icon

### DIFF
--- a/common/app/views/fragments/items/supporting/gallery.scala.html
+++ b/common/app/views/fragments/items/supporting/gallery.scala.html
@@ -1,7 +1,7 @@
 @(supporting: Gallery, index: Int)(implicit request: RequestHeader)
 
-<li class="linkslist__item supporting__item">
-    <a @LinkTo(supporting).map{url=>href="@url"} class="linkslist__action supporting__action action--has-icon" data-link-name="supporting | @{index + 1}">
+<li class="linkslist__item linkslist__item--gallery supporting__item">
+    <a @LinkTo(supporting).map{url=>href="@url"} class="linkslist__action supporting__action" data-link-name="supporting | @{index + 1}">
         @Html(supporting.headline)
     </a>
 </li>


### PR DESCRIPTION
![google chrome 8](https://cloud.githubusercontent.com/assets/80089/4443858/e309a02c-47eb-11e4-9d55-f09b91cb02f5.jpg)

/cc @sndrs 
