### PR TITLE
Add png's to Image profile url generation

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -121,6 +121,11 @@ object Switches extends Collections {
     safeState = On, sellByDate = never
   )
 
+  val PngResizingSwitch = Switch("Performance", "png-resizing",
+    "If this switch is on png images will be resized via the png-resizing server",
+    safeState = Off, sellByDate = never
+  )
+
   val ContentCacheTimeSwitch = Switch("Performance", "content-cache-time",
     "If this switch is on then content will have a shorter cache time",
     safeState = Off, sellByDate = new LocalDate(2014, 11, 15)

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -100,7 +100,7 @@
 
                 @CutOut.fromTrail(trail).map { case cutOut @ CutOut(altText, imageUrl, _) =>
                 <div class="fc-item__avatar">
-                    <div class="fc-item__avatar__media js-image-upgrade @cutOut.cssClass" data-src="@imageUrl"></div>
+                    <div class="fc-item__avatar__media js-image-upgrade @cutOut.cssClass" data-src="@cutOut.getUrl"></div>
                 </div>
                 }
 

--- a/common/app/views/support/CutOut.scala
+++ b/common/app/views/support/CutOut.scala
@@ -32,6 +32,7 @@ case object Landscape extends Orientation
 case object Portrait extends Orientation
 
 case class CutOut(altText: String, imageUrl: String, orientation: Orientation) {
+  def getUrl = ImgSrc(imageUrl, Item300)
   def cssClass = orientation match {
     case Landscape => "image--landscape"
     case Portrait => "image--portrait"

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import model.{Content, MetaData, ImageContainer, ImageAsset}
-import conf.Switches.ImageServerSwitch
+import conf.Switches.{ImageServerSwitch, PngResizingSwitch}
 import java.net.URI
 import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
@@ -109,7 +109,7 @@ object ImgSrc {
   def apply(url: String, imageType: ElementProfile): String = {
     val uri = new URI(url.trim)
 
-    val supportedImages = Seq(".jpg", ".jpeg")
+    val supportedImages = if(PngResizingSwitch.isSwitchedOn) Seq(".jpg", ".jpeg", ".png") else Seq(".jpg", ".jpeg")
     val isSupportedImage = supportedImages.exists(extension => uri.getPath.toLowerCase.endsWith(extension))
 
     hostPrefixMapping.get(uri.getHost)

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import model.{ImageContainer, ImageAsset}
 import com.gu.contentapi.client.model.Asset
-import conf.Switches.ImageServerSwitch
+import conf.Switches.{ImageServerSwitch, PngResizingSwitch}
 import conf.Configuration
 
 
@@ -46,6 +46,13 @@ class ImgSrcTest extends FlatSpec with Matchers  {
   it should "not convert the URL of the image if it is disabled" in {
     ImageServerSwitch.switchOff()
     GalleryLargeTrail.bestFor(image) should be (Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"))
+  }
+
+  it should "convert the URL of the image if it is a PNG" in {
+    ImageServerSwitch.switchOn()
+    PngResizingSwitch.switchOn()
+    val pngImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)), null, 0)
+    GalleryLargeTrail.bestFor(pngImage) should be (Some(s"${imageHost}/static/w-480/h-288/q-95/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png"))
   }
 
   it should "not convert the URL of the image if it is a GIF (we do not support animated GIF)" in {

--- a/png-resizer/app/data/Backends.scala
+++ b/png-resizer/app/data/Backends.scala
@@ -6,6 +6,7 @@ import java.net.{URLDecoder, URI}
 object Backends {
   private val all = Map(
     "static" -> new URI("http://static.guim.co.uk"),
+    "media" -> new URI("http://media.guim.co.uk"),
     "sport" -> new URI("http://sport.guim.co.uk")
   )
 


### PR DESCRIPTION
We currently serve 800px wide profile images inside facia avatar cutouts. This PR enables us to pass cut-outs to our new png resizing service and in turn reducing the foot print of facia pages.
- Add switch for resizing service
- Add profile to Cutout view helper
- Add tests
- Add media service as supported backend to png resizer

/cc @robertberry @rich-nguyen 
