### PR TITLE
Compensate for image-width on media cards

### DIFF
--- a/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
@@ -28,6 +28,10 @@ Media list item. Looks a bit like this:
         display: block;
     }
 
+    .u-faux-block-link__overlay {
+        left: - $image-width;
+    }
+
     .fc-item__media-wrapper {
         @include mq($until: tablet) {
             margin: $gs-baseline / 3;


### PR DESCRIPTION
This will make images clickable/tappable on `list-media` items.

cc @sndrs 

Before:
![screen shot 2014-10-15 at 14 55 36](https://cloud.githubusercontent.com/assets/1607666/4646407/f104ff58-5472-11e4-8e67-5ecadae1fc62.png)

After:
![screen shot 2014-10-15 at 14 55 48](https://cloud.githubusercontent.com/assets/1607666/4646406/efe27e70-5472-11e4-8bd6-6b185e21a68a.png)
