### PR TITLE
Facia-tool: Fix delete fronts image

### DIFF
--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -90,6 +90,17 @@ define([
         this.provisionalImageUrl.subscribe(function(src) {
             var self = this;
 
+            var isEmpty = src === '' || src === undefined;
+            window.console.log("isEmpty: " + isEmpty);
+            window.console.log("src " + src);
+            if(isEmpty){
+                self.props.imageUrl(undefined);
+                self.props.imageWidth(undefined);
+                self.props.imageHeight(undefined);
+                self.props.isImageDisplayed(undefined);
+                return;
+            }
+
             if (src === this.props.imageUrl()) { return; }
 
             validateImageSrc(src, {minWidth: 120})

--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -90,10 +90,7 @@ define([
         this.provisionalImageUrl.subscribe(function(src) {
             var self = this;
 
-            var isEmpty = src === '' || src === undefined;
-            window.console.log("isEmpty: " + isEmpty);
-            window.console.log("src " + src);
-            if(isEmpty){
+            if(!src){
                 self.props.imageUrl(undefined);
                 self.props.imageWidth(undefined);
                 self.props.imageHeight(undefined);


### PR DESCRIPTION
Allows the front image to be deleted. Unchecks the display image box if it's marked.
![screen shot 2014-10-01 at 18 53 25](https://cloud.githubusercontent.com/assets/1492162/4557900/9b380f1a-4ed8-11e4-8278-aa703be4d1cc.png)
