### PR TITLE
Ensure gallery light-box is visible with overlay. Fix: #7078

### DIFF
--- a/static/src/stylesheets/module/content/_gallery-lightbox.scss
+++ b/static/src/stylesheets/module/content/_gallery-lightbox.scss
@@ -371,6 +371,10 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
     margin: 0 auto;
     margin-top: gs-height(1);
 
+    &.fc-container {
+        display: block;
+    }
+
     @include mq(leftCol) {
         width: gs-span(12) + $gs-gutter*2;
 


### PR DESCRIPTION
This ensures the gallery end-slate is always visible.

/cc @mattosborn @paperboyo
