### PR TITLE
Social interaction tracking on mail share icon

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/clickstream.js
+++ b/static/src/javascripts/projects/common/modules/analytics/clickstream.js
@@ -37,6 +37,10 @@ define([
                     protocol = window.location.protocol;
                 }
 
+                if (url.indexOf('mailto:') === 0) {
+                    return false;
+                }
+
                 // Lack of a urlHost implies a relative url
                 return !urlHost || (urlHost === host && urlProtocol === protocol);
             },


### PR DESCRIPTION
The clickstream logic was picking up mailto links as internal, relative links and therefore not firing an E16 when they're clicked. 
