### PR TITLE
Fix isAdvertisementFeature Check

### DIFF
--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -44,7 +44,8 @@ trait DfpAgent {
   private def isPaidFor(available: Seq[Sponsorship], tagId: String, section: Option[String]): Boolean = {
 
     def sectionMatches(sponsorshipSections: Seq[String]): Boolean = {
-      section.isEmpty || sponsorshipSections.isEmpty || sponsorshipSections.contains(section.get)
+      section.isEmpty || sponsorshipSections.isEmpty ||
+        sponsorshipSections.exists(section.get.startsWith)
     }
 
     available exists { sponsorship =>

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -45,7 +45,9 @@ class DfpAgentTest extends FlatSpec with Matchers {
 
     override protected def advertisementFeatureSponsorships: Seq[Sponsorship] = Seq(
       Sponsorship(Seq("ad-feature"), sections = Nil, Some("spon2"), Nil, 4),
-      Sponsorship(Seq("film"), sections = Nil, None, Nil, 5)
+      Sponsorship(Seq("film"), sections = Nil, None, Nil, 5),
+      Sponsorship(Seq("grundfos-partner-zone", "sustainable-business-grundfos-partner-zone"),
+        sections = Seq("sustainable-business"), None, Nil, 8)
     )
 
     override protected def foundationSupported: Seq[Sponsorship] = Seq(
@@ -175,6 +177,17 @@ class DfpAgentTest extends FlatSpec with Matchers {
     forEvery(apiQueries) { q =>
       testDfpAgent.isAdvertisementFeature(apiQuery(q)) should be(false)
     }
+  }
+
+  it should "be true for front of an ad feature section with a multi-part section name" in {
+    testDfpAgent.isAdvertisementFeature("sustainable-business/grundfos-partner-zone",
+      Some("sustainable-business/grundfos-partner-zone")) should be(true)
+  }
+
+  it should "be true for an article in an ad feature section with a multi-part section name" in {
+    testDfpAgent.isAdvertisementFeature(
+      "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone",
+      Some("sustainable-business/grundfos-partner-zone")) should be(true)
   }
 
   "hasInlineMerchandise" should "be true if tag id has inline merchandising" in {


### PR DESCRIPTION
So that it works for sections with multi-part names, eg sustainable-business/grundfos-partner-zone.
