### PR TITLE
dont truncate at all

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -121,10 +121,6 @@ Comments.prototype.ready = function() {
         var comment = $('#comment-'+ this.options.commentId);
         this.showHiddenComments();
         $('.d-discussion__show-all-comments').addClass('u-h');
-        if (comment.attr('hidden')) {
-            bean.fire($(this.getClass('showReplies'), comment.parent())[0], 'click');
-        }
-
         window.location.replace('#comment-'+ this.options.commentId);
     }
 
@@ -233,7 +229,7 @@ Comments.prototype.fetchComments = function(options) {
         displayThreaded: !this.options.unthreaded
     };
 
-    if (!this.options.expand) {
+    if (!this.options.expand && !this.options.commentId ) {
         queryParams.maxResponses = 3;
     }
 


### PR DESCRIPTION
Fix permalinks take two: 

In this incarnation - don't do any truncation at all if we are permalinking to a comment. 

www.theguardian.com/commentisfree/2014/oct/07/why-supermarkets-are-on-the-way-out-aldi-lidl#comment-41935830

As implemented here: 

![permalink](https://cloud.githubusercontent.com/assets/986155/4591755/91c1e042-5071-11e4-90df-e8c2ad02c5e9.png)
