### PR TITLE
Prefer item level tag or section kickers to collection level settings

### DIFF
--- a/common/app/views/support/ItemKicker.scala
+++ b/common/app/views/support/ItemKicker.scala
@@ -8,12 +8,20 @@ object ItemKicker {
   def fromTrail(trail: Trail, config: model.Config): Option[ItemKicker] = {
     lazy val maybeTag = firstTag(trail)
 
-    if ((trail.showKickerTag || config.showTags) && maybeTag.isDefined) {
-      maybeTag map { tag =>
-        TagKicker(tag.name, tag.webUrl)
-      }
-    } else if (config.showSections || trail.showKickerSection) {
-      Some(SectionKicker(trail.sectionName.capitalize, "/" + trail.section))
+    def tagKicker = maybeTag map { tag =>
+      TagKicker(tag.name, tag.webUrl)
+    }
+
+    def sectionKicker = Some(SectionKicker(trail.sectionName.capitalize, "/" + trail.section))
+
+    if (trail.showKickerTag && maybeTag.isDefined) {
+      tagKicker
+    } else if (trail.showKickerSection) {
+      sectionKicker
+    } else if (config.showTags && maybeTag.isDefined) {
+      tagKicker
+    } else if (config.showSections) {
+      sectionKicker
     } else if (!config.hideKickers) {
       tonalKicker(trail)
     } else {

--- a/common/test/views/support/ItemKickerTest.scala
+++ b/common/test/views/support/ItemKickerTest.scala
@@ -1,0 +1,62 @@
+package views.support
+
+import model.{Tag, Config, Trail}
+import org.joda.time.DateTime
+import org.scala_tools.time.Imports
+import org.scalatest.{OptionValues, FlatSpec, Matchers}
+import com.gu.openplatform.contentapi.model.{Tag => ApiTag}
+
+class ItemKickerTest extends FlatSpec with Matchers with OptionValues {
+  def createTrailFixture(showTag: Boolean, showSection: Boolean) = new Trail {
+    override def webPublicationDate: Imports.DateTime = DateTime.now()
+
+    override def url: String = ""
+
+    override def isLive: Boolean = false
+
+    override def section: String = "testsection"
+
+    override def trailText: Option[String] = None
+
+    //sectionId
+    override def sectionName: String = "Test Section"
+
+    override def linkText: String = ""
+
+    override def headline: String = ""
+
+    override def webUrl: String = ""
+
+    override def showKickerTag: Boolean = showTag
+
+    override def showKickerSection: Boolean = showSection
+
+    override def tags: Seq[Tag] = Seq(
+      Tag(
+        ApiTag(
+          "testTag",
+          "test",
+          Some("section"),
+          Some("Section"),
+          "Test Tag",
+          "testtag",
+          "testtag"
+        )
+      )
+    )
+  }
+
+  "ItemKicker" should "prefer item level tag kicker to collection level section kicker" in {
+    ItemKicker.fromTrail(
+      createTrailFixture(showTag = true, showSection = false),
+      Config("").copy(showSections = true)
+    ).value shouldEqual TagKicker("Test Tag", "testtag")
+  }
+
+  it should "prefer item level section kicker to collection level tag kicker" in {
+    ItemKicker.fromTrail(
+      createTrailFixture(showTag = false, showSection = true),
+      Config("").copy(showTags = true)
+    ).value shouldEqual SectionKicker("Test Section", "/testsection")
+  }
+}


### PR DESCRIPTION
If an item is set to show a tag kicker or a section kicker, that setting should override whatever the collection level kicker setting is.

This does that thang

CC lovely Scala heads @rich-nguyen @janua @gklopper 
