### PR TITLE
Correct inline3 size at mobile

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -134,6 +134,13 @@ define([
                     tablet: '300,250'
                 }
             },
+            inline3: {
+                sizeMappings: {
+                    mobile: '300,50',
+                    'mobile-landscape': '300,50|320,50',
+                    tablet: '300,250'
+                }
+            },
             'merchandising-high': {
                 label: false,
                 refresh: false,

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -27,16 +27,12 @@ define([
     };
 
     MostPopular.prototype.prerender = function () {
-        this.$mpu = $('.js-facia-slice__item--mpu', this.elem);
-        this.$mpu.attr('id', 'inline-3')
-                    .attr('data-name', 'inline-3')
-                    .attr('data-label', 'true')
-                    .attr('data-mobile', '300,250')
-                    .html('<div class="ad-container"></div>');
+        this.$mpu = $('.js-facia-slice__item--mpu', this.elem)
+            .append(dfp.createAdSlot('inline3', 'container-inline'));
     };
 
     MostPopular.prototype.ready = function () {
-        dfp.addSlot(this.$mpu);
+        dfp.addSlot($('.ad-slot', this.$mpu));
         this.$mpu.removeClass('facia-slice__item--no-mpu');
         mediator.emit('modules:popular:loaded', this.elem);
         mediator.emit('register:end', 'popular-in-section');

--- a/static/test/javascripts/spec/common/onward/popular.spec.js
+++ b/static/test/javascripts/spec/common/onward/popular.spec.js
@@ -16,7 +16,10 @@ define([
                 },
                 'common/modules/commercial/dfp': function () {
                     return {
-                        addSlot: function () {}
+                        addSlot: function () {},
+                        createAdSlot: function () {
+                            return '<div class="ad-slot"></div>';
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Also use dfp.js' `createAdSlot` to, er, create the ad slot

cc: @phamann 
