### PR TITLE
Pagination accessibility

### DIFF
--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -56,7 +56,7 @@
     } else {
     <div class="pagination u-cf">
     }
-        <div class="u-unstyled pagination__list">
+        <div class="pagination__list">
             @if(pagination.lastPage > 5) {
                 @paginationPointer(pagination.previous, "prev", page.url)
 
@@ -68,7 +68,7 @@
             @pagination.pages.map{ pageNum =>
 
                 @if(pageNum == pagination.currentPage) {
-                    <span class="button button--small button--tertiary pagination__action is-active" aria-label="Current page">@pageNum</span>
+                    <span class="button button--small button--tertiary pagination__action is-active" aria-label="Current page" tabindex="0">@pageNum</span>
                 } else {
                     <a class="button button--small button--tertiary pagination__action @actionClass"
                     data-page="@pageNum"

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -74,7 +74,7 @@
                     data-page="@pageNum"
                     href="@paginated(page.url, pageNum)"
                     data-link-name="Pagination view page @pageNum"
-                    aria-label="@ariaContext page @pageNum" tabindex="0">@pageNum</a>
+                    aria-label="@ariaContext page @pageNum">@pageNum</a>
                 }
             }
 

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -27,7 +27,7 @@
 }
 
 @paginationDivider = {
-    <span class="pagination__text">&#8230;</span>
+    <span class="pagination__text">…</span>
 }
 
 @paginationExtreme(pageNo: Option[Int], dir: String, url: String) = {
@@ -57,34 +57,34 @@
     <div class="pagination u-cf">
     }
         <div class="pagination__list">
-            @if(pagination.lastPage > 5) {
-                @paginationPointer(pagination.previous, "prev", page.url)
+        @if(pagination.lastPage > 5) {
+            @paginationPointer(pagination.previous, "prev", page.url)
 
-                @if(pagination.currentPage - 2 > 1) {
-                    @paginationExtreme(pagination.previous.map(_ => 1), "first", page.url)
-                }
+            @if(pagination.currentPage - 2 > 1) {
+                @paginationExtreme(pagination.previous.map(_ => 1), "first", page.url)
+            }
+        }
+
+        @pagination.pages.map{ pageNum =>
+
+            @if(pageNum == pagination.currentPage) {
+                <span class="button button--small button--tertiary pagination__action is-active" aria-label="Current page" tabindex="0">@pageNum</span>
+            } else {
+                <a class="button button--small button--tertiary pagination__action @actionClass"
+                data-page="@pageNum"
+                href="@paginated(page.url, pageNum)"
+                data-link-name="Pagination view page @pageNum"
+                aria-label="@ariaContext page @pageNum">@pageNum</a>
+            }
+        }
+
+        @if(pagination.lastPage > 5) {
+            @if(pagination.currentPage + 2 < pagination.lastPage) {
+                @paginationExtreme(Some(pagination.lastPage), "last", page.url)
             }
 
-            @pagination.pages.map{ pageNum =>
-
-                @if(pageNum == pagination.currentPage) {
-                    <span class="button button--small button--tertiary pagination__action is-active" aria-label="Current page" tabindex="0">@pageNum</span>
-                } else {
-                    <a class="button button--small button--tertiary pagination__action @actionClass"
-                    data-page="@pageNum"
-                    href="@paginated(page.url, pageNum)"
-                    data-link-name="Pagination view page @pageNum"
-                    aria-label="@ariaContext page @pageNum">@pageNum</a>
-                }
-            }
-
-            @if(pagination.lastPage > 5) {
-                @if(pagination.currentPage + 2 < pagination.lastPage) {
-                    @paginationExtreme(Some(pagination.lastPage), "last", page.url)
-                }
-
-                @paginationPointer(pagination.next, "next", page.url)
-            }
+            @paginationPointer(pagination.next, "next", page.url)
+        }
         </div>
     </div>
 }

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -1,7 +1,8 @@
 @(  page: MetaData,
     pagination: Pagination,
     actionClass: Option[String] = None,
-    showFull: Boolean = true)(implicit request: RequestHeader)
+    showFull: Boolean = true,
+    ariaContext: Option[String] = None)(implicit request: RequestHeader)
 
 @import model._
 @import common._
@@ -10,22 +11,23 @@
 @paginated(url: String, pageNum: Int) = {@common.LinkTo(url+(if(pageNum > 1){"?page="+pageNum}else{""}))}
 @paginationPointer(pageNo: Option[Int], dir: String, url: String) = {
     @pageNo.map { p =>
-        <li class="pagination__item pagination__item--pointer">
-            <a class="button button--small button--tertiary pagination__action--static @actionClass" data-page="@p" rel="@dir" href="@paginated(url, p)" data-link-name="Pagination view @dir">
-                @if(dir == "next") {
-                <i class="i i-arrow-right-grey"><span class="u-h">@dir.capitalize(0)</span></i>
-                } else {
-                <i class="i i-arrow-left-grey"><span class="u-h">@dir.capitalize(0)</span></i>
-                }
-            </a>
-        </li>
+        <a class="button button--small button--tertiary pagination__action--static @actionClass"
+            data-page="@p"
+            rel="@dir"
+            href="@paginated(url, p)"
+            data-link-name="Pagination view @dir"
+            aria-label="@ariaContext @dir page">
+            @if(dir == "next") {
+            <i aria-hidden="true" class="i i-arrow-right-grey"></i><span class="u-h">@dir</span>
+            } else {
+            <i aria-hidden="true" class="i i-arrow-left-grey"></i><span class="u-h">@dir</span>
+            }
+        </a>
     }
 }
 
 @paginationDivider = {
-    <li class="pagination__item">
-        <span class="pagination__text">&#8230;</span>
-    </li>
+    <span class="pagination__text">&#8230;</span>
 }
 
 @paginationExtreme(pageNo: Option[Int], dir: String, url: String) = {
@@ -33,9 +35,13 @@
         @if(dir == "last") {
             @paginationDivider
         }
-        <li class="pagination__item">
-            <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass" href="@paginated(url, p)" data-page="@p" data-link-name="Pagination view page @p">@p</a>
-        </li>
+
+        <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass"
+        href="@paginated(url, p)"
+        data-page="@p"
+        data-link-name="Pagination view page @p"
+        aria-label="@ariaContext @dir page">@p</a>
+
       @if(dir == "first") {
           @paginationDivider
       }
@@ -50,8 +56,7 @@
     } else {
     <div class="pagination u-cf">
     }
-
-        <ol class="u-unstyled pagination__list">
+        <div class="u-unstyled pagination__list">
             @if(pagination.lastPage > 5) {
                 @paginationPointer(pagination.previous, "prev", page.url)
 
@@ -61,13 +66,16 @@
             }
 
             @pagination.pages.map{ pageNum =>
-                <li class="pagination__item">
-                    @if(pageNum == pagination.currentPage) {
-                        <span class="button button--small button--tertiary pagination__action is-active">@pageNum</span>
-                    } else {
-                        <a class="button button--small button--tertiary pagination__action @actionClass" data-page="@pageNum" href="@paginated(page.url, pageNum)" data-link-name="Pagination view page @pageNum">@pageNum</a>
-                    }
-                </li>
+
+                @if(pageNum == pagination.currentPage) {
+                    <span class="button button--small button--tertiary pagination__action is-active" aria-label="Current page">@pageNum</span>
+                } else {
+                    <a class="button button--small button--tertiary pagination__action @actionClass"
+                    data-page="@pageNum"
+                    href="@paginated(page.url, pageNum)"
+                    data-link-name="Pagination view page @pageNum"
+                    aria-label="@ariaContext page @pageNum" tabindex="0">@pageNum</a>
+                }
             }
 
             @if(pagination.lastPage > 5) {
@@ -77,6 +85,6 @@
 
                 @paginationPointer(pagination.next, "next", page.url)
             }
-        </ol>
+        </div>
     </div>
 }

--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -28,7 +28,7 @@
 
     @if(!isTopComments) {
     <div class="discussion__pagination discussion__pagination--bottom js-discussion-pagination">
-        @page.pagination.map{ paginate => @fragments.pagination(page, paginate, Some("js-discussion-change-page"), false) }
+        @page.pagination.map{ paginate => @fragments.pagination(page, paginate, Some("js-discussion-change-page"), false, Some("Comments")) }
     </div>
     @fragments.reportComment()
     }

--- a/discussion/app/views/profileActivity/comments.scala.html
+++ b/discussion/app/views/profileActivity/comments.scala.html
@@ -24,7 +24,7 @@
             }
         </div>
         <div class="activity-stream__pagination u-cf">
-            @fragments.pagination(page, profileComments.pagination, Some("js-activity-stream-page-change"), false)
+            @fragments.pagination(page, profileComments.pagination, Some("js-activity-stream-page-change"), false, Some("Comments"))
         </div>
     }
 </div>

--- a/discussion/app/views/profileActivity/discussions.scala.html
+++ b/discussion/app/views/profileActivity/discussions.scala.html
@@ -29,7 +29,7 @@
             </div>
         }
         <div class="activity-stream__pagination u-cf">
-            @fragments.pagination(page, profileDiscussions.pagination, Some("js-activity-stream-page-change"), false)
+            @fragments.pagination(page, profileDiscussions.pagination, Some("js-activity-stream-page-change"), false, Some("Comments"))
         </div>
     }
 </div>

--- a/static/src/stylesheets/module/facia/_pagination.scss
+++ b/static/src/stylesheets/module/facia/_pagination.scss
@@ -25,7 +25,7 @@ The user needs to view a subset of sorted data that is not easily displayed on o
             <span class="pagination__action is-active">5</span>
         </li>
         <li class="pagination__item">
-            <span class="pagination__text">&#8230;</span>
+            <span class="pagination__text">…</span>
         </li>
         <li class="pagination__item">
             <a class="pagination__action" href="#">6</a>


### PR DESCRIPTION
I ran through the pagination with NVDA screen reader and I would like to do some changes:
1. I am passing parameter to pagination so we can tell if it use to paginate pages or comments (it could be confusing to just say page 2 when user is on comments)
2. added some aria-labels. This is different across screen readers. NVDA is using it when going through the page using keyboard. It's ignoring it on span element ("Current page") but for example VoiceOver is getting it.
3. I decided to remove pagination from list (ol). It's not really adding any semantic value in this case and some screen readers are then reading some stuff that is not important before actually getting to the pagination ("List, x list items etc) This approach was recommended by Reinhard Stebner and I agree (after trying to use NVDA) that it is a little bit more straightforward. And it is removing some `li` elements in the process which is nice.
