### PR TITLE
The nav Analytics feed now contains the Editionalised URL.

### DIFF
--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -8,23 +8,23 @@ import play.api.mvc.{Action, Controller}
 
 object NavigationController extends Controller {
 
-  private case class SectionLinkAndEdition(item: SectionLink, edition: Edition)
-  private case class NavItemAndEdition(item: NavItem, edition: Edition)
+  private case class SectionLinkAndEdition(link: SectionLink, edition: Edition)
+  private case class NavItemAndEdition(link: NavItem, edition: Edition)
 
   def nav() = Action{ implicit request =>
     Cached(500) {
 
       implicit val sectionLinkWrites = new Writes[SectionLinkAndEdition] {
         def writes(item: SectionLinkAndEdition) = obj(
-          "title" -> item.item.title,
-          "href" -> LinkTo(item.item.href, item.edition)
+          "title" -> item.link.title,
+          "href" -> LinkTo(item.link.href, item.edition)
         )
       }
 
       implicit val navItemWrites = new Writes[NavItemAndEdition] {
         def writes(item: NavItemAndEdition) = obj(
-          "section" -> SectionLinkAndEdition(item.item.name, item.edition),
-          "subSections" -> item.item.links.map(link => SectionLinkAndEdition(link, item.edition))
+          "section" -> SectionLinkAndEdition(item.link.name, item.edition),
+          "subSections" -> item.link.links.map(link => SectionLinkAndEdition(link, item.edition))
         )
       }
 

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{SectionLink, NavItem, Edition}
+import common.{LinkTo, SectionLink, NavItem, Edition}
 import model.Cached
 import play.api.libs.json.Json._
 import play.api.libs.json.Writes
@@ -8,21 +8,29 @@ import play.api.mvc.{Action, Controller}
 
 object NavigationController extends Controller {
 
-  private implicit val sectionLinkWrites = new Writes[SectionLink] {
-    def writes(item: SectionLink) = obj(
-      "title" -> item.title,
-      "href" -> item.href
-    )
-  }
+  private case class SectionLinkAndEdition(item: SectionLink, edition: Edition)
+  private case class NavItemAndEdition(item: NavItem, edition: Edition)
 
-  private implicit val navItemWrites = new Writes[NavItem] {
-    def writes(item: NavItem) = obj(
-      "section" -> item.name,
-      "subSections" -> item.links
-    )
-  }
+  def nav() = Action{ implicit request =>
+    Cached(500) {
 
-  def nav() = Action{ Cached(500)(
-      Ok(arr(Edition.all.map{ edition => obj(edition.id -> arr(edition.navigation))}))
-  )}
+      implicit val sectionLinkWrites = new Writes[SectionLinkAndEdition] {
+        def writes(item: SectionLinkAndEdition) = obj(
+          "title" -> item.item.title,
+          "href" -> LinkTo(item.item.href, item.edition)
+        )
+      }
+
+      implicit val navItemWrites = new Writes[NavItemAndEdition] {
+        def writes(item: NavItemAndEdition) = obj(
+          "section" -> SectionLinkAndEdition(item.item.name, item.edition),
+          "subSections" -> item.item.links.map(link => SectionLinkAndEdition(link, item.edition))
+        )
+      }
+
+      Ok(arr(Edition.all.map { edition =>
+        obj(edition.id -> arr(edition.navigation.map(item => NavItemAndEdition(item, edition))))
+      }))
+    }
+  }
 }


### PR DESCRIPTION
So /us/sport instead of /sport

BTW - The data science team uses this endpoint to match up Nav to user journeys. It is not publicly available on www.theguardian.com
