### PR TITLE
Fix container title colour on media page

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -19,6 +19,8 @@
 .tonal--tone-podcast,
 .tonal--tone-media {
     .tonal__main {
+        color: $c-neutral7;
+
         .byline,
         .content__dateline {
             color: $c-neutral3;


### PR DESCRIPTION
Fix a tiny regression resulting from https://github.com/guardian/frontend/pull/6585

Broken: 
![screen shot 2014-10-20 at 13 11 42](https://cloud.githubusercontent.com/assets/813383/4700911/8e86189c-5852-11e4-920c-b85b1fd0513c.png)

Fixed:
![screen shot 2014-10-20 at 13 11 52](https://cloud.githubusercontent.com/assets/813383/4700914/93d8945a-5852-11e4-93fa-c10b164d9823.png)
