### PR TITLE
Dedup Keyword IDs in Facia Pages

### DIFF
--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -19,11 +19,15 @@ case class FaciaPage(id: String,
   override lazy val title: Option[String] = seoData.title
 
   lazy val keywordIds: Seq[String] = {
-    if (id.split("/").size == 1) {
-      Seq(s"$id/$id")
+    val path = Edition.all.foldLeft(id) { case (soFar, edition) =>
+      val editionName = edition.id.toLowerCase
+      soFar.stripPrefix(s"$editionName/")
+    }
+    if (path.split("/").size == 1) {
+      Seq(s"$path/$path")
     } else {
-      val normalizedId = id.replace("/", "-")
-      Seq(id, s"$normalizedId/$normalizedId")
+      val normalizedPath = path.replace("/", "-")
+      Seq(path, s"$normalizedPath/$normalizedPath")
     }
   }
 

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -19,8 +19,12 @@ case class FaciaPage(id: String,
   override lazy val title: Option[String] = seoData.title
 
   lazy val keywordIds: Seq[String] = {
-    val normalizedId = id.replace("/", "-")
-    Seq(id, s"$normalizedId/$normalizedId")
+    if (id.split("/").size == 1) {
+      Seq(s"$id/$id")
+    } else {
+      val normalizedId = id.replace("/", "-")
+      Seq(id, s"$normalizedId/$normalizedId")
+    }
   }
 
   override lazy val isFront = true

--- a/facia/test/model/FaciaPageTest.scala
+++ b/facia/test/model/FaciaPageTest.scala
@@ -1,0 +1,29 @@
+package model
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class FaciaPageTest extends FlatSpec with Matchers {
+
+  private def toFaciaPage(id: String): FaciaPage = {
+    FaciaPage(id, SeoData.empty, FrontProperties.empty, Nil)
+  }
+
+  "keywordIds" should "be same as section keyword ID for content pages in an editorial section" in {
+    toFaciaPage("culture").keywordIds should be(Seq("culture/culture"))
+  }
+
+  it should
+    "be same as section keyword ID for content pages in a commercial hub" in {
+    toFaciaPage("sustainable-business").keywordIds should be(Seq(
+      "sustainable-business/sustainable-business"))
+  }
+
+  it should
+    "reflect that front could be either a section front or a tag page in a commercial partner " +
+      "zone" in {
+    toFaciaPage("sustainable-business/grundfos-partner-zone").keywordIds should be(Seq(
+      "sustainable-business/grundfos-partner-zone",
+      "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone"))
+  }
+
+}

--- a/facia/test/model/FaciaPageTest.scala
+++ b/facia/test/model/FaciaPageTest.scala
@@ -12,8 +12,16 @@ class FaciaPageTest extends FlatSpec with Matchers {
     toFaciaPage("fashion").keywordIds should be(Seq("fashion/fashion"))
   }
 
-  it should "be same as section keyword ID for content pages in an editionalised section" in {
+  it should "be same as section keyword ID for content pages in a UK editionalised section" in {
     toFaciaPage("uk/culture").keywordIds should be(Seq("culture/culture"))
+  }
+
+  it should "be same as section keyword ID for content pages in a AU editionalised section" in {
+    toFaciaPage("au/business").keywordIds should be(Seq("business/business"))
+  }
+
+  it should "be same as section keyword ID for content pages in a US editionalised section" in {
+    toFaciaPage("us/commentisfree").keywordIds should be(Seq("commentisfree/commentisfree"))
   }
 
   it should

--- a/facia/test/model/FaciaPageTest.scala
+++ b/facia/test/model/FaciaPageTest.scala
@@ -8,8 +8,12 @@ class FaciaPageTest extends FlatSpec with Matchers {
     FaciaPage(id, SeoData.empty, FrontProperties.empty, Nil)
   }
 
-  "keywordIds" should "be same as section keyword ID for content pages in an editorial section" in {
-    toFaciaPage("culture").keywordIds should be(Seq("culture/culture"))
+  "keywordIds" should "be same as section keyword ID for content pages in a section" in {
+    toFaciaPage("fashion").keywordIds should be(Seq("fashion/fashion"))
+  }
+
+  it should "be same as section keyword ID for content pages in an editionalised section" in {
+    toFaciaPage("uk/culture").keywordIds should be(Seq("culture/culture"))
   }
 
   it should
@@ -19,8 +23,7 @@ class FaciaPageTest extends FlatSpec with Matchers {
   }
 
   it should
-    "reflect that front could be either a section front or a tag page in a commercial partner " +
-      "zone" in {
+    "reflect that front could be either a section front or a tag page in a partner zone" in {
     toFaciaPage("sustainable-business/grundfos-partner-zone").keywordIds should be(Seq(
       "sustainable-business/grundfos-partner-zone",
       "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone"))


### PR DESCRIPTION
To stop sending redundant keyword parameters in ad calls.

Currently, for example:
- www.theguardian.com/uk/culture has keyword IDs uk/culture and uk-culture/uk-culture
- www.theguardian.com/fashion has keyword IDs fashion and fashion/fashion
