### PR TITLE
Enhanced logic for tweet upgrading in live blogs

### DIFF
--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -41,7 +41,8 @@ define([
         initTruncateAndTwitter: function() {
             // Ensure that truncation occurs before the tweet upgrading.
             truncate();
-            twitter.init().enhanceTweets();
+            twitter.init();
+            twitter.enhanceTweets();
         }
 
     };

--- a/common/app/assets/javascripts/bootstraps/article.js
+++ b/common/app/assets/javascripts/bootstraps/article.js
@@ -41,7 +41,7 @@ define([
         initTruncateAndTwitter: function() {
             // Ensure that truncation occurs before the tweet upgrading.
             truncate();
-            twitter.init();
+            twitter.init().enhanceTweets();
         }
 
     };

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -36,7 +36,6 @@ define([
 
         tweetElements.forEach( function(element) {
             var $el = bonzo(element);
-            console.log($el.offset().bottom);
             if(((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) && (bonzo(document.body).scrollTop() < ($el.offset().top + $el.offset().height))) {
                 $(element).removeClass('js-tweet').addClass('twitter-tweet');
             }

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -36,7 +36,8 @@ define([
 
         tweetElements.forEach( function(element) {
             var $el = bonzo(element);
-            if((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) {
+            if(((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) && (bonzo(document.body).scrollTop() < $el.offset().top)) {
+                console.log("Upgrade! Scroll: " + bonzo(document.body).scrollTop() + " / Element: " + $el.offset().top);
                 $(element).removeClass('js-tweet').addClass('twitter-tweet');
             }
         });

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -37,7 +37,6 @@ define([
         tweetElements.forEach( function(element) {
             var $el = bonzo(element);
             if(((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) && (bonzo(document.body).scrollTop() < $el.offset().top)) {
-                console.log("Upgrade! Scroll: " + bonzo(document.body).scrollTop() + " / Element: " + $el.offset().top);
                 $(element).removeClass('js-tweet').addClass('twitter-tweet');
             }
         });

--- a/common/app/assets/javascripts/modules/article/twitter.js
+++ b/common/app/assets/javascripts/modules/article/twitter.js
@@ -36,7 +36,8 @@ define([
 
         tweetElements.forEach( function(element) {
             var $el = bonzo(element);
-            if(((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) && (bonzo(document.body).scrollTop() < $el.offset().top)) {
+            console.log($el.offset().bottom);
+            if(((bonzo(document.body).scrollTop() + (viewportHeight * 2.5)) > $el.offset().top) && (bonzo(document.body).scrollTop() < ($el.offset().top + $el.offset().height))) {
                 $(element).removeClass('js-tweet').addClass('twitter-tweet');
             }
         });


### PR DESCRIPTION
Adjusted the logic for enhancing tweets to take into account linking to specific blocks/comments.

It now won't load any tweets above the current scroll position.

// @mattosborn 
