### PR TITLE
Gallery block level sharing bug fix

### DIFF
--- a/static/src/javascripts/bootstraps/gallery.js
+++ b/static/src/javascripts/bootstraps/gallery.js
@@ -66,8 +66,10 @@ define([
             var galleryHash = window.location.hash,
                 lightbox = new LightboxGallery.GalleryLightbox(),
                 hashIndex = galleryHash.split('#')[1];
+                parsedGalleryIndex = parseInt(hashIndex, 10),
+                galleryIndex = isNaN(parsedGalleryIndex) ? 1 : parsedGalleryIndex;// 1-based index
             if (galleryHash) {
-                lightbox.loadGalleryfromJson(config.page.galleryLightbox, hashIndex);
+                lightbox.loadGalleryfromJson(config.page.galleryLightbox, galleryIndex);
             }
 
             verticallyResponsiveImages();

--- a/static/src/javascripts/bootstraps/gallery.js
+++ b/static/src/javascripts/bootstraps/gallery.js
@@ -65,7 +65,7 @@ define([
             // Opens block level sharing links in the lightbox
             var galleryHash = window.location.hash,
                 lightbox = new LightboxGallery.GalleryLightbox(),
-                hashIndex = galleryHash.split('#')[1],
+                hashIndex = galleryHash.substr(1),
                 parsedGalleryIndex = parseInt(hashIndex, 10),
                 galleryIndex = isNaN(parsedGalleryIndex) ? 1 : parsedGalleryIndex;// 1-based index
             if (galleryHash) {

--- a/static/src/javascripts/bootstraps/gallery.js
+++ b/static/src/javascripts/bootstraps/gallery.js
@@ -65,7 +65,7 @@ define([
             // Opens block level sharing links in the lightbox
             var galleryHash = window.location.hash,
                 lightbox = new LightboxGallery.GalleryLightbox(),
-                hashIndex = galleryHash.split('#')[1];
+                hashIndex = galleryHash.split('#')[1],
                 parsedGalleryIndex = parseInt(hashIndex, 10),
                 galleryIndex = isNaN(parsedGalleryIndex) ? 1 : parsedGalleryIndex;// 1-based index
             if (galleryHash) {


### PR DESCRIPTION
The block ID is now parsed when opening the light box when coming in from a block level link. 
