### PR TITLE
Add ad slot below container's 'show more' button

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -133,9 +133,14 @@ define([
                 .map(function (adSlot) {
                     return bonzo(adSlot);
                 })
-                // filter out hidden ads
+                // filter out (and remove) hidden ads
                 .filter(function ($adSlot) {
-                    return $css($adSlot, 'display') !== 'none';
+                    if ($css($adSlot, 'display') === 'none') {
+                        $adSlot.remove();
+                        return false;
+                    } else {
+                        return true;
+                    }
                 })
                 .map(function ($adSlot) {
                     return [$adSlot.attr('id'), defineSlot($adSlot)];

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -65,11 +65,19 @@ define([
             _(adSlices)
                 .slice(0, adNames.length)
                 .forEach(function ($adSlice, index) {
-                    var adName = adNames[index],
-                        $adSlot = bonzo(createAdSlot(adName, 'container-inline'));
+                    var adName        = adNames[index],
+                        $mobileAdSlot = bonzo(createAdSlot(adName, 'container-inline'))
+                            .addClass('mobile-only'),
+                        $tabletAdSlot = bonzo(createAdSlot(adName, 'container-inline'))
+                            .addClass('hide-on-mobile');
+
+                    // add a tablet+ ad to the slice
                     $adSlice
                         .removeClass('facia-slice__item--no-mpu')
-                        .append($adSlot);
+                        .append($tabletAdSlot);
+                    // add a mobile advert after the container
+                    $mobileAdSlot
+                        .insertAfter($.ancestor($adSlice[0], 'container'));
                 })
                 .valueOf();
 

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -52,10 +52,10 @@ define([
                 expect(sliceAdverts).toBeDefined();
             });
 
-            it('should only create a maximum of 2 advert slots', function (sliceAdverts) {
+            it('should only create a maximum of 4 advert slots', function (sliceAdverts) {
                 sliceAdverts.init();
 
-                expect(qwery('.ad-slot', $fixtureContainer).length).toEqual(2);
+                expect(qwery('.ad-slot', $fixtureContainer).length).toEqual(4);
             });
 
             it('should remove the "facia-slice__item--no-mpu" class', function (sliceAdverts) {
@@ -71,7 +71,9 @@ define([
                 var $adSlots = $('.ad-slot', $fixtureContainer).map(function (slot) { return $(slot); });
 
                 expect($adSlots[0].data('name')).toEqual('inline1');
-                expect($adSlots[1].data('name')).toEqual('inline2');
+                expect($adSlots[1].data('name')).toEqual('inline1');
+                expect($adSlots[2].data('name')).toEqual('inline2');
+                expect($adSlots[3].data('name')).toEqual('inline2');
             });
 
             it('should have the correct size mappings', function (sliceAdverts) {
@@ -126,6 +128,18 @@ define([
                 expect(qwery('.container-third .ad-slot', $fixtureContainer).length).toBe(1);
                 expect(qwery('.container-fifth .ad-slot', $fixtureContainer).length).toBe(1);
             });
+
+            it(
+                'should add one slot for tablet, one slot for mobile after container',
+                function (sliceAdverts) {
+                    sliceAdverts.init();
+
+                    expect($('.container-first .ad-slot', $fixtureContainer).hasClass('hide-on-mobile'))
+                        .toBe(true);
+                    expect($('.container-first + .ad-slot', $fixtureContainer).hasClass('mobile-only'))
+                        .toBe(true);
+                }
+            );
 
         }
     });


### PR DESCRIPTION
We now add two container slots
- one for tablet+ which is placed in the ad slice
- one for mobile that is placed after the container

![screen shot 2014-10-28 at 23 22 30](https://cloud.githubusercontent.com/assets/74132/4818873/52d018b8-5ef9-11e4-8893-b31831080ef0.png)
