### PR TITLE
Refactor liveblog right-hand story package to use new facia item styles

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -101,12 +101,13 @@
                     @if(model.related.hasStoryPackage) {
                         <aside role="complementary" class="blog__related">
                             <h3 class="blog__related__head">More on this story</h3>
-                            <ul class="u-unstyled facia-slice facia-slice--no-flex">
+                            <ul class="u-unstyled facia-slice facia-slice--single-col">
                                 @model.related.storyPackage.take(3).zipWithIndex.map { case (trail, index) =>
                                     @item(
                                         Card(index, trail, None),
                                         ItemClasses(mobile = "list-media",tablet = "standard"),
                                         0,
+                                        isRow = false,
                                         isList = false
                                     )(request, CollectionConfig.emptyConfig)
                                 }

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -5,6 +5,8 @@
 @import views.support.TrailCssClasses.articleToneClass
 @import com.gu.facia.client.models.CollectionConfig
 @import views.BodyCleaner
+@import layout.{Card, ItemClasses}
+@import views.html.fragments.items.facia_cards.item
 
 @defining(model.article) {  article =>
 <div class="l-side-margins l-side-margins--layout-content">
@@ -99,9 +101,14 @@
                     @if(model.related.hasStoryPackage) {
                         <aside role="complementary" class="blog__related">
                             <h3 class="blog__related__head">More on this story</h3>
-                            <ul class="u-unstyled">
-                                @model.related.storyPackage.take(4).zipWithIndex.map { case (item, index) =>
-                                    @fragments.collections.items.standard(item, index, 1, "blog__related__item")(request, CollectionConfig.emptyConfig)
+                            <ul class="u-unstyled facia-slice facia-slice--no-flex">
+                                @model.related.storyPackage.take(3).zipWithIndex.map { case (trail, index) =>
+                                    @item(
+                                        Card(index, trail, None),
+                                        ItemClasses(mobile = "list-media",tablet = "standard"),
+                                        0,
+                                        isList = false
+                                    )(request, CollectionConfig.emptyConfig)
                                 }
                             </ul>
                         </aside>

--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -9,7 +9,7 @@
         @column match {
             case SingleItem(colSpan, itemClasses) => {
                 @cards.headOption.map { card =>
-                    @item(card, itemClasses, containerIndex, false, colSpan)
+                    @item(card, itemClasses, containerIndex, isList = false, colSpan = colSpan)
                 }
             }
 

--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -9,7 +9,7 @@
         @column match {
             case SingleItem(colSpan, itemClasses) => {
                 @cards.headOption.map { card =>
-                    @item(card, itemClasses, containerIndex, isList = false, colSpan = colSpan)
+                    @item(card, itemClasses, containerIndex, colSpan = colSpan)
                 }
             }
 

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -1,4 +1,4 @@
-@(card: layout.Card, modifierClasses: layout.ItemClasses, containerIndex: Int, isList: Boolean = false, colSpan: Int = 1)(implicit request: RequestHeader, config: com.gu.facia.client.models.CollectionConfig)
+@(card: layout.Card, modifierClasses: layout.ItemClasses, containerIndex: Int, isRow: Boolean = true, isList: Boolean = false, colSpan: Int = 1)(implicit request: RequestHeader, config: com.gu.facia.client.models.CollectionConfig)
 
 @import common.LinkTo
 @import model.{FaciaDisplayElement, InlineVideo, VideoPlayer, Content}
@@ -12,7 +12,15 @@
 
 @defining((card.item, card.index)) { case (trail, index) =>
 
-<li class="facia-slice__item u-faux-block-link l-row__item l-row__item--span-@colSpan @if(isList){ l-list__item }@card.cssClasses">
+<li class="@RenderClasses(Map(
+        ("facia-slice__item", true),
+        ("u-faux-block-link", true),
+        ("l-row__item", isRow),
+        (s"l-row__item--span-$colSpan", isRow),
+        ("l-list__item", isList),
+        (card.cssClasses, true)
+    ))">
+
     @defining((trail.visualTone, containerIndex == 0)) { case (tone, isFirstContainer) =>
         <div class="@GetClasses.forNewStyleItem(trail, isFirstContainer, Sublinks.numberOfSublinks(trail, modifierClasses)) @modifierClasses.classes @if(!isList){js-snappable}"
             @if(trail.isCommentable) {

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -708,6 +708,13 @@ $timeline-width: 15px;
 .blog__related {
     width: gs-span(3);
     margin-left: gs-span(1) + $gs-gutter;
+
+    .tone-news--item {
+        .fc-item__content {
+            padding-left: 0;
+            padding-right: 0;
+        }
+    }
 }
 
 .blog__related__head {
@@ -715,31 +722,6 @@ $timeline-width: 15px;
     padding-top: $gs-baseline / 4;
     margin-bottom: ($gs-baseline/3)*4;
     border-top: 1px solid $c-neutral4;
-}
-
-.blog__related__item {
-    width: auto !important;
-    padding-bottom: 0;
-    margin-bottom: $gs-baseline*2;
-
-    .item {
-        padding: 0;
-        margin: 0;
-    }
-
-    .item__tonal-border {
-        border-color: $c-neutral4;
-    }
-
-    & + &:before, // Vertical item separator
-    .item__byline,
-    .item__meta {
-        display: none;
-    }
-
-    .item__title {
-        @include fs-headline(2);
-    }
 }
 
 /* Football components

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -712,7 +712,9 @@ $timeline-width: 15px;
 
 .blog__related__head {
     @include fs-header(2);
+    padding-top: $gs-baseline / 4;
     margin-bottom: ($gs-baseline/3)*4;
+    border-top: 1px solid $c-neutral4;
 }
 
 .blog__related__item {

--- a/static/src/stylesheets/module/facia-cards/_items.scss
+++ b/static/src/stylesheets/module/facia-cards/_items.scss
@@ -221,9 +221,9 @@
 }
 
 //Live blog items
-.facia-slice--no-flex {
+.facia-slice--single-col {
+
     .facia-slice__item {
-        width: 100%;
         padding-bottom: 0;
 
         &:before {
@@ -234,12 +234,5 @@
     .fc-item {
         margin-left: 0;
         margin-right: 0;
-    }
-
-    .tone-news--item {
-        .fc-item__content {
-            padding-left: 0;
-            padding-right: 0;
-        }
     }
 }

--- a/static/src/stylesheets/module/facia-cards/_items.scss
+++ b/static/src/stylesheets/module/facia-cards/_items.scss
@@ -219,3 +219,29 @@
 .fc-item--list-compact--media {
     @include fc-item--list-compact--media;
 }
+
+//Live blog items
+.facia-slice--no-flex {
+    .facia-slice__item {
+        width: 100%;
+        padding-bottom: 0;
+
+        &:before {
+            display:none;
+        }
+    }
+
+    .fc-item {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .tone-news--item {
+        .fc-item__content {
+            padding-left: 0;
+            padding-right: 0;
+        }
+    }
+}
+
+

--- a/static/src/stylesheets/module/facia-cards/_items.scss
+++ b/static/src/stylesheets/module/facia-cards/_items.scss
@@ -227,7 +227,7 @@
         padding-bottom: 0;
 
         &:before {
-            display:none;
+            display: none;
         }
     }
 
@@ -243,5 +243,3 @@
         }
     }
 }
-
-


### PR DESCRIPTION
One of the last templates to use old style facia cards. This refactors the template to use new style ones.

![google chrome](https://cloud.githubusercontent.com/assets/80089/4809816/cc598278-5eae-11e4-9114-3baa06ce9104.png)

/cc @sndrs 
