### PR TITLE
Move audio page body below meta

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -81,17 +81,22 @@
                                     case v: Video => {
                                         @fragments.standfirst(v)
                                     }
-                                    case a: Audio => {
-                                        @a.body.map { b =>
-                                            <div class="from-content-api">
-                                                @Html(b)
-                                            </div>
-                                        }
-                                    }
+                                    case a: Audio => { }
                                 }
                             </div>
 
                             @fragments.contentMeta(media)
+
+                            @media match {
+                                case a: Audio => {
+                                    @a.body.map { b =>
+                                        <div class="from-content-api">
+                                            @Html(b)
+                                        </div>
+                                    }
+                                }
+                                case _ => { }
+                            }
 
                             @fragments.submeta(media)
                         </div>

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -3,13 +3,14 @@
 
 @if(
     SponsoredSwitch.isSwitchedOn &&
-    (content.isSponsored || content.isAdvertisementFeature) &&
+    (content.isSponsored || content.isAdvertisementFeature || content.isFoundationSupported) &&
     !content.isInappropriateForSponsorship
 ) {
     @defining((
         content match {
             case c if c.isSponsored => {"spbadge"}
-            case _ => {"adbadge"}
+            case c if c.isAdvertisementFeature => {"adbadge"}
+            case _ => {"fobadge"}
         },
         content match {
             case _: LiveBlog => {"live-blog"}

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -34,7 +34,11 @@
     @if(!content.hasMainPicture && !content.hasMainVideo && !content.hasMainAudio && !content.hasMainEmbed){ content__meta-container--float}">
 
     @if(showBadge) {
-        @fragments.commercial.badge(content)
+        @* on articles, foundation supported badges go inline *@
+        @content match {
+            case a: Article if a.isFoundationSupported => { }
+            case c => { @fragments.commercial.badge(c) }
+        }
     }
 
     @if(content.showBylinePic) {


### PR DESCRIPTION
Also, put the "foundation supported" badge back in for non-article pages
### Before

![screen shot 2014-10-28 at 20 19 47](https://cloud.githubusercontent.com/assets/74132/4816468/d6b580a6-5edf-11e4-8749-077dd0cf7ba1.png)
### After

![screen shot 2014-10-28 at 20 17 47](https://cloud.githubusercontent.com/assets/74132/4816457/b7354e14-5edf-11e4-92cf-04449cc93538.png)
