### PR TITLE
facia tool: edit multiple fronts

### DIFF
--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -30,6 +30,9 @@ GET           /                          controllers.FaciaToolController.priorit
 GET           /editorial                 controllers.FaciaToolController.collectionEditor(priority="editorial")
 GET           /commercial                controllers.FaciaToolController.collectionEditor(priority="commercial")
 
+GET           /editorial/2               controllers.FaciaToolController.multiPane(panes:Int=2)
+GET           /editorial/3               controllers.FaciaToolController.multiPane(panes:Int=3)
+
 GET           /editorial/config          controllers.FaciaToolController.configEditor(priority="editorial")
 GET           /commercial/config         controllers.FaciaToolController.configEditor(priority="commercial")
 

--- a/facia-tool/app/controllers/FaciaToolController.scala
+++ b/facia-tool/app/controllers/FaciaToolController.scala
@@ -13,6 +13,10 @@ import tools.FaciaApi
 
 object FaciaToolController extends Controller with Logging with ExecutionContexts {
 
+  def multiPane(panes: Int) = ExpiringActions.ExpiringAuthAction { request =>
+    Cached(60) { Ok(views.html.multipane(panes)) }
+  }
+
   def priorities() = ExpiringActions.ExpiringAuthAction { request =>
     val identity = request.user
     Cached(60) { Ok(views.html.priority(Configuration.environment.stage, "", Option(identity))) }

--- a/facia-tool/app/views/admin_main.scala.html
+++ b/facia-tool/app/views/admin_main.scala.html
@@ -74,7 +74,7 @@
         <span class="message message--important">Temporarily disabled. Please try again shortly.</span>
     } else {
         <header>
-            <a href="/">
+            <a href="/" target="_top">
                 <img class="logo" src="@routes.Assets.at("images/plane.png")" />
                 <h1>
                     <span data-bind="text: title()">fronts</span>

--- a/facia-tool/app/views/multipane.scala.html
+++ b/facia-tool/app/views/multipane.scala.html
@@ -1,0 +1,14 @@
+@(panes: Int)
+
+@if(panes==3) {
+    <frameset cols="50%,25%,25%">
+        <frame src="/editorial" />
+        <frame src="/editorial" />
+        <frame src="/editorial" />
+    </frameset>
+} else {
+    <frameset cols="65%,35%">
+        <frame src="/editorial" />
+        <frame src="/editorial" />
+    </frameset>
+}

--- a/facia-tool/app/views/priority.scala.html
+++ b/facia-tool/app/views/priority.scala.html
@@ -3,8 +3,14 @@
 @admin_main("Fronts Editor", env, Some(priority), isAuthed = true, identity=identity) {
 
 <div class="front-priorities">
-    <a class="front-priorities--priority" href="/editorial">Editorial Fronts</a>
-    <a class="front-priorities--priority" href="/commercial">Commercial Fronts</a>
+    <div class="front-priorities--priority">
+        <a href="/editorial">Editorial Fronts</a>
+        · <a href="/editorial/2">2</a>
+        · <a href="/editorial/3">3</a>
+    </div>
+    <div class="front-priorities--priority">
+        <a href="/commercial">Commercial Fronts</a>
+    </div>
 </div>
 
 }

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -22,6 +22,9 @@ GET           /                          controllers.FaciaToolController.priorit
 GET           /editorial                 controllers.FaciaToolController.collectionEditor(priority="editorial")
 GET           /commercial                controllers.FaciaToolController.collectionEditor(priority="commercial")
 
+GET           /editorial/2               controllers.FaciaToolController.multiPane(panes:Int=2)
+GET           /editorial/3               controllers.FaciaToolController.multiPane(panes:Int=3)
+
 GET           /editorial/config          controllers.FaciaToolController.configEditor(priority="editorial")
 GET           /commercial/config         controllers.FaciaToolController.configEditor(priority="commercial")
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -117,12 +117,13 @@ h1 {
     position: absolute;
     top: 60px;
     left: 20px;
+    color: #999999;
 }
 
 .front-priorities--priority {
     display: block;
-    font-size: 17px;
-    padding: 10px 0 0 0;
+    font-size: 18px;
+    padding: 15px 0 0 0;
 }
 
 .finder__controls {


### PR DESCRIPTION
Open in two or three panes, to edit multiple fronts. Note the ironic use of `<frameset>`.

![fronts-tool](https://cloud.githubusercontent.com/assets/1147913/4663670/b21e5f02-553d-11e4-86a8-40b9ea5fcb20.png)

![screen shot 2014-10-16 at 14 53 18 2](https://cloud.githubusercontent.com/assets/1147913/4663481/f4c90584-553b-11e4-88ac-9e08527f9ba5.png)
