### PR TITLE
Quote marks appear on same line as headline

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_tones-images.scss
+++ b/static/src/stylesheets/module/facia-cards/_tones-images.scss
@@ -26,13 +26,11 @@
 
 .fc-item__title--quoted {
     .fc-item__link {
-        &:before {
-            @include icon(quote-grey, false);
-            content: '';
-            height: .72em;
-            width: 1.2em;
-            padding-right: .2em;
-        }
+        @include icon(quote-grey, false);
+        content: '';
+        background-size: 1.2em .75em !important;
+        background-position: 0 .2em !important;
+        text-indent: 1.4em;
     }
 
     .tone-podcast--item & .fc-item__link {


### PR DESCRIPTION
Before:
![screen shot 2014-10-21 at 16 33 59](https://cloud.githubusercontent.com/assets/1607666/4721709/5740137c-593a-11e4-865a-84a51c2c737a.png)

After:
![screen shot 2014-10-21 at 16 33 46](https://cloud.githubusercontent.com/assets/1607666/4721710/585241cc-593a-11e4-9a41-9fcbfdff6884.png)
