### PR TITLE
Slim elements on facia-press

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -5,7 +5,7 @@ import org.apache.commons.math3.fraction.Fraction
 import views.support.{Naked, ImgSrc}
 import scala.util.matching.Regex
 
-case class ImageAsset(private val delegate: Asset, index: Int) {
+case class ImageAsset(delegate: Asset, index: Int) {
 
   private lazy val fields: Map[String,String] = delegate.typeData
   private lazy val aspectRatio: Fraction = {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -109,7 +109,7 @@ trait Elements {
   private val trailPicMinDesiredSize = 460
 
   // Find a main picture crop which matches this aspect ratio.
-  def trailPicture(aspectWidth: Int, aspectHeight: Int): Option[ImageContainer] =
+  def trailPictureAll(aspectWidth: Int, aspectHeight: Int): List[ImageContainer] =
     (thumbnail.find(_.imageCrops.exists(_.width >= trailPicMinDesiredSize)) ++ mainPicture ++ thumbnail)
       .map{ image =>
         image.imageCrops.filter{ crop => crop.aspectRatioWidth == aspectWidth && crop.aspectRatioHeight == aspectHeight } match {
@@ -118,7 +118,9 @@ trait Elements {
         }
       }
       .flatten
-      .headOption
+      .toList
+
+  def trailPicture(aspectWidth: Int, aspectHeight: Int): Option[ImageContainer] = trailPictureAll(aspectWidth, aspectHeight).headOption
 
   // trail picture is used on index pages (i.e. Fronts and tag pages)
   def trailPicture: Option[ImageContainer] = thumbnail.find(_.imageCrops.exists(_.width >= trailPicMinDesiredSize))

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -7,7 +7,7 @@ import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
 import conf.Configuration
 
-abstract class ElementProfile {
+trait ElementProfile {
 
   def width: Option[Int]
   def height: Option[Int]

--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -18,7 +18,7 @@ GET           /logout                    controllers.OAuthLoginController.logout
 GET           /humans.txt                controllers.Assets.at(path="/public", file="humans.txt")
 GET           /assets/javascripts/*file  dev.DevAssetsController.atJavascripts(file)
 GET           /assets/stylesheets/*file  dev.DevAssetsController.atStylesheets(file)
-GET           /assets/*file              controllers.Assets.at(path="/public", file)
+GET           /assets/*file              controllers.UncachedAssets.at(file)
 GET           /assets/fonts/*path        dev.DevAssetsController.atFonts(path)
 
 ##################### NOTE ############################

--- a/facia-press/app/frontpress/jsonModels.scala
+++ b/facia-press/app/frontpress/jsonModels.scala
@@ -6,6 +6,8 @@ import conf.Switches
 import model._
 import org.joda.time.DateTime
 import play.api.libs.json._
+import com.gu.contentapi.client.model.{Element => ApiElement}
+import views.support.Naked
 
 object ElementJson {
   implicit val assetFormat = Json.format[Asset]
@@ -125,10 +127,16 @@ object TrailJson {
       content.trailText,
       content.byline,
       content.delegate.safeFields,
-      content.elements.map(ElementJson.fromElement),
+      apiElementsToElements(slimElements(content)).map(ElementJson.fromElement),
       ItemMeta.fromContent(content)
     )
   }
+
+  def slimElements(content: Content): List[ApiElement] = content.trailPictureAll(5, 3).map {
+    imageContainer => imageContainer.delegate.copy(assets = Naked.elementFor(imageContainer).map(_.delegate).toList)}
+
+  def apiElementsToElements(apiElements: List[ApiElement]): List[Element] =
+    apiElements.zipWithIndex.map{case (element, index) => Element(element, index)}
 }
 
 case class TrailJson(


### PR DESCRIPTION
Start slimming down the size of the `elements` key for each piece of content in the `pressed.json` files. This dramatically decreases the size of the file.

For example; `/uk` on `DEV` for me was coming out at around `5.3MB`, it is now `1.8MB`.
`/au/culture` went from `4.2MB` to `1MB`.

This simply emulates how the templates get elements from pieces of `content`; using `trailPicture(5, 3)` and also using `ElementsProfile.elementFor` to take the largest `Asset`.

@robertberry @stephanfowler 
