### PR TITLE
Faux 'position: sticky' module 

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -316,9 +316,9 @@ define([
             windowEventListeners: function () {
                 var event,
                     events = {
-                        resize: 'window:resize',
-                        orientationchange: 'window:orientationchange',
-                        scroll: 'window:scroll'
+                        resize:            'window:resize',
+                        scroll:            'window:scroll',
+                        orientationchange: 'window:orientationchange'
                     },
                     emitEvent = function (eventName) {
                         return function (e) {
@@ -328,6 +328,9 @@ define([
                 for (event in events) {
                     bean.on(window, event, debounce(emitEvent(events[event]), 200));
                 }
+
+                // also adding an (non-debounced, non-throttled) event for scroll - this often needs to be immediate
+                bean.on(window, 'scroll', mediator.emit.bind(mediator, 'window:scroll-immediate'));
             },
 
             checkIframe: function () {

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -5,7 +5,6 @@ define([
     'bonzo',
     'enhancer',
     'fastclick',
-    'lodash/functions/debounce',
     'qwery',
 
     'common/utils/$',
@@ -53,7 +52,6 @@ define([
     bonzo,
     enhancer,
     FastClick,
-    debounce,
     qwery,
 
     $,
@@ -319,18 +317,10 @@ define([
                         resize:            'window:resize',
                         scroll:            'window:scroll',
                         orientationchange: 'window:orientationchange'
-                    },
-                    emitEvent = function (eventName) {
-                        return function (e) {
-                            mediator.emit(eventName, e);
-                        };
                     };
                 for (event in events) {
-                    bean.on(window, event, debounce(emitEvent(events[event]), 200));
+                    bean.on(window, event, mediator.emit.bind(mediator, events[event]));
                 }
-
-                // also adding an (non-debounced, non-throttled) event for scroll - this often needs to be immediate
-                bean.on(window, 'scroll', mediator.emit.bind(mediator, 'window:scroll-immediate'));
             },
 
             checkIframe: function () {

--- a/static/src/javascripts/bootstraps/football.js
+++ b/static/src/javascripts/bootstraps/football.js
@@ -1,33 +1,35 @@
 define([
-    'common/utils/$',
-    'bonzo',
     'bean',
+    'bonzo',
+    'lodash/functions/debounce',
+    'common/utils/$',
     'common/utils/ajax',
     'common/utils/config',
-    'common/utils/page',
-    'common/utils/mediator',
     'common/utils/detect',
-    'common/modules/ui/rhc',
+    'common/utils/mediator',
+    'common/utils/page',
     'common/modules/charts/table-doughnut',
-    'common/modules/sport/football/match-list-live',
+    'common/modules/sport/football/football',
     'common/modules/sport/football/match-info',
+    'common/modules/sport/football/match-list-live',
     'common/modules/sport/football/score-board',
-    'common/modules/sport/football/football'
+    'common/modules/ui/rhc'
 ], function (
-    $,
-    bonzo,
     bean,
+    bonzo,
+    debounce,
+    $,
     ajax,
     config,
-    page,
-    mediator,
     detect,
-    rhc,
+    mediator,
+    page,
     Doughnut,
-    MatchListLive,
+    football,
     MatchInfo,
+    MatchListLive,
     ScoreBoard,
-    football
+    rhc
 ) {
 
     function renderNav(match, callback) {
@@ -315,7 +317,7 @@ define([
                     }
                     return r;
                 })();
-                mediator.on('window:resize', resize);
+                mediator.on('window:resize', debounce(resize, 200));
                 bean.on(document, 'click', '.dropdown__button', resize);
             })();
         }

--- a/static/src/javascripts/bootstraps/gallery.js
+++ b/static/src/javascripts/bootstraps/gallery.js
@@ -1,23 +1,25 @@
 define([
-    'common/utils/mediator',
-    'common/utils/$',
-    'common/utils/config',
-    'common/modules/component',
-    'common/modules/gallery/lightbox',
-    'lodash/collections/forEach',
+    'bean',
     'bonzo',
     'qwery',
-    'bean'
+    'lodash/collections/forEach',
+    'lodash/functions/debounce',
+    'common/utils/$',
+    'common/utils/config',
+    'common/utils/mediator',
+    'common/modules/component',
+    'common/modules/gallery/lightbox'
 ], function (
-    mediator,
-    $,
-    config,
-    Component,
-    LightboxGallery,
-    forEach,
+    bean,
     bonzo,
     qwery,
-    bean
+    forEach,
+    debounce,
+    $,
+    config,
+    mediator,
+    Component,
+    LightboxGallery
 ) {
 
     var verticallyResponsiveImages = function () {
@@ -38,8 +40,8 @@ define([
 
             setHeight();
             mediator.addListeners({
-                'window:resize': setHeight,
-                'window:orientationchange': setHeight,
+                'window:resize': debounce(setHeight, 200),
+                'window:orientationchange': debounce(setHeight, 200),
                 'ui:images:vh': setHeight
             });
         },

--- a/static/src/javascripts/bootstraps/liveblog.js
+++ b/static/src/javascripts/bootstraps/liveblog.js
@@ -18,8 +18,8 @@ define([
     'common/modules/ui/dropdowns',
     'common/modules/ui/message',
     'common/modules/ui/notification-counter',
-    'bootstraps/article',
-    'common/modules/ui/relativedates'
+    'common/modules/ui/relativedates',
+    'bootstraps/article'
 ], function (
     bean,
     bonzo,
@@ -40,8 +40,8 @@ define([
     dropdowns,
     Message,
     NotificationCounter,
-    article,
-    RelativeDates
+    RelativeDates,
+    article
 ) {
     'use strict';
 
@@ -78,7 +78,7 @@ define([
 
         function unselectOnScroll() {
             bean.off(curBinding);
-            curBinding = bean.one(document, 'scroll', function () { unselect(); });
+            curBinding = mediator.once('window:scroll', function () { unselect(); });
         }
 
         bean.on(document.body, 'click', 'a', function (e) {

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -1,11 +1,13 @@
 define([
-    'common/utils/$',
     'bonzo',
+    'lodash/functions/debounce',
+    'common/utils/$',
     'common/utils/mediator',
     'common/modules/identity/api'
 ], function (
-    $,
     bonzo,
+    debounce,
+    $,
     mediator,
     Id
 ) {
@@ -100,12 +102,12 @@ define([
             scroll = function () {
                 if (!track.seen && !timer && track.areCommentsVisible()) {
                     track.scrolledToComments();
-                    mediator.off('window:scroll', scroll);
+                    mediator.off('window:scroll', debounce(scroll, 200));
                 }
             };
 
         if (!track.seen) {
-            mediator.on('window:scroll', scroll);
+            mediator.on('window:scroll', debounce(scroll, 200));
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/analytics/scrollDepth.js
+++ b/static/src/javascripts/projects/common/modules/analytics/scrollDepth.js
@@ -1,9 +1,11 @@
 define([
-    'common/utils/mediator',
-    'lodash/objects/assign'
+    'lodash/functions/debounce',
+    'lodash/objects/assign',
+    'common/utils/mediator'
 ], function (
-    mediator,
-    extend
+    debounce,
+    extend,
+    mediator
 ) {
 
     function ScrollDepth(config) {
@@ -96,7 +98,7 @@ define([
     };
 
     ScrollDepth.prototype.init = function () {
-        mediator.on('window:scroll', this.assertScrolling.bind(this));
+        mediator.on('window:scroll', debounce(this.assertScrolling.bind(this), 200));
         mediator.on('scrolldepth:inactive', this.hasDataChanged.bind(this));
         mediator.on('module:clickstream:click', this.hasDataChanged.bind(this));
     };

--- a/static/src/javascripts/projects/common/modules/analytics/scrollDepth.js
+++ b/static/src/javascripts/projects/common/modules/analytics/scrollDepth.js
@@ -4,12 +4,12 @@ define([
     'common/utils/mediator'
 ], function (
     debounce,
-    extend,
+    assign,
     mediator
 ) {
 
     function ScrollDepth(config) {
-        this.config = extend(this.config, config);
+        this.config = assign(this.config, config);
 
         if (this.config.isContent) {
             this.config.contentEl = this.contentEl || document.getElementById('article') || document.getElementById('live-blog');

--- a/static/src/javascripts/projects/common/modules/article/twitter.js
+++ b/static/src/javascripts/projects/common/modules/article/twitter.js
@@ -5,6 +5,7 @@ define([
     'bonzo',
     'qwery',
     'lodash/collections/forEach',
+    'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/config',
     'common/utils/detect',
@@ -14,6 +15,7 @@ define([
     bonzo,
     qwery,
     forEach,
+    debounce,
     $,
     config,
     detect,
@@ -22,7 +24,7 @@ define([
     var body = qwery('.js-liveblog-body');
 
     function bootstrap() {
-        mediator.on('window:scroll', enhanceTweets);
+        mediator.on('window:scroll', debounce(enhanceTweets, 200));
     }
 
     function enhanceTweets() {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -28,6 +28,7 @@ define([
     'common/modules/commercial/tags/criteo',
     'common/modules/commercial/user-ad-targeting',
     'common/modules/experiments/ab',
+    'common/modules/ui/sticky',
     'text!common/views/commercial/ad-slot.html'
 ], function (
     bean,
@@ -58,6 +59,7 @@ define([
     criteo,
     userAdTargeting,
     ab,
+    Sticky,
     adSlotTpl
 ) {
 
@@ -147,6 +149,22 @@ define([
                 sizeMappings: {
                     mobile: '140,90'
                 }
+            }
+        },
+        callbacks = {
+            '300,250': function (e, $adSlot) {
+                console.log('1');
+                var $col   = $('.content__secondary-column'),
+                    bottom = $col.dim().height + $col[0].getBoundingClientRect().top + window.scrollY,
+                    sticky = new Sticky($adSlot[0], 12, { bottom: bottom });
+                console.log('2');
+            },
+            '300,600': function (e, $adSlot) {
+                console.log('3');
+                var $col   = $('.content__secondary-column'),
+                    bottom = $col.dim().height + $col[0].getBoundingClientRect().top + window.scrollY,
+                    sticky = new Sticky($adSlot[0], 12, { bottom: bottom });
+                console.log('4');
             }
         },
 
@@ -388,10 +406,11 @@ define([
             return slot;
         },
         parseAd = function (event) {
-            var $slot = $('#' + event.slot.getSlotId().getDomId());
+            var $slot = $('#' + event.slot.getSlotId().getDomId()),
+                size  = event.size.join(',');
 
             // remove any placeholder ad content
-            $('.ad-slot__content--placeholder', $slot[0]).remove();
+            $('.ad-slot__content--placeholder', $slot).remove();
 
             if (event.isEmpty) {
                 removeLabel($slot);
@@ -399,6 +418,9 @@ define([
                 checkForBreakout($slot);
                 addLabel($slot);
             }
+
+            // is there a callback for this size
+            callbacks[size] && callbacks[size](event, $slot);
         },
         addLabel = function ($slot) {
             if (shouldRenderLabel($slot)) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -152,19 +152,8 @@ define([
             }
         },
         callbacks = {
-            '300,250': function (e, $adSlot) {
-                console.log('1');
-                var $col   = $('.content__secondary-column'),
-                    bottom = $col.dim().height + $col[0].getBoundingClientRect().top + window.scrollY,
-                    sticky = new Sticky($adSlot[0], 12, { bottom: bottom });
-                console.log('2');
-            },
-            '300,600': function (e, $adSlot) {
-                console.log('3');
-                var $col   = $('.content__secondary-column'),
-                    bottom = $col.dim().height + $col[0].getBoundingClientRect().top + window.scrollY,
-                    sticky = new Sticky($adSlot[0], 12, { bottom: bottom });
-                console.log('4');
+            '300,251': function (e, $adSlot) {
+                var sticky = new Sticky($adSlot[0], { top: 12, container: qwery('.content__secondary-column')[0] });
             }
         },
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -153,7 +153,7 @@ define([
         },
         callbacks = {
             '300,251': function (e, $adSlot) {
-                var sticky = new Sticky($adSlot[0], { top: 12, container: qwery('.content__secondary-column')[0] });
+                new Sticky($adSlot[0], { top: 12, container: qwery('.content__secondary-column')[0] }).init();
             }
         },
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -153,7 +153,7 @@ define([
         },
         callbacks = {
             '300,251': function (e, $adSlot) {
-                new Sticky($adSlot[0], { top: 12, container: qwery('.content__secondary-column')[0] }).init();
+                new Sticky($adSlot.parent()[0], { top: 12 }).init();
             }
         },
 

--- a/static/src/javascripts/projects/common/modules/experiments/affix.js
+++ b/static/src/javascripts/projects/common/modules/experiments/affix.js
@@ -2,17 +2,21 @@ define([
     'bean',
     'bonzo',
     'lodash/functions/debounce',
-    'common/utils/request-animation-frame',
-    'common/utils/mediator'
-], function (bean, bonzo, debounce, raf, mediator) {
+    'common/utils/mediator',
+    'common/utils/request-animation-frame'
+], function (
+    bean,
+    bonzo,
+    debounce,
+    mediator,
+    raf
+) {
 
     var Affix = function (options) {
 
-        bean.on(window, 'scroll', debounce(this.checkPositionWithEventLoop.bind(this), 10));
         bean.on(window, 'click', this.checkPositionWithEventLoop.bind(this));
-
-        // Use mediator here, because the standard debounce time interval is adequate, unlike scroll.
-        mediator.addListener('window:resize', this.calculateContainerPositioning.bind(this));
+        mediator.addListener('window:scroll', debounce(this.checkPositionWithEventLoop.bind(this), 10));
+        mediator.addListener('window:resize', debounce(this.calculateContainerPositioning.bind(this), 200));
 
         this.affixed  = null;
         this.$markerTop = bonzo(options.topMarker);

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -1,33 +1,33 @@
 define([
-    'common/utils/_',
     'bean',
     'bonzo',
     'qwery',
     'common/utils/$',
+    'common/utils/_',
     'common/utils/ajax',
-    'common/utils/url',
     'common/utils/config',
-    'common/utils/mediator',
-    'common/utils/fsm',
     'common/utils/detect',
+    'common/utils/fsm',
+    'common/utils/mediator',
+    'common/utils/template',
+    'common/utils/url',
     'common/modules/component',
-    'common/modules/ui/images',
-    'common/utils/template'
+    'common/modules/ui/images'
 ], function (
-    _,
     bean,
     bonzo,
     qwery,
     $,
+    _,
     ajax,
-    url,
     config,
-    mediator,
-    FiniteStateMachine,
     detect,
+    FiniteStateMachine,
+    mediator,
+    template,
+    url,
     Component,
-    imagesModule,
-    template
+    imagesModule
 ) {
     function GalleryLightbox() {
 
@@ -314,14 +314,14 @@ define([
 
                 // event bindings
                 bean.on(this.$swipeContainer[0], 'click', '.js-gallery-content', this.toggleInfo);
-                bean.on(window, 'resize', this.resize);
+                mediator.on('window:resize', this.resize);
 
                 // meta
                 this.$indexEl.text(this.index);
             },
             leave: function() {
                 bean.off(this.$swipeContainer[0], 'click', this.toggleInfo);
-                bean.off(window, 'resize', this.resize);
+                mediator.off('window:resize', this.resize);
             },
             events: {
                 'next': function(interactionType) {
@@ -382,11 +382,11 @@ define([
             enter: function() {
                 this.translateContent(this.$slides.length, 0, 0);
                 this.index = this.images.length + 1;
-                bean.on(window, 'resize', this.resize);
+                mediator.on('window:resize', this.resize);
                 imagesModule.upgrade(this.endslateEl);
             },
             leave: function() {
-                bean.off(window, 'resize', this.resize);
+                mediator.off('window:resize', this.resize);
             },
             events: {
                 'next': function(interactionType) {

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe.js
@@ -1,9 +1,11 @@
 define([
-    'common/utils/$',
-    'bean'
+    'bean',
+    'lodash/functions/debounce',
+    'common/utils/$'
 ], function (
-    $,
-    bean
+    bean,
+    debounce,
+    $
 ) {
 
     function FormstackIframe(el, config) {
@@ -20,7 +22,7 @@ define([
                 }
             });
 
-            bean.on(window, 'resize', self.refreshHeight);
+            mediator.on('window:resize', self.refreshHeight);
 
             // Listen for load of form confirmation or error page,
             // which has no form, so won't instantiate the Formstack module

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe.js
@@ -1,11 +1,13 @@
 define([
     'bean',
     'lodash/functions/debounce',
-    'common/utils/$'
+    'common/utils/$',
+    'common/utils/mediator'
 ], function (
     bean,
     debounce,
-    $
+    $,
+    mediator
 ) {
 
     function FormstackIframe(el, config) {

--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -2,6 +2,7 @@ define([
     'bonzo',
     'imager',
     'lodash/collections/forEach',
+    'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/$css',
     'common/utils/mediator'
@@ -10,6 +11,7 @@ function (
     bonzo,
     imager,
     forEach,
+    debounce,
     $,
     $css,
     mediator
@@ -49,12 +51,12 @@ function (
 
         listen: function () {
             mediator.addListeners({
-                'window:resize': function () {
+                'window:resize': debounce(function () {
                     images.upgrade();
-                },
-                'window:orientationchange': function () {
+                }, 200),
+                'window:orientationchange': debounce(function () {
                     images.upgrade();
-                },
+                }, 200),
                 'ui:images:upgrade': function (context) {
                     images.upgrade(context);
                 }

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -12,6 +12,9 @@ define([
         this.element          = element;
         this.top              = options.top || 0;
         this.container        = options.container;
+    };
+
+    Sticky.prototype.init = function () {
         // position of element from document top
         this.elementDocOffset = this.element.getBoundingClientRect().top + window.scrollY;
 

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -9,9 +9,9 @@ define([
 ) {
 
     var Sticky = function (element, options) {
-        this.element          = element;
-        this.top              = options.top || 0;
-        this.container        = options.container;
+        this.element   = element;
+        this.top       = options.top || 0;
+        this.container = options.container;
     };
 
     Sticky.prototype.init = function () {
@@ -24,18 +24,18 @@ define([
     };
 
     Sticky.prototype.updatePosition = function () {
-        var css, elementTop,
+        var css, stickyTop,
             $element = bonzo(this.element);
         // have we scrolled past the element
         if (window.scrollY >= this.elementDocOffset - this.top) {
-            elementTop = this.container ?
+            stickyTop = this.container ?
                 // make sure the element stays within the container
                 Math.min(this.top, this.container.getBoundingClientRect().bottom - $element.dim().height) :
                 this.top;
 
             css = {
                 position: 'fixed',
-                top:      elementTop
+                top:      stickyTop
             };
         } else {
             css = {

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -21,24 +21,26 @@ define([
     };
 
     Sticky.prototype.updatePosition = function () {
+        var css,
+            $element = bonzo(this.element);
         // have we scrolled past the element
         if (window.scrollY >= this.elementDocOffset - this.top) {
             var elementTop = this.container ?
                 // make sure the element stays within the container
-                Math.min(this.top, this.container.getBoundingClientRect().bottom - bonzo(this.element).dim().height) :
+                Math.min(this.top, this.container.getBoundingClientRect().bottom - $element.dim().height) :
                 this.top;
 
-            this.css(this.element, 'fixed', elementTop);
+            css = {
+                position: fixed,
+                top:      elementTop
+            };
         } else {
-            this.css(this.element, null, null);
+            css = {
+                position: null,
+                top:      null
+            };
         }
-    };
-
-    Sticky.prototype.css = function (element, position, top) {
-        return bonzo(element).css({
-            position: position,
-            top:      top
-        });
+        return $element.css();
     };
 
     return Sticky;

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -26,6 +26,7 @@ define([
     Sticky.prototype.updatePosition = function () {
         var css, stickyTop,
             $element = bonzo(this.element);
+
         // have we scrolled past the element
         if (window.scrollY >= this.elementDocOffset - this.top) {
             stickyTop = this.container ?
@@ -43,6 +44,7 @@ define([
                 top:      null
             };
         }
+
         return $element.css();
     };
 

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -24,11 +24,11 @@ define([
     };
 
     Sticky.prototype.updatePosition = function () {
-        var css,
+        var css, elementTop,
             $element = bonzo(this.element);
         // have we scrolled past the element
         if (window.scrollY >= this.elementDocOffset - this.top) {
-            var elementTop = this.container ?
+            elementTop = this.container ?
                 // make sure the element stays within the container
                 Math.min(this.top, this.container.getBoundingClientRect().bottom - $element.dim().height) :
                 this.top;

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -1,0 +1,42 @@
+define([
+    'bonzo',
+    'common/utils/$',
+    'common/utils/mediator'
+], function (
+    bonzo,
+    $,
+    mediator
+) {
+
+    var Sticky = function (element, top, options) {
+        this.$element   = bonzo(element);
+        this.top        = top;
+        this.bottom     = options.bottom;
+        // position of element from document top
+        this.elementTop = element.getBoundingClientRect().top + window.scrollY;
+
+        mediator.on('window:scroll-immediate', this.updatePosition.bind(this));
+        // kick off an initial position update
+        this.updatePosition();
+    };
+
+    Sticky.prototype.updatePosition = function () {
+        if (window.scrollY >= this.elementTop) {
+            // if there's a bottom param, limit how far the bottom of the element is from the top of the document
+            var limit = this.bottom ? this.bottom - window.scrollY + this.$element.dim().height : this.top;
+            this.css(this.$element, 'fixed', Math.min(this.top, limit));
+        } else {
+            this.css(this.$element, null, null);
+        }
+    };
+
+    Sticky.prototype.css = function ($element, position, top) {
+        return $element.css({
+            position: position,
+            top:      top
+        });
+    };
+
+    return Sticky;
+
+});

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -8,10 +8,12 @@ define([
     mediator
 ) {
 
+    /**
+     * @todo: check if browser natively supports "position: sticky"
+     */
     var Sticky = function (element, options) {
-        this.element   = element;
-        this.top       = options.top || 0;
-        this.container = options.container;
+        this.element = element;
+        this.top     = options.top || 0;
     };
 
     Sticky.prototype.init = function () {
@@ -24,19 +26,18 @@ define([
     };
 
     Sticky.prototype.updatePosition = function () {
-        var css, stickyTop,
+        var parent, fixedTop, css,
             $element = bonzo(this.element);
 
         // have we scrolled past the element
         if (window.scrollY >= this.elementDocOffset - this.top) {
-            stickyTop = this.container ?
-                // make sure the element stays within the container
-                Math.min(this.top, this.container.getBoundingClientRect().bottom - $element.dim().height) :
-                this.top;
+            parent = $element.parent()[0];
+            // make sure the element stays within its parent
+            fixedTop = Math.min(this.top, parent.getBoundingClientRect().bottom - $element.dim().height);
 
             css = {
                 position: 'fixed',
-                top:      stickyTop
+                top:      fixedTop
             };
         } else {
             css = {
@@ -45,7 +46,7 @@ define([
             };
         }
 
-        return $element.css();
+        return $element.css(css);
     };
 
     return Sticky;

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -15,7 +15,7 @@ define([
         // position of element from document top
         this.elementDocOffset = this.element.getBoundingClientRect().top + window.scrollY;
 
-        mediator.on('window:scroll-immediate', throttle(this.updatePosition.bind(this), 10));
+        mediator.on('window:scroll', throttle(this.updatePosition.bind(this), 10));
         // kick off an initial position update
         this.updatePosition();
     };
@@ -31,7 +31,7 @@ define([
                 this.top;
 
             css = {
-                position: fixed,
+                position: 'fixed',
                 top:      elementTop
             };
         } else {

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -1,6 +1,7 @@
 define([
-    'common/utils/$',
     'bonzo',
+    'lodash/functions/debounce',
+    'common/utils/$',
     'common/utils/ajax',
     'common/utils/mediator',
     'common/utils/template',
@@ -8,8 +9,9 @@ define([
     'common/modules/ui/relativedates',
     'facia/modules/ui/football-snaps'
 ], function (
-    $,
     bonzo,
+    debounce,
+    $,
     ajax,
     mediator,
     template,
@@ -26,9 +28,9 @@ define([
         snaps.forEach(fetchSnap);
 
         if (snaps.length) {
-            mediator.on('window:resize', function () {
+            mediator.on('window:resize', debounce(function () {
                 snaps.forEach(function (el) { addCss(el, true); });
-            });
+            }, 200));
         }
     }
 


### PR DESCRIPTION
Needed a simple js 'position sticky' module for a MPU test

Also, often we need access to the non-debounced window events (scroll, etc), so removed it from the mediator events, and moved the onus on the listener to throttle/debounce
