### PR TITLE
Don't apply responsive-img to cutouts on mega-full

### DIFF
--- a/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--mega-full.scss
+++ b/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--mega-full.scss
@@ -46,6 +46,11 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
             min-height: gs-height(5) + $gs-baseline * 3;
         }
 
+        .responsive-img {
+            top: auto;
+            height: 100%;
+        }
+
         .fc-item__content {
             width: auto;
             max-width: gs-span(6);


### PR DESCRIPTION
Before:
![screen shot 2014-10-10 at 15 01 18](https://cloud.githubusercontent.com/assets/1607666/4593413/d1f930d4-5085-11e4-8188-0af933b1c265.png)

After:
![screen shot 2014-10-10 at 15 01 34](https://cloud.githubusercontent.com/assets/1607666/4593412/d1f4416e-5085-11e4-9625-761b54c50ab6.png)
