### PR TITLE
Force users to be recently authenticated to view their Profile [#MEM-403]

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -30,7 +30,7 @@ class EditProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
   with ExecutionContexts
   with SafeLogging{
 
-  import authenticatedActions.authActionWithUser
+  import authenticatedActions._
 
   type OmniPage = IdentityPage with Omniture
 
@@ -45,7 +45,7 @@ class EditProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
   def displayMembershipForm = displayForm(membershipPage)
 
   protected def displayForm(page: OmniPage) = CSRFAddToken {
-    authActionWithUser.async { implicit request =>
+    recentlyAuthenticated.async { implicit request =>
       profileFormsView(page.tracking, ProfileForms(request.user, false))
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 object Dependencies {
   val cucumberVersion = "1.1.5"
-  val identityLibVersion = "3.41"
+  val identityLibVersion = "3.43"
   val seleniumVersion = "2.43.1"
   val slf4jVersion = "1.7.5"
 


### PR DESCRIPTION
With this commit, the user must have a recently dropped  (last 20 minutes) SC_GA_LA ('Last Authentication') cookie to access these urls:

https://profile.theguardian.com/account/edit
https://profile.theguardian.com/public/edit
https://profile.theguardian.com/membership/edit

https://jira.gutools.co.uk/browse/MEM-403

cc @adamnfish @Nick-Smith @dbgdngit @JuliaBellis
