### PR TITLE
Use u-h class to hide ad slot

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -178,7 +178,7 @@ define([
                 new Sticky($adSlot.parent()[0], { top: 12 }).init();
             },
             '300,1': function (e, $adSlot) {
-                $adSlot.css('display', 'none');
+                $adSlot.addClass('u-h');
             }
         },
 


### PR DESCRIPTION
Using `display: none` seems to have odd effects, e.g. the ad's scripts aren't always fired
