### PR TITLE
show linebreaks in comments

### DIFF
--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -496,10 +496,6 @@ $avatarPadding: $gs-gutter / 2;
     @include font-size(14, 20);
     margin-bottom: $gs-baseline * 2 / 3;
 
-    br {
-        display: none;
-    }
-
     p {
         margin-top: $gs-baseline * 2 / 3;
         word-wrap: break-word;


### PR DESCRIPTION
Not sure why I hid these in the first place..
## Before

![image](https://cloud.githubusercontent.com/assets/960919/4991439/7ece06e0-698b-11e4-89ca-61d66a3ec35f.png)
## After

![image](https://cloud.githubusercontent.com/assets/960919/4991427/5c7ca0e2-698b-11e4-8dc5-93a1c4ee725e.png)
