### PR TITLE
Use JsObject for serialising item meta in Facia Press (22 field limit on case class!)

### DIFF
--- a/facia-press/app/frontpress/jsonModels.scala
+++ b/facia-press/app/frontpress/jsonModels.scala
@@ -52,55 +52,35 @@ case class TagJson(
 )
 
 object ItemMeta {
-  implicit lazy val jsonFormat = Json.format[ItemMeta]
+  private def flattenedJsObject(xs: (String, Option[JsValue])*) = JsObject(xs collect {
+    case (k, Some(v)) => k -> v
+  })
 
-  def fromContent(content: Content): ItemMeta = ItemMeta(
-    headline = content.apiContent.metaData.get("headline"),
-    trailText = content.apiContent.metaData.get("trailText"),
-    byline = content.apiContent.metaData.get("byline"),
-    showByline = content.apiContent.metaData.get("showByline").flatMap(_.asOpt[Boolean]),
-    group = content.apiContent.metaData.get("group"),
-    isBoosted = content.apiContent.metaData.get("isBoosted").flatMap(_.asOpt[Boolean]),
-    imageHide = content.apiContent.metaData.get("imageHide").flatMap(_.asOpt[Boolean]),
-    imageCutoutReplace = content.apiContent.metaData.get("imageCutoutReplace").flatMap(_.asOpt[Boolean]),
-    imageCutoutSrc = content.apiContent.metaData.get("imageCutoutSrc"),
-    imageCutoutSrcWidth = content.apiContent.metaData.get("imageCutoutSrcWidth"),
-    imageCutoutSrcHeight = content.apiContent.metaData.get("imageCutoutSrcHeight"),
-    isBreaking = content.apiContent.metaData.get("isBreaking").flatMap(_.asOpt[Boolean]),
-    supporting = Option(content.supporting.map(item => Json.toJson(TrailJson.fromContent(item)))).filter(_.nonEmpty),
-    href = content.apiContent.metaData.get("href"),
-    snapType = content.apiContent.metaData.get("snapType"),
-    snapCss = content.apiContent.metaData.get("snapCss"),
-    snapUri = content.apiContent.metaData.get("snapUri"),
-    showKickerTag = content.apiContent.metaData.get("showKickerTag"),
-    showKickerSection = content.apiContent.metaData.get("showKickerSection"),
-    showMainVideo = content.apiContent.metaData.get("showMainVideo")
+  def fromContent(content: Content): JsObject = flattenedJsObject(
+    ("headline", content.apiContent.metaData.get("headline")),
+    ("trailText", content.apiContent.metaData.get("trailText")),
+    ("byline", content.apiContent.metaData.get("byline")),
+    ("showByline", content.apiContent.metaData.get("showByline")),
+    ("group", content.apiContent.metaData.get("group")),
+    ("isBoosted", content.apiContent.metaData.get("isBoosted")),
+    ("imageHide", content.apiContent.metaData.get("imageHide")),
+    ("imageCutoutReplace", content.apiContent.metaData.get("imageCutoutReplace")),
+    ("imageCutoutSrc", content.apiContent.metaData.get("imageCutoutSrc")),
+    ("imageCutoutSrcWidth", content.apiContent.metaData.get("imageCutoutSrcWidth")),
+    ("imageCutoutSrcHeight", content.apiContent.metaData.get("imageCutoutSrcHeight")),
+    ("isBreaking", content.apiContent.metaData.get("isBreaking")),
+    ("supporting", Option(content.supporting.map(item => Json.toJson(TrailJson.fromContent(item))))
+      .filter(_.nonEmpty)
+      .map(JsArray.apply)),
+    ("href", content.apiContent.metaData.get("href")),
+    ("snapType", content.apiContent.metaData.get("snapType")),
+    ("snapCss", content.apiContent.metaData.get("snapCss")),
+    ("snapUri", content.apiContent.metaData.get("snapUri")),
+    ("showKickerTag", content.apiContent.metaData.get("showKickerTag")),
+    ("showKickerSection", content.apiContent.metaData.get("showKickerSection")),
+    ("showMainVideo", content.apiContent.metaData.get("showMainVideo"))
   )
 }
-
-case class ItemMeta(
-  headline:      Option[JsValue],
-  trailText:     Option[JsValue],
-  byline:        Option[JsValue],
-  showByline:    Option[Boolean],
-  group:         Option[JsValue],
-  isBoosted:     Option[Boolean],
-  imageHide:     Option[Boolean],
-  imageCutoutReplace:   Option[Boolean],
-  imageCutoutSrc:       Option[JsValue],
-  imageCutoutSrcWidth:  Option[JsValue],
-  imageCutoutSrcHeight: Option[JsValue],
-  isBreaking:    Option[Boolean],
-  supporting:    Option[Seq[JsValue]],
-  href:          Option[JsValue],
-  snapType:      Option[JsValue],
-  snapCss:       Option[JsValue],
-  snapUri:       Option[JsValue],
-  showKickerTag: Option[JsValue],
-  showKickerSection: Option[JsValue],
-  showMainVideo: Option[JsValue]
-)
-
 
 object TrailJson {
   implicit val jsonFormat = Json.format[TrailJson]
@@ -133,7 +113,7 @@ case class TrailJson(
   byline: Option[String],
   safeFields: Map[String, String],
   elements: Seq[ElementJson],
-  meta: ItemMeta
+  meta: JsObject
 )
 
 object CollectionJson {
@@ -179,4 +159,4 @@ case class CollectionJson(
   hideKickers:  Boolean,
   showDateHeader: Boolean,
   showLatestUpdate: Boolean
-                           )
+)


### PR DESCRIPTION
Boring reasons for why there is a 22 field limit: http://www.scala-lang.org/old/node/7910

The short of it is we ought to fix this by making our data-types nicer. Fields like all the image cut out ones should be in their own data type, so instead of occupying four fields, it only occupies one. That's not a simple change at this point, and as throughout the rest of the stack we treat the metadata as an untyped map, we'll revert to doing so here as well.

CC @janua @stephanfowler 
