### PR TITLE
Include sublink-kicker when altering colour of slashes after kickers

### DIFF
--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -25,7 +25,8 @@
         color: $c-featureMute;
     }
 
-    .fc-item__kicker:after {
+    .fc-item__kicker:after,
+    .fc-sublink__kicker:after {
         color: fade-out($c-headline, .8);
     }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -25,7 +25,8 @@
         color: $c-liveMute;
     }
 
-    .fc-item__kicker:after {
+    .fc-item__kicker:after,
+    .fc-sublink__kicker:after {
         color: fade-out($c-headline, .8);
     }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -24,8 +24,9 @@
         color: $c-mediaDefault;
     }
 
-    .fc-item__kicker:after {
-        color: fade-out($c-headline, .8);
+    .fc-item__kicker:after,
+    .fc-sublink__kicker:after {
+        color: fade-out($c-headline, .6);
     }
 
     .fc-item__standfirst,

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -24,7 +24,8 @@
         color: $c-podcastDefault;
     }
 
-    .fc-item__kicker:after {
+    .fc-item__kicker:after,
+    .fc-sublink__kicker:after {
         color: fade-out($c-headline, .8);
     }
 

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -24,7 +24,8 @@
         color: $c-reviewAccent;
     }
 
-    .fc-item__kicker:after {
+    .fc-item__kicker:after,
+    .fc-sublink__kicker:after {
         color: fade-out($c-headline, .8);
     }
 


### PR DESCRIPTION
The new-ish `.fc-sublink__kicker` class was being omitted from styling in the tone files. This adds it.

Before:
![screen shot 2014-11-03 at 16 33 47](https://cloud.githubusercontent.com/assets/1607666/4885833/71d50110-6377-11e4-86b4-1edc92428912.png)

After:
![screen shot 2014-11-03 at 16 33 23](https://cloud.githubusercontent.com/assets/1607666/4885832/71cf6dc2-6377-11e4-8acc-652c02ef50e9.png)
