### PR TITLE
remove ellipis overflow in the nav

### DIFF
--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -232,8 +232,6 @@ $mq-breakpoints: mq-add-breakpoint(navigationBreakOnTwoLevelsWithWideToggle, mq-
 .local-navigation__item,
 .top-navigation__item,
 .global-navigation__item {
-    text-overflow: ellipsis;
-    overflow: hidden;
     white-space: nowrap;
 }
 .top-navigation__item--current {


### PR DESCRIPTION
![screen shot 2014-10-27 at 12 00 13](https://cloud.githubusercontent.com/assets/867233/4790392/aeef4eea-5dd0-11e4-9e24-901d24b0d935.png)
becomes
![screen shot 2014-10-27 at 12 00 07](https://cloud.githubusercontent.com/assets/867233/4790387/a56e3b88-5dd0-11e4-9124-052b81c07ed5.png)

only seems to have affected firefox

fixes #6756
