### PR TITLE
Show membership number in Identity

### DIFF
--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -121,6 +121,19 @@
                 </div>
             </div>
         </li>
+        <li class="is-hidden js-membership-number-container">
+            <div class="fieldset__heading">
+                <h2 class="form__heading">
+                    Membership number
+                </h2>
+            </div>
+
+            <div class="fieldset__fields">
+                <div class="form-field">
+                    <span class="js-membership-number"></span>
+                </div>
+            </div>
+        </li>
     </ul>
     <ul class="is-hidden u-unstyled membership-tab__details-list membership-tab__details-list--lower js-membership-details-list-lower">
         <li>

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -88,9 +88,7 @@
             </div>
 
             <div class="fieldset__fields">
-                <div class="form-field">
-                    <span class="js-membership-number"></span>
-                </div>
+                <div class="form-field js-membership-number"></div>
             </div>
         </li>
         <li>

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -80,7 +80,19 @@
     </div>
 
     <ul class="u-unstyled membership-tab__details-list js-membership-details-list-upper">
+        <li class="is-hidden js-membership-number-container">
+            <div class="fieldset__heading">
+                <h2 class="form__heading">
+                    Membership number
+                </h2>
+            </div>
 
+            <div class="fieldset__fields">
+                <div class="form-field">
+                    <span class="js-membership-number"></span>
+                </div>
+            </div>
+        </li>
         <li>
             <div class="fieldset__heading">
                 <h2 class="form__heading">
@@ -118,19 +130,6 @@
             <div class="fieldset__fields">
                 <div class="form-field">
                     <span class="membership-tab__currency">£</span><span class="membership-payment-cost js-membership-payment-cost"></span>
-                </div>
-            </div>
-        </li>
-        <li class="is-hidden js-membership-number-container">
-            <div class="fieldset__heading">
-                <h2 class="form__heading">
-                    Membership number
-                </h2>
-            </div>
-
-            <div class="fieldset__fields">
-                <div class="form-field">
-                    <span class="js-membership-number"></span>
                 </div>
             </div>
         </li>

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -111,7 +111,7 @@
         <li>
             <div class="fieldset__heading">
                 <h2 class="form__heading">
-                    <span class="js-membership-plan-interval"></span> payment
+                    <span class="js-membership-plan-interval"></span> Payment
                 </h2>
             </div>
 

--- a/static/src/javascripts/projects/membership/membership-tab.js
+++ b/static/src/javascripts/projects/membership/membership-tab.js
@@ -40,6 +40,8 @@ define([
         JOIN: 'js-membership-join-date',
         NEXT: 'js-membership-payment-next',
         INTERVAL: 'js-membership-plan-interval',
+        NUM_CONTAINER: 'js-membership-number-container',
+        NUM_TEXT: 'js-membership-number',
         CC_SUMMARY_LAST4: 'js-membership-summary-card-lastfour',
         CC_PAYMENT_LAST4: 'js-membership-payment-card-lastfour',
         CC_PAYMENT_TYPE: 'js-membership-payment-card-type',
@@ -118,7 +120,9 @@ define([
             notificationCancelElement = self.getElem('NOTIFICATION_CANCEL'),
             notificationChangeElement = self.getElem('NOTIFICATION_CHANGE'),
             upperTabDetailsList = self.getClass('TAB_DETAILS_LIST_UPPER'),
-            lowerTabDetailsList = self.getClass('TAB_DETAILS_LIST_LOWER');
+            lowerTabDetailsList = self.getClass('TAB_DETAILS_LIST_LOWER'),
+            membershipNumberContainer = self.getElem('NUM_CONTAINER'),
+            membershipNumberElement = self.getElem('NUM_TEXT');
 
         ajax({
             url: config.page.membershipUrl + '/user/me/details',
@@ -155,6 +159,12 @@ define([
                 } else {
                     self.displayLowerTabContents.call(self, lowerTabDetailsList, resp, subscriptionDates);
                 }
+            }
+
+            // this field is generated in batches so isn't available immediately after registering
+            if (resp.regNumber) {
+                $(membershipNumberContainer).removeClass('is-hidden');
+                $(membershipNumberElement).text(resp.regNumber);
             }
 
             self.ready();


### PR DESCRIPTION
This fixes `MEM-159`.

Basically adds this 'Membership number' field to the Membership tab on Identity:

![image](https://cloud.githubusercontent.com/assets/394376/4703008/3a00f660-5867-11e4-87c0-5d8e75b9fbd5.png)

This field often resolves to `null`, either because:

a) the user is on a free tier and therefore doesn't have an ID in the system
b) the batch job which generates these numbers hasn't run yet (eg. the user signed up very recently)

This field only shows when the ID exists.
