### PR TITLE
adding fluid 250 links to admin page

### DIFF
--- a/admin/app/controllers/CommercialController.scala
+++ b/admin/app/controllers/CommercialController.scala
@@ -15,6 +15,10 @@ object CommercialController extends Controller with Logging with AuthLogging {
     NoCache(Ok(views.html.commercial.commercial(Configuration.environment.stage)))
   }
 
+  def renderFluidAds = AuthActions.AuthActionTest { implicit request =>
+    NoCache(Ok(views.html.commercial.fluidAds(Configuration.environment.stage)))
+  }
+
   def renderSponsorships = AuthActions.AuthActionTest { implicit request =>
     val sponsoredTags = Store.getDfpSponsoredTags()
     val advertisementTags = Store.getDfpAdvertisementTags()
@@ -42,5 +46,5 @@ object CommercialController extends Controller with Logging with AuthLogging {
   def renderCreativeTemplates = AuthActions.AuthActionTest { implicit request =>
     val templates = DfpDataHydrator.loadActiveUserDefinedCreativeTemplates()
     NoCache(Ok(views.html.commercial.templates(Configuration.environment.stage, templates)))
-  }
+  } 
 }

--- a/admin/app/controllers/CommercialController.scala
+++ b/admin/app/controllers/CommercialController.scala
@@ -46,5 +46,5 @@ object CommercialController extends Controller with Logging with AuthLogging {
   def renderCreativeTemplates = AuthActions.AuthActionTest { implicit request =>
     val templates = DfpDataHydrator.loadActiveUserDefinedCreativeTemplates()
     NoCache(Ok(views.html.commercial.templates(Configuration.environment.stage, templates)))
-  } 
+  }
 }

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -106,6 +106,7 @@
                         <li><a href="http://m.code.dev-theguardian.com/commercial/test-page">Components test page</a>, (on dev)</li>
                         <li><a href="http://adimage.theguardian.com/cookietest/cookies.html">Adserver test cookies</a></li>
                         <li><a href="@controllers.admin.routes.CommercialAdUnitController.renderToApprove()">NG Ad Units for approval</a></li>
+                        <li><a href="@controllers.admin.routes.CommercialController.renderFluidAds()">Fluid 250 Ads</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/app/views/commercial/fluidAds.scala.html
+++ b/admin/app/views/commercial/fluidAds.scala.html
@@ -1,0 +1,27 @@
+@(env: String)
+
+@admin_main("Commercial", env, isAuthed = true, hasCharts = true) {
+
+    <link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/commercial.css")">
+
+    <h1>Commercial</h1>
+
+    <h3>Fluid 250 ads</h3>
+    
+    <p>These are links to the "fluid 250" ads that we have created so far. All are served from DFP and are hidden behind cookies.</p>
+    
+    <ul class="list-group">
+        <li class="list-group-item">
+            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng101&view=mobile">Live Better</a></h4>
+        </li>
+        <li class="list-group-item">
+            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng102&view=mobile">Nissan</a></h4>
+        </li>
+        <li class="list-group-item">
+            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng103&view=mobile">Own the Weekend</a></h4>
+        </li>
+        <li class="list-group-item">
+            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng104&view=mobile">ITV - Grantchester</a></h4>
+        </li>
+    </ul>
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -55,6 +55,7 @@ GET         /analytics/commercial/im-sponsorships   controllers.admin.Commercial
 GET         /analytics/commercial/templates         controllers.admin.CommercialController.renderCreativeTemplates()
 GET         /commercialtools/adunits/toapprove      controllers.admin.CommercialAdUnitController.renderToApprove()
 POST        /commercialtools/adunits/toapprove      controllers.admin.CommercialAdUnitController.approve()
+GET         /admin/commercial/fluid250              controllers.admin.CommercialController.renderFluidAds()
 
 # Metrics
 GET         /metrics/loadbalancers        controllers.admin.MetricsController.renderLoadBalancers()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -268,7 +268,9 @@ GET         /commercial/capi                                                    
 
 GET         /commercialtools/adunits/toapprove                                                                       controllers.admin.CommercialAdUnitController.renderToApprove()
 POST        /commercialtools/adunits/toapprove                                                                       controllers.admin.CommercialAdUnitController.approve()
+GET         /admin/commercial/fluid250                                                                               controllers.admin.CommercialController.renderFluidAds()
 GET         /commercial/multi.json                                                                                   controllers.commercial.Multi.renderMulti
+
 # dev-build only
 GET         /commercial/magento/token                                                                                controllers.commercial.magento.AccessTokenGenerator.generate
 GET         /commercial/magento/resource                                                                             controllers.commercial.magento.ApiSandbox.getResource(t: String)


### PR DESCRIPTION
This adds a page with links out to the fluid 250 examples on code, (all hidden behind cookies.)
