### PR TITLE
Release Redundant Data from Memory on Admin Server

### DIFF
--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -18,6 +18,7 @@ object DfpDataHydrator {
 }
 
 class DfpDataHydrator extends Logging {
+
   private val dfpSession: Option[DfpSession] = try {
     for {
       clientId <- AdminConfiguration.dfpApi.clientId
@@ -42,7 +43,10 @@ class DfpDataHydrator extends Logging {
       None
   }
 
-  def loadCurrentLineItems(): Seq[GuLineItem] = dfpSession.fold(Seq[GuLineItem]()) { session =>
+  private val dfpServiceRegistry = dfpSession map (session => new DfpServiceRegistry(session))
+
+  def loadCurrentLineItems(): Seq[GuLineItem] =
+    dfpServiceRegistry.fold(Seq[GuLineItem]()) { serviceRegistry =>
 
     try {
 
@@ -52,7 +56,7 @@ class DfpDataHydrator extends Logging {
         .withBindVariableValue("readyStatus", ComputedStatus.READY.toString)
         .withBindVariableValue("deliveringStatus", ComputedStatus.DELIVERING.toString)
 
-      val dfpLineItems = DfpApiWrapper.fetchLineItems(session, currentLineItems)
+      val dfpLineItems = DfpApiWrapper.fetchLineItems(serviceRegistry, currentLineItems)
 
       val optSponsorFieldId = loadCustomFieldId("sponsor")
 
@@ -137,20 +141,21 @@ class DfpDataHydrator extends Logging {
     }
   }
 
-  def loadCustomFieldId(name: String): Option[Long] = dfpSession flatMap { session =>
+  def loadCustomFieldId(name: String): Option[Long] = dfpServiceRegistry flatMap {
+    serviceRegistry =>
     val statementBuilder = new StatementBuilder().where("name = :name").withBindVariableValue("name", name)
-    val field = DfpApiWrapper.fetchCustomFields(session, statementBuilder).headOption
+      val field = DfpApiWrapper.fetchCustomFields(serviceRegistry, statementBuilder).headOption
     field map (_.getId)
   }
 
-  def loadActiveDescendantAdUnits(rootName: String): Map[String, GuAdUnit] = dfpSession.fold(Map[String, GuAdUnit]()) {
-    session =>
+  def loadActiveDescendantAdUnits(rootName: String): Map[String, GuAdUnit] =
+    dfpServiceRegistry.fold(Map[String, GuAdUnit]()) { serviceRegistry =>
 
       val statementBuilder = new StatementBuilder()
         .where("status = :status")
         .withBindVariableValue("status", InventoryStatus._ACTIVE)
 
-      val dfpAdUnits = DfpApiWrapper.fetchAdUnits(session, statementBuilder)
+      val dfpAdUnits = DfpApiWrapper.fetchAdUnits(serviceRegistry, statementBuilder)
 
       val rootAndDescendantAdUnits = dfpAdUnits filter { adUnit =>
         Option(adUnit.getParentPath) exists { path =>
@@ -164,11 +169,11 @@ class DfpDataHydrator extends Logging {
       }.toMap
   }
 
-  def loadAdUnitsForApproval(rootName: String): Seq[GuAdUnit] = dfpSession.fold(Seq[GuAdUnit]()) {
-    session =>
+  def loadAdUnitsForApproval(rootName: String): Seq[GuAdUnit] =
+    dfpServiceRegistry.fold(Seq[GuAdUnit]()) { serviceRegistry =>
       val statementBuilder = new StatementBuilder()
 
-      val suggestedAdUnits = DfpApiWrapper.fetchSuggestedAdUnits(session, statementBuilder)
+      val suggestedAdUnits = DfpApiWrapper.fetchSuggestedAdUnits(serviceRegistry, statementBuilder)
 
       val allUnits = suggestedAdUnits.map { adUnit =>
         val fullpath: List[String] = adUnit.getParentPath.map(_.getName).toList ::: adUnit.getPath.toList
@@ -179,43 +184,48 @@ class DfpDataHydrator extends Logging {
       allUnits.filter(au => (au.path.last == "ng" || au.path.last == "r2") && au.path.size == 4).sortBy(_.id).distinct
   }
 
-  def approveTheseAdUnits(adUnits: Iterable[String]): Try[String] = dfpSession.map {
-    session =>
+  def approveTheseAdUnits(adUnits: Iterable[String]): Try[String] =
+    dfpServiceRegistry.map { serviceRegistry =>
       val adUnitsList: String = adUnits.mkString(",")
 
       val statementBuilder = new StatementBuilder()
         .where(s"id in ($adUnitsList)")
 
-      DfpApiWrapper.approveTheseAdUnits(session, statementBuilder)
+      DfpApiWrapper.approveTheseAdUnits(serviceRegistry, statementBuilder)
   }.getOrElse(Failure(new DfpSessionException()))
 
 
-  def loadAllCustomTargetKeys(): Map[Long, String] = dfpSession.fold(Map[Long, String]()) { session =>
-    DfpApiWrapper.fetchCustomTargetingKeys(session, new StatementBuilder()).map { k =>
+  def loadAllCustomTargetKeys(): Map[Long, String] =
+    dfpServiceRegistry.fold(Map[Long, String]()) { serviceRegistry =>
+      DfpApiWrapper.fetchCustomTargetingKeys(serviceRegistry, new StatementBuilder()).map { k =>
       k.getId.longValue() -> k.getName
     }.toMap
   }
 
-  def loadAllCustomTargetValues(): Map[Long, String] = dfpSession.fold(Map[Long, String]()) { session =>
-    DfpApiWrapper.fetchCustomTargetingValues(session, new StatementBuilder()).map { v =>
+  def loadAllCustomTargetValues(): Map[Long, String] =
+    dfpServiceRegistry.fold(Map[Long, String]()) { serviceRegistry =>
+      DfpApiWrapper.fetchCustomTargetingValues(serviceRegistry, new StatementBuilder()).map { v =>
       v.getId.longValue() -> v.getName
     }.toMap
   }
 
-  def loadAdUnitIdsByPlacement(): Map[Long, Seq[String]] = dfpSession.fold(Map[Long, Seq[String]]()) { session =>
-    DfpApiWrapper.fetchPlacements(session, new StatementBuilder()).map { placement =>
+  def loadAdUnitIdsByPlacement(): Map[Long, Seq[String]] =
+    dfpServiceRegistry.fold(Map[Long, Seq[String]]()) { serviceRegistry =>
+      DfpApiWrapper.fetchPlacements(serviceRegistry, new StatementBuilder()).map { placement =>
       placement.getId.toLong -> placement.getTargetedAdUnitIds.toSeq
     }.toMap
   }
 
-  def loadActiveUserDefinedCreativeTemplates(): Seq[GuCreativeTemplate] = dfpSession.fold(Seq.empty[GuCreativeTemplate]) { session =>
+  def loadActiveUserDefinedCreativeTemplates(): Seq[GuCreativeTemplate] =
+    dfpServiceRegistry.fold(Seq.empty[GuCreativeTemplate]) { serviceRegistry =>
     val templatesQuery = new StatementBuilder()
       .where("status = :active and type = :type")
       .withBindVariableValue("active", CreativeTemplateStatus.ACTIVE.getValue)
       .withBindVariableValue("type", CreativeTemplateType.USER_DEFINED.getValue)
       .orderBy("name ASC")
 
-    val dfpCreativeTemplates = DfpApiWrapper.fetchCreativeTemplates(session, templatesQuery) filterNot { template =>
+      val dfpCreativeTemplates = DfpApiWrapper.fetchCreativeTemplates(serviceRegistry,
+        templatesQuery) filterNot { template =>
       val name = template.getName.toUpperCase
       name.startsWith("APPS - ") || name.startsWith("AS ") || name.startsWith("QC ")
     }
@@ -227,7 +237,7 @@ class DfpDataHydrator extends Logging {
       .withBindVariableValue("width", "140")
       .withBindVariableValue("height", "90")
 
-    val creatives = DfpApiWrapper.fetchTemplateCreatives(session, creativesQuery)
+      val creatives = DfpApiWrapper.fetchTemplateCreatives(serviceRegistry, creativesQuery)
 
     dfpCreativeTemplates map { template =>
       val templateCreatives = creatives getOrElse(template.getId, Nil)

--- a/admin/app/dfp/DfpServiceRegistry.scala
+++ b/admin/app/dfp/DfpServiceRegistry.scala
@@ -1,0 +1,35 @@
+package dfp
+
+import com.google.api.ads.dfp.axis.factory.DfpServices
+import com.google.api.ads.dfp.axis.v201403._
+import com.google.api.ads.dfp.lib.client.DfpSession
+
+case class DfpServiceRegistry(session: DfpSession) {
+
+  private val dfpServices = new DfpServices()
+
+  lazy val lineItemService =
+    dfpServices.get(session, classOf[LineItemServiceInterface])
+
+  lazy val customFieldService =
+    dfpServices.get(session, classOf[CustomFieldServiceInterface])
+
+  lazy val customTargetingService =
+    dfpServices.get(session, classOf[CustomTargetingServiceInterface])
+
+  lazy val inventoryService =
+    dfpServices.get(session, classOf[InventoryServiceInterface])
+
+  lazy val suggestedAdUnitService =
+    dfpServices.get(session, classOf[SuggestedAdUnitServiceInterface])
+
+  lazy val placementService =
+    dfpServices.get(session, classOf[PlacementServiceInterface])
+
+  lazy val creativeTemplateService =
+    dfpServices.get(session, classOf[CreativeTemplateServiceInterface])
+
+  lazy val creativeService =
+    dfpServices.get(session, classOf[CreativeServiceInterface])
+
+}


### PR DESCRIPTION
This change avoids holding state in the `DfpApiWrapper` object, which may be causing redundant data not to be garbage collected.  Even if it isn't the cause of the problem, it's still good practice.
Now all the data gathered by the `DfpDataHydrator` should be garbage collected when it dies.
