### PR TITLE
Dev-friendly relative url for geo most popular

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
@@ -24,8 +24,7 @@ define([
 
     Component.define(GeoMostPopularFront);
 
-    // Geo is only available via the CDN, hence hardcoded url
-    GeoMostPopularFront.prototype.endpoint = 'http://api.nextgen.guardianapps.co.uk/most-read-geo.json';
+    GeoMostPopularFront.prototype.endpoint = '/most-read-geo.json';
     GeoMostPopularFront.prototype.isNetworkFront = config.page.contentType === 'Network Front';
     GeoMostPopularFront.prototype.manipulationType = 'html';
 


### PR DESCRIPTION
The default region for content will be rest-of-world, but at least it will be local.

@sammorrisdesign @robertberry 
