### PR TITLE
Move block video ads to data attribute in player

### DIFF
--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -308,6 +308,8 @@ define([
 
                     var mediaId = $el.attr('data-media-id'),
                         blockVideoAds = $el.attr('data-block-video-ads') === 'true',
+                        showEndSlate = $el.attr('data-show-end-slate') === 'true',
+                        endSlateUri = $el.attr('data-end-slate'),
                         vjs = modules.createVideoObject(el, {
                             controls: true,
                             autoplay: false,
@@ -358,11 +360,8 @@ define([
                                     modules.bindContentEvents(player);
                                 }
 
-                                if (
-                                    $el.attr('data-show-end-slate') === 'true' &&
-                                    detect.isBreakpoint({ min: 'desktop' })
-                                ) {
-                                    modules.initEndSlate(player, $el.attr('data-end-slate'));
+                                if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
+                                    modules.initEndSlate(player, endSlateUri);
                                 }
                             } else {
                                 vjs.playlist({

--- a/common/app/assets/javascripts/bootstraps/media.js
+++ b/common/app/assets/javascripts/bootstraps/media.js
@@ -301,11 +301,13 @@ define([
                 videojs.plugin('fullscreener', modules.fullscreener);
 
                 $('.js-gu-media').each(function (el) {
-                    var mediaType = el.tagName.toLowerCase();
+                    var mediaType = el.tagName.toLowerCase(),
+                        $el = bonzo(el);
 
-                    bonzo(el).addClass('vjs');
+                    $el.addClass('vjs');
 
-                    var mediaId = bonzo(el).attr('data-media-id'),
+                    var mediaId = $el.attr('data-media-id'),
+                        blockVideoAds = $el.attr('data-block-video-ads') === 'true',
                         vjs = modules.createVideoObject(el, {
                             controls: true,
                             autoplay: false,
@@ -342,7 +344,7 @@ define([
                                 player.fullscreener();
 
                                 // Init plugins
-                                if (config.switches.videoAdverts && !config.page.blockVideoAds && !config.page.isPreview) {
+                                if (config.switches.videoAdverts && !blockVideoAds && !config.page.isPreview) {
                                     modules.bindPrerollEvents(player);
                                     player.adCountDown();
                                     player.trigger(constructEventName('preroll:request', player));
@@ -357,10 +359,10 @@ define([
                                 }
 
                                 if (
-                                    bonzo(el).attr('data-show-end-slate') === 'true' &&
+                                    $el.attr('data-show-end-slate') === 'true' &&
                                     detect.isBreakpoint({ min: 'desktop' })
                                 ) {
-                                    modules.initEndSlate(player, bonzo(el).attr('data-end-slate'));
+                                    modules.initEndSlate(player, $el.attr('data-end-slate'));
                                 }
                             } else {
                                 vjs.playlist({

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -56,7 +56,6 @@ trait VideoContainer extends Element {
   protected implicit val ordering = EncodingOrdering
 
   lazy val videoAssets: List[VideoAsset] = {
-
     val images = delegate.assets.filter(_.assetType == "image").zipWithIndex.map{ case (asset, index) =>
       ImageAsset(asset, index)
     }
@@ -65,6 +64,8 @@ trait VideoContainer extends Element {
 
     delegate.assets.filter(_.assetType == "video").map( v => VideoAsset(v, container)).sortBy(-_.width)
   }
+
+  lazy val blockVideoAds = videoAssets.exists(_.blockVideoAds)
 
   lazy val encodings: Seq[Encoding] = {
     videoAssets.toList.collect {

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -10,8 +10,7 @@ case class VideoPlayer(
   autoPlay: Boolean,
   showControlsAtStart: Boolean,
   endSlatePath: String,
-  overrideIsRatioHd: Option[Boolean] = None,
-  overrideBlockVideoAds: Option[Boolean] = None
+  overrideIsRatioHd: Option[Boolean] = None
 ) {
   def poster = profile.bestFor(video).getOrElse(Static("images/media-holding.jpg").path)
 
@@ -23,5 +22,5 @@ case class VideoPlayer(
 
   def isRatioHd = overrideIsRatioHd getOrElse profile.isRatioHD
 
-  def blockVideoAds = overrideBlockVideoAds.getOrElse(video.blockVideoAds)
+  def blockVideoAds = video.blockVideoAds
 }

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -10,7 +10,8 @@ case class VideoPlayer(
   autoPlay: Boolean,
   showControlsAtStart: Boolean,
   endSlatePath: String,
-  overrideIsRatioHd: Option[Boolean] = None
+  overrideIsRatioHd: Option[Boolean] = None,
+  blockVideoAds: Boolean
 ) {
   def poster = profile.bestFor(video).getOrElse(Static("images/media-holding.jpg").path)
 

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -11,7 +11,7 @@ case class VideoPlayer(
   showControlsAtStart: Boolean,
   endSlatePath: String,
   overrideIsRatioHd: Option[Boolean] = None,
-  blockVideoAds: Boolean
+  overrideBlockVideoAds: Option[Boolean] = None
 ) {
   def poster = profile.bestFor(video).getOrElse(Static("images/media-holding.jpg").path)
 
@@ -22,4 +22,6 @@ case class VideoPlayer(
   def showEndSlate = width >= Video640.width.get
 
   def isRatioHd = overrideIsRatioHd getOrElse profile.isRatioHD
+
+  def blockVideoAds = overrideBlockVideoAds.getOrElse(video.blockVideoAds)
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -32,7 +32,6 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   lazy val shortUrlPath: String = shortUrl.replace("http://gu.com", "")
   lazy val allowUserGeneratedContent: Boolean = fields.get("allowUgc").exists(_.toBoolean)
   lazy val isExpired = delegate.isExpired.getOrElse(false)
-  lazy val blockVideoAds: Boolean = videoAssets.exists(_.blockVideoAds)
   lazy val isBlog: Boolean = blogs.nonEmpty
   lazy val isSeries: Boolean = series.nonEmpty
   lazy val isFromTheObserver: Boolean = publication == "The Observer"
@@ -467,7 +466,7 @@ class Audio(content: ApiContentWithMeta) extends Media(content) {
   override lazy val contentType = GuardianContentTypes.Audio
 
   override lazy val metaData: Map[String, JsValue] =
-    super.metaData ++ Map("contentType" -> JsString(contentType), "blockVideoAds" -> JsBoolean(blockVideoAds))
+    super.metaData ++ Map("contentType" -> JsString(contentType))
 
   lazy val downloadUrl: Option[String] = mainAudio
     .flatMap(_.encodings.find(_.format == "audio/mpeg").map(_.url.replace("static.guim", "download.guardian")))
@@ -492,7 +491,6 @@ class Video(content: ApiContentWithMeta) extends Media(content) {
   override lazy val metaData: Map[String, JsValue] =
     super.metaData ++ Map(
       "contentType" -> JsString(contentType),
-      "blockVideoAds" -> JsBoolean(blockVideoAds),
       "source" -> JsString(source.getOrElse(""))
     )
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -48,7 +48,6 @@ trait MetaData extends Tags {
     ("buildNumber", JsString(buildNumber)),
     ("revisionNumber", JsString(revision.take(7))),
     ("analyticsName", JsString(analyticsName)),
-    ("blockVideoAds", JsBoolean(false)),
     ("isFront", JsBoolean(isFront)),
     ("adUnit", JsString(s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitRoot}/$adUnitSuffix/ng")),
     ("isSurging", JsString(isSurging.mkString(","))),

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -14,7 +14,8 @@
             ("gu-media--show-controls-at-start", player.showControlsAtStart),
             ("js-gu-media", true)
         ))" data-title="@player.title" data-auto-play="@player.autoPlay" data-show-end-slate="@player.showEndSlate"
-            poster="@player.poster" data-duration="@player.video.duration.toString()" data-media-id="@player.video.id" data-end-slate="@player.endSlatePath">
+            poster="@player.poster" data-duration="@player.video.duration.toString()" data-media-id="@player.video.id"
+            data-end-slate="@player.endSlatePath" data-block-video-ads="@player.blockVideoAds">
 
             @player.video.encodings.map { encoding =>
                 <source src="@encoding.url" type="@encoding.format" />

--- a/identity/app/model/IdentityPage.scala
+++ b/identity/app/model/IdentityPage.scala
@@ -1,7 +1,6 @@
 package model
 
-import play.api.libs.json
-import play.api.libs.json.{JsBoolean, JsValue}
+import play.api.libs.json.JsValue
 import tracking.Omniture
 
 class IdentityPage(id: String, webTitle: String, analyticsName: String, overridenMetadata: Option[Map[String, JsValue]] = None)
@@ -10,7 +9,7 @@ class IdentityPage(id: String, webTitle: String, analyticsName: String, override
   override val hasClassicVersion: Boolean = false
 
   override def metaData: Map[String, JsValue] =
-    overridenMetadata.getOrElse(super.metaData + ("blockVideoAds" -> JsBoolean(true)))
+    overridenMetadata.getOrElse(super.metaData)
 }
 
 object IdentityPage {


### PR DESCRIPTION
So that it can be done on a player-specific basis, rather than page basis, which doesn't make sense anymore given we can multiple players per page.
