### PR TITLE
Blue pullquotes for tone-news

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-news.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-news.scss
@@ -1,6 +1,15 @@
 @include tone-content-icons(news, 'news');
 
 .tonal--tone-news {
+    .tonal__main {
+        .element-pullquote {
+            &:before,
+            &:after {
+                background-color: $c-newsDefault;
+            }
+        }
+    }
+
     // Interactives need help because their headers are not tonal
     &.content--interactive {
         .commentcount i {


### PR DESCRIPTION
Before:
![screen shot 2014-10-30 at 12 46 33](https://cloud.githubusercontent.com/assets/813383/4843500/f8f868dc-6032-11e4-83db-affc4728fafb.png)

After:
![screen shot 2014-10-30 at 12 46 50](https://cloud.githubusercontent.com/assets/813383/4843502/fbd8d438-6032-11e4-96e7-160c36d51a93.png)
