### PR TITLE
Fix the last edited heading in collections

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -221,7 +221,7 @@
                     css: {'has-concurrent-user': state.hasConcurrentEdits}">
                     <!-- ko if: state.timeAgo -->
                         <span class="list-header__timings__last-updated" data-bind="text: state.timeAgo"></span>
-                        ago by <span class="list-header__timings__user" data-bind="text: collectionMeta.updatedBy"></span>
+                        by <span class="list-header__timings__user" data-bind="text: collectionMeta.updatedBy"></span>
                     <!-- /ko -->
                     <a data-bind="
                         click: reset,

--- a/facia-tool/public/js/.bowerrc
+++ b/facia-tool/public/js/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "components/",
+  "analytics": false
+}

--- a/facia-tool/public/js/bower.json
+++ b/facia-tool/public/js/bower.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "jasmine": "~1.3.1",
-    "sinon": "~1.7.3"
+    "sinon": "~1.7.3",
+    "jquery-mockjax": "1.6.1"
   }
 }

--- a/facia-tool/public/js/components/jquery-mockjax/.bower.json
+++ b/facia-tool/public/js/components/jquery-mockjax/.bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "jquery-mockjax",
+  "version": "1.6.1",
+  "main": [
+    "jquery.mockjax.js"
+  ],
+  "ignore": [
+    ".editorconfig",
+    ".gitignore",
+    ".jshintrc",
+    "*.md",
+    "*.json",
+    "lib",
+    "test"
+  ],
+  "homepage": "https://github.com/jakerella/jquery-mockjax",
+  "_release": "1.6.1",
+  "_resolution": {
+    "type": "version",
+    "tag": "v1.6.1",
+    "commit": "e4969fd891a50f259e65a2f61a646038d773f2c1"
+  },
+  "_source": "git://github.com/jakerella/jquery-mockjax.git",
+  "_target": "~1.6.1",
+  "_originalSource": "jquery-mockjax"
+}

--- a/facia-tool/public/js/components/jquery-mockjax/bower.json
+++ b/facia-tool/public/js/components/jquery-mockjax/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "jquery-mockjax",
+  "version": "1.6.1",
+  "main": ["jquery.mockjax.js"],
+  "ignore": [
+    ".editorconfig",
+    ".gitignore",
+    ".jshintrc",
+    "*.md",
+    "*.json",
+    "lib",
+    "test"
+  ]
+}

--- a/facia-tool/public/js/components/jquery-mockjax/jquery.mockjax.js
+++ b/facia-tool/public/js/components/jquery-mockjax/jquery.mockjax.js
@@ -1,0 +1,692 @@
+/*!
+ * MockJax - jQuery Plugin to Mock Ajax requests
+ *
+ * Version:  1.6.1
+ * Released:
+ * Home:   https://github.com/jakerella/jquery-mockjax
+ * Author:   Jonathan Sharp (http://jdsharp.com)
+ * License:  MIT,GPL
+ *
+ * Copyright (c) 2014 appendTo, Jordan Kasper
+ * NOTE: This repository was taken over by Jordan Kasper (@jakerella) October, 2014
+ * 
+ * Dual licensed under the MIT or GPL licenses.
+ * http://opensource.org/licenses/MIT OR http://www.gnu.org/licenses/gpl-2.0.html
+ */
+(function($) {
+	var _ajax = $.ajax,
+		mockHandlers = [],
+		mockedAjaxCalls = [],
+		unmockedAjaxCalls = [],
+		CALLBACK_REGEX = /=\?(&|$)/,
+		jsc = (new Date()).getTime();
+
+
+	// Parse the given XML string.
+	function parseXML(xml) {
+		if ( window.DOMParser == undefined && window.ActiveXObject ) {
+			DOMParser = function() { };
+			DOMParser.prototype.parseFromString = function( xmlString ) {
+				var doc = new ActiveXObject('Microsoft.XMLDOM');
+				doc.async = 'false';
+				doc.loadXML( xmlString );
+				return doc;
+			};
+		}
+
+		try {
+			var xmlDoc = ( new DOMParser() ).parseFromString( xml, 'text/xml' );
+			if ( $.isXMLDoc( xmlDoc ) ) {
+				var err = $('parsererror', xmlDoc);
+				if ( err.length == 1 ) {
+					throw new Error('Error: ' + $(xmlDoc).text() );
+				}
+			} else {
+				throw new Error('Unable to parse XML');
+			}
+			return xmlDoc;
+		} catch( e ) {
+			var msg = ( e.name == undefined ? e : e.name + ': ' + e.message );
+			$(document).trigger('xmlParseError', [ msg ]);
+			return undefined;
+		}
+	}
+
+	// Check if the data field on the mock handler and the request match. This
+	// can be used to restrict a mock handler to being used only when a certain
+	// set of data is passed to it.
+	function isMockDataEqual( mock, live ) {
+		var identical = true;
+		// Test for situations where the data is a querystring (not an object)
+		if (typeof live === 'string') {
+			// Querystring may be a regex
+			return $.isFunction( mock.test ) ? mock.test(live) : mock == live;
+		}
+		$.each(mock, function(k) {
+			if ( live[k] === undefined ) {
+				identical = false;
+				return identical;
+			} else {
+				if ( typeof live[k] === 'object' && live[k] !== null ) {
+					if ( identical && $.isArray( live[k] ) ) {
+						identical = $.isArray( mock[k] ) && live[k].length === mock[k].length;
+					}
+					identical = identical && isMockDataEqual(mock[k], live[k]);
+				} else {
+					if ( mock[k] && $.isFunction( mock[k].test ) ) {
+						identical = identical && mock[k].test(live[k]);
+					} else {
+						identical = identical && ( mock[k] == live[k] );
+					}
+				}
+			}
+		});
+
+		return identical;
+	}
+
+    // See if a mock handler property matches the default settings
+    function isDefaultSetting(handler, property) {
+        return handler[property] === $.mockjaxSettings[property];
+    }
+
+	// Check the given handler should mock the given request
+	function getMockForRequest( handler, requestSettings ) {
+		// If the mock was registered with a function, let the function decide if we
+		// want to mock this request
+		if ( $.isFunction(handler) ) {
+			return handler( requestSettings );
+		}
+
+		// Inspect the URL of the request and check if the mock handler's url
+		// matches the url for this ajax request
+		if ( $.isFunction(handler.url.test) ) {
+			// The user provided a regex for the url, test it
+			if ( !handler.url.test( requestSettings.url ) ) {
+				return null;
+			}
+		} else {
+			// Look for a simple wildcard '*' or a direct URL match
+			var star = handler.url.indexOf('*');
+			if (handler.url !== requestSettings.url && star === -1 ||
+					!new RegExp(handler.url.replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&").replace(/\*/g, '.+')).test(requestSettings.url)) {
+				return null;
+			}
+		}
+
+		// Inspect the data submitted in the request (either POST body or GET query string)
+		if ( handler.data ) {
+			if ( ! requestSettings.data || !isMockDataEqual(handler.data, requestSettings.data) ) {
+				// They're not identical, do not mock this request
+				return null;
+			}
+		}
+		// Inspect the request type
+		if ( handler && handler.type &&
+				handler.type.toLowerCase() != requestSettings.type.toLowerCase() ) {
+			// The request type doesn't match (GET vs. POST)
+			return null;
+		}
+
+		return handler;
+	}
+
+	function parseResponseTimeOpt(responseTime) {
+		if ($.isArray(responseTime)) {
+			var min = responseTime[0];
+			var max = responseTime[1];
+			return (typeof min === 'number' && typeof max === 'number') ? Math.floor(Math.random() * (max - min)) + min : null;
+		} else {
+			return (typeof responseTime === 'number') ? responseTime: null;
+		}
+	}
+
+	// Process the xhr objects send operation
+	function _xhrSend(mockHandler, requestSettings, origSettings) {
+
+		// This is a substitute for < 1.4 which lacks $.proxy
+		var process = (function(that) {
+			return function() {
+				return (function() {
+					// The request has returned
+					this.status     = mockHandler.status;
+					this.statusText = mockHandler.statusText;
+					this.readyState	= 1;
+
+					var finishRequest = function () {
+						this.readyState	= 4;
+
+						var onReady;
+						// Copy over our mock to our xhr object before passing control back to
+						// jQuery's onreadystatechange callback
+						if ( requestSettings.dataType == 'json' && ( typeof mockHandler.responseText == 'object' ) ) {
+							this.responseText = JSON.stringify(mockHandler.responseText);
+						} else if ( requestSettings.dataType == 'xml' ) {
+							if ( typeof mockHandler.responseXML == 'string' ) {
+								this.responseXML = parseXML(mockHandler.responseXML);
+								//in jQuery 1.9.1+, responseXML is processed differently and relies on responseText
+								this.responseText = mockHandler.responseXML;
+							} else {
+								this.responseXML = mockHandler.responseXML;
+							}
+						} else if (typeof mockHandler.responseText === 'object' && mockHandler.responseText !== null) {
+							// since jQuery 1.9 responseText type has to match contentType
+							mockHandler.contentType = 'application/json';
+							this.responseText = JSON.stringify(mockHandler.responseText);
+						} else {
+							this.responseText = mockHandler.responseText;
+						}
+						if( typeof mockHandler.status == 'number' || typeof mockHandler.status == 'string' ) {
+							this.status = mockHandler.status;
+						}
+						if( typeof mockHandler.statusText === "string") {
+							this.statusText = mockHandler.statusText;
+						}
+						// jQuery 2.0 renamed onreadystatechange to onload
+						onReady = this.onreadystatechange || this.onload;
+
+						// jQuery < 1.4 doesn't have onreadystate change for xhr
+						if ( $.isFunction( onReady ) ) {
+							if( mockHandler.isTimeout) {
+								this.status = -1;
+							}
+							onReady.call( this, mockHandler.isTimeout ? 'timeout' : undefined );
+						} else if ( mockHandler.isTimeout ) {
+							// Fix for 1.3.2 timeout to keep success from firing.
+							this.status = -1;
+						}
+					};
+
+					// We have an executable function, call it to give
+					// the mock handler a chance to update it's data
+					if ( $.isFunction(mockHandler.response) ) {
+						// Wait for it to finish
+						if ( mockHandler.response.length === 2 ) {
+							mockHandler.response(origSettings, function () {
+								finishRequest.call(that);
+							});
+							return;
+						} else {
+							mockHandler.response(origSettings);
+						}
+					}
+
+					finishRequest.call(that);
+				}).apply(that);
+			};
+		})(this);
+
+		if ( mockHandler.proxy ) {
+			// We're proxying this request and loading in an external file instead
+			_ajax({
+				global: false,
+				url: mockHandler.proxy,
+				type: mockHandler.proxyType,
+				data: mockHandler.data,
+				dataType: requestSettings.dataType === "script" ? "text/plain" : requestSettings.dataType,
+				complete: function(xhr) {
+					mockHandler.responseXML = xhr.responseXML;
+					mockHandler.responseText = xhr.responseText;
+                    // Don't override the handler status/statusText if it's specified by the config
+                    if (isDefaultSetting(mockHandler, 'status')) {
+					    mockHandler.status = xhr.status;
+                    }
+                    if (isDefaultSetting(mockHandler, 'statusText')) {
+					    mockHandler.statusText = xhr.statusText;
+                    }
+					this.responseTimer = setTimeout(process, parseResponseTimeOpt(mockHandler.responseTime) || 0);
+				}
+			});
+		} else {
+			// type == 'POST' || 'GET' || 'DELETE'
+			if ( requestSettings.async === false ) {
+				// TODO: Blocking delay
+				process();
+			} else {
+				this.responseTimer = setTimeout(process, parseResponseTimeOpt(mockHandler.responseTime) || 50);
+			}
+		}
+	}
+
+	// Construct a mocked XHR Object
+	function xhr(mockHandler, requestSettings, origSettings, origHandler) {
+		// Extend with our default mockjax settings
+		mockHandler = $.extend(true, {}, $.mockjaxSettings, mockHandler);
+
+		if (typeof mockHandler.headers === 'undefined') {
+			mockHandler.headers = {};
+		}
+		if (typeof requestSettings.headers === 'undefined') {
+			requestSettings.headers = {};
+		}
+		if ( mockHandler.contentType ) {
+			mockHandler.headers['content-type'] = mockHandler.contentType;
+		}
+
+		return {
+			status: mockHandler.status,
+			statusText: mockHandler.statusText,
+			readyState: 1,
+			open: function() { },
+			send: function() {
+				origHandler.fired = true;
+				_xhrSend.call(this, mockHandler, requestSettings, origSettings);
+			},
+			abort: function() {
+				clearTimeout(this.responseTimer);
+			},
+			setRequestHeader: function(header, value) {
+				requestSettings.headers[header] = value;
+			},
+			getResponseHeader: function(header) {
+				// 'Last-modified', 'Etag', 'content-type' are all checked by jQuery
+				if ( mockHandler.headers && mockHandler.headers[header] ) {
+					// Return arbitrary headers
+					return mockHandler.headers[header];
+				} else if ( header.toLowerCase() == 'last-modified' ) {
+					return mockHandler.lastModified || (new Date()).toString();
+				} else if ( header.toLowerCase() == 'etag' ) {
+					return mockHandler.etag || '';
+				} else if ( header.toLowerCase() == 'content-type' ) {
+					return mockHandler.contentType || 'text/plain';
+				}
+			},
+			getAllResponseHeaders: function() {
+				var headers = '';
+				// since jQuery 1.9 responseText type has to match contentType
+				if (mockHandler.contentType) {
+					mockHandler.headers['Content-Type'] = mockHandler.contentType;
+				}
+				$.each(mockHandler.headers, function(k, v) {
+					headers += k + ': ' + v + "\n";
+				});
+				return headers;
+			}
+		};
+	}
+
+	// Process a JSONP mock request.
+	function processJsonpMock( requestSettings, mockHandler, origSettings ) {
+		// Handle JSONP Parameter Callbacks, we need to replicate some of the jQuery core here
+		// because there isn't an easy hook for the cross domain script tag of jsonp
+
+		processJsonpUrl( requestSettings );
+
+		requestSettings.dataType = "json";
+		if(requestSettings.data && CALLBACK_REGEX.test(requestSettings.data) || CALLBACK_REGEX.test(requestSettings.url)) {
+			createJsonpCallback(requestSettings, mockHandler, origSettings);
+
+			// We need to make sure
+			// that a JSONP style response is executed properly
+
+			var rurl = /^(\w+:)?\/\/([^\/?#]+)/,
+				parts = rurl.exec( requestSettings.url ),
+				remote = parts && (parts[1] && parts[1] !== location.protocol || parts[2] !== location.host);
+
+			requestSettings.dataType = "script";
+			if(requestSettings.type.toUpperCase() === "GET" && remote ) {
+				var newMockReturn = processJsonpRequest( requestSettings, mockHandler, origSettings );
+
+				// Check if we are supposed to return a Deferred back to the mock call, or just
+				// signal success
+				if(newMockReturn) {
+					return newMockReturn;
+				} else {
+					return true;
+				}
+			}
+		}
+		return null;
+	}
+
+	// Append the required callback parameter to the end of the request URL, for a JSONP request
+	function processJsonpUrl( requestSettings ) {
+		if ( requestSettings.type.toUpperCase() === "GET" ) {
+			if ( !CALLBACK_REGEX.test( requestSettings.url ) ) {
+				requestSettings.url += (/\?/.test( requestSettings.url ) ? "&" : "?") +
+					(requestSettings.jsonp || "callback") + "=?";
+			}
+		} else if ( !requestSettings.data || !CALLBACK_REGEX.test(requestSettings.data) ) {
+			requestSettings.data = (requestSettings.data ? requestSettings.data + "&" : "") + (requestSettings.jsonp || "callback") + "=?";
+		}
+	}
+
+	// Process a JSONP request by evaluating the mocked response text
+	function processJsonpRequest( requestSettings, mockHandler, origSettings ) {
+		// Synthesize the mock request for adding a script tag
+		var callbackContext = origSettings && origSettings.context || requestSettings,
+			newMock = null;
+
+
+		// If the response handler on the moock is a function, call it
+		if ( mockHandler.response && $.isFunction(mockHandler.response) ) {
+			mockHandler.response(origSettings);
+		} else {
+
+			// Evaluate the responseText javascript in a global context
+			if( typeof mockHandler.responseText === 'object' ) {
+				$.globalEval( '(' + JSON.stringify( mockHandler.responseText ) + ')');
+			} else {
+				$.globalEval( '(' + mockHandler.responseText + ')');
+			}
+		}
+
+		// Successful response
+		setTimeout(function() {
+			jsonpSuccess( requestSettings, callbackContext, mockHandler );
+			jsonpComplete( requestSettings, callbackContext, mockHandler );
+		}, parseResponseTimeOpt(mockHandler.responseTime) || 0);
+
+		// If we are running under jQuery 1.5+, return a deferred object
+		if($.Deferred){
+			newMock = new $.Deferred();
+			if(typeof mockHandler.responseText == "object"){
+				newMock.resolveWith( callbackContext, [mockHandler.responseText] );
+			}
+			else{
+				newMock.resolveWith( callbackContext, [$.parseJSON( mockHandler.responseText )] );
+			}
+		}
+		return newMock;
+	}
+
+
+	// Create the required JSONP callback function for the request
+	function createJsonpCallback( requestSettings, mockHandler, origSettings ) {
+		var callbackContext = origSettings && origSettings.context || requestSettings;
+		var jsonp = requestSettings.jsonpCallback || ("jsonp" + jsc++);
+
+		// Replace the =? sequence both in the query string and the data
+		if ( requestSettings.data ) {
+			requestSettings.data = (requestSettings.data + "").replace(CALLBACK_REGEX, "=" + jsonp + "$1");
+		}
+
+		requestSettings.url = requestSettings.url.replace(CALLBACK_REGEX, "=" + jsonp + "$1");
+
+
+		// Handle JSONP-style loading
+		window[ jsonp ] = window[ jsonp ] || function( tmp ) {
+			data = tmp;
+			jsonpSuccess( requestSettings, callbackContext, mockHandler );
+			jsonpComplete( requestSettings, callbackContext, mockHandler );
+			// Garbage collect
+			window[ jsonp ] = undefined;
+
+			try {
+				delete window[ jsonp ];
+			} catch(e) {}
+
+			if ( head ) {
+				head.removeChild( script );
+			}
+		};
+	}
+
+	// The JSONP request was successful
+	function jsonpSuccess(requestSettings, callbackContext, mockHandler) {
+		// If a local callback was specified, fire it and pass it the data
+		if ( requestSettings.success ) {
+			requestSettings.success.call( callbackContext, mockHandler.responseText || "", status, {} );
+		}
+
+		// Fire the global callback
+		if ( requestSettings.global ) {
+			(requestSettings.context ? $(requestSettings.context) : $.event).trigger("ajaxSuccess", [{}, requestSettings]);
+		}
+	}
+
+	// The JSONP request was completed
+	function jsonpComplete(requestSettings, callbackContext) {
+		// Process result
+		if ( requestSettings.complete ) {
+			requestSettings.complete.call( callbackContext, {} , status );
+		}
+
+		// The request was completed
+		if ( requestSettings.global ) {
+			(requestSettings.context ? $(requestSettings.context) : $.event).trigger("ajaxComplete", [{}, requestSettings]);
+		}
+
+		// Handle the global AJAX counter
+		if ( requestSettings.global && ! --$.active ) {
+			$.event.trigger( "ajaxStop" );
+		}
+	}
+
+
+	// The core $.ajax replacement.
+	function handleAjax( url, origSettings ) {
+		var mockRequest, requestSettings, mockHandler, overrideCallback;
+
+		// If url is an object, simulate pre-1.5 signature
+		if ( typeof url === "object" ) {
+			origSettings = url;
+			url = undefined;
+		} else {
+			// work around to support 1.5 signature
+			origSettings = origSettings || {};
+			origSettings.url = url;
+		}
+
+		// Extend the original settings for the request
+		requestSettings = $.extend(true, {}, $.ajaxSettings, origSettings);
+
+		// Generic function to override callback methods for use with
+		// callback options (onAfterSuccess, onAfterError, onAfterComplete)
+		overrideCallback = function(action, mockHandler) {
+			var origHandler = origSettings[action.toLowerCase()];
+			return function() {
+				if ( $.isFunction(origHandler) ) {
+					origHandler.apply(this, [].slice.call(arguments));
+				}
+				mockHandler['onAfter' + action]();
+			};
+		};
+
+		// Iterate over our mock handlers (in registration order) until we find
+		// one that is willing to intercept the request
+		for(var k = 0; k < mockHandlers.length; k++) {
+			if ( !mockHandlers[k] ) {
+				continue;
+			}
+
+			mockHandler = getMockForRequest( mockHandlers[k], requestSettings );
+			if(!mockHandler) {
+				// No valid mock found for this request
+				continue;
+			}
+
+			mockedAjaxCalls.push(requestSettings);
+
+			// If logging is enabled, log the mock to the console
+			$.mockjaxSettings.log( mockHandler, requestSettings );
+
+
+			if ( requestSettings.dataType && requestSettings.dataType.toUpperCase() === 'JSONP' ) {
+				if ((mockRequest = processJsonpMock( requestSettings, mockHandler, origSettings ))) {
+					// This mock will handle the JSONP request
+					return mockRequest;
+				}
+			}
+
+
+			// Removed to fix #54 - keep the mocking data object intact
+			//mockHandler.data = requestSettings.data;
+
+			mockHandler.cache = requestSettings.cache;
+			mockHandler.timeout = requestSettings.timeout;
+			mockHandler.global = requestSettings.global;
+
+			// In the case of a timeout, we just need to ensure
+			// an actual jQuery timeout (That is, our reponse won't)
+			// return faster than the timeout setting.
+			if ( mockHandler.isTimeout ) {
+				if ( mockHandler.responseTime > 1 ) {
+					origSettings.timeout = mockHandler.responseTime - 1;
+				} else {
+					mockHandler.responseTime = 2;
+					origSettings.timeout = 1;
+				}
+				mockHandler.isTimeout = false;
+			}
+
+			// Set up onAfter[X] callback functions
+			if ( $.isFunction( mockHandler.onAfterSuccess ) ) {
+				origSettings.success = overrideCallback('Success', mockHandler);
+			}
+			if ( $.isFunction( mockHandler.onAfterError ) ) {
+				origSettings.error = overrideCallback('Error', mockHandler);
+			}
+			if ( $.isFunction( mockHandler.onAfterComplete ) ) {
+				origSettings.complete = overrideCallback('Complete', mockHandler);
+			}
+
+			copyUrlParameters(mockHandler, origSettings);
+
+			(function(mockHandler, requestSettings, origSettings, origHandler) {
+
+				mockRequest = _ajax.call($, $.extend(true, {}, origSettings, {
+					// Mock the XHR object
+					xhr: function() { return xhr( mockHandler, requestSettings, origSettings, origHandler ); }
+				}));
+			})(mockHandler, requestSettings, origSettings, mockHandlers[k]);
+
+			return mockRequest;
+		}
+
+		// We don't have a mock request
+		unmockedAjaxCalls.push(origSettings);
+		if($.mockjaxSettings.throwUnmocked === true) {
+			throw new Error('AJAX not mocked: ' + origSettings.url);
+		}
+		else { // trigger a normal request
+			return _ajax.apply($, [origSettings]);
+		}
+	}
+
+	/**
+	* Copies URL parameter values if they were captured by a regular expression
+	* @param {Object} mockHandler
+	* @param {Object} origSettings
+	*/
+	function copyUrlParameters(mockHandler, origSettings) {
+		//parameters aren't captured if the URL isn't a RegExp
+		if (!(mockHandler.url instanceof RegExp)) {
+			return;
+		}
+		//if no URL params were defined on the handler, don't attempt a capture
+		if (!mockHandler.hasOwnProperty('urlParams')) {
+			return;
+		}
+		var captures = mockHandler.url.exec(origSettings.url);
+		//the whole RegExp match is always the first value in the capture results
+		if (captures.length === 1) {
+			return;
+		}
+		captures.shift();
+		//use handler params as keys and capture resuts as values
+		var i = 0,
+		capturesLength = captures.length,
+		paramsLength = mockHandler.urlParams.length,
+		//in case the number of params specified is less than actual captures
+		maxIterations = Math.min(capturesLength, paramsLength),
+		paramValues = {};
+		for (i; i < maxIterations; i++) {
+			var key = mockHandler.urlParams[i];
+			paramValues[key] = captures[i];
+		}
+		origSettings.urlParams = paramValues;
+	}
+
+
+	// Public
+
+	$.extend({
+		ajax: handleAjax
+	});
+
+	$.mockjaxSettings = {
+		//url:        null,
+		//type:       'GET',
+		log:          function( mockHandler, requestSettings ) {
+			if ( mockHandler.logging === false ||
+				 ( typeof mockHandler.logging === 'undefined' && $.mockjaxSettings.logging === false ) ) {
+				return;
+			}
+			if ( window.console && console.log ) {
+				var message = 'MOCK ' + requestSettings.type.toUpperCase() + ': ' + requestSettings.url;
+				var request = $.extend({}, requestSettings);
+
+				if (typeof console.log === 'function') {
+					console.log(message, request);
+				} else {
+					try {
+						console.log( message + ' ' + JSON.stringify(request) );
+					} catch (e) {
+						console.log(message);
+					}
+				}
+			}
+		},
+		logging:       true,
+		status:        200,
+		statusText:    "OK",
+		responseTime:  500,
+		isTimeout:     false,
+		throwUnmocked: false,
+		contentType:   'text/plain',
+		response:      '',
+		responseText:  '',
+		responseXML:   '',
+		proxy:         '',
+		proxyType:     'GET',
+
+		lastModified:  null,
+		etag:          '',
+		headers: {
+			etag: 'IJF@H#@923uf8023hFO@I#H#',
+			'content-type' : 'text/plain'
+		}
+	};
+
+	$.mockjax = function(settings) {
+		var i = mockHandlers.length;
+		mockHandlers[i] = settings;
+		return i;
+	};
+	$.mockjax.clear = function(i) {
+		if ( arguments.length == 1 ) {
+			mockHandlers[i] = null;
+		} else {
+			mockHandlers = [];
+		}
+		mockedAjaxCalls = [];
+		unmockedAjaxCalls = [];
+	};
+	// support older, deprecated version
+	$.mockjaxClear = function(i) {
+		window.console && window.console.warn && window.console.warn( 'DEPRECATED: The $.mockjaxClear() method has been deprecated in 1.6.0. Please use $.mockjax.clear() as the older function will be removed soon!' );
+		$.mockjax.clear();
+	};
+	$.mockjax.handler = function(i) {
+		if ( arguments.length == 1 ) {
+			return mockHandlers[i];
+		}
+	};
+	$.mockjax.mockedAjaxCalls = function() {
+		return mockedAjaxCalls;
+	};
+	$.mockjax.unfiredHandlers = function() {
+		var results = [];
+		for (var i=0, len=mockHandlers.length; i<len; i++) {
+			var handler = mockHandlers[i];
+            if (handler !== null && !handler.fired) {
+				results.push(handler);
+			}
+		}
+		return results;
+	};
+	$.mockjax.unmockedAjaxCalls = function() {
+		return unmockedAjaxCalls;
+	};
+})(jQuery);

--- a/facia-tool/test/public/conf/karma.conf.js
+++ b/facia-tool/test/public/conf/karma.conf.js
@@ -1,0 +1,35 @@
+module.exports = function(config) {
+  config.set({
+    basePath: '../../..',
+    frameworks: ['jasmine'],
+    files: [
+        {pattern: 'app/views/**/*.html', included: false},
+        {pattern: 'public/js/components/jquery/jquery.js', included: true},
+        {pattern: 'public/js/components/jquery-mockjax/jquery.mockjax.js', included: true},
+        {pattern: 'public/js/components/curl/dist/curl-with-js-and-domReady/curl.js', included: true},
+        {pattern: 'public/js/components/underscore/underscore.js', included: true},
+        {pattern: 'public/js/**/*.js', included: false},
+        {pattern: 'public/css/*.css', included: true},
+        {pattern: 'public/css/!(*.css)', included: false},
+        {pattern: 'test/public/config.js', included: true},
+        {pattern: 'test/public/spec/**/*', included: false},
+        {pattern: 'test/public/mocks/*.js', included: true},
+        {pattern: 'test/public/fixtures/*.js', included: false},
+        {pattern: 'test/public/test-main.js', included: true}
+    ],
+
+    exclude: [],
+
+    // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
+    reporters: ['progress'],
+    port: 9876,
+    colors: true,
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_ERROR,
+    autoWatch: true,
+
+    browsers: ['PhantomJS'],
+    captureTimeout: 60000,
+    singleRun: false
+  });
+};

--- a/facia-tool/test/public/config.js
+++ b/facia-tool/test/public/config.js
@@ -1,0 +1,17 @@
+curl.config({
+    baseUrl: "base/public/js/",
+    paths: {
+        knockout:      'components/knockout.js/knockout.js',
+        EventEmitter:  'components/eventEmitter/EventEmitter',
+        reqwest:       'components/reqwest/reqwest',
+        bean:          'components/bean/bean',
+        bonzo:         'components/bonzo/bonzo',
+        omniture:      'omniture.js',
+        views:         '../../app/views',
+        css:           '../css',
+        fixtures:      '../../test/public/fixtures'
+    },
+    pluginPath: 'components/curl/src/curl/plugin'
+});
+
+$.mockjaxSettings.logging = false;

--- a/facia-tool/test/public/fixtures/one-front-config.js
+++ b/facia-tool/test/public/fixtures/one-front-config.js
@@ -1,0 +1,21 @@
+define([
+    'mock-config'
+], function (
+    mockConfig
+) {
+    mockConfig.set({
+        fronts: {
+            uk: {
+                collections: ['latest'],
+                description: 'Broken news',
+                title: 'UK',
+                priority: 'test'
+            }
+        },
+        collections: {
+            'latest': {
+                displayName: 'politics'
+            }
+        }
+    });
+});

--- a/facia-tool/test/public/mocks/collection.js
+++ b/facia-tool/test/public/mocks/collection.js
@@ -1,0 +1,22 @@
+define('mock-collection', ['utils/mediator'], function (
+    mediator
+) {
+    var all = {};
+
+    $.mockjax({
+        url: /collection\/(.+)/,
+        urlParams: ['collection'],
+        response: function (req) {
+            this.responseText = all[req.urlParams.collection];
+        },
+        onAfterComplete: function () {
+            mediator.emit('mock:collection');
+        }
+    });
+
+    return {
+        set: function (collections) {
+            all = _.extend(all, collections);
+        }
+    };
+});

--- a/facia-tool/test/public/mocks/config.js
+++ b/facia-tool/test/public/mocks/config.js
@@ -1,0 +1,25 @@
+define('mock-config', ['utils/mediator'], function (
+    mediator
+) {
+    // Default response, if missing the application navigates away
+    var mockResponse = {
+        fronts: {},
+        collections: {}
+    };
+
+    $.mockjax({
+        url: '/config',
+        response: function (req) {
+            this.responseText = mockResponse;
+        },
+        onAfterComplete: function () {
+            mediator.emit('mock:config');
+        }
+    });
+
+    return {
+        set: function (response) {
+            mockResponse = response;
+        }
+    };
+});

--- a/facia-tool/test/public/mocks/globals.js
+++ b/facia-tool/test/public/mocks/globals.js
@@ -1,0 +1,25 @@
+define('config', function() {
+    return {
+        env: 'test',
+        priority: 'test',
+        editions: ['uk','us','au'],
+        navSections: ['news', 'uk-news', 'us-news', 'au-news'],
+        email: '',
+        avatarUrl: '',
+        lowFrequency: 60,
+        highFrequency: 2,
+        standardFrequency: 5
+    };
+});
+
+define('fixed-containers', function () {
+    return [
+        {'name':'fixed/test'}
+    ];
+});
+
+define('dynamic-containers', function () {
+    return [
+        {'name':'dynamic/test'}
+    ];
+});

--- a/facia-tool/test/public/mocks/lastmodified.js
+++ b/facia-tool/test/public/mocks/lastmodified.js
@@ -1,0 +1,28 @@
+define('mock-lastmodified', ['utils/mediator'], function (
+    mediator
+) {
+    var lastModified = {};
+
+    $.mockjax({
+        url: /\/front\/lastmodified\/(.+)/,
+        urlParams: ['front'],
+        response: function (req) {
+            var response = lastModified[req.urlParams.front];
+            if (!response) {
+                response = {
+                    status: 'fail'
+                };
+            }
+            this.responseText = response;
+        },
+        onAfterComplete: function () {
+            mediator.emit('mock:lastmodified');
+        }
+    });
+
+    return {
+        set: function (response) {
+            lastModified = _.extend(lastModified, response);
+        }
+    };
+});

--- a/facia-tool/test/public/mocks/query-param.js
+++ b/facia-tool/test/public/mocks/query-param.js
@@ -1,0 +1,12 @@
+define('utils/query-params', function () {
+    var queryParams = {};
+
+    var getter = function () {
+        return queryParams;
+    };
+    getter.set = function (params) {
+        queryParams = params;
+    };
+
+    return getter;
+});

--- a/facia-tool/test/public/mocks/search.js
+++ b/facia-tool/test/public/mocks/search.js
@@ -1,0 +1,55 @@
+define("mock-search", ['utils/mediator'], function (
+    mediator
+) {
+    var latestArticles = {
+        response: {
+            status: "ok",
+            userTier: "internal",
+            total: 0,
+            startIndex: 1,
+            pageSize: 50,
+            currentPage: 1,
+            pages: 0,
+            orderBy: "newest",
+            results: []
+        }
+    };
+    var allArticles = {};
+
+    $.mockjax({
+        url: /\/api\/proxy\/search\?(.+)/,
+        urlParams: ["queryString"],
+        response: function (req) {
+            var urlParams = parse(req.urlParams.queryString);
+            if (!urlParams.ids) {
+                this.responseText = latestArticles;
+            } else {
+                this.responseText = allArticles[urlParams.ids];
+            }
+        },
+        onAfterComplete: function () {
+            mediator.emit('mock:search');
+        }
+    });
+
+    function parse (string) {
+        var result = {};
+        var params = string.split("&");
+        for (var i = 0; i < params.length; i += 1) {
+            var pair = params[i].split("=");
+            result[pair[0]] = decodeURIComponent(pair[1]);
+        }
+        return result;
+    }
+
+    return {
+        set: function (articles) {
+            allArticles = _.extend(allArticles, articles);
+        },
+        latest: function (articles) {
+            latestArticles.response.results = articles;
+            latestArticles.response.total = articles.length;
+            latestArticles.response.pages = Math.ceil(articles.length / latestArticles.response.pageSize);
+        }
+    };
+});

--- a/facia-tool/test/public/mocks/switches.js
+++ b/facia-tool/test/public/mocks/switches.js
@@ -1,0 +1,29 @@
+define("mock-switches", ['utils/mediator'], function (
+    mediator
+) {
+    // Default response, if missing the application navigates away
+    var mockResponse = {
+        'facia-tool-disable': false,
+        'facia-tool-draft-content': true,
+        'facia-tool-sparklines': false
+    };
+
+    $.mockjax({
+        url: "/switches",
+        response: function (req) {
+            this.responseText = mockResponse;
+        },
+        onAfterComplete: function () {
+            mediator.emit('mock:switches');
+        }
+    });
+
+    return {
+        set: function (response) {
+            mockResponse = response;
+        },
+        override: function (keys) {
+            mockResponse = _.extend(mockResponse, keys);
+        }
+    };
+});

--- a/facia-tool/test/public/spec/collections.spec.js
+++ b/facia-tool/test/public/spec/collections.spec.js
@@ -1,0 +1,73 @@
+/* global curl: true */
+define([
+    'models/collections/main',
+    'fixtures/one-front-config',
+    'mock-switches',
+    'mock-search',
+    'mock-collection',
+    'utils/query-params',
+    'text!views/collections.scala.html',
+    'utils/mediator'
+], function(
+    CollectionsEditor,
+    fixConfig,
+    mockSwitches,
+    mockSearch,
+    mockCollection,
+    queryParams,
+    templateCollections,
+    mediator
+){
+    var yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    var testArticle = {
+        apiUrl: '/capi',
+        id: 'politics/uk/2014/nov/07/i-won-the-elections',
+        webPublicationDate: '2014-11-07T14:45:00Z',
+        webTitle: 'I won the elections',
+        webUrl: 'http://theguardian.com/uk',
+        fields: {
+            headline: 'I won the elections',
+            thumbnail: '/thumbnail',
+            internalContentCode: "1234567890"
+        }
+    };
+    var collections = {
+        latest: {
+            lastUpdated: yesterday.toISOString(),
+            live: [{
+                id: 'politics/uk/2014/nov/07/i-won-the-elections',
+                frontPublicationDate: 1415193273347
+            }],
+            updatedBy: 'Test'
+        }
+    };
+
+    mockSearch.latest([testArticle]);
+    mockSearch.set({
+        'politics/uk/2014/nov/07/i-won-the-elections': {
+            response: {
+                results: [testArticle]
+            }
+        }
+    });
+    mockCollection.set(collections);
+
+    document.body.innerHTML += templateCollections;
+    queryParams.set({
+        front: 'uk'
+    });
+
+    describe('Collections', function () {
+        it('displays the correct timing', function (done) {
+            new CollectionsEditor().init();
+            mediator.on('mock:search', _.after(2, function () {
+                expect(
+                    $('.list-header__timings').text().replace(/\s+/g, ' ')
+                ).toMatch('1 day ago by Test');
+                done();
+            }));
+        });
+    });
+});

--- a/facia-tool/test/public/test-main.js
+++ b/facia-tool/test/public/test-main.js
@@ -1,0 +1,17 @@
+// Make karma asynchronous
+window.__karma__.loaded = function () {};
+
+// Load all tests specs through curl
+(function () {
+    var tests = [];
+    var specFileExpr = /.*\.spec\.js$/;
+    for (var file in window.__karma__.files) {
+        if (specFileExpr.test(file)) {
+            tests.push(file);
+        }
+    }
+
+    curl(tests).then(function () {
+        window.__karma__.start();
+    });
+})();

--- a/grunt-configs/karma.js
+++ b/grunt-configs/karma.js
@@ -16,6 +16,9 @@ module.exports = function(grunt, options) {
         },
         membership: {
             configFile: options.testConfDir + 'membership.js'
+        },
+        'facia-tool': {
+            configFile: 'facia-tool/test/public/conf/karma.conf.js'
         }
     };
 };


### PR DESCRIPTION
Last modified time shows as 'x days ago ago' (top right in the picture).

![before the fix](https://cloud.githubusercontent.com/assets/680284/4977127/c2e92e1a-68e4-11e4-9938-7ac9208b77b8.png)

The commit also introcudes a way of running unit(?) tests for knockout.
The spec loads a mocked list of fronts, collections and items and starts the application.
The test is trivial, it just asserts the text of an element, but it can be extended in the future to run assertion on user interaction.

Tests run automatically on team city or manually with `grunt test:unit:facia-tool`.
Debugging can be done with

```
cd facia-tool/test/public/config
karma start
```
