### PR TITLE
Tag All page nav fix

### DIFF
--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -8,58 +8,53 @@
 @import common.LinkTo
 
 @defining(collection.displayName) { title =>
-
-    @defining(templateDeduping(15, collection.items)) { items =>
-        @if(items.nonEmpty) {
-            <section
-                class="@GetClasses.forNewStyleContainer(config, false, title.nonEmpty, Seq("fc-container--first","container--news"))"
-                data-link-name="all index"
-                @config.sponsorshipKeyword.map { keyword =>
-                data-keywords="@keyword"
-                }
-                data-component="all index">
-                <div class="facia-container__inner">
-                    <div class="tone-accent-border"></div>
-                    <div class="container__header">
-                        <h2 class="container__title">
-                            <span class="container__title__label today">
-                                <b class="today__dayofweek js-dayofweek">@Format(date, "EEEE")</b>
-                                <span class="u-nobr today__sub">
-                                    <span class="today__dayofmonth js-dayofmonth">@Format(date, "d")</span>
-                                    <span class="today__month">@Format(date, "MMMM")</span>
-                                    <span class="today__year">@Format(date, "yyyy")</span>
-                                </span>
-                            </span>
-                        </h2>
-                    </div>
-                    <div class="container__body container--rolled-up-hide">
-                        @for(sliceWithCards <- containerLayout.slices) {
-                            @slice(sliceWithCards, containerIndex)
-                        }
-
-                        @if(nav.isDefined) {
-                            <div class="pagination u-cf">
-                                <ol class="u-unstyled pagination__links">
-                                    <li class="pagination__item pagination__item--next">
-                                        @nav.prev.map{ prev => <a rel="prev" href="@LinkTo{@prev}">Older</a> }
-                                    </li>
-
-                                    <li class="pagination__item pagination__item--prev">
-                                        @nav.next.map{ next => <a rel="next" href="@LinkTo{@next}">Newer</a> }
-                                    </li>
-                                </ol>
-                            </div>
-                        }
-                    </div>
-                    @defining(topTags(collection.items).filterNot(_.id == page.id).take(20)) { tags =>
-                        @if(tags.nonEmpty) {
-                            <div class="related-keywords">
-                                @keywordList(tags, 5, "See also")
-                            </div>
-                        }
-                    }
-                </div>
-            </section>
+    <section
+        class="@GetClasses.forNewStyleContainer(config, false, title.nonEmpty, Seq("fc-container--first","container--news"))"
+        data-link-name="all index"
+        @config.sponsorshipKeyword.map { keyword =>
+        data-keywords="@keyword"
         }
-    }
+        data-component="all index">
+        <div class="facia-container__inner">
+            <div class="tone-accent-border"></div>
+            <div class="container__header">
+                <h2 class="container__title">
+                    <span class="container__title__label today">
+                        <b class="today__dayofweek js-dayofweek">@Format(date, "EEEE")</b>
+                        <span class="u-nobr today__sub">
+                            <span class="today__dayofmonth js-dayofmonth">@Format(date, "d")</span>
+                            <span class="today__month">@Format(date, "MMMM")</span>
+                            <span class="today__year">@Format(date, "yyyy")</span>
+                        </span>
+                    </span>
+                </h2>
+            </div>
+            <div class="container__body container--rolled-up-hide">
+                @for(sliceWithCards <- containerLayout.slices) {
+                    @slice(sliceWithCards, containerIndex)
+                }
+
+                @if(nav.isDefined) {
+                    <div class="pagination u-cf">
+                        <ol class="u-unstyled pagination__links">
+                            <li class="pagination__item pagination__item--next">
+                                @nav.prev.map{ prev => <a rel="prev" href="@LinkTo{@prev}">Older</a> }
+                            </li>
+
+                            <li class="pagination__item pagination__item--prev">
+                                @nav.next.map{ next => <a rel="next" href="@LinkTo{@next}">Newer</a> }
+                            </li>
+                        </ol>
+                    </div>
+                }
+            </div>
+            @defining(topTags(collection.items).filterNot(_.id == page.id).take(20)) { tags =>
+                @if(tags.nonEmpty) {
+                    <div class="related-keywords">
+                        @keywordList(tags, 5, "See also")
+                    </div>
+                }
+            }
+        </div>
+    </section>
 }


### PR DESCRIPTION
As we are doing templateDeduping in containerLayout we don't need it tag all template.

I also removed nonEmpty statement on items. It should never happen and if it will happen it will be nicer to show at least title than totally blank page.
