### PR TITLE
Decrease batch size

### DIFF
--- a/facia-tool/public/js/modules/vars.js
+++ b/facia-tool/public/js/modules/vars.js
@@ -54,7 +54,7 @@ define([
 
         searchPageSize:        50,
 
-        capiBatchSize:         20,
+        capiBatchSize:         10,
 
         collectionsPollMs:     10000,
         latestArticlesPollMs:  30000,


### PR DESCRIPTION
Because search URLs are getting too long for Capi.
