### PR TITLE
Fix breaking issue with date

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/date.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/date.scala.html
@@ -4,7 +4,7 @@
 
 <div class="fc-today">
     <span class="fc-today__dayofweek js-dayofweek">@Format(date, "EEEE")</span>
-    <span class="u-nobr today__sub">
+    <span class="u-nobr fc-today__sub">
         <span class="fc-today__dayofmonth js-dayofmonth">@Format(date, "d")</span>
         <span class="fc-today__month">@Format(date, "MMMM")</span>
         <span class="fc-today__year">@Format(date, "yyyy")</span>

--- a/static/src/stylesheets/module/facia-cards/_container.scss
+++ b/static/src/stylesheets/module/facia-cards/_container.scss
@@ -166,7 +166,7 @@ $header-image-size-desktop: 120px;
 
     @include mq(wide) {
         .has-page-skin & {
-            display: inline;
+            display: none;
         }
     }
 }

--- a/static/src/stylesheets/module/facia-cards/_container.scss
+++ b/static/src/stylesheets/module/facia-cards/_container.scss
@@ -1,19 +1,6 @@
 $header-image-size-mobile: 80px;
 $header-image-size-desktop: 120px;
 
-@mixin left-col {
-    @include mq($from: leftCol, $to: wide) {
-        @content
-    }
-
-    /** When there is a page skin, there is no left column on wide */
-    body:not(.has-page-skin) {
-        @include mq(wide) {
-            @content
-        }
-    }
-}
-
 .fc-container {
     padding-bottom: $gs-baseline;
     margin-bottom: 0;
@@ -111,15 +98,28 @@ $header-image-size-desktop: 120px;
     padding-top: $gs-baseline/3;
     @include fs-headline(2);
 
-    @include left-col {
+    @include mq(leftCol) {
         border-top: 1px solid $c-neutral5;
         margin-top: $gs-baseline/2;
     }
+
+    @include mq(wide) {
+        .has-page-skin & {
+            border-top: 0;
+            margin-top: 0;
+        }
+    }
 }
 
-@include left-col {
-    .fc-today__sub {
+.fc-today__sub {
+    @include mq(leftCol) {
         display: block;
+    }
+
+    @include mq(wide) {
+        .has-page-skin & {
+            display: inline;
+        }
     }
 }
 
@@ -160,8 +160,14 @@ $header-image-size-desktop: 120px;
 
     @include fs-headline(1);
 
-    @include left-col {
+    @include mq(leftCol) {
         display: block;
+    }
+
+    @include mq(wide) {
+        .has-page-skin & {
+            display: inline;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia-cards/_container.scss
+++ b/static/src/stylesheets/module/facia-cards/_container.scss
@@ -1,6 +1,19 @@
 $header-image-size-mobile: 80px;
 $header-image-size-desktop: 120px;
 
+@mixin left-col {
+    @include mq($from: leftCol, $to: wide) {
+        @content
+    }
+
+    /** When there is a page skin, there is no left column on wide */
+    body:not(.has-page-skin) {
+        @include mq(wide) {
+            @content
+        }
+    }
+}
+
 .fc-container {
     padding-bottom: $gs-baseline;
     margin-bottom: 0;
@@ -95,20 +108,16 @@ $header-image-size-desktop: 120px;
 }
 
 .fc-today {
-    @include mq(leftCol) {
+    padding-top: $gs-baseline/3;
+    @include fs-headline(2);
+
+    @include left-col {
         border-top: 1px solid $c-neutral5;
         margin-top: $gs-baseline/2;
     }
-
-    padding-top: $gs-baseline/3;
-    @include fs-headline(2);
 }
 
-.fc-today__dayofweek {
-    font-weight: 500;
-}
-
-@include mq(wide) {
+@include left-col {
     .fc-today__sub {
         display: block;
     }
@@ -144,14 +153,15 @@ $header-image-size-desktop: 120px;
 
 .fc-container__updated {
     color: $c-neutral2;
-    display: block;
-    @include fs-headline(1);
+    display: none;
     margin-top: ($gs-baseline/3)*5;
     padding-bottom: $gs-baseline/3;
     border-bottom: 1px dotted $c-neutral5;
 
-    @include mq($until: leftCol) {
-        display: none;
+    @include fs-headline(1);
+
+    @include left-col {
+        display: block;
     }
 }
 


### PR DESCRIPTION
Fixes this ugliness:

![screen shot 2014-10-08 at 17 51 35](https://cloud.githubusercontent.com/assets/1001642/4563173/6770b7b2-4f0b-11e4-8ac4-c4af54f53d4c.png)

Now looks like this:

![screen shot 2014-10-08 at 17 50 23](https://cloud.githubusercontent.com/assets/1001642/4563169/52876a94-4f0b-11e4-9818-cb47e6edff0c.png)
