### PR TITLE
Render tag and section names as HTML fields in kickers

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
@@ -1,7 +1,6 @@
-@(trail: Trail, itemIndex: Int, containerIndex: Int, isSubLink: Boolean)(implicit request: RequestHeader, config: Config)
+@(trail: model.Trail, itemIndex: Int, containerIndex: Int, isSubLink: Boolean)(implicit request: RequestHeader, config: model.Config)
 
 @import common.LinkTo
-@import model.{Config, Trail}
 @import views.support._
 
 <h3 class="fc-sublinks__item-title">
@@ -19,7 +18,7 @@
     }
 
     case PodcastKicker(Some(series)) => {
-      <a href="@LinkTo(series.url)" class="fc-item__kicker">@series.name</a>
+      <a href="@LinkTo(series.url)" class="fc-item__kicker">@Html(series.name)</a>
     }
 
     case PodcastKicker(None) => {
@@ -31,11 +30,11 @@
     }
 
     case TagKicker(tagName, tagLink) => {
-      <a href="@LinkTo(tagLink)" class="fc-item__kicker">@tagName</a>
+      <a href="@LinkTo(tagLink)" class="fc-item__kicker">@Html(tagName)</a>
     }
 
     case SectionKicker(sectionName, sectionLink) => {
-      <a href="@LinkTo(sectionLink)" class="fc-item__kicker">@sectionName</a>
+      <a href="@LinkTo(sectionLink)" class="fc-item__kicker">@Html(sectionName)</a>
     }
 
     case FreeHtmlKicker(html) => {

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -20,7 +20,7 @@
         }
 
         case PodcastKicker(Some(series)) => {
-            <a href="@LinkTo(series.url)" class="fc-item__kicker">@series.name</a>
+            <a href="@LinkTo(series.url)" class="fc-item__kicker">@Html(series.name)</a>
         }
 
         case PodcastKicker(None) => {
@@ -32,11 +32,11 @@
         }
 
         case TagKicker(tagName, tagLink) => {
-            <a href="@LinkTo(tagLink)" class="fc-item__kicker">@tagName</a>
+            <a href="@LinkTo(tagLink)" class="fc-item__kicker">@Html(tagName)</a>
         }
 
         case SectionKicker(sectionName, sectionLink) => {
-            <a href="@LinkTo(sectionLink)" class="fc-item__kicker">@sectionName</a>
+            <a href="@LinkTo(sectionLink)" class="fc-item__kicker">@Html(sectionName)</a>
         }
 
         case FreeHtmlKicker(html) => {


### PR DESCRIPTION
This fixes the issue with "TV &amp; Radio" in kickers ... 

I think this field should probably be a text field, but it's probably too late to easily fix it.
