### PR TITLE
Target Pageskins by Edition Instead of by Country

### DIFF
--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -2,18 +2,40 @@
 @import tools.DfpLink
 @import tools.SiteLink
 
+@listItem(sponsorship: dfp.PageSkinSponsorship) = {
+  <li style="margin:20px">@sponsorship.lineItemName
+    (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
+    @if(sponsorship.editions.isEmpty) {
+      <br /><span style="color:red">No edition</span>
+    } else {
+      <br /><small>Editions:</small> @sponsorship.editions.map(_.id).mkString(" ")
+    }
+    @if(sponsorship.countries.isEmpty) {
+      <br /><span style="color : red">No country</span>
+    } else {
+      <br /><small>Countries:</small> @sponsorship.countries.mkString(" ")
+    }
+    <br /><small>Ad Units:</small>
+    <ul>
+      @if(sponsorship.adUnits.isEmpty) {<li>Run of network</li>}
+      @for(adUnit <- sponsorship.adUnits) {
+        <li>@SiteLink.adUnit(adUnit).map { link => <a href="@link">@adUnit</a>}.getOrElse {@adUnit}</li>
+      }
+    </ul>
+  </li>
+}
+
 @admin_main("Commercial", env, isAuthed = true, hasCharts = true) {
 
     <link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/commercial.css")">
 
     <h1>Pageskins</h1>
-    <p>Pages will squish to accommodate pageskins according to these criteria:
+    <p>Pages will squish to accommodate pageskins according to these criteria:</p>
     <ol>
         <li>The Ad Unit must be a <em>front</em></li>
         <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
         <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>
     </ol>
-    </p>
     <p>Some of these are not targetting fronts. They are just here so you can work it out.</p>
 
     <h2>Pageskinned Ad Units</h2>
@@ -21,51 +43,20 @@
 
     <h3>Deliverable to NGW</h3>
     <ol>
-    @for(sponsorship <- pageSkinnedAdUnits.deliverableSponsorships) {
-        <li style="margin: 20px">@sponsorship.lineItemName (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
-            @if(sponsorship.countries.nonEmpty){<br />Editions: @for(country <- sponsorship.countries){@{country.editionId}<span style="font-size:75%">&nbsp;&nbsp;&nbsp;[deduced from country: @{country.name}]</span>}}
-        <br />Ad Units:
-        <ul>
-        @for(adUnit <- sponsorship.adUnits) {
-            <li>@SiteLink.adUnit(adUnit).map{link => <a href="@link">@adUnit</a>}.getOrElse{@adUnit}</li>
-        }
-        </ul>
-        </li>
-    }
+    @for(sponsorship <- pageSkinnedAdUnits.deliverableSponsorships) {@listItem(sponsorship)}
     </ol>
 
     <h3>Behind Test Cookie</h3>
     @if(pageSkinnedAdUnits.testSponsorships.isEmpty) {
-        <p>None</p>
+      <p>None</p>
     } else {
-        <ol>
-        @for(sponsorship <- pageSkinnedAdUnits.testSponsorships) {
-            <li style="margin : 20px">@sponsorship.lineItemName (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
-                @if(sponsorship.countries.nonEmpty){<br />Editions: @for(country <- sponsorship.countries) {@{country.editionId} <span style="font-size : 75 %">&nbsp;&nbsp;&nbsp;[deduced from country: @{country.name}]</span>}}
-            <br />Ad Units:
-            <ul>
-            @for(adUnit <- sponsorship.adUnits) {
-                <li>@SiteLink.adUnit(adUnit).map { link => <a href="@link">@adUnit</a>}.getOrElse {@adUnit}</li>
-            }
-            </ul>
-            </li>
-        }
-        </ol>
+      <ol>
+      @for(sponsorship <- pageSkinnedAdUnits.testSponsorships) {@listItem(sponsorship)}
+      </ol>
     }
 
     <h3>R2 Only</h3>
     <ol>
-    @for(sponsorship <- pageSkinnedAdUnits.legacySponsorships) {
-        <li style="margin: 20px">@sponsorship.lineItemName (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
-            @if(sponsorship.countries.nonEmpty){<br />Editions: @for(country <- sponsorship.countries){@{country.editionId}<span style="font-size:75%">&nbsp;&nbsp;&nbsp;[deduced from country: @{country.name}]</span>}}
-            <br />Ad Units:
-            <ul>
-                @if(sponsorship.adUnits.isEmpty) {
-                } else {
-                    @for(adUnit <- sponsorship.adUnits) {<li>@adUnit</li>}
-                }
-            </ul>
-        </li>
-    }
+    @for(sponsorship <- pageSkinnedAdUnits.legacySponsorships) {@listItem(sponsorship)}
     </ol>
 }

--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -25,7 +25,7 @@
   </li>
 }
 
-@admin_main("Commercial", env, isAuthed = true, hasCharts = true) {
+@admin_main("Pageskins", env, isAuthed = true) {
 
     <link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/commercial.css")">
 

--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -33,6 +33,7 @@
     <p>Pages will squish to accommodate pageskins according to these criteria:</p>
     <ol>
         <li>The Ad Unit must be a <em>front</em></li>
+        <li>The Line Item must target an <em>edition</em> in its customised criteria</li>
         <li>The Line Item must have a Roadblocking type of <em>Creative Set</em></li>
         <li>The Line Item Placeholder should target the <em>Out of Page (1x1 pixel)</em> slot.</li>
     </ol>

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -1,8 +1,8 @@
 package common
 
-import play.api.mvc.RequestHeader
 import org.joda.time.DateTimeZone
-import model.MetaData
+import play.api.libs.json._
+import play.api.mvc.RequestHeader
 
 // describes the ways in which editions differ from each other
 abstract class Edition(
@@ -64,6 +64,14 @@ object Edition {
   def others(id: String): Seq[Edition] = byId(id).map(others(_)).getOrElse(Nil)
 
   def byId(id: String) = all.find(_.id.equalsIgnoreCase(id))
+
+  implicit val editionWrites: Writes[Edition] = new Writes[Edition] {
+    def writes(edition: Edition): JsValue = Json.obj("id" -> edition.id)
+  }
+
+  implicit val editionReads: Reads[Edition] = {
+    (__ \ "id").read[String] map (Edition.byId(_).getOrElse(defaultEdition))
+  }
 }
 
 object Editionalise {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -247,7 +247,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val dfpAdvertisementFeatureTagsDataKey = s"$dfpRoot/advertisement-feature-tags-v5.json"
     lazy val dfpFoundationSupportedTagsDataKey = s"$dfpRoot/foundation-supported-tags-v5.json"
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
-    lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v5.json"
+    lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v6.json"
     lazy val dfpLineItemsKey = s"$dfpRoot/lineitems.json"
 
     lazy val travelOffersS3Key = s"${environment.stage.toUpperCase}/commercial/cache/traveloffers.xml"

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -96,13 +96,14 @@ trait DfpAgent {
   def hasInlineMerchandise(tags: Seq[Tag]): Boolean = tags exists inlineMerchandisingTargetedTags.hasTag
 
   def isPageSkinned(adUnitWithoutRoot: String, edition: Edition): Boolean = {
+
     if (PageSkin.isValidForNextGenPageSkin(adUnitWithoutRoot)) {
       val adUnitWithRoot: String = s"$dfpAdUnitRoot/$adUnitWithoutRoot"
 
       def targetsAdUnitAndMatchesTheEdition(sponsorship: PageSkinSponsorship) = {
         val adUnits = sponsorship.adUnits map (_.stripSuffix("/ng"))
         adUnits.contains(adUnitWithRoot) &&
-          (sponsorship.countries.isEmpty || sponsorship.countries.exists(_.editionId == edition.id)) &&
+          (sponsorship.editions.isEmpty || sponsorship.editions.contains(edition)) &&
           !sponsorship.isR2Only
       }
 

--- a/common/app/dfp/DfpAgent.scala
+++ b/common/app/dfp/DfpAgent.scala
@@ -103,7 +103,7 @@ trait DfpAgent {
       def targetsAdUnitAndMatchesTheEdition(sponsorship: PageSkinSponsorship) = {
         val adUnits = sponsorship.adUnits map (_.stripSuffix("/ng"))
         adUnits.contains(adUnitWithRoot) &&
-          (sponsorship.editions.isEmpty || sponsorship.editions.contains(edition)) &&
+          sponsorship.editions.contains(edition) &&
           !sponsorship.isR2Only
       }
 

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -29,6 +29,7 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
   val isKeywordTag = isPositive("k")
   val isSeriesTag = isPositive("se")
   val isContributorTag = isPositive("co")
+  val isEditionTag = isPositive("edition")
 
   val targetsR2Only: Boolean = isPlatform("r2") || isNotPlatform("ng")
 }

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -120,7 +120,10 @@ object GuAdUnit {
 }
 
 
-case class GuTargeting(adUnits: Seq[GuAdUnit], geoTargetsIncluded: Seq[GeoTarget], geoTargetsExcluded: Seq[GeoTarget], customTargetSets: Seq[CustomTargetSet]) {
+case class GuTargeting(adUnits: Seq[GuAdUnit],
+                       geoTargetsIncluded: Seq[GeoTarget],
+                       geoTargetsExcluded: Seq[GeoTarget],
+                       customTargetSets: Seq[CustomTargetSet]) {
 
   def hasAdTestTargetting = customTargetSets.exists(_.targetsAdTest)
 

--- a/common/app/dfp/PageSkinSponsorship.scala
+++ b/common/app/dfp/PageSkinSponsorship.scala
@@ -1,43 +1,15 @@
 package dfp
 
-import common.{Edition, Logging, editions}
+import common.{Edition, Logging}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-
-
-case class Country(name: String, editionId: String)
-
-object Country {
-
-  implicit val countryWrites = new Writes[Country] {
-    def writes(country: Country): JsValue = {
-      Json.obj(
-        "name" -> country.name,
-        "editionId" -> country.editionId
-      )
-    }
-  }
-
-  implicit val countryReads: Reads[Country] = (
-    (JsPath \ "name").read[String] and
-      (JsPath \ "editionId").read[String]
-    )(Country.apply _)
-
-  def fromName(name: String) = {
-    val edition = name match {
-      case "United States" => editions.Us
-      case "Australia" => editions.Au
-      case _ => Edition.defaultEdition
-    }
-    Country(name, edition.id)
-  }
-}
 
 
 case class PageSkinSponsorship(lineItemName: String,
                                lineItemId: Long,
                                adUnits: Seq[String],
-                               countries: Seq[Country],
+                               editions: Seq[Edition],
+                               countries: Seq[String],
                                isR2Only: Boolean,
                                targetsAdTest: Boolean)
 
@@ -49,6 +21,7 @@ object PageSkinSponsorship {
         "lineItem" -> sponsorship.lineItemName,
         "lineItemId" -> sponsorship.lineItemId,
         "adUnits" -> sponsorship.adUnits,
+        "editions" -> sponsorship.editions,
         "countries" -> sponsorship.countries,
         "isR2Only" -> sponsorship.isR2Only,
         "isAdTest" -> sponsorship.targetsAdTest
@@ -60,7 +33,8 @@ object PageSkinSponsorship {
     (JsPath \ "lineItem").read[String] and
       (JsPath \ "lineItemId").read[Long] and
       (JsPath \ "adUnits").read[Seq[String]] and
-      (JsPath \ "countries").read[Seq[Country]] and
+      (JsPath \ "editions").read[Seq[Edition]] and
+      (JsPath \ "countries").read[Seq[String]] and
       (JsPath \ "isR2Only").read[Boolean] and
       (JsPath \ "isAdTest").read[Boolean]
     )(PageSkinSponsorship.apply _)

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -1,13 +1,13 @@
 package dfp
 
+import com.gu.contentapi.client.model.{Tag => ApiTag}
 import com.gu.facia.client.models.CollectionConfig
-import common.editions.Uk
-import common.{Edition, editions}
+import common.Edition.defaultEdition
+import common.editions.{Au, Uk, Us}
 import conf.Configuration.commercial.dfpAdUnitRoot
 import model.Tag
 import org.scalatest.Inspectors._
 import org.scalatest.{FlatSpec, Matchers}
-import com.gu.contentapi.client.model.{ Tag => ApiTag }
 
 
 class DfpAgentTest extends FlatSpec with Matchers {
@@ -374,32 +374,33 @@ class DfpAgentTest extends FlatSpec with Matchers {
   }
 
   "isPageSkinned" should "be true for a front with a pageskin in given edition" in {
-    testDfpAgent.isPageSkinned("business/front", Edition.defaultEdition) should be(true)
+    testDfpAgent.isPageSkinned("business/front", edition = defaultEdition) should be(true)
   }
 
   it should "be false for a front with a pageskin in another edition" in {
-    testDfpAgent.isPageSkinned("business/front", editions.Au) should be(false)
+    testDfpAgent.isPageSkinned("business/front", edition = Au) should be(false)
   }
 
   it should "be false for a front without a pageskin" in {
-    testDfpAgent.isPageSkinned("culture/front", Edition.defaultEdition) should be(false)
+    testDfpAgent.isPageSkinned("culture/front", edition = defaultEdition) should be(false)
   }
 
-  it should "be true for a front with a pageskin in all editions" in {
-    testDfpAgent.isPageSkinned("music/front", Edition.defaultEdition) should be(true)
-    testDfpAgent.isPageSkinned("music/front", editions.Us) should be(true)
+  it should "be false for a front with a pageskin in no edition" in {
+    testDfpAgent.isPageSkinned("music/front", edition = defaultEdition) should be(false)
+    testDfpAgent.isPageSkinned("music/front", edition = Us) should be(false)
   }
 
   it should "be false for any content (non-front) page" in {
-    testDfpAgent.isPageSkinned("sport", Edition.defaultEdition) should be(false)
+    testDfpAgent.isPageSkinned("sport", edition = defaultEdition) should be(false)
   }
 
   "production DfpAgent" should "should not recognise adtest targetted line items" in {
-    testDfpAgent.isPageSkinned("testSport/front", Edition.defaultEdition) should be(false)
+    testDfpAgent.isPageSkinned("testSport/front", edition = defaultEdition) should be(false)
   }
 
   "non production DfpAgent" should "should recognise adtest targetted line items" in {
-    notProductionTestDfpAgent.isPageSkinned("testSport/front", Edition.defaultEdition) should be(true)
+    notProductionTestDfpAgent.isPageSkinned("testSport/front", edition = defaultEdition) should be(
+      true)
   }
 
   "generate tag to sponsors map" should "glom sponsorships together" in {

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -1,6 +1,7 @@
 package dfp
 
 import com.gu.facia.client.models.CollectionConfig
+import common.editions.Uk
 import common.{Edition, editions}
 import conf.Configuration.commercial.dfpAdUnitRoot
 import model.Tag
@@ -15,22 +16,26 @@ class DfpAgentTest extends FlatSpec with Matchers {
     PageSkinSponsorship("lineItemName",
       1234L,
       Seq(s"$dfpAdUnitRoot/business/front"),
-      Seq(Country("United Kingdom", "UK")),
+      Seq(Uk),
+      Seq("United Kingdom"),
       false, false),
     PageSkinSponsorship("lineItemName2",
       12345L,
       Seq(s"$dfpAdUnitRoot/music/front"),
+      Nil,
       Nil,
       false, false),
     PageSkinSponsorship("lineItemName3",
       123456L,
       Seq(s"$dfpAdUnitRoot/sport"),
       Nil,
+      Nil,
       false, false),
     PageSkinSponsorship("lineItemName4",
       1234567L,
       Seq(s"$dfpAdUnitRoot/testSport/front"),
-      Seq(Country("United Kingdom", "UK")),
+      Seq(Uk),
+      Seq("United Kingdom"),
       false, true)
   )
 

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -72,9 +72,9 @@ class DfpAgentTest extends FlatSpec with Matchers {
 
     override def isProd = true
 
-    override protected def tagToSponsorsMap: Map[String, Set[String]] = ???
+    override protected def tagToSponsorsMap: Map[String, Set[String]] = Map.empty
 
-    override protected def tagToAdvertisementFeatureSponsorsMap: Map[String, Set[String]] = ???
+    override protected def tagToAdvertisementFeatureSponsorsMap: Map[String, Set[String]] = Map.empty
   }
 
   private object notProductionTestDfpAgent extends DfpAgent {
@@ -90,9 +90,10 @@ class DfpAgentTest extends FlatSpec with Matchers {
 
     override protected def inlineMerchandisingTargetedTags: InlineMerchandisingTagSet = InlineMerchandisingTagSet()
 
-    override protected def tagToSponsorsMap: Map[String, Set[String]] = ???
 
-    override protected def tagToAdvertisementFeatureSponsorsMap: Map[String, Set[String]] = ???
+    override protected def tagToSponsorsMap: Map[String, Set[String]] = Map.empty
+
+    override protected def tagToAdvertisementFeatureSponsorsMap: Map[String, Set[String]] = Map.empty
   }
 
   def apiQuery(apiQuery: String) = {


### PR DESCRIPTION
Previously a page was being identified as having a pageskin ad if its targeted country was in the same edition as the page's edition.  This change uses the edition targeted by DFP directly.

Admin dashboard now looks like this:

![image](https://cloud.githubusercontent.com/assets/1722550/4917462/5c498c8e-64e5-11e4-9541-5885543595f9.png)
