### PR TITLE
Stop standfirsts from appearing on mobile by mistake

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_slices.scss
+++ b/static/src/stylesheets/module/facia-cards/_slices.scss
@@ -66,7 +66,9 @@ Hence why a greater depth of selector specificity is needed.
 
     .fc-item--standard-tablet {
         .fc-item__standfirst {
-            display: block;
+            @include mq(tablet) {
+                display: block;
+            }
         }
     }
 }


### PR DESCRIPTION
Media queries are important
