### PR TITLE
Enable show/hide on most-popular container

### DIFF
--- a/common/app/views/fragments/containers/popular.scala.html
+++ b/common/app/views/fragments/containers/popular.scala.html
@@ -12,6 +12,7 @@
             class="@RenderClasses(Map(
                 ("container", true),
                 (s"container--${style.containerType}", true),
+                ("js-container--toggle", true),
                 ("container--first" -> (containerIndex == 0))))"
             data-link-name="@FaciaComponentName(config, collection)"
             data-id="@config.id"

--- a/static/src/javascripts/bootstraps/facia.js
+++ b/static/src/javascripts/bootstraps/facia.js
@@ -72,7 +72,7 @@ define([
 
             upgradeMostPopularToGeo: function (config) {
                 if (config.page.contentType === 'Network Front' && config.switches.geoMostPopular) {
-                    //new GeoMostPopularFront(mediator, config).go();
+                    new GeoMostPopularFront(mediator, config).go();
                 }
             }
         },

--- a/static/src/javascripts/bootstraps/facia.js
+++ b/static/src/javascripts/bootstraps/facia.js
@@ -60,9 +60,10 @@ define([
                 };
                 mediator.addListeners({
                     'page:front:ready': containerToggleAdd,
-                    'ui:container-toggle:add':  containerToggleAdd
+                    'ui:container-toggle:add':  containerToggleAdd,
+                    'modules:geomostpopular:ready': containerToggleAdd
                 });
-                mediator.on(/page:front:ready|ui:container-toggle:add/, function (config, context) {
+                mediator.on(/page:front:ready|ui:container-toggle:add|modules:geomostpopular:ready/, function (config, context) {
                     $('.js-container--toggle', context).each(function (container) {
                         new ContainerToggle(container).addToggle();
                     });
@@ -71,7 +72,7 @@ define([
 
             upgradeMostPopularToGeo: function (config) {
                 if (config.page.contentType === 'Network Front' && config.switches.geoMostPopular) {
-                    new GeoMostPopularFront(mediator, config).go();
+                    //new GeoMostPopularFront(mediator, config).go();
                 }
             }
         },

--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
@@ -6,12 +6,14 @@ define([
     'qwery',
     'lodash/objects/assign',
     'common/modules/component',
-    'common/modules/analytics/register'
+    'common/modules/analytics/register',
+    'common/utils/mediator'
 ], function (
     qwery,
     extend,
     Component,
-    register
+    register,
+    mediator
     ) {
 
     function GeoMostPopularFront(mediator, config) {
@@ -35,6 +37,7 @@ define([
 
     GeoMostPopularFront.prototype.ready = function () {
         register.end('most-popular');
+        mediator.emit('modules:geomostpopular:ready');
     };
 
     return GeoMostPopularFront;


### PR DESCRIPTION
We currently do not apply the show/hide toggle functionality to the most popular container. UX think this is inconsistency.
- Apply JS hook to container
- Ensure async geo-most-popular containers get upgraded

/cc @sndrs @robertberry 
