### PR TITLE
Let Identity skip confirmation for registration

### DIFF
--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -10,6 +10,7 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
   def apply(request: RequestHeader): IdentityRequest = {
     val returnUrl = returnUrlVerifier.getVerifiedReturnUrl(request)
     val ip = clientIp(request)
+    val skipConfirmation = request.getQueryString("skipConfirmation").map(_ == "true")
     IdentityRequest(
       TrackingData(
         returnUrl,
@@ -20,9 +21,10 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
         request.headers.get("User-Agent")
       ),
       returnUrl,
-      ip
+      ip,
+      skipConfirmation
     )
   }
 }
 
-case class IdentityRequest(trackingData: TrackingData, returnUrl: Option[String], clientIp: Option[String])
+case class IdentityRequest(trackingData: TrackingData, returnUrl: Option[String], clientIp: Option[String], skipConfirmation: Option[Boolean])

--- a/identity/app/services/IdentityUrlBuilder.scala
+++ b/identity/app/services/IdentityUrlBuilder.scala
@@ -7,7 +7,11 @@ import java.net.URLEncoder
 class IdentityUrlBuilder @Inject()(conf: IdentityConfiguration) {
 
   def queryParams(idRequest: IdentityRequest): List[(String, String)] = {
-    val params = List("returnUrl" -> idRequest.returnUrl, "type" -> idRequest.trackingData.registrationType)
+    val params = List(
+      "returnUrl" -> idRequest.returnUrl,
+      "type" -> idRequest.trackingData.registrationType,
+      "skipConfirmation" -> idRequest.skipConfirmation.map(_.toString)
+    )
     params.flatMap(param => if (param._2.isDefined) Some(param._1 -> param._2.get) else None)
   }
 

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -17,7 +17,7 @@ POST        /password/change                        @controllers.ChangePasswordC
 GET         /password/reset-confirmation            @controllers.ResetPasswordController.renderPasswordResetConfirmation
 GET         /password/email-sent                    @controllers.ResetPasswordController.renderEmailSentConfirmation
 GET         /requestnewtoken                        @controllers.ResetPasswordController.requestNewToken
-GET         /register                               @controllers.RegistrationController.renderForm(returnUrl : Option[String])
+GET         /register                               @controllers.RegistrationController.renderForm(returnUrl : Option[String], skipConfirmation : Option[Boolean])
 POST        /register                               @controllers.RegistrationController.processForm
 GET         /register/confirm                       @controllers.RegistrationController.renderRegistrationConfirmation(returnUrl)
 GET         /email-prefs                            @controllers.EmailController.preferences

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -103,12 +103,12 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
         verify(api).register(Matchers.same(user), Matchers.anyObject())
       }
 
-      "shuold pass the the omniture data to the the api" in Fake {
+      "should pass the the omniture data to the the api" in Fake {
         registrationController.processForm()(fakeRequest)
         verify(api).register(Matchers.anyObject(), Matchers.same(trackingData))
       }
 
-      "should provide user IP, exrtacted from the X-Forwarded-For header value" in Fake {
+      "should provide user IP, extracted from the X-Forwarded-For header value" in Fake {
         registrationController.processForm()(fakeRequest)
 
         object TrackingDataIpMatcher extends ArgumentMatcher {

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -28,7 +28,7 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
   val createdUser = mock[User]
   val trackingData = mock[TrackingData]
 
-  val identityRequest = IdentityRequest(trackingData, Some("http://example.com/comeback"), Some("123.456.789.12"))
+  val identityRequest = IdentityRequest(trackingData, Some("http://example.com/comeback"), Some("123.456.789.12"), Some(false))
   val conf = new IdentityConfiguration
   val signinService = new PlaySigninService(conf)
   val user = User("test@example.com", "123")
@@ -46,7 +46,7 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
       val request = TestRequest()
       val returnUrl = Some("http://example.com/return")
       when(returnUrlVerifier.getVerifiedReturnUrl(request)).thenReturn(returnUrl)
-      val result = registrationController.renderForm(returnUrl)(request)
+      val result = registrationController.renderForm(returnUrl, Some(false))(request)
       status(result) should equal(OK)
     }
   }

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -22,7 +22,7 @@ class ResetPasswordControllerTest extends path.FreeSpec with ShouldMatchers with
   val idUrlBuilder = mock[IdentityUrlBuilder]
   val trackingData = mock[TrackingData]
   val authenticationService = mock[AuthenticationService]
-  val identityRequest = IdentityRequest(trackingData, None, Some("123.456.789.10"))
+  val identityRequest = IdentityRequest(trackingData, None, Some("123.456.789.10"), Some(false))
 
   val resetPasswordController = new ResetPasswordController(api, requestParser, idUrlBuilder, authenticationService)
   when(requestParser.apply(anyObject())).thenReturn(identityRequest)

--- a/identity/test/controllers/SigninControllerTest.scala
+++ b/identity/test/controllers/SigninControllerTest.scala
@@ -33,7 +33,7 @@ class SigninControllerTest extends path.FreeSpec with ShouldMatchers with Mockit
   val api = mock[IdApiClient]
   val conf = new IdentityConfiguration
   val trackingData = mock[TrackingData]
-  val identityRequest = IdentityRequest(trackingData, Some("http://example.com/return"), None)
+  val identityRequest = IdentityRequest(trackingData, Some("http://example.com/return"), None, Some(false))
   val signInService = new PlaySigninService(conf)
 
   val signinController = new SigninController(returnUrlVerifier, api, requestParser, idUrlBuilder, signInService)

--- a/identity/test/controllers/SignoutControllerTest.scala
+++ b/identity/test/controllers/SignoutControllerTest.scala
@@ -34,7 +34,7 @@ class SignoutControllerTest extends path.FreeSpec with ShouldMatchers with Mocki
   val signoutController = new SignoutController( returnUrlVerifier, conf, api, idRequestParser, signInService)
   val trackingData = mock[TrackingData]
 
-  val identityRequest = IdentityRequest(trackingData, Some("http://example.com/return"), None)
+  val identityRequest = IdentityRequest(trackingData, Some("http://example.com/return"), None, Some(false))
   when(idRequestParser.apply(anyObject())).thenReturn(identityRequest)
 
   "the signout method" - {

--- a/identity/test/services/IdentityUrlBuilderTest.scala
+++ b/identity/test/services/IdentityUrlBuilderTest.scala
@@ -13,6 +13,7 @@ class IdentityUrlBuilderTest extends path.FreeSpec with Matchers with MockitoSug
   val omnitureTracking = mock[TrackingData]
   when(idRequest.trackingData) thenReturn omnitureTracking
   when(idRequest.returnUrl) thenReturn None
+  when(idRequest.skipConfirmation) thenReturn None
   when(omnitureTracking.registrationType) thenReturn None
 
   val idUrlBuilder = new IdentityUrlBuilder(conf)
@@ -34,7 +35,15 @@ class IdentityUrlBuilderTest extends path.FreeSpec with Matchers with MockitoSug
       }
     }
 
-    "if provided a regitration type parameter" - {
+    "if told to skip confirmation" - {
+      when(idRequest.skipConfirmation) thenReturn Some(true)
+
+      "should include skipConfirmation in the returned params" in {
+        idUrlBuilder.queryParams(idRequest) should contain("skipConfirmation" -> "true")
+      }
+    }
+
+    "if provided a registration type parameter" - {
       when(omnitureTracking.registrationType) thenReturn Some("test")
 
       "should include type parameter" in {
@@ -42,7 +51,7 @@ class IdentityUrlBuilderTest extends path.FreeSpec with Matchers with MockitoSug
       }
     }
 
-    "if not provided a regitration type" - {
+    "if not provided a registration type" - {
       when(omnitureTracking.registrationType) thenReturn None
 
       "should not include returnUrl in returned params" in {


### PR DESCRIPTION
This is predominantly for Membership, although NGW can opt-in if you like too. Basically, you can append `?skipConfirmation=true` to a link to `https://profile.theguardian.com/register` which, when used in combination with a `returnUrl`, means the user will never be shown this page:

![image](https://cloud.githubusercontent.com/assets/394376/4648045/417493c0-547f-11e4-9c69-a7e770eafed8.png)

Apparently that confirmation page is a requirement for Guardian Jobs and/or Discussion, but for Membership we don't require a confirmed email address (and in any case that button doesn't really do anything except remind people to confirm) and we want to ensure a smooth user journey after registering.

Credit to @wpf500 for help with the Scala here.
