### PR TITLE
Add Links to Creatives Built from DFP Templates

### DIFF
--- a/admin/app/tools/DfpLink.scala
+++ b/admin/app/tools/DfpLink.scala
@@ -12,6 +12,10 @@ object DfpLink {
   def creativeTemplate(templateId: Long) = {
     s"https://www.google.com/dfp/$dfpAccountId#delivery/CreateCreativeTemplate/creativeTemplateId=$templateId"
   }
+
+  def creative(creativeId: Long) = {
+    s"https://www.google.com/dfp/$dfpAccountId#delivery/CreativeDetail/creativeId=$creativeId"
+  }
 }
 
 object SiteLink {

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -12,10 +12,10 @@
         <li style="margin-top:60px;margin-bottom:60px">
             <p style="font-size:large;font-weight:bold">@template.name (<a href="@DfpLink.creativeTemplate(template.id)">@template.id</a>)</p>
             <p>@{template.description}</p>
-            @if(template.creativeIds.isEmpty){<p><b>This template is not in use.</b></p>}
-            @if(template.creativeIds.nonEmpty){
-                <p>Creatives built from this template:<ul>@for(creativeId <- template.creativeIds){
-                    <li><a href="@DfpLink.creative(creativeId)">@creativeId</a></li>
+            @if(template.creatives.isEmpty){<p><b>This template is not in use.</b></p>}
+            @if(template.creatives.nonEmpty){
+                <p>Creatives built from this template:<ul>@for(creative <- template.creatives){
+                    <li>@{creative.name} (<a href="@DfpLink.creative(creative.id)">@{creative.id}</a>)</li>
                 }</ul></p>
             }
             <div>
@@ -33,6 +33,10 @@
             </div>
             <p style="font-weight:bold">Snippet</p>
             <p>@{template.snippet}</p>
+            @for(example <- template.example) {
+                <p style="font-weight : bold">Example</p>
+                <p>@Html(example)</p>
+            }
         </li>
     }
     </ol>

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -1,11 +1,16 @@
 @(env: String, templates: Seq[dfp.GuCreativeTemplate])
 @import tools.DfpLink
 
-@admin_main("Commercial Templates", env, isAuthed = true) {
+@admin_main("Creative Templates", env, isAuthed = true) {
 
     <link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/commercial.css")">
 
     <h1>Creative Templates</h1>
+
+    <p>This dashboard is to help debug DFP creative templates.<br />
+        All unarchived creative templates are shown.</p>
+    <p>The creatives listed under each template are only those owned by the Guardian Merchandising account.<br />
+        So a template might appear to be unused when in fact other creatives have been built from it.</p>
 
     <ol>
     @for(template <- templates) {

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -1,4 +1,4 @@
-@(env: String, templates: Seq[com.google.api.ads.dfp.axis.v201403.CreativeTemplate])
+@(env: String, templates: Seq[dfp.GuCreativeTemplate])
 @import tools.DfpLink
 
 @admin_main("Commercial Templates", env, isAuthed = true) {
@@ -10,23 +10,29 @@
     <ol>
     @for(template <- templates) {
         <li style="margin-top:60px;margin-bottom:60px">
-            <p style="font-size:large;font-weight:bold">@template.getName (<a href="@DfpLink.creativeTemplate(template.getId)">@template.getId</a>)</p>
-            <p>@{template.getDescription}</p>
+            <p style="font-size:large;font-weight:bold">@template.name (<a href="@DfpLink.creativeTemplate(template.id)">@template.id</a>)</p>
+            <p>@{template.description}</p>
+            @if(template.creativeIds.isEmpty){<p><b>This template is not in use.</b></p>}
+            @if(template.creativeIds.nonEmpty){
+                <p>Creatives built from this template:<ul>@for(creativeId <- template.creativeIds){
+                    <li><a href="@DfpLink.creative(creativeId)">@creativeId</a></li>
+                }</ul></p>
+            }
             <div>
                 <p style="font-weight:bold">Parameters:</p>
                 <table style="margin-bottom:20px">
-                    @for(param <- template.getVariables) {
+                    @for(param <- template.parameters) {
                         <tr>
-                            <td style="padding-right:10px;word-break:normal">@{param.getLabel}</td>
-                            <td style="padding-right:10px">@{param.getCreativeTemplateVariableType.stripSuffix("CreativeTemplateVariable")}</td>
-                            <td style="padding-right:10px"><span style="font-size:small">@if(param.getIsRequired){Required}else{Optional}</span></td>
-                            <td style="padding-right:10px">@{param.getDescription}</td>
+                            <td style="padding-right:10px;word-break:normal">@{param.label}</td>
+                            <td style="padding-right:10px">@{param.parameterType}</td>
+                            <td style="padding-right:10px"><span style="font-size:small">@if(param.isRequired){Required}else{Optional}</span></td>
+                            <td style="padding-right:10px">@{param.description}</td>
                         </tr>
                     }
                 </table>
             </div>
             <p style="font-weight:bold">Snippet</p>
-            <p>@{template.getSnippet}</p>
+            <p>@{template.snippet}</p>
         </li>
     }
     </ol>

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -230,6 +230,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val soulmates_url = configuration.getMandatoryStringProperty("commercial.soulmates_url")
     lazy val travel_url = configuration.getMandatoryStringProperty("commercial.travel_url")
     lazy val traveloffers_url = configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
+    lazy val guMerchandisingAdvertiserId = configuration.getMandatoryStringProperty("dfp.guMerchandising.advertiserId")
 
     private lazy val dfpRoot = s"${environment.stage.toUpperCase}/commercial/dfp"
     lazy val dfpSponsoredTagsDataKey = s"$dfpRoot/sponsored-tags-v5.json"

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -179,3 +179,13 @@ object GuLineItem {
   }
 
 }
+
+
+case class CreativeTemplateParameter(parameterType: String, label: String, isRequired: Boolean, description: String)
+
+case class GuCreativeTemplate(id: Long,
+                              name: String,
+                              description: String,
+                              parameters: Seq[CreativeTemplateParameter],
+                              snippet: String,
+                              creativeIds: Seq[Long])

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -79,6 +79,7 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
+dfp.guMerchandising.advertiserId=24113847
 
 #Pressing
 admin.pressjob.standard.push.rate.inminutes=5

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -70,6 +70,7 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
+dfp.guMerchandising.advertiserId=24113847
 
 #Facia-tool Oauth
 faciatool.oauth.clientid=283258724824-gv88hsfbl2os5n9qlt2ocs8bu94cao5r.apps.googleusercontent.com

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -74,6 +74,7 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
+dfp.guMerchandising.advertiserId=24113847
 
 # Pressing
 admin.pressjob.standard.push.rate.inminutes=5


### PR DESCRIPTION
This is the first step in showing an example of each DFP creative template in the templates dashboard.

For each template there is now a list of links to the creatives built from that template.

![image](https://cloud.githubusercontent.com/assets/1722550/4556474/78d69d2e-4ec9-11e4-8db5-31a5552a1dec.png)

@ironsidevsquincy 
