### PR TITLE
Facia tool: decrease minimum width for replaced images

### DIFF
--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -475,7 +475,7 @@ define([
                 this.meta.imageSrcHeight,
                 {
                     maxWidth: 1000,
-                    minWidth: 500,
+                    minWidth: 400,
                     widthAspectRatio: 3,
                     heightAspectRatio: 5
                 }


### PR DESCRIPTION
Allows inCopy-originated article images to be used on fronts.
