### PR TITLE
Add billing address to Identity

### DIFF
--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -32,7 +32,13 @@ object AccountDetailsMapping extends UserFormMapping[AccountFormData] with Addre
     ("privateFields.address3", "address.line3"),
     ("privateFields.address4", "address.line4"),
     ("privateFields.postcode", "address.postcode"),
-    ("privateFields.country", "address.country")
+    ("privateFields.country", "address.country"),
+    ("privateFields.billingAddress1", "billingAddress.line1"),
+    ("privateFields.billingAddress2", "billingAddress.line2"),
+    ("privateFields.billingAddress3", "billingAddress.line3"),
+    ("privateFields.billingAddress4", "billingAddress.line4"),
+    ("privateFields.billingPostcode", "billingAddress.postcode"),
+    ("privateFields.billingCountry", "billingAddress.country")
   )
 }
 

--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -15,7 +15,8 @@ object AccountDetailsMapping extends UserFormMapping[AccountFormData] with Addre
       ("secondName", textField),
       ("gender", comboList(genders)),
       "birthDate" -> dateMapping,
-      "address" -> idAddress
+      "address" -> idAddress,
+      "billingAddress" -> idAddress
     )(AccountFormData.apply)(AccountFormData.unapply)
   }
 
@@ -45,7 +46,8 @@ case class AccountFormData(
   secondName: String,
   gender: String,
   birthDate: DateFormData,
-  address: AddressFormData
+  address: AddressFormData,
+  billingAddress: AddressFormData
 ) extends UserFormData{
 
   def toUserUpdate(currentUser: User): UserUpdate = UserUpdate(
@@ -60,7 +62,13 @@ case class AccountFormData(
       address3 = toUpdate(address.address3, currentUser.privateFields.address3),
       address4 = toUpdate(address.address4, currentUser.privateFields.address4),
       postcode = toUpdate(address.postcode, currentUser.privateFields.postcode),
-      country = toUpdate(address.country, currentUser.privateFields.country)
+      country = toUpdate(address.country, currentUser.privateFields.country),
+      billingAddress1 = toUpdate(billingAddress.address1, currentUser.privateFields.billingAddress1),
+      billingAddress2 = toUpdate(billingAddress.address2, currentUser.privateFields.billingAddress2),
+      billingAddress3 = toUpdate(billingAddress.address3, currentUser.privateFields.billingAddress3),
+      billingAddress4 = toUpdate(billingAddress.address4, currentUser.privateFields.billingAddress4),
+      billingPostcode = toUpdate(billingAddress.postcode, currentUser.privateFields.billingPostcode),
+      billingCountry  = toUpdate(billingAddress.country, currentUser.privateFields.billingCountry)
     ))
   )
 
@@ -81,6 +89,14 @@ object AccountFormData {
       address4 = user.privateFields.address4 getOrElse "",
       postcode = user.privateFields.postcode getOrElse "",
       country = user.privateFields.country getOrElse ""
+    ),
+    billingAddress = AddressFormData(
+      address1 = user.privateFields.billingAddress1 getOrElse "",
+      address2 = user.privateFields.billingAddress2 getOrElse "",
+      address3 = user.privateFields.billingAddress3 getOrElse "",
+      address4 = user.privateFields.billingAddress4 getOrElse "",
+      postcode = user.privateFields.billingPostcode getOrElse "",
+      country = user.privateFields.billingCountry getOrElse ""
     )
   )
 }

--- a/identity/app/views/fragments/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/accountDetailsForm.scala.html
@@ -123,4 +123,28 @@
         </div>
     </fieldset>
 
+    @if(user.privateFields.billingAddress1) {
+
+        <fieldset class="fieldset">
+            <div class="fieldset__heading">
+                <h2 class="form__heading">Billing address</h2>
+            </div>
+
+            <div class="fieldset__fields">
+                <ul class="u-unstyled">
+                    @inputField(Input(accountDetailsForm("billingAddress.line1"), ('_label, "Address line 1"), (Symbol("data-test-id"), "addr-line-1")))
+                    @inputField(Input(accountDetailsForm("billingAddress.line2"), ('_label, "Address line 2"), (Symbol("data-test-id"), "addr-line-2")))
+                    @inputField(Input(accountDetailsForm("billingAddress.line3"), ('_label, "Town"), (Symbol("data-test-id"), "addr-town")))
+                    @inputField(Input(accountDetailsForm("billingAddress.line4"), ('_label, "County or State"), (Symbol("data-test-id"), "addr-county")))
+                    @inputField(Input(accountDetailsForm("billingAddress.postcode"), ('_label, "Postcode/Zipcode"), (Symbol("data-test-id"), "addr-postcode")))
+                    @select(
+                        accountDetailsForm("billingAddress.country"),
+                        ("", "None") :: (Countries.all map {c => (c, c)}),
+                        ('_label, "Country"),
+                        ('_default, ""), (Symbol("data-test-id"), "addr-country")
+                    )
+                </ul>
+            </div>
+        </fieldset>
+    }
 </form>

--- a/identity/app/views/fragments/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/accountDetailsForm.scala.html
@@ -116,9 +116,6 @@
                     ('_label, "Country"),
                     ('_default, ""), (Symbol("data-test-id"), "addr-country")
                 )
-                <li>
-                    <button type="submit" class="submit-input" data-link-name="Create account" data-test-id="save-changes">Save changes</button>
-                </li>
             </ul>
         </div>
     </fieldset>
@@ -147,4 +144,13 @@
             </div>
         </fieldset>
     }
+
+    <fieldset class="fieldset">
+        <div class="fieldset__heading"></div>
+        <div class="fieldset__fields">
+            <button type="submit" class="submit-input" data-link-name="Create account" data-test-id="save-changes">Save changes</button>
+        </div>
+    </fieldset>
+
+
 </form>

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -102,6 +102,12 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
     val address4 = ""
     val postcode = "N1 9GU"
     val country = Countries.UK
+    val billingAddress1 = "Buckingham Palace"
+    val billingAddress2 = "London"
+    val billingAddress3 = ""
+    val billingAddress4 = ""
+    val billingPostcode = "SW1A 1AA"
+    val billingCountry = Countries.UK
 
     "with a valid CSRF request" - Fake{
       val fakeRequest = FakeCSRFRequest(POST, "/email-prefs")
@@ -115,7 +121,13 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
           ("address.line3", address3),
           ("address.line4", address4),
           ("address.postcode", postcode),
-          ("address.country", country)
+          ("address.country", country),
+          ("billingAddress.line1", billingAddress1),
+          ("billingAddress.line2", billingAddress2),
+          ("billingAddress.line3", billingAddress3),
+          ("billingAddress.line4", billingAddress4),
+          ("billingAddress.postcode", billingPostcode),
+          ("billingAddress.country", billingCountry)
         )
 
       val updatedUser = user.copy(

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -141,7 +141,13 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
           address3 = Some(address3),
           address4 = Some(address4),
           postcode = Some(postcode),
-          country = Some(country)
+          country = Some(country),
+          billingAddress1 = Some(billingAddress1),
+          billingAddress2 = Some(billingAddress2),
+          billingAddress3 = Some(billingAddress3),
+          billingAddress4 = Some(billingAddress4),
+          billingPostcode = Some(billingPostcode),
+          billingCountry  = Some(billingCountry)
         )
       )
 
@@ -166,6 +172,12 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
         userUpdate.privateFields.value.address4 should equal(None)
         userUpdate.privateFields.value.postcode.value should equal(postcode)
         userUpdate.privateFields.value.country.value should equal(country)
+        userUpdate.privateFields.value.billingAddress1.value should equal(billingAddress1)
+        userUpdate.privateFields.value.billingAddress2.value should equal(billingAddress2)
+        userUpdate.privateFields.value.billingAddress3 should equal(None)
+        userUpdate.privateFields.value.billingAddress4 should equal(None)
+        userUpdate.privateFields.value.billingPostcode.value should equal(billingPostcode)
+        userUpdate.privateFields.value.billingCountry.value should equal(billingCountry)
       }
 
       "then a status 200 should be returned" in {
@@ -174,4 +186,3 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
     }
   }
 }
-


### PR DESCRIPTION
For registered (paid-up) Membership users, we should show their billing address as well as their normal (delivery) address, eg:

![image](https://cloud.githubusercontent.com/assets/394376/4704856/b36a3080-5875-11e4-96f0-a907c1f117a5.png)
