### PR TITLE
revert to initialising identity bootstrap in the app.js

### DIFF
--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -1,3 +1,4 @@
+/*global guardian:true */
 define([
     'raven',
     'qwery',
@@ -5,6 +6,9 @@ define([
     'common/utils/detect',
     'common/utils/config',
     'common/utils/userTiming',
+
+    'common/modules/ui/fonts',
+    'common/modules/commercial/user-ad-targeting',
 
     'bootstraps/common',
     'bootstraps/tag',
@@ -14,6 +18,7 @@ define([
     'bootstraps/liveblog',
     'bootstraps/media',
     'bootstraps/gallery',
+    'bootstraps/identity',
     'bootstraps/profile',
     'bootstraps/sport'
 ], function (
@@ -23,6 +28,9 @@ define([
     detect,
     config,
     userTiming,
+
+    Fonts,
+    userAdTargeting,
 
     bootstrapCommon,
     tag,
@@ -49,9 +57,32 @@ define([
                 }
             );
         },
+        modules = {
+
+            loadFonts: function (ua) {
+                if (config.switches.webFonts && !guardian.shouldLoadFontsAsynchronously) {
+                    var fileFormat = detect.getFontFormatSupport(ua),
+                        fontStyleNodes = document.querySelectorAll('[data-cache-name].initial'),
+                        f = new Fonts(fontStyleNodes, fileFormat);
+                    f.loadFromServerAndApply();
+                }
+            },
+
+            initId: function () {
+                identity.init(config);
+            },
+
+            initUserAdTargeting: function () {
+                userAdTargeting.requestUserSegmentsFromId();
+            }
+        },
 
         routes = function () {
             userTiming.mark('App Begin');
+
+            modules.loadFonts(navigator.userAgent);
+            modules.initId();
+            modules.initUserAdTargeting();
 
             bootstrapContext('common', bootstrapCommon);
 

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -1,14 +1,11 @@
 /* jshint nonew: false */
 /* TODO - fix module constructors so we can remove the above jshint override */
-/*global guardian:true */
 define([
     'bean',
     'bonzo',
     'enhancer',
     'fastclick',
     'qwery',
-
-    'bootstraps/identity',
 
     'common/utils/$',
     'common/utils/ajax',
@@ -24,7 +21,6 @@ define([
     'common/modules/analytics/omniture',
     'common/modules/analytics/register',
     'common/modules/analytics/scrollDepth',
-    'common/modules/commercial/user-ad-targeting',
     'common/modules/discussion/api',
     'common/modules/discussion/comment-count',
     'common/modules/discussion/loader',
@@ -45,7 +41,6 @@ define([
     'common/modules/release-message',
     'common/modules/ui/dropdowns',
     'common/modules/ui/faux-block-link',
-    'common/modules/ui/fonts',
     'common/modules/ui/message',
     'common/modules/ui/relativedates',
     'common/modules/ui/smartAppBanner',
@@ -58,8 +53,6 @@ define([
     enhancer,
     FastClick,
     qwery,
-
-    identity,
 
     $,
     ajax,
@@ -75,7 +68,6 @@ define([
     Omniture,
     register,
     ScrollDepth,
-    userAdTargeting,
     discussionApi,
     CommentCount,
     DiscussionLoader,
@@ -96,7 +88,6 @@ define([
     releaseMessage,
     Dropdowns,
     fauxBlockLink,
-    Fonts,
     Message,
     RelativeDates,
     smartAppBanner,
@@ -241,7 +232,7 @@ define([
                     config.switches.releaseMessage &&
                     config.page.showClassicVersion &&
                     (detect.getBreakpoint() !== 'mobile')
-                ) {
+                    ) {
                     // force the visitor in to the alpha release for subsequent visits
                     Cookies.add('GU_VIEW', 'responsive', 365);
 
@@ -421,29 +412,9 @@ define([
                         }, 1);
                     }
                 });
-            },
-            loadFonts: function (ua) {
-                if (config.switches.webFonts && !guardian.shouldLoadFontsAsynchronously) {
-                    var fileFormat = detect.getFontFormatSupport(ua),
-                        fontStyleNodes = document.querySelectorAll('[data-cache-name].initial'),
-                        f = new Fonts(fontStyleNodes, fileFormat);
-                    f.loadFromServerAndApply();
-                }
-            },
-
-            initId: function () {
-                identity.init(config);
-            },
-
-            initUserAdTargeting: function () {
-                userAdTargeting.requestUserSegmentsFromId();
             }
         },
         ready = function () {
-            modules.initDiscussion();
-            modules.loadFonts(navigator.userAgent);
-            modules.initUserAdTargeting();
-            modules.initId();
             modules.initFastClick();
             modules.testCookie();
             modules.windowEventListeners();
@@ -467,6 +438,7 @@ define([
             modules.repositionComments();
             modules.showMoreTagsLink();
             modules.showSmartBanner();
+            modules.initDiscussion();
             modules.logLiveStats();
             modules.loadAnalytics();
             modules.cleanupCookies();


### PR DESCRIPTION
Reverts this change: https://github.com/guardian/frontend/pull/6533 - which broke the public profile pages. This will reinstate the comments but reintroduce the broken avatar feature. Once we've restored the comments, I'll look at fixing the avatar without breaking them
