### PR TITLE
Fix for football live blog key events/scores overlap 

### DIFF
--- a/static/src/javascripts/bootstraps/liveblog.js
+++ b/static/src/javascripts/bootstraps/liveblog.js
@@ -172,7 +172,7 @@ define([
                 dropdown.addClass('dropdown--active');
                 dropdowns.updateAria(dropdown);
 
-                if (detect.isBreakpoint({ min: 'desktop' }) && config.page.section != 'football') {
+                if (detect.isBreakpoint({ min: 'desktop' }) && config.page.section !== 'football') {
                     topMarker = qwery('.js-top-marker')[0];
                     affix = new Affix({
                         element: qwery('.js-live-blog__timeline-container')[0],

--- a/static/src/javascripts/bootstraps/liveblog.js
+++ b/static/src/javascripts/bootstraps/liveblog.js
@@ -172,7 +172,7 @@ define([
                 dropdown.addClass('dropdown--active');
                 dropdowns.updateAria(dropdown);
 
-                if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0) {
+                if (detect.isBreakpoint({ min: 'desktop' }) && config.page.section != 'football') {
                     topMarker = qwery('.js-top-marker')[0];
                     affix = new Affix({
                         element: qwery('.js-live-blog__timeline-container')[0],


### PR DESCRIPTION
Fix for key events overlap on football live blogs that haven't got the football/football tag. 
Now changed so that key events aren't fixed on live blogs in the football section.

Example of problem: http://www.theguardian.com/football/live/2014/oct/11/brazil-argentina-live-friendly-beijing

![screen shot 2014-10-13 at 10 54 37](https://cloud.githubusercontent.com/assets/2236852/4611822/f79eee9c-52be-11e4-8a96-668eafac582f.png)
