### PR TITLE
Suppress tonal kickers on a collection

### DIFF
--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -13,7 +13,8 @@ case class Config(
                    groups: Seq[String],
                    collectionType: Option[String],
                    showTags: Boolean = false,
-                   showSections: Boolean = false
+                   showSections: Boolean = false,
+                   hideKickers: Boolean = false
                    ) {
 
   lazy val isSponsored: Boolean = DfpAgent.isSponsored(this)

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -63,7 +63,8 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
         (collectionJson \ "groups").asOpt[Seq[String]] getOrElse Nil,
         (collectionJson \ "type").asOpt[String],
         (collectionJson \ "showTags").asOpt[Boolean] getOrElse false,
-        (collectionJson \ "showSections").asOpt[Boolean] getOrElse false
+        (collectionJson \ "showSections").asOpt[Boolean] getOrElse false,
+        (collectionJson \ "hideKickers").asOpt[Boolean] getOrElse false
       )
     }
   }

--- a/common/app/views/support/ItemKicker.scala
+++ b/common/app/views/support/ItemKicker.scala
@@ -14,7 +14,15 @@ object ItemKicker {
       }
     } else if (config.showSections || trail.showKickerSection) {
       Some(SectionKicker(trail.sectionName.capitalize, "/" + trail.section))
-    } else if (trail.isBreaking) {
+    } else if (!config.hideKickers) {
+      tonalKicker(trail)
+    } else {
+      None
+    }
+  }
+
+  private def tonalKicker(trail: Trail): Option[ItemKicker] = {
+    if (trail.isBreaking) {
       Some(BreakingNewsKicker)
     } else if (trail.isLive) {
       Some(LiveKicker)

--- a/facia-press/app/frontpress/jsonModels.scala
+++ b/facia-press/app/frontpress/jsonModels.scala
@@ -136,7 +136,8 @@ object CollectionJson {
       href           = collection.href.orElse(config.href),
       `type`         = config.collectionType,
       showTags       = config.showTags,
-      showSections   = config.showSections
+      showSections   = config.showSections,
+      hideKickers    = config.hideKickers
     )
 }
 
@@ -154,5 +155,6 @@ case class CollectionJson(
   groups:       Option[Seq[String]],
   href:         Option[String],
   showTags:     Boolean,
-  showSections: Boolean
-)
+  showSections: Boolean,
+  hideKickers:  Boolean
+                           )

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -45,6 +45,7 @@ case class Collection(
   uneditable: Option[Boolean],
   showTags: Option[Boolean],
   showSections: Option[Boolean],
+  hideKickers: Option[Boolean],
   showMainVideo: Option[Boolean]
 )
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -116,11 +116,14 @@
                     <span class="cnf-form__value" data-bind="text: meta.groups"></span>
                 <!-- /ko -->
 
-                <label for="showTags" >Show tags</label>
+                <label for="showTags" >Show tag kickers</label>
                 <input id="showTags" type="checkbox" data-bind="checked: meta.showTags" />
 
-                <label for="showSections" >Show sections</label>
+                <label for="showSections" >Show section kickers</label>
                 <input id="showSections" type="checkbox" data-bind="checked: meta.showSections" />
+
+                <label for="hideKickers" >Suppress kickers</label>
+                <input id="hideKickers" type="checkbox" data-bind="checked: meta.hideKickers" />
 
                 <label>No curation</label>
                 <input type="checkbox" data-bind="

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -122,7 +122,7 @@
                 <label for="showSections" >Show section kickers</label>
                 <input id="showSections" type="checkbox" data-bind="checked: meta.showSections" />
 
-                <label for="hideKickers" >Suppress kickers</label>
+                <label for="hideKickers" >Suppress tone kickers</label>
                 <input id="hideKickers" type="checkbox" data-bind="checked: meta.hideKickers" />
 
                 <label>No curation</label>

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1055,7 +1055,7 @@ button {
 .cnf-form label {
     font-size: 12px;
     color: #666666;
-    width: 115px;
+    width: 120px;
     float: left;
     clear: left;
     margin: 1px 0 0 0;

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1055,7 +1055,7 @@ button {
 .cnf-form label {
     font-size: 12px;
     color: #666666;
-    width: 85px;
+    width: 115px;
     float: left;
     clear: left;
     margin: 1px 0 0 0;

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -39,6 +39,7 @@ define([
             'uneditable',
             'showTags',
             'showSections',
+            'hideKickers',
             'apiQuery']);
 
         populateObservables(this.meta, opts);

--- a/facia-tool/test/config/TransformationsSpec.scala
+++ b/facia-tool/test/config/TransformationsSpec.scala
@@ -15,7 +15,8 @@ import test.ConfiguredTestSuite
     uneditable = Some(false),
     showTags = Some(true),
     showSections = Some(false),
-    showMainVideo = None
+    showMainVideo = None,
+    hideKickers = Some(false)
   )
 
   val createCommandFixture = CreateFront(
@@ -34,6 +35,7 @@ import test.ConfiguredTestSuite
   )
 
   val emptyCollectionFixture = Collection(
+    None,
     None,
     None,
     None,

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -136,7 +136,8 @@ trait FrontJson extends ExecutionContexts with Logging {
       groups          = (json \ "groups").asOpt[List[String]].getOrElse(Nil),
       collectionType  = (json \ "type").asOpt[String],
       showTags        = (json \ "showTags").asOpt[Boolean] getOrElse false,
-      showSections    = (json \ "showSections").asOpt[Boolean] getOrElse false
+      showSections    = (json \ "showSections").asOpt[Boolean] getOrElse false,
+      hideKickers     = (json \ "hideKickers").asOpt[Boolean] getOrElse false
     )
   }
 


### PR DESCRIPTION
Stephan Fowler & I:

Adds an option to suppress tonal kickers on a collection. You might want to do this, for example, if you had a collection that was called Analysis and only contained Analysis items.

![screen shot 2014-09-30 at 15 02 33](https://cloud.githubusercontent.com/assets/1001642/4459389/ab212936-48aa-11e4-8685-6878ec0d7cd1.png)
