### PR TITLE
Fix conversion of fields

### DIFF
--- a/facia-tool/app/services/ContentApiWrite.scala
+++ b/facia-tool/app/services/ContentApiWrite.scala
@@ -91,7 +91,7 @@ trait ContentApiWrite extends ExecutionContexts with Logging {
 
   private def generateItems(items: List[Trail]): List[Item] =
     items.filterNot(t => Snap.isSnap(t.id)).map { trail =>
-      Item(trail.id, trail.meta)
+      Item(trail.id, trail.meta.map(trailMetaData => trailMetaData.copy(json = trailMetaData.json.map(convertFields))))
     }
 
   //TODO: These are in transition and will be removed


### PR DESCRIPTION
We lost the use of `convertFields` during the big refactor.

The Content API needs the fields to be different to how we use them;
They demanded:
- `group` is an Int
- `supporting` is called `supportingContent`
- `meta` is called `metaData`

@stephanfowler 
