### PR TITLE
Remove margin right on camera icon

### DIFF
--- a/static/src/stylesheets/module/_icons.scss
+++ b/static/src/stylesheets/module/_icons.scss
@@ -21,7 +21,7 @@ blockquote.quoted:before {
 .caption--img:before {
     content: '';
     vertical-align: top;
-    margin: 1px 4px 0 0;
+    margin-top: 1px;
     @include icon(image);
 }
 


### PR DESCRIPTION
Closing up space between camera icon and caption to be consistent with fronts. 

![screen shot 2014-10-24 at 15 23 58](https://cloud.githubusercontent.com/assets/3416696/4770883/72c32eee-5b89-11e4-9def-53e0211ca7d9.png)
![screen shot 2014-10-24 at 15 23 34](https://cloud.githubusercontent.com/assets/3416696/4770884/72c7d246-5b89-11e4-8021-4fc3f61a89bd.png)
