### PR TITLE
putting superhigh commercial component back in line to prevent overlap

### DIFF
--- a/static/src/stylesheets/module/commercial/_commercial-component.scss
+++ b/static/src/stylesheets/module/commercial/_commercial-component.scss
@@ -193,12 +193,7 @@ $commercial-cta-diameter: (
     float: left;
     @include mq(leftCol) {
         @include box-sizing(border-box);
-        width: $left-column + $gs-gutter;
-        margin-left: -($left-column + $gs-gutter);
-    }
-    @include mq(wide) {
         width: $left-column-wide + $gs-gutter;
-        margin-left: -($left-column-wide + $gs-gutter);
     }
 }
 .commercial {
@@ -529,7 +524,7 @@ $commercial-cta-diameter: (
                 margin-bottom: $gs-baseline/2;
             }
         }
-        @include mq(leftCol, wide) {
+        @include mq(leftCol) {
             .highitem__img {
                 width: 100%;
                 float: none;


### PR DESCRIPTION
Now that the left column on articles is being used for tags etc we have the chance that the inline component that was being pulled into the left column could overlap. This puts the component back in line on leftCol breakpoint and above.

Before;
![screen shot 2014-10-10 at 12 42 32](https://cloud.githubusercontent.com/assets/1303616/4591845/ce2485e8-5072-11e4-8631-9aecf0224f20.png)

After;
![screen shot 2014-10-10 at 12 44 00](https://cloud.githubusercontent.com/assets/1303616/4591849/d4cdd21e-5072-11e4-9cae-19730b218f73.png)
