### PR TITLE
Ensure snaps get init on container update. Fixes: #6966

### DIFF
--- a/static/src/javascripts/bootstraps/facia.js
+++ b/static/src/javascripts/bootstraps/facia.js
@@ -36,6 +36,7 @@ define([
 
             showSnaps: function () {
                 snaps.init();
+                mediator.on('modules:container:rendered', snaps.init);
             },
 
             showContainerShowMore: function () {


### PR DESCRIPTION
Reload snap init, when containers have updated. Fixes: #6966

/cc @robertberry 
