### PR TITLE
Add image fallback for video players on mobile

### DIFF
--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -49,6 +49,9 @@
                                     @video(player)
                                     </div>
                                 </div>
+                                <div class="fc-item__video-fallback">
+                                    @image(trail, inlineImage = containerIndex == 0 && index < 4)
+                                </div>
                             }
                         }
 


### PR DESCRIPTION
Sometimes items that have video players on desktop shrink to a size where a video player shouldn't be rendered on mobile. At the moment the behaviour is borked, as it attempts to render the video player but then hides it and there isn't a fallback.

There originally was a fallback and CSS still exists for it, so I've just added it back in.

CC @phamann @sndrs @sammorrisdesign 

Before:

![screen shot 2014-10-27 at 16 06 18](https://cloud.githubusercontent.com/assets/1001642/4794771/cb867ee0-5df6-11e4-8e26-dc7bab338e39.png)

After:

![screen shot 2014-10-27 at 16 29 05](https://cloud.githubusercontent.com/assets/1001642/4794780/d6d896c0-5df6-11e4-94c3-c4cc9bd954ee.png)
