### PR TITLE
Move media most popular items to new fc-item classes

### DIFF
--- a/onward/app/views/fragments/mediaItem.scala.html
+++ b/onward/app/views/fragments/mediaItem.scala.html
@@ -8,7 +8,7 @@
     <div class="fc-item__container">
         <a class="fc-item__action" href="@LinkTo{@content.url}" data-link-name="item @index">
             @content.trailPicture(5, 3).map{ image =>
-                <div class="fc--item__img u-responsive-ratio">
+                <div class="fc-item__img u-responsive-ratio">
                     <img class="responsiveimg" src="@Item140.bestFor(image)" alt="" />
                 </div>
             }

--- a/onward/app/views/fragments/mediaItem.scala.html
+++ b/onward/app/views/fragments/mediaItem.scala.html
@@ -4,15 +4,15 @@
 @import model.{Audio, Video}
 @import views.support.Item140
 
-<li class="item">
-    <div class="item__container">
-        <a class="item__action" href="@LinkTo{@content.url}" data-link-name="item @index">
+<li class="fc-item fc-item--media">
+    <div class="fc-item__container">
+        <a class="fc-item__action" href="@LinkTo{@content.url}" data-link-name="item @index">
             @content.trailPicture(5, 3).map{ image =>
-                <div class="item__img u-responsive-ratio">
+                <div class="fc--item__img u-responsive-ratio">
                     <img class="responsiveimg" src="@Item140.bestFor(image)" alt="" />
                 </div>
             }
-            <h4 class="item__title">@content match {
+            <h4 class="fc-item__title">@content match {
                 case a: Audio => { @a.webTitle }
                 case v: Video => { @v.videoLinkText }
             }</h4>

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -191,7 +191,7 @@
     margin-left: -$gs-gutter/2;
     margin-right: -$gs-gutter/2;
 
-    .media-item {
+    .item {
         @include mq($until: tablet) {
             &:nth-child(odd) {
                 border-right: 1px solid colour(neutral-2);
@@ -227,7 +227,7 @@
             }
         }
     }
-    .media-item__title {
+    .item__title {
         @include text-clamp(3, get-line-height(headline, 1));
         height: get-line-height(headline, 1) * 3;
     }

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -91,21 +91,40 @@
 /* Media item
    ========================================================================== */
 
-.items--media {
-    .item {
-        position: relative;
-        float: left;
-        width: 50%;
-        @include box-sizing(border-box);
-        margin-bottom: $gs-baseline*2;
-        padding-left: $gs-gutter/2;
-        padding-right: $gs-gutter/2;
+.fc-item--media {
+    position: relative;
+    float: left;
+    width: 50%;
+    @include box-sizing(border-box);
+    margin-bottom: $gs-baseline*2;
+    padding-left: $gs-gutter/2;
+    padding-right: $gs-gutter/2;
 
-        .item__container {
-            margin-top: -$gs-baseline;
+    &.fc-item {
+        background-color: transparent;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    &:nth-child(2n) {
+        &:before {
+            content: '';
+            display: block;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            width: 1px;
+            height: 100%;
+            border-left: 1px solid colour(neutral-2);
         }
     }
-    .item__action {
+
+    .fc-item__container {
+        margin-top: -$gs-baseline;
+    }
+
+    .fc-item__action {
         display: block;
         padding-top: $gs-baseline;
         color: colour(neutral-5);
@@ -119,10 +138,10 @@
             color: darken(colour(neutral-5), 20%);
         }
     }
-    .item__img {
+    .fc-item__img {
         margin-bottom: $gs-baseline/3;
     }
-    .item__title {
+    .fc-item__title {
         @include fs-headline(1);
         font-weight: 500;
         text-align: left; //Required for end slate items
@@ -141,11 +160,11 @@
 
 
 
-.items--video .item__title:before {
+.items--video .fc-item__title:before {
     @include icon(video-icon, false);
 }
 
-.items--audio .item__title:before {
+.items--audio .fc-item__title:before {
     @include icon(volume-high--tone-media, false);
 }
 
@@ -172,7 +191,7 @@
     margin-left: -$gs-gutter/2;
     margin-right: -$gs-gutter/2;
 
-    .item {
+    .media-item {
         @include mq($until: tablet) {
             &:nth-child(odd) {
                 border-right: 1px solid colour(neutral-2);
@@ -208,7 +227,7 @@
             }
         }
     }
-    .item__title {
+    .media-item__title {
         @include text-clamp(3, get-line-height(headline, 1));
         height: get-line-height(headline, 1) * 3;
     }


### PR DESCRIPTION
Just when i thought merging the mega branch was too good to be true. This brings the most popular video items inline with new facia `fc-item` classes.
### before

![google chrome](https://cloud.githubusercontent.com/assets/80089/4997202/ac3aec40-69c4-11e4-92a2-52321c7416e0.png)
### after

![google chrome](https://cloud.githubusercontent.com/assets/80089/4997203/b1e74a80-69c4-11e4-9ff6-77ed6f3e2ac5.png)

/cc @mattosborn @rich-nguyen 
