### PR TITLE
Disable app banner on FirefoxOS App

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -175,7 +175,7 @@ define([
 
             s.prop14    = config.page.buildNumber || '';
 
-            s.prop60    = navigator.mozApps && !window.locationbar.visible ? 'firefoxosapp' : null;
+            s.prop60    = detect.isFireFoxOSApp() ? 'firefoxosapp' : null;
 
             s.prop19     = platform;
             s.eVar19     = platform;

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -1,9 +1,11 @@
-define([
+    define([
+    'common/utils/detect',
     'common/utils/storage',
     'common/utils/template',
     'common/modules/userPrefs',
     'common/modules/ui/message'
 ], function (
+    detect,
     storage,
     template,
     userPrefs,
@@ -33,8 +35,6 @@ define([
                 STORE: 'in Google Play'
             }
         },
-        isIOS = /(iPad|iPhone|iPod touch);.*CPU.*OS 7_\d/i.test(navigator.userAgent),
-        isAndroid = /Android/i.test(navigator.userAgent),
         impressions = (storage.local.get(IMPRESSION_KEY)) ? parseInt(storage.local.get(IMPRESSION_KEY), 10) : 0,
         tmp = '<img src="{{LOGO}}" class="app__logo" alt="Guardian App logo" /><div class="app__cta"><h4 class="app__heading">The Guardian app</h4>' +
             '<p class="app__copy">Instant alerts. Offline reading.<br/>Tailored to you.</p>' +
@@ -42,7 +42,7 @@ define([
             '<img src="{{SCREENSHOTS}}" class="app__screenshots" alt="screenshots" />';
 
     function isDevice() {
-        return (isIOS || isAndroid);
+        return ((detect.isIOS() || detect.isAndroid()) && !detect.isFireFoxOSApp());
     }
 
     function canShow() {
@@ -50,7 +50,7 @@ define([
     }
 
     function showMessage() {
-        var platform = (isIOS) ? 'ios' : 'android',
+        var platform = (detect.isIOS()) ? 'ios' : 'android',
             msg = new Message(platform);
 
         msg.show(template(tmp, DATA[platform.toUpperCase()]));

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -1,4 +1,4 @@
-    define([
+define([
     'common/utils/detect',
     'common/utils/storage',
     'common/utils/template',

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -113,13 +113,25 @@ define([
         return totalTime;
     }
 
+    function isIOS() {
+        return /(iPad|iPhone|iPod touch);.*CPU.*OS 7_\d/i.test(navigator.userAgent);
+    }
+
+    function isAndroid() {
+        return /Android/i.test(navigator.userAgent);
+    }
+
+    function isFireFoxOSApp() {
+        return navigator.mozApps && !window.locationbar.visible;
+    }
+
     function getConnectionSpeed(performance, connection, reportUnknown) {
 
         connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
 
         var isMobileNetwork = connection.type === 3 // connection.CELL_2G
-                  || connection.type === 4 // connection.CELL_3G
-                  || /^[23]g$/.test(connection.type), // string value in new spec
+                || connection.type === 4 // connection.CELL_3G
+                || /^[23]g$/.test(connection.type), // string value in new spec
             loadTime,
             speed;
 
@@ -318,6 +330,9 @@ define([
         hasPushStateSupport: hasPushStateSupport,
         getOrientation: getOrientation,
         getBreakpoint: getBreakpoint,
+        isIOS: isIOS,
+        isAndroid: isAndroid,
+        isFireFoxOSApp: isFireFoxOSApp,
         isBreakpoint: isBreakpoint,
         initPageVisibility: initPageVisibility,
         pageVisible: pageVisible,


### PR DESCRIPTION
Due to some great work by @jamesgorrie we now have the site wrapped in a FirefoxOS app, which is great and can be found in the market place [here](https://marketplace.firefox.com/app/guardian)

Unfortunately, our native app upsell banner is kicking in inside the FirefoxOS app trying to get the user to install the Android app. This is not good and is leading to tweets such as this: https://twitter.com/firt/status/526786343805136896

![](https://pbs.twimg.com/media/B0-FYr1IMAA_Cxh.png:small)

This PR refactors our smart up logic to exclude OS apps, and abstracts the UA detection into `detect.js` where it belongs.

Thanks to @kaelig for pointing this out to us.
