### PR TITLE
football snaps fix

### DIFF
--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -176,10 +176,10 @@ define([
         apiQuery += 'show-editors-picks=true&show-fields=headline';
 
         contentApi.fetchContent(apiQuery)
-        .always(function(results) {
+        .done(function(results) {
             if (cc === checkCount) {
-                self.capiResults(results);
-                self.state.apiQueryStatus(results.length ? 'valid' : 'invalid');
+                self.capiResults(results || []);
+                self.state.apiQueryStatus(results && results.length ? 'valid' : 'invalid');
             }
         });
     };

--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -52,7 +52,7 @@ function (
                     err;
 
                 // ContentApi item
-                if (results.length === 1) {
+                if (results && results.length === 1) {
                     capiItem = results[0];
                     icc = internalContentCode(capiItem);
                     if (icc) {
@@ -72,11 +72,11 @@ function (
                     err = 'Sorry, that link cannot be added to a front';
 
                 // A snap, but not an absolute url
-                } else if (!item.id().match(/^https?:\/\//) && results.length === 0) {
-                    err = 'Sorry, that\'s not a valid URL';
+                } else if (!item.id().match(/^https?:\/\//)) {
+                    err = 'Sorry, that\'s not a valid absolute URL';
 
                 // A snap, but a link to unavailable guardian content
-                } else if (isFromGuardian && results.length === 0) {
+                } else if (isFromGuardian && results && results.length === 0) {
                     err = 'Sorry, that Guardian content is unavailable';
 
                 // A snap that's legitimate (includes case where results.length > 1, eg. is the target is a Guardian tag page)
@@ -117,7 +117,7 @@ function (
 
         fetchContentByIds(ids)
         .done(function(results){
-            results.forEach(function(result) {
+            [].concat(results).forEach(function(result) {
                 var icc = internalContentCode(result);
 
                 if(icc) {
@@ -162,8 +162,8 @@ function (
         authedAjax.request({
             url: vars.CONST.apiSearchBase + '/' + apiUrl
         }).always(function(resp) {
-            if (!resp.response) {
-                defer.resolve([]);
+            if (!resp.response || resp.response.status === 'error') {
+                defer.resolve();
             } else if (resp.response.content) {
                 defer.resolve([resp.response.content]);
             } else {

--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -117,7 +117,11 @@ function (
 
         fetchContentByIds(ids)
         .done(function(results){
-            [].concat(results).forEach(function(result) {
+            if (!_.isArray(results)) {
+                return;
+            }
+
+            results.forEach(function(result) {
                 var icc = internalContentCode(result);
 
                 if(icc) {

--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -63,6 +63,10 @@ function (
                         err = 'Sorry, that article is malformed (has no internalContentCode)';
                     }
 
+                // A snap, but not an absolute url
+                } else if (!item.id().match(/^https?:\/\//)) {
+                    err = 'Sorry, URLs must begin with http...';
+
                 // A snap, but snaps can only be created to the Clipboard
                 } else if (item.group.parentType !== 'Clipboard') {
                     err = 'Sorry, special links must be dragged to the Clipboard, initially';
@@ -70,10 +74,6 @@ function (
                 // A snap, but a link off of the tool itself
                 } else if (_.some([window.location.hostname, vars.CONST.viewer], function(str) { return item.id().indexOf(str) > -1; })) {
                     err = 'Sorry, that link cannot be added to a front';
-
-                // A snap, but not an absolute url
-                } else if (!item.id().match(/^https?:\/\//)) {
-                    err = 'Sorry, that\'s not a valid absolute URL';
 
                 // A snap, but a link to unavailable guardian content
                 } else if (isFromGuardian && results && results.length === 0) {


### PR DESCRIPTION
Fixes the case where a Guardian URL is dragged in as asSnap, but it isn't a capi id. Eg. `football/live`
