### PR TITLE
Implement tracking on Identity

### DIFF
--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -32,21 +32,18 @@
                 analyticsImage.height = "1";
                 document.body.appendChild(analyticsImage);
 
-                @* there is currently no SSL version of the beacon *@
-                @if(!Configuration.environment.secure){
-                    @*
-                    // this is used to sanity check our analytics calls
-                    *@
-                    var img = new Image();
-                    img.src = "@{Configuration.debug.beaconUrl}/count/pva.gif";
+                @*
+                // this is used to sanity check our analytics calls
+                *@
+                var img = new Image();
+                img.src = "@{Configuration.debug.beaconUrl}/count/pva.gif";
 
-                    var s = document.createElement('script'),
-                            sc = document.getElementsByTagName('script')[0];
+                var s = document.createElement('script'),
+                        sc = document.getElementsByTagName('script')[0];
 
-                    s.src = '@Static("javascripts/bootstraps/ophan.js")';
-                    s.aysnc = true;
-                    sc.parentNode.insertBefore(s, sc);
-                }
+                s.src = '@Static("javascripts/bootstraps/ophan.js")';
+                s.aysnc = true;
+                sc.parentNode.insertBefore(s, sc);
             }
         </script>
     }
@@ -59,10 +56,7 @@
     </div>
 </noscript>
 
-@* there is currently no SSL version of the beacon *@
-@if(!Configuration.environment.secure) {
-    @page match {
-        case v: model.Video => { <img src="@Configuration.debug.beaconUrl/counts.gif?c=pv&c=vpv" alt="" style="display : none ;" rel="nofollow"/> }
-        case _ => { <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/> }
-    }
+@page match {
+    case v: model.Video => { <img src="@Configuration.debug.beaconUrl/counts.gif?c=pv&c=vpv" alt="" style="display : none ;" rel="nofollow"/> }
+    case _ => { <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/> }
 }

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -91,7 +91,7 @@
             <div class="fieldset__fields u-cf">
                 <div class="form-field">
                     <span class="js-membership-tier"></span>
-                    <a href="@(conf.Configuration.id.membershipUrl)/tier/change" class="submit-input membership-tab__update-button">Change tier</a>
+                    <a href="@(conf.Configuration.id.membershipUrl)/tier/change" class="submit-input membership-tab__update-button" data-link-name="Change tier">Change tier</a>
                 </div>
             </div>
         </li>
@@ -149,7 +149,7 @@
                     <span class="membership-tab__card-details">
                         •••• •••• •••• <span class="js-membership-payment-card-lastfour"></span>
                     </span>
-                    <button class="submit-input js-membership-change-cc-open membership-tab__update-button">Change card</button>
+                    <button class="submit-input js-membership-change-cc-open membership-tab__update-button" data-link-name="Change card">Change card</button>
                 </div>
             </div>
         </li>
@@ -199,7 +199,7 @@
                         </p>
                     </div>
                     <div class="form-field">
-                        <button class="submit-input js-membership-change-cc-submit" type="submit">Update</button><div class="is-updating js-updating"></div>
+                        <button class="submit-input js-membership-change-cc-submit" type="submit" data-link-name="Update card details">Update</button><div class="is-updating js-updating"></div>
                     </div>
                 </div>
             </form>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -16,6 +16,7 @@
                 <div class="email-subscription__description">@subscription.description</div>
                 <div class="email-subscription__meta u-cf">
                     <button class="email-subscription__button"
+                            data-link-name="@if(subscription.subscribedTo){Unsubscribe}else{Subscribe} to @subscription.name"
                             name="addEmailSubscription"
                             type="submit"
                             value="@if(subscription.subscribedTo){unsubscribe-}@subscription.listId">

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -195,7 +195,7 @@ define([
 
                 omniture.go(config);
 
-                if (config.switches.ophan && !config.page.isSSL) {
+                if (config.switches.ophan) {
                     require('ophan/ng', function (ophan) {
                         ophan.record({ab: ab.getParticipations()});
 

--- a/static/src/javascripts/projects/common/modules/analytics/beacon.js
+++ b/static/src/javascripts/projects/common/modules/analytics/beacon.js
@@ -2,11 +2,8 @@ define(['common/utils/config'], function(config) {
 
     return {
         fire: function(path){
-            // There is currently no SSL version of the beacon
-            if(!config.page.isSSL) {
-                var img = new Image();
-                img.src = config.page.beaconUrl + path;
-            }
+            var img = new Image();
+            img.src = config.page.beaconUrl + path;
         }
     };
 });


### PR DESCRIPTION
Now that Ophan and Beacon are available over HTTPS, remove the SSL checks in the templates and bootstrap previously put in place.

Additionally add some missed `data-link-name` attributes.

cc @jamesgorrie 
