### PR TITLE
Updated pasteup-buttons dep

### DIFF
--- a/static/src/stylesheets/components/pasteup-buttons/.bower.json
+++ b/static/src/stylesheets/components/pasteup-buttons/.bower.json
@@ -1,7 +1,7 @@
 {
   "name": "pasteup-buttons",
   "description": "Button component in the Pasteup collection",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "main": [
     "build/buttons.min.css",
     "src/_buttons.scss"
@@ -16,16 +16,17 @@
     "guss-grid-system": "~1.2.1",
     "guss-typography": "~3.0.0",
     "guss-webfonts": "~3.0.0",
-    "pasteup-palette": "~3.1.0"
+    "pasteup-palette": "~3.1.0",
+    "sass-mq": "~2.1.1"
   },
   "devDependencies": {
     "Cortana": "~1.2.7"
   },
-  "_release": "0.4.9",
+  "_release": "0.4.10",
   "_resolution": {
     "type": "version",
-    "tag": "0.4.9",
-    "commit": "0108e1cf96365883c0037bd38b07b4733268ac45"
+    "tag": "0.4.10",
+    "commit": "c9ae1c9d2210715d0152bc063a16a08093a1ca8c"
   },
   "_source": "git://github.com/guardian/pasteup-buttons.git",
   "_target": "~0.4.0",

--- a/static/src/stylesheets/components/pasteup-buttons/bower.json
+++ b/static/src/stylesheets/components/pasteup-buttons/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "pasteup-buttons",
   "description": "Button component in the Pasteup collection",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "main": [
     "build/buttons.min.css",
     "src/_buttons.scss"
@@ -16,7 +16,8 @@
     "guss-grid-system": "~1.2.1",
     "guss-typography": "~3.0.0",
     "guss-webfonts": "~3.0.0",
-    "pasteup-palette": "~3.1.0"
+    "pasteup-palette": "~3.1.0",
+    "sass-mq": "~2.1.1"
   },
   "devDependencies": {
     "Cortana": "~1.2.7"

--- a/static/src/stylesheets/components/pasteup-buttons/src/_buttons.scss
+++ b/static/src/stylesheets/components/pasteup-buttons/src/_buttons.scss
@@ -56,6 +56,10 @@ Show more button:
 ```
 */
 
+/**
+ * 1. As on mobile devices we use Helvetica font which have a different baseline
+ *    we have to change line-height depending on resolution.
+ */
 @mixin button-height($button-size) {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
@@ -63,9 +67,13 @@ Show more button:
     height: $button-size;
     padding: 0 ($button-size / 3);
     margin-right: $button-size / 3;
-    line-height: $button-size + 2px;
+    line-height: $button-size - 2px; /* [1] */
     border-width: 1px;
     border-style: solid;
+
+    @include mq($from: desktop) {
+        line-height: $button-size + 2px;
+    }
 
     .i {
         width: $button-size;

--- a/static/src/stylesheets/components/pasteup-buttons/src/buttons.scss
+++ b/static/src/stylesheets/components/pasteup-buttons/src/buttons.scss
@@ -5,6 +5,7 @@ $guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
 @import 'bower_components/guss-typography/_typography';
 @import 'bower_components/guss-webfonts/src/_webfonts';
 @import 'bower_components/pasteup-palette/src/_palette';
+@import 'bower_components/sass-mq/_mq';
 
 @include guss-webfonts;
 


### PR DESCRIPTION
This will fix wrong text vertical align on mobile:
![screen shot 2014-10-21 at 16 47 36](https://cloud.githubusercontent.com/assets/2579465/4721583/a4be6bf4-5939-11e4-9032-3413273180d6.png)
