### PR TITLE
Removed tonal colourings for tag lozenges 

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -83,7 +83,7 @@
                     @if(gallery.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="submeta" data-link-name="keywords">
                             <h2 class="submeta__head">Topics</h2>
-                            @fragments.keywordList(gallery.keywords, tone = "media")
+                            @fragments.keywordList(gallery.keywords, tone = Some("media"))
                         </div>
                     }
                     <div class="submeta" data-component="share">

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -96,7 +96,7 @@
                                     @if(media.keywords.filterNot(_.isSectionTag).nonEmpty) {
                                         <div class="submeta" data-link-name="keywords">
                                             <h2 class="submeta__head">Topics</h2>
-                                            @fragments.keywordList(media.keywords, tone = "media")
+                                            @fragments.keywordList(media.keywords, tone = Some("media"))
                                         </div>
                                     }
                                     <div class="submeta hide-from-leftcol" data-component="share">

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -42,7 +42,7 @@
                     @if(article.keywords.filterNot(_.isSectionTag).nonEmpty) {
                         <div class="submeta" data-link-name="keywords">
                             <h2 class="submeta__head">Topics</h2>
-                            @fragments.keywordList(article.keywords, tone = article.visualTone)
+                            @fragments.keywordList(article.keywords)
                         </div>
                     }
                     @if(!article.tooSmallForBottomSocialButtons) {

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -82,7 +82,7 @@
 
                     <div class="submeta-container">
                         <div class="submeta" data-link-name="keywords">
-                            @fragments.keywordList(article.keywords, tone = article.visualTone)
+                            @fragments.keywordList(article.keywords, tone = Some(article.visualTone))
                         </div>
                         <div class="submeta" data-component="share">
                             @fragments.social(article)

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -1,4 +1,4 @@
-@(keywords: Seq[model.Tag], visibleKeywords: Int = 5, title: String = "Tags", tone: String = "news")(implicit request: RequestHeader)
+@(keywords: Seq[model.Tag], visibleKeywords: Int = 5, title: String = "Tags", tone: Option[String] = None)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import model.Tag
@@ -6,7 +6,7 @@
 
 @renderItem(keyword: Tag, row: RowInfo, clazz: String = "", trailingComma: Boolean = false) = {
     <li class="inline-list__item @clazz">
-        <a class="@if(keyword.isFootballTeam){js-football-team} @if(keyword.isFootballCompetition){ js-football-competition} button button--small button--tag button--tone-@tone"
+        <a class="@if(keyword.isFootballTeam){js-football-team} @if(keyword.isFootballCompetition){ js-football-competition} button button--small button--tag @tone.map("button--tone-" + _).getOrElse("button--secondary")"
            href="@LinkTo(keyword.url)"
            data-link-name="keyword: @keyword.id"
            itemprop="keywords">
@@ -27,7 +27,7 @@
                 @if(hiddenKeywords.nonEmpty) {
 
                     <li class="inline-list__item js-more-tags more-tags modern-hidden">
-                        <button class="u-button-reset js-more-tags__link button button--small button--tag button--tone-@tone-variant button--more"
+                        <button class="u-button-reset js-more-tags__link button button--small button--tag @tone.map("button--tone-" + _ + "variant").getOrElse("button--tertiary") button--more"
                            data-link-name="more-tags">More…</button>
                     </li>
 

--- a/static/src/stylesheets/components/guss-webfonts/.bower.json
+++ b/static/src/stylesheets/components/guss-webfonts/.bower.json
@@ -1,23 +1,20 @@
 {
   "name": "guss-webfonts",
   "description": "Guardian web fonts, for your prototyping needs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": [
     "src/_webfonts.scss"
-  ],
-  "ignore": [
-    "webfonts"
   ],
   "homepage": "https://github.com/guardian/guss-webfonts",
   "repository": {
     "type": "git",
     "url": "http://github.com/guardian/guss-webfonts.git"
   },
-  "_release": "3.0.0",
+  "_release": "3.0.1",
   "_resolution": {
     "type": "version",
-    "tag": "3.0.0",
-    "commit": "ce3f71f89ac9a6eeafe160b27d2e31535701fc95"
+    "tag": "3.0.1",
+    "commit": "76411109b5b9c6b4c883c7e043f2c41889948adb"
   },
   "_source": "git://github.com/guardian/guss-webfonts.git",
   "_target": "~3.0.0",

--- a/static/src/stylesheets/components/guss-webfonts/Gruntfile.js
+++ b/static/src/stylesheets/components/guss-webfonts/Gruntfile.js
@@ -8,6 +8,8 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-sassdoc');
     grunt.loadNpmTasks('grunt-scss-lint');
 
+    grunt.task.renameTask('release', 'git-release');
+
     grunt.initConfig({
         // if you update this, don't forget to update ./src/_webfonts.config.scss#L18
         fontsVersion: '0.1.0',

--- a/static/src/stylesheets/components/guss-webfonts/README.md
+++ b/static/src/stylesheets/components/guss-webfonts/README.md
@@ -11,7 +11,7 @@ The font files are for internal use exclusively. You may use them for
 prototyping purposes but not serve them publicly on your own domain
 unless you have a license for it.
 
-For more information, read the Commercial Type End User License Agreement.
+For more information, read the [Commercial Type End User License Agreement](./Commercial Type EULA Web-general.pdf).
 
 [Read the docs](http://guardian.github.io/guss-webfonts/docs/) or
 [view the demo](http://guardian.github.io/guss-webfonts/demo/)
@@ -28,20 +28,9 @@ $ bower install guss-webfonts --save
 
 1. [Manually download the repository](https://github.com/guardian/guss-webfonts/archive/master.zip)
 2. Decompress the archive
-3. Copy all or part of the `webfonts` directory to `bower_components/guss-webfonts/webfonts`
-   depending on what fonts your project needs
+3. Copy all or part of the `webfonts` directory
 
-### Point directly to the css
-
-This will load all the Guardian Next Gen webfonts, hinted, with the largest
-character set available:
-
-```html
-<link rel="stylesheet" href="bower_components/guss-webfonts/nextgen-webfonts.css" type="text/css" />
-```
-
-
-### …or import the file in Sass
+### Import the file in Sass
 
 #### 1. Configure and import guss-webfonts
 
@@ -81,8 +70,15 @@ $guss-webfonts-hinting: 'on';
  */
 $guss-webfonts-kerning: 'on';
 
+/**
+ * Version
+ *
+ * Version of the fonts to use
+ */
+$guss-webfonts-version: '0.1.0';
 
-@import 'path/to/guss-webfonts/_webfonts';
+
+@import 'bower_components/guss-webfonts/src/_webfonts';
 ```
 
 #### 2. Output @font-face rules
@@ -95,23 +91,18 @@ $guss-webfonts-kerning: 'on';
 
 ## Curating a selection of web fonts
 
-Font properties are stored in the `$guss-webfonts` map, in `_webfonts.config.scss`.
+Font properties are stored in the `$guss-webfonts` map, in `src/_webfonts.config.scss`.
 
 You can curate your own list of @font-face rules like so:
 
 ```scss
 // Only Guardian Agate Sans 1 Web
-
 @include guss-webfonts('Guardian Agate Sans 1 Web');
 
-
 // Guardian Agate Sans 1 Web and Guardian Sans Web
-
 @include guss-webfonts('Guardian Agate Sans 1 Web' 'Guardian Sans Web');
 
-
 // For Guardian Next Gen products, we use this configuration:
-
 @include guss-webfonts(
     (
         'Guardian Agate Sans 1 Web': (
@@ -144,7 +135,7 @@ You can curate your own list of @font-face rules like so:
 
 ## Uploading fonts
 
-Update the version number in the [Gruntfile](Gruntfile.js). Then
+Update the version number in the [Gruntfile](Gruntfile.js#L13). Then
 
 ```
 $ grunt release:fonts --id=AWS_ACCESS_KEY --secret=AWS_SECRET_KEY

--- a/static/src/stylesheets/components/guss-webfonts/bower.json
+++ b/static/src/stylesheets/components/guss-webfonts/bower.json
@@ -1,12 +1,9 @@
 {
   "name": "guss-webfonts",
   "description": "Guardian web fonts, for your prototyping needs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": [
     "src/_webfonts.scss"
-  ],
-  "ignore": [
-    "webfonts"
   ],
   "homepage": "https://github.com/guardian/guss-webfonts",
   "repository": {

--- a/static/src/stylesheets/components/pasteup-buttons/.bower.json
+++ b/static/src/stylesheets/components/pasteup-buttons/.bower.json
@@ -1,7 +1,7 @@
 {
   "name": "pasteup-buttons",
   "description": "Button component in the Pasteup collection",
-  "version": "0.4.2",
+  "version": "0.4.7",
   "main": [
     "build/buttons.min.css",
     "src/_buttons.scss"
@@ -21,11 +21,11 @@
   "devDependencies": {
     "Cortana": "~1.2.7"
   },
-  "_release": "0.4.2",
+  "_release": "0.4.7",
   "_resolution": {
     "type": "version",
-    "tag": "0.4.2",
-    "commit": "be4c2b21f61f57343aa213399bad276ff64b4bd1"
+    "tag": "0.4.7",
+    "commit": "3000b9882abe22e48948402f6a02ee7b79e425a6"
   },
   "_source": "git://github.com/guardian/pasteup-buttons.git",
   "_target": "~0.4.0",

--- a/static/src/stylesheets/components/pasteup-buttons/bower.json
+++ b/static/src/stylesheets/components/pasteup-buttons/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "pasteup-buttons",
   "description": "Button component in the Pasteup collection",
-  "version": "0.4.2",
+  "version": "0.4.7",
   "main": [
     "build/buttons.min.css",
     "src/_buttons.scss"

--- a/static/src/stylesheets/components/pasteup-buttons/src/_buttons.scss
+++ b/static/src/stylesheets/components/pasteup-buttons/src/_buttons.scss
@@ -108,7 +108,7 @@ They come in different sizes:
     @include button-colour(
         guss-colour(news-main-2, $pasteup-palette),
         #ffffff,
-         guss-colour(news-main-1, $pasteup-palette)
+        guss-colour(news-main-1, $pasteup-palette)
      );
 
     &:hover,
@@ -121,27 +121,24 @@ They come in different sizes:
     @include button-colour(
         guss-colour(guardian-brand, $pasteup-palette),
         #ffffff,
-        darken(guss-colour(news-main-1, $pasteup-palette), 10%)
+        darken(guss-colour(guardian-brand, $pasteup-palette), 10%)
     );
 }
 .button--secondary {
-    @include button-colour(guss-colour(neutral-2, $pasteup-palette), #ffffff, guss-colour(neutral-1, $pasteup-palette));
+    @include button-colour(
+        guss-colour(neutral-7, $pasteup-palette),
+        guss-colour(neutral-1, $pasteup-palette),
+        darken(guss-colour(neutral-7, $pasteup-palette), 10%)
+    );
 }
 .button--tertiary {
     @include button-colour(
-        transparent,
-        guss-colour(neutral-2, $pasteup-palette),
-        transparent,
-        guss-colour(neutral-3, $pasteup-palette)
+        #ffffff,
+        guss-colour(neutral-1, $pasteup-palette),
+        #ffffff,
+        darken(guss-colour(neutral-3, $pasteup-palette), 10%),
+        guss-colour(neutral-4, $pasteup-palette)
     );
-    border-color: guss-colour(neutral-3, $pasteup-palette);
-
-    &:hover,
-    &:focus,
-    &:active {
-        color: guss-colour(neutral-1, $pasteup-palette);
-        border-color: guss-colour(neutral-1, $pasteup-palette);
-    }
 }
 
 .button--tone-media {
@@ -173,7 +170,7 @@ They come in different sizes:
         guss-colour(news-main-1, $pasteup-palette),
         #ffffff,
         darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-5, $pasteup-palette)
+        guss-colour(neutral-4, $pasteup-palette)
     );
 }
 .button--tone-feature {
@@ -189,7 +186,7 @@ They come in different sizes:
         guss-colour(features-support-1, $pasteup-palette),
         #ffffff,
         darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-3, $pasteup-palette)
+        guss-colour(neutral-4, $pasteup-palette)
     );
 }
 .button--tone-comment {
@@ -205,20 +202,20 @@ They come in different sizes:
         guss-colour(comment-main-1, $pasteup-palette),
         #ffffff,
         darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-3, $pasteup-palette)
+        guss-colour(neutral-4, $pasteup-palette)
     );
 }
 .button--tone-live {
     @include button-colour(
         guss-colour(neutral-6, $pasteup-palette),
-        guss-colour(news-main-1, $pasteup-palette),
+        guss-colour(neutral-1, $pasteup-palette),
         darken(guss-colour(neutral-6, $pasteup-palette), 10%)
     );
 }
 .button--tone-live-variant {
     @include button-colour(
         guss-colour(neutral-8, $pasteup-palette),
-        guss-colour(news-main-1, $pasteup-palette),
+        guss-colour(neutral-1, $pasteup-palette),
         guss-colour(neutral-8, $pasteup-palette),
         darken(guss-colour(neutral-3, $pasteup-palette), 10%),
         guss-colour(neutral-3, $pasteup-palette)

--- a/static/src/stylesheets/components/sass-mq/.bower.json
+++ b/static/src/stylesheets/components/sass-mq/.bower.json
@@ -34,6 +34,6 @@
     "commit": "454e5e7e0cb53661240d5546a8a701cf6415a7f8"
   },
   "_source": "git://github.com/guardian/sass-mq.git",
-  "_target": "~2.1.1",
+  "_target": "~2",
   "_originalSource": "sass-mq"
 }


### PR DESCRIPTION
Tags now only have tonal colourings on live blogs & gallery pages, all other tags are grey.

This also pulls in pasteup-buttons release 0.4.7

![screen shot 2014-10-03 at 17 29 18](https://cloud.githubusercontent.com/assets/2236852/4509199/e4fe1d48-4b1c-11e4-9ddb-e3f1e7ff78fa.png)
