### PR TITLE
Fix pressed json format

### DIFF
--- a/facia-press/app/frontpress/FrontPress.scala
+++ b/facia-press/app/frontpress/FrontPress.scala
@@ -32,9 +32,9 @@ trait FrontPress extends Logging {
   def generateJson(id: String,
                    seoData: SeoData,
                    frontProperties: FrontProperties,
-                   collections: Seq[(CollectionConfig, Collection)]): Try[JsObject] = {
+                   collections: Seq[(CollectionConfigWithId, Collection)]): Try[JsObject] = {
     val collectionsWithBackFills = collections.toList collect {
-      case (config, collection) if config.apiQuery.isDefined => collection
+      case (configWithId, collection) if configWithId.config.apiQuery.isDefined => collection
     }
 
     if (collectionsWithBackFills.nonEmpty && collectionsWithBackFills.forall(_.isBackFillEmpty)) {
@@ -42,8 +42,8 @@ trait FrontPress extends Logging {
       log.error(errorMessage)
       Failure(new RuntimeException(errorMessage))
     } else {
-      val collectionsJson = collections.map { case (config, collection) =>
-        Json.obj(id -> Json.toJson(CollectionJson.fromCollection(config, collection)))
+      val collectionsJson = collections.map { case (configWithId, collection) =>
+        Json.obj(configWithId.id -> Json.toJson(CollectionJson.fromCollection(configWithId.config, collection)))
       }.foldLeft(Json.arr()) { case (l, jsObject) => l :+ jsObject}
 
       Success(Json.obj(
@@ -54,9 +54,9 @@ trait FrontPress extends Logging {
     }
   }
 
-  private def retrieveCollectionsById(id: String, parseCollection: ParseCollection): Future[Seq[(CollectionConfig, Collection)]] = {
+  private def retrieveCollectionsById(id: String, parseCollection: ParseCollection): Future[Seq[(CollectionConfigWithId, Collection)]] = {
     val collectionIds: List[CollectionConfigWithId] = ConfigAgent.getConfigForId(id).getOrElse(Nil)
-    val collections = collectionIds.map(config => parseCollection.getCollection(config.id, config.config, Uk).map((config.config, _)))
+    val collections = collectionIds.map(config => parseCollection.getCollection(config.id, config.config, Uk).map((config, _)))
     Future.sequence(collections)
   }
 

--- a/facia-press/test/frontpress/FrontPressTest.scala
+++ b/facia-press/test/frontpress/FrontPressTest.scala
@@ -4,6 +4,7 @@ import com.gu.facia.client.models.CollectionConfig
 import model._
 import org.scalatest.{DoNotDiscover, TryValues, Matchers, FlatSpec}
 import com.gu.openplatform.contentapi.model.{Content => ApiContent}
+import services.CollectionConfigWithId
 import test.ConfiguredTestSuite
 
 @DoNotDiscover class FrontPressTest extends FlatSpec with Matchers with TryValues with ConfiguredTestSuite {
@@ -24,7 +25,7 @@ import test.ConfiguredTestSuite
     None
   )
 
-  val configWithBackFill = CollectionConfig.emptyConfig.copy(apiQuery = Some(""))
+  val configWithBackFill = CollectionConfigWithId("NoId", CollectionConfig.emptyConfig.copy(apiQuery = Some("")))
 
   val emptyCollection = Collection(
     Nil
@@ -55,7 +56,7 @@ import test.ConfiguredTestSuite
 
   it should "not return an error if there are no back fills" in {
     FrontPress.generateJson("", seoDataFixture, frontPropertiesFixture, List(
-      CollectionConfig.emptyConfig -> emptyCollection
+      CollectionConfigWithId("NoId", CollectionConfig.emptyConfig) -> emptyCollection
     )) should be a 'success
   }
 


### PR DESCRIPTION
Since yesterday we are using the wrong ID for each collection in the `pressed.json` files.

@stephanfowler 
