### PR TITLE
Add hide kickers to whitelist

### DIFF
--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -171,6 +171,7 @@ trait UpdateActions extends Logging {
     "isBreaking",
     "showKickerTag",
     "showKickerSection",
+    "hideKickers",
     "showMainVideo"
   )
 


### PR DESCRIPTION
Currently the tool is unable to actually set hide kickers. This must have been lost in a merge conflict.
