### PR TITLE
Add sustainable-business to editionalised sections

### DIFF
--- a/common/app/common/editions/EditionalisedSections.scala
+++ b/common/app/common/editions/EditionalisedSections.scala
@@ -7,7 +7,8 @@ object EditionalisedSections {
 
   val sections = Seq(
     "", // network front
-    "commentisfree", "culture", "business", "money", "sport"
+    "commentisfree", "culture", "business", "money", "sport",
+    "sustainable-business"
   )
 
   def isEditionalised(id: String) = sections.contains(id)


### PR DESCRIPTION
This will mean links to `/sustainable-business` will become editionalised via `LinkTo` to `<edition>/sustainable-business`.

E.g. The [link at the top of an article](http://www.theguardian.com/sustainable-business/2014/oct/16/chocolate-coffee-fair-trade-certification-price-ebola-starbucks-ghana-philippines-ecuador) in `sustainable-business`.

@gklopper
