### PR TITLE
Live blog update endpoint gets the same cache time as the live blog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Local Install Requirements
 * Installed Ruby >= v1.9.x (on Ubuntu: `sudo apt-get install ruby ruby-dev`) &
  [bundler](http://gembundler.com/) (You may already have this installed, but
  run `ruby -v` to check version number)
+* Xcode (if on a Mac, one of the Node modules requires it) https://itunes.apple.com/gb/app/xcode/id497799835
 * Installed Memcached `sudo apt-get install memcached` - this is optional
 (most of the time you do not want to use it as caching makes local development
 harder)

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -44,9 +44,11 @@ object ArticleController extends Controller with Logging with ExecutionContexts 
             }
           }
         }
-        Cached(30)(JsonComponent(html))
+        Cached(model.article)(JsonComponent(html))
     }
   }
+
+
 
   def renderLatest(path: String, lastUpdate: Option[String]) = lastUpdate map { renderLatestFrom(path, _) } getOrElse { renderArticle(path) }
 


### PR DESCRIPTION
It is behind the same switch as the short live blog cache time, so can be switched off.
