### PR TITLE
Putting the imagemin, back in

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('sass:compile', ['concurrent:sass']);
 
-    grunt.registerTask('compile:images', ['copy:images', 'shell:spriteGeneration']);
+    grunt.registerTask('compile:images', ['copy:images', 'shell:spriteGeneration', 'imagemin']);
     grunt.registerTask('compile:css', function(fullCompile) {
         grunt.task.run(['mkdir:css', 'compile:images', 'sass:compile', 'sass:compileStyleguide']);
 

--- a/grunt-configs/imagemin.js
+++ b/grunt-configs/imagemin.js
@@ -1,10 +1,7 @@
-var pngquant = require('imagemin-pngquant');
-
 module.exports = function(grunt, options) {
     return {
         options: {
-            optimizationLevel: 2,
-            use: [pngquant()]
+            optimizationLevel: 2
         },
         files: {
             expand: true,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "grunt-text-replace": "0.3.12",
     "grunt-webfontjson": "0.0.4",
     "handlebars": "2.0.0",
-    "imagemin-pngquant": "2.0.0",
     "jit-grunt": "0.8.0",
     "jsonfile": "2.0.0",
     "karma": "0.12.24",


### PR DESCRIPTION
But using the `pngquant` that comes with `grunt-contrib-imagemin`. 

Might be more reliable. 

Might be...
