### PR TITLE
Turn off enforce validity in Google Play Auth for Facia Tool

### DIFF
--- a/facia-tool/app/conf/GoogleAuth.scala
+++ b/facia-tool/app/conf/GoogleAuth.scala
@@ -18,7 +18,8 @@ object GoogleAuth {
       cred.oauthCallback,     // The redirect URL Google send users back to (must be the same as
       // that configured in the developer console)
       Some("guardian.co.uk"), // Google App domain to restrict login
-      Some(maxAuthAge)
+      Some(maxAuthAge),
+      enforceValidity = false
     )
   }
 


### PR DESCRIPTION
OK, I'm not an expert on any of this (as I didn't do this work originally), so please call me up on any nonsense @janua @sihil 

So far as I understand the situation over here, we currently set 'max auth age' to 0, because we want to always re-validate a login once we consider it expired. Once we've initially got validation from Google Auth, we then have a re-authentication loop that is bespoke to frontend, which expires any log ins that haven't been active for 60 seconds.

When @sihil fixed this regression https://github.com/guardian/play-googleauth/commit/796361f9ce6460557c6194989dca3220204e54e1 Play Google Auth started respecting the 'exp' time that Google sent back, meaning that after this time anyone using Facia Tool would be automatically logged out (due to our max auth age being zero), which has resulted in the problems editors are noticing.

This pull request sets the flag that enables this behaviour to false, so that we no longer see the issues. In the meantime, @janua is going to look at Panda auth.
