### PR TITLE
Spacing changes for tops of containers on mobile

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_container.scss
+++ b/static/src/stylesheets/module/facia-cards/_container.scss
@@ -7,7 +7,11 @@ $header-image-size-desktop: 120px;
 
     .facia-container__inner {
         border-top: 1px solid $c-newsAccent;
-        padding-top: $gs-baseline / 2;
+        padding-top: $gs-baseline / 4;
+
+        @include mq(tablet) {
+            padding-top: $gs-baseline / 2;
+        }
     }
 
     &.container--first {
@@ -156,6 +160,10 @@ $header-image-size-desktop: 120px;
     }
 }
 
+.container__toggle i {
+    top: $gs-baseline / 3 * 2;
+}
+
 /**
  * This for adding padding-top. On old layout container--first is taking care of this.
  * When we move to new layout container--news should be deprecated and this class should be
@@ -284,9 +292,14 @@ $header-image-size-desktop: 120px;
 }
 
 .fc-container__body {
-    padding-top: $gs-baseline / 4;
+    padding-top: $gs-baseline;
+    padding-bottom: $gs-baseline;
     opacity: 1;
     @include transition(opacity .25s linear); // Used to fade-in new updates
+
+    @include mq(tablet) {
+        padding-top: $gs-baseline / 4;
+    }
 }
 
 .fc-container__body--is-hidden {


### PR DESCRIPTION
Before:
![screen shot 2014-10-23 at 18 43 00](https://cloud.githubusercontent.com/assets/1607666/4758063/4181f4a8-5adc-11e4-9fc9-1a4f9c2cd28a.png)

After:
![screen shot 2014-10-23 at 18 27 13](https://cloud.githubusercontent.com/assets/1607666/4758064/4183b978-5adc-11e4-863c-46760a7a38a6.png)
