### PR TITLE
Added tabindex to non link headlines.

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -18,7 +18,7 @@
                           @Html(Localisation(title))
                         </a>
                     }.getOrElse {
-                        <span class="u-text-hyphenate">@Html(Localisation(title))</span>
+                        <span class="u-text-hyphenate" tabindex="0">@Html(Localisation(title))</span>
                     }
 
                     @if(containerDefinition.showDateHeader) {


### PR DESCRIPTION
Quick accessibility win. Some headlines are links and some are not. When using keyboard to navigate through the page sometimes it skips right to the 'Hide/Show' button which can be really confusing when using screen reader.
