### PR TITLE
Added simple integration tests for Profile comment pages.

### DIFF
--- a/integrated-tests/src/test/scala/driver/Config.scala
+++ b/integrated-tests/src/test/scala/driver/Config.scala
@@ -24,6 +24,7 @@ object Config {
 
   val remoteMode = optionalProperty("tests.mode").exists(_ == "remote")
   val baseUrl = optionalProperty("tests.baseUrl").getOrElse("http://www.theguardian.com")
+  val profileBaseUrl = optionalProperty("tests.profileBaseUrl").getOrElse("https://profile.theguardian.com")
 
   object stack {
     lazy val userName = mandatoryProperty("stack.userName")

--- a/integrated-tests/src/test/scala/profile/ProfileCommentsTest.scala
+++ b/integrated-tests/src/test/scala/profile/ProfileCommentsTest.scala
@@ -1,0 +1,34 @@
+package profile
+
+import driver.Config._
+import driver.Driver
+import org.scalatest.tags.Retryable
+import org.scalatest.{FlatSpec, Matchers}
+
+
+@Retryable class ProfileCommentsTest extends FlatSpec with Matchers with Driver {
+
+  "Profile pages" should "show user comments" in {
+    go to profileTheguardian("/user/id/4383032")
+
+    $("[itemtype='http://schema.org/UserComments']") should not be empty
+    $("[itemtype='http://schema.org/Comment']") should not be empty
+
+  }
+
+  they should "show replies to user comments" in {
+    go to profileTheguardian("/user/id/4383032/replies")
+
+    $("[itemtype='http://schema.org/UserComments']") should not be empty
+    $("[itemtype='http://schema.org/Comment']") should not be empty
+  }
+
+  they should "show featured (picked) user comments" in {
+    go to profileTheguardian("/user/id/4383032/picks")
+
+    $("[itemtype='http://schema.org/UserComments']") should not be empty
+    $("[itemtype='http://schema.org/Comment']") should not be empty
+  }
+
+  protected def profileTheguardian(path: String) = s"$profileBaseUrl$path"
+}

--- a/integrated-tests/src/test/scala/profile/ProfileCommentsTest.scala
+++ b/integrated-tests/src/test/scala/profile/ProfileCommentsTest.scala
@@ -5,7 +5,6 @@ import driver.Driver
 import org.scalatest.tags.Retryable
 import org.scalatest.{FlatSpec, Matchers}
 
-
 @Retryable class ProfileCommentsTest extends FlatSpec with Matchers with Driver {
 
   "Profile pages" should "show user comments" in {
@@ -13,7 +12,6 @@ import org.scalatest.{FlatSpec, Matchers}
 
     $("[itemtype='http://schema.org/UserComments']") should not be empty
     $("[itemtype='http://schema.org/Comment']") should not be empty
-
   }
 
   they should "show replies to user comments" in {


### PR DESCRIPTION
The answer to **_"Where is Cantlin?"**_ is now **_"In an integration test"**_...

![cantlin](https://cloud.githubusercontent.com/assets/76709/4678087/f0bf675c-55f0-11e4-9646-855f4ee0bb35.png)
