### PR TITLE
Removed compact list

### DIFF
--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -568,7 +568,7 @@ case object TlTlMpu extends Slice {
         rows = 3,
         ItemClasses(
           mobile = "list",
-          tablet = "list-compact"
+          tablet = "list"
         )
       ),
       MPU(
@@ -613,7 +613,7 @@ case object TlTlTl extends Slice {
         rows = 2,
         ItemClasses(
           mobile = "list",
-          tablet = "list-compact"
+          tablet = "list"
         )
       )
     )


### PR DESCRIPTION
I have to remove list-compact we introduced yesterday because it's breaking with comments.

![screen shot 2014-10-02 at 17 44 17](https://cloud.githubusercontent.com/assets/2579465/4494803/5dcf831a-4a55-11e4-844f-b50221b2b0c2.png)

This will be just quick fix and we will figure out how to solve it permanently for list-compact option. 
