### PR TITLE
Refactor limiting number of video players on fronts

### DIFF
--- a/common/app/layout/Column.scala
+++ b/common/app/layout/Column.scala
@@ -1,9 +1,22 @@
 package layout
 
+object ItemClasses {
+  val showMore = ItemClasses(mobile = "list", tablet = "list")
+}
+
 case class ItemClasses(mobile: String, tablet: String, desktop: Option[String] = None) {
   /** Template helper */
-  def classes =
-    s"fc-item--$mobile-mobile fc-item--$tablet-tablet" + desktop.map(d => s" fc-item--$d-desktop").getOrElse("")
+  def classes: String = s"fc-item--$mobile-mobile fc-item--$tablet-tablet" +
+    desktop.map(d => s" fc-item--$d-desktop").getOrElse("")
+
+  /** Video.JS has issues if we render too many videos on a front (even if those videos are never displayed
+    * or loaded).
+    *
+    * As such we only render the video player if there is a breakpoint on which it will be shown. This is
+    * currently determined in quite a hacky way based on the item classes.
+    */
+  def showVideoPlayer =
+    Seq("half", "three", "full", "mega-full").exists(size => classes.contains(size))
 }
 case class SliceLayout(cssClassName: String, columns: Seq[Column])
 

--- a/common/app/views/fragments/containers/facia_cards/show_more.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/show_more.scala.html
@@ -2,6 +2,7 @@
 
 @import model.Config
 @import fragments.items.facia_cards.item
+@import layout.ItemClasses
 
 @* Show More for the new style containers should identical, differing only in number of columns (3 or 4).
  *
@@ -15,7 +16,7 @@
         <div class="linkslist-container">
             <ul class="linkslist u-unstyled l-list facia-slice">
             @cards.map { card =>
-                @item(card, "l-list__item fc-item--list-mobile fc-item--list-tablet", containerIndex, isList = true)
+                @item(card, ItemClasses.showMore, containerIndex, isList = true)
             }
             </ul>
         </div>

--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -9,7 +9,7 @@
         @column match {
             case SingleItem(colSpan, itemClasses) => {
                 @cards.headOption.map { card =>
-                    @item(card, itemClasses.classes, containerIndex, false, colSpan)
+                    @item(card, itemClasses, containerIndex, false, colSpan)
                 }
             }
 
@@ -18,7 +18,7 @@
                     <ul class="u-unstyled l-list l-list--columns-@columns l-list--rows-@rows">
                         @if(cards.nonEmpty) {
                             @cards.map{ card =>
-                                @item(card, itemClasses.classes, containerIndex, isList = true)
+                                @item(card, itemClasses, containerIndex, isList = true)
                             }
                         }
                     </ul>
@@ -29,10 +29,10 @@
                 <li class="facia-slice__item l-row__item l-row__item--span-@colSpan">
                     <ul class="u-unstyled l-list l-list--columns-1 l-list--rows-3">
                         @cards.headOption.map { card =>
-                            @item(card, topItemClasses.classes, containerIndex, isList = true)
+                            @item(card, topItemClasses, containerIndex, isList = true)
                         }
                         @cards.tail.map { card =>
-                            @item(card, bottomItemsClasses.classes, containerIndex, isList = true)
+                            @item(card, bottomItemsClasses, containerIndex, isList = true)
                         }
                     </ul>
                 </li>
@@ -41,7 +41,6 @@
             case MPU(colSpan) => {
                 <li class="facia-slice__item l-row__item l-row__item--span-@colSpan js-facia-slice__item--mpu facia-slice__item--no-mpu"></li>
             }
-
         }
     }
     </ul>

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -1,4 +1,4 @@
-@(card: layout.Card, modifierClasses: String, containerIndex: Int, isList: Boolean = false, colSpan: Int = 1)(implicit request: RequestHeader, config: model.Config)
+@(card: layout.Card, modifierClasses: layout.ItemClasses, containerIndex: Int, isList: Boolean = false, colSpan: Int = 1)(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
 @import model.{FaciaDisplayElement, InlineVideo, VideoPlayer}
@@ -12,11 +12,8 @@
 @defining((card.item, card.index)) { case (trail, index) =>
 
 <li class="facia-slice__item u-faux-block-link l-row__item  l-row__item--span-@colSpan @if(isList){ l-list__item }@card.cssClasses">
-
-
     @defining((trail.visualTone, containerIndex == 0)) { case (tone, isFirstContainer) =>
-        <div
-            class="@GetClasses.forNewStyleItem(trail, isFirstContainer) @modifierClasses u-cf"
+        <div class="@GetClasses.forNewStyleItem(trail, isFirstContainer) @modifierClasses.classes u-cf"
             @if(trail.isCommentable) {
                 @trail.discussionId.map{ id =>
                 data-discussion-id="@id"
@@ -29,7 +26,7 @@
 
             <div class="fc-item__container">
                 @FaciaDisplayElement.fromTrail(trail) match {
-                    case InlineVideo(videoElement, title, endSlatePath) => {
+                    case InlineVideo(videoElement, title, endSlatePath) if modifierClasses.showVideoPlayer => {
                         @defining(VideoPlayer(
                             videoElement,
                             Video640,
@@ -39,17 +36,11 @@
                             endSlatePath,
                             Some(false)
                         )) { player =>
-
-                            @* TODO: This is a temporary HACK until Rob Berry can clean up. *@
-                            @if(Seq("half", "three", "full", "mega-full").exists(size => modifierClasses.contains(size))) {
-                                <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
-                                    <div class="fc-item__video-container">
-                                    @video(player)
-                                    </div>
+                            <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
+                                <div class="fc-item__video-container">
+                                @video(player)
                                 </div>
-                            } else {
-                                @image(trail, inlineImage = containerIndex == 0 && index < 4)
-                            }
+                            </div>
                         }
                     }
 


### PR DESCRIPTION
Doesn't really get rid of the nastiness so much as move it out of the template at least ... 

I think probably the nicer thing to do would be have classes representing item types at different breakpoints, and then have code that converts that into CSS classes. We could also then add additional metadata, such as whether a video player should be shown for that item at that breakpoint. 

However, I think that would make it more difficult to move quickly at this point, and raise the barrier of entry for people editing the slice config, which I don't think is the right thing to do.

Hence just moving the hackiness, rather than eliminating it.

CC @phamann 
