### PR TITLE
All sections link focus - accessibility

### DIFF
--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -33,7 +33,7 @@
                         @fragments.nav.topNavigation(metaData, navigation)
                     </nav>
                 </div>
-                <a class="navigation__toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
+                <a class="navigation__toggle js-navigation-toggle" href="#nav-allsections" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
                     <i class="navigation__toggle-burger honest-burger"><i></i><i></i><i></i></i>
                     <span class="navigation__toggle-label navigation__toggle-label--open">all<span class="navigation__toggle-label__extra"> sections</span></span>
                     <span class="navigation__toggle-label navigation__toggle-label--close">close</span>


### PR DESCRIPTION
This was causing accessibility issue on mobile phones. Using voiceover clicking on all sections button moved focus to the `back to top` button in the footer.
