### PR TITLE
Better logging of ToolPressQueueWorker latency

### DIFF
--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -45,6 +45,8 @@ object FrontPressCron extends JsonQueueWorker[SNSNotification] {
             AllFrontsPressLatencyMetric.recordDuration(stopWatch.elapsed)
           }
 
+          log.info(s"Succesfully pressed $path in ${stopWatch.elapsed} ms")
+
           FrontPressCronSuccess.increment()
         case Failure(error) =>
           log.warn("Error updating collection via cron", error)

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -60,7 +60,7 @@ object ToolPressQueueWorker extends JsonQueueWorker[PressJob] with Logging {
           }
         }
 
-        log.info(s"Successfully pressed $path on $pressType after ${millisToPress}ms")
+        log.info(s"Successfully pressed $path on $pressType after $millisToPress ms")
 
       case Failure(error) =>
         pressType match {


### PR DESCRIPTION
Adds a space so that we can parse this out in `aws` `logs`.
