### PR TITLE
Log registrations from tor

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -335,6 +335,10 @@ object Switches extends Collections {
     safeState = On, sellByDate = never)
   // A/B Tests
 
+  val IdentityLogRegistrationsFromTor = Switch("Feature", "id-log-tor-registrations",
+    "If switched on, any user registrations from a known tor esit node will be logged",
+    safeState = On, sellByDate = never)
+
   val ABHighCommercialComponent = Switch("A/B Tests", "ab-high-commercial-component",
     "Switch for the High Commercial Component A/B test.",
     safeState = Off, sellByDate = never
@@ -439,6 +443,7 @@ object Switches extends Collections {
     FaciaToolDraftContent,
     GuShiftCookieSwitch,
     IdentityBlockSpamEmails,
+    IdentityLogRegistrationsFromTor,
     ABHighCommercialComponent,
     EnhancedMediaPlayerSwitch,
     BreakingNewsSwitch,

--- a/identity/app/conf/context.scala
+++ b/identity/app/conf/context.scala
@@ -15,14 +15,14 @@ class IdentityJobsPlugin(app: Application) extends Plugin with ExecutionContexts
          BlockedEmailDomainList.run()
       }
 
-      Jobs.schedule("TorExitNodeRefeshJob","0 0/30  * * * ?" ) {
+      Jobs.schedule("TorExitNodeRefeshJob","0 0/30 * * * ?" ) {
          TorExitNodeList.run()
       }
   }
 
   def descheduleJobs() {
     Jobs.deschedule("BlockedEmailsRefreshJobs")
-    Jobs.deschedule("TorExitNodeRefeshJob");
+    Jobs.deschedule("TorExitNodeRefeshJob")
   }
 
   override def onStart() {

--- a/identity/app/conf/context.scala
+++ b/identity/app/conf/context.scala
@@ -2,22 +2,27 @@ package conf
 
 import common.{AkkaAsync, Jobs, ExecutionContexts}
 import play.api.{Plugin, Application}
-import jobs.BlockedEmailDomainList
+import jobs.{TorExitNodeList, BlockedEmailDomainList}
 import scala.concurrent.duration._
 
 /**
  * Created by nbennett on 21/10/14.
  */
-class BlockedEmailDomainsPlugin(app: Application) extends Plugin with ExecutionContexts {
+class IdentityJobsPlugin(app: Application) extends Plugin with ExecutionContexts {
 
   def scheduleJobs() {
       Jobs.schedule("BlockedEmailsRefreshJobs", "0 0/30 * * * ?") {
          BlockedEmailDomainList.run()
       }
+
+      Jobs.schedule("TorExitNodeRefeshJob","0 0/30  * * * ?" ) {
+         TorExitNodeList.run()
+      }
   }
 
   def descheduleJobs() {
     Jobs.deschedule("BlockedEmailsRefreshJobs")
+    Jobs.deschedule("TorExitNodeRefeshJob");
   }
 
   override def onStart() {
@@ -26,6 +31,7 @@ class BlockedEmailDomainsPlugin(app: Application) extends Plugin with ExecutionC
 
     AkkaAsync.after(5.seconds) {
       BlockedEmailDomainList.run()
+      TorExitNodeList.run()
     }
   }
 

--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -19,7 +19,7 @@ import form.Mappings
 class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
                                      userCreationService : UserCreationService,
                                      api: IdApiClient,
-                                     idRequestParser : IdRequestParser,
+                                     idRequestParser : TorNodeLoggingIdRequestParser,
                                      idUrlBuilder : IdentityUrlBuilder,
                                      signinService : PlaySigninService  )
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms {
@@ -57,8 +57,8 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
   }
 
   def processForm = Action.async { implicit request =>
-    val idRequest = idRequestParser(request)
     val boundForm = registrationForm.bindFromRequest
+    val idRequest = idRequestParser(request, boundForm.data.getOrElse(emailKey,"unable to extract email from form data" ))
     val trackingData = idRequest.trackingData
     val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
     var skipConfirmation = idRequest.skipConfirmation

--- a/identity/app/jobs/TorExitNodeList.scala
+++ b/identity/app/jobs/TorExitNodeList.scala
@@ -1,0 +1,28 @@
+package jobs
+
+import common.{Logging, ExecutionContexts, AkkaAgent}
+import scala.collection.JavaConversions._
+import java.net.{URL, InetAddress}
+import scala.io.Source
+
+object TorExitNodeList extends ExecutionContexts with Logging {
+
+  private val torExitNodeAgent = AkkaAgent[Set[String]](Set.empty)
+  private final val torNodeListUrl = "https://check.torproject.org/cgi-bin/TorBulkExitList.py"
+
+  def run() {
+      log.info("Updating tor list for current list for %s".format("profile.theguardian.com") )
+      val addresses = InetAddress.getAllByName("profile.theguardian.com")
+
+      val nodes = addresses map { address =>
+         val ip = address.getHostAddress
+         val url = s"$torNodeListUrl?ip=$ip&port=80"
+         Source.fromURL(url).getLines.toList.filterNot{ line => line.startsWith("#") }
+      }
+
+      val allNodes = nodes.toList.flatMap{ x => x }.toSet
+      torExitNodeAgent.send(allNodes)
+  }
+
+  def getTorExitNodes = torExitNodeAgent.get()
+}

--- a/identity/app/jobs/TorExitNodeList.scala
+++ b/identity/app/jobs/TorExitNodeList.scala
@@ -8,7 +8,7 @@ import scala.io.Source
 object TorExitNodeList extends ExecutionContexts with Logging {
 
   private val torExitNodeAgent = AkkaAgent[Set[String]](Set.empty)
-  private final val torNodeListUrl = "https://check.torproject.org/cgi-bin/TorBulkExitList.py"
+  private val torNodeListUrl = "https://check.torproject.org/cgi-bin/TorBulkExitList.py"
 
   def run() {
       log.info("Updating tor list for current list for %s".format("profile.theguardian.com") )

--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -5,6 +5,7 @@ import play.api.mvc.RequestHeader
 import com.google.inject.{Inject, Singleton}
 import utils.RemoteAddress
 import jobs.TorExitNodeList
+import conf.Switches
 
 @Singleton
 class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends RemoteAddress {
@@ -32,13 +33,11 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
 class TorNodeLoggingIdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends IdRequestParser(returnUrlVerifier)  {
   private val emailKey = "user.primaryEmailAddress"
 
-  //I don't really like having to pass the email as a param here,
-  // but Dave infosec is adamant about needing it into the logs and I can't find a way of getting hold of the form data vi the RequestHeader Object
   def apply(request: RequestHeader, email: String) : IdentityRequest = {
 
     clientIp(request) match {
       case Some(ip) => {
-        if (request.method == "POST" && TorExitNodeList.getTorExitNodes.contains(ip)) {
+        if (Switches.IdentityLogRegistrationsFromTor.isSwitchedOn && TorExitNodeList.getTorExitNodes.contains(ip)) {
           log.info(s"Attempted registration from know tor exit node: $ip email: $email")
         }
       }

--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -31,7 +31,6 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
 
 @Singleton
 class TorNodeLoggingIdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends IdRequestParser(returnUrlVerifier)  {
-  private val emailKey = "user.primaryEmailAddress"
 
   def apply(request: RequestHeader, email: String) : IdentityRequest = {
 

--- a/identity/conf/play.plugins
+++ b/identity/conf/play.plugins
@@ -1,3 +1,3 @@
 100:conf.SwitchBoardPlugin
-200:conf.BlockedEmailDomainsPlugin
+200:conf.IdentityJobsPlugin
 

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -22,7 +22,7 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
 
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val api = mock[IdApiClient]
-  val requestParser = mock[IdRequestParser]
+  val requestParser = mock[TorNodeLoggingIdRequestParser]
   val urlBuilder = mock[IdentityUrlBuilder]
   val userCreationService = mock[UserCreationService]
   val createdUser = mock[User]

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -37,6 +37,7 @@ class RegistrationControllerTest extends path.FreeSpec with ShouldMatchers with 
   when(userCreationService.createUser(Matchers.any[String], Matchers.any[String], Matchers.any[String], Matchers.any[String], Matchers.any[String], Matchers.any[Boolean], Matchers.any[Boolean], Matchers.any[Option[String]]))
     .thenReturn(user)
   when(requestParser.apply(Matchers.anyObject())).thenReturn(identityRequest)
+  when(requestParser.apply(Matchers.anyObject(), Matchers.anyString())).thenReturn(identityRequest)
   when(trackingData.ipAddress).thenReturn(Some("123.456.789.12"))
 
   val registrationController = new RegistrationController(returnUrlVerifier, userCreationService, api, requestParser, urlBuilder, signinService)


### PR DESCRIPTION
This logs any attempt to register at www.theguardian.com via tor - as requested by infosec
(1) An agent maintains a set of possible tor exitnodes for profile.theguardian.com
(2) Implements a switch to control whether registrations should be logged.
(3) If the switch is turned on then any registration attempt will check whether their ip is a tor exit node and if so log their email address,

@gklopper - I've demo'd this to Dave B and Vishal.  
