### PR TITLE
Quick fix for timeline css

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -558,7 +558,7 @@ $block-padding-right: $gs-gutter;
 
 /* Timeline
    ========================================================================== */
-$timeline-width: 14px;
+$timeline-width: 15px;
 
 .blog__timeline {
     @include mq(desktop) {
@@ -663,7 +663,7 @@ $timeline-width: 14px;
         }
 
         .timeline__item:last-child & {
-            border-left: 0;
+            border-color: transparent;
         }
     }
 }


### PR DESCRIPTION
I've noticed that timeline circles and the last item are 1px off.

![screen shot 2014-10-28 at 10 11 05](https://cloud.githubusercontent.com/assets/2579465/4807213/019e7230-5e92-11e4-87da-f8ce309b38c9.png)

So this is a quick fix:
![screen shot 2014-10-28 at 11 00 07](https://cloud.githubusercontent.com/assets/2579465/4807216/090d31c8-5e92-11e4-9996-5c56ff940858.png)
