### PR TITLE
Start GZipping facia-press pressed files

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -17,6 +17,8 @@ import sun.misc.BASE64Encoder
 import com.amazonaws.auth.AWSSessionCredentials
 import common.S3Metrics.S3ClientExceptionsMetric
 import com.gu.googleauth.UserIdentity
+import java.util.zip.GZIPOutputStream
+import java.io._
 
 trait S3 extends Logging {
 
@@ -85,6 +87,37 @@ trait S3 extends Logging {
 
   def putPrivate(key: String, value: String, contentType: String) {
     put(key: String, value: String, contentType: String, Private)
+  }
+
+  def putPrivateGzipped(key: String, value: String, contentType: String) {
+    putGzipped(key: String, value: String, contentType: String, Private)
+  }
+
+  private def putGzipped(key: String, value: String, contentType: String, accessControlList: CannedAccessControlList) {
+    lazy val request = {
+      val metadata = new ObjectMetadata()
+
+      metadata.setCacheControl("no-cache,no-store")
+      metadata.setContentType(contentType)
+      metadata.setContentEncoding("gzip")
+
+      val valueAsBytes = value.getBytes("UTF-8")
+      val os = new ByteArrayOutputStream()
+      val gzippedStream = new GZIPOutputStream(os)
+      gzippedStream.write(valueAsBytes)
+      gzippedStream.flush()
+      gzippedStream.close()
+
+      new PutObjectRequest(bucket, key, new ByteArrayInputStream(os.toByteArray), metadata).withCannedAcl(accessControlList)
+    }
+
+    try {
+      client.foreach(_.putObject(request))
+    } catch {
+      case e: Exception =>
+        S3ClientExceptionsMetric.increment()
+        throw e
+    }
   }
 
   private def put(key: String, value: String, contentType: String, accessControlList: CannedAccessControlList) {

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -189,10 +189,10 @@ object S3FrontsApi extends S3 {
   def getCollectionIds(prefix: String): List[String] = getListing(prefix, "/collection.json")
 
   def putLivePressedJson(path: String, json: String) =
-    putPrivate(getLivePressedKeyForPath(path), json, "application/json")
+    putPrivateGzipped(getLivePressedKeyForPath(path), json, "application/json")
 
   def putDraftPressedJson(path: String, json: String) =
-    putPrivate(getDraftPressedKeyForPath(path), json, "application/json")
+    putPrivateGzipped(getDraftPressedKeyForPath(path), json, "application/json")
 
   def getPressedLastModified(path: String): Option[String] =
     getLastModified(getLivePressedKeyForPath(path)).map(_.toString)

--- a/dev-build/conf/application.conf
+++ b/dev-build/conf/application.conf
@@ -5,6 +5,8 @@ application : {
     langs: "en"
 }
 
+ws.compressionEnabled: true
+
 # Define the Global object class for this application, defaults to Global in the root package.
 #global: Global
 

--- a/facia-end-to-end/conf/application.conf
+++ b/facia-end-to-end/conf/application.conf
@@ -5,6 +5,8 @@ application : {
     langs: "en"
 }
 
+ws.compressionEnabled: true
+
 # Define the Global object class for this application, defaults to Global in the root package.
 #global: Global
 

--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -5,6 +5,8 @@ application : {
     langs: "en"
 }
 
+ws.compressionEnabled: true
+
 # Define the Global object class for this application, defaults to Global in the root package.
 #global: Global
 


### PR DESCRIPTION
This starts putting `pressed.json` files compressed in `GZip` format.

In order to read them, `WS` needs `ws.compressEnabled: true` in `application.conf`; after which it can then read naturally.
Browsers can still view the files as they have the header `Content-Encoding: gzip`.

For `/uk` on `DEV`, I have seen a decrease in filesize from `1.9MB` to `502KB`.

@stephanfowler @robertberry 
