### PR TITLE
use section name instead of section ID in tag page <title>

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -17,6 +17,7 @@ case class Tag(private val delegate: ApiTag, override val pagination: Option[Pag
 
   lazy val webUrl: String = delegate.webUrl
   lazy val webTitle: String = delegate.webTitle
+  lazy val sectionName: String = delegate.sectionName.getOrElse("global")
   override lazy val description = delegate.description
 
   override lazy val url: String = SupportedUrl(delegate)

--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -10,7 +10,7 @@ object Title {
   def apply(page: MetaData)(implicit request: RequestHeader): Html = Html{
     val title = page match {
       case c: Content => s"${c.webTitle}${pagination(c)}${getSectionConsideringWebtitle(c.webTitle, Option(c.sectionName))}"
-      case t: Tag     => s"${t.webTitle}${pagination(page)}${getSectionConsideringWebtitle(t.webTitle, Option(page.section))}"
+      case t: Tag     => s"${t.webTitle}${pagination(page)}${getSectionConsideringWebtitle(t.webTitle, Option(t.sectionName))}"
       case _          => page.title.filter(_.nonEmpty).getOrElse(s"${page.webTitle}${pagination(page)}${getSectionConsideringWebtitle(page.webTitle, Option(page.section))}")
     }
     s"${title.trim} | The Guardian"

--- a/common/test/views/support/TitleTest.scala
+++ b/common/test/views/support/TitleTest.scala
@@ -37,11 +37,19 @@ class TitleTest extends FlatSpec with Matchers {
 
   it should "should create a title for a Tag" in {
     val tag = new ApiTag("sport/foobar", "type", webTitle = "The title", webUrl = "http://foo.bar",
-      apiUrl = "http://foo.bar", sectionId = Some("sport"))
+      apiUrl = "http://foo.bar", sectionName = Some("Sport"))
 
     Title(Tag(tag))(FakeRequest("GET", "/sport/foobar")).body should be ("The title | Sport | The Guardian")
 
     Title(Tag(tag, Some(Pagination(3, 4, 10))))(FakeRequest("GET", "/sport/foobar")).body should be ("The title | Page 3 of 4 | Sport | The Guardian")
+  }
+
+  it should "should use the section name in the Tag title" in {
+    val tag = new ApiTag("lifeandstyle/foobar", "type", webTitle = "The title", webUrl = "http://foo.bar",
+      apiUrl = "http://foo.bar", sectionName = Some("Life and style"))
+
+    Title(Tag(tag))(FakeRequest("GET", "/lifeandstyle/foobar")).body should be ("The title | Life and style | The Guardian")
+
   }
 
   it should "filter out section if it is the same as webTitle" in {


### PR DESCRIPTION
As per content pages use the section title instead of the section ID on tag pages.

Before 
![screen shot 2014-10-16 at 17 22 17](https://cloud.githubusercontent.com/assets/1764158/4666192/352d13b2-5551-11e4-81b7-7956b0f54646.png)

After
![screen shot 2014-10-16 at 17 25 13](https://cloud.githubusercontent.com/assets/1764158/4666194/39d1357e-5551-11e4-94a4-2dec25c07f0f.png)
