### PR TITLE
facia tool: disable collection poller

### DIFF
--- a/facia-tool/public/js/models/collections/main.js
+++ b/facia-tool/public/js/models/collections/main.js
@@ -322,7 +322,7 @@ define([
                 updateScrollables();
                 window.onresize = updateScrollables;
 
-                startCollectionsPoller();
+                //startCollectionsPoller();
                 startSparksPoller();
                 startRelativeTimesPoller();
 


### PR DESCRIPTION
There's a possible memory leak in the tool UI, almost certainly exacerbated by repeatedly polling collections.  Disabling the latter while I investigate.  
