### PR TITLE
Prevent duplicate comment counts

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -62,8 +62,8 @@ define([
                 $node.removeClass('u-h');
 
                 if ($node.attr('data-discussion-inline-upgrade') === 'true') {
-                    $('.js-item__comment-count', node).append(formatters.integerCommas(c.count));
-                    $('.js-item__comment-or-comments', node).append(commentOrComments);
+                    $('.js-item__comment-count', node).html(formatters.integerCommas(c.count));
+                    $('.js-item__comment-or-comments', node).html(commentOrComments);
                     $('.js-item__inline-comment-template', node).show('inline');
                 } else {
                     // put in trail__meta, if exists


### PR DESCRIPTION
Prevents this madness on article:

![screen shot 2014-11-04 at 20 55 53](https://cloud.githubusercontent.com/assets/1001642/4907870/1c0912b4-6465-11e4-9a48-8e0d2cc1e571.png)
