### PR TITLE
Add More Keywords to Section Fronts

### DIFF
--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -14,10 +14,7 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
   lazy val webUrl: String = delegate.webUrl
   lazy val webTitle: String = delegate.webTitle
 
-  lazy val keywordId: String = {
-    val normalizedId = id.replace("/", "-")
-    s"$normalizedId/$normalizedId"
-  }
+  lazy val keywordIds: Seq[String] = frontKeywordIds(id)
 
   override lazy val isFront = true
 
@@ -29,15 +26,29 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
 
   override lazy val metaData: Map[String, JsValue] = super.metaData ++ Map(
     "keywords" -> JsString(webTitle),
-    "keywordIds" -> JsString(keywordId),
+    "keywordIds" -> JsString(keywordIds.mkString(",")),
     "content-type" -> JsString("Section")
   )
 
-  override lazy val isSponsored: Boolean = DfpAgent.isSponsored(keywordId, Some(id))
-  override lazy val hasMultipleSponsors: Boolean = DfpAgent.hasMultipleSponsors(keywordId)
-  override lazy val isAdvertisementFeature: Boolean = DfpAgent.isAdvertisementFeature(keywordId, Some(id))
-  override lazy val hasMultipleFeatureAdvertisers: Boolean = DfpAgent.hasMultipleFeatureAdvertisers(keywordId)
-  override lazy val isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(keywordId, Some(id))
-  override lazy val sponsor: Option[String] = DfpAgent.getSponsor(keywordId)
+  override lazy val isSponsored: Boolean = keywordIds exists (DfpAgent.isSponsored(_, Some(id)))
+
+  override lazy val hasMultipleSponsors: Boolean = keywordIds exists {
+    DfpAgent.hasMultipleSponsors
+  }
+
+  override lazy val isAdvertisementFeature: Boolean = keywordIds exists {
+    DfpAgent.isAdvertisementFeature(_, Some(id))
+  }
+
+  override lazy val hasMultipleFeatureAdvertisers: Boolean = keywordIds exists {
+    DfpAgent.hasMultipleFeatureAdvertisers
+  }
+
+  override lazy val isFoundationSupported: Boolean = keywordIds exists {
+    DfpAgent.isFoundationSupported(_, Some(id))
+  }
+
+  override lazy val sponsor: Option[String] = keywordIds.flatMap(DfpAgent.getSponsor(_)).headOption
+
   override def hasPageSkin(edition: Edition): Boolean = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 }

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -1,8 +1,8 @@
 package model
 
-import com.gu.openplatform.contentapi.model.{ Content => ApiContent, MediaAsset }
+import com.gu.openplatform.contentapi.model.{MediaAsset, Content => ApiContent}
 import common.Edition
-import org.joda.time.format.ISODateTimeFormat
+
 import scala.math.abs
 
 object `package` {
@@ -49,14 +49,19 @@ object `package` {
   }
 
   def frontKeywordIds(pageId: String): Seq[String] = {
-    val path = Edition.all.foldLeft(pageId) { case (soFar, edition) =>
-      val editionName = edition.id.toLowerCase
-      soFar.stripPrefix(s"$editionName/")
+    val editions = Edition.all.map(_.id.toLowerCase).toSet
+
+    val parts = pageId.split("/").toList match {
+      case edition :: rest if editions.contains(edition) => rest
+      case uneditionalised => uneditionalised
     }
-    if (path.split("/").size == 1) {
+
+    val path = parts.mkString("/")
+
+    if (parts.size == 1) {
       Seq(s"$path/$path")
     } else {
-      val normalizedPath = path.replace("/", "-")
+      val normalizedPath = parts.mkString("-")
       Seq(path, s"$normalizedPath/$normalizedPath")
     }
   }

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -47,4 +47,18 @@ object `package` {
     def distanceFrom(j: Int) = abs(j - i)
     def in(range: Range): Boolean = range contains i
   }
+
+  def frontKeywordIds(pageId: String): Seq[String] = {
+    val path = Edition.all.foldLeft(pageId) { case (soFar, edition) =>
+      val editionName = edition.id.toLowerCase
+      soFar.stripPrefix(s"$editionName/")
+    }
+    if (path.split("/").size == 1) {
+      Seq(s"$path/$path")
+    } else {
+      val normalizedPath = path.replace("/", "-")
+      Seq(path, s"$normalizedPath/$normalizedPath")
+    }
+  }
+
 }

--- a/common/test/model/SectionTest.scala
+++ b/common/test/model/SectionTest.scala
@@ -11,12 +11,13 @@ class SectionTest extends FlatSpec with Matchers {
     Section(delegate)
   }
 
-  "keywordId" should "be same as section keyword ID for content pages in section" in {
+  "keywordIds" should "be same as section keyword ID for content pages in section" in {
 
-    toSection("culture").keywordId should be("culture/culture")
+    toSection("culture").keywordIds should be(Seq("culture/culture"))
 
-    toSection("sustainable-business/grundfos-partner-zone").keywordId should be(
-      "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone")
+    toSection("sustainable-business/grundfos-partner-zone").keywordIds should be(Seq(
+      "sustainable-business/grundfos-partner-zone",
+      "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone"))
   }
 
 }

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -18,18 +18,7 @@ case class FaciaPage(id: String,
   override lazy val webTitle: String = seoData.webTitle
   override lazy val title: Option[String] = seoData.title
 
-  lazy val keywordIds: Seq[String] = {
-    val path = Edition.all.foldLeft(id) { case (soFar, edition) =>
-      val editionName = edition.id.toLowerCase
-      soFar.stripPrefix(s"$editionName/")
-    }
-    if (path.split("/").size == 1) {
-      Seq(s"$path/$path")
-    } else {
-      val normalizedPath = path.replace("/", "-")
-      Seq(path, s"$normalizedPath/$normalizedPath")
-    }
-  }
+  lazy val keywordIds: Seq[String] = frontKeywordIds(id)
 
   override lazy val isFront = true
 


### PR DESCRIPTION
This makes non-facia section fronts consistent with facia pages, so that ads work.
Eg global-development-professionals-network/malaria-consortium-partner-zone
![image](https://cloud.githubusercontent.com/assets/1722550/4717421/d4411b9e-5914-11e4-93c8-ac4160104e55.png)
