### PR TITLE
Transparent nav-list items

### DIFF
--- a/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--list-compact.scss
+++ b/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--list-compact.scss
@@ -10,6 +10,7 @@ x x x x x x x x x x x x x x x x x x x x x x x
     @include fs-bodyHeading(2);
     padding-bottom: $gs-baseline;
     display: block !important;
+    background-color: transparent;
 
     .fc-item__container {
         display: block !important;


### PR DESCRIPTION
It was happening because `fc-item` comes with a background colour by default (probably for the best).

Before:
![screen shot 2014-10-23 at 15 09 32](https://cloud.githubusercontent.com/assets/1607666/4754485/4fc2959a-5abe-11e4-8cd6-fc6a6bb7de48.png)

After:
![screen shot 2014-10-23 at 15 09 57](https://cloud.githubusercontent.com/assets/1607666/4754486/4fd4aa14-5abe-11e4-97f3-b4d4d66fe5f3.png)
