### PR TITLE
Speed up front-commercial-component test

### DIFF
--- a/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
+++ b/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
@@ -1,9 +1,11 @@
 define([
+    'bonzo',
     'qwery',
     'common/utils/$',
     'helpers/fixtures',
     'jasq'
 ], function (
+    bonzo,
     qwery,
     $,
     fixtures
@@ -58,7 +60,8 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    expect($('#' + fixturesConfig.id + '> *:nth-child(3)').next().hasClass('ad-slot')).toBe(true);
+                    var adSlot = qwery('#' + fixturesConfig.id)[0].children[3];
+                    expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );
 
@@ -71,7 +74,8 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    expect($('#' + fixturesConfig.id + '> *:nth-child(1)').next().hasClass('ad-slot')).toBe(true);
+                    var adSlot = qwery('#' + fixturesConfig.id)[0].children[1];
+                    expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );
 
@@ -86,7 +90,8 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    expect($('#' + fixturesConfig.id + '> *:nth-child(4)').next().hasClass('ad-slot')).toBe(true);
+                    var adSlot = qwery('#' + fixturesConfig.id)[0].children[4];
+                    expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );
 

--- a/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
+++ b/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
@@ -60,7 +60,7 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    var adSlot = qwery('#' + fixturesConfig.id)[0].children[3];
+                    var adSlot = $('#' + fixturesConfig.id + ' > *').get(3);
                     expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );
@@ -74,7 +74,7 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    var adSlot = qwery('#' + fixturesConfig.id)[0].children[1];
+                    var adSlot = $('#' + fixturesConfig.id + ' > *').get(1);
                     expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );
@@ -90,7 +90,7 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    var adSlot = qwery('#' + fixturesConfig.id)[0].children[4];
+                    var adSlot = $('#' + fixturesConfig.id + ' > *').get(4);
                     expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );


### PR DESCRIPTION
`nth-child` seems particularly slow
