### PR TITLE
Radiator RSS

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -60,7 +60,7 @@ object RadiatorController extends Controller with Logging with AuthLogging {
       .withAuth(user, password,  WSAuthScheme.BASIC)
       .withHeaders("App-Key" ->  apiKey)
       .get().map { response =>
-        NoCache(Ok(Json.toJson(response.body)))
+        NoCache(Ok(Json.parse(response.body)))
       }
   }
 }

--- a/static/src/javascripts/projects/admin/bootstraps/radiator.js
+++ b/static/src/javascripts/projects/admin/bootstraps/radiator.js
@@ -30,7 +30,7 @@ define([
         }).then(
             function(status) {
                 JSON.parse(status).checks.filter(function (check) {
-                    return /ELB|Host|CDN/.test(check.name);
+                    return /ELB|Host|CDN|RSS/i.test(check.name);
                 }).forEach(function(check){
                         var li = document.createElement('li');
                         li.className = check.status;

--- a/static/src/javascripts/projects/admin/bootstraps/radiator.js
+++ b/static/src/javascripts/projects/admin/bootstraps/radiator.js
@@ -30,7 +30,7 @@ define([
         }).then(
             function(status) {
                 status.checks.filter(function (check) {
-                    return /ELB|Host|CDN|RSS/i.test(check.name);
+                    return /elb|host|cdn|rss/.test(check.name.toLowerCase());
                 }).forEach(function(check){
                         var li = document.createElement('li');
                         li.className = check.status;

--- a/static/src/javascripts/projects/admin/bootstraps/radiator.js
+++ b/static/src/javascripts/projects/admin/bootstraps/radiator.js
@@ -29,7 +29,7 @@ define([
             crossOrigin: false
         }).then(
             function(status) {
-                JSON.parse(status).checks.filter(function (check) {
+                status.checks.filter(function (check) {
                     return /ELB|Host|CDN|RSS/i.test(check.name);
                 }).forEach(function(check){
                         var li = document.createElement('li');


### PR DESCRIPTION
We added 3 new pingdom pings to pingdom:
- Network Front Rss
- Editors Picks Rss (Google News)
- Sport Cycling Rss

This is to ensure there is visibility on the RSS feeds for when they break.

The endpoint `/radiator/pingdom` was not showing me any response, so I changed it to return `JSON` instead of a `String`, and stopped parsing in javascript.

@rich-nguyen @gklopper 
