### PR TITLE
Do not show current version button on banner for users in a cohort

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -63,7 +63,7 @@ define([
     $,
     ajax,
     config,
-    Cookies,
+    cookies,
     detect,
     mediator,
     Url,
@@ -208,22 +208,22 @@ define([
             },
 
             cleanupCookies: function () {
-                Cookies.cleanUp(['mmcore.pd', 'mmcore.srv', 'mmid', 'GU_ABFACIA', 'GU_FACIA', 'GU_ALPHA']);
-                Cookies.cleanUpDuplicates(['GU_VIEW']);
+                cookies.cleanUp(['mmcore.pd', 'mmcore.srv', 'mmid', 'GU_ABFACIA', 'GU_FACIA', 'GU_ALPHA']);
+                cookies.cleanUpDuplicates(['GU_VIEW']);
             },
 
             // opt-in to the responsive alpha
             optIn: function () {
                 var countMeIn = /#countmein/.test(window.location.hash);
                 if (countMeIn) {
-                    Cookies.add('GU_VIEW', 'responsive', 365);
+                    cookies.add('GU_VIEW', 'responsive', 365);
                 }
             },
 
             // display a flash message to devices over 600px who don't have the mobile cookie
             displayReleaseMessage: function () {
 
-                var exitLink, msg, usMsg, feedbackLink,
+                var exitLink, msg, compulsoryMsg, feedbackLink, shift,
                     path = (document.location.pathname) ? document.location.pathname : '/',
                     releaseMessage = new Message('alpha', {pinOnHide: true});
 
@@ -233,7 +233,7 @@ define([
                     (detect.getBreakpoint() !== 'mobile')
                 ) {
                     // force the visitor in to the alpha release for subsequent visits
-                    Cookies.add('GU_VIEW', 'responsive', 365);
+                    cookies.add('GU_VIEW', 'responsive', 365);
 
                     exitLink = '/preference/platform/classic?page=' + encodeURIComponent(path + '?view=classic');
 
@@ -256,7 +256,7 @@ define([
                         '</li>' +
                         '</ul>';
 
-                    usMsg = '<p class="site-message__message" id="site-message__message">' +
+                    compulsoryMsg = '<p class="site-message__message" id="site-message__message">' +
                         'You’re viewing a beta release of the Guardian’s responsive website.' +
                         ' We’d love to hear what you think.' +
                         '</p>' +
@@ -271,8 +271,11 @@ define([
                         '</li>' +
                         '</ul>';
 
-                    if (config.page.edition === 'US') {
-                        releaseMessage.show(usMsg);
+                    // The shift cookie may be 'in|...', 'ignore', or 'out'.
+                    shift = cookies.get('GU_SHIFT') || '';
+
+                    if (config.page.edition === 'US' || /in\|/.test(shift)) {
+                        releaseMessage.show(compulsoryMsg);
                     } else {
                         releaseMessage.show(msg);
                     }
@@ -386,7 +389,7 @@ define([
             testCookie: function () {
                 var queryParams = Url.getUrlVars();
                 if (queryParams.test) {
-                    Cookies.addSessionCookie('GU_TEST', encodeURIComponent(queryParams.test));
+                    cookies.addSessionCookie('GU_TEST', encodeURIComponent(queryParams.test));
                 }
             },
 


### PR DESCRIPTION
This prepares our welcome banner so that the 'User current version' button is replaced with a 'Find out more' button. Otherwise users in the cohort will be tempted to hit the 'back to r2' action, which is really intended for those hit came to us from the 'try beta' r2 action.

![screen shot 2014-11-05 at 15 13 22](https://cloud.githubusercontent.com/assets/4549425/4919945/5aef3af0-64fe-11e4-86bc-2ad38bc49825.png)
