### PR TITLE
Add sbt-updates dependency plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,5 @@ resolvers ++= Seq(
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.1")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.6")


### PR DESCRIPTION
Add `com.timushev.sbt.sbt-updates`.

The plugin says the command to use is `dependency-updates`; I had to use `dependencyUpdates`.

@kelvin-chappell @gklopper 

---

Currently gives the following output:

```
[root] $ dependencyUpdates
[info] Found 4 dependency updates for root
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info] Found 6 dependency updates for applications
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for archive
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for preview
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for discussion
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for facia-press
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 7 dependency updates for diagnostics
[info]   com.typesafe.play:play                 : 2.3.2   -> 2.3.5                      
[info]   com.typesafe.play:play-docs:docs       : 2.3.2   -> 2.3.5                      
[info]   com.typesafe.play:play-test:test       : 2.3.2   -> 2.3.5                      
[info]   net.sf.uadetector:uadetector-resources : 2013.04          -> 2013.12 -> 2014.09
[info]   org.mockito:mockito-all:test           : 1.9.5            -> 1.10.8            
[info]   org.scala-lang:scala-library           : 2.10.4           -> 2.11.3            
[info]   org.scalatest:scalatest:test           : 2.2.1   -> 2.2.2                      
[info] Found 6 dependency updates for article
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 10 dependency updates for admin
[info]   com.google.api-ads:dfp-axis      : 1.27.0                 -> 1.34.0                 
[info]   com.typesafe.play:anorm          : 2.3.2         -> 2.3.5                           
[info]   com.typesafe.play:play           : 2.3.2         -> 2.3.5                           
[info]   com.typesafe.play:play-docs:docs : 2.3.2         -> 2.3.5                           
[info]   com.typesafe.play:play-jdbc      : 2.3.2         -> 2.3.5                           
[info]   com.typesafe.play:play-test:test : 2.3.2         -> 2.3.5                           
[info]   org.mockito:mockito-all:test     : 1.9.5                  -> 1.10.8                 
[info]   org.scala-lang:scala-library     : 2.10.4                 -> 2.11.3                 
[info]   org.scalatest:scalatest:test     : 2.2.1         -> 2.2.2                           
[info]   postgresql:postgresql            : 8.4-703.jdbc4                    -> 9.1-901.jdbc4
[info] Found 6 dependency updates for commercial
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 7 dependency updates for facia-tool
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5                   
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5                   
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5                   
[info]   org.julienrf:play-json-variants  : 0.2                       -> 1.0.0
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8         
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3         
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2                   
[info] Found 7 dependency updates for sport
[info]   com.typesafe.akka:akka-contrib   : 2.3.5  -> 2.3.6          
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for png-resizer
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for onward
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for router
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 6 dependency updates for image
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5          
[info]   org.mockito:mockito-all:test     : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2          
[info] Found 7 dependency updates for facia
[info]   com.typesafe.play:play           : 2.3.2  -> 2.3.5           
[info]   com.typesafe.play:play-docs:docs : 2.3.2  -> 2.3.5           
[info]   com.typesafe.play:play-test:test : 2.3.2  -> 2.3.5           
[info]   org.mockito:mockito-all:test     : 1.9.5            -> 1.10.8
[info]   org.scala-lang:scala-library     : 2.10.4           -> 2.11.3
[info]   org.scalacheck:scalacheck:test   : 1.11.5 -> 1.11.6          
[info]   org.scalatest:scalatest:test     : 2.2.1  -> 2.2.2           
ency-updates
[info] Found 10 dependency updates for identity
[info]   com.github.nscala-time:nscala-time : 1.2.0           -> 1.4.0 
[info]   com.typesafe.play:filters-helpers  : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play             : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-docs:docs   : 2.3.2  -> 2.3.5          
[info]   com.typesafe.play:play-test:test   : 2.3.2  -> 2.3.5          
[info]   net.liftweb:lift-json              : 2.5    -> 2.5.1          
[info]   org.mockito:mockito-all:test       : 1.9.5           -> 1.10.8
[info]   org.scala-lang:scala-library       : 2.10.4          -> 2.11.3
[info]   org.scalatest:scalatest:test       : 2.2.1  -> 2.2.2          
[info]   org.slf4j:slf4j-ext                : 1.7.5  -> 1.7.7          
[info] Found 22 dependency updates for common
[info]   com.amazonaws:aws-java-sdk              : 1.8.7   -> 1.8.11  -> 1.9.0         
[info]   com.bionicspirit:shade                  : 1.5.0              -> 1.6.0         
[info]   com.gu:content-api-client               : 2.20                          -> 3.0
[info]   com.gu:flexible-content-block-to-text   : 0.1                -> 0.2           
[info]   com.typesafe.akka:akka-agent            : 2.3.4   -> 2.3.6                    
[info]   com.typesafe.play:filters-helpers       : 2.3.2   -> 2.3.5                    
[info]   com.typesafe.play:play                  : 2.3.2   -> 2.3.5                    
[info]   com.typesafe.play:play-docs:docs        : 2.3.2   -> 2.3.5                    
[info]   com.typesafe.play:play-test:test        : 2.3.2   -> 2.3.5                    
[info]   com.typesafe.play:play-ws               : 2.3.2   -> 2.3.5                    
[info]   net.liftweb:lift-json                   : 2.5     -> 2.5.1                    
[info]   org.apache.commons:commons-math3        : 3.2                -> 3.3           
[info]   org.codehaus.jackson:jackson-core-asl   : 1.9.6   -> 1.9.13                   
[info]   org.codehaus.jackson:jackson-mapper-asl : 1.9.6   -> 1.9.13                   
[info]   org.jboss.dna:dna-common                : 0.6                -> 0.7           
[info]   org.jsoup:jsoup                         : 1.7.3              -> 1.8.1         
[info]   org.mockito:mockito-all:test            : 1.9.5              -> 1.10.8        
[info]   org.quartz-scheduler:quartz             : 2.2.0   -> 2.2.1                    
[info]   org.scala-lang:scala-library            : 2.10.4             -> 2.11.3        
[info]   org.scalacheck:scalacheck:test          : 1.11.5  -> 1.11.6                   
[info]   org.scalatest:scalatest:test            : 2.2.1   -> 2.2.2                    
[info]   org.xerial.snappy:snappy-java           : 1.0.5.1 -> 1.0.5.4 -> 1.1.1.3
```
