### PR TITLE
Log disccusion ajax failures in Sentry

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -2,6 +2,7 @@ define([
     'bean',
     'bonzo',
     'qwery',
+    'raven',
 
     'common/utils/$',
     'common/utils/_',
@@ -22,6 +23,7 @@ define([
     bean,
     bonzo,
     qwery,
+    raven,
     $,
     _,
     ajax,
@@ -125,7 +127,9 @@ Loader.prototype.initMainComments = function() {
             }
         });
         this.getUser();
-    }.bind(this));
+    }.bind(this)).fail(function() {
+        raven.captureMessage("Comments failed to load.", {tags: { contentType: "comments" }});
+    });
 };
 
 

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -127,9 +127,15 @@ Loader.prototype.initMainComments = function() {
             }
         });
         this.getUser();
+
     }.bind(this)).fail(function() {
-        raven.captureMessage("Comments failed to load.", {tags: { contentType: "comments" }});
-    });
+        raven.captureMessage("Comments failed to load.", {
+            tags: {
+                contentType: "comments",
+                discussionId: this.getDiscussionId()
+            }
+        });
+    }.bind(this));
 };
 
 


### PR DESCRIPTION
We have been getting a few reports of comments not always loading. This is a first step to instrument/diagnose the issue, by triggering an event in Sentry for every failed ajax load. This should give us an indication of how many user and which user agents this is happening on.

/cc @ironsidevsquincy 
