### PR TITLE
Discussion hyperlink button changes

### DIFF
--- a/discussion/app/views/fragments/commentBox.scala.html
+++ b/discussion/app/views/fragments/commentBox.scala.html
@@ -37,7 +37,7 @@
             <li class="d-comment-box__formatting-bold" title="Bold">B</li>
             <li class="d-comment-box__formatting-italic" title="Italic">i</li>
             <li class="d-comment-box__formatting-quote" title="Quote">&#8221;</li>
-            <li class="d-comment-box__formatting-link" title="Link">http://</li>
+            <li class="d-comment-box__formatting-link" title="Link">Link</li>
         </ul>
         <div class="d-comment-box__preview-wrapper">
             <div class="d-comment-box__preview-spout"></div>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -418,13 +418,13 @@ CommentBox.prototype.formatComment = function(formatStyle) {
         var linkURL;
         if (/^https?:\/\//i.test(selectedText)) {
             href = selectedText;
-        } else if(selectedText) {
-            linkURL = window.prompt('Your URL:', 'http://www.');
-            href = linkURL;
         } else {
             linkURL = window.prompt('Your URL:', 'http://www.');
             href = linkURL;
-            selectedText = linkURL;
+
+            if(!selectedText) {
+                selectedText = linkURL;
+            }
         }
         var newText = '<a href="' + href + '">' + selectedText + '</a>';
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -422,9 +422,7 @@ CommentBox.prototype.formatComment = function(formatStyle) {
             linkURL = window.prompt('Your URL:', 'http://www.');
             href = linkURL;
 
-            if(!selectedText) {
-                selectedText = linkURL;
-            }
+            selectedText = selectedText || linkURL;
         }
         var newText = '<a href="' + href + '">' + selectedText + '</a>';
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -415,14 +415,14 @@ CommentBox.prototype.formatComment = function(formatStyle) {
 
     var formatSelectionLink = function() {
         var href;
-
+        var linkURL;
         if (/^https?:\/\//i.test(selectedText)) {
             href = selectedText;
         } else if(selectedText) {
-            var linkURL = prompt("Your URL:", "http://www.");
+            linkURL = window.prompt('Your URL:', 'http://www.');
             href = linkURL;
         } else {
-            var linkURL = prompt("Your URL:", "http://www.");
+            linkURL = window.prompt('Your URL:', 'http://www.');
             href = linkURL;
             selectedText = linkURL;
         }

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -418,15 +418,18 @@ CommentBox.prototype.formatComment = function(formatStyle) {
 
         if (/^https?:\/\//i.test(selectedText)) {
             href = selectedText;
+        } else if(selectedText) {
+            var linkURL = prompt("Your URL:", "http://www.");
+            href = linkURL;
         } else {
-            href = 'http://';
+            var linkURL = prompt("Your URL:", "http://www.");
+            href = linkURL;
+            selectedText = linkURL;
         }
         var newText = '<a href="' + href + '">' + selectedText + '</a>';
 
         commentBody.value = commentBody.value.substring(0, commentBody.selectionStart) +
             newText + commentBody.value.substring(commentBody.selectionEnd);
-
-        selectNewText(newText);
     };
 
     var selectNewText = function(newText) {


### PR DESCRIPTION
Updates to the hyperlink button. 

The button now says "link" as opposed to "http://" & the logic has changed to more closely remember R2. 

The user is now prompted input the link URL if one isn't provided, as they would in R2.

![screen shot 2014-10-09 at 17 27 44](https://cloud.githubusercontent.com/assets/2236852/4579937/42f5159c-4fd1-11e4-8595-fff8e04d741b.png)
