### PR TITLE
Hide closed discussion threads with zero comments

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -338,6 +338,7 @@ Loader.prototype.getDiscussionClosed = function() {
  * TODO (jamesgorrie): Needs a refactor, good ol' copy and paste.
  */
 Loader.prototype.renderCommentCount = function() {
+    var self = this;
     ajax({
         url: '/discussion/comment-counts.json?shortUrls=' + this.getDiscussionId(),
         type: 'json',
@@ -357,6 +358,8 @@ Loader.prototype.renderCommentCount = function() {
                                '</a>';
 
                     bonzo(qwery('.js-comment-count')).html(html);
+                } else {
+                    self.setState('empty');
                 }
             }
         }

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -338,7 +338,6 @@ Loader.prototype.getDiscussionClosed = function() {
  * TODO (jamesgorrie): Needs a refactor, good ol' copy and paste.
  */
 Loader.prototype.renderCommentCount = function() {
-    var self = this;
     ajax({
         url: '/discussion/comment-counts.json?shortUrls=' + this.getDiscussionId(),
         type: 'json',
@@ -359,10 +358,10 @@ Loader.prototype.renderCommentCount = function() {
 
                     bonzo(qwery('.js-comment-count')).html(html);
                 } else {
-                    self.setState('empty');
+                    this.setState('empty');
                 }
             }
-        }
+        }.bind(this)
     });
 };
 

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -15,6 +15,10 @@ $avatarPadding: $gs-gutter / 2;
     }
 }
 
+.discussion--closed.discussion--empty {
+    display: none;
+}
+
 .id--signed-in .content--liveblog + .content-footer .discussion .content__main-column {
     @include mq(desktop) {
         margin-left: gs-span(2) + $gs-gutter;


### PR DESCRIPTION
The discussion block is hidden for comment threads that have zero comments and are closed to avoid the following: 

![screen shot 2014-10-09 at 17 36 20](https://cloud.githubusercontent.com/assets/2236852/4580085/6cfa3150-4fd2-11e4-911c-49afbf507035.png)
