### PR TITLE
increase localStorage page history variety

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -308,14 +308,17 @@ define([
 
             logReadingHistory: function () {
                 mediator.on('page:common:ready', function () {
+                    var oldItems, items, newItem;
                     if (config.page.contentType !== 'Network Front') {
-                        history.log({
-                            id: '/' + config.page.pageId,
-                            meta: {
-                                section: config.page.section,
-                                keywords: config.page.keywordIds && (config.page.keywordIds + '').split(',').slice(0, 5)
-                            }
-                        });
+
+                        newItem = history.preparePage(config.page);
+
+                        oldItems = history.impure.get();
+
+                        items = history.getUpdatedHistory(newItem, oldItems, Date.now(), history.maxSize);
+
+                        history.impure.set(items.recentPages, items.summary);
+
                     }
                 });
             },

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -308,17 +308,8 @@ define([
 
             logReadingHistory: function () {
                 mediator.on('page:common:ready', function () {
-                    var oldItems, items, newItem;
                     if (config.page.contentType !== 'Network Front') {
-
-                        newItem = history.preparePage(config.page);
-
-                        oldItems = history.impure.get();
-
-                        items = history.getUpdatedHistory(newItem, oldItems, Date.now(), history.maxSize);
-
-                        history.impure.set(items.recentPages, items.summary);
-
+                        history.log(config.page);
                     }
                 });
             },

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -55,10 +55,7 @@ define([
     }
 
     function shouldAutoPlay(player) {
-        var pageHasBeenSeen = _.find(history.get(), function (historyItem) {
-            return (historyItem.id === '/' + config.page.pageId) && historyItem.count > 1;
-        });
-        return $('.vjs-tech', player.el()).attr('data-auto-play') === 'true' && isDesktop && !pageHasBeenSeen;
+        return $('.vjs-tech', player.el()).attr('data-auto-play') === 'true' && isDesktop && !history.pageHasBeenSeen(config.page.pageId);
     }
 
     function constructEventName(eventName, player) {

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -66,7 +66,9 @@ define([
                         return matchers;
                     }, {}),
 
-                    historyMatchers = assign({}, assign(history.getSummary().sections, history.getSummary().keywords)),
+                    summary = history.impure.getSummary(),
+
+                    historyMatchers = assign({}, assign(history.getSectionCounts(summary), history.getLeadKeywordCounts(summary))),
 
                     articles = flatten([
                         collections.filter(function (c) { return c.href === 'global'; }).map(function (c) { return c.content; }),

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -66,7 +66,7 @@ define([
                         return matchers;
                     }, {}),
 
-                    summary = history.impure.getSummary(),
+                    summary = history.getSummary(),
 
                     historyMatchers = assign({}, assign(history.getSectionCounts(summary), history.getLeadKeywordCounts(summary))),
 

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -3,103 +3,180 @@
  Description: Gets and sets users reading history
  */
 define([
+    'lodash/arrays/zip',
+    'lodash/collections/reduceRight',
     'lodash/objects/assign',
+    'lodash/objects/mapValues',
     'common/utils/storage'
 ], function (
+    zip,
+    reduceRight,
     assign,
+    mapValues,
     storage
 ) {
 
-    var history,
-        summary,
+    var historyCache,
+        summaryCache,
         storageKeyHistory = 'gu.history',
-        storageKeySummary = 'gu.history.summary',
-        maxSize = 100;
+        storageKeySummary = storageKeyHistory + '.summary';
 
-    function HistoryItem(item) {
-        assign(this, item.meta);
-        this.id = item.id;
-        this.timestamp = Date.now();
+    function HistoryItem(item, now) {
+        assign(this, item);
+        this.timestamp = now;
         this.count = 1;
         return this;
     }
 
-    function setHistory(data) {
-        history = data;
-        return storage.local.set(storageKeyHistory, data);
+    function Summary() {
+        this.section = {};
+        this.series = {};
+        this.leadKeyword = {};
+        this.leadAuthor = {};
+        this.leadBlog = {};
     }
 
-    function setSummary(data) {
-        summary = data;
-        return storage.local.set(storageKeySummary, data);
+    function updateSummaryTypeFromIdName(idName, summary) {
+
+        var nameCount = summary[idName[0]] || [idName[1], 0];
+        nameCount[1] = nameCount[1] + 1;
+        nameCount[0] = idName[1];
+        summary[idName[0]] = nameCount;
+
+        return summary;
     }
 
-    function updateSummary(summary, meta) {
-        var section = meta.section,
-            keyword = (meta.keywords || [])[0];
+    function updateSummaryFromAllMeta(metaList, summary) {
 
-        if (section) {
-            summary.sections[section] = (summary.sections[section] || 0) + 1;
+        var metaType, idName;
+
+        for (metaType in metaList) {
+
+            if (!metaList.hasOwnProperty(metaType) || !new Summary().hasOwnProperty(metaType)) {
+                continue;
+            }
+
+            idName = metaList[metaType];
+            summary[metaType] = updateSummaryTypeFromIdName(idName, summary[metaType]);
+
         }
 
-        if (keyword) {
-            summary.keywords[keyword] = (summary.keywords[keyword] || 0) + 1;
-        }
+        return summary
+    }
+
+    function addItemAndUpdateSummary(itemsSoFar, itemToAdd) {
+
+        itemsSoFar.recentPages.unshift(itemToAdd);
+
+        itemsSoFar.summary = updateSummaryFromAllMeta(itemToAdd.meta, itemsSoFar.summary);
+
+        return itemsSoFar;
+    }
+
+    function getUpdatedHistory(newItem, oldItems, now, maxSize) {
+        var initialValue, reduceItems, items;
+
+        initialValue = {
+            currentItem: new HistoryItem(newItem, now),
+            recentPages: [],
+            summary: new Summary()
+        };
+
+        reduceItems = function (items, item) {
+            if (item.id === newItem.id) {
+                items.currentItem.count = items.currentItem.count + item.count;
+            } else {
+                if (item.meta) { // only add non legacy items with a meta block
+                    items = addItemAndUpdateSummary(items, item);
+                }
+            }
+
+            return items;
+        };
+
+        items = reduceRight(oldItems, reduceItems, initialValue);
+        addItemAndUpdateSummary(items, items.currentItem);
+        delete items.currentItem;
+
+        items.recentPages = items.recentPages.slice(0, maxSize);
+        items.summary.count = items.recentPages.length;
+        return items;
+    }
+
+    function getCountsMap(metaName, summary) {
+        return mapValues(summary[metaName], function (nameCount) {
+            return nameCount[1];
+        });
     }
 
     return {
-        reset: function () {
-            history = undefined;
-            summary = undefined;
-            storage.local.remove(storageKeyHistory);
-            storage.local.remove(storageKeySummary);
-        },
 
-        get: function () {
-            history = history || storage.local.get(storageKeyHistory) || [];
-            return history;
-        },
+        test: {
+            Summary: Summary,
+            updateSummaryTypeFromIdName: updateSummaryTypeFromIdName,
+            updateSummaryFromAllMeta: updateSummaryFromAllMeta,
 
-        getSummary: function () {
-            summary = summary || storage.local.get(storageKeySummary) || {sections: {}, keywords: {}};
-            return summary;
-        },
-
-        getSize: function () {
-            return this.get().length;
-        },
-
-        contains: function (id) {
-            return this.get().some(function (el) {
-                return el.id === id;
-            });
-        },
-
-        log: function (newItem) {
-            var foundItem,
-                summary = {sections: {}, keywords: {}},
-                hist = this.get().filter(function (item) {
-                    var found = (item.id === newItem.id);
-
-                    updateSummary(summary, item);
-                    foundItem = found ? item : foundItem;
-                    return !found;
-                });
-
-            if (foundItem) {
-                foundItem.count = (foundItem.count || 0) + 1;
-                foundItem.timestamp = Date.now();
-                hist.unshift(foundItem);
-            } else {
-                updateSummary(summary, newItem.meta);
-                hist.unshift(new HistoryItem(newItem));
-                hist = hist.slice(0, maxSize);
+            reset: function () {
+                historyCache = undefined;
+                summaryCache = undefined;
+                storage.local.remove(storageKeyHistory);
+                storage.local.remove(storageKeySummary);
             }
 
-            summary.count = hist.length;
+        },
 
-            setSummary(summary);
-            setHistory(hist);
+        maxSize: 100,
+
+        impure: {
+
+            getSummary: function () {
+                summaryCache = summaryCache || storage.local.get(storageKeySummary) || new Summary();
+                return summaryCache;
+            },
+
+            getHistory: function () {
+                historyCache = historyCache || storage.local.get(storageKeyHistory) || [];
+                return historyCache;
+            },
+
+            set: function (history, summary) {
+                historyCache = history;
+                storage.local.set(storageKeyHistory, history);
+                summaryCache = summary;
+                storage.local.set(storageKeySummary, summary);
+            }
+
+        },
+
+        getSectionCounts: function (summary) {
+            return getCountsMap('section', summary);
+        },
+
+        getLeadKeywordCounts: function (summary) {
+            return getCountsMap('leadKeyword', summary);
+        },
+
+        getUpdatedHistory: getUpdatedHistory,
+
+        preparePage: function (page) {
+            return {
+                id: '/' + page.pageId,
+                meta: new (function () {
+
+                    var getHead = function (csString) {
+                        return csString && ((csString + '').split(',')[0]);
+                    };
+
+                    // everything in here is summarised with counts
+                    page.section && (this.section = [page.section, page.sectionName]);
+                    page.seriesId && (this.series = [page.seriesId, page.series]);
+                    page.keywordIds && (this.leadKeyword = [getHead(page.keywordIds), getHead(page.keywords)]);
+                    page.authorIds && (this.leadAuthor = [getHead(page.authorIds), getHead(page.author)]);
+                    page.blogIds && (this.leadBlog = [getHead(page.blogIds), getHead(page.blogs)]);
+                })()
+            };
+
         }
+
     };
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -61,7 +61,7 @@ define([
 
         }
 
-        return summary
+        return summary;
     }
 
     function addItemAndUpdateSummary(itemsSoFar, itemToAdd) {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -7,19 +7,24 @@ define([
     'lodash/collections/reduceRight',
     'lodash/objects/assign',
     'lodash/objects/mapValues',
+    'lodash/objects/omit',
+    'common/utils/_',
     'common/utils/storage'
 ], function (
     zip,
     reduceRight,
     assign,
     mapValues,
+    omit,
+    _,
     storage
 ) {
 
     var historyCache,
         summaryCache,
         storageKeyHistory = 'gu.history',
-        storageKeySummary = storageKeyHistory + '.summary';
+        storageKeySummary = storageKeyHistory + '.summary',
+        maxSize = 100;
 
     function HistoryItem(item, now) {
         assign(this, item);
@@ -37,8 +42,8 @@ define([
     }
 
     function updateSummaryTypeFromIdName(idName, summary) {
-
         var nameCount = summary[idName[0]] || [idName[1], 0];
+
         nameCount[1] = nameCount[1] + 1;
         nameCount[0] = idName[1];
         summary[idName[0]] = nameCount;
@@ -47,54 +52,38 @@ define([
     }
 
     function updateSummaryFromAllMeta(metaList, summary) {
-
         var metaType, idName;
 
         for (metaType in metaList) {
-
-            if (!metaList.hasOwnProperty(metaType) || !new Summary().hasOwnProperty(metaType)) {
-                continue;
-            }
-
             idName = metaList[metaType];
             summary[metaType] = updateSummaryTypeFromIdName(idName, summary[metaType]);
-
         }
 
         return summary;
     }
 
     function addItemAndUpdateSummary(itemsSoFar, itemToAdd) {
-
         itemsSoFar.recentPages.unshift(itemToAdd);
-
         itemsSoFar.summary = updateSummaryFromAllMeta(itemToAdd.meta, itemsSoFar.summary);
 
         return itemsSoFar;
     }
 
     function getUpdatedHistory(newItem, oldItems, now, maxSize) {
-        var initialValue, reduceItems, items;
-
-        initialValue = {
-            currentItem: new HistoryItem(newItem, now),
-            recentPages: [],
-            summary: new Summary()
-        };
-
-        reduceItems = function (items, item) {
+        var items = reduceRight(oldItems, function (items, item) {
             if (item.id === newItem.id) {
                 items.currentItem.count = items.currentItem.count + item.count;
-            } else {
-                if (item.meta) { // only add non legacy items with a meta block
-                    items = addItemAndUpdateSummary(items, item);
-                }
+            } else if (item.meta) { // only add non legacy items with a meta block
+                items = addItemAndUpdateSummary(items, item);
             }
 
             return items;
-        };
+        }, {
+            currentItem: new HistoryItem(newItem, now),
+            recentPages: [],
+            summary: new Summary()
+        });
 
-        items = reduceRight(oldItems, reduceItems, initialValue);
         addItemAndUpdateSummary(items, items.currentItem);
         delete items.currentItem;
 
@@ -109,12 +98,59 @@ define([
         });
     }
 
+    function pageInHistory(pageId, history) {
+        var foundItem = _.find(history, function (historyItem) {
+            return (historyItem.id === pageId);
+        });
+        return foundItem.count > 1;
+    }
+
+    function getHead(csString) {
+        return csString && ((csString + '').split(',')[0]);
+    }
+
+    function preparePage(page) {
+        return {
+            id: page.pageId,
+            meta: omit({
+                section: [page.section, page.sectionName],
+                series: [page.seriesId, page.series],
+                leadKeyword: [getHead(page.keywordIds), getHead(page.keywords)],
+                leadAuthor: [getHead(page.authorIds), getHead(page.author)],
+                leadBlog: [getHead(page.blogIds), getHead(page.blogs)]
+            }, function (pair) {
+                return !pair[0] || !pair[1];
+            })
+        };
+    }
+
+    function getSummary() {
+        summaryCache = summaryCache || storage.local.get(storageKeySummary) || new Summary();
+        return summaryCache;
+    }
+
+    function getHistory() {
+        historyCache = historyCache || storage.local.get(storageKeyHistory) || [];
+        return historyCache;
+    }
+
+    function set(history, summary) {
+        historyCache = history;
+        storage.local.set(storageKeyHistory, history);
+        summaryCache = summary;
+        storage.local.set(storageKeySummary, summary);
+    }
+
     return {
 
         test: {
             Summary: Summary,
             updateSummaryTypeFromIdName: updateSummaryTypeFromIdName,
             updateSummaryFromAllMeta: updateSummaryFromAllMeta,
+            getUpdatedHistory: getUpdatedHistory,
+            preparePage: preparePage,
+            set: set,
+            pageInHistory: pageInHistory,
 
             reset: function () {
                 historyCache = undefined;
@@ -125,28 +161,9 @@ define([
 
         },
 
-        maxSize: 100,
+        getSummary: getSummary,
 
-        impure: {
-
-            getSummary: function () {
-                summaryCache = summaryCache || storage.local.get(storageKeySummary) || new Summary();
-                return summaryCache;
-            },
-
-            getHistory: function () {
-                historyCache = historyCache || storage.local.get(storageKeyHistory) || [];
-                return historyCache;
-            },
-
-            set: function (history, summary) {
-                historyCache = history;
-                storage.local.set(storageKeyHistory, history);
-                summaryCache = summary;
-                storage.local.set(storageKeySummary, summary);
-            }
-
-        },
+        getHistory: getHistory,
 
         getSectionCounts: function (summary) {
             return getCountsMap('section', summary);
@@ -156,25 +173,16 @@ define([
             return getCountsMap('leadKeyword', summary);
         },
 
-        getUpdatedHistory: getUpdatedHistory,
+        pageHasBeenSeen: function (pageId) {
+            return pageInHistory(pageId, getHistory());
+        },
 
-        preparePage: function (page) {
-            return {
-                id: '/' + page.pageId,
-                meta: new (function () {
+        log: function (page) {
+            var newItem = preparePage(page),
+                oldItems = getHistory(),
+                items = getUpdatedHistory(newItem, oldItems, Date.now(), maxSize);
 
-                    var getHead = function (csString) {
-                        return csString && ((csString + '').split(',')[0]);
-                    };
-
-                    // everything in here is summarised with counts
-                    page.section && (this.section = [page.section, page.sectionName]);
-                    page.seriesId && (this.series = [page.seriesId, page.series]);
-                    page.keywordIds && (this.leadKeyword = [getHead(page.keywordIds), getHead(page.keywords)]);
-                    page.authorIds && (this.leadAuthor = [getHead(page.authorIds), getHead(page.author)]);
-                    page.blogIds && (this.leadBlog = [getHead(page.blogIds), getHead(page.blogs)]);
-                })()
-            };
+            set(items.recentPages, items.summary);
 
         }
 

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -34,29 +34,31 @@ define([
     }
 
     function Summary() {
-        this.section = {};
+        this.sections = {};
         this.series = {};
-        this.leadKeyword = {};
-        this.leadAuthor = {};
-        this.leadBlog = {};
+        this.keywords = {};
+        this.authors = {};
+        this.blogs = {};
     }
 
-    function updateSummaryTypeFromIdName(idName, summary) {
-        var nameCount = summary[idName[0]] || [idName[1], 0];
+    function updateSummaryTypeFromIdName(idNameMap, summary) {
+        var id = idNameMap[0][0],
+            name = idNameMap[0][1],
+            nameCount = summary[id] || [name, 0];
 
         nameCount[1] = nameCount[1] + 1;
-        nameCount[0] = idName[1];
-        summary[idName[0]] = nameCount;
+        nameCount[0] = name;
+        summary[id] = nameCount;
 
         return summary;
     }
 
     function updateSummaryFromAllMeta(metaList, summary) {
-        var metaType, idName;
+        var metaType, idNameMap;
 
         for (metaType in metaList) {
-            idName = metaList[metaType];
-            summary[metaType] = updateSummaryTypeFromIdName(idName, summary[metaType]);
+            idNameMap = metaList[metaType];
+            summary[metaType] = updateSummaryTypeFromIdName(idNameMap, summary[metaType]);
         }
 
         return summary;
@@ -113,13 +115,13 @@ define([
         return {
             id: page.pageId,
             meta: omit({
-                section: [page.section, page.sectionName],
-                series: [page.seriesId, page.series],
-                leadKeyword: [getHead(page.keywordIds), getHead(page.keywords)],
-                leadAuthor: [getHead(page.authorIds), getHead(page.author)],
-                leadBlog: [getHead(page.blogIds), getHead(page.blogs)]
-            }, function (pair) {
-                return !pair[0] || !pair[1];
+                sections: [[page.section, page.sectionName]],
+                series: [[page.seriesId, page.series]],
+                keywords: [[getHead(page.keywordIds), getHead(page.keywords)]],
+                authors: [[getHead(page.authorIds), getHead(page.author)]],
+                blogs: [[getHead(page.blogIds), getHead(page.blogs)]]
+            }, function (list) {
+                return !list[0][0] || !list[0][1];
             })
         };
     }
@@ -166,11 +168,11 @@ define([
         getHistory: getHistory,
 
         getSectionCounts: function (summary) {
-            return getCountsMap('section', summary);
+            return getCountsMap('sections', summary);
         },
 
         getLeadKeywordCounts: function (summary) {
-            return getCountsMap('leadKeyword', summary);
+            return getCountsMap('keywords', summary);
         },
 
         pageHasBeenSeen: function (pageId) {

--- a/static/test/javascripts/fixtures/history/config-page.js
+++ b/static/test/javascripts/fixtures/history/config-page.js
@@ -1,0 +1,23 @@
+define(function () {
+    return {
+        // no series (so series is missing completely)
+        // no blogs (so blogs is empty)
+        // has a section, keywords, authors
+        'author':'John Harris',
+        'toneIds':'tone/comment',
+        'tones':'Comment',
+        'blogIds':'',
+        'sectionName':'Comment is free',
+        'blogs':'',
+        'section':'commentisfree',
+        'shortUrl':'http://gu.com/p/428pg',
+        'pageId':'commentisfree/2014/oct/08/clacton-byelection-parties-defiance-coast-strood-ukip',
+        'references':[
+
+        ],
+        'keywordIds':'politics/ukip,politics/clacton-byelection,politics/politics,politics/douglas-carswell,politics/nigel-farage,uk/uk',
+        'contentType':'Article',
+        'authorIds':'profile/johnharris',
+        'keywords':'UK Independence party (Ukip),Clacton byelection 2014,Politics,Douglas Carswell,Nigel Farage,UK news'
+    };
+});

--- a/static/test/javascripts/spec/common/onward/history.spec.js
+++ b/static/test/javascripts/spec/common/onward/history.spec.js
@@ -49,7 +49,12 @@ define([
         });
     }
 
-    describe('addMeta', function() {
+    // basic item
+    var newItem1 = {id: 'a', meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']} };
+    // different article, and note that the display names are different from the previous IDs
+    var newItem2 = {id: 'a2', meta: { section: ['s','sn2'], leadKeyword: ['k', 'kn2']} };
+
+    describe('updateSummaryTypeFromIdName', function() {
 
         beforeEach(addObjectMatcher);
 
@@ -76,7 +81,7 @@ define([
 
     });
 
-    describe('addAllMeta', function() {
+    describe('updateSummaryFromAllMeta', function() {
 
         beforeEach(addObjectMatcher);
 
@@ -102,16 +107,16 @@ define([
 
         });
 
-        it("should not add when they aren't known", function () {
-            var summary = new hist.test.Summary();
-
-            var expectedSummary = {};
-
-            var newSummary = hist.test.updateSummaryFromAllMeta({unknownShouldntBeAdded: ['id','name']}, summary);
-
-            expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
-
-        });
+        //it("should not add when they aren't known", function () {
+        //    var summary = new hist.test.Summary();
+        //
+        //    var expectedSummary = {};
+        //
+        //    var newSummary = hist.test.updateSummaryFromAllMeta({unknownShouldntBeAdded: ['id','name']}, summary);
+        //
+        //    expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+        //
+        //});
 
         it("should increment when a tag is reused, and update the name", function () {
             var summary = new hist.test.Summary();
@@ -127,14 +132,9 @@ define([
 
     });
 
-    describe('pure history', function() {
+    describe('getUpdatedHistory', function() {
 
         beforeEach(addObjectMatcher);
-
-        // basic item
-        var newItem1 = {id: 'a', meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']} };
-        // different article, and note that the display names are different from the previous IDs
-        var newItem2 = {id: 'a2', meta: { section: ['s','sn2'], leadKeyword: ['k', 'kn2']} };
 
         it('should store the first article correctly', function() {
             var oldItems = [];
@@ -142,7 +142,7 @@ define([
             var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
             var expectedRecent0 = {id: 'a', count: 1, timestamp: 123, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
 
-            var result = hist.getUpdatedHistory(newItem1, oldItems, 123, 10);
+            var result = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10);
 
             expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
             expect(result.recentPages.length).toBe(1);
@@ -155,8 +155,8 @@ define([
             var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
             var expectedRecent0 = {id: 'a', count: 2, timestamp: 124, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
 
-            var afterFirst = hist.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
-            var result = hist.getUpdatedHistory(newItem1, afterFirst, 124, 10);
+            var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
+            var result = hist.test.getUpdatedHistory(newItem1, afterFirst, 124, 10);
 
             expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
             expect(result.recentPages.length).toBe(1);
@@ -170,8 +170,8 @@ define([
             var expectedRecent0 = {id: 'a2', count: 1, timestamp: 124, meta: { section: ['s','sn2'], leadKeyword: ['k', 'kn2']}};
             var expectedRecent1 = {id: 'a', count: 1, timestamp: 123, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
 
-            var afterFirst = hist.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
-            var result = hist.getUpdatedHistory(newItem2, afterFirst, 124, 10);
+            var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
+            var result = hist.test.getUpdatedHistory(newItem2, afterFirst, 124, 10);
 
             expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
             expect(result.recentPages.length).toBe(2);
@@ -185,10 +185,10 @@ define([
             var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
             var expectedRecent0 = {id: 'a', count: 1, timestamp: 124, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
 
-            var afterFirst = hist.getUpdatedHistory(newItem2, oldItems, 123, 1).recentPages;
-            var preResult = hist.getUpdatedHistory(newItem1, afterFirst, 124, 1);
+            var afterFirst = hist.test.getUpdatedHistory(newItem2, oldItems, 123, 1).recentPages;
+            var preResult = hist.test.getUpdatedHistory(newItem1, afterFirst, 124, 1);
             // because the trim happens afterwards, the summary will actually have an extra one, so relogging it to forget about that
-            var result = hist.getUpdatedHistory(newItem1, preResult, 124, 1);
+            var result = hist.test.getUpdatedHistory(newItem1, preResult, 124, 1);
 
             expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
             expect(result.recentPages.length).toBe(1);
@@ -205,14 +205,14 @@ define([
     };
 
     var item = {
-            id:"/p/3jbcb",
+            id:"p/3jbcb",
             meta: {
                 section: ["foobar", 'name'],
                 leadKeyword: ['foo', 'fooName']
             }
         };
 
-    describe('History', function () {
+    describe('reading/writing history to localStorage', function () {
 
         beforeEach(function () {
             hist.test.reset();
@@ -220,32 +220,56 @@ define([
         });
 
         it('should get history from local storage', function () {
-            expect(hist.impure.getHistory()).toEqual(contains);
+            expect(hist.getHistory()).toEqual(contains);
         });
 
         it('should set history to local storage', function () {
-            hist.impure.set([item], {leadKeyword: 'testing'});
+            hist.test.set([item], {leadKeyword: 'testing'});
 
-            expect(hist.impure.getHistory()[0].id).toEqual(item.id);
-            expect(hist.impure.getSummary().leadKeyword).toEqual('testing');
+            expect(hist.getHistory()[0].id).toEqual(item.id);
+            expect(hist.getSummary().leadKeyword).toEqual('testing');
         });
 
-        it('should set the section count in the summary, once per article', function () {
+    });
+
+    describe('history processing functions', function() {
+
+        beforeEach(addObjectMatcher);
+
+        it('getSectionCounts should set the section count in the summary, once per article', function () {
             var oldItems = [];
 
-            var afterFirst = hist.getUpdatedHistory(item, oldItems, 123, 10).recentPages;
-            var result = hist.getUpdatedHistory(item, afterFirst, 124, 10);
+            var afterFirst = hist.test.getUpdatedHistory(item, oldItems, 123, 10).recentPages;
+            var result = hist.test.getUpdatedHistory(item, afterFirst, 124, 10);
 
             expect(hist.getSectionCounts(result.summary).foobar).toEqual(1);
         });
 
-        it('should set the first keyword\'s count in the summary, once per article', function () {
+        it('getLeadKeywordCounts should set the first keyword\'s count in the summary, once per article', function () {
             var oldItems = [];
 
-            var afterFirst = hist.getUpdatedHistory(item, oldItems, 123, 10).recentPages;
-            var result = hist.getUpdatedHistory(item, afterFirst, 124, 10);
+            var afterFirst = hist.test.getUpdatedHistory(item, oldItems, 123, 10).recentPages;
+            var result = hist.test.getUpdatedHistory(item, afterFirst, 124, 10);
 
             expect(hist.getLeadKeywordCounts(result.summary).foo).toEqual(1);
+        });
+
+        it('pageInHistory if its in there twice should be true', function () {
+            var oldItems = [];
+
+            var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
+            var result = hist.test.getUpdatedHistory(newItem1, afterFirst, 124, 10);
+
+            expect(hist.test.pageInHistory(newItem1.id, result.recentPages)).toBeTruthy();
+        });
+
+        it('pageInHistory if its in there once should be false', function () {
+            var oldItems = [];
+
+            var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
+            var result = hist.test.getUpdatedHistory(newItem2, afterFirst, 124, 10);
+
+            expect(hist.test.pageInHistory(newItem1.id, result.recentPages)).toBeFalsy();
         });
 
     });
@@ -259,12 +283,12 @@ define([
 
         it('should return a blank summary if one is not set', function () {
 
-            expect(hist.impure.getSummary()).toSameProps(new hist.test.Summary());
+            expect(hist.getSummary()).toSameProps(new hist.test.Summary());
         });
 
         it('should return a blank history if one is not set', function () {
 
-            expect(hist.impure.getHistory()).toSameProps([]);
+            expect(hist.getHistory()).toSameProps([]);
         });
 
     });
@@ -275,10 +299,10 @@ define([
 
         it('should handle a real config.page into a newItem object', function () {
 
-            var preparedPage = hist.preparePage(configPage);
+            var preparedPage = hist.test.preparePage(configPage);
 
             expect(preparedPage).toSameProps({
-                id: '/commentisfree/2014/oct/08/clacton-byelection-parties-defiance-coast-strood-ukip',
+                id: 'commentisfree/2014/oct/08/clacton-byelection-parties-defiance-coast-strood-ukip',
                 meta: {
                     // no series (so series is missing completely)
                     // no blogs (so blogs is empty)

--- a/static/test/javascripts/spec/common/onward/history.spec.js
+++ b/static/test/javascripts/spec/common/onward/history.spec.js
@@ -50,9 +50,9 @@ define([
     }
 
     // basic item
-    var newItem1 = {id: 'a', meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']} };
+    var newItem1 = {id: 'a', meta: { sections: [['s','sn']], keywords: [['k', 'kn']]} };
     // different article, and note that the display names are different from the previous IDs
-    var newItem2 = {id: 'a2', meta: { section: ['s','sn2'], leadKeyword: ['k', 'kn2']} };
+    var newItem2 = {id: 'a2', meta: { sections: [['s','sn2']], keywords: [['k', 'kn2']]} };
 
     describe('updateSummaryTypeFromIdName', function() {
 
@@ -63,7 +63,7 @@ define([
 
             var expectedSummary = {id: ['name', 1]};
 
-            var newSummary = hist.test.updateSummaryTypeFromIdName(['id', 'name'], summary);
+            var newSummary = hist.test.updateSummaryTypeFromIdName([['id', 'name']], summary);
 
             expect(newSummary).toSameProps(expectedSummary);
         });
@@ -73,8 +73,8 @@ define([
 
             var expectedSummary = {id: ['name2', 2]};
 
-            var intermediate = hist.test.updateSummaryTypeFromIdName(['id','name'], summary);
-            var newSummary = hist.test.updateSummaryTypeFromIdName(['id','name2'], intermediate);
+            var intermediate = hist.test.updateSummaryTypeFromIdName([['id','name']], summary);
+            var newSummary = hist.test.updateSummaryTypeFromIdName([['id','name2']], intermediate);
 
             expect(newSummary).toSameProps(expectedSummary);
         });
@@ -88,9 +88,9 @@ define([
         it("should add the things when they are set normally", function () {
             var summary = new hist.test.Summary();
 
-            var expectedSummary = {section: {id: ['name', 1]}, leadKeyword: {kid: ['kname', 1]}};
+            var expectedSummary = {sections: {id: ['name', 1]}, keywords: {kid: ['kname', 1]}};
 
-            var newSummary = hist.test.updateSummaryFromAllMeta({section: ['id','name'], leadKeyword: ['kid', 'kname']}, summary);
+            var newSummary = hist.test.updateSummaryFromAllMeta({sections: [['id','name']], keywords: [['kid', 'kname']]}, summary);
 
             expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
 
@@ -107,24 +107,13 @@ define([
 
         });
 
-        //it("should not add when they aren't known", function () {
-        //    var summary = new hist.test.Summary();
-        //
-        //    var expectedSummary = {};
-        //
-        //    var newSummary = hist.test.updateSummaryFromAllMeta({unknownShouldntBeAdded: ['id','name']}, summary);
-        //
-        //    expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
-        //
-        //});
-
         it("should increment when a tag is reused, and update the name", function () {
             var summary = new hist.test.Summary();
 
-            var expectedSummary = {section: {id: ['name2', 2]}, leadKeyword: {kid: ['kname', 1], anotherkid: ['anotherkname', 1]}};
+            var expectedSummary = {sections: {id: ['name2', 2]}, keywords: {kid: ['kname', 1], anotherkid: ['anotherkname', 1]}};
 
-            var intermediate = hist.test.updateSummaryFromAllMeta({section: ['id','name2'], leadKeyword: ['kid', 'kname']}, summary);
-            var newSummary = hist.test.updateSummaryFromAllMeta({section: ['id','name2'], leadKeyword: ['anotherkid', 'anotherkname']}, intermediate);
+            var intermediate = hist.test.updateSummaryFromAllMeta({sections: [['id','name2']], keywords: [['kid', 'kname']]}, summary);
+            var newSummary = hist.test.updateSummaryFromAllMeta({sections: [['id','name2']], keywords: [['anotherkid', 'anotherkname']]}, intermediate);
 
             expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
 
@@ -139,8 +128,8 @@ define([
         it('should store the first article correctly', function() {
             var oldItems = [];
 
-            var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
-            var expectedRecent0 = {id: 'a', count: 1, timestamp: 123, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+            var expectedSummary = {sections: {s: ['sn', 1]}, keywords: {k: ['kn', 1]}, count: 1};
+            var expectedRecent0 = {id: 'a', count: 1, timestamp: 123, meta: { sections: [['s','sn']], keywords: [['k', 'kn']]}};
 
             var result = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10);
 
@@ -152,8 +141,8 @@ define([
         it('should not store the first article twice but should update the timestamp', function() {
             var oldItems = [];
 
-            var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
-            var expectedRecent0 = {id: 'a', count: 2, timestamp: 124, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+            var expectedSummary = {sections: {s: ['sn', 1]}, keywords: {k: ['kn', 1]}, count: 1};
+            var expectedRecent0 = {id: 'a', count: 2, timestamp: 124, meta: { sections: [['s','sn']], keywords: [['k', 'kn']]}};
 
             var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
             var result = hist.test.getUpdatedHistory(newItem1, afterFirst, 124, 10);
@@ -166,9 +155,9 @@ define([
         it('should store the second article correctly', function() {
             var oldItems = [];
 
-            var expectedSummary = {section: {s: ['sn2', 2]}, leadKeyword: {k: ['kn2', 2]}, count: 2};
-            var expectedRecent0 = {id: 'a2', count: 1, timestamp: 124, meta: { section: ['s','sn2'], leadKeyword: ['k', 'kn2']}};
-            var expectedRecent1 = {id: 'a', count: 1, timestamp: 123, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+            var expectedSummary = {sections: {s: ['sn2', 2]}, keywords: {k: ['kn2', 2]}, count: 2};
+            var expectedRecent0 = {id: 'a2', count: 1, timestamp: 124, meta: { sections: [['s','sn2']], keywords: [['k', 'kn2']]}};
+            var expectedRecent1 = {id: 'a', count: 1, timestamp: 123, meta: { sections: [['s','sn']], keywords: [['k', 'kn']]}};
 
             var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
             var result = hist.test.getUpdatedHistory(newItem2, afterFirst, 124, 10);
@@ -182,8 +171,8 @@ define([
         it('should lose the oldest article when the limit is exceeded', function() {
             var oldItems = [];
 
-            var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
-            var expectedRecent0 = {id: 'a', count: 1, timestamp: 124, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+            var expectedSummary = {sections: {s: ['sn', 1]}, keywords: {k: ['kn', 1]}, count: 1};
+            var expectedRecent0 = {id: 'a', count: 1, timestamp: 124, meta: { sections: [['s','sn']], keywords: [['k', 'kn']]}};
 
             var afterFirst = hist.test.getUpdatedHistory(newItem2, oldItems, 123, 1).recentPages;
             var preResult = hist.test.getUpdatedHistory(newItem1, afterFirst, 124, 1);
@@ -207,8 +196,8 @@ define([
     var item = {
             id:"p/3jbcb",
             meta: {
-                section: ["foobar", 'name'],
-                leadKeyword: ['foo', 'fooName']
+                sections: [["foobar", 'name']],
+                keywords: [['foo', 'fooName']]
             }
         };
 
@@ -224,10 +213,10 @@ define([
         });
 
         it('should set history to local storage', function () {
-            hist.test.set([item], {leadKeyword: 'testing'});
+            hist.test.set([item], {keywords: 'testing'});
 
             expect(hist.getHistory()[0].id).toEqual(item.id);
-            expect(hist.getSummary().leadKeyword).toEqual('testing');
+            expect(hist.getSummary().keywords).toEqual('testing');
         });
 
     });
@@ -260,7 +249,7 @@ define([
             var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
             var result = hist.test.getUpdatedHistory(newItem1, afterFirst, 124, 10);
 
-            expect(hist.test.pageInHistory(newItem1.id, result.recentPages)).toBeTruthy();
+            expect(hist.test.pageInHistory(newItem1.id, result.recentPages)).toBe(true);
         });
 
         it('pageInHistory if its in there once should be false', function () {
@@ -269,7 +258,7 @@ define([
             var afterFirst = hist.test.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
             var result = hist.test.getUpdatedHistory(newItem2, afterFirst, 124, 10);
 
-            expect(hist.test.pageInHistory(newItem1.id, result.recentPages)).toBeFalsy();
+            expect(hist.test.pageInHistory(newItem1.id, result.recentPages)).toBe(false);
         });
 
     });
@@ -307,9 +296,9 @@ define([
                     // no series (so series is missing completely)
                     // no blogs (so blogs is empty)
                     // has a section, keywords, authors
-                    section: ['commentisfree', 'Comment is free'],
-                    leadKeyword: ['politics/ukip', 'UK Independence party (Ukip)'],
-                    leadAuthor: ['profile/johnharris', 'John Harris']
+                    sections: [['commentisfree', 'Comment is free']],
+                    keywords: [['politics/ukip', 'UK Independence party (Ukip)']],
+                    authors: [['profile/johnharris', 'John Harris']]
                 }
             });
         });

--- a/static/test/javascripts/spec/common/onward/history.spec.js
+++ b/static/test/javascripts/spec/common/onward/history.spec.js
@@ -1,81 +1,295 @@
 define([
     'common/modules/onward/history',
+    'fixtures/history/config-page',
     'fixtures/history/contains',
     'fixtures/history/max',
-], function(hist, contains, max) {
+    'lodash/collections/reduce',
+    'lodash/collections/sortBy',
+    'lodash/objects/assign',
+    'lodash/objects/isEqual'
+], function (hist, configPage, contains, max, reduce, sortBy, assign, isEqual) {
 
-    var setStorageItem = function(item) {
+    function addObjectMatcher() {
+        jasmine.addMatchers({
+            toSameProps: function () {
+
+                return {
+                    compare: function (actual, expected) {
+
+                        function isSame(actual, expected) {
+                            var sameProps = isEqual(sortBy(Object.keys(actual)), sortBy(Object.keys(expected)));
+                            var differingProps;
+                            if (sameProps) {
+                                differingProps = reduce(Object.keys(actual), function (sofar, propToCheck) {
+                                    if (typeof expected[propToCheck] === 'object' && expected[propToCheck] ) {
+                                        // if it's an object, recurse
+                                        var nestedSame = isSame(actual[propToCheck], expected[propToCheck]);
+                                        if (!nestedSame[0]) {
+                                            sofar.push('{'+propToCheck + ': [' + nestedSame[1] + ']}');
+                                        }
+                                    } else if (!isEqual(expected[propToCheck], actual[propToCheck])) {
+                                        sofar.push(propToCheck + ' <<expected: ' + expected[propToCheck] + ' actual: ' + actual[propToCheck] + '>>');
+                                    }
+                                    return sofar;
+                                }, []);
+                            }
+                            return [sameProps && differingProps.length == 0, sameProps ? differingProps : "property names expected: " + Object.keys(expected) + ' actual: ' + Object.keys(actual)];
+                        }
+
+                        var sameProps = isSame(actual, expected);
+                        return {
+                            pass: sameProps[0],
+                            message: 'incorrect data values: ' + sameProps[1] + " Expected " + JSON.stringify(actual) + " to be similar to " + JSON.stringify(expected)
+                        };
+
+                    }
+                }
+
+            }
+        });
+    }
+
+    describe('addMeta', function() {
+
+        beforeEach(addObjectMatcher);
+
+        it("should add a first section to the summary", function () {
+            var summary = {};
+
+            var expectedSummary = {id: ['name', 1]};
+
+            var newSummary = hist.test.updateSummaryTypeFromIdName(['id', 'name'], summary);
+
+            expect(newSummary).toSameProps(expectedSummary);
+        });
+
+        it("should increment in the summary and update the name", function () {
+            var summary = {};
+
+            var expectedSummary = {id: ['name2', 2]};
+
+            var intermediate = hist.test.updateSummaryTypeFromIdName(['id','name'], summary);
+            var newSummary = hist.test.updateSummaryTypeFromIdName(['id','name2'], intermediate);
+
+            expect(newSummary).toSameProps(expectedSummary);
+        });
+
+    });
+
+    describe('addAllMeta', function() {
+
+        beforeEach(addObjectMatcher);
+
+        it("should add the things when they are set normally", function () {
+            var summary = new hist.test.Summary();
+
+            var expectedSummary = {section: {id: ['name', 1]}, leadKeyword: {kid: ['kname', 1]}};
+
+            var newSummary = hist.test.updateSummaryFromAllMeta({section: ['id','name'], leadKeyword: ['kid', 'kname']}, summary);
+
+            expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+
+        });
+
+        it("should not add when they're not set", function () {
+            var summary = new hist.test.Summary();
+
+            var expectedSummary = {};
+
+            var newSummary = hist.test.updateSummaryFromAllMeta({}, summary);
+
+            expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+
+        });
+
+        it("should not add when they aren't known", function () {
+            var summary = new hist.test.Summary();
+
+            var expectedSummary = {};
+
+            var newSummary = hist.test.updateSummaryFromAllMeta({unknownShouldntBeAdded: ['id','name']}, summary);
+
+            expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+
+        });
+
+        it("should increment when a tag is reused, and update the name", function () {
+            var summary = new hist.test.Summary();
+
+            var expectedSummary = {section: {id: ['name2', 2]}, leadKeyword: {kid: ['kname', 1], anotherkid: ['anotherkname', 1]}};
+
+            var intermediate = hist.test.updateSummaryFromAllMeta({section: ['id','name2'], leadKeyword: ['kid', 'kname']}, summary);
+            var newSummary = hist.test.updateSummaryFromAllMeta({section: ['id','name2'], leadKeyword: ['anotherkid', 'anotherkname']}, intermediate);
+
+            expect(newSummary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+
+        });
+
+    });
+
+    describe('pure history', function() {
+
+        beforeEach(addObjectMatcher);
+
+        // basic item
+        var newItem1 = {id: 'a', meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']} };
+        // different article, and note that the display names are different from the previous IDs
+        var newItem2 = {id: 'a2', meta: { section: ['s','sn2'], leadKeyword: ['k', 'kn2']} };
+
+        it('should store the first article correctly', function() {
+            var oldItems = [];
+
+            var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
+            var expectedRecent0 = {id: 'a', count: 1, timestamp: 123, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+
+            var result = hist.getUpdatedHistory(newItem1, oldItems, 123, 10);
+
+            expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+            expect(result.recentPages.length).toBe(1);
+            expect(result.recentPages[0]).toSameProps(expectedRecent0);
+        });
+
+        it('should not store the first article twice but should update the timestamp', function() {
+            var oldItems = [];
+
+            var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
+            var expectedRecent0 = {id: 'a', count: 2, timestamp: 124, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+
+            var afterFirst = hist.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
+            var result = hist.getUpdatedHistory(newItem1, afterFirst, 124, 10);
+
+            expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+            expect(result.recentPages.length).toBe(1);
+            expect(result.recentPages[0]).toSameProps(expectedRecent0);
+        });
+
+        it('should store the second article correctly', function() {
+            var oldItems = [];
+
+            var expectedSummary = {section: {s: ['sn2', 2]}, leadKeyword: {k: ['kn2', 2]}, count: 2};
+            var expectedRecent0 = {id: 'a2', count: 1, timestamp: 124, meta: { section: ['s','sn2'], leadKeyword: ['k', 'kn2']}};
+            var expectedRecent1 = {id: 'a', count: 1, timestamp: 123, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+
+            var afterFirst = hist.getUpdatedHistory(newItem1, oldItems, 123, 10).recentPages;
+            var result = hist.getUpdatedHistory(newItem2, afterFirst, 124, 10);
+
+            expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+            expect(result.recentPages.length).toBe(2);
+            expect(result.recentPages[0]).toSameProps(expectedRecent0);
+            expect(result.recentPages[1]).toSameProps(expectedRecent1);
+        });
+
+        it('should lose the oldest article when the limit is exceeded', function() {
+            var oldItems = [];
+
+            var expectedSummary = {section: {s: ['sn', 1]}, leadKeyword: {k: ['kn', 1]}, count: 1};
+            var expectedRecent0 = {id: 'a', count: 1, timestamp: 124, meta: { section: ['s','sn'], leadKeyword: ['k', 'kn']}};
+
+            var afterFirst = hist.getUpdatedHistory(newItem2, oldItems, 123, 1).recentPages;
+            var preResult = hist.getUpdatedHistory(newItem1, afterFirst, 124, 1);
+            // because the trim happens afterwards, the summary will actually have an extra one, so relogging it to forget about that
+            var result = hist.getUpdatedHistory(newItem1, preResult, 124, 1);
+
+            expect(result.summary).toSameProps(assign(new hist.test.Summary(), expectedSummary));
+            expect(result.recentPages.length).toBe(1);
+            expect(result.recentPages[0]).toSameProps(expectedRecent0);
+        });
+
+
+    });
+
+    var setStorageItem = function (item) {
         window.localStorage.setItem('gu.history', JSON.stringify({
-            'value' : item
+            'value': item
         }));
     };
 
     var item = {
             id:"/p/3jbcb",
             meta: {
-                section: "foobar",
-                keywords: ['foo', 'bar']
+                section: ["foobar", 'name'],
+                leadKeyword: ['foo', 'fooName']
             }
-        },
-        hist;
+        };
 
-    describe('History', function() {
+    describe('History', function () {
 
-        beforeEach(function() {
-            hist.reset();
+        beforeEach(function () {
+            hist.test.reset();
             setStorageItem(contains);
         });
 
-        it('should get history from local storage', function() {
-            expect(hist.get()).toEqual(contains);
+        it('should get history from local storage', function () {
+            expect(hist.impure.getHistory()).toEqual(contains);
         });
 
-        it('should set history to local storage', function() {
-            hist.log(item);
+        it('should set history to local storage', function () {
+            hist.impure.set([item], {leadKeyword: 'testing'});
 
-            expect(hist.get()[0].id).toEqual(item.id);
+            expect(hist.impure.getHistory()[0].id).toEqual(item.id);
+            expect(hist.impure.getSummary().leadKeyword).toEqual('testing');
         });
 
-        it('should set current timestamp for new log entries', function() {
-            hist.log(item);
+        it('should set the section count in the summary, once per article', function () {
+            var oldItems = [];
 
-            expect(hist.get()[0].timestamp).toBeDefined();
-            expect(hist.get()[0].timestamp).toEqual(jasmine.any(Number));
+            var afterFirst = hist.getUpdatedHistory(item, oldItems, 123, 10).recentPages;
+            var result = hist.getUpdatedHistory(item, afterFirst, 124, 10);
+
+            expect(hist.getSectionCounts(result.summary).foobar).toEqual(1);
         });
 
-        it('should extend any optional meta data directly onto the logged items object', function() {
-            hist.log(item);
+        it('should set the first keyword\'s count in the summary, once per article', function () {
+            var oldItems = [];
 
-            expect(hist.get()[0].section).toBeDefined();
-            expect(hist.get()[0].section).toEqual("foobar");
+            var afterFirst = hist.getUpdatedHistory(item, oldItems, 123, 10).recentPages;
+            var result = hist.getUpdatedHistory(item, afterFirst, 124, 10);
+
+            expect(hist.getLeadKeywordCounts(result.summary).foo).toEqual(1);
         });
 
-        it('should be able to check if an item id exists', function() {
-            hist.log(item);
-
-            expect(hist.contains(item.id)).toBeTruthy();
-        });
-
-        it('should only store 100 latest entries', function() {
-            setStorageItem(max);
-            hist.log(item);
-
-            expect(hist.getSize()).toEqual(100);
-        });
-
-        it('should set the section count in the summary, once per article', function() {
-            hist.log(item);
-            hist.log(item);
-
-            expect(hist.getSummary().sections.foobar).toEqual(1);
-        });
-
-        it('should set the first keyword\'s count in the summary, once per article', function() {
-            hist.log(item);
-            hist.log(item);
-
-            expect(hist.getSummary().keywords.foo).toEqual(1);
-            expect(hist.getSummary().keywords.bar).toEqual(undefined);
-        });
     });
+
+    describe('History defaults', function () {
+
+        beforeEach(function () {
+            hist.test.reset();
+            addObjectMatcher();
+        });
+
+        it('should return a blank summary if one is not set', function () {
+
+            expect(hist.impure.getSummary()).toSameProps(new hist.test.Summary());
+        });
+
+        it('should return a blank history if one is not set', function () {
+
+            expect(hist.impure.getHistory()).toSameProps([]);
+        });
+
+    });
+
+    describe('preparePage', function () {
+
+        beforeEach(addObjectMatcher);
+
+        it('should handle a real config.page into a newItem object', function () {
+
+            var preparedPage = hist.preparePage(configPage);
+
+            expect(preparedPage).toSameProps({
+                id: '/commentisfree/2014/oct/08/clacton-byelection-parties-defiance-coast-strood-ukip',
+                meta: {
+                    // no series (so series is missing completely)
+                    // no blogs (so blogs is empty)
+                    // has a section, keywords, authors
+                    section: ['commentisfree', 'Comment is free'],
+                    leadKeyword: ['politics/ukip', 'UK Independence party (Ukip)'],
+                    leadAuthor: ['profile/johnharris', 'John Harris']
+                }
+            });
+        });
+
+    });
+
 });


### PR DESCRIPTION
we already summarise lead keyword and section totals for the last 100 articles.

this is to add lead author, blog and series, as well as all the display names

The aim is so later we can use the info to show a "Jump-to" bar on the front based on what users like.

/cc @stephanfowler I'd love some feedback since it's your area of expertise =)

the `gu.history` looks like this now - see below for the summary

```
[  
   {  
      "id":"business/2014/nov/06/morrisons-recovery-sales-supermarket",
      "meta":{  
         "sections":[  
            [  
               "business",
               "Business"
            ]
         ],
         "keywords":[  
            [  
               "business/morrisons",
               "Morrisons"
            ]
         ],
         "authors":[  
            [  
               "profile/juliakollewe",
               "Julia Kollewe"
            ]
         ]
      },
      "timestamp":1415810791141,
      "count":1
   },
   {  
      "id":"uk/business",
      "meta":{  
         "keywords":[  
            [  
               "business/business",
               "Economy"
            ]
         ]
      },
      "timestamp":1415810775810,
      "count":1
   },
   {  
      "id":"culture/tvandradioblog/video/2014/nov/12/monty-python-stephen-hawking-brian-cox-eric-idle-video",
      "meta":{  
         "sections":[  
            [  
               "culture",
               "Culture"
            ]
         ],
         "keywords":[  
            [  
               "culture/monty-python",
               "Monty Python"
            ]
         ],
         "blogs":[  
            [  
               "tvandradioblog",
               "TV and radio blog"
            ]
         ]
      },
      "timestamp":1415810726040,
      "count":2
   }
]
```

thje `gu.history.summary` looks like this:

```
{  
   "sections":{  
      "culture":[  
         "Culture",
         1
      ],
      "business":[  
         "Business",
         1
      ]
   },
   "series":{  

   },
   "keywords":{  
      "culture/monty-python":[  
         "Monty Python",
         1
      ],
      "business/business":[  
         "Economy",
         1
      ],
      "business/morrisons":[  
         "Morrisons",
         1
      ]
   },
   "authors":{  
      "profile/juliakollewe":[  
         "Julia Kollewe",
         1
      ]
   },
   "blogs":{  
      "tvandradioblog":[  
         "TV and radio blog",
         1
      ]
   },
   "count":3
}
```
