### PR TITLE
Navigation remove jump to footer - accessibility

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -11,12 +11,17 @@ define([
         init: function () {
             this.addMegaNavMenu();
             this.enableMegaNavToggle();
+            this.replaceAllSectionsLink();
         },
 
         addMegaNavMenu: function () {
             var megaNav     = $('.js-transfuse'),
                 placeholder = $('.' + megaNav.attr('data-transfuse-target'));
             placeholder.html(megaNav.html());
+        },
+
+        replaceAllSectionsLink: function () {
+            $('.js-navigation-header .js-navigation-toggle').attr('href', '#nav-allsections');ocal
         },
 
         enableMegaNavToggle: function () {

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -21,7 +21,7 @@ define([
         },
 
         replaceAllSectionsLink: function () {
-            $('.js-navigation-header .js-navigation-toggle').attr('href', '#nav-allsections');ocal
+            $('.js-navigation-header .js-navigation-toggle').attr('href', '#nav-allsections');
         },
 
         enableMegaNavToggle: function () {

--- a/static/test/javascripts/spec/common/navigation/navigation.spec.js
+++ b/static/test/javascripts/spec/common/navigation/navigation.spec.js
@@ -1,0 +1,74 @@
+define([
+    'bonzo',
+    'bean',
+    'common/utils/$',
+    'common/modules/navigation/navigation',
+    'helpers/fixtures'
+], function(
+    bonzo,
+    bean,
+    $,
+    sut,
+    fixtures
+) {
+    describe("Navigation", function() {
+
+        beforeEach(function() {
+            fixtures.render({
+                id: 'navigation-fixture',
+                fixtures: [
+                        '<div class="js-navigation-header navigation--collapsed">' +
+                        '<a class="js-navigation-toggle" href="#footer-nav" data-target-nav="js-navigation-header"></a>' +
+                        '<div class="js-mega-nav-placeholder"></div>' +
+                        '</div>' +
+                        '<div class="js-transfuse" data-transfuse-target="js-mega-nav-placeholder">Nav</div>'
+                ]
+            })
+        });
+
+        afterEach(function() {
+            fixtures.clean('navigation-fixture');
+        });
+
+        it("should initialise", function() {
+            expect(sut).toEqual(jasmine.any(Object));
+
+            spyOn(sut, "addMegaNavMenu");
+            spyOn(sut, "enableMegaNavToggle");
+            spyOn(sut, "replaceAllSectionsLink");
+
+            sut.init();
+
+            expect(sut.addMegaNavMenu).toHaveBeenCalled();
+            expect(sut.enableMegaNavToggle).toHaveBeenCalled();
+            expect(sut.replaceAllSectionsLink).toHaveBeenCalled();
+        });
+
+        it("should add mega nav menu", function() {
+            sut.addMegaNavMenu();
+
+            expect($('.js-mega-nav-placeholder').html()).toEqual('Nav');
+        });
+
+        it("should change all sections link", function() {
+            expect($('.js-navigation-header .js-navigation-toggle').attr("href")).toEqual("#footer-nav");
+
+            sut.replaceAllSectionsLink();
+
+            expect($('.js-navigation-header .js-navigation-toggle').attr("href")).toEqual("#nav-allsections");
+        });
+
+        it("should toggle navigation class", function() {
+            var className = $('.js-navigation-toggle').attr('data-target-nav');
+
+            expect($('.' + className).hasClass('navigation--collapsed')).toBeTruthy();
+
+            sut.enableMegaNavToggle();
+
+            bean.fire($('.js-navigation-toggle')[0], 'click');
+
+            expect($('.' + className).hasClass('navigation--expanded')).toBeTruthy();
+        });
+    });
+});
+


### PR DESCRIPTION
When using screenreader on mobile devices clicking on `all sections` button will focus on `back to top` button because link is set to `#footer-nav`. This is done for navigation without JS.

So the solution is to change it after we know that JS is used.

I also included unit tests for the navigation.
