### PR TITLE
Hide the image and give the headline a little boost for q-qqq

### DIFF
--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -462,7 +462,7 @@ case object QuarterThreeQuarter extends Slice {
       SingleItem(
         colSpan = 1,
         ItemClasses(
-          mobile = "list-media",
+          mobile = "list",
           tablet = "standard"
         )
       ),

--- a/static/src/stylesheets/module/facia-cards/_slices.scss
+++ b/static/src/stylesheets/module/facia-cards/_slices.scss
@@ -64,6 +64,16 @@ Hence why a greater depth of selector specificity is needed.
     }
 }
 
+.facia-slice--q-qqq {
+    .fc-item--list-mobile {
+        @include mq($until: tablet) {
+            .fc-item__header {
+                @include fs-headline(3, true);
+            }
+        }
+    }
+}
+
 // reduce type size on q-q-q-q slice if it follows another slice in the same container
 .facia-slice-wrapper + .facia-slice-wrapper {
     .facia-slice--q-q-q-q {


### PR DESCRIPTION
Before this looked dumb, so I fixed it.

Before:
![screen shot 2014-10-21 at 11 14 54](https://cloud.githubusercontent.com/assets/1607666/4716669/223f28d6-590b-11e4-938e-478cf09bfff7.png)

After:
![screen shot 2014-10-21 at 11 12 43](https://cloud.githubusercontent.com/assets/1607666/4716657/0d6a364e-590b-11e4-9791-daa2890a2b9c.png)
