### PR TITLE
Fix layout of most popular galleries container

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -23,7 +23,7 @@
         </div>
     </article>
 
-    <div class="gallery__most-popular facia-container fc-container--media facia-container--layout-content facia-container--default-heading hide-on-childrens-books-site">
+    <div class="gallery__most-popular facia-container fc-container--media fc-container--layout-content hide-on-childrens-books-site">
         <div class="js-gallery-most-popular tonal--@articleToneClass(gallery)">
             <div class="fc-container">
                 <div class="fc-container__inner">

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -404,7 +404,7 @@ $header-image-size-desktop: 120px;
 
 .fc-container--media {
     .fc-container__inner,
-    .fc-slice__item:before {
+    .fc-slice__item+.fc-slice__item:before {
         border-color: colour(neutral-2);
     }
 


### PR DESCRIPTION
I broke this with the super branch yesterday.
### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/5008952/85eed2c8-6a59-11e4-980d-9e7636d84c12.png)
### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/5009289/52ea0650-6a5d-11e4-9d85-d4fab36fc7f6.png)
