### PR TITLE
New container class rolled back

### DIFF
--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.containers.facia_cards.slice
 @import views.html.fragments.keywordList
 @import views.support.MostPopularTags.topTags
-@import views.support.{GetClasses, Format, PreviousAndNext, TemplateDeduping}
+@import views.support.{GetClasses, Format, NewsContainer, PreviousAndNext, TemplateDeduping}
 @import common.LinkTo
 
 @defining(collection.displayName) { title =>
@@ -12,10 +12,11 @@
     @defining(templateDeduping(15, collection.items)) { items =>
         @if(items.nonEmpty) {
             <section
-                class="@GetClasses.forNewStyleContainer(config, true, title.nonEmpty)"
+                class="@GetClasses.forContainer(NewsContainer(showMore = false), config, containerIndex, title.nonEmpty)"
                 data-link-name="all index"
+                data-type="@NewsContainer(showMore = false).containerType"
                 @config.sponsorshipKeyword.map { keyword =>
-                    data-keywords="@keyword"
+                data-keywords="@keyword"
                 }
                 data-component="all index">
                 <div class="facia-container__inner">


### PR DESCRIPTION
I had to put the container news style back.

Because it was doing this on leftCol:
![screen shot 2014-10-02 at 14 08 12](https://cloud.githubusercontent.com/assets/2579465/4491275/186fc60e-4a37-11e4-9674-176e81683b04.png)

And it should do this:
![screen shot 2014-10-02 at 14 17 51](https://cloud.githubusercontent.com/assets/2579465/4491279/25333a74-4a37-11e4-987e-1936660f76ce.png)

The reason is this: `.facia-container--layout-front .container--news .container__title`
I found it cheaper to add back the container--news class to section than possibly create another variation for container__title as we already have 13 variations in the CSS.

I think this is a good example of why nesting is wrong with CSS. It leads to extreme specificity.
