### PR TITLE
Added tabindex to maincontent div

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -39,7 +39,7 @@
             @fragments.commercial.topBannerMobile()
         }
 
-        <div id="maincontent"></div>
+        <div id="maincontent" tabindex="0"></div>
 
         @if(BreakingNewsSwitch.isSwitchedOn) {
             <div class="js-breaking-news-placeholder breaking-news"></div>


### PR DESCRIPTION
I've found out that some browsers are moving view to the maincontent after triggering skip to content link but they are not adding focus so using tab key again will send user back to the top of the page. Screen readers are mostly smart enough but this fix will make some keyboard users life easier.
