### PR TITLE
Add a header identifying the backend to all responses.

### DIFF
--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -118,6 +118,12 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
     status(result) should be (200)
   }
 
+  it should "know which backend served the request" in {
+    val result = route(app, TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")).head
+    status(result) should be (200)
+    header("X-Gu-Backend-App", result).head should be ("test-project")
+  }
+
   it should "error if there is an appropriate header and it is switched on" in {
     ForceHttpResponseCodeSwitch.switchOn()
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -341,8 +341,6 @@ import collection.JavaConversions._
         Then("the ad slot placeholder is rendered")
         val adPlaceholder = $(".ad-slot--top-banner-ad")
 
-        System.out.println(adPlaceholder);
-
         And("the placeholder has the correct data attributes")
         adPlaceholder.getAttribute("data-name") should be("top-above-nav")
         adPlaceholder.getAttribute("data-mobile") should be("300,1|88,70|728,90")

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -102,7 +102,8 @@ trait SingleServerSuite extends OneServerPerSuite with TestSettings with OneBrow
       withGlobal = globalSettingsOverride,
       additionalPlugins = testPlugins,
       additionalConfiguration = Map(
-        ("application.secret", "this_is_not_a_real_secret_just_for_tests")
+        ("application.secret", "this_is_not_a_real_secret_just_for_tests"),
+        ("guardian.projectName", "test-project")
       )
   )
 }


### PR DESCRIPTION
this can now be logged in Fastly for debugging purposes.
