### PR TITLE
Disable asset caching for Facia tool

### DIFF
--- a/facia-tool/app/actions/NoCache.scala
+++ b/facia-tool/app/actions/NoCache.scala
@@ -1,0 +1,20 @@
+package actions
+
+import play.api.mvc.{Result, Request, Action}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+case class NoCache[A](action: Action[A]) extends Action[A] {
+  override def apply(request: Request[A]): Future[Result] = {
+    action(request) map { response =>
+      response.withHeaders(
+        ("Cache-Control", "no-cache, no-store, must-revalidate"),
+        ("Pragma", "no-cache"),
+        ("Expires", "0")
+      )
+    }
+  }
+
+  lazy val parser = action.parser
+}

--- a/facia-tool/app/controllers/UncachedAssets.scala
+++ b/facia-tool/app/controllers/UncachedAssets.scala
@@ -1,0 +1,10 @@
+package controllers
+
+import actions.NoCache
+import play.api.mvc.Controller
+
+object UncachedAssets extends Controller {
+  def at(file: String) = NoCache {
+    Assets.at("/public", file)
+  }
+}

--- a/facia-tool/app/views/admin_main.scala.html
+++ b/facia-tool/app/views/admin_main.scala.html
@@ -12,19 +12,19 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <meta charset="utf-8"/>
 
-        <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/32x32.ico")" />
+        <link rel="shortcut icon" type="image/png" href="@routes.UncachedAssets.at("images/32x32.ico")" />
 
-        <link rel="apple-touch-icon" sizes="144x144" href="@routes.Assets.at("images/144x144.png")" />
-        <link rel="apple-touch-icon" sizes="114x114" href="@routes.Assets.at("images/114x114.png")" />
-        <link rel="apple-touch-icon" sizes="72x72" href="@routes.Assets.at("images/72x72.png")" />
-        <link rel="apple-touch-icon-precomposed" href="@routes.Assets.at("images/57x57.png")" />
+        <link rel="apple-touch-icon" sizes="144x144" href="@routes.UncachedAssets.at("images/144x144.png")" />
+        <link rel="apple-touch-icon" sizes="114x114" href="@routes.UncachedAssets.at("images/114x114.png")" />
+        <link rel="apple-touch-icon" sizes="72x72" href="@routes.UncachedAssets.at("images/72x72.png")" />
+        <link rel="apple-touch-icon-precomposed" href="@routes.UncachedAssets.at("images/57x57.png")" />
 
         <meta name="apple-mobile-web-app-title" content="Guardian" />
         <meta name="application-name" content="The Guardian" />
         <meta name="msapplication-TileColor" content="#005689" />
-        <meta name="msapplication-TileImage" content="@routes.Assets.at("images/windows_tile_144_b.png")" />
+        <meta name="msapplication-TileImage" content="@routes.UncachedAssets.at("images/windows_tile_144_b.png")" />
 
-        <link href="@routes.Assets.at("css/style.css?v2")" rel="stylesheet">
+        <link href="@routes.UncachedAssets.at("css/style.css?v2")" rel="stylesheet">
         <script>
             var curl = {
                 baseUrl: '/assets/js',
@@ -39,9 +39,9 @@
             }
         </script>
 
-        <script src="@routes.Assets.at("js/components/jquery/jquery.js")"></script>
-        <script src="@routes.Assets.at("js/components/curl/dist/curl-with-js-and-domReady/curl.js")" type="text/javascript"></script>
-        <script src="@routes.Assets.at("js/components/underscore/underscore.js")" type="text/javascript"></script>
+        <script src="@routes.UncachedAssets.at("js/components/jquery/jquery.js")"></script>
+        <script src="@routes.UncachedAssets.at("js/components/curl/dist/curl-with-js-and-domReady/curl.js")" type="text/javascript"></script>
+        <script src="@routes.UncachedAssets.at("js/components/underscore/underscore.js")" type="text/javascript"></script>
 
         <script>
             define('config', function() {
@@ -75,7 +75,7 @@
     } else {
         <header>
             <a href="/" target="_top">
-                <img class="logo" src="@routes.Assets.at("images/plane.png")" />
+                <img class="logo" src="@routes.UncachedAssets.at("images/plane.png")" />
                 <h1>
                     <span data-bind="text: title()">fronts</span>
                     @if(Play.isDev && Configuration.facia.stage.toLowerCase != "dev") { : @Configuration.facia.stage }

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -388,5 +388,5 @@
 
 </div>
 
-<script src="@routes.Assets.at("js/app-collections.js")"></script>
+<script src="@routes.UncachedAssets.at("js/app-collections.js")"></script>
 }

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -263,5 +263,5 @@
 
 </div>
 
-<script src="@routes.Assets.at("js/app-config.js")"></script>
+<script src="@routes.UncachedAssets.at("js/app-config.js")"></script>
 }

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -11,7 +11,7 @@ GET           /oauth2callback            controllers.OAuthLoginController.oauth2
 GET           /logout                    controllers.OAuthLoginController.logout
 
 # static files
-GET           /assets/*file              controllers.Assets.at(path="/public", file)
+GET           /assets/*file              controllers.UncachedAssets.at(file)
 
 ##################### NOTE ############################
 #all endpoints below this line should be authenticated#


### PR DESCRIPTION
Ideally we should asset hash files, but this is a quick fix for an annoying situation (we deploy and the editors can't see the changes because their browser has cached the files). As it's a single page app I think this is OK.

![cat](https://cloud.githubusercontent.com/assets/1001642/4703427/faa15cf4-586a-11e4-93b4-6e5129e292b9.gif)
