### PR TITLE
fix infosec domain test

### DIFF
--- a/identity/app/jobs/BlockedEmailDomainList.scala
+++ b/identity/app/jobs/BlockedEmailDomainList.scala
@@ -5,14 +5,14 @@ import services.S3Infosec
 
 object BlockedEmailDomainList extends ExecutionContexts with Logging {
 
-  private val blockedDomainAgent = AkkaAgent[List[String]](List.empty)
+  private val blockedDomainAgent = AkkaAgent[Set[String]](Set.empty)
 
   def run () {
     log.info("Updating email blocked domains list")
 
     val domains = S3Infosec.getBlockedEmailDomains map {
-      blockedDomains => blockedDomains.split("\n").toList
-    } getOrElse List()
+      blockedDomains => blockedDomains.split("\n").toSet
+    } getOrElse Set()
     blockedDomainAgent.send(domains)
   }
 


### PR DESCRIPTION
I made a schoolboy error here: https://github.com/guardian/frontend/pull/6730
Which means nasty people can still register on theguardian.com
This fixes this
