### PR TITLE
Add Sponsors' Logo Creatives to Templates Example Page

### DIFF
--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -15,7 +15,6 @@ import scala.util.{Failure, Try}
 
 object DfpDataHydrator extends Logging {
 
-
   private lazy val dfpSession: Option[DfpSession] = try {
     for {
       clientId <- AdminConfiguration.dfpApi.clientId
@@ -218,9 +217,12 @@ object DfpDataHydrator extends Logging {
       name.startsWith("APPS - ") || name.startsWith("AS ") || name.startsWith("QC ")
     }
 
+    // fetch merchandising creatives by advertiser and logo creatives by size
     val creativesQuery = new StatementBuilder()
-      .where("advertiserId = :advertiserId")
+      .where("advertiserId = :advertiserId or (width = :width and height = :height)")
       .withBindVariableValue("advertiserId", guMerchandisingAdvertiserId)
+      .withBindVariableValue("width", "140")
+      .withBindVariableValue("height", "90")
 
     val creatives = DfpApiWrapper.fetchTemplateCreatives(session, creativesQuery)
 

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -24,8 +24,8 @@
             <div class="facia-container__inner">
                 <h1>Creative Templates</h1>
                 <p>This dashboard is to help debug DFP creative templates.<br />
-                    All unarchived creative templates are shown.</p>
-                <p>The creatives listed under each template are only those owned by the Guardian Merchandising account.<br />
+                    All unarchived custom creative templates are shown.</p>
+                <p>The creatives listed under each template are only either creatives owned by the Guardian Merchandising account, or sponsors' logos of size 140x90.<br />
                     So a template might appear to be unused when in fact other creatives have been built from it.</p>
             </div>
 


### PR DESCRIPTION
Used to show:

![image](https://cloud.githubusercontent.com/assets/1722550/4703286/98d11754-5869-11e4-86b2-71fa4cd1bfb5.png)

Now shows:

![image](https://cloud.githubusercontent.com/assets/1722550/4703295/a8883bd2-5869-11e4-913a-e092521758e5.png)

@ironsidevsquincy 
