### PR TITLE
Facia hover states

### DIFF
--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -81,6 +81,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__container {
     position: relative;
+    @include transition(background-color 0.25s ease);
 
     &:before {
         content: '';
@@ -114,6 +115,22 @@ $fc-item-gutter: $gs-gutter / 4;
     .u-faux-block-link__promote {
         @include mq($until: desktop) {
             z-index: initial;
+        }
+    }
+
+    .u-faux-block-link--hover {
+        background-color: $c-neutral6;
+
+        .fc-item__image-container {
+            background-color: #000;
+
+            img {
+                opacity: 0.8;
+            }
+        }
+
+        .u-faux-block-link__cta {
+            text-decoration: none;
         }
     }
 
@@ -172,6 +189,15 @@ $fc-item-gutter: $gs-gutter / 4;
     padding-right: $fc-item-gutter;
 }
 
+.fc-item__image-container {
+    @include transition(background-color .25s ease);
+    background-color: rgba(0, 0, 0, .1);
+
+    img {
+        @include transition(opacity .25s ease);
+    }
+}
+
 .fc-item__image-container,
 .fc-item__video-fallback {
     display: none;
@@ -214,6 +240,10 @@ $fc-item-gutter: $gs-gutter / 4;
     padding-top: $gs-baseline / 4;
     padding-bottom: 0;
     word-wrap: break-word;
+}
+
+.fc-item__link {
+    z-index: 0;
 }
 
 .fc-item__kicker,

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -113,6 +113,10 @@ $fc-item-gutter: $gs-gutter / 4;
     .u-faux-block-link & a,
     .u-faux-block-link & abbr[title],
     .u-faux-block-link__promote {
+        &.fc-item__link {
+            z-index: 0;
+        }
+
         @include mq($until: desktop) {
             z-index: initial;
         }
@@ -240,10 +244,6 @@ $fc-item-gutter: $gs-gutter / 4;
     padding-top: $gs-baseline / 4;
     padding-bottom: 0;
     word-wrap: break-word;
-}
-
-.fc-item__link {
-    z-index: 0;
 }
 
 .fc-item__kicker,

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -1,4 +1,5 @@
 $fc-item-gutter: $gs-gutter / 4;
+$fc-hover-transition: .25s ease-out;
 
 /* Items
    ==========================================================================
@@ -81,7 +82,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__container {
     position: relative;
-    @include transition(background-color .25s ease);
+    @include transition(background-color $fc-hover-transition);
 
     &:before {
         content: '';
@@ -194,11 +195,11 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 .fc-item__image-container {
-    @include transition(background-color .25s ease);
+    @include transition(background-color $fc-hover-transition);
     background-color: rgba(0, 0, 0, .1);
 
     img {
-        @include transition(opacity .25s ease);
+        @include transition(opacity $fc-hover-transition);
     }
 }
 

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -1,5 +1,5 @@
 $fc-item-gutter: $gs-gutter / 4;
-$fc-hover-transition: .25s ease-out;
+$fc-hover-transition: .25s ease;
 
 /* Items
    ==========================================================================

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -129,7 +129,7 @@ $fc-item-gutter: $gs-gutter / 4;
             background-color: #000000;
 
             img {
-                opacity: 0.8;
+                opacity: .8;
             }
         }
 

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -81,7 +81,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__container {
     position: relative;
-    @include transition(background-color 0.25s ease);
+    @include transition(background-color .25s ease);
 
     &:before {
         content: '';
@@ -126,7 +126,7 @@ $fc-item-gutter: $gs-gutter / 4;
         background-color: $c-neutral6;
 
         .fc-item__image-container {
-            background-color: #000;
+            background-color: #000000;
 
             img {
                 opacity: 0.8;

--- a/static/src/stylesheets/module/facia-cards/_item.scss
+++ b/static/src/stylesheets/module/facia-cards/_item.scss
@@ -129,7 +129,8 @@ $fc-hover-transition: .25s ease;
         .fc-item__image-container {
             background-color: #000000;
 
-            img {
+            // This should be changed to fc-item__image when Imager allows class names to be adapted from inline elements
+            .responsive-img {
                 opacity: .8;
             }
         }
@@ -198,7 +199,8 @@ $fc-hover-transition: .25s ease;
     @include transition(background-color $fc-hover-transition);
     background-color: rgba(0, 0, 0, .1);
 
-    img {
+    // This should be changed to fc-item__image when Imager allows class names to be adapted from inline elements
+    .responsive-img {
         @include transition(opacity $fc-hover-transition);
     }
 }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-analysis.scss
@@ -4,6 +4,10 @@
         color: $c-analysisDefault;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-analysisBackground, 5%);
+    }
+
     .fc-item__container:before {
         background-color: $c-analysisAccent;
     }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -5,7 +5,7 @@
     }
 
     .u-faux-block-link--hover {
-        background-color: darken($c-analysisBackground, 7.5%);
+        background-color: darken($c-commentBackground, 3%);
     }
 
     .fc-item__container:before {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-comment.scss
@@ -4,6 +4,10 @@
         background-color: $c-commentBackground;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-analysisBackground, 7.5%);
+    }
+
     .fc-item__container:before {
         background-color: $c-commentDefault;
     }

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-editorial.scss
@@ -8,6 +8,10 @@
         color: $c-headline;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-editorialDefault, 5%);
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-feature.scss
@@ -8,6 +8,10 @@
         color: $c-headline;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-featureDefault, 5%);
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-live.scss
@@ -8,6 +8,10 @@
         color: $c-headline;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-liveDefault, 5%);
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-media.scss
@@ -8,6 +8,10 @@
         color: $c-headline;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-mediaBackground, 15%);
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-podcast.scss
@@ -8,6 +8,10 @@
         color: $c-headline;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-podcastBackground, 7.5%);
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {

--- a/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia-cards/item-tones/_tone-review.scss
@@ -8,6 +8,10 @@
         color: $c-headline;
     }
 
+    .u-faux-block-link--hover {
+        background-color: darken($c-reviewBackground, 7.5%);
+    }
+
     .fc-item__link,
     .fc-sublink__link {
         &:visited {


### PR DESCRIPTION
These aren't amazing but they're probably better than what we have (also they match up with buttons and other parts of the site fading slightly darker on hover).

![screen recording 2014-11-05 at 12 50 pm](https://cloud.githubusercontent.com/assets/1607666/4917866/8425d7ee-64ea-11e4-9800-b3b472d544c5.gif)

This also adds a placeholder image as a result of the transition, which we wanted to add on mobile for when images were loading in.

![screen shot 2014-11-05 at 12 52 20](https://cloud.githubusercontent.com/assets/1607666/4917872/99415cac-64ea-11e4-981c-cc8a2fb3ce98.png)
