### PR TITLE
Add response status and message to comment loading diagnosis

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -142,11 +142,13 @@ Loader.prototype.initMainComments = function() {
                     this.setState('truncated');
                 }
             }.bind(this))
-            .fail(function() {
-                raven.captureMessage('Comments failed to load.', {
+            .fail(function(err) {
+                var msg = 'Comments failed to load.' + ('statusText' in err ? ' ' + err.statusText : '');
+                raven.captureMessage(msg, {
                     tags: {
                         contentType: 'comments',
-                        discussionId: this.getDiscussionId()
+                        discussionId: this.getDiscussionId(),
+                        status: 'status' in err ? err.status : ''
                     }
                 });
             }.bind(this));


### PR DESCRIPTION
We've been instrumenting failed comments loading with Sentry to try and diagnose the issue. Reqwest unfortunately does not return an error object but the XHR object, therefore i'm extracting the status code and status response message. This should give us an indication if they are 40x or 50x or timeouts.

http://frontend.errors.gutools.co.uk/guardian/frontend/group/5039/

/cc @rich-nguyen @mattosborn @ironsidevsquincy 
