### PR TITLE
Only enhance tweets when they approach the viewport

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -41,7 +41,7 @@ define([
         initTruncateAndTwitter: function() {
             // Ensure that truncation occurs before the tweet upgrading.
             truncate();
-            twitter.enhanceTweets();
+            twitter.init();
         }
 
     };

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -24,7 +24,6 @@ define([
     function removeTruncation() {
         // Reinstate tweets and enhance them.
         $('.truncated-block blockquote.tweet-truncated').removeClass('tweet-truncated').addClass('tweet');
-        twitter.enhanceTweets();
 
         $truncatedBlocks.removeClass(truncatedClass);
         $('.article-elongator').addClass('u-h');

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -24,10 +24,9 @@ define([
     function removeTruncation() {
         // Reinstate tweets and enhance them.
         $('.truncated-block blockquote.tweet-truncated').removeClass('tweet-truncated').addClass('js-tweet');
-        twitter.enhanceTweets();
-
         $truncatedBlocks.removeClass(truncatedClass);
         $('.article-elongator').addClass('u-h');
+        twitter.enhanceTweets();
     }
 
     function truncate() {

--- a/common/app/assets/javascripts/modules/article/truncate.js
+++ b/common/app/assets/javascripts/modules/article/truncate.js
@@ -23,7 +23,8 @@ define([
 
     function removeTruncation() {
         // Reinstate tweets and enhance them.
-        $('.truncated-block blockquote.tweet-truncated').removeClass('tweet-truncated').addClass('tweet');
+        $('.truncated-block blockquote.tweet-truncated').removeClass('tweet-truncated').addClass('js-tweet');
+        twitter.enhanceTweets();
 
         $truncatedBlocks.removeClass(truncatedClass);
         $('.article-elongator').addClass('u-h');
@@ -59,7 +60,7 @@ define([
 
             $truncatedBlocks.addClass(truncatedClass);
             // Avoid running the twitter widget on truncated tweets.
-            $('.truncated-block blockquote.tweet').removeClass('tweet').addClass('tweet-truncated');
+            $('.truncated-block blockquote.tweet').removeClass('js-tweet').addClass('tweet-truncated');
         }
     }
 

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -37,7 +37,6 @@ define([
         tweetElements.forEach( function(element) {
             var $el = bonzo(element);
             if((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) {
-                console.log("upgrade" + $el.offset().top);
                 $(element).removeClass('js-tweet').addClass('twitter-tweet');
             }
         });

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -1,30 +1,48 @@
 /*global twttr:false */
 
 define([
+    'bean',
+    'bonzo',
     'qwery',
+    'lodash/collections/forEach',
     'common/utils/$',
+    'common/utils/config',
     'common/utils/detect',
-    'common/utils/config'
+    'common/utils/mediator'
 ], function(
+    bean,
+    bonzo,
     qwery,
+    forEach,
     $,
+    config,
     detect,
-    config
+    mediator
 ) {
-    function enhanceTweets() {
 
+    function bootstrap() {
+        mediator.on('window:scroll', enhanceTweets);
+    }
+
+    function enhanceTweets() {
+    console.log("scroll: " + bonzo(document.body).scrollTop())
         if (detect.getBreakpoint() === 'mobile' || !config.switches.enhanceTweets) {
             return;
         }
 
         var tweetElements = qwery('blockquote.tweet'),
-            widgetScript  = qwery('#twitter-widget');
+            widgetScript  = qwery('#twitter-widget'),
+            viewportHeight = bonzo.viewport().height;
 
         tweetElements.forEach( function(element) {
-            // Reformat the tweet element to match twitter's native element structure.
-            $('.tweet-body', element).after($('.tweet-date', element));
-            $('.tweet-user', element).remove();
-            $(element).removeClass('tweet').addClass('twitter-tweet');
+            var $el = bonzo(element);
+            if((bonzo(document.body).scrollTop() + (viewportHeight*2)) > $el.offset().top) {
+                console.log("Upgrade! Element at position:" + $el.offset().top + " / " + $el.offset().top);
+                // Reformat the tweet element to match twitter's native element structure.
+                $('.tweet-body', element).after($('.tweet-date', element));
+                $('.tweet-user', element).remove();
+                $(element).removeClass('tweet').addClass('twitter-tweet');
+            }
         });
 
         var nativeTweetElements = qwery('blockquote.twitter-tweet');
@@ -45,6 +63,7 @@ define([
     }
 
     return {
+        init: bootstrap,
         enhanceTweets: enhanceTweets
     };
 });

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -36,7 +36,8 @@ define([
 
         tweetElements.forEach( function(element) {
             var $el = bonzo(element);
-            if((bonzo(document.body).scrollTop() + (viewportHeight*2.5)) > $el.offset().top) {
+            if((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) {
+                console.log("upgrade" + $el.offset().top);
                 $(element).removeClass('js-tweet').addClass('twitter-tweet');
             }
         });

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -19,29 +19,25 @@ define([
     detect,
     mediator
 ) {
+    var body = qwery('.js-liveblog-body');
 
     function bootstrap() {
         mediator.on('window:scroll', enhanceTweets);
     }
 
     function enhanceTweets() {
-    console.log("scroll: " + bonzo(document.body).scrollTop())
         if (detect.getBreakpoint() === 'mobile' || !config.switches.enhanceTweets) {
             return;
         }
 
-        var tweetElements = qwery('blockquote.tweet'),
+        var tweetElements = qwery('blockquote.js-tweet'),
             widgetScript  = qwery('#twitter-widget'),
             viewportHeight = bonzo.viewport().height;
 
         tweetElements.forEach( function(element) {
             var $el = bonzo(element);
-            if((bonzo(document.body).scrollTop() + (viewportHeight*2)) > $el.offset().top) {
-                console.log("Upgrade! Element at position:" + $el.offset().top + " / " + $el.offset().top);
-                // Reformat the tweet element to match twitter's native element structure.
-                $('.tweet-body', element).after($('.tweet-date', element));
-                $('.tweet-user', element).remove();
-                $(element).removeClass('tweet').addClass('twitter-tweet');
+            if((bonzo(document.body).scrollTop() + (viewportHeight*2.5)) > $el.offset().top) {
+                $(element).removeClass('js-tweet').addClass('twitter-tweet');
             }
         });
 
@@ -56,7 +52,7 @@ define([
                 $(document.body).append(scriptElement);
             } else {
                 if (typeof twttr !== 'undefined' && 'widgets' in twttr && 'load' in twttr.widgets) {
-                    twttr.widgets.load();
+                    twttr.widgets.load(body);
                 }
             }
         }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -436,9 +436,10 @@ object TweetCleaner extends HtmlCleaner {
         val date = el.child(1).attr("class", "tweet-date")
         val user = el.ownText()
         val userEl = document.createElement("span").attr("class", "tweet-user").text(user)
+        val link = document.createElement("a").attr("href", date.attr("href")).attr("style", "display: none;")
 
-        element.empty().attr("class", "tweet")
-        element.appendChild(userEl).appendChild(date).appendChild(body)
+          element.empty().attr("class", "js-tweet tweet")
+        element.appendChild(userEl).appendChild(date).appendChild(body).appendChild(link)
       }
     }
     document

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -438,7 +438,7 @@ object TweetCleaner extends HtmlCleaner {
         val userEl = document.createElement("span").attr("class", "tweet-user").text(user)
         val link = document.createElement("a").attr("href", date.attr("href")).attr("style", "display: none;")
 
-          element.empty().attr("class", "js-tweet tweet")
+        element.empty().attr("class", "js-tweet tweet")
         element.appendChild(userEl).appendChild(date).appendChild(body).appendChild(link)
       }
     }


### PR DESCRIPTION
Modified the logic for enhancing tweets on live blog and article pages so that they only load in when they are approaching the viewport. 

This fixes the lag encountered when you 'view all updates' on a live blog with a lot of embedded tweets.

// @mattosborn 
