### PR TITLE
Put result endpoint

### DIFF
--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -157,4 +157,10 @@ object FaciaToolController extends Controller with Logging with ExecutionContext
     val now: Option[String] = S3FrontsApi.getPressedLastModified(path)
     now.map(Ok(_)).getOrElse(NotFound)
   }
+
+  def generatePutForCollectionId(collectionId: String) = ExpiringActions.ExpiringAuthAction { request =>
+    ConfigAgent.getConfig(collectionId).map { collectionConfig =>
+      Ok(Json.toJson(ContentApiWrite.generateContentApiPut(collectionId, collectionConfig)))
+    }.getOrElse(NotFound(s"Collection ID $collectionId does not exist in ConfigAgent"))
+  }
 }

--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -74,7 +74,7 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
     }) getOrElse Future.failed(new RuntimeException(s"Missing config properties for Content API write"))
   }
 
-  private def generateContentApiPut(id: String, config: CollectionConfig): ContentApiPut = {
+  def generateContentApiPut(id: String, config: CollectionConfig): ContentApiPut = {
     val maybeBlock = FaciaApi.getBlock(id)
 
     ContentApiPut(

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -36,6 +36,7 @@ POST          /press/draft/*path         controllers.FaciaToolController.pressDr
 
 GET           /front/lastmodified/*path  controllers.FaciaToolController.getLastModified(path)
 
+GET           /collection-put/*collectionId controllers.FaciaToolController.generatePutForCollectionId(collectionId)
 GET           /collection/*id            controllers.FaciaToolController.readBlock(id)
 POST          /edits                     controllers.FaciaToolController.collectionEdits
 GET           /collection                controllers.FaciaToolController.listCollections


### PR DESCRIPTION
This will allow us to see what `facia-tool` generates for a given `collectionId` when putting to the Content API.

E.g. `/collection-put/au/new/regular-stories` 

It is behind `ExpiringActions.ExpiringAuthAction`, so you need to be logged in to use it.

@stephanfowler 
