### PR TITLE
Add back overflow: hidden on root elements

### DIFF
--- a/static/src/stylesheets/base/_base.scss
+++ b/static/src/stylesheets/base/_base.scss
@@ -14,6 +14,13 @@ body {
     background-color: #ffffff;
 }
 
+@if $old-ie == false {
+    html,
+    body {
+        overflow-x: hidden;
+    }
+}
+
 /**
  * Breakpoint definition for JS - see https://github.com/JoshBarr/on-media-query
  */


### PR DESCRIPTION
This was removed as a quick fix for the relative sizing bugs, but now that has been properly resolved we need to add this back, as is breaking page layouts.
### Fixes

![google chrome](https://cloud.githubusercontent.com/assets/80089/4974768/9268c48e-68c7-11e4-9e31-61f9a6c0873b.png)
