### PR TITLE
Reduce space between icon and headline on media tone pages

### DIFF
--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -31,7 +31,7 @@
         content: '';
         display: inline-block;
         height: .65em;
-        margin-right: .3em;
+        margin-right: .1em;
     }
 
     .content__main-column--video {


### PR DESCRIPTION
Before
![screen shot 2014-10-29 at 12 38 42](https://cloud.githubusercontent.com/assets/3416696/4825756/a5627e6c-5f68-11e4-9582-ec7def8ab8c8.png)

After
![screen shot 2014-10-29 at 12 37 55](https://cloud.githubusercontent.com/assets/3416696/4825758/aa29fa7e-5f68-11e4-932a-e93741901789.png)
