### PR TITLE
Adding tracking to whether we're in the FFOS app

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -165,7 +165,9 @@ define([
 
             s.prop14    = config.page.buildNumber || '';
 
-            var platform = !(navigator.mozApps && !window.locationbar.visible) ? 'frontend' : 'firefoxosapp';
+            s.prop60    = navigator.mozApps && !window.locationbar.visible ? 'firefoxosapp' : null;
+
+            var platform = 'frontend';
             s.prop19     = platform;
             s.eVar19     = platform;
 


### PR DESCRIPTION
Removing #5743 and putting it in it's own tracking `prop` provided by Matt Kopka.

![](http://i.imgur.com/zY24IS1.gif)
