### PR TITLE
reinstate more fixtures button on football page

### DIFF
--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -46,7 +46,7 @@
                                         </div>
                                     </div>
                                 }
-                            </div>                                                            f
+                            </div>
                         }
                     </div>
 

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -50,35 +50,21 @@
                         }
                     </div>
 
-                    @if(matchesList.previousPage.isDefined || matchesList.nextPage.isDefined) {
+                    @if( matchesList.nextPage.isDefined) {
                         <div class="matches-nav" data-link-name="@matchesList.pageType nav">
-                            @matchesList.previousPage.map{url =>
-                                <a href="@url" class="collection__show-more"
-                                   data-shows-more=".football-matches__day"
-                                   data-puts-more-into="football-matches"
-                                   data-new-url="previous"
-                                   data-link-name="previous"
-                                   title="Previous page">
-                                    <span class="collection__show-more__icon">
-                                        <span class="i i-minus-white-mask"></span>
-                                        <span class="i i-minus-white"></span>
-                                    </span>
-                                    <span class="u-h">Previous</span>
-                                </a>
-                            }
                             @matchesList.nextPage.map{url =>
-                                <a href="@url" class="collection__show-more js-show-more"
+                                <button href="@url" class="collection__show-more football-matches__show-more js-show-more button--show-more button button--medium button--primary"
                                    data-shows-more=".football-matches__day"
                                    data-puts-more-into="football-matches"
                                    data-new-url="next"
                                    data-link-name="next"
                                    title="Next page">
                                     <span class="collection__show-more__icon">
-                                        <span class="i i-plus-white-mask"></span>
-                                        <span class="i i-plus-white"></span>
+                                        <i class="i i-plus-white"></i>
+                                        More
                                     </span>
                                     <span class="u-h">Next</span>
-                                </a>
+                                </button>
                             }
                         </div>
                     }

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -46,25 +46,24 @@
                                         </div>
                                     </div>
                                 }
-                            </div>
+                            </div>                                                            f
                         }
                     </div>
 
                     @if( matchesList.nextPage.isDefined) {
                         <div class="matches-nav" data-link-name="@matchesList.pageType nav">
                             @matchesList.nextPage.map{url =>
-                                <button href="@url" class="collection__show-more football-matches__show-more js-show-more button--show-more button button--medium button--primary"
+                                <a href="@url" class="collection__show-more football-matches__show-more js-show-more button--show-more button button--medium button--primary"
                                    data-shows-more=".football-matches__day"
                                    data-puts-more-into="football-matches"
                                    data-new-url="next"
                                    data-link-name="next"
                                    title="Next page">
                                     <span class="collection__show-more__icon">
-                                        <i class="i i-plus-white"></i>
-                                        More
+                                        <i class="i i-plus-white"></i>More
                                     </span>
                                     <span class="u-h">Next</span>
-                                </button>
+                                </a>
                             }
                         </div>
                     }

--- a/static/src/stylesheets/module/football/_matches.scss
+++ b/static/src/stylesheets/module/football/_matches.scss
@@ -133,6 +133,11 @@
     cursor: pointer;
 }
 
+.football-matches__show-more {
+    margin-top: $gs-baseline/2;
+    outline: none;
+}
+
 /* Footnotes */
 // [1] See: http://css-tricks.com/fighting-the-space-between-inline-block-elements/
 //     It would be nice to not do this, but I felt the tidyness of the HTML was more important in this instant.


### PR DESCRIPTION
Reinstates broken show more fixtures button here: /football/fixtures. As discussed wtih @cantlin the show less button is nuked

![show-more](https://cloud.githubusercontent.com/assets/986155/4842973/26adb400-602c-11e4-9f49-369db4624f85.png)
