### PR TITLE
correct bad class name on commercial travel component 

### DIFF
--- a/commercial/app/views/travelOfferFragments/travelOffer.scala.html
+++ b/commercial/app/views/travelOfferFragments/travelOffer.scala.html
@@ -20,7 +20,7 @@
             </div>
         </a>
         <a class="lineitem__cta button button--primary button--small" href="@AdLink{@travelOffer.offerUrl}">
-            Book now<i class="i i-arrow-white i-right"></i>
+            Book now<i class="i i-arrow-white-right i-right"></i>
         </a>
     </div>
 </li>

--- a/commercial/app/views/travelOfferFragments/travelOffer.scala.html
+++ b/commercial/app/views/travelOfferFragments/travelOffer.scala.html
@@ -20,7 +20,7 @@
             </div>
         </a>
         <a class="lineitem__cta button button--primary button--small" href="@AdLink{@travelOffer.offerUrl}">
-            Book now<i class="i i-arrow-black-white i-right"></i>
+            Book now<i class="i i-arrow-white i-right"></i>
         </a>
     </div>
 </li>


### PR DESCRIPTION
My fault, now corrected class name so that arrow appears. (Vertical alignment of text is a separate issue.)

Before;

![screen shot 2014-10-23 at 11 01 40](https://cloud.githubusercontent.com/assets/1303616/4751283/d6595990-5a9b-11e4-8d75-661654b027b2.png)

After;

![screen shot 2014-10-23 at 11 02 58](https://cloud.githubusercontent.com/assets/1303616/4751284/dae5fba8-5a9b-11e4-8964-fe247c345b52.png)
