### PR TITLE
Data link name fixes

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -10,7 +10,7 @@
 @defining(config.displayName.orElse(collection.displayName)) { case (title) =>
     <section id="@FaciaComponentName(config, collection)"
              class="@GetClasses.forNewStyleContainer(config, containerIndex == 0, title.nonEmpty)"
-             data-link-name="@FaciaComponentName(config, collection)"
+             data-link-name="@{containerIndex + 1} | @FaciaComponentName(config, collection)"
              data-id="@dataId"
              @DfpAgent.sponsorshipTag(config).map { keyword =>
                  data-keywords="@keyword"

--- a/common/app/views/fragments/items/elements/facia_cards/sublinks.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/sublinks.scala.html
@@ -7,9 +7,9 @@
 @defining(Sublinks.takeSublinks(supporting, modifierClasses)) { sublinks =>
     @if(sublinks.nonEmpty) {
         <ul class="fc-sublinks u-unstyled u-faux-block-link__promote">
-        @sublinks.map { link =>
-            <li class="@GetClasses.forSubLink(link)">
-            @sublink(link, 0, 0, true)
+        @sublinks.zipWithIndex.map { case (link, index) =>
+            <li class="@GetClasses.forSubLink(link)" data-link-name="sublinks | @{index + 1}">
+                @sublink(link, 0, 0, true)
             </li>
         }
         </ul>

--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -22,6 +22,7 @@ module.exports = function(grunt, options) {
                 react:        'components/react/react',
                 reqwest:      'components/reqwest/reqwest',
                 omniture:     '../../public/javascripts/vendor/omniture',
+                socketio:     'components/socket.io-client/socket.io',
                 stripe:       '../../public/javascripts/vendor/stripe/stripe.min',
                 // plugins
                 text:         'components/requirejs-text/text'
@@ -173,15 +174,12 @@ module.exports = function(grunt, options) {
             options: {
                 name: 'bootstraps/dev',
                 out: options.staticTargetDir + 'javascripts/bootstraps/dev.js',
-                paths: {
-                    socketio: 'components/socket.io-client/socket.io'
-                }
-            },
-            exclude: [
-                'core',
-                'bootstraps/app',
-                'text'
-            ]
+                exclude: [
+                    'core',
+                    'bootstraps/app',
+                    'text'
+                ]
+            }
         }
     };
 };

--- a/static/src/javascripts/bootstraps/dev.js
+++ b/static/src/javascripts/bootstraps/dev.js
@@ -1,7 +1,10 @@
 define([
-    'socketio'
-], function (io) {
-
+    'socketio',
+    'common/modules/dev/debugObject'
+], function (
+    io,
+    debugObject
+) {
     var options = {
             reconnection: false
         },
@@ -14,7 +17,11 @@ define([
         }
     }
 
-    function init() {
+    function createGlobalDebugObject() {
+        window.GuardianDebug = debugObject;
+    }
+
+    function setUpDevMode() {
         var loc = window.location,
             domain = loc.protocol + '//' + loc.hostname,
             reloadUrl = domain + ':8005',
@@ -61,6 +68,11 @@ define([
             log('url', url);
             window.location = url;
         });
+    }
+
+    function init() {
+        createGlobalDebugObject();
+        setUpDevMode();
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/dev/dataLinkNameDebug.js
+++ b/static/src/javascripts/projects/common/modules/dev/dataLinkNameDebug.js
@@ -40,7 +40,7 @@ define([
             if (linkName) {
                 $elem.attr('title', linkName);
                 deactivateCallbacks.push(function () {
-                    $elem.attr('title', oldTitle || "");
+                    $elem.attr('title', oldTitle || '');
                 });
             }
         });

--- a/static/src/javascripts/projects/common/modules/dev/dataLinkNameDebug.js
+++ b/static/src/javascripts/projects/common/modules/dev/dataLinkNameDebug.js
@@ -1,0 +1,59 @@
+define([
+    'bonzo',
+    'common/utils/$'
+], function (
+    bonzo,
+    $
+) {
+    var deactivateCallbacks = [];
+
+    function dataLinkName(elem) {
+        var iterate = function (elem, nameSoFar) {
+            if (elem === document.body || !elem) {
+                return nameSoFar;
+            } else {
+                var thisDataLinkName = bonzo(elem).attr('data-link-name');
+
+                if (thisDataLinkName) {
+                    return iterate(
+                        elem.parentNode,
+                        !nameSoFar ? thisDataLinkName : thisDataLinkName + ' | ' + nameSoFar
+                    );
+                } else {
+                    return iterate(
+                        elem.parentNode,
+                        nameSoFar
+                    );
+                }
+            }
+        };
+
+        return iterate(elem, null);
+    }
+
+    function activate() {
+        $('a').each(function (elem) {
+            var $elem = bonzo(elem),
+                oldTitle = $elem.attr('title'),
+                linkName = dataLinkName(elem);
+
+            if (linkName) {
+                $elem.attr('title', linkName);
+                deactivateCallbacks.push(function () {
+                    $elem.attr('title', oldTitle || "");
+                });
+            }
+        });
+    }
+
+    function deactivate() {
+        deactivateCallbacks.forEach(function (callback) {
+            callback();
+        });
+    }
+
+    return {
+        activate: activate,
+        deactivate: deactivate
+    };
+});

--- a/static/src/javascripts/projects/common/modules/dev/debugObject.js
+++ b/static/src/javascripts/projects/common/modules/dev/debugObject.js
@@ -1,0 +1,7 @@
+define([
+    'common/modules/dev/dataLinkNameDebug'
+], function (dataLinkNameDebug) {
+    return {
+        dataLinkName: dataLinkNameDebug
+    };
+});


### PR DESCRIPTION
This fixes two issues with data-link-name on fronts:
### Position of container

Previously link names would only contain the container name itself, not its position on the page. It is now 1-indexed, so links to articles with have a data-link-name such as `front | /uk | 1 | headlines | analysis | 1 | article`, which means you've clicked on an analysis article in the first position of the headlines container, which is in the first position of the uk front.
### Sublinks

Previously sublinks were not getting their own data-link-name separate from the article's own. Now you get the sublink position, such as `front | /uk | 1 | headlines | analysis | 1 | sublinks | 1`, meaning you've clicked the 1st sublink on an analysis article in the 1st position of the headlines container which is in the first position of the uk front.

CC @crifmulholland @gklopper @phamann 

NOTE!

I've also added some debugging stuff for `data-link-name`, which I imagine might be contentious. If so, I'm happy to move it out of this pull request. Basically, on dev machines, it creates a GuardianDebug object which has a function you can call to replace the titles of links with their data-link-name. This makes it a lot easier to debug at a glance data link names on a front, which I needed for testing.

![hello](https://cloud.githubusercontent.com/assets/1001642/4796997/063fed4e-5e08-11e4-8957-f574c6bd17a2.png)
