### PR TITLE
Always include standfirst on h-q_ql2-ql4

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_slices.scss
+++ b/static/src/stylesheets/module/facia-cards/_slices.scss
@@ -54,6 +54,16 @@ Hence why a greater depth of selector specificity is needed.
     }
 }
 
+.facia-slice--h-q_ql2-ql4 {
+    .fc-item--half-tablet {
+        .fc-item__standfirst {
+            @include mq(tablet) {
+                display: block !important;
+            }
+        }
+    }
+}
+
 // reduce type size on q-q-q-q slice if it follows another slice in the same container
 .facia-slice-wrapper + .facia-slice-wrapper {
     .facia-slice--q-q-q-q {


### PR DESCRIPTION
It's the ol' `h-q_ql2-ql4` issue again. It's getting baggy. Let's sort it. Nice.

Before:
![screen shot 2014-10-17 at 15 03 55](https://cloud.githubusercontent.com/assets/1607666/4680128/4dc5c678-5608-11e4-834f-dff897a61e03.png)

After:
![screen shot 2014-10-17 at 15 18 48](https://cloud.githubusercontent.com/assets/1607666/4680138/5b140326-5608-11e4-92fa-6963c602938a.png)
