### PR TITLE
Add 'show byline' option for Facia cards

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
@@ -5,7 +5,8 @@
         background-color: $c-analysisBackground;
     }
 
-    .fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-analysisAccent;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
@@ -5,7 +5,10 @@
         background-color: $c-analysisBackground;
     }
 
-    .fc-item__kicker {
-        color: $c-analysisAccent;
+    .fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-analysisAccent;
+        }
     }
 }

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -5,8 +5,11 @@
         background-color: $c-commentBackground;
     }
 
-    .fc-item__kicker {
-        color: $c-commentDefault;
+    .fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-commentDefault;
+        }
     }
 
     .fc-item__meta {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -5,7 +5,8 @@
         background-color: $c-commentBackground;
     }
 
-    .fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-commentDefault;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
@@ -6,8 +6,11 @@
         }
     }
 
-    a.fc-item__kicker {
-        color: $c-liveDefault;
+    a.fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-liveDefault;
+        }
     }
 
     .fc-item__meta {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
@@ -6,7 +6,8 @@
         }
     }
 
-    a.fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-liveDefault;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -11,8 +11,11 @@
         }
     }
 
-    .fc-item__kicker {
-        color: $c-featureMute !important;
+    .fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-featureMute !important;
+        }
     }
 
     .fc-item__title .i {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -11,7 +11,8 @@
         }
     }
 
-    .fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-featureMute !important;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -10,8 +10,11 @@
         }
     }
 
-    a.fc-item__kicker {
-        color: $c-liveMute;
+    a.fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-liveMute;
+        }
     }
 
     .fc-item__meta {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -10,7 +10,8 @@
         }
     }
 
-    a.fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-liveMute;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -10,8 +10,11 @@
         }
     }
 
-    .fc-item__kicker {
-        color: $c-mediaDefault;
+    .fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-mediaDefault;
+        }
     }
 
     &.fc-item--has-image:before {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -10,7 +10,8 @@
         }
     }
 
-    .fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-mediaDefault;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -1,5 +1,6 @@
 .tone-news {
-    .fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-analysisAccent;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -1,6 +1,9 @@
 .tone-news {
-    .fc-item__kicker {
-        color: $c-analysisAccent;
+    .fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-analysisAccent;
+        }
     }
 
     &.fc-item--has-image:before {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -16,8 +16,11 @@
             color: $c-neutral1;
         }
 
-        a.fc-item__kicker {
-            color: $c-podcastAccent;
+        a.fc-item__kicker, .fc-item__byline {
+            &,
+            & a {
+                color: $c-podcastAccent;
+            }
         }
     }
 }

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -16,7 +16,8 @@
             color: $c-neutral1;
         }
 
-        a.fc-item__kicker, .fc-item__byline {
+        .fc-item__kicker,
+        .fc-item__byline {
             &,
             & a {
                 color: $c-podcastAccent;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -5,7 +5,8 @@
         background-color: $c-reviewBackground;
     }
 
-    .fc-item__kicker, .fc-item__byline {
+    .fc-item__kicker,
+    .fc-item__byline {
         &,
         & a {
             color: $c-reviewAccent;

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -5,8 +5,11 @@
         background-color: $c-reviewBackground;
     }
 
-    .fc-item__kicker {
-        color: $c-reviewAccent;
+    .fc-item__kicker, .fc-item__byline {
+        &,
+        & a {
+            color: $c-reviewAccent;
+        }
     }
 
     .fc-item__meta {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -105,7 +105,6 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     Jsoup.clean(delegate.safeFields.getOrElse("body",""), Whitelist.none()).split("\\s+").size
   }
 
-  override lazy val byline: Option[String] = fields.get("byline")
   override lazy val trailType: Option[String] = {
     if (tags.exists(_.id == "tone/comment")) {
       Option("comment")
@@ -126,6 +125,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   override lazy val description: Option[String] = trailText
   override lazy val headline: String = apiContent.metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(fields("headline"))
   override lazy val trailText: Option[String] = apiContent.metaData.get("trailText").flatMap(_.asOpt[String]).orElse(fields.get("trailText"))
+  override lazy val byline: Option[String] = apiContent.metaData.get("byline").flatMap(_.asOpt[String]).orElse(fields.get("byline"))
   override def isSurging: Seq[Int] = SurgingContentAgent.getSurgingLevelsFor(id)
 
   // Meta Data used by plugins on the page

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -126,6 +126,8 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   override lazy val headline: String = apiContent.metaData.get("headline").flatMap(_.asOpt[String]).getOrElse(fields("headline"))
   override lazy val trailText: Option[String] = apiContent.metaData.get("trailText").flatMap(_.asOpt[String]).orElse(fields.get("trailText"))
   override lazy val byline: Option[String] = apiContent.metaData.get("byline").flatMap(_.asOpt[String]).orElse(fields.get("byline"))
+  override val showByline = apiContent.metaData.get("showByline").flatMap(_.asOpt[Boolean]).getOrElse(isComment)
+
   override def isSurging: Seq[Int] = SurgingContentAgent.getSurgingLevelsFor(id)
 
   // Meta Data used by plugins on the page

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -7,6 +7,7 @@
 @import views.html.fragments.items.facia_cards.meta
 @import views.html.fragments.items.elements.facia_cards._
 @import views.html.fragments.items.elements.starRating
+@import Function.const
 
 @defining((card.item, card.index)) { case (trail, index) =>
 
@@ -62,7 +63,17 @@
                     ("fc-item__header--inline-video", FaciaDisplayElement.isVideo(trail) && trail.isBoosted)
                 ))">
                     @title(trail, index, containerIndex)
-                    @trail match { case content:model.Content => @starRating(content) }
+                    @trail match {
+                        case content: model.Content => {
+                            @content.byline.filter(const(content.showByline)).map { byline =>
+                                <div class="fc-item__byline tone-colour">@byline</div>
+                            }
+
+                            @starRating(content)
+                        }
+
+                        case _ => {}
+                    }
                     @if(tone == "comment") {
                         @trail.byline.map { byLine =>
                             @trail match { case content:model.Content =>

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -2,7 +2,7 @@
 
 @import common.LinkTo
 @import model.{FaciaDisplayElement, InlineVideo, VideoPlayer}
-@import views.support.{GetClasses, RemoveOuterParaHtml, RenderClasses, SnapData, Video640, TrailCssClasses}
+@import views.support.{GetClasses, RemoveOuterParaHtml, RenderClasses, SnapData, Video640, ContributorLinks}
 @import views.html.fragments.media.video
 @import views.html.fragments.items.facia_cards.meta
 @import views.html.fragments.items.elements.facia_cards._
@@ -66,20 +66,15 @@
                     @trail match {
                         case content: model.Content => {
                             @content.byline.filter(const(content.showByline)).map { byline =>
-                                <div class="fc-item__byline tone-colour">@Html(byline)</div>
+                                <div class="fc-item__byline">
+                                    @ContributorLinks(Html(byline), content.contributors)
+                                </div>
                             }
 
                             @starRating(content)
                         }
 
                         case _ => {}
-                    }
-                    @if(tone == "comment") {
-                        @trail.byline.map { byLine =>
-                            @trail match { case content:model.Content =>
-                            <p class="fc-item__byline tone-colour">@ContributorLinks(Html(byLine), content.contributors)</p>
-                            }
-                        }
                     }
                 </div>
 

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -66,7 +66,7 @@
                     @trail match {
                         case content: model.Content => {
                             @content.byline.filter(const(content.showByline)).map { byline =>
-                                <div class="fc-item__byline tone-colour">@byline</div>
+                                <div class="fc-item__byline tone-colour">@Html(byline)</div>
                             }
 
                             @starRating(content)

--- a/facia-press/app/frontpress/jsonModels.scala
+++ b/facia-press/app/frontpress/jsonModels.scala
@@ -57,6 +57,8 @@ object ItemMeta {
   def fromContent(content: Content): ItemMeta = ItemMeta(
     headline = content.apiContent.metaData.get("headline"),
     trailText = content.apiContent.metaData.get("trailText"),
+    byline = content.apiContent.metaData.get("byline"),
+    showByline = content.apiContent.metaData.get("showByline").flatMap(_.asOpt[Boolean]),
     group = content.apiContent.metaData.get("group"),
     isBoosted = content.apiContent.metaData.get("isBoosted").flatMap(_.asOpt[Boolean]),
     imageHide = content.apiContent.metaData.get("imageHide").flatMap(_.asOpt[Boolean]),
@@ -75,6 +77,8 @@ object ItemMeta {
 case class ItemMeta(
   headline:      Option[JsValue],
   trailText:     Option[JsValue],
+  byline:        Option[JsValue],
+  showByline:    Option[Boolean],
   group:         Option[JsValue],
   isBoosted:     Option[Boolean],
   imageHide:     Option[Boolean],
@@ -102,6 +106,7 @@ object TrailJson {
       content.webUrl,
       content.tags.map(TagJson.fromTag),
       content.trailText,
+      content.byline,
       content.delegate.safeFields,
       content.elements.map(ElementJson.fromElement),
       ItemMeta.fromContent(content)
@@ -117,6 +122,7 @@ case class TrailJson(
   webUrl: String,
   tags: Seq[TagJson],
   trailText: Option[String],
+  byline: Option[String],
   safeFields: Map[String, String],
   elements: Seq[ElementJson],
   meta: ItemMeta

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -157,6 +157,8 @@ trait UpdateActions extends Logging {
     "snapCss",
     "snapUri",
     "trailText",
+    "byline",
+    "showByline",
     "group",
     "supporting",
     "isBoosted",

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -129,7 +129,8 @@
                         hasFocus: hasFocus,
                         attr: {
                             class: 'element__' + key + (hasFocus() ? ' active' : ''),
-                            placeholder: field() || label + '...'
+                            placeholder: field() || label + '...',
+                            title: label
                         },
                         autoResize: true,
                         tabbableFormField: true,

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -651,15 +651,14 @@ select {
     color: #000000;
 }
 
-.element__headline a,
 .element__headline {
     color: #000000 !important;
     font-size: 16px;
     line-height: 16px;
 }
 
-.element__trailText a,
-.element__trailText {
+.element__trailText,
+.element__byline {
     color: #666666 !important;
 }
 

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -42,6 +42,7 @@ define([
             capiFields = [
                 'headline',
                 'trailText',
+                'byline',
                 'isLive',
                 'firstPublicationDate',
                 'scheduledPublicationDate',
@@ -64,6 +65,13 @@ define([
                     key: 'trailText',
                     editable: true,
                     label: 'trail text',
+                    type: 'text'
+                },
+                {
+                    key: 'byline',
+                    editable: true,
+                    requires: 'showByline',
+                    label: 'byline',
                     type: 'text'
                 },
                 {
@@ -93,7 +101,12 @@ define([
                     label: 'boost',
                     type: 'boolean'
                 },
-
+                {
+                    key: 'showByline',
+                    editable: true,
+                    label: 'show byline',
+                    type: 'boolean'
+                },
                 {
                     key: 'hasMainVideo',
                     label: 'has a video',
@@ -107,7 +120,6 @@ define([
                     label: 'show video',
                     type: 'boolean'
                 },
-
                 {
                     key: 'imageHide',
                     editable: true,


### PR DESCRIPTION
@stephanfowler & I:

The tool now has a 'showByline' option and an editable byline. Contributor names will automatically be replaced with links, still.

The same tonal colour as the kicker is used for the byline.

In the tool:

![screen shot 2014-09-30 at 12 19 50](https://cloud.githubusercontent.com/assets/1001642/4457193/04d17e2a-4894-11e4-81bd-5cc4aad951d4.png)

On the front:

![screen shot 2014-09-30 at 12 20 03](https://cloud.githubusercontent.com/assets/1001642/4457196/0c7896c2-4894-11e4-95ab-8a7d3133badf.png)

CC @kungpochicken @sndrs @sammorrisdesign @phamann @gklopper 
