### PR TITLE
Temporary fix for live stream interactive embeds

### DIFF
--- a/static/src/stylesheets/_extends-only.scss
+++ b/static/src/stylesheets/_extends-only.scss
@@ -51,3 +51,20 @@
     margin: 0;
     list-style: none;
 }
+
+%u-responsive-ratio {
+    @include fix-aspect-ratio(5, 3); // 1
+
+    img,
+    object,
+    embed,
+    iframe,
+    video {
+        // 2
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+}

--- a/static/src/stylesheets/_extends-only.scss
+++ b/static/src/stylesheets/_extends-only.scss
@@ -53,14 +53,13 @@
 }
 
 %u-responsive-ratio {
-    @include fix-aspect-ratio(5, 3); // 1
+    @include fix-aspect-ratio(5, 3);
 
     img,
     object,
     embed,
     iframe,
     video {
-        // 2
         width: 100%;
         height: 100%;
         position: absolute;

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -111,4 +111,9 @@
     .element-interactive {
         background-color: #ffffff;
     }
+
+    //TODO: Temporary hack for live-streams until we discuss a better solution with composer
+    [data-alt="Live stream"] {
+        @extend %u-responsive-ratio;
+    }
 }


### PR DESCRIPTION
This is a temporary fix for a [live-stream event tomorrow ](http://preview.gutools.co.uk/stage/ng-interactive/2014/oct/16/watch-speak-bitterness-by-forced-entertainment-live-stream), after discussing with @mattosborn we thought it would be too dangerous to apply `.u-responsive-ratio` to all `.element-embeds` as could potentially break many other interactives. 

Therefore have gone for the hacky but more resilient route of using the `data` attribute as the selector to extend.
