### PR TITLE
Support Multi-part Section IDs

### DIFF
--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -28,7 +28,8 @@ case class Sponsorship(tags: Seq[String],
                        sponsor: Option[String],
                        countries: Seq[String],
                        lineItemId: Long) {
-  def hasTag(tagId: String): Boolean = tags contains tagId.split('/').last
+
+  def hasTag(tagId: String): Boolean = tags exists tagId.endsWith
 }
 
 

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -27,11 +27,11 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
     "content-type" -> JsString("Section")
   )
 
-  override lazy val isSponsored: Boolean = DfpAgent.isSponsored(this.id)
-  override lazy val hasMultipleSponsors: Boolean = DfpAgent.hasMultipleSponsors(this.id)
-  override lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(this.id)
-  override lazy val hasMultipleFeatureAdvertisers: Boolean = DfpAgent.hasMultipleFeatureAdvertisers(this.id)
-  override lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(id)
-  override lazy val sponsor: Option[String] = DfpAgent.getSponsor(this.id)
+  override lazy val isSponsored: Boolean = DfpAgent.isSponsored(id, Some(id))
+  override lazy val hasMultipleSponsors: Boolean = DfpAgent.hasMultipleSponsors(id)
+  override lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(id, Some(id))
+  override lazy val hasMultipleFeatureAdvertisers: Boolean = DfpAgent.hasMultipleFeatureAdvertisers(id)
+  override lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(id, Some(id))
+  override lazy val sponsor: Option[String] = DfpAgent.getSponsor(id)
   override def hasPageSkin(edition: Edition): Boolean = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 }

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -34,9 +34,9 @@ trait Trail extends Elements with Tags with FaciaFields with Dates {
     isAdvertisementFeature && webPublicationDate.isOlderThan(2.weeks)
   }
 
-  override def isSponsored: Boolean = DfpAgent.isSponsored(tags, Some(section))
-  override def isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(tags, Some(section))
-  override def isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(tags, Some(section))
+  override lazy val isSponsored: Boolean = DfpAgent.isSponsored(tags, Some(section))
+  override lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(tags, Some(section))
+  override lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(tags, Some(section))
 }
 
 //Facia tool values

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -30,11 +30,11 @@ case class FaciaPage(id: String,
 
   override lazy val contentType: String = if (isNetworkFront) GuardianContentTypes.NetworkFront else GuardianContentTypes.Section
 
-  override lazy val isSponsored = DfpAgent.isSponsored(id)
+  override lazy val isSponsored = DfpAgent.isSponsored(id, Some(section))
   override def hasMultipleSponsors = false // Todo: need to think about this
-  override lazy val isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id)
+  override lazy val isAdvertisementFeature = DfpAgent.isAdvertisementFeature(id, Some(section))
   override def hasMultipleFeatureAdvertisers = false // Todo: need to think about this
-  override lazy val isFoundationSupported = DfpAgent.isFoundationSupported(id)
+  override lazy val isFoundationSupported = DfpAgent.isFoundationSupported(id, Some(section))
   override def sponsor = DfpAgent.getSponsor(id)
   override def hasPageSkin(edition: Edition) = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 


### PR DESCRIPTION
Now sections containing a '/' should be able to show sponsor logos.

http://www.theguardian.com/sustainable-business/grundfos-partner-zone already works because it targets the partial section _sustainable-business_.
