### PR TITLE
Remove standard-quarter

### DIFF
--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -43,7 +43,7 @@ case object QuarterQlQlQl extends Slice {
         1,
         ItemClasses(
           mobile = "list-media-large",
-          tablet = "standard-quarter"
+          tablet = "standard"
         )
       ),
       Rows(
@@ -72,14 +72,14 @@ case object QuarterQuarterQlQl extends Slice {
         1,
         ItemClasses(
           mobile = "list-media-large",
-          tablet = "standard-quarter"
+          tablet = "standard"
         )
       ),
       SingleItem(
         1,
         ItemClasses(
           mobile = "list-media-large",
-          tablet = "standard-quarter"
+          tablet = "standard"
         )
       ),
       Rows(
@@ -108,21 +108,21 @@ case object QuarterQuarterQuarterQl extends Slice {
         1,
         ItemClasses(
           mobile = "list-media",
-          tablet = "standard-quarter"
+          tablet = "standard"
         )
       ),
       SingleItem(
         1,
         ItemClasses(
           mobile = "list-media",
-          tablet = "standard-quarter"
+          tablet = "standard"
         )
       ),
       SingleItem(
         1,
         ItemClasses(
           mobile = "list-media",
-          tablet = "standard-quarter"
+          tablet = "standard"
         )
       ),
       Rows(
@@ -151,28 +151,28 @@ case object QuarterQuarterQuarterQuarter extends Slice {
           1,
           ItemClasses(
             mobile = "list-media-large",
-            tablet = "standard-quarter"
+            tablet = "standard"
           )
         ),
         SingleItem(
           1,
           ItemClasses(
             mobile = "list-media-large",
-            tablet = "standard-quarter"
+            tablet = "standard"
           )
         ),
         SingleItem(
           1,
           ItemClasses(
             mobile = "list-media-large",
-            tablet = "standard-quarter"
+            tablet = "standard"
           )
         ),
         SingleItem(
           1,
           ItemClasses(
             mobile = "list-media-large",
-            tablet = "standard-quarter"
+            tablet = "standard"
           )
         )
       )

--- a/static/src/stylesheets/module/facia-cards/_items.scss
+++ b/static/src/stylesheets/module/facia-cards/_items.scss
@@ -92,8 +92,7 @@
     }
 }
 
-.fc-item--standard-tablet,
-.fc-item--standard-quarter-tablet {
+.fc-item--standard-tablet {
     @include mq(tablet) {
         @include fc-item--standard;
     }

--- a/static/src/stylesheets/module/facia-cards/_slices.scss
+++ b/static/src/stylesheets/module/facia-cards/_slices.scss
@@ -47,8 +47,7 @@ Hence why a greater depth of selector specificity is needed.
 }
 
 .facia-slice--q-q-q-q {
-    .fc-item--standard-tablet,
-    .fc-item--standard-quarter-tablet {
+    .fc-item--standard-tablet {
         .fc-item__header {
             @include mq(tablet) {
                 @include fs-headline(2, true);


### PR DESCRIPTION
For some reason we had both `standard` and `standard-quarter` sizes and were using them inconsistency. This removes all `standard-quarter` classes and uses `standard` instead.
