### PR TITLE
Measure code coverage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,15 +124,12 @@ module.exports = function (grunt) {
     });
     grunt.registerTask('test', ['test:unit']);
     grunt.registerTask('coverage', function() {
-        var target = this.args.length ? ":" + this.args.join(":") : "";
+        var target = this.args.length ? ':' + this.args.join(':') : '';
         grunt.config.set('karma.options.reporters',
             grunt.config.get('karma.options.reporters').concat('coverage')
         );
         grunt.config.set('karma.options.preprocessors',
-            {
-                'static/src/javascripts/**/*.js': ['coverage'],
-                'static/public/javascripts/**/*.js': ['coverage']
-            }
+            grunt.config.get('coverage.preprocessors')
         );
         grunt.task.run('test' + target);
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -123,6 +123,19 @@ module.exports = function (grunt) {
         grunt.task.run('karma' + target);
     });
     grunt.registerTask('test', ['test:unit']);
+    grunt.registerTask('coverage', function() {
+        var target = this.args.length ? ":" + this.args.join(":") : "";
+        grunt.config.set('karma.options.reporters',
+            grunt.config.get('karma.options.reporters').concat('coverage')
+        );
+        grunt.config.set('karma.options.preprocessors',
+            {
+                'static/src/javascripts/**/*.js': ['coverage'],
+                'static/public/javascripts/**/*.js': ['coverage']
+            }
+        );
+        grunt.task.run('test' + target);
+    });
 
     /**
      * Analyse tasks

--- a/grunt-configs/coverage.js
+++ b/grunt-configs/coverage.js
@@ -1,0 +1,8 @@
+module.exports = function(grunt, options) {
+    return {
+        preprocessors: {
+            'static/src/javascripts/**/*.js': ['coverage'],
+            'static/public/javascripts/**/*.js': ['coverage']
+        }
+    };
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "karma": "0.12.24",
     "karma-chrome-launcher": "0.1.5",
     "karma-coffee-preprocessor": "0.2.1",
+    "karma-coverage": "^0.2.6",
     "karma-firefox-launcher": "0.1.3",
     "karma-html2js-preprocessor": "0.1.0",
     "karma-jasmine": "0.2.2",

--- a/static/test/javascripts/conf/common.js
+++ b/static/test/javascripts/conf/common.js
@@ -4,4 +4,4 @@ module.exports = function(config) {
         { pattern: 'static/test/javascripts/spec/common/**/*.spec.js', included: false }
     );
     config.set(settings);
-}
+};

--- a/static/test/javascripts/conf/facia.js
+++ b/static/test/javascripts/conf/facia.js
@@ -4,4 +4,4 @@ module.exports = function(config) {
         { pattern: 'static/test/javascripts/spec/facia/**/*.js', included: false }
     );
     config.set(settings);
-}
+};

--- a/static/test/javascripts/conf/settings.js
+++ b/static/test/javascripts/conf/settings.js
@@ -38,6 +38,15 @@ module.exports = function(config) {
         // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
         browsers: ['PhantomJS'],
         captureTimeout: 60000,
-        singleRun: false
+        singleRun: false,
+        coverageReporter: {
+            reporters: [
+                {
+                    type: 'html',
+                    dir: 'tmp/coverage/'
+                },
+                {type: 'text-summary'}
+            ]
+        }
     };
 };


### PR DESCRIPTION
Running tests with `grunt coverage` reports the code coverage in the terminal and generates an html report for better understanding what’s left uncovered.

The syntax is the same as `grunt test`:
`grunt coverage:unit:facia` runs only the unit tests for `facia` package.

There's also the possibility of writing team city coverage report, but I'm not sure if we want that.

Out of curiosity
- common

```
=============================== Coverage summary ===============================
Statements   : 49.1% ( 4843/9864 )
Branches     : 33.27% ( 2150/6462 )
Functions    : 54.52% ( 1092/2003 )
Lines        : 61.92% ( 4451/7188 )
================================================================================
```
- facia

```
=============================== Coverage summary ===============================
Statements   : 49.67% ( 2026/4079 )
Branches     : 24.54% ( 703/2865 )
Functions    : 51.04% ( 465/911 )
Lines        : 50.48% ( 1990/3942 )
================================================================================
```
- membership

```
=============================== Coverage summary ===============================
Statements   : 39.64% ( 1598/4031 )
Branches     : 15.61% ( 454/2909 )
Functions    : 39.43% ( 362/918 )
Lines        : 41.71% ( 1532/3673 )
================================================================================
```
