### PR TITLE
Turn off faux-link promoted/elevated links on items below desktop

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -99,6 +99,14 @@ $fc-item-gutter: $gs-gutter / 4;
         color: inherit;
     }
 
+    .u-faux-block-link & a,
+    .u-faux-block-link & abbr[title],
+    .u-faux-block-link__promote {
+        @include mq($until: desktop) {
+            z-index: initial;
+        }
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -99,6 +99,14 @@ $fc-item-gutter: $gs-gutter / 4;
         color: inherit;
     }
 
+    .u-faux-block-link a,
+    .u-faux-block-link abbr[title],
+    .u-faux-block-link__promote {
+        @include mq($until: desktop) {
+            z-index: initial;
+        }
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -242,6 +242,12 @@ $fc-item-gutter: $gs-gutter / 4;
     bottom: 0;
     @include fs-textSans(1);
     color: $c-neutral2;
+
+    a {
+        // make sure meta links always clickable,
+        // even on mobile/tablet
+        z-index: 1 !important;
+    }
 }
 
 .fc-item__timestamp,

--- a/static/src/stylesheets/module/facia-cards/_sublinks.scss
+++ b/static/src/stylesheets/module/facia-cards/_sublinks.scss
@@ -5,6 +5,8 @@
 
     a {
         display: block;
+        // make sure sublink always clickable, even on mobile/tablet
+        z-index: 1 !important;
     }
 }
 


### PR DESCRIPTION
Without a pointing device it's not clear that kickers etc are separate links which may not actually take you to the article they describe. 

Since it's [hard to reliably detect a touch device](http://www.stucox.com/blog/you-cant-detect-a-touchscreen), this PR kills promoted/elevated links until desktop breakpoint is reached (except for sublinks). 

This isn't ideal, since large tablets and small laptops share screen sizes. Def up for other suggestions...
