### PR TITLE
Add global development tracking for Bill & Melinda Gates Foundation

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -229,7 +229,7 @@ object Switches extends Collections {
 
   val GlobalDevelopmentQualtrics = Switch("Commercial", "golbal-development-qualtrics",
     "If this switch is on, the Qualtrics tracking tag for global development will be enabled.",
-    safeState = On, sellByDate = new LocalDate(2014, 11, 30)
+    safeState = Off, sellByDate = new LocalDate(2014, 11, 30)
   )
 
   // Monitoring

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -227,6 +227,11 @@ object Switches extends Collections {
     "If this switch is on, commercial components will be fed by the Guardian Bookshop feed.",
     safeState = Off, sellByDate = never)
 
+  val GlobalDevelopmentQualtrics = Switch("Commercial", "golbal-development-qualtrics",
+    "If this switch is on, the Qualtrics tracking tag for global development will be enabled.",
+    safeState = On, sellByDate = new LocalDate(2014, 11, 30)
+  )
+
   // Monitoring
 
   val OphanSwitch = Switch("Monitoring", "ophan",
@@ -453,7 +458,8 @@ object Switches extends Collections {
     CircuitBreakerSwitch,
     ContentCacheTimeSwitch,
     PollPreviewForFreshContentSwitch,
-    PngResizingSwitch
+    PngResizingSwitch,
+    GlobalDevelopmentQualtrics
   )
 
   val httpSwitches: List[Switch] = List(

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -3,6 +3,7 @@
 @import common.AnalyticsHost
 @import views.support.OmnitureAnalyticsData
 @import conf.Static
+@import conf.Switches.{GlobalDevelopmentQualtrics}
 
 @defining(s"${request.host}${request.path}") { path =>
 
@@ -57,4 +58,19 @@
 </noscript>
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
+
+@if(page.section == "global-development" || page.section == "world" && GlobalDevelopmentQualtrics.isSwitchedOn) {
+    <!--BEGIN QUALTRICS SITE INTERCEPT-->
+    <script type='text/javascript'>
+    (function(){var g=function(e,h,f,g){
+    this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+    this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+    this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+    this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.async=true;a.src=g+ "&t=" + (new Date()).getTime();document.body&&document.body.appendChild(a)}};
+    this.start=function(){var a=this;window.addEventListener?window.addEventListener("load",function(){a.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){a.go()})}};
+    try{(new g(100,"r","QSI_S_SI_5aOWnkTFKWfkBaR","//zn_ey9aoragdqewxb7-uscannenberg.siteintercept.qualtrics.com/WRSiteInterceptEngine/?Q_SIID=SI_5aOWnkTFKWfkBaR&Q_LOC="+encodeURIComponent(window.location.href))).start()}catch(i){}})();
+    </script><div id='SI_5aOWnkTFKWfkBaR'><!--DO NOT REMOVE-CONTENTS PLACED HERE--></div>
+    <!--END SITE INTERCEPT-->
+}
+
 

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -3,7 +3,7 @@
 @import common.AnalyticsHost
 @import views.support.OmnitureAnalyticsData
 @import conf.Static
-@import conf.Switches.{GlobalDevelopmentQualtrics}
+@import conf.Switches.GlobalDevelopmentQualtrics
 
 @defining(s"${request.host}${request.path}") { path =>
 


### PR DESCRIPTION
This adds a tracking tag for the month of November only for the Global development and World secitons on the site. As requested by the Bill and Melinda Gates Foundation.

This is a one-off exception and has been wrapped in a switch to ensure it gets deleted.

/cc @gklopper @cantlin 
