### PR TITLE
Content containers (Part 1 of 3)

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -523,7 +523,7 @@ import collection.JavaConversions._
         import browser._
 
         Then("I should see the main ARIA roles described")
-        findFirst(".related__container").getAttribute("role") should be("complementary")
+        findFirst(".related").getAttribute("role") should be("complementary")
         findFirst("aside").getAttribute("role") should be("complementary")
         findFirst("header").getAttribute("role") should be("banner")
         findFirst(".l-footer__secondary").getAttribute("role") should be("contentinfo")
@@ -532,8 +532,7 @@ import collection.JavaConversions._
         browser.find("nav", 1).getAttribute("role") should be("navigation")
         browser.find("nav", 1).getAttribute("aria-label") should not be empty
         findFirst("#article").getAttribute("role") should be("main")
-        findFirst(".related__container").getAttribute("role") should be("complementary")
-        findFirst(".related__container").getAttribute("aria-labelledby") should be("related-content-head")
+        findFirst(".related").getAttribute("aria-labelledby") should be("related-content-head")
       }
     }
 
@@ -544,7 +543,7 @@ import collection.JavaConversions._
         import browser._
 
         Then("I should see a fancy gallery trail")
-        $(".item--gallery") should have size 1
+        $(".fc-item--gallery") should have size 1
       }
 
     }

--- a/common/app/model/RelatedContent.scala
+++ b/common/app/model/RelatedContent.scala
@@ -4,10 +4,10 @@ import com.gu.contentapi.client.model.ItemResponse
 
 case class RelatedContent(
   // A manually curated list of related content. You want to to favour this over `related`
-  storyPackage: Seq[Trail],
+  storyPackage: Seq[Content],
 
   // Related content worked out by an algorithm
-  related: Seq[Trail]
+  related: Seq[Content]
 ) {
   val hasStoryPackage: Boolean = storyPackage.nonEmpty
 }

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -41,6 +41,11 @@ object TagContainers {
 object FixedContainers {
   import ContainerDefinition.{ofSlices => slices}
 
+  //TODO: Temporary vals for content until we refactor
+  val fixedMediumSlowVII = slices(HalfQQ, QuarterQuarterQuarterQuarter)
+  val fixedMediumFastXI = slices(HalfQQ, Ql2Ql2Ql2Ql2)
+  val fixedMediumFastXII = slices(QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)
+
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(Full)),
     ("fixed/small/slow-III", slices(HalfQQ)),
@@ -52,10 +57,10 @@ object FixedContainers {
     ("fixed/small/fast-VIII", slices(QuarterQuarterQlQl)),
     ("fixed/small/fast-X", slices(QuarterQlQlQl)),
     ("fixed/medium/slow-VI", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter)),
-    ("fixed/medium/slow-VII", slices(HalfQQ, QuarterQuarterQuarterQuarter)),
+    ("fixed/medium/slow-VII", fixedMediumSlowVII),
     ("fixed/medium/slow-XII-mpu", slices(TTT, TlTlMpu)),
-    ("fixed/medium/fast-XI", slices(HalfQQ, Ql2Ql2Ql2Ql2)),
-    ("fixed/medium/fast-XII", slices(QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
+    ("fixed/medium/fast-XI", fixedMediumFastXI),
+    ("fixed/medium/fast-XII", fixedMediumFastXII),
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/large/fast-XV", slices(HalfQQ, Ql3Ql3Ql3Ql3))
   )

--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -34,7 +34,7 @@
             }
         }
         @defining(frontProperties.isImageDisplayed || frontProperties.onPageDescription.isDefined){ hasDescription =>
-            @if(containerIndex == 0 && hasDescription){
+            @if(hasDescription){
                 <div class="@RenderClasses(Map(
                     "fc-container__header__description" -> true,
                     "fc-container__header__description--image" -> frontProperties.isImageDisplayed))">

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -11,7 +11,7 @@
         }
 
         @if(!content.shouldHideAdverts) {
-            <div class="facia-container acia-container--commercial">
+            <div class="facia-container facia-container--commercial">
                 @fragments.commercial.commercialComponentHigh()
             </div>
         }

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -1,6 +1,6 @@
 @(content: model.Content, related: model.RelatedContent, cssClass: String = "")(implicit request: RequestHeader)
 
-<div class="content-footer @if(cssClass){ content-footer--@cssClass }">
+<div class="content-footer @if(cssClass){ content-footer--@cssClass } facia-container--layout-content">
 
     @* majority of footer components we don't want to appear on advertisement feature articles *@
     @if(!content.isAdvertisementFeature) {
@@ -11,12 +11,11 @@
         }
 
         @if(!content.shouldHideAdverts) {
-            <div class="facia-container facia-container--layout-content facia-container--commercial">
+            <div class="facia-container acia-container--commercial">
                 @fragments.commercial.commercialComponentHigh()
             </div>
         }
 
-        @fragments.referredContentPlaceholder(content.visualTone)
         @fragments.storyPackagePlaceholder(content, related)
         @fragments.onwardPlaceholder(content.visualTone)
 
@@ -26,7 +25,7 @@
 
         @content match {
             case article: Article if !article.isLiveBlog => {
-                <div class="facia-container facia-container--layout-content facia-container--outbrain hide-on-childrens-books-site">
+                <div class="facia-container facia-container--outbrain hide-on-childrens-books-site">
                     @fragments.outbrainPlaceholder()
                 </div>
             }
@@ -34,7 +33,7 @@
         }
 
         @if(!content.shouldHideAdverts) {
-            <div class="facia-container facia-container--layout-content facia-container--commercial">
+            <div class="facia-container facia-container--commercial">
                 @fragments.commercial.commercialComponent()
             </div>
         }

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -6,7 +6,7 @@
     <div class="discussion__heading">
 
         <div class="container__meta">
-            <h2 class="container__meta__title">Comments <span class="discussion__comment-count js-discussion-comment-count"></span></h2>
+            <h2 class="container__meta__title">comments <span class="discussion__comment-count js-discussion-comment-count"></span></h2>
 
             <p class="container__meta__item discussion__meta discussion__meta--open-signed-out"><a class="u-underline" href="@Configuration.id.url/signin">Sign in</a>
                 or <a class="u-underline" href="@Configuration.id.url/register">create your Guardian account</a> to join the discussion.

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -2,7 +2,7 @@
 
 @defining(Some(section).filter{ section => section.nonEmpty && !section.equals("global")}.map{ section => s"/most-read/$section" }.getOrElse("/most-read")){ url =>
     <section
-    class="container fc-container container--has-toggle facia-container--layout-content"
+    class="container fc-container container--has-toggle"
     data-link-name="most-popular"
     data-component="most-popular">
         <div class="facia-container__inner">

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -15,7 +15,7 @@
 @defining(Seq("related") ++ (if(content.isAdvertisementFeature) Seq("container--advertisement-feature") else Nil)) { classes =>
 
     @if(related.hasStoryPackage) {
-        <aside class="@classes.mkString(" ") more-on-this-story@if(related.storyPackage.size == 1){ more-on-this-story--one-item}" role="complementary">
+        <aside class="@classes.mkString(" ") more-on-this-story@if(related.storyPackage.size == 1){ more-on-this-story--one-item}" role="complementary" aria-labelledby="related-content-head">
             @container(related.storyPackage, "more on this story", "more-on-this-story")
         </aside>
     } else {

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -1,14 +1,26 @@
 @(content: model.Content, related: model.RelatedContent)(implicit request: RequestHeader)
 
+@import layout.ContainerLayout
+@import model.{Collection, FrontProperties}
+@import views.support.TemplateDeduping
+@import views.html.fragments.containers
+@import slices.{FixedContainers}
+
+@container(stories: Seq[model.Content], title: String, dataId: String) = {
+    @defining(Collection(stories, Some(title))) { collection =>
+        @containers.facia_cards.container(collection, ContainerLayout(FixedContainers.all("fixed/medium/fast-XII"), collection, None), 2, FrontProperties.empty, dataId = dataId)(request, new views.support.TemplateDeduping, com.gu.facia.client.models.CollectionConfig.emptyConfig)
+    }
+}
+
 @defining(Seq("related") ++ (if(content.isAdvertisementFeature) Seq("container--advertisement-feature") else Nil)) { classes =>
 
     @if(related.hasStoryPackage) {
         <aside class="@classes.mkString(" ") more-on-this-story@if(related.storyPackage.size == 1){ more-on-this-story--one-item}" role="complementary">
-            @fragments.relatedTrails(related.storyPackage, heading = "More on this story", visibleTrails = 15, dataComponent = "story-package")
+            @container(related.storyPackage, "more on this story", "more-on-this-story")
         </aside>
     } else {
         <aside class="@classes.mkString(" ") js-related hide-on-childrens-books-site" role="complementary" data-test-id="related-content">
-            @fragments.relatedTrails(related.related, heading = "Related content", visibleTrails = 5, dataComponent = "related-content")
+            @container(related.related, "related content", "related-content")
         </aside>
     }
 

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -8,7 +8,7 @@
 
 @container(stories: Seq[model.Content], title: String, dataId: String) = {
     @defining(Collection(stories, Some(title))) { collection =>
-        @containers.facia_cards.container(collection, ContainerLayout(FixedContainers.all("fixed/medium/fast-XII"), collection, None), 2, FrontProperties.empty, dataId = dataId)(request, new views.support.TemplateDeduping, com.gu.facia.client.models.CollectionConfig.emptyConfig)
+        @containers.facia_cards.container(collection, ContainerLayout(FixedContainers.fixedMediumFastXII, collection, None), 2, FrontProperties.empty, dataId = dataId)(request, new views.support.TemplateDeduping, com.gu.facia.client.models.CollectionConfig.emptyConfig)
     }
 }
 

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -77,7 +77,7 @@ object MediaInSectionController extends Controller with Logging with Paging with
     val dataId = s"$pluralMediaType in section"
     val displayName =  Some(s"more ${sectionName} $pluralMediaType")
     val collection = Collection(trails.take(7), displayName)
-    val layout = ContainerLayout(FixedContainers.all("fixed/medium/fast-XI"), collection, None)
+    val layout = ContainerLayout(FixedContainers.fixedMediumFastXI, collection, None)
     val templateDeduping = new TemplateDeduping
     implicit val config = CollectionConfig.withDefaults(href = Some(tagCombinedHref), displayName = displayName)
 

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -1,9 +1,12 @@
 package controllers
 
+import com.gu.facia.client.models.CollectionConfig
 import common._
+import layout.ContainerLayout
 import model._
 import play.api.mvc.{ RequestHeader, Controller, Action }
 import services._
+import slices.FixedContainers
 
 object PopularInTag extends Controller with Related with Logging with ExecutionContexts {
 
@@ -15,9 +18,15 @@ object PopularInTag extends Controller with Related with Logging with ExecutionC
     }
   }
 
-  private def renderPopularInTag(trails: Seq[Trail])(implicit request: RequestHeader) = Cached(600) {
+  private def renderPopularInTag(trails: Seq[Content])(implicit request: RequestHeader) = Cached(600) {
+    val dataId: String = "related content"
+    val displayName = Some(dataId)
+    val properties = FrontProperties.empty
+    val collection = Collection(trails.take(8), displayName)
+    val layout = ContainerLayout(FixedContainers.all("fixed/medium/fast-XII"), collection, None)
+    val config = CollectionConfig.withDefaults(displayName = displayName)
 
-    val html = views.html.fragments.relatedTrails(trails, "Related content", 10)
+    val html = views.html.fragments.containers.facia_cards.container(collection, layout, 1, properties, dataId)(request, new views.support.TemplateDeduping, config)
 
     JsonComponent(
       "html" -> html

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -23,7 +23,7 @@ object PopularInTag extends Controller with Related with Logging with ExecutionC
     val displayName = Some(dataId)
     val properties = FrontProperties.empty
     val collection = Collection(trails.take(8), displayName)
-    val layout = ContainerLayout(FixedContainers.all("fixed/medium/fast-XII"), collection, None)
+    val layout = ContainerLayout(FixedContainers.fixedMediumFastXII, collection, None)
     val config = CollectionConfig.withDefaults(displayName = displayName)
 
     val html = views.html.fragments.containers.facia_cards.container(collection, layout, 1, properties, dataId)(request, new views.support.TemplateDeduping, config)

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -26,7 +26,7 @@ object RelatedController extends Controller with Related with Logging with Execu
     val displayName = Some(dataId)
     val properties = FrontProperties.empty
     val collection = Collection(trails.take(8), displayName)
-    val layout = ContainerLayout(FixedContainers.all("fixed/medium/fast-XII"), collection, None)
+    val layout = ContainerLayout(FixedContainers.fixedMediumFastXII, collection, None)
     val config = CollectionConfig.withDefaults(displayName = displayName)
 
     val html = views.html.fragments.containers.facia_cards.container(collection, layout, 1, properties, dataId)(request, new views.support.TemplateDeduping, config)

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -1,10 +1,13 @@
 package controllers
 
+import com.gu.facia.client.models.CollectionConfig
 import common._
+import layout.ContainerLayout
 import model._
 import play.api.mvc.{ RequestHeader, Controller }
 import services._
 import performance.MemcachedAction
+import slices.FixedContainers
 import scala.concurrent.duration._
 
 object RelatedController extends Controller with Related with Logging with ExecutionContexts {
@@ -18,8 +21,15 @@ object RelatedController extends Controller with Related with Logging with Execu
     }
   }
 
-  private def renderRelated(trails: Seq[Trail])(implicit request: RequestHeader) = Cached(30.minutes) {
-    val html = views.html.fragments.relatedTrails(trails, "Related content", 5)
+  private def renderRelated(trails: Seq[Content])(implicit request: RequestHeader) = Cached(30.minutes) {
+    val dataId: String = "related content"
+    val displayName = Some(dataId)
+    val properties = FrontProperties.empty
+    val collection = Collection(trails.take(8), displayName)
+    val layout = ContainerLayout(FixedContainers.all("fixed/medium/fast-XII"), collection, None)
+    val config = CollectionConfig.withDefaults(displayName = displayName)
+
+    val html = views.html.fragments.containers.facia_cards.container(collection, layout, 1, properties, dataId)(request, new views.support.TemplateDeduping, config)
 
     if (request.isJson) {
       JsonComponent("html" -> html)

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -53,7 +53,7 @@ object SeriesController extends Controller with Logging with Paging with Executi
     val displayName = Some(series.tag.webTitle)
     val properties = FrontProperties(series.tag.description, None, None, None, false, None)
     val collection = Collection(series.trails.take(7), displayName)
-    val layout = ContainerLayout(FixedContainers.all("fixed/medium/slow-VII"), collection, None)
+    val layout = ContainerLayout(FixedContainers.fixedMediumSlowVII, collection, None)
 
     implicit val config = CollectionConfig.withDefaults(
       apiQuery = Some(series.id), displayName = displayName, href = Some(series.id)

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -9,7 +9,9 @@ import implicits.Requests
 import conf.LiveContentApi
 import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.{Content => ApiContent}
-import views.support.{TemplateDeduping, SeriesContainer}
+import views.support.{TemplateDeduping}
+import layout.ContainerLayout
+import slices.{FixedContainers}
 
 case class Series(id: String, tag: Tag, trails: Seq[Content])
 
@@ -47,11 +49,18 @@ object SeriesController extends Controller with Logging with Paging with Executi
   }
 
   private def renderSeriesTrails(series: Series)(implicit request: RequestHeader) = {
-    val dataId: String = series.tag.webTitle
+    val dataId = "series"
+    val displayName = Some(series.tag.webTitle)
+    val properties = FrontProperties(series.tag.description, None, None, None, false, None)
+    val collection = Collection(series.trails.take(7), displayName)
+    val layout = ContainerLayout(FixedContainers.all("fixed/medium/slow-VII"), collection, None)
+
     implicit val config = CollectionConfig.withDefaults(
-      apiQuery = Some(series.id), displayName = Some("Series:"), href = Some(series.id)
+      apiQuery = Some(series.id), displayName = displayName, href = Some(series.id)
     )
-    val response = () => views.html.fragments.containers.series(Collection(series.trails.take(7)), SeriesContainer(), 1, series.tag.description, dataId)
+
+    val response = () => views.html.fragments.containers.facia_cards.container(collection, layout, 1, properties, dataId)(request, new views.support.TemplateDeduping, config)
+
     renderFormat(response, response, 1)
   }
 }

--- a/onward/app/services/repositories.scala
+++ b/onward/app/services/repositories.scala
@@ -8,7 +8,7 @@ import feed.MostReadAgent
 import conf.Switches.RelatedContentSwitch
 
 trait Related extends ConciergeRepository {
-  def related(edition: Edition, path: String): Future[Seq[Trail]] = {
+  def related(edition: Edition, path: String): Future[Seq[Content]] = {
 
     if (RelatedContentSwitch.isSwitchedOff) {
       Future.successful(Nil)
@@ -28,7 +28,7 @@ trait Related extends ConciergeRepository {
     }
   }
 
-  def getPopularInTag(edition: Edition, tag: String): Future[Seq[Trail]] = {
+  def getPopularInTag(edition: Edition, tag: String): Future[Seq[Content]] = {
 
     val response = LiveContentApi.search(edition)
       .tag(tag)

--- a/onward/test/RelatedFeatureTest.scala
+++ b/onward/test/RelatedFeatureTest.scala
@@ -45,7 +45,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
         article.find(".fc-item__standfirst").size should be > 0
         article.findFirst("time").getAttribute("data-timestamp") should not be empty
 
-        findFirst("ul").find(".fc-item__title").size should should be > 0
+        findFirst("ul").find(".fc-item__title").size should be > 0
       }
     }
 

--- a/onward/test/RelatedFeatureTest.scala
+++ b/onward/test/RelatedFeatureTest.scala
@@ -24,7 +24,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
       goTo("/related/uk/2012/aug/07/woman-torture-burglary-waterboard-surrey") { browser =>
         import browser._
         Then("I should see the related links")
-        $(".item") should have length 5
+        $(".fc-item") should have length 8
 
       }
     }
@@ -42,22 +42,10 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
         val article = findFirst("li")
         article.findFirst("a").getAttribute("href").length should be > 0
         article.findFirst("h2").getText.length should be > 0
-        article.find(".item__standfirst").size should be > 0
+        article.find(".fc-item__standfirst").size should be > 0
         article.findFirst("time").getAttribute("data-timestamp") should not be empty
 
-        findFirst("ul").find(".item__title") should have length 5
-      }
-    }
-
-    scenario("Show the published dates for non-media trails") { // GFE-37
-
-      Given("Shell spending millions of dollars on security in Nigeria, leaked data shows")
-      goTo("/related/business/2012/aug/19/shell-spending-security-nigeria-leak") { browser =>
-        import browser._
-        Then("I see each trail block displays the published date of the corresponding article")
-
-        $(".item__timestamp").size should be > 0
-
+        findFirst("ul").find(".fc-item__title").size should should be > 0
       }
     }
 

--- a/onward/test/VideoInSectionTest.scala
+++ b/onward/test/VideoInSectionTest.scala
@@ -8,7 +8,8 @@ import play.api.test.Helpers._
   "Video In Section controller" should "provide a tag combiner link" in {
     val result = controllers.MediaInSectionController.renderSectionMedia("video", "football")(TestRequest())
     status(result) should be (200)
-    contentAsString(result) should include ("href=\"/football/football+content/video\">More Football videos")
+    contentAsString(result) should include ("href=\"/football/football+content/video\"")
+    contentAsString(result) should include ("more football videos")
   }
 
   "Video In Section controller" should "exclude videos in the series specified" in {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -62,8 +62,10 @@ $avatarPadding: $gs-gutter / 2;
 }
 
 .discussion__top-border {
-    border-top: 1px solid colour(neutral-4);
-    margin-top: -1px;
+    @include mq(tablet) {
+        border-top: 1px solid $c-newsAccent;
+        margin-top: -1px;
+    }
 }
 
 .discussion--lowered {
@@ -94,11 +96,13 @@ $avatarPadding: $gs-gutter / 2;
 
 .discussion__heading {
     margin-bottom: 0;
-    padding-top: $gs-baseline / 3;
+    padding-top: 0;
+    border-top: 1px solid $c-newsAccent;
 
     @include mq(tablet) {
-        padding-top: $gs-baseline / 2;
+        border-top: 0;
     }
+
     @include mq(leftCol) {
         position: absolute;
         margin-left: -1 * ($left-column + $gs-gutter);

--- a/static/src/stylesheets/module/facia-cards/_l-list.scss
+++ b/static/src/stylesheets/module/facia-cards/_l-list.scss
@@ -10,6 +10,10 @@
 .l-list__item {
     float: left;
 
+    @include mq(tablet) {
+        max-width: 50%;
+    }
+
     .has-flex-wrap & {
         @include flex-grow(0);
         @include flex-basis(100%);

--- a/static/src/stylesheets/module/facia/_mixins.scss
+++ b/static/src/stylesheets/module/facia/_mixins.scss
@@ -168,7 +168,7 @@ $breakpoints: (
     .container__meta {
         padding-top: $gs-baseline/2;
         @include mq($halfWidthBreakpoint) {
-            padding-top: $gs-baseline/1.5;
+            padding-top: $gs-baseline/2;
         }
         @include mq($halfWidthBreakpoint, $leftColumn) {
             max-width: 50%;

--- a/static/src/stylesheets/module/facia/_tag-meta.scss
+++ b/static/src/stylesheets/module/facia/_tag-meta.scss
@@ -12,11 +12,12 @@
     }
     .container__meta__title {
         padding-bottom: $gs-baseline/3;
-        line-height: get-line-height(header, 2) !important;
-        @include fs-header(3);
+        line-height: get-line-height(header, 2);
+        @include fs-header(5);
+        color: guss-colour(guardian-brand-dark, $pasteup-palette);
 
         @include mq($until: tablet) {
-            padding: $gs-baseline/4 0 $gs-baseline/3;
+            padding: 0 0 $gs-baseline/3;
         }
         a {
             color: inherit;


### PR DESCRIPTION
This refactors most of the onward journey containers below content to use the new facia container patterns.

In this PR:
- Related content (now shows 8 rather than 4) 
- Story package (now shows max of 8 rather than 4) 
- Series container
- Popular in media
- Refactor discussion header styling to match new containers
- Fix tests
### Related content

![google chrome](https://cloud.githubusercontent.com/assets/80089/4752142/b44bbc10-5aa7-11e4-8551-5ac9971515e1.png)
### Series container

![google chrome](https://cloud.githubusercontent.com/assets/80089/4752145/b8ced1be-5aa7-11e4-8a2d-1176940d770c.png)

/cc @mattosborn @rich-nguyen @robertberry @sndrs 
