### PR TITLE
Add weird trim function to minimise whitespace in kickers

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
@@ -1,7 +1,12 @@
-@(isFirstItemOnPage: Boolean)(html: Html)
+@(isFirstItemOnPage: Boolean)(kickerHtml: Html)(linkHtml: Html)
 
-@if(isFirstItemOnPage) {
-    <h1 class="fc-item__title">@html</h1>
-} else {
-    <h2 class="fc-item__title">@html</h2>
+@import views.support.KickerHtml.trimAndAppend
+
+@defining(trimAndAppend(kickerHtml, linkHtml)) { innerHtml =>
+    @if(isFirstItemOnPage) {
+        <h1 class="fc-item__title">@innerHtml</h1>
+    } else {
+        <h2 class="fc-item__title">@innerHtml</h2>
+    }
 }
+

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -6,7 +6,7 @@
 @import views.support._
 
 @itemHeader(containerIndex == 0 && itemIndex == 0) {
-    @ItemKicker.fromTrail(trail, if (isSubLink) None else Some(config)).map {
+    @ItemKicker.fromTrail(trail, if(isSubLink) None else Some(config)).map {
         case BreakingNewsKicker => {
             <span class="fc-item__live-indicator">Breaking news</span>
         }
@@ -43,10 +43,8 @@
             <span class="fc-item__kicker">@Html(html)</span>
         }
     }
-
+} {
     @LinkTo(trail).map { url =>
-        <a href="@url" class="fc-item__link" data-link-name="article">
-            <span class="@labelCssClasses">@RemoveOuterParaHtml(trail.headline)</span>
-        </a>
+        <a href="@url" class="fc-item__link" data-link-name="article"><span class="@labelCssClasses">@RemoveOuterParaHtml(trail.headline)</span></a>
     }
 }

--- a/common/app/views/support/KickerHtml.scala
+++ b/common/app/views/support/KickerHtml.scala
@@ -1,0 +1,10 @@
+package views.support
+
+import play.twirl.api.{HtmlFormat, Html}
+
+/** Because I've given up on whitespace reduction in Play templates */
+object KickerHtml {
+  def trimAndAppend(left: Html, right: Html): Html = {
+    HtmlFormat.raw(left.body.trim + right.body.trim)
+  }
+}


### PR DESCRIPTION
This is for @sammorrisdesign 

We don't want any whitespace rendered in between HTML elements in the header as it makes it impossible to consistent spacing between the kicker and title for Facia cards.

Had to write a nasty hacky function to do this, I'm pretty sure no sensible way exists.
