### PR TITLE
Modify Jobs Feed URL

### DIFF
--- a/commercial/app/model/commercial/jobs/JobsApi.scala
+++ b/commercial/app/model/commercial/jobs/JobsApi.scala
@@ -15,7 +15,13 @@ object JobsApi extends ExecutionContexts with Logging {
 
   // url changes daily so cannot be val
   def url = {
-    val feedDate = new LocalDateTime(DateTimeZone.UTC).toString("yyyy-MM-dd")
+
+    /*
+     * Using offset time because this appears to be how the URL is constructed.
+     * With UTC time we lose the feed for 2 hours at midnight every day.
+     */
+    val feedDate = new DateTime(DateTimeZone.forOffsetHours(-2)).toString("yyyy-MM-dd")
+
     val urlTemplate = CommercialConfiguration.getProperty("jobs.api.url.template")
     urlTemplate map (_ replace("yyyy-MM-dd", feedDate))
   }


### PR DESCRIPTION
Think we'll be going through this every six months until we get a URL that makes sense.
I'll try to find out why they have to give date-specific feeds.
