### PR TITLE
Make signin and register cta more visible

### DIFF
--- a/identity/app/views/fragments/identityPageHeader.scala.html
+++ b/identity/app/views/fragments/identityPageHeader.scala.html
@@ -1,0 +1,9 @@
+@(title: String)(detail: Html)
+<div class="identity-page-header">
+    <div class="identity-page-header__title">
+        <h1 class="identity-title">@title</h1>
+    </div>
+    <div class="identity-page-header__detail">
+    @detail
+    </div>
+</div>

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -4,12 +4,14 @@
 @import views.html.fragments.form.{inputField, checkbox}
 @import views.html.fragments.registrationFooter
 @import views.html.fragments.socialSignin
+@import views.html.fragments.identityPageHeader
 
 @identityMain(page, conf.Switches.all){
 }{
 <div class="identity-wrapper monocolumn-wrapper">
-    <h1 class="identity-title">Create your Guardian account</h1>
-    <p>Already have an account? <a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)">Sign in</a>.</p>
+    @identityPageHeader("Create your Guardian account") {
+        <p>Already have an account? <a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)">Sign in</a>.</p>
+    }
 
     <form class="form js-register-form" novalidate action="@idUrlBuilder.buildUrl("/register", idRequest)" role="main" method="post">
         @if(registrationForm.globalError.isDefined) {

--- a/identity/app/views/signin.scala.html
+++ b/identity/app/views/signin.scala.html
@@ -3,12 +3,14 @@
 @import form.IdFormHelpers._
 @import views.html.fragments.form.{inputField, checkbox}
 @import views.html.fragments.socialSignin
+@import views.html.fragments.identityPageHeader
 
 @identityMain(page, conf.Switches.all){
 }{
 <div class="identity-wrapper monocolumn-wrapper">
-    <h1 class="identity-title">Sign in to the Guardian</h1>
-    <p>Don't have an account? <a class="u-underline" data-test-id="register-link" href="@idUrlBuilder.buildUrl("/register", idRequest)">Register now</a>.</p>
+    @identityPageHeader("Sign in to the Guardian") {
+        <p>Don't have an account? <a class="u-underline" data-test-id="register-link" href="@idUrlBuilder.buildUrl("/register", idRequest)">Register now</a>.</p>
+    }
 
     <form class="form js-signin-form" novalidate action="@idUrlBuilder.buildUrl("/signin", idRequest)" role="main" method="post">
         @if(signinForm.globalError.isDefined) {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -31,6 +31,23 @@
     }
 }
 
+@include mq(desktop) {
+    .identity-page-header {
+        .identity-page-header__title {
+            display: table-cell;
+            width: gs-span(6);
+            vertical-align: top;
+            padding-right: $gs-gutter*5;
+        }
+        .identity-page-header__detail {
+            display: table-cell;
+            width: gs-span(6);
+            vertical-align: top;
+            text-align: right;
+        }
+    }
+}
+
 .identity-section {
     border-top: 1px solid $c-neutral7;
     @include box-sizing(border-box);


### PR DESCRIPTION
Moved the CTA for signin and registration to the right of the page on desktop.
# Before
## Registration

![screen shot 2014-10-13 at 16 39 17](https://cloud.githubusercontent.com/assets/2305016/4616036/a7cb0e74-52ef-11e4-8ab6-e672fe38a360.png)
## Signin

![screen shot 2014-10-13 at 16 39 09](https://cloud.githubusercontent.com/assets/2305016/4616038/abce29b6-52ef-11e4-9e5c-498393260409.png)
# After
## Registration

![screen shot 2014-10-13 at 16 38 32](https://cloud.githubusercontent.com/assets/2305016/4616055/c1948c86-52ef-11e4-9c50-c8374dddea73.png)
## Signin

![screen shot 2014-10-13 at 16 38 22](https://cloud.githubusercontent.com/assets/2305016/4616058/caca8cce-52ef-11e4-8121-78dc700f07c8.png)
