### PR TITLE
Fix IE horizontal flex items

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -33,6 +33,8 @@ $fc-item-gutter: $gs-gutter / 4;
 
         .fc-item__content {
             @include flex-basis(100% - $media-width);
+            // DAMN YOU IE10/11 FLEXWRAP BOX SIZING BUG
+            max-width: 100% - $media-width;
         }
 
         .fc-item__footer--horizontal {


### PR DESCRIPTION
was 

![image 2014-10-27 at 5 52 19 pm](https://cloud.githubusercontent.com/assets/867233/4796288/65b4ab62-5e02-11e4-99b7-d2b53cfab7b0.png)

now

![image 2014-10-27 at 5 51 40 pm](https://cloud.githubusercontent.com/assets/867233/4796291/6f3b88a4-5e02-11e4-8627-6f32e1da6f0f.png)
