### PR TITLE
Removed plugins from image server.

### DIFF
--- a/image/conf/play.plugins
+++ b/image/conf/play.plugins
@@ -1,1 +1,0 @@
-100:conf.SwitchBoardPlugin


### PR DESCRIPTION
Those plugins require 'common' and randomly break here.
