### PR TITLE
Page skin class fallback

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -169,10 +169,10 @@ define([
             }
         },
         callbacks = {
-            '300,251': function (e, $adSlot) {
+            '300,251': function (event, $adSlot) {
                 new Sticky($adSlot.parent()[0], { top: 12 }).init();
             },
-            '300,1': function (e, $adSlot) {
+            '300,1': function (event, $adSlot) {
                 $adSlot.addClass('u-h');
             },
             '300,1050': function () {
@@ -180,6 +180,12 @@ define([
                 geoMostPopular.whenRendered.then(function (geoMostPopular) {
                     bonzo(geoMostPopular.elem).remove();
                 });
+            },
+            '1,1': function (event) {
+                if (e.slot.getOutOfPage()) {
+                    // add page skin class to body, to be sure
+                    bonzo(document.body).addClass('has-page-skin');
+                }
             }
         },
 
@@ -411,8 +417,8 @@ define([
             return slot;
         },
         parseAd = function (event) {
-            var $slot = $('#' + event.slot.getSlotId().getDomId()),
-                size  = event.size.join(',');
+            var size,
+                $slot = $('#' + event.slot.getSlotId().getDomId());
 
             // remove any placeholder ad content
             $('.ad-slot__content--placeholder', $slot).remove();
@@ -422,10 +428,12 @@ define([
             } else {
                 checkForBreakout($slot);
                 addLabel($slot);
+
+                // is there a callback for this size
+                size = event.size.join(',');
+                callbacks[size] && callbacks[size](event, $slot);
             }
 
-            // is there a callback for this size
-            callbacks[size] && callbacks[size](event, $slot);
         },
         addLabel = function ($slot) {
             if (shouldRenderLabel($slot)) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -182,7 +182,7 @@ define([
                 });
             },
             '1,1': function (event) {
-                if (e.slot.getOutOfPage()) {
+                if (event.slot.getOutOfPage()) {
                     // add page skin class to body, to be sure
                     bonzo(document.body).addClass('has-page-skin');
                 }


### PR DESCRIPTION
Edge cases arise where we haven't added the `has-page-skin` class to the body, even though a page skin is served

This adds an extra level of safety by checking if a returned ad is a page skin (i.e. it is 1x1 and 'out of page'), and adding the class

cc @gklopper, @kelvin-chappell, @kenlim 
