### PR TITLE
Multiple id request for FaciaPress

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -301,6 +301,8 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val frontPressToolQueue = configuration.getStringProperty("frontpress.sqs.tool_queue_url")
     /** When retrieving items from Content API, maximum number of requests to make concurrently */
     lazy val frontPressItemBatchSize = configuration.getIntegerProperty("frontpress.item_batch_size", 30)
+    /** When retrieving items from Content API, maximum number of items to request per concurrent request */
+    lazy val frontPressItemSearchBatchSize = configuration.getIntegerProperty("frontpress.item_batch_size", 20)
     lazy val configBeforePressTimeout: Int = 1000
 
     val oauthCredentials: Option[OAuthCredentials] =

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -302,7 +302,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     /** When retrieving items from Content API, maximum number of requests to make concurrently */
     lazy val frontPressItemBatchSize = configuration.getIntegerProperty("frontpress.item_batch_size", 30)
     /** When retrieving items from Content API, maximum number of items to request per concurrent request */
-    lazy val frontPressItemSearchBatchSize = configuration.getIntegerProperty("frontpress.item_batch_size", 20)
+    lazy val frontPressItemSearchBatchSize = configuration.getIntegerProperty("frontpress.item_search_batch_size", 20)
     lazy val configBeforePressTimeout: Int = 1000
 
     val oauthCredentials: Option[OAuthCredentials] =

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -69,7 +69,7 @@ trait QueryDefaults extends implicits.Collections with ExecutionContexts {
     val tag = "tag=type/gallery|type/article|type/video|type/sudoku"
     val editorsPicks = "show-editors-picks=true"
     val showInlineFields = s"show-fields=$trailFields"
-    val showFields = "trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent"
+    val showFields = "trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent,internalContentCode"
     val showFieldsWithBody = showFields + ",body"
 
     val all = Seq(tag, editorsPicks, showInlineFields, showFields)

--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -157,7 +157,7 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
     Futures.batchedTraverse(collectionItems.grouped(Configuration.faciatool.frontPressItemSearchBatchSize).toSeq, Configuration.faciatool.frontPressItemBatchSize)({ collectionItems =>
       getContentApiItemFromCollectionItem(collectionItems, edition) map { maybeItem =>
         maybeItem.map(_.map {content =>
-          val internalContentCode: String = content.fields.getOrElse(Map.empty).get("internalContentCode").get
+          val internalContentCode: String = content.fields.getOrElse(Map.empty).get("internalContentCode").getOrElse("")
           val internalContentCodeFormatted: String = s"internal-code/content/$internalContentCode"
           TrailId(internalContentCodeFormatted) -> content
         }).getOrElse(Nil)

--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -157,10 +157,11 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
     Futures.batchedTraverse(collectionItems.grouped(Configuration.faciatool.frontPressItemSearchBatchSize).toSeq, Configuration.faciatool.frontPressItemBatchSize)({ collectionItems =>
       getContentApiItemFromCollectionItem(collectionItems, edition) map { maybeItem =>
         maybeItem.map(_.map {content =>
-          val internalContentCode: String = content.fields.getOrElse(Map.empty).get("internalContentCode").getOrElse("")
-          val internalContentCodeFormatted: String = s"internal-code/content/$internalContentCode"
-          TrailId(internalContentCodeFormatted) -> content
-        }).getOrElse(Nil)
+          content.fields.getOrElse(Map.empty).get("internalContentCode").map { internalContentCode =>
+            val internalContentCodeFormatted: String = s"internal-code/content/$internalContentCode"
+            TrailId(internalContentCodeFormatted) -> content
+          }
+        }).flatten.getOrElse(Nil)
       }
     }).map(_.flatten.toMap)
 

--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -47,7 +47,7 @@ object Result {
 case class TrailId(get: String) extends AnyVal
 
 trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging {
-  implicit def apiContentCodec = JsonCodecs.snappyCodec[Option[ApiContent]]
+  implicit def apiContentCodec = JsonCodecs.snappyCodec[Option[List[ApiContent]]]
 
   implicit def resultCodec = JsonCodecs.snappyCodec[Result]
 

--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -154,7 +154,7 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
 
   private def batchGetContentApiItems(collectionItems: Seq[TrailId],
                                       edition: Edition): Future[Map[TrailId, ApiContent]] =
-    Futures.batchedTraverse(collectionItems.grouped(10).toSeq, Configuration.faciatool.frontPressItemBatchSize)({ collectionItems =>
+    Futures.batchedTraverse(collectionItems.grouped(Configuration.faciatool.frontPressItemSearchBatchSize).toSeq, Configuration.faciatool.frontPressItemBatchSize)({ collectionItems =>
       getContentApiItemFromCollectionItem(collectionItems, edition) map { maybeItem =>
         maybeItem.map(_.map {content =>
           val internalContentCode: String = content.fields.getOrElse(Map.empty).get("internalContentCode").get

--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -156,13 +156,13 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
                                       edition: Edition): Future[Map[TrailId, ApiContent]] =
     Futures.batchedTraverse(collectionItems.grouped(Configuration.faciatool.frontPressItemSearchBatchSize).toSeq, Configuration.faciatool.frontPressItemBatchSize)({ collectionItems =>
       getContentApiItemFromCollectionItem(collectionItems, edition) map { maybeItem =>
-        maybeItem.map(_.map {content =>
-          content.fields.getOrElse(Map.empty).get("internalContentCode").map { internalContentCode =>
-            val internalContentCodeFormatted: String = s"internal-code/content/$internalContentCode"
-            TrailId(internalContentCodeFormatted) -> content
-          }
-        }).flatten.getOrElse(Nil)
-      }
+        maybeItem.map { items =>
+          items.map { item =>
+            item.fields.flatMap(_.get("internalContentCode")).map { internalContentCode =>
+              val internalContentCodeFormatted: String = s"internal-code/content/$internalContentCode"
+              TrailId(internalContentCodeFormatted) -> item}
+          }.flatten
+        }.getOrElse(Nil)}
     }).map(_.flatten.toMap)
 
   private def getContentApiItemFromCollectionItem(collectionItems: Seq[TrailId],


### PR DESCRIPTION
Instead of requesting each piece of content individually and concurrently, this switches to requesting content through the `/search` endpoint using an `id` filter.

This means `facia-press` will make a lot less individual requests to the `Content API` in favour of requests that carry more data.
So now, requests are batched to the amount of items per **single** request AND on top of that they are batched to how many of these requests can run concurrently; which is currently the case except with single ID requests.

@stephanfowler @robertberry 
