### PR TITLE
Fix auth-call to Identity API: ask for appropriate cookie persistence [#MEM-403]

### DIFF
--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -57,11 +57,13 @@ class ReauthenticationController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
 
     def onSuccess(password: String): Future[Result] = {
         logger.trace("reauthenticating with ID API")
-        val authResponse = api.authBrowser(EmailPassword(request.user.primaryEmailAddress, password, idRequest.clientIp), idRequest.trackingData)
         val persistent = request.user.auth match {
           case ScGuU(_, v) => v.isPersistent
           case _ => false
         }
+        val auth = EmailPassword(request.user.primaryEmailAddress, password, idRequest.clientIp)
+        val authResponse = api.authBrowser(auth, idRequest.trackingData, Some(persistent))
+
         signInService.getCookies(authResponse, persistent) map {
           case Left(errors) =>
             logger.error(errors.toString())

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -60,7 +60,7 @@ class SigninController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
     def onSuccess(form: (String, String, Boolean)): Future[Result] = form match {
       case (email, password, rememberMe) =>
         logger.trace("authing with ID API")
-        val authResponse = api.authBrowser(EmailPassword(email, password, idRequest.clientIp), idRequest.trackingData)
+        val authResponse = api.authBrowser(EmailPassword(email, password, idRequest.clientIp), idRequest.trackingData, Some(rememberMe))
         signInService.getCookies(authResponse, rememberMe) map {
           case Left(errors) =>
             logger.error(errors.toString())

--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -26,8 +26,8 @@ abstract class IdApi(val apiRootUrl: String, http: Http, jsonBodyParser: JsonBod
   def extractUser: (client.Response[HttpResponse]) => client.Response[User] = extract(jsonField("user"))
 
   // AUTH
-  def authBrowser(userAuth: Auth, trackingData: TrackingData): Future[Response[CookiesResponse]] = {
-    val params = buildParams(Some(userAuth), Some(trackingData), Iterable("format" -> "cookies"))
+  def authBrowser(userAuth: Auth, trackingData: TrackingData, persistent: Option[Boolean] = None): Future[Response[CookiesResponse]] = {
+    val params = buildParams(Some(userAuth), Some(trackingData), Seq("format" -> "cookies") ++ persistent.map("persistent" -> _.toString))
     val headers = buildHeaders(Some(userAuth))
     val response = http.POST(apiUrl("auth"), None, params, headers)
     response map extract(jsonField("cookies"))

--- a/identity/test/controllers/SigninControllerTest.scala
+++ b/identity/test/controllers/SigninControllerTest.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import org.mockito.Matchers
 import org.scalatest.path
 import org.scalatest.{Matchers => ShouldMatchers}
 import org.scalatest.mock.MockitoSugar
@@ -53,7 +54,7 @@ class SigninControllerTest extends path.FreeSpec with ShouldMatchers with Mockit
 
       "so api is not called" in Fake {
         signinController.processForm()(fakeRequest)
-        verify(api, never).authBrowser(any[Auth], same(trackingData))
+        verify(api, never).authBrowser(any[Auth], same(trackingData), any[Option[Boolean]])
       }
 
       "form is re-shown with errors" in Fake {
@@ -62,17 +63,22 @@ class SigninControllerTest extends path.FreeSpec with ShouldMatchers with Mockit
     }
 
     "with valid API response" - {
-      val fakeRequest = FakeRequest(POST, "/signin").withFormUrlEncodedBody("email" -> "test@example.com", "password" -> "testpassword")
+      val fakeRequest = FakeRequest(POST, "/signin").withFormUrlEncodedBody("email" -> "test@example.com", "password" -> "testpassword", "keepMeSignedIn" -> "true")
+      val fakeSharedComputerRequest = FakeRequest(POST, "/signin").withFormUrlEncodedBody("email" -> "test@example.com", "password" -> "testpassword")
       val auth = EmailPassword("test@example.com", "testpassword", identityRequest.clientIp)
 
       "if api call succeeds" - {
-        when(api.authBrowser(any[Auth], same(trackingData))).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("testCookie", "testVal"), CookieResponse("SC_testCookie", "secureVal"))))))
+        when(api.authBrowser(any[Auth], same(trackingData), any[Option[Boolean]])).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("testCookie", "testVal"), CookieResponse("SC_testCookie", "secureVal"))))))
 
         "should call authBrowser with provided credentials" in Fake {
           signinController.processForm()(fakeRequest)
-          verify(api).authBrowser(auth, trackingData)
+          verify(api).authBrowser(auth, trackingData, Some(true))
         }
 
+        "should call authBrowser with provided credentials, asking for non-persistent cookies" in Fake {
+          signinController.processForm()(fakeSharedComputerRequest)
+          verify(api).authBrowser(auth, trackingData, Some(false))
+        }
 
         "should redirect the user to the returnUrl" in Fake {
           when(returnUrlVerifier.getVerifiedReturnUrl(fakeRequest)).thenReturn(Some("http://example.com/return"))


### PR DESCRIPTION
Frontend Identity should pass the 'persistent' parameter to the Identity API when authenticating:
- [NGW](https://github.com/guardian/frontend/blob/d2a26a768d/identity/app/idapiclient/IdApi.scala#L37-L42) - note that only `format` got sent
- [Identity API](https://github.com/guardian/identity/blob/d85a787fcb/identity-api/src/main/scala/com/gu/identity/api/servlet/AuthServlet.scala#L49) - note the API takes both `format` _and_ `persistent` parameters

All `GU_U` cookies dropped by Frontend Identity up till now have had their `persistent` flag (the 6th value in the cookie) set to **`0`** rather than `1`, even if you ticked 'Remember Me' when you signed in. The cookies [still got the correct lifespan](https://github.com/guardian/frontend/blob/420f585f/identity/app/services/PlaySigninService.scala#L18) but they didn't contain the right _value_ for the 'persistent' field. This affected the lifespan of regenerated cookies when the user completed the reauthentication process at https://profile.theguardian.com/reauthenticate .

https://github.com/guardian/frontend/pull/6468#issuecomment-59018464

cc @adamnfish 
