### PR TITLE
Handle media errors

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -421,7 +421,10 @@ define([
 
     function ready() {
         if (config.switches.enhancedMediaPlayer) {
-            require('bootstraps/video-player', initPlayer);
+            require('bootstraps/video-player', raven.wrap(
+                { tags: { feature: 'media' } },
+                initPlayer
+            ));
         }
         initMoreInSection();
         initMostViewedMedia();

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -1,7 +1,6 @@
 define([
     'bean',
     'bonzo',
-    'raven',
     'lodash/arrays/flatten',
     'lodash/arrays/intersection',
     'lodash/objects/assign',
@@ -13,7 +12,6 @@ define([
 ], function (
     bean,
     bonzo,
-    raven,
     flatten,
     intersection,
     assign,

--- a/static/src/javascripts/projects/common/modules/onward/onward-content.js
+++ b/static/src/javascripts/projects/common/modules/onward/onward-content.js
@@ -1,12 +1,10 @@
 define([
-    'raven',
     'common/utils/config',
     'common/modules/analytics/register',
     'common/modules/commercial/badges',
     'common/modules/component',
     'common/modules/ui/images'
 ], function (
-    raven,
     config,
     register,
     badges,

--- a/static/src/javascripts/projects/common/modules/onward/popular-fronts.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular-fronts.js
@@ -1,6 +1,5 @@
 define([
     'bonzo',
-    'raven',
     'common/utils/$',
     'common/utils/ajax',
     'common/utils/config',
@@ -9,7 +8,6 @@ define([
     'common/modules/ui/relativedates'
 ], function (
     bonzo,
-    raven,
     $,
     ajax,
     config,

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -1,7 +1,6 @@
 define([
     'bonzo',
     'qwery',
-    'raven',
     'lodash/arrays/intersection',
     'common/utils/$',
     'common/utils/config',
@@ -13,7 +12,6 @@ define([
 ], function (
     bonzo,
     qwery,
-    raven,
     intersection,
     $,
     config,

--- a/static/src/javascripts/projects/common/modules/onward/tonal.js
+++ b/static/src/javascripts/projects/common/modules/onward/tonal.js
@@ -1,12 +1,10 @@
 define([
-    'raven',
     'common/utils/config',
     'common/utils/mediator',
     'common/modules/analytics/register',
     'common/modules/component',
     'common/modules/ui/images'
 ], function (
-    raven,
     config,
     mediator,
     register,


### PR DESCRIPTION
Our raven bootstrap context, the existing context we use during application init, does not catch errors in async require modules. Errors that are thrown in async require modules will actually bubble up to their respective script tag parent, thanks to curl.

The only way to catch this class of error is by wrapping on one side of the app-module call. It's typically easier to wrap things on the app side, like we do here, with the caveat that any module init errors are not within the wrap (that still gets caught in the bootstrap context).
