### PR TITLE
Override column-fill property on popular container at tablet breakpoint. Fixes: #6700

### DIFF
--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -90,6 +90,7 @@
 
     .headline-column {
         min-height: gs-height(11) - $gs-baseline;
+        max-height: gs-height(12) - $gs-baseline;
         -webkit-column-fill: auto;
         -moz-column-fill: auto;
         column-fill: auto;

--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -90,6 +90,9 @@
 
     .headline-column {
         min-height: gs-height(11) - $gs-baseline;
+        -webkit-column-fill: auto;
+        -moz-column-fill: auto;
+        column-fill: auto;
     }
 
     .headline-column__item {


### PR DESCRIPTION
This fixes #6700 turns out both Safari and Firefox were behaving correctly, as the [column-fill](https://developer.mozilla.org/en-US/docs/Web/CSS/column-fill) property defaults to `balance`

This is a temporary fix for US launch until I can submit a PR to guss-layout to enable the author to pass in a column-fill parameter to the column mixin.

/cc @michaelwmcnamara @ironsidevsquincy @sndrs 
### Before

![safari](https://cloud.githubusercontent.com/assets/80089/4813449/93177d48-5ec8-11e4-9ffa-ea39e08439a4.png)
### After

![safari](https://cloud.githubusercontent.com/assets/80089/4813450/972dec8c-5ec8-11e4-9d3f-5e1f2d985b50.png)
