### PR TITLE
Automatically generate SVG thumbnails for container layouts in Facia tool

### DIFF
--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -57,6 +57,9 @@ GET           /switches                  controllers.SwitchesProxy.getSwitches()
 GET           /api/proxy/*path           controllers.FaciaContentApiProxy.proxy(path)
 GET           /json/proxy/*absUrl        controllers.FaciaContentApiProxy.json(absUrl)
 
+# thumbnails
+GET           /thumbnails/*id.svg        controllers.ThumbnailController.container(id)
+
 # Updating config
 
 POST          /config/fronts             controllers.FrontController.create()

--- a/facia-tool/app/controllers/ThumbnailController.scala
+++ b/facia-tool/app/controllers/ThumbnailController.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import common.{ExecutionContexts, Logging}
+import play.api.mvc.{Action, Controller}
+import thumbnails.ContainerThumbnails
+
+object ThumbnailController extends Controller with Logging with ExecutionContexts {
+  def container(id: String) = Action {
+    ContainerThumbnails.fromId(id) match {
+      case Some(thumbnail) =>
+        Ok(thumbnail).as("image/svg+xml")
+
+      case None => NotFound
+    }
+  }
+}

--- a/facia-tool/app/thumbnails/ContainerThumbnails.scala
+++ b/facia-tool/app/thumbnails/ContainerThumbnails.scala
@@ -128,8 +128,8 @@ object ContainerThumbnails {
 
       <svg xmlns="http://www.w3.org/2000/svg"
            xmlns:xlink="http://www.w3.org/1999/xlink"
-           width={(Width + 2).toString}
-           height={((container.slices.length * SliceHeight) + 2).toString}>
+           width={Width.toString}
+           height={container.slices.map(sliceHeight).sum.toString}>
         {container.slices.zip(yPositions).map((drawSlice _).tupled)}
       </svg>
     }

--- a/facia-tool/app/thumbnails/ContainerThumbnails.scala
+++ b/facia-tool/app/thumbnails/ContainerThumbnails.scala
@@ -3,47 +3,100 @@ package thumbnails
 import layout._
 import slices.{Slice, FixedContainers}
 
+case class Rectangle(x: Double, y: Double, width: Double, height: Double)
+
 object ContainerThumbnails {
   val SliceHeight = 25
+  // if rows are not stretched to accommodate another column
+  val BaseRowHeight = 7
   val Width = 100
 
-  val Style = "fill:#ccc;stroke:white;stroke-width:1"
+  val Style = "fill: #94b1ca; stroke: white; stroke-width: 1"
 
   def totalSpan(columns: Seq[Column]) = columns.map(_.colSpan).sum
 
-  def drawSlice(slice: Slice, index: Int) = {
+  def sliceHeight(slice: Slice) = {
+    slice.layout.columns match {
+      case Rows(_, _, rows, _) +: Nil => (rows * (BaseRowHeight + 1)) + 1
+      case _ => SliceHeight
+    }
+  }
+
+  def summing[A](as: Seq[A])(f: A => Double) = as.inits.toSeq.reverse map { xs =>
+    xs.map(f).sum
+  }
+
+  def drawSlice(slice: Slice, yPos: Double) = {
     val columns = slice.layout.columns
 
     val totalColSpan = totalSpan(columns)
     val unitSpanWidth = Width.toDouble / totalColSpan
 
-    val columnLeftSides = columns.inits.toSeq.reverse map { columnsSoFar =>
-      totalSpan(columnsSoFar) * unitSpanWidth
-    }
+    val columnLeftSides = summing(columns)(_.colSpan * unitSpanWidth)
 
     ((columns zip columnLeftSides) map { case (column, x) =>
-      drawColumn(column, x, index * SliceHeight, column.colSpan * unitSpanWidth, SliceHeight)
+      drawColumn(column, x, yPos, column.colSpan * unitSpanWidth, sliceHeight(slice))
     }).flatten
+  }
+
+  def drawImage(x: Double, y: Double, width: Double, height: Double, itemClasses: ItemClasses) = {
+    lazy val third = (width - 2) / 3
+
+    ((itemClasses.tablet match {
+      case "list-media" =>
+        Some(Rectangle(x + 1, y + 1, width / 2, height - 2))
+      case "three-quarters" =>
+        Some(Rectangle(x + 1 + third, y + 1, third * 2, height - 2))
+      case "three-quarters-right" =>
+        Some(Rectangle(x + 1, y + 1, third * 2, height - 2))
+      case "standard" | "half" | "third" =>
+        Some(Rectangle(x + 1, y + 1, width - 2, height * 2.0 / 3.0))
+      case _ =>
+        None
+    }) map { rectDef =>
+      <rect x={rectDef.x.toString}
+            y={rectDef.y.toString}
+            width={rectDef.width.toString}
+            height={rectDef.height.toString}
+            style="fill: #005689; stroke-width: 0"
+        />
+    }).toSeq
   }
 
   def drawColumn(column: Column, x: Double, y: Double, width: Double, height: Double) = {
     def box = <rect x={x.toString} y={y.toString} width={width.toString} height={height.toString} style={Style} />
 
-    column match {
-      case _: SingleItem => box
+    def image(itemClasses: ItemClasses) =
+      drawImage(x, y, width, height, itemClasses)
 
-      case Rows(_, columns, rows, _) =>
+    column match {
+      case SingleItem(_, itemClasses) =>
+        <g>
+          {box}
+          {image(itemClasses)}
+        </g>
+
+
+      case Rows(_, columns, rows, itemClasses) =>
         val rowWidth = width / columns.toDouble
         val rowHeight = height / rows.toDouble
 
         for {
           col <- 0 until columns
           row <- 0 until rows
-        } yield <rect x={(x + col * rowWidth).toString}
-                      y={(y + row * rowHeight).toString}
-                      width={rowWidth.toString}
-                      height={rowHeight.toString}
-                      style={Style} />
+        } yield {
+          val left = x + col * rowWidth
+          val top = y + row * rowHeight
+
+          <g>
+            <rect x={left.toString}
+                  y={top.toString}
+                  width={rowWidth.toString}
+                  height={rowHeight.toString}
+                  style={Style}/>
+            {drawImage(left, top, rowWidth, rowHeight, itemClasses)}
+          </g>
+        }
 
       case _: MPU =>
         val centreX = x + width / 2
@@ -71,11 +124,13 @@ object ContainerThumbnails {
 
   def fromId(id: String) = {
     FixedContainers.unapply(Some(id)) map { container =>
+      val yPositions = summing(container.slices)(sliceHeight)
+
       <svg xmlns="http://www.w3.org/2000/svg"
            xmlns:xlink="http://www.w3.org/1999/xlink"
            width={(Width + 2).toString}
            height={((container.slices.length * SliceHeight) + 2).toString}>
-        {container.slices.zipWithIndex.map((drawSlice _).tupled)}
+        {container.slices.zip(yPositions).map((drawSlice _).tupled)}
       </svg>
     }
   }

--- a/facia-tool/app/thumbnails/ContainerThumbnails.scala
+++ b/facia-tool/app/thumbnails/ContainerThumbnails.scala
@@ -1,7 +1,7 @@
 package thumbnails
 
 import layout._
-import slices.{Slice, FixedContainers}
+import slices._
 
 case class Rectangle(x: Double, y: Double, width: Double, height: Double)
 
@@ -110,27 +110,53 @@ object ContainerThumbnails {
                 style="font: 10px Arial, Verdana, sans-serif; alignment-baseline: central; fill: white;">MPU</text>
         </g>
 
-      case _: SplitColumn =>
+      case SplitColumn(_, topItemClasses, bottomItemClasses) =>
         val centreY = y + height / 2
 
         <g>
-          <rect x={x.toString} y={y.toString} width={width.toString} height={(height / 2).toString} style={Style} />
-          <rect x={x.toString} y={centreY.toString} width={width.toString} height={(height / 4).toString} style={Style} />
-          <rect x={x.toString} y={(centreY + height / 4).toString} width={width.toString} height={(height / 4).toString} style={Style} />
+          <rect x={x.toString}
+                y={y.toString}
+                width={width.toString}
+                height={(height / 2).toString}
+                style={Style} />
+          {drawImage(x, y, width, height / 2, topItemClasses)}
+          <rect x={x.toString}
+                y={centreY.toString}
+                width={width.toString}
+                height={(height / 4).toString}
+                style={Style} />
+          {drawImage(x, centreY, width, height / 4, bottomItemClasses)}
+          <rect x={x.toString}
+                y={(centreY + height / 4).toString}
+                width={width.toString}
+                height={(height / 4).toString}
+                style={Style} />
+          {drawImage(x, centreY + height / 4, width, height / 4, bottomItemClasses)}
         </g>
 
     }
   }
 
   def fromId(id: String) = {
-    FixedContainers.unapply(Some(id)) map { container =>
-      val yPositions = summing(container.slices)(sliceHeight)
+    val maybeSlices = id match {
+      case "dynamic/fast" =>
+        Some(Seq(HalfQuarterQl2Ql4))
+
+      case "dynamic/slow" =>
+        Some(Seq(Hl4Half))
+
+      case _ =>
+        FixedContainers.unapply(Some(id)).map(_.slices)
+    }
+
+    maybeSlices map { slices =>
+      val yPositions = summing(slices)(sliceHeight)
 
       <svg xmlns="http://www.w3.org/2000/svg"
            xmlns:xlink="http://www.w3.org/1999/xlink"
            width={Width.toString}
-           height={container.slices.map(sliceHeight).sum.toString}>
-        {container.slices.zip(yPositions).map((drawSlice _).tupled)}
+           height={slices.map(sliceHeight).sum.toString}>
+        {slices.zip(yPositions).map((drawSlice _).tupled)}
       </svg>
     }
   }

--- a/facia-tool/app/thumbnails/ContainerThumbnails.scala
+++ b/facia-tool/app/thumbnails/ContainerThumbnails.scala
@@ -45,11 +45,11 @@ object ContainerThumbnails {
     ((itemClasses.tablet match {
       case "list-media" =>
         Some(Rectangle(x + 1, y + 1, width / 2, height - 2))
-      case "three-quarters" =>
+      case "three-quarters" | "full" =>
         Some(Rectangle(x + 1 + third, y + 1, third * 2, height - 2))
       case "three-quarters-right" =>
         Some(Rectangle(x + 1, y + 1, third * 2, height - 2))
-      case "standard" | "half" | "third" =>
+      case "standard" | "half" | "third" | "mega-full" =>
         Some(Rectangle(x + 1, y + 1, width - 2, height * 2.0 / 3.0))
       case _ =>
         None
@@ -107,7 +107,7 @@ object ContainerThumbnails {
           <text x={centreX.toString}
                 y={centreY.toString}
                 text-anchor="middle"
-                style="font: 10px Arial, Verdana; alignment-baseline: central; fill: white;">MPU</text>
+                style="font: 10px Arial, Verdana, sans-serif; alignment-baseline: central; fill: white;">MPU</text>
         </g>
 
       case _: SplitColumn =>

--- a/facia-tool/app/thumbnails/ContainerThumbnails.scala
+++ b/facia-tool/app/thumbnails/ContainerThumbnails.scala
@@ -1,0 +1,82 @@
+package thumbnails
+
+import layout._
+import slices.{Slice, FixedContainers}
+
+object ContainerThumbnails {
+  val SliceHeight = 25
+  val Width = 100
+
+  val Style = "fill:#ccc;stroke:white;stroke-width:1"
+
+  def totalSpan(columns: Seq[Column]) = columns.map(_.colSpan).sum
+
+  def drawSlice(slice: Slice, index: Int) = {
+    val columns = slice.layout.columns
+
+    val totalColSpan = totalSpan(columns)
+    val unitSpanWidth = Width.toDouble / totalColSpan
+
+    val columnLeftSides = columns.inits.toSeq.reverse map { columnsSoFar =>
+      totalSpan(columnsSoFar) * unitSpanWidth
+    }
+
+    ((columns zip columnLeftSides) map { case (column, x) =>
+      drawColumn(column, x, index * SliceHeight, column.colSpan * unitSpanWidth, SliceHeight)
+    }).flatten
+  }
+
+  def drawColumn(column: Column, x: Double, y: Double, width: Double, height: Double) = {
+    def box = <rect x={x.toString} y={y.toString} width={width.toString} height={height.toString} style={Style} />
+
+    column match {
+      case _: SingleItem => box
+
+      case Rows(_, columns, rows, _) =>
+        val rowWidth = width / columns.toDouble
+        val rowHeight = height / rows.toDouble
+
+        for {
+          col <- 0 until columns
+          row <- 0 until rows
+        } yield <rect x={(x + col * rowWidth).toString}
+                      y={(y + row * rowHeight).toString}
+                      width={rowWidth.toString}
+                      height={rowHeight.toString}
+                      style={Style} />
+
+      case _: MPU =>
+        val centreX = x + width / 2
+        val centreY = y + height / 2
+
+        <g>
+          {box}
+          <text x={centreX.toString}
+                y={centreY.toString}
+                text-anchor="middle"
+                style="font: 10px Arial, Verdana; alignment-baseline: central; fill: white;">MPU</text>
+        </g>
+
+      case _: SplitColumn =>
+        val centreY = y + height / 2
+
+        <g>
+          <rect x={x.toString} y={y.toString} width={width.toString} height={(height / 2).toString} style={Style} />
+          <rect x={x.toString} y={centreY.toString} width={width.toString} height={(height / 4).toString} style={Style} />
+          <rect x={x.toString} y={(centreY + height / 4).toString} width={width.toString} height={(height / 4).toString} style={Style} />
+        </g>
+
+    }
+  }
+
+  def fromId(id: String) = {
+    FixedContainers.unapply(Some(id)) map { container =>
+      <svg xmlns="http://www.w3.org/2000/svg"
+           xmlns:xlink="http://www.w3.org/1999/xlink"
+           width={(Width + 2).toString}
+           height={((container.slices.length * SliceHeight) + 2).toString}>
+        {container.slices.zipWithIndex.map((drawSlice _).tupled)}
+      </svg>
+    }
+  }
+}

--- a/facia-tool/app/thumbnails/ContainerThumbnails.scala
+++ b/facia-tool/app/thumbnails/ContainerThumbnails.scala
@@ -6,12 +6,12 @@ import slices._
 case class Rectangle(x: Double, y: Double, width: Double, height: Double)
 
 object ContainerThumbnails {
-  val SliceHeight = 25
+  val SliceHeight = 40
   // if rows are not stretched to accommodate another column
   val BaseRowHeight = 7
   val Width = 100
 
-  val Style = "fill: #94b1ca; stroke: white; stroke-width: 1"
+  val Style = "fill: rgba(0,0,0,.04); stroke: rgba(255,255,255,.75); stroke-width: 1"
 
   def totalSpan(columns: Seq[Column]) = columns.map(_.colSpan).sum
 
@@ -44,13 +44,19 @@ object ContainerThumbnails {
 
     ((itemClasses.tablet match {
       case "list-media" =>
-        Some(Rectangle(x + 1, y + 1, width / 2, height - 2))
+        Some(Rectangle(x + 1, y + 1, width * .3, height))
       case "three-quarters" | "full" =>
         Some(Rectangle(x + 1 + third, y + 1, third * 2, height - 2))
       case "three-quarters-right" =>
         Some(Rectangle(x + 1, y + 1, third * 2, height - 2))
-      case "standard" | "half" | "third" | "mega-full" =>
-        Some(Rectangle(x + 1, y + 1, width - 2, height * 2.0 / 3.0))
+      case "standard"  =>
+        Some(Rectangle(x + 1, y + 1, width - 2, height * .4))
+      case "half"  =>
+        Some(Rectangle(x + 1, y + 1, width - 2, height * .7))
+      case "third" =>
+        Some(Rectangle(x + 1, y + 1, width - 2, height * .4))
+      case "mega-full" =>
+        Some(Rectangle(x + 1, y + 1, width - 2, height * .6))
       case _ =>
         None
     }) map { rectDef =>
@@ -58,7 +64,7 @@ object ContainerThumbnails {
             y={rectDef.y.toString}
             width={rectDef.width.toString}
             height={rectDef.height.toString}
-            style="fill: #005689; stroke-width: 0"
+            style="fill: rgba(0,0,0,.045); stroke-width: 0"
         />
     }).toSeq
   }

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -112,7 +112,7 @@
                     value: meta.type"></select>
 
                 <!-- ko if: containerThumbnail -->
-                <img data-bind="attr: { src: containerThumbnail }" />
+                <img class="cnf-form__thumbnail" data-bind="attr: { src: containerThumbnail }" />
                 <!-- /ko -->
 
                 <!-- ko if: meta.groups -->

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -111,6 +111,10 @@
                     options: $root.types,
                     value: meta.type"></select>
 
+                <!-- ko if: containerThumbnail -->
+                <img data-bind="attr: { src: containerThumbnail }" />
+                <!-- /ko -->
+
                 <!-- ko if: meta.groups -->
                     <label>Groups</label>
                     <span class="cnf-form__value" data-bind="text: meta.groups"></span>

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -50,6 +50,9 @@ GET           /switches                  controllers.SwitchesProxy.getSwitches()
 GET           /api/proxy/*path           controllers.FaciaContentApiProxy.proxy(path)
 GET           /json/proxy/*absUrl        controllers.FaciaContentApiProxy.json(absUrl)
 
+# thumbnails
+GET           /thumbnails/*id.svg        controllers.ThumbnailController.container(id)
+
 # Updating config
 
 POST          /config/fronts             controllers.FrontController.create()

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1172,6 +1172,11 @@ button {
     display: block;
 }
 
+.cnf-form__thumbnail {
+    position: absolute;
+    right: 10px;
+}
+
 /*****************************************/
 /* ICONS */
 /*****************************************/

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -58,7 +58,7 @@ define([
         this.containerThumbnail = ko.computed(function () {
             var containerId = this.meta.type();
 
-            if (/^fixed\//.test(containerId)) {
+            if (/^(fixed|dynamic)\//.test(containerId)) {
                 return "/thumbnails/" + containerId + ".svg";
             } else {
                 return null;

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -55,6 +55,16 @@ define([
             return _.some(this.parents(), function(front) {return front.props.priority() === vars.priority; });
         }, this);
 
+        this.containerThumbnail = ko.computed(function () {
+            var containerId = this.meta.type();
+
+            if (/^fixed\//.test(containerId)) {
+                return "/thumbnails/" + containerId + ".svg";
+            } else {
+                return null;
+            }
+        }, this);
+
         this.meta.apiQuery.subscribe(function(apiQuery) {
             if (this.state.isOpen()) {
                 this.meta.apiQuery(apiQuery.replace(/\s+/g, ''));


### PR DESCRIPTION
Somebody who's slightly less ham-fisted than me when it comes to styling could probably make these look nicer, but it's cool that we can now automatically generate these, having moved so much display information into Scala.

![screen shot 2014-10-20 at 12 29 56](https://cloud.githubusercontent.com/assets/867233/4700390/6b05aff0-584c-11e4-9d0a-3697c0c93638.png)

Also we could think about improving the actual selector itself so that rather than exposing the IDs directly we have a UI component that an editor can select a thumbnail from. I'm too lazy to do that right now, though.
