### PR TITLE
When hiding MPUs, don't use hide-on-mobile class

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -67,9 +67,9 @@ define([
                 .forEach(function ($adSlice, index) {
                     var adName        = adNames[index],
                         $mobileAdSlot = bonzo(createAdSlot(adName, 'container-inline'))
-                            .addClass('mobile-only'),
+                            .addClass('ad-slot--mobile'),
                         $tabletAdSlot = bonzo(createAdSlot(adName, 'container-inline'))
-                            .addClass('hide-on-mobile');
+                            .addClass('ad-slot--not-mobile');
 
                     // add a tablet+ ad to the slice
                     $adSlice

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -13,6 +13,17 @@
 .ad-slot--dark {
     background-color: lighten($c-mediaBackground, 2.5%);
 }
+.ad-slot--mobile {
+    @include mq(tablet) {
+        display: none;
+    }
+}
+.ad-slot--not-mobile {
+     @include mq($until: tablet) {
+         display: none;
+     }
+ }
+
 .ad-slot__label {
     height: $mpu-ad-label-height;
     background-color: $c-neutral8;

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -134,9 +134,9 @@ define([
                 function (sliceAdverts) {
                     sliceAdverts.init();
 
-                    expect($('.container-first .ad-slot', $fixtureContainer).hasClass('hide-on-mobile'))
+                    expect($('.container-first .ad-slot', $fixtureContainer).hasClass('ad-slot--not-mobile'))
                         .toBe(true);
-                    expect($('.container-first + .ad-slot', $fixtureContainer).hasClass('mobile-only'))
+                    expect($('.container-first + .ad-slot', $fixtureContainer).hasClass('ad-slot--mobile'))
                         .toBe(true);
                 }
             );


### PR DESCRIPTION
Not a particularly useful class as it includes

```
@include mq(tablet) {
    display: block !important;
}
```

i.e. with `!important`, so they can't be hidden in the future (which DFP does to ad slots if no ad is served)
