### PR TITLE
Facia keywords/tags fix

### DIFF
--- a/common/app/assets/stylesheets/module/facia/_container-related-keywords.scss
+++ b/common/app/assets/stylesheets/module/facia/_container-related-keywords.scss
@@ -1,5 +1,5 @@
 .facia-container__related-keywords {
-    margin: $gs-baseline $gs-gutter;
+    margin: $gs-baseline 0;
     @include fs-textSans(2);
 
     @include mq(wide) {

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -28,15 +28,18 @@
                 }
             }
 
-            @defining(topTags(faciaPage.allItems).take(20)) { tags =>
-                @if(tags.nonEmpty) {
-                    <div class="facia-container__related-keywords">
-                        <div class="facia-container__related-keywords__body">
-                            @keywordList(tags, 5, "See also")
+
+            <section class="facia-container__inner">
+                @defining(topTags(faciaPage.allItems).take(20)) { tags =>
+                    @if(tags.nonEmpty) {
+                        <div class="facia-container__related-keywords">
+                            <div class="facia-container__related-keywords__body">
+                                @keywordList(tags, 5, "See also")
+                            </div>
                         </div>
-                    </div>
+                    }
                 }
-            }
+            </section>
 
             @fragments.commercial.commercialComponent()
         </div>


### PR DESCRIPTION
Now:
![screen shot 2014-10-02 at 18 31 04](https://cloud.githubusercontent.com/assets/2579465/4495300/368a7c10-4a5a-11e4-8bfe-ed02a3fc91fb.png)

The fix is to wrap it and remove margin top and bottom.

We will redesign this component in the near future to work better across all pages.
