### PR TITLE
Kill off content negotiation.

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -13,13 +13,9 @@ trait Requests {
 
     def getBooleanParameter(name: String): Option[Boolean] = getParameter(name).map(_.toBoolean)
 
-    lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.headers.get("Accept").exists{ header =>
-      header.contains("application/json") ||
-      header.contains("text/javascript") ||
-      header.contains("application/javascript")
-    } || r.path.endsWith(".json")
+    lazy val isJson: Boolean = r.getQueryString("callback").isDefined || r.path.endsWith(".json")
 
-    lazy val isRss: Boolean = r.headers.get("Accept").exists(_.contains("application/rss+xml")) || r.path.endsWith("/rss")
+    lazy val isRss: Boolean = r.path.endsWith("/rss")
 
     lazy val isWebp: Boolean = {
       val requestedContentType = r.acceptedTypes.sorted(MediaRange.ordering)


### PR DESCRIPTION
If it is json it ends with `.json`. If it is RSS it ends with `/rss`

I checked the router conf file and all paths are `.json`

Leaving in callback for now.
