### PR TITLE
Add componentId field to FaciaContainer class

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -92,7 +92,8 @@ object Front extends implicits.Collections {
             container,
             config,
             collection.copy(items = newItems),
-            Some(containerLayout)
+            Some(containerLayout),
+            None
           ))
         } getOrElse {
           ((newSeen, context), FaciaContainer.fromConfig(
@@ -100,6 +101,7 @@ object Front extends implicits.Collections {
             container,
             config,
             collection.copy(items = newItems),
+            None,
             None
           ))
         }
@@ -139,7 +141,8 @@ object FaciaContainer {
     index: Int,
     container: Container,
     config: CollectionConfigWithId,
-    collectionEssentials: CollectionEssentials
+    collectionEssentials: CollectionEssentials,
+    componentId: Option[String] = None
   ): FaciaContainer = fromConfig(
     index,
     container,
@@ -150,7 +153,8 @@ object FaciaContainer {
       ContainerLayoutContext.empty,
       config.config,
       collectionEssentials.items
-    ).map(_._1)
+    ).map(_._1),
+    componentId
   )
 
   def fromConfig(
@@ -158,12 +162,14 @@ object FaciaContainer {
     container: Container,
     config: CollectionConfigWithId,
     collectionEssentials: CollectionEssentials,
-    containerLayout: Option[ContainerLayout]
+    containerLayout: Option[ContainerLayout],
+    componentId: Option[String]
   ): FaciaContainer = FaciaContainer(
     index,
     config.id,
     config.config.displayName orElse collectionEssentials.displayName,
     config.config.href orElse collectionEssentials.href,
+    componentId,
     container,
     collectionEssentials,
     containerLayout,
@@ -184,7 +190,8 @@ object FaciaContainer {
       index = 2,
       container = Fixed(layout),
       config = CollectionConfigWithId(dataId, CollectionConfig.emptyConfig),
-      CollectionEssentials(items take 8, Some(title), None, None, None)
+      collectionEssentials = CollectionEssentials(items take 8, Some(title), None, None, None),
+      componentId = None
     )
   }
 }
@@ -222,6 +229,7 @@ case class FaciaContainer(
   dataId: String,
   displayName: Option[String],
   href: Option[String],
+  componentId: Option[String],
   container: Container,
   collectionEssentials: CollectionEssentials,
   containerLayout: Option[ContainerLayout],
@@ -230,9 +238,11 @@ case class FaciaContainer(
   commercialOptions: ContainerCommercialOptions
 ) {
 
-  def faciaComponentName = displayName map { title: String =>
-    title.toLowerCase.replace(" ", "-")
-  } getOrElse "no-name"
+  def faciaComponentName = componentId getOrElse {
+    displayName map { title: String =>
+      title.toLowerCase.replace(" ", "-")
+    } getOrElse "no-name"
+  }
 
   def latestUpdate = (collectionEssentials.items.map(_.webPublicationDate) ++
     collectionEssentials.lastUpdated.map(DateTime.parse(_))).sortBy(-_.getMillis).headOption

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -73,6 +73,7 @@ object MediaInSectionController extends Controller with Logging with Paging with
 
     val dataId = s"$pluralMediaType in section"
     val displayName = Some(s"more $sectionName $pluralMediaType")
+    val componentId = Some("more-media-in-section")
 
     implicit val config = CollectionConfig.withDefaults(href = Some(tagCombinedHref), displayName = displayName)
 
@@ -81,7 +82,8 @@ object MediaInSectionController extends Controller with Logging with Paging with
         1,
         Fixed(FixedContainers.fixedMediumFastXI),
         CollectionConfigWithId(dataId, config),
-        CollectionEssentials(trails take 7, displayName, None, None, None)
+        CollectionEssentials(trails take 7, displayName, None, None, None),
+        componentId
       ),
       FrontProperties.empty
     )(request)

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -48,6 +48,7 @@ object SeriesController extends Controller with Logging with Paging with Executi
 
   private def renderSeriesTrails(series: Series)(implicit request: RequestHeader) = {
     val dataId = "series"
+    val componentId = Some("series")
     val displayName = Some(series.tag.webTitle)
     val properties = FrontProperties(series.tag.description, None, None, None, false, None)
 
@@ -60,7 +61,8 @@ object SeriesController extends Controller with Logging with Paging with Executi
         1,
         Fixed(FixedContainers.fixedMediumSlowVII),
         CollectionConfigWithId(dataId, config),
-        CollectionEssentials(series.trails take 7, displayName, None, None, None)
+        CollectionEssentials(series.trails take 7, displayName, None, None, None),
+        componentId
       ),
       properties
     )(request)


### PR DESCRIPTION
The new containers currently use a hyphenated version of their display name for the `data-component-id` tracking identifier. This works in most cases but not for things like series containers and "more in this section", the side-effect of this was fragmenting our component dashboard.

This introduces a new `componentId` field to the `FaciaContainer` class.

/cc @robertberry @cantlin 
