### PR TITLE
Set the Content-Length when putting GZipped objects

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -108,6 +108,8 @@ trait S3 extends Logging {
       gzippedStream.flush()
       gzippedStream.close()
 
+      metadata.setContentLength(os.size())
+
       new PutObjectRequest(bucket, key, new ByteArrayInputStream(os.toByteArray), metadata).withCannedAcl(accessControlList)
     }
 


### PR DESCRIPTION
Seeing this message in the logs:
`2014-11-10 13:58:02,372 [application-play.akka.actor.front-press-3073] WARN  c.a.services.s3.AmazonS3Client - No content length specified for stream data.  Stream contents will be buffered in memory and could result in out of memory errors.`

@gklopper @robertberry 
