### PR TITLE
Facia cards half design tweaks

### DIFF
--- a/common/app/assets/stylesheets/_vars.scss
+++ b/common/app/assets/stylesheets/_vars.scss
@@ -102,9 +102,9 @@ $c-featureAccent: guss-colour(features-support-3, $pasteup-palette);
 $c-featureAccent2: guss-colour(features-main-2, $pasteup-palette);
 $c-featureMute: guss-colour(features-support-3, $pasteup-palette);
 
-$c-analysisAccent: guss-colour(news-support-2, $pasteup-palette);
+$c-analysisAccent: guss-colour(news-main-2, $pasteup-palette);
 $c-analysisMute: guss-colour(comment-support-2, $pasteup-palette);
-$c-analysisBackground: guss-colour(neutral-5, $pasteup-palette);
+$c-analysisBackground: guss-colour(neutral-7, $pasteup-palette);
 
 $c-commentDefault: guss-colour(comment-support-4, $pasteup-palette);;
 $c-commentAccent: guss-colour(comment-main-2, $pasteup-palette);

--- a/common/app/assets/stylesheets/module/facia-cards/_items.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_items.scss
@@ -40,12 +40,6 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-.fc-item--list-desktop {
-    @include mq(desktop) {
-        @include fc-item--list;
-    }
-}
-
 .fc-item--list-compact-tablet {
     @include mq(tablet) {
         @include fc-item--list;
@@ -67,12 +61,6 @@ $fc-item-gutter: $gs-gutter / 4;
         @include fc-item--list-media(4, 1);
     }
 
-    @include mq(desktop) {
-        @include fc-item--list-media;
-    }
-}
-
-.fc-item--list-media-desktop {
     @include mq(desktop) {
         @include fc-item--list-media;
     }

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -5,6 +5,11 @@
         background-color: $c-commentBackground;
     }
 
+    .fc-item__title,
+    .fc-item__byline {
+        font-weight: 400;
+    }
+
     .fc-item__kicker,
     .fc-item__byline {
         &,

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
@@ -1,23 +1,9 @@
 .tone-dead {
-    &.fc-item {
-        &,
-        & a {
-            color: $c-neutral1;
-        }
-    }
-
     .fc-item__kicker,
     .fc-item__byline {
         &,
         & a {
-            color: $c-liveDefault;
-        }
-    }
-
-    .fc-item__meta {
-        &,
-        & a {
-            color: $c-liveMute;
+            color: $c-liveAccent;
         }
     }
 

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -11,6 +11,11 @@
         }
     }
 
+    .fc-item__title,
+    .fc-item__byline {
+        font-weight: 400;
+    }
+
     .fc-item__kicker,
     .fc-item__byline {
         &,

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -3,7 +3,7 @@
     .fc-item__byline {
         &,
         & a {
-            color: $c-analysisAccent;
+            color: $c-newsDefault;
         }
     }
 

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -17,24 +17,16 @@
         }
     }
 
-    &.fc-item--list-tablet .fc-item__container,
-    &.fc-item--list-media-tablet .fc-item__container {
-        @include mq(tablet) {
-            @include box-shadow(inset 0 1px $c-newsAccent);
-        }
-    }
-
-    &.fc-item--list-desktop .fc-item__container {
-        @include mq(tablet) {
-            @include box-shadow(inset 0 1px $c-newsAccent);
-        }
-    }
-
-    &.fc-item--list-compact-tablet .fc-item__container {
-        @include mq(tablet) {
-            @include box-shadow(inset 0 1px $c-newsAccent);
-        }
-    }
+    &.fc-item--list-tablet,
+    &.fc-item--list-media-tablet,
+    &.fc-item--list-desktop,
+    &.fc-item--list-compact-tablet {
+        .fc-item__container {
+            @include mq(tablet) {
+                @include box-shadow(inset 0 1px $c-newsAccent);
+            }
+         }
+     }
 
     &.fc-item--list-media-mobile,
     &.fc-item--list-media-large-mobile {

--- a/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -5,6 +5,11 @@
         background-color: $c-reviewBackground;
     }
 
+    .fc-item__title,
+    .fc-item__byline {
+        font-weight: 400;
+    }
+
     .fc-item__kicker,
     .fc-item__byline {
         &,

--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -568,8 +568,7 @@ case object TlTlMpu extends Slice {
         rows = 3,
         ItemClasses(
           mobile = "list",
-          tablet = "list-compact",
-          desktop = Some("list-media")
+          tablet = "list-compact"
         )
       ),
       MPU(
@@ -722,8 +721,7 @@ case object TTlMpu extends Slice {
         rows = 3,
         ItemClasses(
           mobile = "list",
-          tablet = "list",
-          desktop = Some("list-media")
+          tablet = "list"
         )
       ),
       MPU(


### PR DESCRIPTION
A series of mergeable design fixes from [`facia-cards-design-tweaks`](https://github.com/guardian/frontend/tree/facia-cards-design-tweaks), as to not conflict with @sndrs work with sublinks.

[`facia-cards-design-tweaks`](https://github.com/guardian/frontend/tree/facia-cards-design-tweaks) will be manually rolled into his branch when it's ready.

Example of a few edits (lighter font in places and different analysis colours)
![screen shot 2014-10-01 at 11 57 12](https://cloud.githubusercontent.com/assets/1607666/4473961/9a3fffca-4959-11e4-9bd9-4a65c4df987c.png)
