### PR TITLE
Add data-link-name to kickers

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
@@ -23,7 +23,7 @@
     }
 
     case PodcastKicker(Some(series)) => {
-      <a href="@LinkTo(series.url)" class="fc-sublink__kicker">@Html(series.name)</a>
+      <a href="@LinkTo(series.url)" data-link-name="kicker" class="fc-sublink__kicker">@Html(series.name)</a>
     }
 
     case PodcastKicker(None) => {
@@ -35,11 +35,11 @@
     }
 
     case TagKicker(tagName, tagLink) => {
-      <a href="@LinkTo(tagLink)" class="fc-sublink__kicker">@Html(tagName)</a>
+      <a href="@LinkTo(tagLink)" data-link-name="kicker" class="fc-sublink__kicker">@Html(tagName)</a>
     }
 
     case SectionKicker(sectionName, sectionLink) => {
-      <a href="@LinkTo(sectionLink)" class="fc-sublink__kicker">@Html(sectionName)</a>
+      <a href="@LinkTo(sectionLink)" data-link-name="kicker" class="fc-sublink__kicker">@Html(sectionName)</a>
     }
 
     case FreeHtmlKicker(html) => {

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -24,7 +24,7 @@
         }
 
         case PodcastKicker(Some(series)) => {
-            <a href="@LinkTo(series.url)" class="fc-item__kicker">@Html(series.name)</a>
+            <a href="@LinkTo(series.url)" data-link-name="kicker" class="fc-item__kicker">@Html(series.name)</a>
         }
 
         case PodcastKicker(None) => {
@@ -36,11 +36,11 @@
         }
 
         case TagKicker(tagName, tagLink) => {
-            <a href="@LinkTo(tagLink)" class="fc-item__kicker">@Html(tagName)</a>
+            <a href="@LinkTo(tagLink)" data-link-name="kicker" class="fc-item__kicker">@Html(tagName)</a>
         }
 
         case SectionKicker(sectionName, sectionLink) => {
-            <a href="@LinkTo(sectionLink)" class="fc-item__kicker">@Html(sectionName)</a>
+            <a href="@LinkTo(sectionLink)" data-link-name="kicker" class="fc-item__kicker">@Html(sectionName)</a>
         }
 
         case FreeHtmlKicker(html) => {


### PR DESCRIPTION
Looks like this:

![screen shot 2014-10-29 at 17 28 54](https://cloud.githubusercontent.com/assets/1001642/4830967/589529ee-5f91-11e4-96e9-47ef6709ae0b.png)

@crifmulholland also asked me to look at the data-link-name for bylines, but it looks like it's already being inserted as 'auto tag link' (as it's the one that looks at the contributor tags then rewrites the byline with links if it matches names):

![screen shot 2014-10-29 at 17 29 06](https://cloud.githubusercontent.com/assets/1001642/4830986/72376e48-5f91-11e4-95f3-cdef4f9c8e59.png)
