### PR TITLE
Enable Admin Pages in Dev-Build

### DIFF
--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -25,4 +25,9 @@ object DevAssetsController extends Controller with ExecutionContexts {
   def atFonts(path: String) = at(s"fonts/$path")
   def atJavascripts(file: String) = at(s"javascripts/$file")
   def atStylesheets(file: String) = at(s"stylesheets/$file")
+
+  def humans(): Action[AnyContent] = controllers.Assets.at(path = "/public", file = "humans.txt")
+
+  def surveys(file: String): Action[AnyContent] =
+    controllers.Assets.at(path = "/public/surveys", file, aggressiveCaching = false)
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -2,8 +2,8 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET         /humans.txt                                                                                              controllers.Assets.at(path="/public", file="humans.txt")
-GET         /surveys/*file                                                                                           controllers.Assets.at(path="/public/surveys", file)
+GET         /humans.txt                                                                                              dev.DevAssetsController.humans()
+GET         /surveys/*file                                                                                           dev.DevAssetsController.surveys(file)
 GET         /commercial/test-page                                                                                    controllers.commercial.CreativeTestPage.allComponents
 
 # For dev machines
@@ -21,6 +21,7 @@ GET         /analytics/abtests                                                  
 GET         /analytics/confidence                                                                                    controllers.admin.AnalyticsConfidenceController.renderConfidence()
 GET         /analytics/google-referrers                                                                              controllers.admin.GoogleReferrerController.renderGoogleReferrerDashboard()
 GET         /analytics/content/gallery                                                                               controllers.admin.ContentPerformanceController.renderGalleryDashboard()
+GET         /analytics/content/liveblog                                                                              controllers.admin.ContentPerformanceController.renderLiveBlogDashboard()
 GET         /analytics/omniture/segments/:rsid                                                                       controllers.admin.OmnitureReportController.getSegments(rsid)
 GET         /analytics/omniture/*reportName                                                                          controllers.admin.OmnitureReportController.getReport(reportName)
 GET         /analytics/commercial                                                                                    controllers.admin.CommercialController.renderCommercial()


### PR DESCRIPTION
Reverse routing stopped working:
- Using the same controller for multiple route patterns gives a NoSuchMethodException.
- There was a missing route referred to in a template.
