### PR TITLE
Commercial components: Correct font weight for item titles

### DIFF
--- a/static/src/stylesheets/module/commercial/v2/_lineitem.scss
+++ b/static/src/stylesheets/module/commercial/v2/_lineitem.scss
@@ -50,6 +50,7 @@
     .lineitem__title {
         color: $c-neutral1;
         @include fs-header(1);
+        font-weight: 500;
         padding-top: 2px;
         margin-bottom: $gs-baseline;
     }


### PR DESCRIPTION
To match container item titles, font weight should be 500, not 900 (my fault!) /cc @austinh7 
