### PR TITLE
Remove extra space around review stars

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -219,7 +219,6 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__meta {
     @include fs-textSans(1);
-    margin-bottom: $gs-baseline / 4;
     color: $c-neutral2;
 
     &:after {
@@ -233,6 +232,7 @@ $fc-item-gutter: $gs-gutter / 4;
 .fc-trail__count {
     position: relative;
     float: left;
+    margin-bottom: $gs-baseline / 4;
 }
 
 .fc-item__timestamp {

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -107,8 +107,14 @@ $fc-item-gutter: $gs-gutter / 4;
         color: inherit;
     }
 
+    @include stars();
+
     .stars {
         margin-bottom: 0;
+
+        .star__item {
+            vertical-align: bottom;
+        }
     }
 
     .gu-media-wrapper {
@@ -172,8 +178,6 @@ $fc-item-gutter: $gs-gutter / 4;
     .fc-item--has-boosted-title & {
         @include fs-headline(4, true);
     }
-
-    @include stars($margin-top: 4px);
 }
 
 .fc-item__title,


### PR DESCRIPTION
The review stars should be equal to the line-height and nothing more. This removes the extra space to just a 1px, which is coming from somewhere else that I'll fix in a separate PR.

Before:
![screen shot 2014-10-17 at 16 01 06](https://cloud.githubusercontent.com/assets/1607666/4681074/f3b4c906-560f-11e4-8351-0f8e500e0197.png)

After:
![screen shot 2014-10-17 at 16 00 36](https://cloud.githubusercontent.com/assets/1607666/4681075/f5043af8-560f-11e4-9c6a-3ecf053a0b02.png)
