### PR TITLE
Widescreen showcase image may not always appear on articles with feature as primary tone

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -7,7 +7,8 @@
 <div class="l-side-margins l-side-margins--layout-content">
     <article id="article" data-test-id="article-root"
         class="content content--article tonal tonal--@articleToneClass(article) section-@article.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
-        @if(article.isAdvertisementFeature){content--advertisement-feature}"
+        @if(article.isAdvertisementFeature){content--advertisement-feature}
+        @if(article.isFeature && article.hasShowcaseMainPicture){has-feature-showcase-picture}"
         itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
 
         @fragments.headTonal(article)

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -136,7 +136,8 @@ figure {
     @include deport-left;
 }
 
-.tonal--tone-feature .media-primary.media-primary--showcase {
+// Articles can have the feature tone applied, but it's not always primary tone
+.has-feature-showcase-picture .media-primary.media-primary--showcase {
     margin-left: 0;
     z-index: 2; // Put the image on top of the left and right layout borders
     position: relative;


### PR DESCRIPTION
Fixes issue when article has feature tone tag, but primary tone is something different, i.e.:

~~redacted~~

In this case, image goes full width, growing as wide as the browser window, which is incorrect.

This fix ensures the same logic is applied to the CSS as the Scala. Longer term, we may want to detach the logic around super-wide showcase images being so heavily attached to tones…
