### PR TITLE
Separate embedding from snaps

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -28,6 +28,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   lazy val snapType: Option[String] = apiContent.metaData.flatMap(_.snapType).filter(_.nonEmpty)
   lazy val snapCss: Option[String] = apiContent.metaData.flatMap(_.snapCss).filter(_.nonEmpty)
   lazy val snapUri: Option[String]  = apiContent.metaData.flatMap(_.snapUri).filter(_.nonEmpty)
+  lazy val snapUrl: Option[String] = apiContent.metaData.flatMap(_.href).filter(_.nonEmpty)
 
   lazy val publication: String = fields.getOrElse("publication", "")
   lazy val lastModified: DateTime = fields.get("lastModified").map(_.parseISODateTime).getOrElse(DateTime.now)
@@ -387,12 +388,6 @@ class Snap(snapId: String,
            snapElements: List[ApiElement] = Nil
             ) extends Content(new ApiContentWithMeta(SnapApiContent(snapElements), supporting = snapSupporting, metaData = snapMeta)) {
 
-  override lazy val snapType: Option[String] = snapMeta.flatMap(_.snapType)
-  override lazy val snapCss: Option[String] = snapMeta.flatMap(_.snapCss)
-  override lazy val snapUri: Option[String] = snapMeta.flatMap(_.snapUri)
-
-  lazy val snapUrl: Option[String] = snapMeta.flatMap(_.href)
-
   //We set this to snapId as TemplateDeduping uses this ID to dedupe
   override lazy val url: String = snapId
 
@@ -401,7 +396,7 @@ class Snap(snapId: String,
 
   //Trail implementations
   override lazy val shortUrl: String = ""
-  override lazy val headline: String = snapMeta.flatMap(_.headline).getOrElse("Link")
+  override lazy val headline: String = apiContent.metaData.flatMap(_.headline).getOrElse("Link")
 
   //Meta implementations
   override lazy val webPublicationDate = snapWebPublicationDate

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -25,6 +25,10 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
 
   lazy val delegate: ApiContent = apiContent.delegate
 
+  lazy val snapType: Option[String] = apiContent.metaData.flatMap(_.snapType).filter(_.nonEmpty)
+  lazy val snapCss: Option[String] = apiContent.metaData.flatMap(_.snapCss).filter(_.nonEmpty)
+  lazy val snapUri: Option[String]  = apiContent.metaData.flatMap(_.snapUri).filter(_.nonEmpty)
+
   lazy val publication: String = fields.getOrElse("publication", "")
   lazy val lastModified: DateTime = fields.get("lastModified").map(_.parseISODateTime).getOrElse(DateTime.now)
   lazy val internalContentCode: String = delegate.safeFields("internalContentCode")
@@ -383,9 +387,9 @@ class Snap(snapId: String,
            snapElements: List[ApiElement] = Nil
             ) extends Content(new ApiContentWithMeta(SnapApiContent(snapElements), supporting = snapSupporting, metaData = snapMeta)) {
 
-  val snapType: Option[String] = snapMeta.flatMap(_.snapType)
-  val snapCss: Option[String] = snapMeta.flatMap(_.snapCss)
-  val snapUri: Option[String] = snapMeta.flatMap(_.snapUri)
+  override lazy val snapType: Option[String] = snapMeta.flatMap(_.snapType)
+  override lazy val snapCss: Option[String] = snapMeta.flatMap(_.snapCss)
+  override lazy val snapUri: Option[String] = snapMeta.flatMap(_.snapUri)
 
   lazy val snapUrl: Option[String] = snapMeta.flatMap(_.href)
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -1048,6 +1048,9 @@ object SnapData {
     case snap: Snap =>
       snap.snapType.filter(_.nonEmpty).map(t => s"data-snap-type=$t") ++
       snap.snapUri.filter(_.nonEmpty).map(t => s"data-snap-uri=$t")
+    case content: Content =>
+        content.snapType.filter(_.nonEmpty).map(t => s"data-snap-type=$t") ++
+        content.snapUri.filter(_.nonEmpty).map(t => s"data-snap-uri=$t")
     case _  => Nil
   }
 }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -993,6 +993,7 @@ object GetClasses {
 
   def makeSnapClasses(trail: Trail): Seq[String] = trail match {
     case snap: Snap => "js-snap facia-snap" +: snap.snapCss.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
+    case content: Content => "js-snap facia-snap" +: content.snapCss.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
     case _  => Nil
   }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -992,7 +992,6 @@ object GetClasses {
   }
 
   def makeSnapClasses(trail: Trail): Seq[String] = trail match {
-    case snap: Snap => "js-snap facia-snap" +: snap.snapCss.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
     case content: Content => "js-snap facia-snap" +: content.snapCss.map(t => Seq(s"facia-snap--$t")).getOrElse(Seq("facia-snap--default"))
     case _  => Nil
   }
@@ -1046,9 +1045,6 @@ object SnapData {
   def apply(trail: Trail): String = generateDataArrtibutes(trail).mkString(" ")
 
   private def generateDataArrtibutes(trail: Trail): Iterable[String] = trail match {
-    case snap: Snap =>
-      snap.snapType.filter(_.nonEmpty).map(t => s"data-snap-type=$t") ++
-      snap.snapUri.filter(_.nonEmpty).map(t => s"data-snap-uri=$t")
     case content: Content =>
         content.snapType.filter(_.nonEmpty).map(t => s"data-snap-type=$t") ++
         content.snapUri.filter(_.nonEmpty).map(t => s"data-snap-uri=$t")

--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -28,10 +28,6 @@ function (
             item.id(snapId);
             defer.resolve(item);
 
-        } else if (item.meta.snapType()) {
-            item.convertToSnap();
-            defer.resolve(item);
-
         } else if (data) {
             item.id(capiId);
             populate(item, data);

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -72,7 +72,7 @@ define([
             '<div style="height:{{height}}px; overflow:hidden; width: 100%;">' +
                 '<iframe src="{{src}}" style="height:{{height}}px; width: 100%; border: none;"></iframe>' +
             '</div>',
-            {src: el.getAttribute('data-snap-uri'), height: 250}
+            {src: el.getAttribute('data-snap-uri'), height: 300}
         ));
     }
 


### PR DESCRIPTION
Embeds are when an item is swapped for some external content. Snaps are links to anything that isn't a single CAPI item (tag pages, external pages, etc). Separate out these two concepts, which are currently coupled.  
