### PR TITLE
Respect the `sessionCookie` flag for the SC_GU_LA cookie [#MEM-403]

### DIFF
--- a/identity/app/idapiclient/responses/CookiesResponse.scala
+++ b/identity/app/idapiclient/responses/CookiesResponse.scala
@@ -2,5 +2,8 @@ package idapiclient.responses
 
 import org.joda.time.DateTime
 
-case class CookieResponse(key: String, value: String)
+case class CookieResponse(key: String, value: String, sessionCookie: Option[Boolean]) {
+  val isSessionCookie = sessionCookie.getOrElse(false)
+}
+
 case class CookiesResponse(expiresAt: DateTime, values: List[CookieResponse])

--- a/identity/app/services/PlaySigninService.scala
+++ b/identity/app/services/PlaySigninService.scala
@@ -18,7 +18,9 @@ class PlaySigninService @Inject()(conf: IdentityConfiguration) extends SafeLoggi
         val maxAge = if(rememberMe) Some(Seconds.secondsBetween(DateTime.now, apiCookies.expiresAt).getSeconds) else None
         apiCookies.values.map { cookie =>
           val secureHttpOnly = cookie.key.startsWith("SC_")
-          new Cookie(cookie.key, cookie.value, maxAge, "/", Some(conf.id.domain), secureHttpOnly, secureHttpOnly)
+          val cookieMaxAgeOpt = maxAge.filterNot(_ => cookie.isSessionCookie)
+
+          Cookie(cookie.key, cookie.value, cookieMaxAgeOpt, "/", Some(conf.id.domain), secureHttpOnly, secureHttpOnly)
         }
       }
     }


### PR DESCRIPTION
This is part of the work to enforce that users are recently signed-in when they view their personal profile:

https://profile.theguardian.com/account/edit

The Identity API will now be proving Cookie info for the new SC_GU_LA cookie, which stores when the user last authenticated: https://github.com/guardian/identity/pull/176

...this change to NGW Frontend is required to get it to respect the new `sessionCookie` flag, so that the SC_GU_LA cookie is only session-scoped and dies when the user closes the browser.

Here's an example of the cookies now dropped when running Identity and NGW Frontend on my local machine:

![sc_gu_la cookie](https://cloud.githubusercontent.com/assets/52038/4457056/3369256e-4892-11e4-9396-cc3737d43319.png)

https://jira.gutools.co.uk/browse/MEM-403

cc @dbgdngit @adamnfish @mchv 
