### PR TITLE
Fix Keyword Targeting of Containers

### DIFF
--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -6,9 +6,9 @@ import akka.agent.Agent
 import com.gu.facia.client.models.CollectionConfig
 import common._
 import conf.Configuration
-import conf.Configuration.commercial.{dfpAdUnitRoot, dfpAdvertisementFeatureTagsDataKey, dfpInlineMerchandisingTagsDataKey, dfpPageSkinnedAdUnitsKey, dfpSponsoredTagsDataKey}
-import model.Tag
 import conf.Configuration.commercial._
+import model.Tag
+import model.`package`.frontKeywordIds
 import play.api.{Application, GlobalSettings}
 import services.S3
 
@@ -24,11 +24,15 @@ trait DfpAgent {
   protected def inlineMerchandisingTargetedTags: InlineMerchandisingTagSet
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship]
 
-  private def containerSponsoredTag(config: CollectionConfig, p: String => Boolean): Option[String] = {
+  private def containerSponsoredTag(config: CollectionConfig,
+                                    p: String => Boolean): Option[String] = {
+    val stopWords = Set("newest", "order-by", "published", "search", "tag", "use-date")
+
     config.apiQuery.flatMap { encodedQuery =>
       val query = URLDecoder.decode(encodedQuery, "utf-8")
-      val tokens = query.split( """\?|&|=|\(|\)|\||\,""").map(_.replaceFirst(".*/", ""))
-      tokens find p
+      val tokens = query.split( """\?|&|=|\(|\)|\||\,""")
+      val possibleKeywords = tokens filterNot stopWords.contains flatMap frontKeywordIds
+      possibleKeywords find p
     }
   }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -922,17 +922,22 @@ object GetClasses {
     case _  => Nil
   }
 
-  private def commonContainerStyles(config: CollectionConfig, isFirst: Boolean, hasTitle: Boolean): Seq[String] = {
+  private def commonContainerStyles(config: CollectionConfig,
+                                    isFirst: Boolean,
+                                    hasTitle: Boolean): Seq[String] = {
+    val isSponsored = DfpAgent.isSponsored(config)
+    val isAdvertisementFeature = DfpAgent.isAdvertisementFeature(config)
+    val isFoundationSupported = DfpAgent.isFoundationSupported(config)
+    val isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
+
     Seq(
       ("container", true),
       ("container--first", isFirst),
-      ("container--sponsored", DfpAgent.isSponsored(config)),
-      ("container--advertisement-feature", DfpAgent.isAdvertisementFeature(config)),
-      ("container--foundation-supported", DfpAgent.isFoundationSupported(config)),
-      ("js-sponsored-container", (
-        (DfpAgent.isSponsored(config) || DfpAgent.isAdvertisementFeature(config) || DfpAgent.isFoundationSupported(config))
-      )),
-      ("js-container--toggle", (!isFirst && hasTitle && !(DfpAgent.isAdvertisementFeature(config) || DfpAgent.isSponsored(config))))
+      ("container--sponsored", isSponsored),
+      ("container--advertisement-feature", isAdvertisementFeature),
+      ("container--foundation-supported", isFoundationSupported),
+      ("js-sponsored-container", isPaidFor),
+      ("js-container--toggle", !isFirst && hasTitle && !isPaidFor)
     ) collect {
       case (kls, true) => kls
     }

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -51,7 +51,8 @@ class DfpAgentTest extends FlatSpec with Matchers {
       Sponsorship(Seq("ad-feature"), sections = Nil, Some("spon2"), Nil, 4),
       Sponsorship(Seq("film"), sections = Nil, None, Nil, 5),
       Sponsorship(Seq("grundfos-partner-zone", "sustainable-business-grundfos-partner-zone"),
-        sections = Seq("sustainable-business"), None, Nil, 8)
+        sections = Seq("sustainable-business"), None, Nil, 8),
+      Sponsorship(Seq("media-network-adobe-partner-zone"), sections = Nil, None, Nil, 9)
     )
 
     override protected def foundationSupported: Seq[Sponsorship] = Seq(
@@ -144,6 +145,15 @@ class DfpAgentTest extends FlatSpec with Matchers {
       "books/film?edition=au",
       "film"
     )
+
+    forEvery(apiQueries) { q =>
+      testDfpAgent.isAdvertisementFeature(apiQuery(q)) should be(true)
+    }
+  }
+
+  it should "be true for a partner zone container" in {
+
+    val apiQueries = Seq("media-network/adobe-partner-zone")
 
     forEvery(apiQueries) { q =>
       testDfpAgent.isAdvertisementFeature(apiQuery(q)) should be(true)


### PR DESCRIPTION
Sponsors' logos weren't showing in some cases.  This should fix that by applying same logic to containers as used by facia pages and section fronts.
