### PR TITLE
Snap heights

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -67,12 +67,14 @@ define([
     }
 
     function injectIframe(el) {
+        var height = Math.min(Math.max(bonzo(el).offset().height || 0, 200), 400);
+
         // Wrapping iframe to fix iOS height-setting bug
         bonzo(el).html(template(
             '<div style="height:{{height}}px; overflow:hidden; width: 100%;">' +
                 '<iframe src="{{src}}" style="height:{{height}}px; width: 100%; border: none;"></iframe>' +
             '</div>',
-            {src: el.getAttribute('data-snap-uri'), height: 300}
+            {src: el.getAttribute('data-snap-uri'), height: height}
         ));
     }
 

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -67,14 +67,16 @@ define([
     }
 
     function injectIframe(el) {
-        var height = Math.min(Math.max(bonzo(el).offset().height || 0, 200), 400);
+        var elHeight = bonzo(el).offset().height || 0,
+            minIframeHeight = Math.ceil((bonzo(el).offset().width || 0) / 2),
+            maxIframeHeight = 400;
 
         // Wrapping iframe to fix iOS height-setting bug
         bonzo(el).html(template(
             '<div style="height:{{height}}px; overflow:hidden; width: 100%;">' +
                 '<iframe src="{{src}}" style="height:{{height}}px; width: 100%; border: none;"></iframe>' +
             '</div>',
-            {src: el.getAttribute('data-snap-uri'), height: height}
+            {src: el.getAttribute('data-snap-uri'), height: Math.min(Math.max(elHeight, minIframeHeight), maxIframeHeight)}
         ));
     }
 

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -67,8 +67,8 @@ define([
     }
 
     function injectIframe(el) {
-        var elHeight = bonzo(el).offset().height || 0,
-            minIframeHeight = Math.ceil((bonzo(el).offset().width || 0) / 2),
+        var spec = bonzo(el).offset(),
+            minIframeHeight = Math.ceil((spec.width || 0) / 2),
             maxIframeHeight = 400;
 
         // Wrapping iframe to fix iOS height-setting bug
@@ -76,7 +76,7 @@ define([
             '<div style="height:{{height}}px; overflow:hidden; width: 100%;">' +
                 '<iframe src="{{src}}" style="height:{{height}}px; width: 100%; border: none;"></iframe>' +
             '</div>',
-            {src: el.getAttribute('data-snap-uri'), height: Math.min(Math.max(elHeight, minIframeHeight), maxIframeHeight)}
+            {src: el.getAttribute('data-snap-uri'), height: Math.min(Math.max(spec.height || 0, minIframeHeight), maxIframeHeight)}
         ));
     }
 


### PR DESCRIPTION
- Make iframes for embeds match the height of their containing item
- Don't let their height go below a 2:1 aspect ratio; eg for letterbox layouts such as on mobile or in a single-item slice (example 2)
- Don't let their height to go above 400px

Example 1:
![screen shot 2014-10-27 at 17 04 52](https://cloud.githubusercontent.com/assets/1147913/4799564/79925f4c-5e1d-11e4-963f-9fc007429f04.png)

Example 2:
![screen shot 2014-10-27 at 17 05 11](https://cloud.githubusercontent.com/assets/1147913/4799572/8a9ff4ca-5e1d-11e4-856c-db50588a723a.png)
