### PR TITLE
Fix flakey Slice with Cards test

### DIFF
--- a/common/test/layout/SliceWithCardsTest.scala
+++ b/common/test/layout/SliceWithCardsTest.scala
@@ -33,7 +33,7 @@ class SliceWithCardsTest extends FlatSpec with Matchers with GeneratorDrivenProp
   "a slice" should "consume as many items as the columns it aggregates consume" in {
     forAll { (layout: SliceLayout) =>
       SliceWithCards.fromItems(cardFixtures, layout)._2.length shouldEqual
-        NumberOfFixtures - layout.columns.map(SliceWithCards.itemsToConsume).sum
+        (0 max (NumberOfFixtures - layout.columns.map(SliceWithCards.itemsToConsume).sum))
     }
   }
 


### PR DESCRIPTION
It looks like if the randomly generated slice layout has enough rows, it can consume more items than there are fixtures. This is valid behaviour so we should allow a 0 value.

@ironsidevsquincy @rich-nguyen This fixes the issue with the build.
