### PR TITLE
Duplicate tags now have their section in brackets

### DIFF
--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -9,7 +9,9 @@
         <a class="@if(keyword.isFootballTeam){js-football-team} @if(keyword.isFootballCompetition){ js-football-competition} button button--small button--tag button--tone-@tone"
            href="@LinkTo(keyword.url)"
            data-link-name="keyword: @keyword.id"
-           itemprop="keywords">@keyword.name</a>
+           itemprop="keywords">
+            @keyword.name
+            @if(keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.section.capitalize) }</a>
     </li>
 }
 

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -10,8 +10,9 @@
            href="@LinkTo(keyword.url)"
            data-link-name="keyword: @keyword.id"
            itemprop="keywords">
-            @keyword.name
-            @if(keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.section.capitalize) }</a>
+               @keyword.name
+               @if(keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.section.capitalize) }
+        </a>
     </li>
 }
 


### PR DESCRIPTION
![screen shot 2014-10-02 at 15 16 49](https://cloud.githubusercontent.com/assets/2236852/4492135/c788a3e8-4a3e-11e4-9ddd-544a8e6a00cf.png)

There are sometimes duplicate tag names with different associated sections. If two tags with the same name are applied to a story then their parent section is now displayed in brackets.
