### PR TITLE
Facia-press block if empty

### DIFF
--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -22,6 +22,8 @@ case class Collection(curated: Seq[Content],
 
   def isBackFillEmpty =
     (editorsPicks ++ mostViewed ++ results).isEmpty
+
+  lazy val isEmpty = items.isEmpty
 }
 
 object Collection {

--- a/facia-press/app/frontpress/FrontPress.scala
+++ b/facia-press/app/frontpress/FrontPress.scala
@@ -33,12 +33,9 @@ trait FrontPress extends Logging {
                    seoData: SeoData,
                    frontProperties: FrontProperties,
                    collections: Seq[(CollectionConfigWithId, Collection)]): Try[JsObject] = {
-    val collectionsWithBackFills = collections.toList collect {
-      case (configWithId, collection) if configWithId.config.apiQuery.isDefined => collection
-    }
 
-    if (collectionsWithBackFills.nonEmpty && collectionsWithBackFills.forall(_.isBackFillEmpty)) {
-      val errorMessage = s"Tried to generate pressed JSON for front $id but all back fills were empty - aborting!"
+    if (collections.forall(_._2.isEmpty)) {
+      val errorMessage = s"Tried to generate pressed JSON for front $id but it ended up being empty - aborting!"
       log.error(errorMessage)
       Failure(new RuntimeException(errorMessage))
     } else {


### PR DESCRIPTION
This changes the current behaviour of `facia-press` to sometime more simple: it will not press if a front/path ends up being completely empty after being generated.

The behaviour currently is to block when there are collections with backfills and they end up all being empty. This is too specific and slightly weird logic.

@stephanfowler @robertberry 
