### PR TITLE
Content API Circuit Breaker onOpen metric

### DIFF
--- a/applications/app/Global.scala
+++ b/applications/app/Global.scala
@@ -16,6 +16,7 @@ object Global extends WithFilters(Filters.common: _*)
   override lazy val applicationName = "frontend-applications"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
-    ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric
+    ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
+    ContentApiMetrics.ContentApiCircuitBreakerOnOpen
   )
 }

--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -17,6 +17,7 @@ object Global
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
     ContentApiMetrics.ElasticHttpTimingMetric,
     ContentApiMetrics.ElasticHttpTimeoutCountMetric,
-    ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric
+    ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
+    ContentApiMetrics.ContentApiCircuitBreakerOnOpen
   )
 }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -141,6 +141,11 @@ object ContentApiMetrics {
     "content-api-circuit-breaker-requests",
     "Number of requests immediately rejected due to the circuit breaker being tripped"
   )
+
+  object ContentApiCircuitBreakerOnOpen extends CountMetric(
+    "content-api-circuit-breaker-on-open-changes",
+    "Number of times circuit breaker is put into the onOpen state"
+  )
 }
 
 object PaMetrics {

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -2,6 +2,7 @@ package contentapi
 
 import akka.actor.ActorSystem
 import com.gu.openplatform.contentapi.Api
+import common.ContentApiMetrics.ContentApiCircuitBreakerOnOpen
 import conf.Switches
 import scala.concurrent.Future
 import common._
@@ -138,6 +139,7 @@ trait CircuitBreakingContentApiClient extends ContentApiClient {
 
   circuitBreaker.onOpen({
     log.error("Reached error threshold for Content API Client circuit breaker - breaker is OPEN!")
+    ContentApiCircuitBreakerOnOpen.increment()
   })
 
   circuitBreaker.onHalfOpen({

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -32,6 +32,7 @@ object Global extends GlobalSettings
     ContentApiMetrics.ContentApiJsonParseExceptionMetric,
     ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
     ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
+    ContentApiMetrics.ContentApiCircuitBreakerOnOpen,
     FaciaToolMetrics.InvalidContentExceptionMetric,
     S3Metrics.S3ClientExceptionsMetric,
     S3Metrics.S3AuthorizationError,


### PR DESCRIPTION
The current metric hides how many onOpen states exist.

This just adds a metric that counts when the circuit breaker goes into the Open state.

@robertberry @stephanfowler 
