### PR TITLE
Start deleting off the press queue on failures

### DIFF
--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -14,6 +14,7 @@ import scala.util.{Failure, Success}
 
 object FrontPressCron extends JsonQueueWorker[SNSNotification] {
   val queueUrl: Option[String] = Configuration.faciatool.frontPressCronQueue
+  override val deleteOnFailure: Boolean = true
 
   override val queue: JsonMessageQueue[SNSNotification] = (Configuration.faciatool.frontPressCronQueue map { queueUrl =>
     val credentials = Configuration.aws.mandatoryCredentials

--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -90,6 +90,9 @@ abstract class JsonQueueWorker[A: Reads] extends Logging with ExecutionContexts 
             consecutiveProcessingErrors.recordSuccess()
 
           case Failure(error) =>
+            queue.delete(receipt) onFailure {
+              case e => log.error(s"Error deleting message $id from queue", e)
+            }
             log.error(s"Error processing message $id", error)
             consecutiveProcessingErrors.recordError()
         }

--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -62,6 +62,7 @@ abstract class JsonQueueWorker[A: Reads] extends Logging with ExecutionContexts 
   import JsonQueueWorker._
 
   val queue: JsonMessageQueue[A]
+  val deleteOnFailure: Boolean = false
 
   final private val lastSuccessfulReceipt = DateTimeRecorder()
   final private val consecutiveProcessingErrors = ConsecutiveErrorsRecorder()
@@ -90,9 +91,9 @@ abstract class JsonQueueWorker[A: Reads] extends Logging with ExecutionContexts 
             consecutiveProcessingErrors.recordSuccess()
 
           case Failure(error) =>
-            queue.delete(receipt) onFailure {
-              case e => log.error(s"Error deleting message $id from queue", e)
-            }
+            if (deleteOnFailure) {
+              queue.delete(receipt) onFailure {
+                case e => log.error(s"Error deleting message $id from queue", e)}}
             log.error(s"Error processing message $id", error)
             consecutiveProcessingErrors.recordError()
         }


### PR DESCRIPTION
This reverts back to an old behaviour; deleting off of the queue on press failure.

This is better, as we will not end up in a press failure loop.

We can implement retries as an alternative to leaving something back on the queue.

@robertberry @stephanfowler 
