### PR TITLE
Revert "Revert "Use background-attachment for scrollable MPU""

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
@@ -1,16 +1,23 @@
 define([
     'bonzo',
     'common/utils/$',
+    'common/utils/detect',
     'common/utils/mediator'
 ], function (
     bonzo,
     $,
+    detect,
     mediator
 ) {
 
-    var adClass          = 'js-scrollable-mpu',
-        updateBgPosition = function ($ad) {
-            $ad.css('background-position', $ad.offset().left + 'px 0');
+    var adClass = 'js-scrollable-mpu',
+        /**
+         * TODO: rather blunt instrument this, due to the fact *most* mobile devices don't have a fixed
+         * background-attachment - need to make this more granular
+         */
+        limitedBgAttachment = detect.isIOS() || detect.isAndroid(),
+        updateBgPosition    = function ($ad) {
+            $ad.css('background-position', $ad.offset().left + 'px 100%');
         };
 
     /**
@@ -20,14 +27,21 @@ define([
 
         run: function () {
             $('.' + adClass).each(function (ad) {
-                var $ad = bonzo(ad);
+                var staticImage,
+                    $ad = bonzo(ad);
 
-                // update bg position
-                updateBgPosition($ad);
-                // to be safe, also update on window resize
-                mediator.on('window:resize', function () {
+                if (limitedBgAttachment) {
+                    staticImage = $ad.data('static-image');
+                    $ad.css('background-image', staticImage);
+                } else {
+                    $ad.css('background-attachment', 'fixed');
+                    // update bg position
                     updateBgPosition($ad);
-                });
+                    // to be safe, also update on window resize
+                    mediator.on('window:resize', function () {
+                        updateBgPosition($ad);
+                    });
+                }
 
                 $ad.removeClass(adClass);
             });

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
@@ -1,23 +1,17 @@
 define([
-    'bean',
     'bonzo',
     'common/utils/$',
-    'common/utils/detect',
     'common/utils/mediator'
 ], function (
-    bean,
     bonzo,
     $,
-    detect,
     mediator
 ) {
 
-    var adClass = 'js-scrollable-mpu',
-        /**
-         * TODO: rather blunt instrument this - due to the fact *most* mobile devices have a crappy onscroll
-         * implementation, i.e. it only fires on scroll end
-         */
-        badOnScroll = detect.isIOS() || detect.isAndroid();
+    var adClass          = 'js-scrollable-mpu',
+        updateBgPosition = function ($ad) {
+            $ad.css('background-position', $ad.offset().left + 'px 0');
+        };
 
     /**
      * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10026567
@@ -25,19 +19,16 @@ define([
     return {
 
         run: function () {
-
             $('.' + adClass).each(function (ad) {
-                var staticImage,
-                    $ad = bonzo(ad);
+                var $ad = bonzo(ad);
 
-                if (badOnScroll) {
-                    staticImage = $ad.data('static-image');
-                    $ad.css('background-image', staticImage);
-                } else {
-                    mediator.on('window:scroll', function () {
-                        ad.style.backgroundPosition = '0 ' + window.pageYOffset + 'px';
-                    });
-                }
+                // update bg position
+                updateBgPosition($ad);
+                // to be safe, also update on window resize
+                mediator.on('window:resize', function () {
+                    updateBgPosition($ad);
+                });
+
                 $ad.removeClass(adClass);
             });
 

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -104,7 +104,7 @@ define([
     }
 
     function isIOS() {
-        return /(iPad|iPhone|iPod touch);.*CPU.*OS 7_\d/i.test(navigator.userAgent);
+        return /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);
     }
 
     function isAndroid() {

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -2,6 +2,6 @@
     display: block;
     height: 250px;
     @include box-sizing(border-box);
-    border: 1px solid #dfdfdf;
-    background: fixed none 0 0 repeat;
+    border: 1px solid colour(neutral-5);
+    background: none 0 0 repeat;
 }

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -1,9 +1,7 @@
 .creative--scrollable-mpu {
     display: block;
     height: 250px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
+    @include box-sizing(border-box);
     border: 1px solid #dfdfdf;
-    background: none 0 0 repeat-y;
+    background: fixed none 0 0 repeat;
 }


### PR DESCRIPTION
Reverts guardian/frontend#7085

Making a pig's ear of this - this method, though still doesn't work on iOS, is better than the other
