### PR TITLE
remove analysis span from analysis articles

### DIFF
--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -11,9 +11,6 @@
                 @fragments.meta.metaInline(content)
 
                 <h1 class="content__headline js-score" itemprop="headline">
-                    @if(content.isAnalysis) {
-                        <span class="content__headline__kicker">Analysis</span>
-                    }
                     @Html(content.headline)
                 </h1>
 


### PR DESCRIPTION
Remove the analysis span from analysis articles. As requested by @cantlin 
Before: 
![some-analysis](https://cloud.githubusercontent.com/assets/986155/4824592/5449aaac-5f5c-11e4-80a6-9628f9aa09c1.png)

After: 
![no-analysis](https://cloud.githubusercontent.com/assets/986155/4824600/676254ae-5f5c-11e4-92f2-9d485237c506.png)
