### PR TITLE
delay initialisation of id bootstrap

### DIFF
--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -1,4 +1,3 @@
-/*global guardian:true */
 define([
     'raven',
     'qwery',
@@ -50,15 +49,11 @@ define([
                 }
             );
         },
-        modules = {
-
-        },
 
         routes = function () {
             userTiming.mark('App Begin');
 
             bootstrapContext('common', bootstrapCommon);
-
 
             // Front
             if (config.page.isFront) {

--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -7,9 +7,6 @@ define([
     'common/utils/config',
     'common/utils/userTiming',
 
-    'common/modules/ui/fonts',
-    'common/modules/commercial/user-ad-targeting',
-
     'bootstraps/common',
     'bootstraps/tag',
     'bootstraps/section',
@@ -18,7 +15,6 @@ define([
     'bootstraps/liveblog',
     'bootstraps/media',
     'bootstraps/gallery',
-    'bootstraps/identity',
     'bootstraps/profile',
     'bootstraps/sport'
 ], function (
@@ -28,9 +24,6 @@ define([
     detect,
     config,
     userTiming,
-
-    Fonts,
-    userAdTargeting,
 
     bootstrapCommon,
     tag,
@@ -59,33 +52,13 @@ define([
         },
         modules = {
 
-            loadFonts: function (ua) {
-                if (config.switches.webFonts && !guardian.shouldLoadFontsAsynchronously) {
-                    var fileFormat = detect.getFontFormatSupport(ua),
-                        fontStyleNodes = document.querySelectorAll('[data-cache-name].initial'),
-                        f = new Fonts(fontStyleNodes, fileFormat);
-                    f.loadFromServerAndApply();
-                }
-            },
-
-            initId: function () {
-                identity.init(config);
-            },
-
-            initUserAdTargeting: function () {
-                userAdTargeting.requestUserSegmentsFromId();
-            }
         },
 
         routes = function () {
             userTiming.mark('App Begin');
 
-            modules.loadFonts(navigator.userAgent);
-            modules.initUserAdTargeting();
-
             bootstrapContext('common', bootstrapCommon);
 
-            modules.initId();
 
             // Front
             if (config.page.isFront) {

--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -81,10 +81,11 @@ define([
             userTiming.mark('App Begin');
 
             modules.loadFonts(navigator.userAgent);
-            modules.initId();
             modules.initUserAdTargeting();
 
             bootstrapContext('common', bootstrapCommon);
+
+            modules.initId();
 
             // Front
             if (config.page.isFront) {

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -7,6 +7,8 @@ define([
     'fastclick',
     'qwery',
 
+    'bootstraps/identity',
+
     'common/utils/$',
     'common/utils/ajax',
     'common/utils/config',
@@ -21,6 +23,7 @@ define([
     'common/modules/analytics/omniture',
     'common/modules/analytics/register',
     'common/modules/analytics/scrollDepth',
+    'common/modules/commercial/user-ad-targeting',
     'common/modules/discussion/api',
     'common/modules/discussion/comment-count',
     'common/modules/discussion/loader',
@@ -41,6 +44,7 @@ define([
     'common/modules/release-message',
     'common/modules/ui/dropdowns',
     'common/modules/ui/faux-block-link',
+    'common/modules/ui/fonts',
     'common/modules/ui/message',
     'common/modules/ui/relativedates',
     'common/modules/ui/smartAppBanner',
@@ -53,6 +57,8 @@ define([
     enhancer,
     FastClick,
     qwery,
+
+    identity,
 
     $,
     ajax,
@@ -68,6 +74,7 @@ define([
     Omniture,
     register,
     ScrollDepth,
+    userAdTargeting,
     discussionApi,
     CommentCount,
     DiscussionLoader,
@@ -88,6 +95,7 @@ define([
     releaseMessage,
     Dropdowns,
     fauxBlockLink,
+    Fonts,
     Message,
     RelativeDates,
     smartAppBanner,
@@ -412,6 +420,22 @@ define([
                         }, 1);
                     }
                 });
+            },
+            loadFonts: function (ua) {
+                if (config.switches.webFonts && !guardian.shouldLoadFontsAsynchronously) {
+                    var fileFormat = detect.getFontFormatSupport(ua),
+                        fontStyleNodes = document.querySelectorAll('[data-cache-name].initial'),
+                        f = new Fonts(fontStyleNodes, fileFormat);
+                    f.loadFromServerAndApply();
+                }
+            },
+
+            initId: function () {
+                identity.init(config);
+            },
+
+            initUserAdTargeting: function () {
+                userAdTargeting.requestUserSegmentsFromId();
             }
         },
         ready = function () {
@@ -439,6 +463,9 @@ define([
             modules.showMoreTagsLink();
             modules.showSmartBanner();
             modules.initDiscussion();
+            modules.loadFonts(navigator.userAgent);
+            modules.initUserAdTargeting();
+            modules.initId();
             modules.logLiveStats();
             modules.loadAnalytics();
             modules.cleanupCookies();

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -440,6 +440,10 @@ define([
             }
         },
         ready = function () {
+            modules.initDiscussion();
+            modules.loadFonts(navigator.userAgent);
+            modules.initUserAdTargeting();
+            modules.initId();
             modules.initFastClick();
             modules.testCookie();
             modules.windowEventListeners();
@@ -463,10 +467,6 @@ define([
             modules.repositionComments();
             modules.showMoreTagsLink();
             modules.showSmartBanner();
-            modules.initDiscussion();
-            modules.loadFonts(navigator.userAgent);
-            modules.initUserAdTargeting();
-            modules.initId();
             modules.logLiveStats();
             modules.loadAnalytics();
             modules.cleanupCookies();

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -1,5 +1,6 @@
 /* jshint nonew: false */
 /* TODO - fix module constructors so we can remove the above jshint override */
+/*global guardian:true */
 define([
     'bean',
     'bonzo',


### PR DESCRIPTION
This fixes this issue: https://github.com/guardian/frontend/issues/6419

Easy to fix - harder to test, though I've been as thorough as I can. Identity bootstrap needs to be initialised after the discussion, otherwise there's no discussion api to retrieve the avatar url from: 

@ironsidevsquincy @chrisfinch - does this look OK to you? 

Before: 
![no-avatar](https://cloud.githubusercontent.com/assets/986155/4661903/117663b4-552a-11e4-9df7-5fdb5cd6a4c0.png)

After:
![avatar](https://cloud.githubusercontent.com/assets/986155/4661912/2458d476-552a-11e4-8df8-194ddb0c418e.png)
