### PR TITLE
Navigation accessibility

### DIFF
--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -12,32 +12,32 @@
         <div class="gs-container">
             <div class="navigation__inner">
                 <div class="navigation__scroll">
+                    <nav class="navigation__container navigation__container--second" data-component="nav" role="navigation" aria-label="Guardian sections">
+                    @fragments.nav.topNavigation(metaData, navigation)
+                    </nav>
+                    <a class="navigation__toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
+                        <i class="navigation__toggle-burger honest-burger"><i></i><i></i><i></i></i>
+                        <span class="navigation__toggle-label navigation__toggle-label--open">all<span class="navigation__toggle-label__extra"> sections</span></span>
+                        <span class="navigation__toggle-label navigation__toggle-label--close">close</span>
+                    </a>
                     <nav class="navigation__container navigation__container--first" data-component="nav" role="navigation" aria-label="Current section">
-                        @if(!Edition.isEditionFront){
-                            @fragments.nav.signposting(metaData, navigation)
+                    @if(!Edition.isEditionFront){
+                        @fragments.nav.signposting(metaData, navigation)
 
-                            @Navigation.topLevelItem(navigation, metaData).map{ topSection =>
-                                @if(Navigation.localLinks(navigation, metaData).nonEmpty) {
-                                    <ul class="local-navigation">
-                                        @Navigation.rotatedLocalNav(topSection, metaData).map{ link =>
-                                            <li class="local-navigation__item">
-                                                <a class="local-navigation__action" href="@LinkTo(link.href)" data-link-name="nav : secondary : @link.title">@Html(link.title)</a>
-                                            </li>
-                                        }
-                                    </ul>
-                                }
+                        @Navigation.topLevelItem(navigation, metaData).map{ topSection =>
+                            @if(Navigation.localLinks(navigation, metaData).nonEmpty) {
+                                <ul class="local-navigation">
+                                    @Navigation.rotatedLocalNav(topSection, metaData).map{ link =>
+                                        <li class="local-navigation__item">
+                                            <a class="local-navigation__action" href="@LinkTo(link.href)" data-link-name="nav : secondary : @link.title">@Html(link.title)</a>
+                                        </li>
+                                    }
+                                </ul>
                             }
                         }
-                    </nav>
-                    <nav class="navigation__container navigation__container--second" data-component="nav" role="navigation" aria-label="Guardian sections">
-                        @fragments.nav.topNavigation(metaData, navigation)
+                    }
                     </nav>
                 </div>
-                <a class="navigation__toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
-                    <i class="navigation__toggle-burger honest-burger"><i></i><i></i><i></i></i>
-                    <span class="navigation__toggle-label navigation__toggle-label--open">all<span class="navigation__toggle-label__extra"> sections</span></span>
-                    <span class="navigation__toggle-label navigation__toggle-label--close">close</span>
-                </a>
             </div>
             <div class="navigation__expandable js-mega-nav-placeholder" data-component="all-nav"></div>
         </div>

--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -12,7 +12,7 @@
         <div class="gs-container">
             <div class="navigation__inner">
                 <div class="navigation__scroll">
-                    <nav class="navigation__container navigation__container--second" data-component="nav" role="navigation" aria-label="Guardian sections">
+                    <nav class="navigation__container navigation__container--main" data-component="nav" role="navigation" aria-label="Guardian sections">
                     @fragments.nav.topNavigation(metaData, navigation)
                     </nav>
                     <a class="navigation__toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
@@ -20,7 +20,7 @@
                         <span class="navigation__toggle-label navigation__toggle-label--open">all<span class="navigation__toggle-label__extra"> sections</span></span>
                         <span class="navigation__toggle-label navigation__toggle-label--close">close</span>
                     </a>
-                    <nav class="navigation__container navigation__container--first" data-component="nav" role="navigation" aria-label="Current section">
+                    <nav class="navigation__container navigation__container--current" data-component="nav" role="navigation" aria-label="Current section">
                     @if(!Edition.isEditionFront){
                         @fragments.nav.signposting(metaData, navigation)
 

--- a/common/app/views/fragments/nav/navigationFooter.scala.html
+++ b/common/app/views/fragments/nav/navigationFooter.scala.html
@@ -10,7 +10,7 @@
         <div class="gs-container">
             <div class="navigation__inner" aria-hidden="true">
                 <div class="navigation__scroll">
-                    <div class="navigation__container navigation__container--second" data-component="footer-nav">
+                    <div class="navigation__container navigation__container--main" data-component="footer-nav">
                         @fragments.nav.topNavigation(metaData, navigation)
                     </div>
                 </div>

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -111,7 +111,7 @@ $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevelsWithWideToggle, mq-
     position: relative;
     background: $c-top-navigation-background;
 }
-.navigation__container--first {
+.navigation__container--current {
     background: $c-top-navigation-background;
     min-height: $navigation-height;
 }
@@ -599,11 +599,11 @@ $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevelsWithWideToggle, mq-
             display: table !important;
             width: 100%;
         }
-        .navigation__container--first {
+        .navigation__container--current {
             background: $c-local-navigation-background;
             border-top: $navigation-height solid $c-top-navigation-background;
         }
-        .navigation__container--second {
+        .navigation__container--main {
             position: absolute;
             top: 0;
         }


### PR DESCRIPTION
Changing the flow of the navigation for better accessibility.

Currently when using keyboard the "current section" is above main navigation:
![flowbefore](https://cloud.githubusercontent.com/assets/2579465/4772100/2aac5dcc-5b95-11e4-8e14-bff0cc2d7339.png)

After this change the flow will be in the correct order:
![flowafter](https://cloud.githubusercontent.com/assets/2579465/4772109/3557cf04-5b95-11e4-9e3e-9138bf8fdfd3.png)

I also changed the names of the classes as the old ones didn't make sense anymore. I've used more vague names now.
