### PR TITLE
Video most popular (take 2)

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -132,6 +132,8 @@
     }
 </div>
 
-@fragments.contentFooter(media, page.related, "media")
+<div class="l-side-margins l-side-margins--layout-content">
+    @fragments.contentFooter(media, page.related, "media")
 
-}
+    }
+</div>

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -44,8 +44,11 @@
             display: block;
             position: relative;
             width: 100%;
+            max-width: gs-span(8);
+            margin: 0 auto;
+        }
+        @include mq(tablet) {
             max-width: gs-span(9);
-            margin: $gs-baseline*2 auto 0;
         }
         @include mq(desktop) {
             padding-left: $gs-gutter/2;
@@ -100,7 +103,6 @@
 
         .item__container {
             margin-top: -$gs-baseline;
-            border-top: 1px solid $c-mediaDefault;
         }
     }
     .item__action {
@@ -122,6 +124,7 @@
     }
     .item__title {
         @include fs-headline(1);
+        font-weight: 500;
         text-align: left; //Required for end slate items
         @include text-clamp(3, get-line-height(headline, 1));
         height: get-line-height(headline, 1) * 3;
@@ -140,14 +143,12 @@
    ========================================================================== */
 
 .most-viewed-container--media {
+    border-top: 1px solid $c-neutral2;
 
     @include mq($until: desktop) {
         margin-top: $gs-baseline*2;
     }
 
-    @include mq(tablet) {
-        border-top: 1px solid $c-mediaDefault;
-    }
     .most-viewed-container__header {
         height: gs-height(1) + $gs-baseline;
     }
@@ -178,6 +179,9 @@
             &:nth-child(3n-1),
             &:nth-child(3n-2) {
                 border-right: 1px solid $c-neutral2;
+            }
+            &:nth-child(1n+4) {
+                margin-bottom: 0;
             }
         }
         @include mq(desktop) {

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -5,7 +5,6 @@
 .container--dark-background {
     background-color: $c-neutral1;
     margin-bottom: 0;
-    padding-bottom: $gs-baseline * 2;
 }
 .container--rolled-up .container--rolled-up-hide {
     display: none;

--- a/static/src/stylesheets/module/facia/_icons.scss
+++ b/static/src/stylesheets/module/facia/_icons.scss
@@ -19,11 +19,11 @@
     .linkslist__item--video .linkslist__action:before {
         @extend %pseudo-icon--media;
         width: 1.2em;
-        @include icon(video-icon-black, $with-width: false);
+        @include icon(video-icon, false);
 
         .svg .container--dark-background &,
         .svg .end-slate--video & {
-            @extend %svg-i-video-icon-white;
+            @extend %svg-i-video-icon;
         }
     }
     .item--gallery .item__title:before,


### PR DESCRIPTION
This is remains a unique pattern to video pages. ie. as it's in the RH column at desktop we don't have this as a pattern in new facia containers. So have just updated the styling to match the new container styles as per @Pearson82 guidelines.
- Font weight of headlines to 500.
- Video icon to yellow
- Remove yellow border-top at cell level.
- Change border above 'popular videos' to `$c-neutral2`
- At mobile/tablet breakpoints there was excessive amount of space above and below the container.
- Currently we are missing the border above the container at mobile. Can we keep this at mobile as per other breakpoints.
## Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/4800700/dd15f3d4-5e28-11e4-8673-01074d466fc6.png)
## After
### Mobile

![google chrome](https://cloud.githubusercontent.com/assets/80089/4800701/e13e087a-5e28-11e4-88f4-b80470987f23.png)
### Tablet

![google chrome](https://cloud.githubusercontent.com/assets/80089/4800705/ea82dfe6-5e28-11e4-90c5-ffc51945f11a.png)
### Desktop

![google chrome](https://cloud.githubusercontent.com/assets/80089/4800725/21ac81b6-5e29-11e4-964c-44b0982d2f75.png)
