### PR TITLE
Request for comment: add date header to new style Facia Cards container

### DIFF
--- a/common/app/assets/stylesheets/module/facia-cards/_container.scss
+++ b/common/app/assets/stylesheets/module/facia-cards/_container.scss
@@ -97,6 +97,22 @@ $header-image-size-desktop: 120px;
     }
 }
 
+.fc-today {
+    @include mq(leftCol) {
+        border-top: 1px solid $c-neutral5;
+        margin-top: $gs-baseline/2;
+    }
+
+    padding-top: $gs-baseline/3;
+    @include fs-headline(2);
+}
+
+@include mq(wide) {
+    .fc-today__sub {
+        display: block;
+    }
+}
+
 .js-on .fc-show-more--hidden .fc-show-more--hide-on-mobile {
     @include mq($until: tablet) {
         display: none !important;

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -17,6 +17,9 @@ case class Config(
                    hideKickers: Boolean = false
                    ) {
 
+  /** TODO do something sensible here */
+  def showDate: Boolean = id == "e5737dab-cc0f-4ea2-bb6a-6992cb21ac8e"
+
   lazy val isSponsored: Boolean = DfpAgent.isSponsored(this)
   lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(this)
   lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(this)

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -14,12 +14,9 @@ case class Config(
                    collectionType: Option[String],
                    showTags: Boolean = false,
                    showSections: Boolean = false,
-                   hideKickers: Boolean = false
+                   hideKickers: Boolean = false,
+                   showDateHeader: Boolean = false
                    ) {
-
-  /** TODO do something sensible here */
-  def showDate: Boolean = id == "e5737dab-cc0f-4ea2-bb6a-6992cb21ac8e"
-
   lazy val isSponsored: Boolean = DfpAgent.isSponsored(this)
   lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(this)
   lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(this)

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -64,7 +64,8 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
         (collectionJson \ "type").asOpt[String],
         (collectionJson \ "showTags").asOpt[Boolean] getOrElse false,
         (collectionJson \ "showSections").asOpt[Boolean] getOrElse false,
-        (collectionJson \ "hideKickers").asOpt[Boolean] getOrElse false
+        (collectionJson \ "hideKickers").asOpt[Boolean] getOrElse false,
+        (collectionJson \ "showDateHeader").asOpt[Boolean] getOrElse false
       )
     }
   }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,7 +1,7 @@
 @(collection: model.Collection, containerLayout: layout.ContainerLayout, containerIndex: Int, frontProperties: model.FrontProperties = model.FrontProperties.empty)(implicit request: RequestHeader, templateDeduping: views.support.TemplateDeduping, config: model.Config)
 
 @import views.support.GetClasses
-@import views.html.fragments.containers.facia_cards.{show_more, slice}
+@import views.html.fragments.containers.facia_cards.{show_more, slice, containerHeader}
 @import model.FaciaComponentName
 
 @defining(config.displayName.orElse(collection.displayName)) { case (title) =>

--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -1,8 +1,8 @@
 @(collection: model.Collection, frontProperties: model.FrontProperties, containerIndex: Int)(implicit request: RequestHeader, config: model.Config)
 
-@import views.support.RenderClasses
 @import common.LinkTo
-@import views.support.{ImgSrc, Item140}
+@import views.support.{ImgSrc, Item140, LatestUpdate, RenderClasses}
+@import views.html.fragments.containers.facia_cards.dateAndLatestUpdate
 
 @defining((config.displayName.orElse(collection.displayName), config.href.orElse(collection.href))) { case (title, href) =>
     <div class="fc-container__header">
@@ -12,10 +12,16 @@
                     "fc-container__header__title" -> true,
                     "tone-comment" -> isContributor,
                     "tone-colour" -> isContributor))">
-                @href.map { href =>
-                   <a class="u-text-hyphenate" data-link-name="section heading" href="@LinkTo {/@href}">@Html(title)</a>
-                }.getOrElse {
-                    <span class="u-text-hyphenate">@Html(title)</span>
+                @if(config.showDate) {
+                    @dateAndLatestUpdate(LatestUpdate(collection, collection.items))
+                } else {
+                    @href.map { href =>
+                        <a class="u-text-hyphenate" data-link-name="section heading" href="@LinkTo {/@href}">
+                          @Html(title)
+                        </a>
+                    }.getOrElse {
+                        <span class="u-text-hyphenate">@Html(title)</span>
+                    }
                 }
                 </div>
             }

--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -12,9 +12,6 @@
                     "fc-container__header__title" -> true,
                     "tone-comment" -> isContributor,
                     "tone-colour" -> isContributor))">
-                @if(config.showDateHeader) {
-                    @dateAndLatestUpdate(LatestUpdate(collection, collection.items))
-                } else {
                     @href.map { href =>
                         <a class="u-text-hyphenate" data-link-name="section heading" href="@LinkTo {/@href}">
                           @Html(title)
@@ -22,7 +19,10 @@
                     }.getOrElse {
                         <span class="u-text-hyphenate">@Html(title)</span>
                     }
-                }
+
+                    @if(config.showDateHeader) {
+                        @dateAndLatestUpdate(LatestUpdate(collection, collection.items))
+                    }
                 </div>
             }
         }

--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -12,7 +12,7 @@
                     "fc-container__header__title" -> true,
                     "tone-comment" -> isContributor,
                     "tone-colour" -> isContributor))">
-                @if(config.showDate) {
+                @if(config.showDateHeader) {
                     @dateAndLatestUpdate(LatestUpdate(collection, collection.items))
                 } else {
                     @href.map { href =>

--- a/common/app/views/fragments/containers/facia_cards/dateAndLatestUpdate.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/dateAndLatestUpdate.scala.html
@@ -3,15 +3,16 @@
 @import org.joda.time.DateTime
 @import views.support.Format
 
-<span class="container__title__label today">
-    <b class="today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</b>
+<div class="fc-today">
+    <span class="fc-today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</span>
     <span class="u-nobr today__sub">
-        <span class="today__dayofmonth js-dayofmonth">@Format(DateTime.now(), "d")</span>
-        <span class="today__month">@Format(DateTime.now(), "MMMM")</span>
-        <span class="today__year">@Format(DateTime.now(), "yyyy")</span>
+        <span class="fc-today__dayofmonth js-dayofmonth">@Format(DateTime.now(), "d")</span>
+        <span class="fc-today__month">@Format(DateTime.now(), "MMMM")</span>
+        <span class="fc-today__year">@Format(DateTime.now(), "yyyy")</span>
     </span>
-</span>
+</div>
 
+@*
 @maybeLatestUpdate.map { latestUpdate =>
     <span class="container__updated">
         <span class="i--circle i--clock">
@@ -26,3 +27,4 @@
         </time>
     </span>
 }
+*@

--- a/common/app/views/fragments/containers/facia_cards/dateAndLatestUpdate.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/dateAndLatestUpdate.scala.html
@@ -1,0 +1,28 @@
+@(maybeLatestUpdate: Option[org.joda.time.DateTime])(implicit requestHeader: RequestHeader)
+
+@import org.joda.time.DateTime
+@import views.support.Format
+
+<span class="container__title__label today">
+    <b class="today__dayofweek js-dayofweek">@Format(DateTime.now(), "EEEE")</b>
+    <span class="u-nobr today__sub">
+        <span class="today__dayofmonth js-dayofmonth">@Format(DateTime.now(), "d")</span>
+        <span class="today__month">@Format(DateTime.now(), "MMMM")</span>
+        <span class="today__year">@Format(DateTime.now(), "yyyy")</span>
+    </span>
+</span>
+
+@maybeLatestUpdate.map { latestUpdate =>
+    <span class="container__updated">
+        <span class="i--circle i--clock">
+            <span class="i i-clock-hands-white"></span>
+        </span>
+        Last updated:
+        <time class="js-timestamp"
+              datetime="@latestUpdate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+              data-relativeformat="long"
+              data-timestamp="@latestUpdate.getMillis">
+            <span class="timestamp__text">@Format(latestUpdate, "E, h:ma")</span>
+        </time>
+    </span>
+}

--- a/facia-press/app/frontpress/jsonModels.scala
+++ b/facia-press/app/frontpress/jsonModels.scala
@@ -147,7 +147,8 @@ object CollectionJson {
       `type`         = config.collectionType,
       showTags       = config.showTags,
       showSections   = config.showSections,
-      hideKickers    = config.hideKickers
+      hideKickers    = config.hideKickers,
+      showDateHeader = config.showDateHeader
     )
 }
 
@@ -166,5 +167,6 @@ case class CollectionJson(
   href:         Option[String],
   showTags:     Boolean,
   showSections: Boolean,
-  hideKickers:  Boolean
+  hideKickers:  Boolean,
+  showDateHeader: Boolean
                            )

--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -46,6 +46,7 @@ case class Collection(
   showTags: Option[Boolean],
   showSections: Option[Boolean],
   hideKickers: Option[Boolean],
+  showDateHeader: Option[Boolean],
   showMainVideo: Option[Boolean]
 )
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -125,6 +125,9 @@
                 <label for="hideKickers" >Suppress tone kickers</label>
                 <input id="hideKickers" type="checkbox" data-bind="checked: meta.hideKickers" />
 
+                <label for="showDateHeader">Show date header</label>
+                <input id="showDateHeader" type="checkbox" data-bind="checked: meta.showDateHeader" />
+
                 <label>No curation</label>
                 <input type="checkbox" data-bind="
                     checked: meta.uneditable" />

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -40,6 +40,7 @@ define([
             'showTags',
             'showSections',
             'hideKickers',
+            'showDateHeader',
             'apiQuery']);
 
         populateObservables(this.meta, opts);

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -137,7 +137,8 @@ trait FrontJson extends ExecutionContexts with Logging {
       collectionType  = (json \ "type").asOpt[String],
       showTags        = (json \ "showTags").asOpt[Boolean] getOrElse false,
       showSections    = (json \ "showSections").asOpt[Boolean] getOrElse false,
-      hideKickers     = (json \ "hideKickers").asOpt[Boolean] getOrElse false
+      hideKickers     = (json \ "hideKickers").asOpt[Boolean] getOrElse false,
+      showDateHeader = (json \ "showDateHeader").asOpt[Boolean] getOrElse false
     )
   }
 


### PR DESCRIPTION
This wires up adding the date and latest update information to a new style Facia Cards container:

![screen shot 2014-10-02 at 16 00 39](https://cloud.githubusercontent.com/assets/1001642/4492921/4561a7f0-4a45-11e4-8cd6-69bbdc7a2799.png)

We need, however, to decide how we're going to choose whether it gets applied to a given collection. @stephanfowler @kungpochicken We could make this an option in the tool -- or we could hard code some collection IDs, as I already have here for testing -- or we could use some logic based on the position of the container within certain fronts in the config.
