### PR TITLE
removal of the initId call and method as this is being handled inside of identity.js

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -431,10 +431,6 @@ define([
                 }
             },
 
-            initId: function () {
-                identity.init(config);
-            },
-
             initUserAdTargeting: function () {
                 userAdTargeting.requestUserSegmentsFromId();
             }
@@ -443,7 +439,6 @@ define([
             modules.initDiscussion();
             modules.loadFonts(navigator.userAgent);
             modules.initUserAdTargeting();
-            modules.initId();
             modules.initFastClick();
             modules.testCookie();
             modules.windowEventListeners();


### PR DESCRIPTION
We have seen a problem on the membership tab with a duplication of content due to an extra call to init the tab

@NathanielBennett heres the change we spoke about
@marchibbins I am away on holiday now can you make sure this gets merged
## Before

![membership identity the guardian](https://cloud.githubusercontent.com/assets/2305016/4681336/2252aff6-5612-11e4-833a-15f37e90453a.png)
## After

![membership identity the guardian 1](https://cloud.githubusercontent.com/assets/2305016/4681341/2cc38582-5612-11e4-95e4-a9b73a54f616.png)
