### PR TITLE
Remove overflow-x:hidden from root elements. Fix: #6850

### DIFF
--- a/static/src/stylesheets/base/_base.scss
+++ b/static/src/stylesheets/base/_base.scss
@@ -14,13 +14,6 @@ body {
     background-color: #ffffff;
 }
 
-@if $old-ie == false {
-    html,
-    body {
-        overflow-x: hidden;
-    }
-}
-
 /**
  * Breakpoint definition for JS - see https://github.com/JoshBarr/on-media-query
  */

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -1,6 +1,5 @@
 .container {
     position: relative;
-    overflow: hidden;
 }
 .container--dark-background {
     background-color: $c-neutral1;


### PR DESCRIPTION
This fixes the relative sizing issues when users default font-size is set to anything higher than 16px.

Only negative impact is 3rd parties such as adverts can now overflow (which is why we prevented it in the first place), see #3970 for more info.

/cc @sndrs @mattosborn @uplne @ironsidevsquincy 
### before

![safari](https://cloud.githubusercontent.com/assets/80089/4880991/c020bde4-6342-11e4-8131-78d63da11557.png)
### after

![safari](https://cloud.githubusercontent.com/assets/80089/4880992/c364e3b8-6342-11e4-9a06-0bd4500f2930.png)
