### PR TITLE
Add sharpen operation to png im4java resize

### DIFF
--- a/png-resizer/app/lib/Im4Java.scala
+++ b/png-resizer/app/lib/Im4Java.scala
@@ -24,6 +24,7 @@ object Im4Java {
     val operation = new IMOperation
 
     operation.addImage()
+    operation.sharpen(1.0)
     operation.resize(width)
     operation.quality(100)
     operation.addImage("png:-")


### PR DESCRIPTION
As requested form @paperboyo, this adds a sharpen operation to our png resizing.
### Before

![felicitycloake-normal](https://cloud.githubusercontent.com/assets/80089/4952783/da884a7e-6678-11e4-801a-f30de5e9a2cf.png) 
### After

![felicitycloake-sharpen](https://cloud.githubusercontent.com/assets/80089/4952786/df86ec92-6678-11e4-81cc-322ea08a1df0.png)

/cc @robertberry 
