### PR TITLE
Restore letters article tone. Fix podcast sublinks on cards

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-letters.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-letters.scss
@@ -1,7 +1,7 @@
 @include tone-content-icons(letters, 'white');
 
 @include tone-content(
-    comment, // $tone
+    letters, // $tone
     $c-commentBackground, // $tonal__header-background
     $c-neutral2, // $tonal__header-text
     $c-commentDefault, // $tonal__header-link

--- a/static/src/stylesheets/module/facia-cards/_item-icons.scss
+++ b/static/src/stylesheets/module/facia-cards/_item-icons.scss
@@ -38,7 +38,7 @@
     }
 
     .tone-podcast--item & .fc-item__link {
-        @include icon(quote-black, false);
+        @include icon(quote-white, false);
     }
 
     .tone-feature--item & .fc-item__link {
@@ -98,6 +98,7 @@
     }
 }
 
+
 // Tonal Overrides
 // =============================================================================
 
@@ -113,14 +114,9 @@
         @include icon(camera-black-large, false);
     }
 
-    .fc-sublink--audio {
-        .fc-sublink__link:before {
-            @include icon(volume-high-black, false);
-        }
-
-        &.tone-podcast--sublink .fc-sublink__link:before {
-            @include icon(volume-high--tone-podcast, false);
-        }
+    .fc-sublink--audio .fc-sublink__link:before,
+    .fc-sublink--audio.tone-podcast--sublink .fc-sublink__link:before {
+        @include icon(volume-high-black, false);
     }
 }
 
@@ -134,17 +130,11 @@
         @include icon(comment-white, false);
     }
 
-    &.fc-item--audio .fc-item__title:before,
-    .fc-sublink--audio .fc-item__title:before {
-        @include icon(volume-high--tone-podcast, false);
-    }
-
-    .fc-sublink--video .fc-sublink__link:before {
-        @include icon(video-icon-white, false);
-    }
-
-    .fc-sublink--gallery .fc-sublink__link:before {
-        @include icon(camera-white-large, false);
+    &.fc-item--audio .fc-item__title,
+    &.fc-sublink--audio .fc-sublink__link {
+        &:before {
+            @include icon(volume-high--tone-podcast, false);
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
@@ -26,10 +26,4 @@
     .fc-sublink__kicker {
         color: $c-analysisAccent;
     }
-
-    @include sublink-style(podcast) {
-        .fc-sublink__kicker {
-            color: #ffffff;
-        }
-    }
 }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -33,10 +33,4 @@
             color: $c-commentBackground;
         }
     }
-
-    @include sublink-style(podcast) {
-        .fc-sublink__kicker {
-            color: #ffffff;
-        }
-    }
 }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-dead.scss
@@ -22,7 +22,7 @@
         color: $c-liveAccent;
     }
 
-    @include sublink-style(editorial, feature, live, review) {
+    @include sublink-style(editorial, feature, live, media, podcast, review) {
         .fc-sublink__kicker {
             color: #ffffff;
         }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
@@ -42,7 +42,7 @@
         color: $c-editorialDefault;
     }
 
-    @include sublink-style(editorial, feature, live, media, review) {
+    @include sublink-style(editorial, feature, live, media, podcast, review) {
         .fc-sublink__kicker {
             color: $c-editorialAccent;
         }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -53,7 +53,7 @@
         color: $c-featureDefault;
     }
 
-    @include sublink-style(editorial, feature, live, media, review) {
+    @include sublink-style(editorial, feature, live, media, podcast, review) {
         .fc-sublink__kicker {
             color: $c-featureMute;
         }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -57,7 +57,7 @@
         color: $c-liveDefault;
     }
 
-    @include sublink-style(editorial, feature, live, review) {
+    @include sublink-style(editorial, feature, live, media, podcast, review) {
         .fc-sublink__kicker {
             color: #ffffff;
         }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -2,7 +2,7 @@
     $c-headline: #ffffff;
 
     @extend %tone-has-background;
-    background-color: $c-neutral1;
+    background-color: $c-mediaBackground;
 
     &,
     .fc-sublink__title {
@@ -12,7 +12,7 @@
     .fc-item__link,
     .fc-sublink__link {
         &:visited {
-            color: mix($c-headline, $c-neutral1, 80%);
+            color: mix($c-headline, $c-mediaBackground, 80%);
         }
     }
 
@@ -42,15 +42,9 @@
         color: $c-mediaDefault;
     }
 
-    @include sublink-style(podcast) {
-        .fc-sublink__kicker {
-            color: #ffffff;
-        }
-    }
-
     @include sublink-style(analysis, comment, letters, dead, news) {
         .fc-sublink__kicker {
-            color: $c-neutral1;
+            color: $c-mediaBackground;
         }
     }
 }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-news.scss
@@ -23,7 +23,7 @@
         color: $c-newsDefault;
     }
     
-    @include sublink-style(editorial, feature, live, media) {
+    @include sublink-style(editorial, feature, live, media, podcast) {
         .fc-sublink__kicker {
             color: #ffffff;
         }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -38,10 +38,6 @@
     .fc-item__meta {
         color: #ffffff;
     }
-
-    .fc-sublink__title:before {
-        border-color: $c-headline;
-    }
 }
 
 .tone-podcast--sublink {
@@ -49,9 +45,9 @@
         color: $c-podcastDefault;
     }
 
-    @include sublink-style(editorial, feature, live, media) {
+    @include sublink-style(analysis, comment, letters, dead, news) {
         .fc-sublink__kicker {
-            color: $c-podcastBackground;
+            color: $c-neutral1;
         }
     }
 }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -42,18 +42,12 @@
 
 .tone-review--sublink {
     .fc-sublink__kicker {
-        color: $c-reviewBackground;
+        color: $c-reviewAccent;
     }
 
-    @include sublink-style(editorial, feature, live, media, review) {
+    @include sublink-style(analysis, comment, dead, letters, news) {
         .fc-sublink__kicker {
-            color: $c-reviewAccent;
-        }
-    }
-
-    @include sublink-style(podcast) {
-        .fc-sublink__kicker {
-            color: #ffffff;
+            color: $c-reviewBackground;
         }
     }
 }


### PR DESCRIPTION
- Restores letters article tone (I accidentally deactivated it in previous PR)
- Ensures furniture on podcast card is correct colour (left overs from changing colour of card from vile blue to light grey)
- Ensure podcast sublink are now the correct colour
- Some stuff Sam asked me to do (make default colour review sub-link yellow not brown)
