### PR TITLE
Sparklines fix

### DIFF
--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -479,7 +479,7 @@ h1 {
 
 .article__times {
     position: absolute;
-    top: 5px;
+    top: 3px;
     right: 5px;
     font-size: 11px;
     line-height: 12px;
@@ -702,7 +702,7 @@ button {
 
 .article__spark {
     position: absolute;
-    top: 18px;
+    top: 16px;
     right: 5px;
 }
 

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -497,19 +497,19 @@ define([
                 window.console.error('ContentApi missing: "' + missingProps.join('", "') + '" for ' + this.id());
             } else {
                 this.state.isLoaded(true);
-                this.sparkline();
+                this.state.imageCutoutSrcFromCapi(getContributorImage(opts));
+                this.state.hasMainVideo(getMainMediaType(opts) === 'video');
+                this.state.tone(opts.frontsMeta && opts.frontsMeta.tone);
+                this.state.ophanUrl(vars.CONST.ophanBase + '?path=/' + urlAbsPath(opts.webUrl));
+
+                this.metaDefaults = _.extend(deepGet(opts, '.frontsMeta.defaults') || {}, this.collectionMetaDefaults);
+
+                populateObservables(this.meta, this.metaDefaults);
+
+                this.updateEditorsDisplay();
+
+                this.loadSparkline();
             }
-
-            this.state.imageCutoutSrcFromCapi(getContributorImage(opts));
-            this.state.hasMainVideo(getMainMediaType(opts) === 'video');
-            this.state.tone(opts.frontsMeta && opts.frontsMeta.tone);
-            this.state.ophanUrl(vars.CONST.ophanBase + '?path=/' + urlAbsPath(opts.webUrl));
-
-            this.metaDefaults = _.extend(deepGet(opts, '.frontsMeta.defaults') || {}, this.collectionMetaDefaults);
-
-            populateObservables(this.meta, this.metaDefaults);
-
-            this.updateEditorsDisplay();
         };
 
         Article.prototype.updateEditorsDisplay = function() {
@@ -523,19 +523,17 @@ define([
             this.scheduledPublicationTime(humanTime(this.fields.scheduledPublicationDate()));
         };
 
-        Article.prototype.sparkline = function() {
-            var path = urlAbsPath(this.props.webUrl());
+        Article.prototype.loadSparkline = function() {
+            var self = this;
 
             if (vars.model.switches()['facia-tool-sparklines']) {
-                this.state.sparkUrl(
-                    vars.sparksBase + path + (this.frontPublicationDate ? '&markers=' + (this.frontPublicationDate/1000) + ':46C430' : '')
-                );
-            }
-        };
-
-        Article.prototype.refreshSparkline = function() {
-            if (vars.model.switches()['facia-tool-sparklines']) {
-                this.state.sparkUrl.valueHasMutated();
+                setTimeout(function() {
+                    if (self.state.sparkUrl()) {
+                        self.state.sparkUrl.valueHasMutated();
+                    } else {
+                        self.state.sparkUrl(vars.sparksBase + urlAbsPath(self.props.webUrl()) + (self.frontPublicationDate ? '&markers=' + (self.frontPublicationDate/1000) + ':46C430' : ''));
+                    }
+                }, Math.floor(Math.random() * 5000));
             }
         };
 

--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -267,7 +267,7 @@ define([
     Collection.prototype.refreshSparklines = function() {
         _.each(this.groups, function(group) {
             _.each(group.items(), function(item) {
-                item.refreshSparkline();
+                item.loadSparkline();
             });
         });
     };


### PR DESCRIPTION
Sparklines were loading too soon and clogging the connection ahead of article images, because they each block on a relatively slow Ophan api call. Defer and spread (over 5 secs) the loading of them.
