### PR TITLE
A re-authentication page that's more friendly to the user [#MEM-403]

### DIFF
--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -1,0 +1,92 @@
+package controllers
+
+import actions.AuthenticatedActions
+import com.google.inject.{Inject, Singleton}
+import common.ExecutionContexts
+import form.Mappings
+import idapiclient.{EmailPassword, IdApiClient}
+import implicits.Forms
+import model.{IdentityPage, NoCache}
+import play.api.data._
+import play.api.data.validation.Constraints
+import play.api.i18n.Messages
+import play.api.mvc._
+import services.{IdRequestParser, IdentityUrlBuilder, PlaySigninService, ReturnUrlVerifier}
+import utils.SafeLogging
+
+import scala.concurrent.Future
+
+
+@Singleton
+class ReauthenticationController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
+                                 api: IdApiClient,
+                                 idRequestParser: IdRequestParser,
+                                 idUrlBuilder: IdentityUrlBuilder,
+                                 authenticatedActions: AuthenticatedActions,
+                                 signInService : PlaySigninService)
+  extends Controller with ExecutionContexts with SafeLogging with Mappings with Forms {
+
+  val page = IdentityPage("/reauthenticate", "Re-authenticate", "reauthenticate")
+
+  val form = Form(
+    Forms.single(
+      "password" -> Forms.text
+        .verifying(Constraints.nonEmpty)
+    )
+  )
+
+  def renderForm(returnUrl: Option[String]) = authenticatedActions.authAction { implicit request =>
+    val filledForm = form.bindFromFlash.getOrElse(form.fill(""))
+
+    logger.trace("Rendering reauth form")
+    val idRequest = idRequestParser(request)
+    NoCache(Ok(views.html.reauthenticate(page, idRequest, idUrlBuilder, filledForm)))
+  }
+
+  def processForm = authenticatedActions.authActionWithUser.async { implicit request =>
+    val idRequest = idRequestParser(request)
+    val boundForm = form.bindFromRequest
+    val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
+
+    def onError(formWithErrors: Form[String]): Future[Result] = {
+      logger.info("Invalid reauthentication form submission")
+      Future.successful {
+        redirectToSigninPage(formWithErrors, verifiedReturnUrlAsOpt)
+      }
+    }
+
+    def onSuccess(password: String): Future[Result] = {
+        logger.trace("reauthenticating with ID API")
+        val authResponse = api.authBrowser(EmailPassword(request.user.primaryEmailAddress, password, idRequest.clientIp), idRequest.trackingData)
+        signInService.getCookies(authResponse, true) map {
+          case Left(errors) =>
+            logger.error(errors.toString())
+            logger.info(s"Reauthentication failed for user, ${errors.toString()}")
+            val formWithErrors = errors.foldLeft(boundForm) { (formFold, error) =>
+              val errorMessage =
+                if ("Invalid email or password" == error.message) Messages("error.login")
+                else error.description
+              formFold.withError(error.context.getOrElse(""), errorMessage)
+            }
+
+            redirectToSigninPage(formWithErrors, verifiedReturnUrlAsOpt)
+
+          case Right(responseCookies) =>
+            logger.trace("Logging user in")
+            SeeOther(verifiedReturnUrlAsOpt.getOrElse(returnUrlVerifier.defaultReturnUrl))
+              .withCookies(responseCookies:_*)
+        }
+    }
+
+    boundForm.fold[Future[Result]](onError, onSuccess)
+  }
+
+  def redirectToSigninPage(formWithErrors: Form[String], returnUrl: Option[String]): Result = {
+    NoCache(SeeOther(routes.ReauthenticationController.renderForm(returnUrl).url).flashing(clearPassword(formWithErrors).toFlash))
+  }
+
+  private def clearPassword(formWithPassword: Form[String]) = {
+    val dataWithoutPassword = formWithPassword.data + ("password" -> "")
+    formWithPassword.copy(data = dataWithoutPassword)
+  }
+}

--- a/identity/app/views/fragments/socialSignin.scala.html
+++ b/identity/app/views/fragments/socialSignin.scala.html
@@ -1,15 +1,15 @@
-@(cta: String, page: model.MetaData, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader)
+@(cta: String, page: model.MetaData, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, confirm: Boolean = false)(implicit request: RequestHeader)
 
 <ul class="social-signin">
     <li class="social-signin__item">
-        <a class="social-signin__action social-signin__action--fb" href="@idUrlBuilder.buildWebappUrl("/facebook/signin", idRequest)"
+        <a class="social-signin__action social-signin__action--fb" href="@idUrlBuilder.buildWebappUrl(if (confirm) "/facebook/confirm" else "/facebook/signin", idRequest)"
                 data-link-name="Register/Sign in with Facebook" data-test-id="facebook-sign-in">
             <span>@cta with Facebook</span>
             <i class="i-fb i social-signin__icon social-signin__icon--fb"></i>
         </a>
     </li>
     <li class="social-signin__item">
-        <a class="social-signin__action social-signin__action--gplus" href="@idUrlBuilder.buildWebappUrl("/google/signin", idRequest)"
+        <a class="social-signin__action social-signin__action--gplus" href="@idUrlBuilder.buildWebappUrl(if (confirm) "/google/confirm" else "/google/signin", idRequest)"
                 data-link-name="Register/Sign in with Google" data-test-id="google-sign-in">
             <span>@cta with Google</span>
             <i class="i-gplus i social-signin__icon social-signin__icon--gplus"></i>

--- a/identity/app/views/reauthenticate.scala.html
+++ b/identity/app/views/reauthenticate.scala.html
@@ -1,0 +1,52 @@
+@(page: model.MetaData, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, reauthenticationForm: Form[String])(implicit request: RequestHeader)
+
+@import form.IdFormHelpers._
+@import views.html.fragments.form.inputField
+@import views.html.fragments.socialSignin
+
+@identityMain(page, conf.Switches.all){
+}{
+<div class="identity-wrapper monocolumn-wrapper">
+    <h1 class="identity-title">Confirm your identity</h1>
+    <p>Your privacy is important to us. Please re-enter your password to access your personal data.</p>
+
+    <form class="form js-signin-form" novalidate action="@idUrlBuilder.buildUrl("/reauthenticate", idRequest)" role="main" method="post">
+        @if(reauthenticationForm.globalError.isDefined) {
+            <div class="form__error">@reauthenticationForm.globalErrors.map(_.message).mkString(", ")</div>
+        }
+
+        <fieldset class="fieldset">
+            <div class="fieldset__heading">
+                <h2 class="form__heading">Use your social account</h2>
+                <div class="form__note">
+                    By proceeding, you agree to the Guardian's <a href="http://www.theguardian.com/help/terms-of-service" data-link-name="Terms of service">Terms of Service</a> and <a href="http://www.theguardian.com/help/privacy-policy" data-link-name="Privacy policy">Privacy Policy</a>.
+                </div>
+            </div>
+            <div class="fieldset__fields">
+                @socialSignin("Confirm", page, idRequest, idUrlBuilder, confirm = true)
+            </div>
+        </fieldset>
+
+        <fieldset class="fieldset">
+            <div class="fieldset__heading">
+                <h2 class="form__heading">Use your Guardian password</h2>
+            </div>
+
+            <div class="fieldset__fields">
+                <ul class="u-unstyled">
+
+                   @inputField(Password(reauthenticationForm("password"), '_label -> "Password",  'tabindex -> 2,
+                        Symbol("data-test-id") -> "signin-pwd"))
+
+                    <li class="form-field">
+                        <div class="form-field__note">
+                            <a class="js-forgotten-password" href='@idUrlBuilder.buildUrl("/reset", idRequest)' data-link-name="Forgotten password">Forgotten your password?</a>
+                        </div>
+                        <button type="submit" class="submit-input" data-link-name="Sign in" data-test-id="sign-in-button" tabindex="3">Confirm</button>
+                    </li>
+                </ul>
+            </div>
+        </fieldset>
+    </form>
+</div>
+}

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -3,6 +3,9 @@ GET         /assets/*path                          dev.DevAssetsController.at(pa
 
 GET         /_healthcheck                          conf.HealthCheck.healthcheck()
 
+GET         /reauthenticate                         @controllers.ReauthenticationController.renderForm(returnUrl : Option[String])
+POST        /reauthenticate                         @controllers.ReauthenticationController.processForm
+
 GET         /signin                                 @controllers.SigninController.renderForm(returnUrl : Option[String])
 POST        /signin                                 @controllers.SigninController.processForm
 GET         /signout                                @controllers.SignoutController.signout


### PR DESCRIPTION
...rather than asking them to re-sign-in (they're already signed in), this page explains why they have to re-enter their password, and offers appropriate social-signin links (we only accept social links if they
actually force the user to re-enter their password).

This change doesn't actually point users to this re-authentication page yet, it just makes it available so UX, etc can review the page and try the social-signin-confirmation flows.

https://jira.gutools.co.uk/browse/MEM-403

cc @adamnfish @mchv 
