### PR TITLE
Style trailtext for newly added tones

### DIFF
--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
@@ -13,11 +13,11 @@
     }
 
     .fc-item__kicker,
-    .fc-item__byline {
+    .fc-item__byline,
+    .fc-item__standfirst {
         color: $c-editorialAccent;
     }
 
-    .fc-item__standfirst,
     .fc-item__meta {
         color: $c-neutral3;
     }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -17,6 +17,10 @@
         color: $c-podcastAccent;
     }
 
+    .fc-item__standfirst {
+        color: $c-neutral1;
+    }
+
     .fc-item__meta {
         color: #ffffff;
     }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -17,6 +17,10 @@
         color: $c-reviewAccent;
     }
 
+    .fc-item__standfirst {
+        color: fade-out(#ffffff, .4);
+    }
+
     .fc-item__meta {
         color: $c-neutral4;
     }


### PR DESCRIPTION
Applying correct colours to trailtext for the newer tones (podcast, editorial and review). Note: screenshot below shows trailtext appearing where it shouldn't, it's just an example bro. 

![screen shot 2014-10-13 at 15 19 41](https://cloud.githubusercontent.com/assets/1607666/4614808/e26239c4-52e3-11e4-9ad1-73fe2ee71d89.png)
