### PR TITLE
Analysis tone fixes

### DIFF
--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -10,6 +10,10 @@
 
                 @fragments.meta.metaInline(content)
 
+                @if(content.isAnalysis) {
+                    <div class="content__headline content__headline--kicker">Analysis</div>
+                }
+
                 <h1 class="content__headline js-score" itemprop="headline">
                     @Html(content.headline)
                 </h1>

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -10,10 +10,6 @@
 
                 @fragments.meta.metaInline(content)
 
-                @if(content.isAnalysis) {
-                    <div class="content__headline content__headline--kicker">Analysis</div>
-                }
-
                 <h1 class="content__headline js-score" itemprop="headline">
                     @Html(content.headline)
                 </h1>

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -210,6 +210,11 @@
     }
 }
 
+.content__headline--kicker {
+    margin-bottom: -$gs-baseline / 2;
+    padding-bottom: 0;
+}
+
 .content__head--byline-pic {
     .byline-img {
         float: right;
@@ -271,13 +276,6 @@
                 padding-right: $gs-gutter*2;
             }
         }
-    }
-}
-
-.content__headline__kicker {
-    &:after {
-        content: ' /';
-        color: fade-out($c-neutral1, .8);
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -211,8 +211,11 @@
 }
 
 .content__headline--kicker {
-    margin-bottom: -$gs-baseline / 2;
     padding-bottom: 0;
+
+    @include mq(leftCol) {
+        margin-bottom: -$gs-baseline / 2;
+    }
 }
 
 .content__head--byline-pic {

--- a/static/src/stylesheets/module/content/_tones-mixins.scss
+++ b/static/src/stylesheets/module/content/_tones-mixins.scss
@@ -71,8 +71,12 @@
             }
 
             .content__headline--byline .tone-colour,
-            .content__headline__kicker {
+            .content__headline--kicker {
                 color: $tonal__headline-accent;
+            }
+
+            .content__headline--kicker {
+                font-weight: 200;
             }
         }
 

--- a/static/src/stylesheets/module/content/tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-analysis.scss
@@ -12,5 +12,5 @@
     $c-neutral2, // $tonal__standfirst-text
     $c-analysisDefault, // $tonal__standfirst-link
     #ffffff, // $tonal__article-background
-    $c-analysisDefault // $tonal__article-link
+    darken($c-analysisAccent, 15%) // $tonal__article-link
 );


### PR DESCRIPTION
Fixes colour of comment counts and byline links on analysis articles. (Also updates styles for header kicker, which will only apply if it gets reinstated in Scala template).

Before:
![screen shot 2014-10-30 at 15 44 29](https://cloud.githubusercontent.com/assets/813383/4846466/0e870c76-604c-11e4-8464-67a6c8c1c91b.png)

After:
![screen shot 2014-10-30 at 15 44 33](https://cloud.githubusercontent.com/assets/813383/4846465/0abd3962-604c-11e4-886f-7500ef859f69.png)
