### PR TITLE
Facia content api calls count

### DIFF
--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -61,6 +61,8 @@ case class FrontendTimingMetric(name: String, description: String) extends Front
   def putDataPoints(points: List[DataPoint]): Unit = points.map(_.value).map(recordDuration)
 
   def isEmpty: Boolean = currentCount.get() == 0L
+
+  def getCount: Long = currentCount.get()
 }
 
 case class GaugeMetric(name: String, description: String, get: () => Long, metricUnit: StandardUnit = StandardUnit.Megabytes) extends FrontendMetric {

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -26,6 +26,7 @@ object Global extends GlobalSettings
     FaciaPressMetrics.FrontPressLiveSuccess,
     FaciaPressMetrics.FrontPressCronSuccess,
     FaciaPressMetrics.FrontPressCronFailure,
+    GaugeMetric("content-api-calls", "Total number of Content API calls", () => ContentApiMetrics.ElasticHttpTimingMetric.getCount),
     ContentApiMetrics.ElasticHttpTimingMetric,
     ContentApiMetrics.ElasticHttpTimeoutCountMetric,
     ContentApiMetrics.ContentApi404Metric,


### PR DESCRIPTION
When pushing all the `datapoints` to `CloudWatch` in the past, we were able to get the amount of times a `FrontendTimingMetric` has been called via `Data Points` and then also the `average`, `maximum`, `sum` and `minimum`.

After I refactored the `FrontendTimingMetric` to make less `CloudWatch` calls, we lost the use of `DataPoints` since this is now being flattened.

This just adds the amount of times the `FrontendTimingMetric` `ElasticHttpTimingMetric` gets called; the amount of Content API requests.

@robertberry @stephanfowler
