### PR TITLE
Update article body ads spacefinder rules

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -1,5 +1,6 @@
 define([
     'lodash/functions/once',
+    'lodash/objects/cloneDeep',
     'common/utils/$',
     'common/utils/config',
     'common/utils/detect',
@@ -7,6 +8,7 @@ define([
     'common/modules/commercial/create-ad-slot'
 ], function (
     once,
+    cloneDeep,
     $,
     config,
     detect,
@@ -26,7 +28,7 @@ define([
         },
         init = function () {
 
-            var breakpoint, rules;
+            var breakpoint, rules, foBadgeRules;
 
             // is the switch off, or not an article, or a live blog
             if (!config.switches.standardAdverts || config.page.contentType !== 'Article' || config.page.isLiveBlog) {
@@ -39,14 +41,17 @@ define([
                 minBelow: 300,
                 selectors: {
                     ' > h2': {minAbove: breakpoint === 'mobile' ? 20 : 0, minBelow: 250},
-                    ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 250},
+                    ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 400},
                     ' .ad-slot': {minAbove: 500, minBelow: 500}
                 }
             };
 
             if (config.page.sponsorshipType === 'foundation-supported') {
                 adNames.unshift(['fobadge', ['im', 'paid-for-badge']]);
-                insertAdAtP(spacefinder.getParaWithSpace(rules));
+                // more lenient rules for foundation badge
+                foBadgeRules = cloneDeep(rules);
+                foBadgeRules.minAbove = 300;
+                insertAdAtP(spacefinder.getParaWithSpace(foBadgeRules));
             }
             if (config.page.hasInlineMerchandise) {
                 adNames.unshift(['im', 'im']);


### PR DESCRIPTION
More lenient for the foundation supported inline logo

Larger gap after non `p`/`h2` elements
