### PR TITLE
Add visited styles for all tones

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -99,6 +99,13 @@ $fc-item-gutter: $gs-gutter / 4;
         color: inherit;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: mix($c-neutral1, #ffffff, 80%);
+        }
+    }
+
     // This is a temp fix until we completely remove tone-colour from fc-item
     .tone-colour,
     .tone-colour:hover,

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
@@ -7,6 +7,13 @@
         color: #ffffff;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: mix(#ffffff, $c-editorialDefault, 80%);
+        }
+    }
+
     .fc-item__content,
     &.fc-item--has-cutout .fc-item__container,
     &.fc-item--list-media-mobile {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
@@ -1,16 +1,18 @@
 .tone-editorial--item {
+    $c-headline: #ffffff;
+
     @extend %tone-has-background;
     background-color: $c-editorialDefault;
 
     &,
     .fc-sublink__title {
-        color: #ffffff;
+        color: $c-headline;
     }
 
     .fc-item__link,
     .fc-sublink__link {
         &:visited {
-            color: mix(#ffffff, $c-editorialDefault, 80%);
+            color: mix($c-headline, $c-editorialDefault, 80%);
         }
     }
 
@@ -31,7 +33,7 @@
     }
 
     .fc-sublink__title:before {
-        border-color: fade-out(#ffffff, .8);
+        border-color: fade-out($c-headline, .8);
     }
 }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -7,6 +7,13 @@
         color: #ffffff;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: mix(#ffffff, $c-featureDefault, 80%);
+        }
+    }
+
     .fc-item__content,
     &.fc-item--has-cutout .fc-item__container,
     &.fc-item--list-media-mobile {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -1,16 +1,18 @@
 .tone-feature--item {
+    $c-headline: #ffffff;
+
     @extend %tone-has-background;
     background-color: $c-featureDefault;
 
     &,
     .fc-sublink__title {
-        color: #ffffff;
+        color: $c-headline;
     }
 
     .fc-item__link,
     .fc-sublink__link {
         &:visited {
-            color: mix(#ffffff, $c-featureDefault, 80%);
+            color: mix($c-headline, $c-featureDefault, 80%);
         }
     }
 
@@ -27,11 +29,11 @@
     }
 
     .fc-item__kicker:after {
-        color: fade-out(#ffffff, .8);
+        color: fade-out($c-headline, .8);
     }
 
     .fc-item__standfirst {
-        color: fade-out(#ffffff, .2);
+        color: fade-out($c-headline, .2);
     }
 
     .fc-item__title .i {
@@ -42,7 +44,7 @@
     }
 
     .fc-sublink__title:before {
-        border-color: fade-out(#ffffff, .8);
+        border-color: fade-out($c-headline, .8);
     }
 }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -7,6 +7,13 @@
         color: #ffffff;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: mix(#ffffff, $c-liveDefault, 80%);
+        }
+    }
+
     .fc-item__content,
     &.fc-item--has-cutout .fc-item__container,
     &.fc-item--list-media-mobile {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -1,16 +1,18 @@
 .tone-live--item {
+    $c-headline: #ffffff;
+
     @extend %tone-has-background;
     background-color: $c-liveDefault;
 
     &,
     .fc-sublink__title {
-        color: #ffffff;
+        color: $c-headline;
     }
 
     .fc-item__link,
     .fc-sublink__link {
         &:visited {
-            color: mix(#ffffff, $c-liveDefault, 80%);
+            color: mix($c-headline, $c-liveDefault, 80%);
         }
     }
 
@@ -27,11 +29,11 @@
     }
 
     .fc-item__kicker:after {
-        color: fade-out(#ffffff, .8);
+        color: fade-out($c-headline, .8);
     }
 
     .fc-item__standfirst {
-        color: fade-out(#ffffff, .2);
+        color: fade-out($c-headline, .2);
     }
 
     .fc-item__live-indicator,
@@ -41,7 +43,7 @@
     }
 
     .fc-sublink__title:before {
-        border-color: fade-out(#ffffff, .8);
+        border-color: fade-out($c-headline, .8);
     }
 }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -1,16 +1,18 @@
 .tone-media--item {
+    $c-headline: #ffffff;
+
     @extend %tone-has-background;
     background-color: $c-neutral1;
 
     &,
     .fc-sublink__title {
-        color: #ffffff;
+        color: $c-headline;
     }
 
     .fc-item__link,
     .fc-sublink__link {
         &:visited {
-            color: mix(#ffffff, $c-neutral1, 80%);
+            color: mix($c-headline, $c-neutral1, 80%);
         }
     }
 
@@ -26,7 +28,7 @@
     }
 
     .fc-item__kicker:after {
-        color: fade-out(#ffffff, .8);
+        color: fade-out($c-headline, .8);
     }
 
     .fc-item__standfirst,

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -7,6 +7,13 @@
         color: #ffffff;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: mix(#ffffff, $c-neutral1, 80%);
+        }
+    }
+
     .fc-item__content,
     &.fc-item--has-cutout .fc-item__container,
     &.fc-item--list-media-mobile {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -7,6 +7,13 @@
         color: $c-neutral1;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: mix($c-neutral1, $c-podcastBackground, 80%);
+        }
+    }
+
     .fc-item__content,
     &.fc-item--has-cutout .fc-item__container,
     &.fc-item--list-media-mobile {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -1,16 +1,18 @@
 .tone-podcast--item {
+    $c-headline: $c-neutral1;
+
     @extend %tone-has-background;
     background-color: $c-podcastBackground;
 
     &,
     .fc-sublink__title {
-        color: $c-neutral1;
+        color: $c-headline;
     }
 
     .fc-item__link,
     .fc-sublink__link {
         &:visited {
-            color: mix($c-neutral1, $c-podcastBackground, 80%);
+            color: mix($c-headline, $c-podcastBackground, 80%);
         }
     }
 
@@ -26,7 +28,7 @@
     }
 
     .fc-item__standfirst {
-        color: $c-neutral1;
+        color: $c-headline;
     }
 
     .fc-item__meta {
@@ -34,7 +36,7 @@
     }
 
     .fc-sublink__title:before {
-        border-color: $c-neutral1;
+        border-color: $c-headline;
     }
 }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -1,11 +1,12 @@
 .tone-review--item {
     $c-headline: #ffffff;
+
     @extend %tone-has-background;
     background-color: $c-reviewBackground;
 
     &,
     .fc-sublink__title {
-        color: $c-headline:
+        color: $c-headline;
     }
 
     .fc-item__link,

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -1,16 +1,17 @@
 .tone-review--item {
+    $c-headline: #ffffff;
     @extend %tone-has-background;
     background-color: $c-reviewBackground;
 
     &,
     .fc-sublink__title {
-        color: #ffffff;
+        color: $c-headline:
     }
 
     .fc-item__link,
     .fc-sublink__link {
         &:visited {
-            color: mix(#ffffff, $c-reviewBackground, 80%);
+            color: mix($c-headline, $c-reviewBackground, 80%);
         }
     }
 
@@ -26,11 +27,11 @@
     }
 
     .fc-item__kicker:after {
-        color: fade-out(#ffffff, .8);
+        color: fade-out($c-headline, .8);
     }
 
     .fc-item__standfirst {
-        color: fade-out(#ffffff, .4);
+        color: fade-out($c-headline, .4);
     }
 
     .fc-item__meta {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -7,6 +7,13 @@
         color: #ffffff;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: mix(#ffffff, $c-reviewBackground, 80%);
+        }
+    }
+
     .fc-item__content,
     &.fc-item--has-cutout .fc-item__container,
     &.fc-item--list-media-mobile {


### PR DESCRIPTION
Using the `mix($color1, $color2, percentage)` because `:visited` doesn't allow for opacity changes, so the new value needs to be pure hex, not rgba.

![screen recording 2014-10-17 at 05 19 pm](https://cloud.githubusercontent.com/assets/1607666/4682116/62895a32-5619-11e4-8ac3-de5c31b74239.gif)
