### PR TITLE
Report slow karma tests

### DIFF
--- a/grunt-configs/karma.js
+++ b/grunt-configs/karma.js
@@ -5,7 +5,8 @@ module.exports = function(grunt, options) {
             singleRun: options.singleRun,
             browserDisconnectTimeout: 10000,
             browserDisconnectTolerance: 3,
-            browserNoActivityTimeout: 15000
+            browserNoActivityTimeout: 15000,
+            reportSlowerThan: 1000
         },
         common: {
             configFile: options.testConfDir + 'common.js'


### PR DESCRIPTION
This shows slow tests when we run `grunt test`.

![screen shot 2014-11-04 at 14 14 43](https://cloud.githubusercontent.com/assets/4549425/4900892/dd21e96e-642c-11e4-89ce-1fc7c4a20739.png)
