### PR TITLE
Remove overhang of link area

### DIFF
--- a/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia-cards/item-layouts/_fc-item--list-media.scss
@@ -33,10 +33,6 @@ Media list item. Looks a bit like this:
         display: block;
     }
 
-    .u-faux-block-link__overlay {
-        left: - $image-width;
-    }
-
     &.fc-item {
         padding-bottom: 0 !important;
     }


### PR DESCRIPTION
Because of a [recent change](https://github.com/guardian/frontend/pull/6912) where we position the image differently inside `list-media`

Before
![screen shot 2014-11-05 at 14 50 57](https://cloud.githubusercontent.com/assets/1607666/4919538/395cae8e-64fb-11e4-9dde-8267d31ca075.png)

After
![screen shot 2014-11-05 at 14 50 06](https://cloud.githubusercontent.com/assets/1607666/4919539/395d31ba-64fb-11e4-99dc-6f261823768b.png)
