### PR TITLE
Set matching persistence-time on cookies generated during re-auth [#MEM-403]

### DIFF
--- a/identity/app/idapiclient/Auth.scala
+++ b/identity/app/idapiclient/Auth.scala
@@ -3,6 +3,8 @@ package idapiclient
 import client.{Auth, Parameters}
 import java.net.URLEncoder
 
+import com.gu.identity.cookie.GuUCookieData
+
 case class EmailPassword(email: String, password: String, ipOpt: Option[String]) extends Auth {
   override def parameters: Parameters = List(
     "email" -> email,
@@ -19,7 +21,7 @@ case class ClientAuth(clientAccessToken: String) extends Auth {
   override def headers: Parameters = List("X-GU-ID-Client-Access-Token" -> s"Bearer $clientAccessToken")
 }
 
-class ScGuU(scGuUValue: String) extends Auth {
+case class ScGuU(scGuUValue: String, data: GuUCookieData) extends Auth {
   override def headers: client.Parameters = Iterable("X-GU-ID-FOWARDED-SC-GU-U" -> scGuUValue)
 }
 

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -26,7 +26,7 @@ class AuthenticationService @Inject()(cookieDecoder: FrontendIdentityCookieDecod
     minimalSecureUser <- cookieDecoder.getUserDataForScGuU(scGuU.value)
     guUCookieData <- cookieDecoder.getUserDataForGuU(guU.value)
     fullUser = guUCookieData.getUser if (fullUser.getId == minimalSecureUser.getId)
-  } yield AuthenticatedUser(fullUser, new ScGuU(scGuU.value))
+  } yield AuthenticatedUser(fullUser, ScGuU(scGuU.value, guUCookieData))
 
   def recentlyAuthenticated(request: RequestHeader): Boolean = (for {
     authedUser <- authenticatedUserFor(request)

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -2,6 +2,7 @@ package controllers
 
 import actions.AuthenticatedActions
 import client.Auth
+import com.gu.identity.cookie.GuUCookieData
 import com.gu.identity.model.{PrivateFields, PublicFields, StatusFields, User}
 import idapiclient.{TrackingData, _}
 import model.Countries
@@ -28,7 +29,7 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
 
   val userId: String = "123"
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
-  val testAuth = new ScGuU("abc")
+  val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
   val authenticatedUser = AuthenticatedUser(user, testAuth)
 
   val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder])

--- a/identity/test/controllers/EmailControllerTest.scala
+++ b/identity/test/controllers/EmailControllerTest.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions.AuthenticatedActions.AuthRequest
+import com.gu.identity.cookie.GuUCookieData
 import org.mockito.Matchers
 import org.scalatest.{ShouldMatchers, path}
 import services._
@@ -37,7 +38,7 @@ class EmailControllerTest extends path.FreeSpec with ShouldMatchers with Mockito
 
   val userId = "123"
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = None, receiveGnmMarketing = None))
-  val testAuth = new ScGuU("abc")
+  val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
   val authenticatedUser = AuthenticatedUser(user, testAuth)
   val error = Error("Test message", "Test description", 500)
   val errors = List(error)

--- a/identity/test/controllers/FormstackControllerTest.scala
+++ b/identity/test/controllers/FormstackControllerTest.scala
@@ -2,6 +2,7 @@ package controllers
 
 import actions.AuthenticatedActions
 import client.Error
+import com.gu.identity.cookie.GuUCookieData
 import com.gu.identity.model.{StatusFields, User}
 import conf.{FrontendIdentityCookieDecoder, Switches}
 import formstack.{FormstackApi, FormstackForm}
@@ -33,7 +34,7 @@ class FormstackControllerTest extends path.FreeSpec with ShouldMatchers with Moc
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
   val authenticatedActions = new AuthenticatedActions(authService, mock[IdApiClient], mock[IdentityUrlBuilder])
 
-  when(authService.authenticatedUserFor(Matchers.any[RequestHeader])) thenReturn Some(AuthenticatedUser(user, new ScGuU("abc")))
+  when(authService.authenticatedUserFor(Matchers.any[RequestHeader])) thenReturn Some(AuthenticatedUser(user, ScGuU("abc", GuUCookieData(user, 0, None))))
 
   when(requestParser.apply(Matchers.any[RequestHeader])) thenReturn idRequest
   when(idRequest.trackingData) thenReturn trackingData


### PR DESCRIPTION
Now check whether the existing GU_U cookie is persistent, and match that when generating the new cookies after re-authentication (we don't have a 'Remember Me' checkbox on the re-auth page). This only affects email&password signin - the Social Signin is handled by a different path in the legacy Identity Webapp, which already handles this case.
