### PR TITLE
Fix margin on .media-primary--showcase

### DIFF
--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -139,6 +139,7 @@ figure {
 // Articles can have the feature tone applied, but it's not always primary tone
 .has-feature-showcase-picture .media-primary.media-primary--showcase {
     margin-left: 0;
+    margin-right: 0;
     z-index: 2; // Put the image on top of the left and right layout borders
     position: relative;
 


### PR DESCRIPTION
On mobile, articles with `.media-primary--showcase` for main image have an additional 10px margin along the right-hand side. This fixes that.

Bug:
![screen shot 2014-11-07 at 12 14 59](https://cloud.githubusercontent.com/assets/813383/4952707/e406093e-6677-11e4-8945-c5014462f64f.png)

/cc @sndrs
