### PR TITLE
Moved social media meta tags above CSS

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -4,11 +4,10 @@
 <title>@views.support.Title(metaData)</title>
 
 @fragments.metaData(metaData)
+@head
 
 @fragments.javaScriptFirstSteps(metaData, curlPaths)
 
 @fragments.commonCssSetup(projectName)
 
 @fragments.javaScriptLaterSteps(metaData, curlPaths)
-
-@head


### PR DESCRIPTION
Some social media meta tags are below some CSS:
![screen shot 2014-10-10 at 10 17 08](https://cloud.githubusercontent.com/assets/2579465/4590342/67b50292-505e-11e4-9725-7d8bcafb5632.png)

This fix moves it up.
