### PR TITLE
Comments now have relative timestamps 

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -156,7 +156,6 @@ Comments.prototype.ready = function() {
     this.on('click', this.getClass('showHidden'), this.showHiddenComments);
     this.on('click', this.getClass('commentReport'), this.reportComment);
     this.on('change', this.getClass('orderControl'), this.setOrder);
-    mediator.on('discussion:timestamps', relativedates.init);
 
     window.setInterval(
         function () {
@@ -179,7 +178,7 @@ Comments.prototype.ready = function() {
     }
 
     this.emit('ready');
-    mediator.emit('discussion:timestamps');
+    this.relativeDates();
 
     $('.js-report-comment-close', this.elem).each(function(close) {
         bean.on(close, 'click', function() {
@@ -275,7 +274,7 @@ Comments.prototype.gotoComment = function(id) {
 Comments.prototype.gotoPage = function(page) {
     this.loading();
     scroller.scrollToElement(qwery('.discussion__comments__container .discussion__heading'), 100);
-    mediator.emit('discussion:timestamps');
+    this.relativeDates();
     return this.fetchComments({
         page: page
     }).then(function() {
@@ -289,7 +288,7 @@ Comments.prototype.gotoPage = function(page) {
 Comments.prototype.changePage = function(e) {
     e.preventDefault();
     var page = parseInt(e.currentTarget.getAttribute('data-page'), 10);
-    mediator.emit('discussion:timestamps');
+    this.relativeDates();
     return this.gotoPage(page);
 };
 
@@ -340,7 +339,7 @@ Comments.prototype.renderComments = function(resp) {
 
     this.emit('loaded');
 
-    mediator.emit('discussion:timestamps');
+    this.relativeDates();
 };
 
 /**
@@ -352,7 +351,7 @@ Comments.prototype.showHiddenComments = function(e) {
     this.removeState('partial');
     this.emit('first-load');
 
-    mediator.emit('discussion:timestamps');
+    this.relativeDates();
 };
 
 /**
@@ -417,7 +416,7 @@ Comments.prototype.getMoreReplies = function(event) {
             });
             RecommendComments.initButtons(btns);
         }
-        mediator.emit('discussion:timestamps');
+        Comments.prototype.relativeDates();
     });
 };
 
@@ -557,7 +556,7 @@ Comments.prototype.showDiscussion = function() {
         showDiscussionElem.addClass('u-h');
     }
 
-    mediator.emit('discussion:timestamps');
+    this.relativeDates();
 };
 
 Comments.prototype.loading = function() {
@@ -597,7 +596,7 @@ Comments.prototype.setOrder = function(e) {
     }).then(function() {
         this.showHiddenComments();
         this.loaded();
-        mediator.emit('discussion:timestamps');
+        this.relativeDates();
     }.bind(this));
 };
 
@@ -657,6 +656,10 @@ Comments.prototype.addUser = function(user) {
             this.on('click', this.getClass('commentPick'), this.handlePickClick);
         }
     }
+};
+
+Comments.prototype.relativeDates = function() {
+    relativedates.init();
 };
 
 return Comments;

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -4,6 +4,7 @@ define([
     'qwery',
 
     'lodash/collections/map',
+    'lodash/functions/throttle',
 
     'common/utils/$',
     'common/utils/ajax',
@@ -16,13 +17,15 @@ define([
     'common/modules/discussion/comment-box',
     'common/modules/discussion/recommend-comments',
     'common/modules/identity/api',
-    'common/modules/userPrefs'
+    'common/modules/userPrefs',
+    'common/modules/ui/relativedates'
 ], function(
     bean,
     bonzo,
     qwery,
     
     _map,
+    throttle,
 
     $,
     ajax,
@@ -35,7 +38,8 @@ define([
     CommentBox,
     RecommendComments,
     Id,
-    userPrefs
+    userPrefs,
+    relativedates
 ) {
 'use strict';
 /**
@@ -154,6 +158,14 @@ Comments.prototype.ready = function() {
     this.on('click', this.getClass('showHidden'), this.showHiddenComments);
     this.on('click', this.getClass('commentReport'), this.reportComment);
     this.on('change', this.getClass('orderControl'), this.setOrder);
+    mediator.on('discussion:Timestamps', relativedates.init);
+
+    window.setInterval(
+        function () {
+            relativedates.init();
+        },
+        60000
+    );
 
     this.addMoreRepliesButtons();
 
@@ -169,6 +181,7 @@ Comments.prototype.ready = function() {
     }
 
     this.emit('ready');
+    mediator.emit('discussion:Timestamps');
 
     $('.js-report-comment-close', this.elem).each(function(close) {
         bean.on(close, 'click', function() {
@@ -270,6 +283,8 @@ Comments.prototype.gotoPage = function(page) {
     }).then(function() {
         this.loaded();
     }.bind(this));
+
+    mediator.emit('discussion:Timestamps');
 };
 
 /**
@@ -279,6 +294,8 @@ Comments.prototype.changePage = function(e) {
     e.preventDefault();
     var page = parseInt(e.currentTarget.getAttribute('data-page'), 10);
     return this.gotoPage(page);
+
+    mediator.emit('discussion:Timestamps');
 };
 
 /**
@@ -327,6 +344,8 @@ Comments.prototype.renderComments = function(resp) {
     }
 
     this.emit('loaded');
+
+    mediator.emit('discussion:Timestamps');
 };
 
 /**
@@ -337,6 +356,8 @@ Comments.prototype.showHiddenComments = function(e) {
     this.removeState('shut');
     this.removeState('partial');
     this.emit('first-load');
+
+    mediator.emit('discussion:Timestamps');
 };
 
 /**
@@ -401,6 +422,7 @@ Comments.prototype.getMoreReplies = function(event) {
             });
             RecommendComments.initButtons(btns);
         }
+        mediator.emit('discussion:Timestamps');
     });
 };
 
@@ -539,6 +561,8 @@ Comments.prototype.showDiscussion = function() {
         bean.fire(showDiscussionElem, 'click');
         showDiscussionElem.addClass('u-h');
     }
+
+    mediator.emit('discussion:Timestamps');
 };
 
 Comments.prototype.loading = function() {

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -275,14 +275,12 @@ Comments.prototype.gotoComment = function(id) {
 Comments.prototype.gotoPage = function(page) {
     this.loading();
     scroller.scrollToElement(qwery('.discussion__comments__container .discussion__heading'), 100);
-
+    mediator.emit('discussion:timestamps');
     return this.fetchComments({
         page: page
     }).then(function() {
         this.loaded();
     }.bind(this));
-
-    mediator.emit('discussion:timestamps');
 };
 
 /**
@@ -291,9 +289,8 @@ Comments.prototype.gotoPage = function(page) {
 Comments.prototype.changePage = function(e) {
     e.preventDefault();
     var page = parseInt(e.currentTarget.getAttribute('data-page'), 10);
-    return this.gotoPage(page);
-
     mediator.emit('discussion:timestamps');
+    return this.gotoPage(page);
 };
 
 /**
@@ -600,6 +597,7 @@ Comments.prototype.setOrder = function(e) {
     }).then(function() {
         this.showHiddenComments();
         this.loaded();
+        mediator.emit('discussion:timestamps');
     }.bind(this));
 };
 

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -338,7 +338,6 @@ Comments.prototype.renderComments = function(resp) {
     }
 
     this.emit('loaded');
-
     this.relativeDates();
 };
 
@@ -350,7 +349,6 @@ Comments.prototype.showHiddenComments = function(e) {
     this.removeState('shut');
     this.removeState('partial');
     this.emit('first-load');
-
     this.relativeDates();
 };
 
@@ -555,7 +553,6 @@ Comments.prototype.showDiscussion = function() {
         bean.fire(showDiscussionElem, 'click');
         showDiscussionElem.addClass('u-h');
     }
-
     this.relativeDates();
 };
 

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -17,8 +17,8 @@ define([
     'common/modules/discussion/comment-box',
     'common/modules/discussion/recommend-comments',
     'common/modules/identity/api',
-    'common/modules/userPrefs',
-    'common/modules/ui/relativedates'
+    'common/modules/ui/relativedates',
+    'common/modules/userPrefs'
 ], function(
     bean,
     bonzo,
@@ -38,8 +38,8 @@ define([
     CommentBox,
     RecommendComments,
     Id,
-    userPrefs,
-    relativedates
+    relativedates,
+    userPrefs
 ) {
 'use strict';
 /**
@@ -158,7 +158,7 @@ Comments.prototype.ready = function() {
     this.on('click', this.getClass('showHidden'), this.showHiddenComments);
     this.on('click', this.getClass('commentReport'), this.reportComment);
     this.on('change', this.getClass('orderControl'), this.setOrder);
-    mediator.on('discussion:Timestamps', relativedates.init);
+    mediator.on('discussion:timestamps', relativedates.init);
 
     window.setInterval(
         function () {
@@ -181,7 +181,7 @@ Comments.prototype.ready = function() {
     }
 
     this.emit('ready');
-    mediator.emit('discussion:Timestamps');
+    mediator.emit('discussion:timestamps');
 
     $('.js-report-comment-close', this.elem).each(function(close) {
         bean.on(close, 'click', function() {
@@ -284,7 +284,7 @@ Comments.prototype.gotoPage = function(page) {
         this.loaded();
     }.bind(this));
 
-    mediator.emit('discussion:Timestamps');
+    mediator.emit('discussion:timestamps');
 };
 
 /**
@@ -295,7 +295,7 @@ Comments.prototype.changePage = function(e) {
     var page = parseInt(e.currentTarget.getAttribute('data-page'), 10);
     return this.gotoPage(page);
 
-    mediator.emit('discussion:Timestamps');
+    mediator.emit('discussion:timestamps');
 };
 
 /**
@@ -345,7 +345,7 @@ Comments.prototype.renderComments = function(resp) {
 
     this.emit('loaded');
 
-    mediator.emit('discussion:Timestamps');
+    mediator.emit('discussion:timestamps');
 };
 
 /**
@@ -357,7 +357,7 @@ Comments.prototype.showHiddenComments = function(e) {
     this.removeState('partial');
     this.emit('first-load');
 
-    mediator.emit('discussion:Timestamps');
+    mediator.emit('discussion:timestamps');
 };
 
 /**
@@ -422,7 +422,7 @@ Comments.prototype.getMoreReplies = function(event) {
             });
             RecommendComments.initButtons(btns);
         }
-        mediator.emit('discussion:Timestamps');
+        mediator.emit('discussion:timestamps');
     });
 };
 
@@ -562,7 +562,7 @@ Comments.prototype.showDiscussion = function() {
         showDiscussionElem.addClass('u-h');
     }
 
-    mediator.emit('discussion:Timestamps');
+    mediator.emit('discussion:timestamps');
 };
 
 Comments.prototype.loading = function() {

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -4,7 +4,6 @@ define([
     'qwery',
 
     'lodash/collections/map',
-    'lodash/functions/throttle',
 
     'common/utils/$',
     'common/utils/ajax',
@@ -25,7 +24,6 @@ define([
     qwery,
     
     _map,
-    throttle,
 
     $,
     ajax,

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -159,8 +159,8 @@ Comments.prototype.ready = function() {
 
     window.setInterval(
         function () {
-            relativedates.init();
-        },
+            this.relativeDates();
+        }.bind(this),
         60000
     );
 
@@ -414,7 +414,7 @@ Comments.prototype.getMoreReplies = function(event) {
             });
             RecommendComments.initButtons(btns);
         }
-        Comments.prototype.relativeDates();
+        self.relativeDates();
     });
 };
 


### PR DESCRIPTION
![screen shot 2014-10-07 at 12 56 54](https://cloud.githubusercontent.com/assets/2236852/4541770/10ebdcac-4e19-11e4-99b1-e207360ad170.png)

Comments now have relative timestamps across the site, with the timestamps also updating every 60 seconds.
