### PR TITLE
Add space back between kicker and title

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/itemHeader.scala.html
@@ -1,9 +1,9 @@
 @(isFirstItemOnPage: Boolean, showQuote: Boolean, boostHeadline: Boolean)(kickerHtml: Html)(linkHtml: Html)
 
 @import views.support.RenderClasses
-@import views.support.KickerHtml.trimAndAppend
+@import views.support.KickerHtml.trimAndAppendWithSpace
 
-@defining(trimAndAppend(kickerHtml, linkHtml), RenderClasses(Map(
+@defining(trimAndAppendWithSpace(kickerHtml, linkHtml), RenderClasses(Map(
     "fc-item__title" -> true,
     "fc-item__title--quoted" -> showQuote,
     "fc-item__title--boosted" -> boostHeadline

--- a/common/app/views/support/KickerHtml.scala
+++ b/common/app/views/support/KickerHtml.scala
@@ -7,4 +7,8 @@ object KickerHtml {
   def trimAndAppend(left: Html, right: Html): Html = {
     HtmlFormat.raw(left.body.trim + right.body.trim)
   }
+
+  def trimAndAppendWithSpace(left: Html, right: Html): Html = {
+    HtmlFormat.raw(List(left.body.trim, right.body.trim).filter(_.nonEmpty).mkString(" "))
+  }
 }


### PR DESCRIPTION
I became a bit too trigger happy with whitespace reduction ... 

This produces the desired html, which is like

``` html
<h2 class="fc-item__title"><a href="/football/2014/sep/25/tottenham-hotspur-takeover-called-off-cain-hoy" class="fc-item__link" data-link-name="article"><span class="u-faux-block-link__cta">Tottenham Hotspur takeover called off by US group Cain Hoy</span></a></h2>
```

without a kicker and like

``` html
<h2 class="fc-item__title fc-item__title--quoted"><a href="/technology/apple-watch" class="fc-item__kicker">Apple Watch</a> <a href="/technology/2014/oct/02/apple-watch-smartwatches-and-the-wearables-fashion-gap" class="fc-item__link" data-link-name="article"><span class="u-faux-block-link__cta">Apple Watch, smartwatches and the wearables fashion gap</span></a></h2>
```

with.

CC @sammorrisdesign 
