### PR TITLE
Detect flex take 2

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.items.facia_cards.item
 
 <div class="facia-slice-wrapper">
-    <ul class="u-unstyled l-row l-row--items-@slice.numberOfItems l-row--cols-@slice.numberOfCols facia-slice facia-slice--@slice.cssClassName">
+    <ul class="u-unstyled l-row  l-row--cols-@slice.numberOfCols facia-slice facia-slice--@slice.cssClassName">
     @for(ColumnAndCards(column, cards) <- slice.columns) {
         @column match {
             case SingleItem(colSpan, itemClasses) => {

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -130,20 +130,29 @@
 
         @* we want to add/remove classes to HTML ASAP to avoid FOUC *@
         if (isModern) {
+            var docClass = document.documentElement.className;
+
             @* http://modernizr.com/download/#-svg *@
             function hasSvgSupport() {
                 var ns = {'svg': 'http://www.w3.org/2000/svg'};
                 return !!document.createElementNS && !!document.createElementNS(ns.svg, 'svg').createSVGRect;
             }
             if (hasSvgSupport()) {
-                document.documentElement.className += ' svg';
+                docClass += ' svg';
             }
-            if(testCssSupport('flex-wrap') || testCssSupport('-ms-flex-wrap') || testCssSupport('-webkit-flex-wrap')) {
-                document.documentElement.className += ' has-flex-wrap';
+
+            if(testCssSupport('flex') || testCssSupport('-ms-flex') || testCssSupport('-webkit-flex') || testCssSupport('-moz-box-flex') || testCssSupport('-webkit-box-flex')) {
+                docClass += ' has-flex';
             } else {
-                document.documentElement.className += ' has-no-flex-wrap';
+                docClass += ' has-no-flex';
             }
-            document.documentElement.className = document.documentElement.className.replace(/\bis-not-modern\b/g, 'is-modern');
+
+            if(testCssSupport('flex-wrap') || testCssSupport('-ms-flex-wrap') || testCssSupport('-webkit-flex-wrap')) {
+                docClass += ' has-flex-wrap';
+            } else {
+                docClass += ' has-no-flex-wrap';
+            }
+            document.documentElement.className = docClass.replace(/\bis-not-modern\b/g, 'is-modern');
         }
     })(guardian.isModernBrowser);
 

--- a/static/src/stylesheets/README.md
+++ b/static/src/stylesheets/README.md
@@ -1,0 +1,26 @@
+Scss
+==========
+
+## Library dependencies
+
+
+We use [Bower](https://github.com/twitter/bower) to handle our Scss dependencies. It uses github tags for versioning.
+
+### Installation
+------------
+
+    $ npm install -g bower
+
+### Usage
+
+ * Installing the dependencies
+
+    $ bower install
+
+ * Listing the dependencies and their versions
+
+    $ bower list
+
+ * Adding a dependency
+
+    $ bower install -D _dependencyname_

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -33,7 +33,7 @@
 @import 'layout/_header';
 @import 'layout/_helpers';
 @import 'layout/_side-margins';
-@include guss-row-utility;
+@include guss-row-utility($detect: true);
 @include guss-columns(
     $base-class: $guss-columns-utility-class,
     $css3-columns-support: false, // Because buggy in some versions of WebKit

--- a/static/src/stylesheets/components/guss-layout/.bower.json
+++ b/static/src/stylesheets/components/guss-layout/.bower.json
@@ -11,12 +11,12 @@
     "sass-mq": "~2"
   },
   "homepage": "https://github.com/guardian/guss-layout",
-  "version": "1.3.3",
-  "_release": "1.3.3",
+  "version": "1.3.4",
+  "_release": "1.3.4",
   "_resolution": {
     "type": "version",
-    "tag": "v1.3.3",
-    "commit": "90d8ff803f00792611c8cc05c7f68245711c92f8"
+    "tag": "1.3.4",
+    "commit": "93017c3a97b2de7a1d7d6fb274d41465592efc7a"
   },
   "_source": "git://github.com/guardian/guss-layout.git",
   "_target": "~1.3.3",

--- a/static/src/stylesheets/components/guss-layout/README.md
+++ b/static/src/stylesheets/components/guss-layout/README.md
@@ -19,7 +19,9 @@ bower install guss-layout --save
 
 ## Features
 
-Low-level responsive layout patterns.
+Low-level responsive layout patterns using flex-box, that falls back to floats where not supported.
+
+Support can be defined via feature-detected class (e.g. using modernizr) or Sass variable (`$browser-supports-flexbox`).
 
 ## Demos
 

--- a/static/src/stylesheets/components/guss-layout/_row.scss
+++ b/static/src/stylesheets/components/guss-layout/_row.scss
@@ -4,7 +4,7 @@
 
 /**
  * Row utility class.
- * 
+ *
  * @type String
  *
  * @group layout
@@ -15,7 +15,7 @@ $guss-row-utility-class: '.l-row' !default;
  * When set to false, output a simpler version with a static width.
  *
  * @link http://caniuse.com/#feat=flexbox Flexbox support table
- * 
+ *
  * @type Bool
  *
  * @group layout
@@ -23,8 +23,21 @@ $guss-row-utility-class: '.l-row' !default;
 $browser-supports-flexbox: true !default;
 
 /**
+ * Classes to manage feature-detection support for flex. Override if your
+ * detection uses a different convention.
+ *
+ * @link http://modernizr.com/docs/#flexbox Modernizr detection for flex
+ *
+ * @type String
+ *
+ * @group layout
+ */
+$has-flex: has-flex !default;
+$has-no-flex: has-no-flex !default;
+
+/**
  * Static width for older browsers.
- * 
+ *
  * @type Number
  *
  * @group layout
@@ -42,7 +55,7 @@ $guss-row-fallback-width: 940px !default;
  * @requires {mixin} mq
  * @requires {mixin} flex-grow
  * @requires {mixin} flex-basis
- * 
+ *
  * @link http://sassmeister.com/gist/9b6033675b0f01de21f0 Examples on Sassmeister
  *
  * @example scss
@@ -65,108 +78,143 @@ $guss-row-fallback-width: 940px !default;
  *
  * @group layout
  */
-@mixin guss-row($base-class) {
-    @if ($browser-supports-flexbox) {
-        @include mq(tablet) {
-            #{$base-class} {
-                display: -webkit-box;
-                display: -moz-box;
-                display: -ms-flexbox;
-                display: -webkit-flex;
-                display: flex;
-                -webkit-box-direction: normal;
-                -moz-box-direction: normal;
-                -webkit-box-orient: horizontal;
-                -moz-box-orient: horizontal;
-                -webkit-flex-direction: row;
-                -ms-flex-direction: row;
-                flex-direction: row;
-                -webkit-flex-wrap: nowrap;
-                -ms-flex-wrap: nowrap;
-                flex-wrap: nowrap;
-                -webkit-align-content: stretch;
-                -ms-flex-line-pack: stretch;
-                align-content: stretch;
-                -webkit-box-align: stretch;
-                -moz-box-align: stretch;
-                -webkit-align-items: stretch;
-                -ms-flex-align: stretch;
-                align-items: stretch;
-                width: 100%; // Prevent consecutive rows from flexing together in FF
-            }
-            #{$base-class}--reverse {
-                -webkit-flex-direction: row-reverse;
-                -ms-flex-direction: row-reverse;
-                flex-direction: row-reverse;
-            }
-            #{$base-class}__item {
-                -webkit-box-flex: 1;
-                -moz-box-flex: 1;
-                -webkit-flex: 1;
-                -ms-flex: 1;
-                flex: 1;
-                @include flex-grow(1);
-                @include flex-basis(0);
-                width: 0; // Prevent items to grow out of their parent in FF
-            }
-            #{$base-class}__item--boost-1 { @include flex-grow(1.5); }
-            #{$base-class}__item--boost-2 { @include flex-grow(2); }
+@mixin guss-row($base-class, $detect: false) {
+    @if ($detect) {
+        .#{$has-flex} {
+            @include flex-row($base-class);
         }
-
-        // Mobile layout variation:
-        // - Items are aligned horizontally, 50% each
-        // - Should degrade into a vertical list
-        //
-        // Browser support:
-        // - iOS 7+ (-webkit- prefix required)
-        // - Chrome
-        // - IE 11+
-        // - Firefox 28+ (for flex-wrap support)
-        @include mq($until: tablet) {
-            #{$base-class}--layout-m {
-                display: -webkit-flex;
-                display: flex;
-                -webkit-flex-wrap: wrap;
-                flex-wrap: wrap;
-
-                // Items fill half the width of their container
-                #{$base-class}__item {
-                    -webkit-flex-basis: 50%;
-                    flex-basis: 50%;
-                }
-
-                // Break the flow on mobile:
-                // Item will fill the whole width of its container
-                #{$base-class}__item--break-m {
-                    -webkit-flex: 1 100%;
-                    flex: 1 100%;
-                }
-            }
+        .#{$has-no-flex} {
+            @include no-flex-row($base-class);
         }
     } @else {
+        @if ($browser-supports-flexbox) {
+            @include flex-row($base-class);
+        } @else {
+            @include no-flex-row($base-class);
+        }
+    }
+}
+
+/**
+ * Rows for flex browsers.
+ *
+ * @requires {variable} base-class
+ *
+ * @group layout
+ */
+
+@mixin flex-row($base-class) {
+    @include mq(tablet) {
         #{$base-class} {
-            width: $guss-row-fallback-width;
-
-            // Micro clearfix (http://nicolasgallagher.com/micro-clearfix-hack/)
-            zoom: 1;
-
-            &:after,
-            &:before {
-                content: "";
-                display: table;
-            }
-            &:after {
-                clear: both;
-            }
+            display: -webkit-box;
+            display: -moz-box;
+            display: -ms-flexbox;
+            display: -webkit-flex;
+            display: flex;
+            -webkit-box-direction: normal;
+            -moz-box-direction: normal;
+            -webkit-box-orient: horizontal;
+            -moz-box-orient: horizontal;
+            -webkit-flex-direction: row;
+            -ms-flex-direction: row;
+            flex-direction: row;
+            -webkit-flex-wrap: nowrap;
+            -ms-flex-wrap: nowrap;
+            flex-wrap: nowrap;
+            -webkit-align-content: stretch;
+            -ms-flex-line-pack: stretch;
+            align-content: stretch;
+            -webkit-box-align: stretch;
+            -moz-box-align: stretch;
+            -webkit-align-items: stretch;
+            -ms-flex-align: stretch;
+            align-items: stretch;
+            width: 100%; // Prevent consecutive rows from flexing together in FF
         }
-
+        #{$base-class}--reverse {
+            -webkit-flex-direction: row-reverse;
+            -ms-flex-direction: row-reverse;
+            flex-direction: row-reverse;
+        }
         #{$base-class}__item {
-            float: left;
+            -webkit-box-flex: 1;
+            -moz-box-flex: 1;
+            -webkit-flex: 1;
+            -ms-flex: 1;
+            flex: 1;
+            @include flex-grow(1);
+            @include flex-basis(0);
+            width: 0; // Prevent items to grow out of their parent in FF
         }
-        @each $i in 2, 3, 4 {
-            #{$base-class}--items-#{$i} #{$base-class}__item {
-                width: $guss-row-fallback-width / $i;
+        #{$base-class}__item--boost-1 { @include flex-grow(1.5); }
+        #{$base-class}__item--boost-2 { @include flex-grow(2); }
+    }
+
+    // Mobile layout variation:
+    // - Items are aligned horizontally, 50% each
+    // - Should degrade into a vertical list
+    //
+    // Browser support:
+    // - iOS 7+ (-webkit- prefix required)
+    // - Chrome
+    // - IE 11+
+    // - Firefox 28+ (for flex-wrap support)
+    @include mq($until: tablet) {
+        #{$base-class}--layout-m {
+            display: -webkit-flex;
+            display: flex;
+            -webkit-flex-wrap: wrap;
+            flex-wrap: wrap;
+
+            // Items fill half the width of their container
+            #{$base-class}__item {
+                -webkit-flex-basis: 50%;
+                flex-basis: 50%;
             }
+
+            // Break the flow on mobile:
+            // Item will fill the whole width of its container
+            #{$base-class}__item--break-m {
+                -webkit-flex: 1 100%;
+                flex: 1 100%;
+            }
+        }
+    }
+}
+
+/**
+ * Rows for non-flex browsers.
+ *
+ * @requires {variable} base-class
+ * @requires {variable} guss-row-fallback-width
+ *
+ * @group layout
+ */
+
+@mixin no-flex-row($base-class) {
+    #{$base-class} {
+        width: $guss-row-fallback-width;
+
+        // Micro clearfix (http://nicolasgallagher.com/micro-clearfix-hack/)
+        zoom: 1;
+
+        &:after,
+        &:before {
+            content: "";
+            display: table;
+        }
+        &:after {
+            clear: both;
+        }
+    }
+
+    #{$base-class}__item {
+        float: left;
+    }
+
+    @each $i in 2, 3, 4 {
+        #{$base-class}--items-#{$i} #{$base-class}__item {
+            width: $guss-row-fallback-width / $i;
         }
     }
 }
@@ -179,6 +227,6 @@ $guss-row-fallback-width: 940px !default;
  *
  * @group layout
  */
-@mixin guss-row-utility {
-    @include guss-row($guss-row-utility-class);
+@mixin guss-row-utility($detect: false) {
+    @include guss-row($guss-row-utility-class, $detect: $detect);
 }

--- a/static/src/stylesheets/module/facia-cards/_items.scss
+++ b/static/src/stylesheets/module/facia-cards/_items.scss
@@ -20,8 +20,11 @@
 // overrides of current slices
 .fc-container {
     .facia-slice__item {
-        @include flex-display;
         padding-bottom: 0;
+
+        .has-flex & {
+            @include flex-display;
+        }
 
         &.l-list__item {
             margin-bottom: 0;

--- a/static/src/stylesheets/module/facia-cards/_l-list.scss
+++ b/static/src/stylesheets/module/facia-cards/_l-list.scss
@@ -22,8 +22,12 @@
         .l-row--cols-#{$column} {
             .l-row__item--span-#{$span} {
                 @include mq(tablet) {
-                    @include flex($span);
                     width: (100% / $column) * $span;
+                    float: left;
+
+                    .has-flex-wrap & {
+                        @include flex($span);
+                    }
                 }
             }
         }
@@ -47,7 +51,9 @@
 
             .has-flex-wrap & {
                 @include mq(tablet) {
-                    @include flex-basis(100% / $column);
+                    .has-flex-wrap & {
+                        @include flex-basis(100% / $column);
+                    }
                 }
             }
         }

--- a/static/src/stylesheets/module/facia-cards/_l-list.scss
+++ b/static/src/stylesheets/module/facia-cards/_l-list.scss
@@ -51,9 +51,7 @@
 
             .has-flex-wrap & {
                 @include mq(tablet) {
-                    .has-flex-wrap & {
-                        @include flex-basis(100% / $column);
-                    }
+                    @include flex-basis(100% / $column);
                 }
             }
         }


### PR DESCRIPTION
this reverts #6689 which reverted #6681 and fixes an accidental double-nesting of `.has-flex-wrap &` which broke some list items.

http://www.browserstack.com/screenshots/8505648367a174246dfd10a5d29f83fe9388322b - this was broken by first attempt

http://www.browserstack.com/screenshots/9dd521a51bf3be892cf322c104a39aa6c533225d - this was broken in non-flex-non-IE before first attempt

FF22
![screen shot 2014-10-23 at 11 14 20](https://cloud.githubusercontent.com/assets/867233/4751381/4b4137c2-5a9d-11e4-9169-63178050b34b.png)

IE11
![screen shot 2014-10-23 at 11 14 36](https://cloud.githubusercontent.com/assets/867233/4751383/529a54ea-5a9d-11e4-92ad-440660615d15.png)
