### PR TITLE
Page title fix

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_container.scss
+++ b/static/src/stylesheets/module/facia-cards/_container.scss
@@ -33,6 +33,16 @@ $header-image-size-desktop: 120px;
     @include mq($until: tablet) {
         @include fs-header(5);
     }
+
+    @include mq(leftCol) {
+        float: left;
+        width: $left-column;
+    }
+
+    @include mq(wide) {
+        width: $left-column-wide;
+    }
+
     a {
         color: inherit;
     }


### PR DESCRIPTION
Page title is broken. I am adding quick fix and will investigate what caused it later.

Now:
![screen shot 2014-10-09 at 16 20 52](https://cloud.githubusercontent.com/assets/2579465/4578877/071653aa-4fc8-11e4-9ff8-51762f1806d1.png)

Should be:
![screen shot 2014-10-09 at 16 21 00](https://cloud.githubusercontent.com/assets/2579465/4578881/0e5b1312-4fc8-11e4-9372-819f2a70587e.png)
