### PR TITLE
Facia cards dead blog fix

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_tones.scss
+++ b/static/src/stylesheets/module/facia-cards/_tones.scss
@@ -1,11 +1,11 @@
-%tone-background {
+%tone-has-background {
     .fc-item__content {
         padding-left: $fc-item-gutter;
         padding-right: $fc-item-gutter;
     }
 }
 
-%tone-without-background {
+%tone-not-background {
     &.fc-item--list-media-mobile,
     &.fc-item--list-media-large-mobile {
         .fc-item__title {

--- a/static/src/stylesheets/module/facia-cards/_tones.scss
+++ b/static/src/stylesheets/module/facia-cards/_tones.scss
@@ -5,6 +5,62 @@
     }
 }
 
+%tone-without-background {
+    &.fc-item--list-media-mobile,
+    &.fc-item--list-media-large-mobile {
+        .fc-item__title {
+            @include mq($until: tablet) {
+                padding-top: 0;
+            }
+        }
+    }
+
+    &.fc-item--three-quarters-tablet,
+    &.fc-item--three-quarters-right-tablet,
+    &.fc-item--full-tablet,
+    &.fc-item--mega-full-tablet {
+        .fc-item__title {
+            @include mq(tablet) {
+                padding-top: 0;
+            }
+        }
+    }
+
+    &.fc-item--list-media-mobile,
+    &.fc-item--list-media-large-mobile {
+        .fc-item__header,
+        .fc-item__standfirst,
+        .fc-item__meta {
+            @include mq($until: tablet) {
+                padding-left: $fc-item-gutter;
+                padding-right: $fc-item-gutter;
+            }
+        }
+    }
+
+    &.fc-item--list-media-tablet {
+        .fc-item__header,
+        .fc-item__standfirst,
+        .fc-item__meta {
+            @include mq(tablet) {
+                padding-left: $fc-item-gutter;
+                padding-right: $fc-item-gutter;
+            }
+        }
+    }
+
+    &.fc-item--list-media-desktop {
+        .fc-item__header,
+        .fc-item__standfirst,
+        .fc-item__meta {
+            @include mq(desktop) {
+                padding-left: $fc-item-gutter;
+                padding-right: $fc-item-gutter;
+            }
+        }
+    }
+}
+
 @import 'item-tones/tone-news';
 @import 'item-tones/tone-live';
 @import 'item-tones/tone-comment';

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
@@ -1,5 +1,5 @@
 .tone-analysis {
-    @extend %tone-background;
+    @extend %tone-has-background;
 
     &.fc-item {
         background-color: $c-analysisBackground;

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -1,5 +1,5 @@
 .tone-comment {
-    @extend %tone-background;
+    @extend %tone-has-background;
 
     &.fc-item {
         background-color: $c-commentBackground;

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
@@ -1,5 +1,5 @@
 .tone-dead {
-    @extend %tone-without-background;
+    @extend %tone-not-background;
 
     .fc-item__kicker,
     .fc-item__byline {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
@@ -1,4 +1,6 @@
 .tone-dead {
+    @extend %tone-without-background;
+
     .fc-item__kicker,
     .fc-item__byline {
         &,

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -1,5 +1,5 @@
 .tone-feature {
-    @extend %tone-background;
+    @extend %tone-has-background;
 
     &.fc-item {
         background-color: $c-featureDefault;

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -1,5 +1,5 @@
 .tone-live {
-    @extend %tone-background;
+    @extend %tone-has-background;
 
     &.fc-item {
         background-color: $c-liveDefault;

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -1,5 +1,5 @@
 .tone-media {
-    @extend %tone-background;
+    @extend %tone-has-background;
 
     &.fc-item {
         background-color: $c-neutral1;

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -1,5 +1,5 @@
 .tone-news {
-    @extend %tone-without-background;
+    @extend %tone-not-background;
 
     .fc-item__kicker,
     .fc-item__byline {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -1,4 +1,6 @@
 .tone-news {
+    @extend %tone-without-background;
+
     .fc-item__kicker,
     .fc-item__byline {
         &,
@@ -24,60 +26,6 @@
         .fc-item__container {
             @include mq(tablet) {
                 @include box-shadow(inset 0 1px $c-newsAccent);
-            }
-        }
-    }
-
-    &.fc-item--list-media-mobile,
-    &.fc-item--list-media-large-mobile {
-        .fc-item__title {
-            @include mq($until: tablet) {
-                padding-top: 0;
-            }
-        }
-    }
-
-    &.fc-item--three-quarters-tablet,
-    &.fc-item--three-quarters-right-tablet,
-    &.fc-item--full-tablet,
-    &.fc-item--mega-full-tablet {
-        .fc-item__title {
-            @include mq(tablet) {
-                padding-top: 0;
-            }
-        }
-    }
-
-    &.fc-item--list-media-mobile,
-    &.fc-item--list-media-large-mobile {
-        .fc-item__header,
-        .fc-item__standfirst,
-        .fc-item__meta {
-            @include mq($until: tablet) {
-                padding-left: $fc-item-gutter;
-                padding-right: $fc-item-gutter;
-            }
-        }
-    }
-
-    &.fc-item--list-media-tablet {
-        .fc-item__header,
-        .fc-item__standfirst,
-        .fc-item__meta {
-            @include mq(tablet) {
-                padding-left: $fc-item-gutter;
-                padding-right: $fc-item-gutter;
-            }
-        }
-    }
-
-    &.fc-item--list-media-desktop {
-        .fc-item__header,
-        .fc-item__standfirst,
-        .fc-item__meta {
-            @include mq(desktop) {
-                padding-left: $fc-item-gutter;
-                padding-right: $fc-item-gutter;
             }
         }
     }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -1,5 +1,5 @@
 .tone-podcast {
-    @extend %tone-background;
+    @extend %tone-has-background;
 
     &.fc-item {
         background-color: $c-podcastBackground;

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -1,5 +1,5 @@
 .tone-review {
-    @extend %tone-background;
+    @extend %tone-has-background;
 
     &.fc-item {
         background-color: $c-reviewBackground;


### PR DESCRIPTION
Initially to fix the spacing around dead blogs, I started replicating a lot of the same code from `.tone-news`. It then made sense to have two placeholder classes for the tones. `%tone-has-background` and `%tone-not-background` which can be applied independently without the need for duplicate code or a hundred overrides.

CC: @sndrs @phamann 

![screen shot 2014-10-06 at 14 13 54](https://cloud.githubusercontent.com/assets/1607666/4526009/c748079c-4d5a-11e4-869e-5ab92e8a131a.png)
