### PR TITLE
Better handling of popular container's classes

### DIFF
--- a/common/app/views/fragments/containers/popular.scala.html
+++ b/common/app/views/fragments/containers/popular.scala.html
@@ -11,7 +11,7 @@
     @if(collection.items.nonEmpty) {
         <section
             id="@FaciaComponentName(config, collection)"
-            class="@GetClasses.forNewStyleContainer(config, containerIndex == 0, title.nonEmpty)"
+            class="container fc-container"
             data-link-name="@FaciaComponentName(config, collection)"
             data-id="@FaciaComponentName(config, collection)"
             data-type="@style.containerType"

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -995,18 +995,14 @@ object GetClasses {
   }
 
   private def commonContainerStyles(config: CollectionConfig, isFirst: Boolean, hasTitle: Boolean): Seq[String] = {
-    val isPopular = config.apiQuery.exists { q =>
-      q.contains("show-most-viewed=true") && q.contains("hide-recent-content=true")
-    }
     Seq(
       ("container", true),
       ("container--first", isFirst),
-      ("container--sponsored", (DfpAgent.isSponsored(config) && !isPopular)),
-      ("container--advertisement-feature", (DfpAgent.isAdvertisementFeature(config) && !isPopular)),
-      ("container--foundation-supported", (DfpAgent.isFoundationSupported(config) && !isPopular)),
+      ("container--sponsored", DfpAgent.isSponsored(config)),
+      ("container--advertisement-feature", DfpAgent.isAdvertisementFeature(config)),
+      ("container--foundation-supported", DfpAgent.isFoundationSupported(config)),
       ("js-sponsored-container", (
-        (DfpAgent.isSponsored(config) || DfpAgent.isAdvertisementFeature(config) || DfpAgent.isFoundationSupported(config)) &&
-        !isPopular
+        (DfpAgent.isSponsored(config) || DfpAgent.isAdvertisementFeature(config) || DfpAgent.isFoundationSupported(config))
       )),
       ("js-container--toggle", (!isFirst && hasTitle && !(DfpAgent.isAdvertisementFeature(config) || DfpAgent.isSponsored(config))))
     ) collect {


### PR DESCRIPTION
Popular container is pretty bespoke, doesn't have a load of potential classes. Hardcode them into the template rather than conditional logic in `GetClasses`
