### PR TITLE
Fronts: fix on-page description HTML render

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -42,7 +42,7 @@
                             <img src="@url" alt="@title" />
                         </div>
                     }
-                    @frontProperties.onPageDescription
+                    @frontProperties.onPageDescription.map(Html(_))
                 </div>
             }
         }

--- a/static/src/stylesheets/module/facia-cards/_container.scss
+++ b/static/src/stylesheets/module/facia-cards/_container.scss
@@ -70,13 +70,12 @@ $header-image-size-desktop: 120px;
 }
 .fc-container__header__description,
 .fc-container__header__description--image {
+    @include fs-headline(2);
     padding-bottom: $gs-baseline / 2;
-
-    @include fs-bodyCopy(1);
+    color: $c-neutral2;
 
     @include mq(tablet) {
         padding-bottom: $gs-baseline;
-        @include fs-bodyCopy(2, true);
     }
 }
 .fc-container__header__description--image {


### PR DESCRIPTION
Display HTML tags properly if present.
Fixes this rendering
![screen shot 2014-10-08 at 11 51 22](https://cloud.githubusercontent.com/assets/1492162/4557936/2659efbe-4ed9-11e4-9f4d-407d86e1ace2.png)
