### PR TITLE
Fix comment truncation

### DIFF
--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -53,6 +53,10 @@ var Comments = function(mediator, options) {
         maxResponses: 3
     };
 
+    this.fetchCommentData = {
+        displayThreaded: true
+    };
+
     this.endpoint = this.options.commentId ?
         '/discussion/comment-context/'+ this.options.commentId + '.json' :
         '/discussion/'+ this.options.discussionId + '.json';
@@ -376,6 +380,7 @@ Comments.prototype.getMoreReplies = function(event) {
         url: '/discussion/comment/'+ event.target.getAttribute('data-comment-id') +'.json',
         type: 'json',
         method: 'get',
+        data: this.fetchCommentData,
         crossOrigin: true
     }).then(function (resp) {
         var comment = bonzo.create(resp.html),

--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -49,7 +49,8 @@ var Comments = function(mediator, options) {
 
     this.fetchData = {
         orderBy: this.options.order,
-        pageSize: detect.isBreakpoint({min: 'desktop'}) ? 25 : 10
+        pageSize: detect.isBreakpoint({min: 'desktop'}) ? 25 : 10,
+        maxResponses: 3
     };
 
     this.endpoint = this.options.commentId ?
@@ -149,6 +150,8 @@ Comments.prototype.ready = function() {
     this.on('click', this.getClass('sentimentControl'), this.setSentiment);
 
     this.mediator.on('discussion:comment:recommend:fail', this.recommendFail.bind(this));
+
+    this.addMoreRepliesButtons();
 
     if (this.options.commentId) {
         var comment = $('#comment-'+ this.options.commentId);
@@ -305,6 +308,9 @@ Comments.prototype.renderComments = function(resp) {
     });
 
     $(this.getClass('jsContent'), this.elem).replaceWith(content);
+    this.addMoreRepliesButtons(qwery(
+        this.getClass('comment'), content
+    ));
 
     if (!this.isReadOnly()) {
         RecommendComments.init();
@@ -334,6 +340,9 @@ Comments.prototype.addMoreRepliesButtons = function (comments) {
         var replies = parseInt(elem.getAttribute('data-comment-replies'), 10),
             renderedReplies = qwery(self.getClass('reply'), elem);
 
+
+        console.log("Replies: " + replies + " Rendered replies: " + renderedReplies.length)
+
         if (renderedReplies.length < replies) {
             var numHiddenReplies = replies - renderedReplies.length,
                 showButtonHtml = '<li>'+
@@ -360,6 +369,8 @@ Comments.prototype.getMoreReplies = function(event) {
     event.preventDefault();
     var self = this,
         source = bonzo(event.target).data('source-comment');
+
+    console.log("+++  Get More comments");
 
     ajax({
         url: '/discussion/comment/'+ event.target.getAttribute('data-comment-id') +'.json',

--- a/common/app/assets/javascripts/modules/discussion/comments.js
+++ b/common/app/assets/javascripts/modules/discussion/comments.js
@@ -344,9 +344,6 @@ Comments.prototype.addMoreRepliesButtons = function (comments) {
         var replies = parseInt(elem.getAttribute('data-comment-replies'), 10),
             renderedReplies = qwery(self.getClass('reply'), elem);
 
-
-        console.log("Replies: " + replies + " Rendered replies: " + renderedReplies.length)
-
         if (renderedReplies.length < replies) {
             var numHiddenReplies = replies - renderedReplies.length,
                 showButtonHtml = '<li>'+
@@ -373,8 +370,6 @@ Comments.prototype.getMoreReplies = function(event) {
     event.preventDefault();
     var self = this,
         source = bonzo(event.target).data('source-comment');
-
-    console.log("+++  Get More comments");
 
     ajax({
         url: '/discussion/comment/'+ event.target.getAttribute('data-comment-id') +'.json',

--- a/common/app/assets/javascripts/modules/discussion/top-comments.js
+++ b/common/app/assets/javascripts/modules/discussion/top-comments.js
@@ -67,7 +67,7 @@ TopComments.prototype.endpoint = '/discussion/:discussionId.json';
 /** @type {Object.<string.*>} */
 TopComments.prototype.defaultOptions = {
     discussionId: null,
-    showRepliesCount: 3,
+    showRepliesCount: 2,
     sectionHeading: 'Featured Comments '
 };
 

--- a/common/app/assets/javascripts/modules/discussion/top-comments.js
+++ b/common/app/assets/javascripts/modules/discussion/top-comments.js
@@ -67,7 +67,7 @@ TopComments.prototype.endpoint = '/discussion/:discussionId.json';
 /** @type {Object.<string.*>} */
 TopComments.prototype.defaultOptions = {
     discussionId: null,
-    showRepliesCount: 2,
+    showRepliesCount: 3,
     sectionHeading: 'Featured Comments '
 };
 

--- a/common/app/assets/stylesheets/module/_discussion.scss
+++ b/common/app/assets/stylesheets/module/_discussion.scss
@@ -752,6 +752,7 @@ $avatarSize: 44px;
 
     span {
         @include icon-button(plus-white-small, 18px);
+        display: inline-block;
         background-color: $c-newsDefault;
         margin-bottom: $gs-baseline / 3 * -1;
         margin-right: ($gs-gutter / 5) * 2;

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -57,8 +57,7 @@ trait CommentsController extends DiscussionController {
 }
 
 case class DiscussionParams(orderBy: String, page: String, pageSize: String, maxResponses: Option[String] = None, sentiment: Option[String] = None, topComments: Boolean)
-object
-DiscussionParams extends {
+object DiscussionParams extends {
   def apply(request: RequestHeader): DiscussionParams = {
     DiscussionParams(
       orderBy = request.getQueryString("orderBy").getOrElse("newest"),

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -18,6 +18,9 @@ trait CommentsController extends DiscussionController {
   def commentJson(id: Int) = comment(id)
   def comment(id: Int) = Action.async { implicit request =>
     val comment = discussionApi.commentFor(id)
+
+    print("Get comment")
+
     comment map {
       comment =>
         Cached(60) {
@@ -56,7 +59,8 @@ trait CommentsController extends DiscussionController {
 }
 
 case class DiscussionParams(orderBy: String, page: String, pageSize: String, maxResponses: Option[String] = None, sentiment: Option[String] = None, topComments: Boolean)
-object DiscussionParams extends {
+object
+DiscussionParams extends {
   def apply(request: RequestHeader): DiscussionParams = {
     DiscussionParams(
       orderBy = request.getQueryString("orderBy").getOrElse("newest"),

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -17,9 +17,7 @@ trait CommentsController extends DiscussionController {
 
   def commentJson(id: Int) = comment(id)
   def comment(id: Int) = Action.async { implicit request =>
-    val comment = discussionApi.commentFor(id)
-
-    print("Get comment")
+    val comment = discussionApi.commentFor(id, request.getQueryString("displayThreaded"))
 
     comment map {
       comment =>

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -51,7 +51,6 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
                     params.sentiment.map{ s: String => "&sentiment="+s }.getOrElse("")+
                     params.maxResponses.map{i => "&maxResponses="+ i}.getOrElse("")
 
-
     getJsonForUri(key, url)
   }
 

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -36,7 +36,8 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
   }
 
   def commentFor(id: Int): Future[Comment] = {
-    getCommentJsonForId(id, s"$apiRoot/comment/$id?displayResponses=true")
+    print("API: " + apiRoot)
+    getCommentJsonForId(id, s"$apiRoot/comment/$id?displayResponses=true&displayThreaded=true")
   }
 
   def commentsFor(key: DiscussionKey, params: DiscussionParams): Future[CommentPage] = {
@@ -47,6 +48,8 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
                     |&showSwitches=true""".stripMargin.replace("\n", "")+
                     params.sentiment.map{ s: String => "&sentiment="+s }.getOrElse("")+
                     params.maxResponses.map{i => "&maxResponses="+ i}.getOrElse("")
+
+    print("URL: " + url)
 
     getJsonForUri(key, url)
   }

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -35,9 +35,11 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
     }
   }
 
-  def commentFor(id: Int): Future[Comment] = {
-    print("API: " + apiRoot)
-    getCommentJsonForId(id, s"$apiRoot/comment/$id?displayResponses=true&displayThreaded=true")
+  def commentFor(id: Int, displayThreaded: Option[String]  = None): Future[Comment] = {
+
+    val url = s"$apiRoot/comment/$id?displayResponses=true" +
+      displayThreaded.map{ dt => "&displayThreaded=" + dt  }.getOrElse("")
+    getCommentJsonForId(id, url)
   }
 
   def commentsFor(key: DiscussionKey, params: DiscussionParams): Future[CommentPage] = {
@@ -49,7 +51,6 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
                     params.sentiment.map{ s: String => "&sentiment="+s }.getOrElse("")+
                     params.maxResponses.map{i => "&maxResponses="+ i}.getOrElse("")
 
-    print("URL: " + url)
 
     getJsonForUri(key, url)
   }


### PR DESCRIPTION
Turns out that for the 'Show more replies' function to work correctly( as per here: https://github.com/guardian/frontend/pull/6231), we need to pass a parameter 'display threaded' to the the discussion API. This does this, reinstates the functionality to truncate reply threads and restyles the 'show more button' ( see below )

![more-comments](https://cloud.githubusercontent.com/assets/986155/4493988/eabee43a-4a4d-11e4-8e23-850cbe474bb5.png)
