### PR TITLE
Fix Ad Targeting on Commercial Microsite Fronts

### DIFF
--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -14,6 +14,11 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
   lazy val webUrl: String = delegate.webUrl
   lazy val webTitle: String = delegate.webTitle
 
+  lazy val keywordId: String = {
+    val normalizedId = id.replace("/", "-")
+    s"$normalizedId/$normalizedId"
+  }
+
   override lazy val isFront = true
 
   override lazy val url: String = SupportedUrl(delegate)
@@ -24,14 +29,15 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
 
   override lazy val metaData: Map[String, JsValue] = super.metaData ++ Map(
     "keywords" -> JsString(webTitle),
+    "keywordIds" -> JsString(keywordId),
     "content-type" -> JsString("Section")
   )
 
-  override lazy val isSponsored: Boolean = DfpAgent.isSponsored(id, Some(id))
-  override lazy val hasMultipleSponsors: Boolean = DfpAgent.hasMultipleSponsors(id)
-  override lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(id, Some(id))
-  override lazy val hasMultipleFeatureAdvertisers: Boolean = DfpAgent.hasMultipleFeatureAdvertisers(id)
-  override lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(id, Some(id))
-  override lazy val sponsor: Option[String] = DfpAgent.getSponsor(id)
+  override lazy val isSponsored: Boolean = DfpAgent.isSponsored(keywordId, Some(id))
+  override lazy val hasMultipleSponsors: Boolean = DfpAgent.hasMultipleSponsors(keywordId)
+  override lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(keywordId, Some(id))
+  override lazy val hasMultipleFeatureAdvertisers: Boolean = DfpAgent.hasMultipleFeatureAdvertisers(keywordId)
+  override lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(keywordId, Some(id))
+  override lazy val sponsor: Option[String] = DfpAgent.getSponsor(keywordId)
   override def hasPageSkin(edition: Edition): Boolean = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 }

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -20,7 +20,7 @@
             }
             data-component="@FaciaComponentName(config, collection)">
             <div class="facia-container__inner">
-                <div class="fc-container__header">
+                <div class="fc-container__header js-container__header">
                     @FootballTagPage(page).asOpt.map{ footballTagPage =>
                         @fragments.containers.elements.footballTeamHeader(footballTagPage, collection)
                     }.getOrElse{

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -184,8 +184,10 @@ class DfpAgentTest extends FlatSpec with Matchers {
   }
 
   it should "be true for front of an ad feature section with a multi-part section name" in {
-    testDfpAgent.isAdvertisementFeature("sustainable-business/grundfos-partner-zone",
-      Some("sustainable-business/grundfos-partner-zone")) should be(true)
+    testDfpAgent.isAdvertisementFeature(
+      tagId = "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone",
+      sectionId = Some("sustainable-business/grundfos-partner-zone")
+    ) should be(true)
   }
 
   it should "be true for an article in an ad feature section with a multi-part section name" in {

--- a/common/test/model/SectionTest.scala
+++ b/common/test/model/SectionTest.scala
@@ -1,0 +1,22 @@
+package model
+
+import com.gu.openplatform.contentapi.model.{Section => ApiSection}
+import org.scalatest.{FlatSpec, Matchers}
+
+class SectionTest extends FlatSpec with Matchers {
+
+  private def toSection(id: String): Section = {
+    val delegate = ApiSection(id,
+      webTitle = "webTitle", webUrl = "webUrl", apiUrl = "apiUrl", editions = Nil)
+    Section(delegate)
+  }
+
+  "keywordId" should "be same as section keyword ID for content pages in section" in {
+
+    toSection("culture").keywordId should be("culture/culture")
+
+    toSection("sustainable-business/grundfos-partner-zone").keywordId should be(
+      "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone")
+  }
+
+}


### PR DESCRIPTION
There's a problem where Ad Ops are having to target different keywords for microsite fronts and content pages.  For example, in ad calls [this front](http://www.theguardian.com/sustainable-business/grundfos-partner-zone) passes _grundfos-partner-zone_ as its keyword parameter whereas [this content page](http://www.theguardian.com/sustainable-business/grundfos-partner-zone/2014/oct/06/saving-co2-desalination-water-italy-aeolian-islands) in the same section passes _sustainable-business-grundfos-partner-zone_ as its section keyword parameter. 

This change solves the problem by giving section fronts a keyword ID that corresponds with the section keyword ID for pages within the section.  Then ad calls target the keyword in the same way as any other keyword. 
