### PR TITLE
keyword list display section name instead of section ID

### DIFF
--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -11,7 +11,7 @@
            data-link-name="keyword: @keyword.id"
            itemprop="keywords">
                @keyword.name
-               @if(keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.section.capitalize) }
+               @if(keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.sectionName) }
         </a>
     </li>
 }


### PR DESCRIPTION
Before
![screen shot 2014-10-31 at 15 15 51](https://cloud.githubusercontent.com/assets/1764158/4862995/197a0e10-6111-11e4-8087-dfa0f9739e48.png)
After
![screen shot 2014-10-31 at 15 14 55](https://cloud.githubusercontent.com/assets/1764158/4862999/20bcac64-6111-11e4-8dd1-715f7b3d802c.png)
