### PR TITLE
Use updated guss-typography

### DIFF
--- a/static/src/stylesheets/bower.json
+++ b/static/src/stylesheets/bower.json
@@ -9,7 +9,7 @@
     "guss-grid-system": "~1.2.1",
     "guss-layout": "~1.3.3",
     "guss-rem": "~1.2.0",
-    "guss-typography": "~3.0.0",
+    "guss-typography": "~3.1.0",
     "guss-webfonts": "~3.0.0"
   }
 }

--- a/static/src/stylesheets/components/guss-typography/.bower.json
+++ b/static/src/stylesheets/components/guss-typography/.bower.json
@@ -7,14 +7,14 @@
     "_typography.scss"
   ],
   "homepage": "https://github.com/guardian/guss-typography",
-  "version": "3.0.0",
-  "_release": "3.0.0",
+  "version": "3.1.0",
+  "_release": "3.1.0",
   "_resolution": {
     "type": "version",
-    "tag": "v3.0.0",
-    "commit": "46b89944d8ff8f06c3ba5baf834f34f0b84da058"
+    "tag": "3.1.0",
+    "commit": "e1ca23603193bb6a0c463cf8908fa440c0305a8e"
   },
   "_source": "git://github.com/guardian/guss-typography.git",
-  "_target": "~3.0.0",
+  "_target": "~3.1.0",
   "_originalSource": "guss-typography"
 }


### PR DESCRIPTION
Change from #6923 was made in [3.1.0 of guss-typography](https://github.com/guardian/guss-typography/commit/e1ca23603193bb6a0c463cf8908fa440c0305a8e) but I forgot to update fronted to use it.
