### PR TITLE
Fix content meta refactor

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -248,7 +248,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
 
   lazy val sectionLabelLink : String = {
     if(this.isCommentIsFree) section else tags.find(_.isKeyword) match {
-      case Some(tag) => tag.webUrl
+      case Some(tag) => tag.id
       case _ => ""
     }
   }

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -4,16 +4,15 @@
 
 <div class="content__labels">
     <div class="content__section-label">
-        <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@content.section}">@Html(Localisation(content.sectionName.toLowerCase))</a>
+        <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@content.sectionLabelLink}">@Html(Localisation(content.sectionLabelName))</a>
     </div>
 
-    @if(content.isSeries) {
-        @content.series.headOption.map { series =>
-            <div class="content__series-label">
-                <a class="content__series-label__link" href="@LinkTo{/@series.id}">@series.name</a>
-            </div>
-        }
-    } else {
+
+    @content.seriesTag.map { series =>
+        <div class="content__series-label">
+            <a class="content__series-label__link" href="@LinkTo{/@series.id}">@series.name</a>
+        </div>
+    }.getOrElse{
         @if(content.isFromTheObserver ) {
             <div class="content__series-label">
                 <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>


### PR DESCRIPTION
Rerun of this reverted pull - uses tag id this time not webURL. ( Which broke the links ) 

Changes to lefthand meta - as requested by @cantlin 
(1) Display section tags in keywords() 
(2) In the meta top left the following logic is followed 
(red arrow) show first keyword apart from for Cif articles, in which case show 'comment is free' 
(blue arrow) show a series tag when there is one, if not show the first blog tag that **isnt** cif

Meta
![left-meta](https://cloud.githubusercontent.com/assets/986155/4814939/4074dc9c-5ed3-11e4-8bed-b2e30f9bf8d4.png)

Taglist
![tags](https://cloud.githubusercontent.com/assets/986155/4814946/53931668-5ed3-11e4-915c-2ca28da1d5d6.png)
