### PR TITLE
Fix coloured comment links

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -204,16 +204,12 @@ $fc-item-gutter: $gs-gutter / 4;
 .fc-item__meta {
     @include fs-textSans(1);
     margin-bottom: $gs-baseline / 4;
+    color: $c-neutral2;
 
     &:after {
         clear: left;
         content: '';
         display: table;
-    }
-
-    &,
-    & a {
-        color: $c-neutral2;
     }
 }
 


### PR DESCRIPTION
Properly colour comment links (as defined in the tone partials).

![screen shot 2014-10-13 at 16 01 29](https://cloud.githubusercontent.com/assets/1607666/4615360/bc294030-52e9-11e4-8495-c2df688bf636.png)
