### PR TITLE
Revert "Dead-blog article tone"

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,13 +1,11 @@
 @(model: ArticlePage)(implicit request: RequestHeader)
-
 @import conf.Switches._
 @import views.support.ArticleLayout.ArticleLayout
-@import views.support.TrailCssClasses.articleToneClass
 
 @defining(model.article) { article =>
 <div class="l-side-margins l-side-margins--layout-content">
     <article id="article" data-test-id="article-root"
-        class="content content--article @articleToneClass(article) @articleToneClass(article)--article section-@article.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
+        class="content content--article tone-@article.visualTone tone-@article.visualTone--article section-@article.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
         @if(article.isAdvertisementFeature && !article.isSponsored){content--advertisement-feature}"
 
         itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">

--- a/article/app/views/fragments/headTonal.scala.html
+++ b/article/app/views/fragments/headTonal.scala.html
@@ -9,7 +9,7 @@
 
                 <div class="content__labels">
                     <div class="content__section-label">
-                        <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@content.section}">@Html(content.sectionName.toLowerCase)</a>
+                        <a class="tone-colour" data-link-name="article section" href="@LinkTo {/@content.section}">@Html(content.sectionName.toLowerCase)</a>
                     </div>
 
                     @fragments.meta.metaInline(content)

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -1,12 +1,11 @@
 @(model: LiveBlogPage)(implicit request: RequestHeader)
 @import conf.Switches._
-@import views.support.TrailCssClasses.articleToneClass
 @import com.gu.facia.client.models.CollectionConfig
 
 @defining(model.article) {  article =>
 <div class="l-side-margins l-side-margins--layout-content">
     <article id="live-blog" data-test-id="live-blog"
-        class="content content--liveblog blog @articleToneClass(article) @articleToneClass(article)--article section-@article.sectionName.toLowerCase"
+        class="content content--liveblog tone-@article.visualTone blog @if(article.isLive){is-live} section-@article.sectionName.toLowerCase"
         itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
 
         <header class="content__head content__head--tonal">
@@ -17,7 +16,7 @@
 
                         <div class="content__labels">
                             <div class="content__section-label">
-                                <a class="content__section-label__link" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>
+                                <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@article.section}">@Html(article.sectionName.toLowerCase)</a>
                             </div>
 
                             @fragments.meta.metaInline(article)

--- a/common/app/views/fragments/headDefault.scala.html
+++ b/common/app/views/fragments/headDefault.scala.html
@@ -6,13 +6,13 @@
 
             <div class="content__labels">
                 <div class="content__section-label">
-                    <a class="content__section-label__link" data-link-name="article section" href="@LinkTo{/@content.section}">@Html(content.sectionName)</a>
+                    <a class="tone-colour" data-link-name="article section" href="@LinkTo{/@content.section}">@Html(content.sectionName)</a>
                 </div>
 
                 @fragments.meta.metaInline(content)
             </div>
 
-            <h1 class="content__headline js-score" itemprop="headline">@Html(content.headline)</h1>
+            <h1 itemprop="headline" class="content__headline js-score">@Html(content.headline)</h1>
 
             @if(!content.delegate.isVideo && !content.delegate.isGallery) {
                 @fragments.standfirst(content)

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -3,13 +3,13 @@
 @if(content.isSeries) {
     @content.series.headOption.map { series =>
         <div class="content__series-label">
-            <a class="content__series-label__link" href="@LinkTo{/@series.id}">@series.name</a>
+            <a href="@LinkTo{/@series.id}" class="tone-colour">@series.name</a>
         </div>
     }
 } else {
     @if(content.isFromTheObserver ) {
         <div class="content__series-label">
-            <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
+            <a href="http://observer.theguardian.com" class="tone-colour">The Observer</a>
         </div>
     }
 }

--- a/common/app/views/support/TrailCssClasses.scala
+++ b/common/app/views/support/TrailCssClasses.scala
@@ -19,21 +19,4 @@ object TrailCssClasses {
 
     s"tone-$tone"
   }
-
-  /** Article will soon support all tone classes so we'll be able to remove this silliness */
-  val SupportedArticleTones: Set[CardStyle] = Set(
-    Media,
-    Comment,
-    LiveBlog,
-    DeadBlog,
-    Feature
-  )
-
-  def articleToneClass(trail: Trail) = {
-    if (SupportedArticleTones.contains(CardStyle(trail))) {
-      toneClass(trail)
-    } else {
-      "tone-news"
-    }
-  }
 }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -165,7 +165,7 @@
         float: none;
     }
 
-    .content__series-label__link {
+    .tone-colour {
         color: $c-neutral2;
     }
 }

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -83,6 +83,8 @@ $block-padding-right: $gs-gutter;
     }
 
     .byline {
+        @include fs-bodyHeading(1);
+        font-weight: normal;
         padding: 0;
         min-height: initial;
         margin: $gs-baseline/3 0 $gs-baseline/2;
@@ -107,7 +109,7 @@ $block-padding-right: $gs-gutter;
 
 .blog__last-updated-container {
     @include box-sizing(border-box);
-    padding-top: $gs-baseline/3;
+    padding-top: $gs-baseline/6;
     color: #ffffff;
     @include fs-textSans(1);
 
@@ -703,6 +705,7 @@ $timeline-width: 14px;
         line-height: $timeline-width;
     }
 }
+
 .timeline__title {
     display: table-cell;
     @include fs-textSans(3);
@@ -761,6 +764,7 @@ $timeline-width: 14px;
 /* Football components
    ========================================================================== */
 .blog {
+
     .tabs__container--multiple {
         margin-bottom: 0;
     }
@@ -829,26 +833,28 @@ $timeline-width: 14px;
         }
     }
 
-    .content__labels {
-        @include mq(desktop) {
-            float: left;
-            width: gs-span(3);
-            margin-left: (gs-span(4) + $gs-gutter) * -1;
-            border-bottom: 0;
+    &.tone-live .content__head--tonal {
+        .content__labels {
+            @include mq(desktop) {
+                float: left;
+                width: gs-span(3);
+                margin-left: (gs-span(4) + $gs-gutter) * -1;
+                border-bottom: 0;
+            }
         }
-    }
 
-    .content__section-label {
-        @include mq(desktop) {
-            @include fs-header(3);
-            float: none;
+        .content__section-label {
+            @include mq(desktop) {
+                @include fs-header(3);
+                float: none;
+            }
         }
-    }
 
-    .content__series-label {
-        @include mq(desktop) {
-            @include fs-headline(3);
-            float: none;
+        .content__series-label {
+            @include mq(desktop) {
+                @include fs-headline(3);
+                float: none;
+            }
         }
     }
 
@@ -885,6 +891,7 @@ $timeline-width: 14px;
 }
 
 .content--liveblog {
+
     .content__standfirst,
     .blog__timeline,
     .content__secondary-column {
@@ -902,10 +909,10 @@ $timeline-width: 14px;
     .content__labels {
         border-bottom-color: $c-neutral5;
     }
-    .content__section-label__link {
+    .content__section-label .tone-colour {
         color: $c-liveDefault;
     }
-    .content__series-label__link {
+    .content__series-label .tone-colour {
         color: $c-neutral2;
     }
     .content__headline {
@@ -998,6 +1005,7 @@ $timeline-width: 14px;
     }
 
     &:hover {
+
         .block-share__item--facebook {
             border-color: darken(#3b5998, 15%);
             .i { @include icon(share-facebook--blue-dark); }

--- a/static/src/stylesheets/module/content/_media.head.scss
+++ b/static/src/stylesheets/module/content/_media.head.scss
@@ -38,8 +38,10 @@
         border-bottom-color: $c-neutral2;
     }
 
-    .content__section-label__link {
-        color: $c-mediaDefault;
+    .content__section-label {
+        .tone-colour {
+            color: $c-mediaDefault;
+        }
     }
 
     .content__series-label {
@@ -47,7 +49,7 @@
             color: fade-out($c-neutral3, .5);
         }
 
-        .content__series-label__link {
+        .tone-colour {
             color: $c-neutral3;
         }
     }

--- a/static/src/stylesheets/theme/_tones-head.scss
+++ b/static/src/stylesheets/theme/_tones-head.scss
@@ -9,11 +9,9 @@
 
 @mixin tones-content {
     // Tonal article styles
-    // @mixin article-header-tone($tone, $backgroundColour, $backgroundAccentColour, $textColour, $textAccentColour, $commentIcon)
-    @include article-header-tone(feature, $c-featureDefault, $c-featureAccent2, #ffffff, $c-featureAccent, 'white');
-    @include article-header-tone(comment, $c-commentBackground, $c-commentDefault, $c-neutral1, $c-commentDefault, 'black');
+    @include article-header-tone(feature, $c-featureDefault, $c-featureAccent2, $c-featureAccent, #ffffff, 'white');
+    @include article-header-tone(comment, $c-commentBackground, $c-commentDefault, $c-commentDefault, $c-neutral1, 'black');
     @include article-header-tone(live, $c-liveDefault, $c-liveAccent, #ffffff, #ffffff, 'white');
-    @include article-header-tone(dead, #ffffff, $c-neutral6, $c-neutral1, $c-liveDefault, 'black');
 
     .content__head--tonal {
         background-color: #ffffff;
@@ -107,31 +105,9 @@
 
     /* Tone specific rules/overrides
        ========================================================================== */
-    .tone-live {
-        .content__head--tonal {
-            .blog__meta-container {
-                color: #ffffff;
-                border-top-color: $c-featureMute;
-            }
-            .blog__last-updated-container,
-            .content__series-label a {
-                color: #ffffff;
-            }
-        }
-    }
-
-    .tone-dead {
-        .content__head--tonal {
-            .content__series-label__link {
-                color: $c-neutral2;
-            }
-            .blog__meta-container {
-                color: $c-neutral2;
-                border-top-color: $c-neutral3;
-            }
-            .blog__last-updated-container {
-                color: $c-neutral2;
-            }
+    .tone-live .content__head--tonal {
+        .content__headline {
+            font-weight: normal;
         }
     }
 

--- a/static/src/stylesheets/theme/_tones.scss
+++ b/static/src/stylesheets/theme/_tones.scss
@@ -64,7 +64,7 @@
     }
 }
 
-@mixin article-header-tone($tone, $backgroundColour, $backgroundAccentColour, $textColour, $textAccentColour, $commentIcon) {
+@mixin article-header-tone($tone, $colour, $accentColour, $textAccentColour, $textColour, $commentIcon) {
     .tone-#{$tone} .content__head--tonal {
         .content__headline,
         .content__standfirst,
@@ -72,12 +72,16 @@
             color: $textColour;
         }
 
+        .content__headline {
+            color: $textColour;
+        }
+
         .tone-background {
-            background-color: $backgroundColour;
+            background-color: $colour;
         }
 
         .tone-background--accent {
-            background-color: $backgroundAccentColour;
+            background-color: $accentColour;
         }
 
         .content__head__comment-count .commentcount {
@@ -88,20 +92,20 @@
             border-bottom-color: rgba($textColour, .3);
         }
 
-        .content__section-label__link {
-            color: $textAccentColour;
-        }
-
-        .content__series-label__link {
+        .content__section-label .tone-colour {
             color: $textColour;
         }
 
+        .content__series-label .tone-colour {
+            color: $textAccentColour;
+        }
+
         .content__standfirst .bullet:before {
-            background-color: lighten($backgroundAccentColour, 25);
+            background-color: lighten($accentColour, 25);
         }
 
         .u-underline {
-            border-bottom-color: lighten($backgroundAccentColour, 25);
+            border-bottom-color: lighten($accentColour, 25);
             &:focus,
             &:active,
             &:hover {
@@ -111,6 +115,6 @@
     }
 
     .content.tone-#{$tone} .drop-cap {
-        color: $backgroundColour;
+        color: $colour;
     }
 }


### PR DESCRIPTION
Reverts guardian/frontend#6371

tone-news is coming through when it shouldn’t

![screen shot 2014-10-10 at 16 21 56](https://cloud.githubusercontent.com/assets/867233/4594620/2423f2bc-5091-11e4-9418-4fc0aa88b0a2.png)
