### PR TITLE
Rename CollectionAndConfig FaciaContainer, make display properties explicit there

### DIFF
--- a/admin/app/views/commercial/sponsoredContainers.scala.html
+++ b/admin/app/views/commercial/sponsoredContainers.scala.html
@@ -2,7 +2,7 @@
 
 @import layout.CollectionEssentials
 @import com.gu.facia.client.models.CollectionConfig
-@import layout.ContainerAndCollection
+@import layout.FaciaContainer
 @import services.CollectionConfigWithId
 @import slices.Fixed
 @import slices.FixedContainers.fixedMediumSlowVI
@@ -12,7 +12,7 @@
     <div class="l-side-margins l-side-margins--layout-front">
         <div class="facia-container facia-container--layout-front js-sponsored-front"
             data-sponsorship="sponsored">
-            @fragments.containers.facia_cards.container(ContainerAndCollection(
+            @fragments.containers.facia_cards.container(FaciaContainer(
                 0,
                 Fixed(fixedMediumSlowVI),
                 CollectionConfigWithId("front", CollectionConfig.withDefaults(displayName = Some("Front"))),
@@ -36,7 +36,7 @@
                     ("title", "Foundation Supported")
                 )
             ).map { c =>
-                @fragments.containers.facia_cards.container(ContainerAndCollection(
+                @fragments.containers.facia_cards.container(FaciaContainer(
                     1,
                     Fixed(fixedMediumSlowVI),
                     CollectionConfigWithId("type", CollectionConfig.withDefaults(

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -87,7 +87,7 @@ object Front extends implicits.Collections {
         val (newSeen, newItems) = deduplicate(seenTrails, container, collection.items)
 
         ContainerLayout.fromContainer(container, context, config.config, newItems) map {
-          case (containerLayout, newContext) => ((newSeen, newContext), ContainerAndCollection.fromConfig(
+          case (containerLayout, newContext) => ((newSeen, newContext), FaciaContainer.fromConfig(
             index,
             container,
             config,
@@ -95,7 +95,7 @@ object Front extends implicits.Collections {
             Some(containerLayout)
           ))
         } getOrElse {
-          ((newSeen, context), ContainerAndCollection.fromConfig(
+          ((newSeen, context), FaciaContainer.fromConfig(
             index,
             container,
             config,
@@ -134,13 +134,13 @@ case class CollectionEssentials(
   showMoreLimit: Option[Int]
 )
 
-object ContainerAndCollection {
+object FaciaContainer {
   def apply(
     index: Int,
     container: Container,
     config: CollectionConfigWithId,
     collectionEssentials: CollectionEssentials
-  ): ContainerAndCollection = fromConfig(
+  ): FaciaContainer = fromConfig(
     index,
     container,
     config,
@@ -159,7 +159,7 @@ object ContainerAndCollection {
     config: CollectionConfigWithId,
     collectionEssentials: CollectionEssentials,
     containerLayout: Option[ContainerLayout]
-  ): ContainerAndCollection = ContainerAndCollection(
+  ): FaciaContainer = FaciaContainer(
     index,
     config.id,
     config.config.displayName orElse collectionEssentials.displayName,
@@ -180,7 +180,7 @@ object ContainerAndCollection {
       case 5 => FixedContainers.fixedSmallSlowVI
       case _ => FixedContainers.fixedMediumFastXII
     }
-    ContainerAndCollection(
+    FaciaContainer(
       index = 2,
       container = Fixed(layout),
       config = CollectionConfigWithId(dataId, CollectionConfig.emptyConfig),
@@ -217,7 +217,7 @@ case class ContainerCommercialOptions(
   def isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
 }
 
-case class ContainerAndCollection(
+case class FaciaContainer(
   index: Int,
   dataId: String,
   displayName: Option[String],
@@ -243,5 +243,5 @@ case class ContainerAndCollection(
 }
 
 case class Front(
-  containers: Seq[ContainerAndCollection]
+  containers: Seq[FaciaContainer]
 )

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -1,6 +1,7 @@
 package layout
 
 import com.gu.facia.client.models.CollectionConfig
+import dfp.DfpAgent
 import model.{Collection, Content, Trail}
 import org.joda.time.DateTime
 import services.CollectionConfigWithId
@@ -164,11 +165,11 @@ object ContainerAndCollection {
     config.config.displayName orElse collectionEssentials.displayName,
     config.config.href orElse collectionEssentials.href,
     container,
-    config,
     collectionEssentials,
     containerLayout,
     config.config.showDateHeader.exists(identity),
-    config.config.showLatestUpdate.exists(identity)
+    config.config.showLatestUpdate.exists(identity),
+    ContainerCommercialOptions.fromConfig(config.config)
   )
 
   def forStoryPackage(dataId: String, items: Seq[Trail], title: String) = {
@@ -188,17 +189,45 @@ object ContainerAndCollection {
   }
 }
 
+object ContainerCommercialOptions {
+  def fromConfig(config: CollectionConfig) = ContainerCommercialOptions(
+    DfpAgent.isSponsored(config),
+    DfpAgent.isAdvertisementFeature(config),
+    DfpAgent.isFoundationSupported(config),
+    DfpAgent.sponsorshipTag(config),
+    DfpAgent.sponsorshipType(config)
+  )
+
+  val empty = ContainerCommercialOptions(
+    false,
+    false,
+    false,
+    None,
+    None
+  )
+}
+
+case class ContainerCommercialOptions(
+  isSponsored: Boolean,
+  isAdvertisementFeature: Boolean,
+  isFoundationSupported: Boolean,
+  sponsorshipTag: Option[String],
+  sponsorshipType: Option[String]
+) {
+  def isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
+}
+
 case class ContainerAndCollection(
   index: Int,
   dataId: String,
   displayName: Option[String],
   href: Option[String],
   container: Container,
-  config: CollectionConfigWithId,
   collectionEssentials: CollectionEssentials,
   containerLayout: Option[ContainerLayout],
   showDateHeader: Boolean,
-  showLatestUpdate: Boolean
+  showLatestUpdate: Boolean,
+  commercialOptions: ContainerCommercialOptions
 ) {
 
   def faciaComponentName = displayName map { title: String =>

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -214,7 +214,7 @@ case class ContainerCommercialOptions(
   sponsorshipTag: Option[String],
   sponsorshipType: Option[String]
 ) {
-  def isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
+  val isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
 }
 
 case class FaciaContainer(

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.facia.client.models.CollectionConfig
 import common.{Edition, ExecutionContexts, Logging}
-import layout.ContainerAndCollection
+import layout.FaciaContainer
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 
@@ -89,7 +89,7 @@ object FrontProperties{
 }
 
 object FaciaComponentName {
-  /** TODO remove this once everything is using ContainerAndCollection */
+  /** TODO remove this once everything is using FaciaContainer */
   def apply(config: CollectionConfig, collection: Collection): String = {
     config.displayName.orElse(collection.displayName).map { title =>
       title.toLowerCase.replace(" ", "-")

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -1,4 +1,4 @@
-@(popular: Seq[model.MostPopular], config: com.gu.facia.client.models.CollectionConfig)(implicit request: RequestHeader)
+@(popular: Seq[model.MostPopular])(implicit request: RequestHeader)
 
 @import common.Localisation
 @import views.support._

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -3,17 +3,16 @@
 @import views.support.GetClasses
 @import views.html.fragments.containers.facia_cards.{standardContainer, navListContainer, navMediaListContainer, mostPopularContainer}
 @import slices.{Dynamic, Fixed, NavList, NavMediaList, MostPopular}
-@import dfp.DfpAgent
 
 @defining(containerDefinition.displayName, containerDefinition.faciaComponentName) { case (title, componentName) =>
     <section id="@componentName"
              class="@GetClasses.forContainerDefinition(containerDefinition)"
              data-link-name="@{containerDefinition.index + 1} @componentName"
              data-id="@containerDefinition.dataId"
-             @DfpAgent.sponsorshipTag(containerDefinition.config.config).map { keyword =>
+             @containerDefinition.commercialOptions.sponsorshipTag.map { keyword =>
                  data-keywords="@keyword"
              }
-             @DfpAgent.sponsorshipType(containerDefinition.config.config).map { sponsorshipType =>
+             @containerDefinition.commercialOptions.sponsorshipType.map { sponsorshipType =>
                  data-sponsorship="@sponsorshipType"
              }
              data-component="@componentName">

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,4 +1,4 @@
-@(containerDefinition: layout.ContainerAndCollection, frontProperties: model.FrontProperties = model.FrontProperties.empty)(implicit request: RequestHeader)
+@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties = model.FrontProperties.empty)(implicit request: RequestHeader)
 
 @import views.support.GetClasses
 @import views.html.fragments.containers.facia_cards.{standardContainer, navListContainer, navMediaListContainer, mostPopularContainer}

--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -1,4 +1,4 @@
-@(containerDefinition: layout.ContainerAndCollection, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
+@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import views.support.{ImgSrc, Item140, RenderClasses}

--- a/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
@@ -28,6 +28,6 @@
         Nil
     )
 )){ popular =>
-    @fragments.collections.popular(popular, containerDefinition.config.config)
+    @fragments.collections.popular(popular)
 }
 </div>

--- a/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
@@ -1,4 +1,4 @@
-@(containerDefinition: layout.ContainerAndCollection, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
+@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
 @import common.LinkTo
 @import model.MostPopular

--- a/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
@@ -1,4 +1,4 @@
-@(collectionDefinition: layout.ContainerAndCollection, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
+@(collectionDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
 @import common.LinkTo
 @import views.html.fragments.containers.facia_cards.containerHeader

--- a/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
@@ -1,4 +1,4 @@
-@(containerDefinition: layout.ContainerAndCollection, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
+@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
 @import common.LinkTo
 @import model.InlineImage

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -1,4 +1,4 @@
-@(containerDefinition: layout.ContainerAndCollection, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
+@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
 
 @import common.Localisation
 @import views.html.fragments.containers.facia_cards.{containerHeader, slice, showMore}

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -9,10 +9,7 @@
 @* TODO Consolidate this with the master container template to get rid of repetition *@
 
 @defining(page.webTitle) { case (webTitle) =>
-    <section
-        class="@GetClasses.forNewStyleContainer(
-            config, false, webTitle.nonEmpty, Seq("fc-container--first"), true
-        )"
+    <section class="@GetClasses.forTagContainer(webTitle.nonEmpty)"
         data-link-name="all index"
         @DfpAgent.sponsorshipTag(config).map { keyword =>
             data-keywords="@keyword"

--- a/common/app/views/fragments/containers/tag.scala.html
+++ b/common/app/views/fragments/containers/tag.scala.html
@@ -11,9 +11,7 @@
 @defining(config.displayName.orElse(collection.displayName)) { title =>
     @if(collection.items.nonEmpty) {
         <section
-            class="@GetClasses.forNewStyleContainer(
-                config, false, title.nonEmpty, Seq("fc-container--first"), true
-            )"
+            class="@GetClasses.forTagContainer(title.nonEmpty)"
             data-link-name="@FaciaComponentName(config, collection)"
             data-id="@dataId"
             @DfpAgent.sponsorshipTag(config).map { keyword =>

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -1,11 +1,11 @@
 @(content: model.Content, related: model.RelatedContent)(implicit request: RequestHeader)
 
-@import layout.ContainerAndCollection
+@import layout.FaciaContainer
 @import views.html.fragments.containers
 
 @container(stories: Seq[model.Content], title: String, dataId: String) = {
     @containers.facia_cards.container(
-        ContainerAndCollection.forStoryPackage(dataId, stories, title)
+        FaciaContainer.forStoryPackage(dataId, stories, title)
     )(request)
 }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -1,10 +1,8 @@
 package views.support
 
-import com.gu.facia.client.models.CollectionConfig
 import common._
 import conf.Switches.ShowAllArticleEmbedsSwitch
-import dfp.DfpAgent
-import layout.{FaciaCard, Sublink, ContainerAndCollection}
+import layout.{ContainerCommercialOptions, FaciaCard, Sublink, ContainerAndCollection}
 import model._
 
 import java.net.URLEncoder._
@@ -793,52 +791,48 @@ object GetClasses {
     case layout.Audio => "fc-sublink--audio"
   }
 
-  private def commonContainerStyles(
-      config: CollectionConfig,
-      isFirst: Boolean,
-      hasTitle: Boolean,
-      disableHide: Boolean
-  ): Seq[String] = {
-    val container = slices.Container.fromConfig(config)
-    val isSponsored = DfpAgent.isSponsored(config)
-    val isAdvertisementFeature = DfpAgent.isAdvertisementFeature(config)
-    val isFoundationSupported = DfpAgent.isFoundationSupported(config)
-    val isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
-
-    Seq(
-      ("container", true),
-      ("container--first", isFirst),
-      ("container--sponsored", isSponsored),
-      ("container--advertisement-feature", isAdvertisementFeature),
-      ("container--foundation-supported", isFoundationSupported),
-      ("js-sponsored-container", isPaidFor),
-      ("js-container--toggle",
-        !disableHide && slices.Container.showToggle(container) && !isFirst && hasTitle && !isPaidFor)
-    ) collect {
-      case (kls, true) => kls
-    }
-  }
-
   def forContainerDefinition(containerDefinition: ContainerAndCollection) =
     forNewStyleContainer(
-      containerDefinition.config.config,
+      containerDefinition.showLatestUpdate,
       containerDefinition.index == 0,
-      containerDefinition.displayName.isDefined
+      containerDefinition.displayName.isDefined,
+      containerDefinition.commercialOptions,
+      Some(containerDefinition.container)
     )
 
+  def forTagContainer(hasTitle: Boolean) = forNewStyleContainer(
+    showLatestUpdate = false,
+    isFirst = true,
+    hasTitle,
+    ContainerCommercialOptions.empty,
+    None,
+    Nil,
+    disableHide = true
+  )
+
   def forNewStyleContainer(
-      config: CollectionConfig,
+      showLatestUpdate: Boolean,
       isFirst: Boolean,
       hasTitle: Boolean,
+      commercialOptions: ContainerCommercialOptions,
+      container: Option[slices.Container] = None,
       extraClasses: Seq[String] = Nil,
       disableHide: Boolean = false
   ) = {
-    RenderClasses(
-      (if (config.showLatestUpdate.exists(identity)) Some("js-container--fetch-updates") else None).toSeq ++
-        Seq("fc-container") ++
-        commonContainerStyles(config, isFirst, hasTitle, disableHide) ++
-        extraClasses: _*
-    )
+    RenderClasses((Seq(
+      ("js-container--fetch-updates", showLatestUpdate),
+      ("fc-container", true),
+      ("container", true),
+      ("container--first", isFirst),
+      ("container--sponsored", commercialOptions.isSponsored),
+      ("container--advertisement-feature", commercialOptions.isAdvertisementFeature),
+      ("container--foundation-supported", commercialOptions.isFoundationSupported),
+      ("js-sponsored-container", commercialOptions.isPaidFor),
+      ("js-container--toggle",
+        !disableHide && !container.exists(!slices.Container.showToggle(_)) && !isFirst && hasTitle && !commercialOptions.isPaidFor)
+    ) collect {
+      case (kls, true) => kls
+    }) ++ extraClasses: _*)
   }
 }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -2,7 +2,7 @@ package views.support
 
 import common._
 import conf.Switches.ShowAllArticleEmbedsSwitch
-import layout.{ContainerCommercialOptions, FaciaCard, Sublink, ContainerAndCollection}
+import layout.{ContainerCommercialOptions, FaciaCard, Sublink, FaciaContainer}
 import model._
 
 import java.net.URLEncoder._
@@ -791,7 +791,7 @@ object GetClasses {
     case layout.Audio => "fc-sublink--audio"
   }
 
-  def forContainerDefinition(containerDefinition: ContainerAndCollection) =
+  def forContainerDefinition(containerDefinition: FaciaContainer) =
     forNewStyleContainer(
       containerDefinition.showLatestUpdate,
       containerDefinition.index == 0,

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.facia.client.models.CollectionConfig
 import common._
 import front._
-import layout.{CollectionEssentials, ContainerAndCollection}
+import layout.{CollectionEssentials, FaciaContainer}
 import model._
 import play.api.mvc._
 import play.api.libs.json.{JsObject, JsValue, Json}
@@ -124,7 +124,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
           Cached(60) {
             val config = ConfigAgent.getConfig(id).getOrElse(CollectionConfig.emptyConfig)
 
-            val containerDefinition = ContainerAndCollection(
+            val containerDefinition = FaciaContainer(
               1,
               Container.fromConfig(config),
               CollectionConfigWithId(id, config),

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -145,7 +145,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     log.info(s"Serving collection $collectionId on front $frontId")
 
     withFaciaPage(frontId) { faciaPage =>
-      faciaPage.front.containers.find(_.config.id == collectionId) match {
+      faciaPage.front.containers.find(_.dataId == collectionId) match {
         case Some(containerDefinition) =>
           Cached(60) {
             JsonComponent(

--- a/facia/app/updates/ContainerIndex.scala
+++ b/facia/app/updates/ContainerIndex.scala
@@ -45,11 +45,11 @@ object FrontIndex {
 
   def fromFaciaPage(faciaPage: FaciaPage): FrontIndex = {
     FrontIndex((faciaPage.front.containers flatMap {
-      case cac: FaciaContainer =>
+      case faciaContainer: FaciaContainer =>
         (for {
-          layout <- cac.containerLayout
-          latestUpdate <- cac.latestUpdate
-        } yield ContainerIndex.fromContainerLayout(layout, latestUpdate)).map(cac.dataId -> _)
+          layout <- faciaContainer.containerLayout
+          latestUpdate <- faciaContainer.latestUpdate
+        } yield ContainerIndex.fromContainerLayout(layout, latestUpdate)).map(faciaContainer.dataId -> _)
     }).toMap)
   }
 }

--- a/facia/app/updates/ContainerIndex.scala
+++ b/facia/app/updates/ContainerIndex.scala
@@ -45,11 +45,11 @@ object FrontIndex {
 
   def fromFaciaPage(faciaPage: FaciaPage): FrontIndex = {
     FrontIndex((faciaPage.front.containers flatMap {
-      case cac @ ContainerAndCollection(_, _, config, _, _) =>
+      case cac: ContainerAndCollection =>
         (for {
           layout <- cac.containerLayout
           latestUpdate <- cac.latestUpdate
-        } yield ContainerIndex.fromContainerLayout(layout, latestUpdate)).map(config.id -> _)
+        } yield ContainerIndex.fromContainerLayout(layout, latestUpdate)).map(cac.dataId -> _)
     }).toMap)
   }
 }

--- a/facia/app/updates/ContainerIndex.scala
+++ b/facia/app/updates/ContainerIndex.scala
@@ -45,7 +45,7 @@ object FrontIndex {
 
   def fromFaciaPage(faciaPage: FaciaPage): FrontIndex = {
     FrontIndex((faciaPage.front.containers flatMap {
-      case cac: ContainerAndCollection =>
+      case cac: FaciaContainer =>
         (for {
           layout <- cac.containerLayout
           latestUpdate <- cac.latestUpdate

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gu.facia.client.models.CollectionConfig
-import layout.{CollectionEssentials, ContainerAndCollection, ContainerLayout}
+import layout.{CollectionEssentials, FaciaContainer, ContainerLayout}
 import play.api.mvc.{ Controller, Action, RequestHeader }
 import common._
 import model._
@@ -77,7 +77,7 @@ object MediaInSectionController extends Controller with Logging with Paging with
     implicit val config = CollectionConfig.withDefaults(href = Some(tagCombinedHref), displayName = displayName)
 
     val response = () => views.html.fragments.containers.facia_cards.container(
-      ContainerAndCollection(
+      FaciaContainer(
         1,
         Fixed(FixedContainers.fixedMediumFastXI),
         CollectionConfigWithId(dataId, config),

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -17,8 +17,6 @@ object MostPopularController extends Controller with Logging with ExecutionConte
     "GFE:Most Read"
   )
 
-  val config = CollectionConfig.withDefaults(displayName = Option("popular"))
-
   def renderHtml(path: String) = render(path)
   def render(path: String) = Action.async { implicit request =>
     val edition = Edition(request)
@@ -31,7 +29,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
         case popular if !request.isJson => Cached(900) { Ok(views.html.mostPopular(page, popular)) }
         case popular => Cached(900) {
           JsonComponent(
-            "html" -> views.html.fragments.collections.popular(popular, config),
+            "html" -> views.html.fragments.collections.popular(popular),
             "rightHtml" -> views.html.fragments.rightMostPopular(globalPopular)
           )
         }
@@ -53,7 +51,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
 
     Cached(900) {
       JsonComponent(
-        "html" -> views.html.fragments.collections.popular(Seq(countryPopular), config),
+        "html" -> views.html.fragments.collections.popular(Seq(countryPopular)),
         "rightHtml" -> views.html.fragments.rightMostPopularGeo(countryPopular, countryNames.get(countryCode), countryCode),
         "country" -> countryCode
       )

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.facia.client.models.CollectionConfig
 import common._
-import layout.{CollectionEssentials, ContainerAndCollection}
+import layout.{CollectionEssentials, FaciaContainer}
 import model.{FrontProperties, Audio, Cached}
 import play.api.mvc.{RequestHeader, Controller, Action}
 import feed.MostViewedAudioAgent
@@ -40,7 +40,7 @@ object MostViewedAudioController extends Controller with Logging with ExecutionC
     val config = CollectionConfig.withDefaults(displayName = displayName)
 
     val html = views.html.fragments.containers.facia_cards.container(
-      ContainerAndCollection(
+      FaciaContainer(
         1,
         Fixed(FixedContainers.fixedSmallSlowIV),
         CollectionConfigWithId(dataId, config),

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.facia.client.models.CollectionConfig
 import common._
-import layout.{CollectionEssentials, ContainerAndCollection}
+import layout.{CollectionEssentials, FaciaContainer}
 import model._
 import services.CollectionConfigWithId
 import slices.{Fixed, FixedContainers}
@@ -37,7 +37,7 @@ object MostViewedGalleryController extends Controller with Logging with Executio
 
   private def renderMostViewedGallery(galleries: Seq[Content])(implicit request: RequestHeader) = {
     val html = views.html.fragments.containers.facia_cards.container(
-      ContainerAndCollection(
+      FaciaContainer(
         1,
         Fixed(FixedContainers.fixedMediumSlowVI),
         CollectionConfigWithId(dataId, config),

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.facia.client.models.CollectionConfig
 import common._
-import layout.{CollectionEssentials, ContainerAndCollection}
+import layout.{CollectionEssentials, FaciaContainer}
 import model._
 import play.api.mvc.{ RequestHeader, Controller, Action }
 import services._
@@ -25,7 +25,7 @@ object PopularInTag extends Controller with Related with Logging with ExecutionC
     val config = CollectionConfig.withDefaults(displayName = displayName)
 
     val html = views.html.fragments.containers.facia_cards.container(
-      ContainerAndCollection(
+      FaciaContainer(
         1,
         Fixed(FixedContainers.fixedMediumFastXII),
         CollectionConfigWithId(dataId, config),

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.facia.client.models.CollectionConfig
 import common._
-import layout.{CollectionEssentials, ContainerAndCollection}
+import layout.{CollectionEssentials, FaciaContainer}
 import model._
 import play.api.mvc.{ RequestHeader, Controller }
 import services._
@@ -28,7 +28,7 @@ object RelatedController extends Controller with Related with Logging with Execu
     val config = CollectionConfig.withDefaults(displayName = displayName)
 
     val html = views.html.fragments.containers.facia_cards.container(
-      ContainerAndCollection(
+      FaciaContainer(
         1,
         Fixed(FixedContainers.fixedMediumFastXII),
         CollectionConfigWithId(dataId, config),

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -10,7 +10,7 @@ import implicits.Requests
 import conf.LiveContentApi
 import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.{Content => ApiContent}
-import layout.{CollectionEssentials, ContainerAndCollection, ContainerLayout}
+import layout.{CollectionEssentials, FaciaContainer, ContainerLayout}
 import slices.{Fixed, FixedContainers}
 
 case class Series(id: String, tag: Tag, trails: Seq[Content])
@@ -56,7 +56,7 @@ object SeriesController extends Controller with Logging with Paging with Executi
     )
 
     val response = () => views.html.fragments.containers.facia_cards.container(
-      ContainerAndCollection(
+      FaciaContainer(
         1,
         Fixed(FixedContainers.fixedMediumSlowVII),
         CollectionConfigWithId(dataId, config),


### PR DESCRIPTION
Sorry, another minor refactor :cry: 

As we're about to change the tag pages so they behave more like fronts, I wanted this done so that I wasn't having to do weird things like construct Configs with IDs that would resolve to the containers I wanted, etc., in order to build the page up.

If you want more details as to the wherefores come over and ask!

I think it does make things a little cleaner, too (similarly to what we did with FaciaCard).

CC @phamann @janua @rich-nguyen 
