### PR TITLE
Add fixed-small-slow-I container

### DIFF
--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -21,6 +21,7 @@ object FixedContainers {
   import ContainerDefinition.{ofSlices => slices}
 
   val all: Map[String, ContainerDefinition] = Map(
+    ("fixed/small/slow-I", slices(Full)),
     ("fixed/small/slow-III", slices(HalfQQ)),
     ("fixed/small/slow-IV", slices(QuarterQuarterQuarterQuarter)),
     ("fixed/small/slow-V-half", slices(Hl4Half)),


### PR DESCRIPTION
This exposes the `Full` slice as a new container `fixed-small-slow-I` this can then be used as the Eyewitness container.

/cc @kungpochicken @robertberry @sndrs 

![google chrome](https://cloud.githubusercontent.com/assets/80089/4540628/9cbb15f0-4e09-11e4-94f2-ad132d17ec04.png)
