### PR TITLE
fix 3/4 size items on ff26, saf 6 etc

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_l-list.scss
+++ b/static/src/stylesheets/module/facia-cards/_l-list.scss
@@ -25,7 +25,7 @@
                     width: (100% / $column) * $span;
                     float: left;
 
-                    .has-flex-wrap & {
+                    .has-flex & {
                         @include flex($span);
                     }
                 }


### PR DESCRIPTION
mainly for journalists:

was
![screen shot 2014-11-04 at 12 53 42](https://cloud.githubusercontent.com/assets/867233/4900004/11df1dc6-6422-11e4-8bd8-f7a18405d0f5.png)

is now
![screen shot 2014-11-04 at 12 53 52](https://cloud.githubusercontent.com/assets/867233/4900006/19015c22-6422-11e4-8ec4-bfc2342060a1.png)

screenshots: http://www.browserstack.com/screenshots/5bda442aac387f699d2677c482cc0ddbd6efa1d5
