### PR TITLE
Change timeout on CircuitBreakingContentApi

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -12,7 +12,7 @@ import org.scala_tools.time.Implicits._
 import conf.Configuration.contentApi
 import com.gu.openplatform.contentapi.model.ItemResponse
 
-import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.duration.{Duration, SECONDS, MILLISECONDS}
 import akka.pattern.{CircuitBreakerOpenException, CircuitBreaker}
 
 trait QueryDefaults extends implicits.Collections with ExecutionContexts {
@@ -133,7 +133,7 @@ trait CircuitBreakingContentApiClient extends ContentApiClient {
   private final val circuitBreaker = new CircuitBreaker(
     scheduler = circuitBreakerActorSystem.scheduler,
     maxFailures = 5,
-    callTimeout = Duration(2, SECONDS),
+    callTimeout = Duration(contentApi.timeout, MILLISECONDS),
     resetTimeout = Duration(20, SECONDS)
   )
 


### PR DESCRIPTION
This now uses what is defined in the `Configuration.contentApi.timeout` value.

@robertberry @stephanfowler 
