### PR TITLE
Bit of space after quote marks

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_tones-images.scss
+++ b/static/src/stylesheets/module/facia-cards/_tones-images.scss
@@ -5,6 +5,7 @@
         content: '';
         height: .8em;
         width: 1em;
+        padding-right: .1em;
     }
 }
 


### PR DESCRIPTION
![screen shot 2014-10-10 at 09 56 51](https://cloud.githubusercontent.com/assets/867233/4590064/6674508e-505b-11e4-860d-7a763e8b5ab6.png)

vs

![screen shot 2014-10-10 at 09 56 31](https://cloud.githubusercontent.com/assets/867233/4590062/648137d8-505b-11e4-9deb-98604a396a99.png)
