### PR TITLE
Remove placeholder of on-page description field in facia-tool

### DIFF
--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -191,9 +191,7 @@
                             value: props.description"></textarea>
 
                         <label>On-page description</label>
-                        <textarea data-bind="
-                            attr: {placeholder: placeholders.onPageDescription},
-                            value: props.onPageDescription"></textarea>
+                        <textarea data-bind="value: props.onPageDescription"></textarea>
 
                         <label>Image</label>
                         <input type="text" placeholder="Image URL, e.g. copied from Batch Uploader"


### PR DESCRIPTION
A quick one.
If the on-page description field is empty, don't display the placeholder text.
![screen shot 2014-09-30 at 17 05 18](https://cloud.githubusercontent.com/assets/1492162/4461602/b43d2d60-48bb-11e4-8b84-32c8292c1abc.png)
