### PR TITLE
Non-secure host for football snaps

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -167,6 +167,8 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val url =
       if (environment.secure) configuration.getStringProperty("ajax.secureUrl").getOrElse("")
       else configuration.getStringProperty("ajax.url").getOrElse("")
+    lazy val nonSecureUrl =
+      configuration.getStringProperty("ajax.url").getOrElse("")
     lazy val corsOrigins: Seq[String] = configuration.getStringProperty("ajax.cors.origin").map(_.split(",")
       .map(_.trim).toSeq).getOrElse(Nil)
   }
@@ -202,7 +204,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   }
 
   object sport {
-    lazy val apiUrl = configuration.getStringProperty("sport.apiUrl").getOrElse(ajax.url)
+    lazy val apiUrl = configuration.getStringProperty("sport.apiUrl").getOrElse(ajax.nonSecureUrl)
   }
 
   object oas {


### PR DESCRIPTION
Snaps currently use a secure host for ajaxing in. 

http -> https makes IE9 unhappy (http://frontend.errors.guim.co.uk/guardian/frontend/group/3258/)

Snaps now use insecure ajax host

@jamesgorrie, looks like the preview snap is pulled in from scala, so should be ok to just use the insecure version everywhere?
