### PR TITLE
facia tool: better sublink behaviour

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -303,24 +303,24 @@
                     attr: {src: state.sparkUrl}" />
 
                 <div class="article__tools">
+                    <a class="tool tool--small tool--small--paste" data-bind="
+                        clickBubble: false,
+                        click: paste">paste</a>
+
                     <a class="tool tool--small tool--small--copy" data-bind="
                         clickBubble: false,
                         click: copy">copy</a>
 
-                    <a class="tool tool--small tool--small--paste" data-bind="
+                    <a class="tool tool--small tool--small--remove" data-bind="
                         clickBubble: false,
-                        click: paste">paste</a>
+                        click: $parent.omitItem">
+                        <i class="icon-trash"></i></a>
 
                     <a class="tool tool--small tool--small--href" target="_blank" data-bind="
                         click: function() { return true; },
                         clickBubble: false,
                         attr: {href: viewUrl}">
                         <i class="icon-share-alt"></i></a>
-
-                    <a class="tool tool--small tool--small--remove" data-bind="
-                        clickBubble: false,
-                        click: $parent.omitItem">
-                        <i class="icon-trash"></i></a>
                 </div>
 
                 <a class="article__content" data-bind="attr: {href: id}">

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -297,8 +297,7 @@
                 </div>
             </div>
 
-            <div class="closed" data-bind="if: !state.isOpen()">
-
+            <div class="closed" data-bind="ifnot: state.isOpen">
                 <img class="article__spark" data-bind="
                     visible: state.sparkUrl,
                     attr: {src: state.sparkUrl}" />
@@ -365,7 +364,7 @@
 
                             <span data-bind="template: {name: 'template_editor_boolean_states', foreach: editorsDisplay}"></span>
 
-                            <span data-bind="
+                            <span class="trailText" data-bind="
                                 html: meta.trailText() || fields.trailText()"></span>
                         </div>
                     <!-- /ko -->

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -350,7 +350,6 @@ h1 {
 
 .article.open {
     height: inherit;
-    min-height: 61px;
     background: #dddddd !important;
 }
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -162,9 +162,8 @@ h1 {
 
 .supporting .droppable {
     padding: 0 0 15px 0;
-    border-top: 1px solid #e9e9e9;
-    border-bottom: 1px solid #e9e9e9;
-    margin: 2px 0;
+    border-bottom: 1px solid #2ea3eb;
+    margin: 0 0 0 -4px;
 }
 
 .droppable.underDrag {
@@ -319,7 +318,7 @@ h1 {
     box-sizing: border-box;
     min-height: 56px;
     overflow: hidden;
-    padding: 0 2px 3px 4px;
+    padding: 0 0 0 4px;
     position: relative;
     color: #999999;
     background: #ffffff;
@@ -336,11 +335,11 @@ h1 {
 
 .article:hover,
 .live-mode .article:hover {
-    background-color: #eeeeee;
+    background-color: #eeeeee !important;
 }
 
-.article:hover .article__spark,
-.article:hover .article__times {
+.article:hover > .closed > .article__spark,
+.article:hover > .closed > .article__times {
     display: none;
 }
 
@@ -460,8 +459,8 @@ h1 {
 
 .article__times {
     position: absolute;
-    top: 4px;
-    right: 2px;
+    top: 5px;
+    right: 5px;
     font-size: 11px;
     line-height: 12px;
 }
@@ -517,8 +516,8 @@ h1 {
     margin: 5px 0 0 5px;
 }
 
+.supporting .trailText,
 .supporting .editor--boolean,
-.supporting .article__ammends,
 .supporting .element__trailText,
 .supporting .element__byline,
 .supporting .element__imageSrc,
@@ -678,7 +677,7 @@ button {
 .article__spark {
     position: absolute;
     top: 18px;
-    right: 3px;
+    right: 5px;
 }
 
 .group-name {
@@ -865,14 +864,12 @@ button {
 .article__tools {
     display: none;
     position: absolute;
-    top: 0;
-    right: 3px;
-    width: 88px;
-    height: 51px;
-}
-
-.latest-articles .article__tools {
-    width: 45px;
+    top: 2px;
+    right: 2px;
+    width: 126px;
+    height: 50px;
+    background: #eeeeee;
+    z-index: 10;
 }
 
 .article:hover > .closed > .article__tools {
@@ -887,10 +884,12 @@ button {
     font-size: 12px;
     line-height: 22px;
     color: #333333;
-    width: 42px;
-    height: 23px;
+    width: 60px;
+    height: 22px;
     padding: 0;
     opacity: 0.7;
+    float: right;
+    border-radius: 1px;
 }
 
 .tool--small i {
@@ -899,18 +898,20 @@ button {
 
 .tool--done {
     float: right;
-    margin: 0 2px 0 0;
 }
 
 
 .article > .closed .tool--small {
-    float: left;
-    margin: 2px 0 0 2px;
+    margin: 1px 1px 0 0;
 }
 
 .latest-articles .tool--small--remove,
 .latest-articles .tool--small--paste {
     display: none;
+}
+
+.latest-articles .tool--small--href {
+    clear: both;
 }
 
 .article > .closed .tool--small:hover {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -162,7 +162,6 @@ h1 {
 
 .supporting .droppable {
     padding: 0 0 15px 0;
-    border-bottom: 1px solid #2ea3eb;
     margin: 0 0 0 -4px;
 }
 
@@ -368,13 +367,16 @@ h1 {
 .article .thumb {
     position: absolute;
     top: 3px;
+    width: 75px;
+    height: 45px;
+    border-radius: 2px;
+    background-color: #dddddd;
 }
 
 .article .thumb img {
     width: 75px;
     height: 45px;
     border-radius: 2px;
-    background-color: #eeeeee;
 }
 
 .article__content {
@@ -864,7 +866,7 @@ button {
     display: none;
     position: absolute;
     top: 2px;
-    right: 2px;
+    right: 3px;
     width: 126px;
     height: 50px;
     background: #eeeeee;

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -329,7 +329,7 @@ define([
 
                 revert: function() { meta(undefined); },
 
-                open:   function() { mediator.emit('ui:open', meta); },
+                open:   function() { mediator.emit('ui:open', meta, self); },
 
                 hasFocus: ko.computed(function() {
                     return meta === vars.model.uiOpenElement();
@@ -353,7 +353,7 @@ define([
                    _.chain(all)
                     .filter(function(editor) { return editor.requires === key; })
                     .first(1)
-                    .each(function(editor) { mediator.emit('ui:open', self.meta[editor.key]); });
+                    .each(function(editor) { mediator.emit('ui:open', self.meta[editor.key], self); });
                 },
 
                 length: ko.computed(function() {
@@ -540,22 +540,22 @@ define([
             this.meta.href(this.id());
             this.id(snap.generateId());
             this.state.isOpen(true);
-            mediator.emit('ui:open', this.meta.headline);
+            mediator.emit('ui:open', this.meta.headline, this);
         };
 
         Article.prototype.open = function() {
             if (this.uneditable) { return; }
 
-            if (!this.state.isOpen()) {
+            this.meta.supporting && this.meta.supporting.items().forEach(function(sublink) { sublink.close(); });
 
+            if (!this.state.isOpen()) {
                 if (this.editors().length === 0) {
                     this.editors(metaFields.map(this.metaEditor, this).filter(function (editor) { return editor; }));
                 }
-
                 this.state.isOpen(true);
-                mediator.emit('ui:open', this.meta.headline);
+                mediator.emit('ui:open', this.meta.headline, this);
             } else {
-                mediator.emit('ui:open', undefined);
+                mediator.emit('ui:open');
             }
         };
 
@@ -589,6 +589,8 @@ define([
 
         ko.bindingHandlers.tabbableFormField = {
             init: function(el, valueAccessor, allBindings, viewModel, bindingContext) {
+                var self = this;
+
                 $(el).on('keydown', function(e) {
                     var keyCode = e.keyCode || e.which,
                         formField,
@@ -600,7 +602,7 @@ define([
                         formField = bindingContext.$rawData;
                         formFields = _.filter(bindingContext.$parent.editors(), function(ed) { return ed.type === "text" && ed.displayEditor(); });
                         nextIndex = mod(formFields.indexOf(formField) + (e.shiftKey ? -1 : 1), formFields.length);
-                        mediator.emit('ui:open', formFields[nextIndex].meta);
+                        mediator.emit('ui:open', formFields[nextIndex].meta, self);
                     }
                 });
             }

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -539,8 +539,6 @@ define([
             this.meta.isSnap(true);
             this.meta.href(this.id());
             this.id(snap.generateId());
-            this.state.isOpen(true);
-            mediator.emit('ui:open', this.meta.headline, this);
         };
 
         Article.prototype.open = function() {

--- a/facia-tool/public/js/models/collections/main.js
+++ b/facia-tool/public/js/models/collections/main.js
@@ -166,6 +166,8 @@ define([
 
         model.uiOpenElement = ko.observable();
 
+        model.uiOpenArticle = ko.observable();
+
         function getFront() {
             return queryParams().front;
         }
@@ -329,8 +331,15 @@ define([
                 model.latestArticles.search();
                 model.latestArticles.startPoller();
 
-                mediator.on('ui:open', function(e) {
-                    model.uiOpenElement(e)
+                mediator.on('ui:open', function(element, article) {
+                    if (model.uiOpenArticle() &&
+                        model.uiOpenArticle().group &&
+                        model.uiOpenArticle().group.parentType === 'Article' &&
+                        model.uiOpenArticle() !== article) {
+                        model.uiOpenArticle().close();
+                    }
+                    model.uiOpenArticle(article);
+                    model.uiOpenElement(element);
                 });
             });
 


### PR DESCRIPTION
Sublinks now open/close for editability as you click on/off them, and show their publication dates and sparklines properly.

![fronts-tool](https://cloud.githubusercontent.com/assets/1147913/4462594/0fe2c5dc-48c4-11e4-9cd2-41f9458559f6.png)
