### PR TITLE
Go straight to the UK front

### DIFF
--- a/integrated-tests/src/test/scala/facia/ShowMoreTest.scala
+++ b/integrated-tests/src/test/scala/facia/ShowMoreTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
   "Facia containers" should "have show more functionality" in {
 
-    go to theguardian("/")
+    go to theguardian("/uk")
 
     withClue("Should show the 'show more' button") {
       first("[data-test-id='show-more']").isDisplayed should be (true)


### PR DESCRIPTION
Redirects were causing intermittent test failures.

Depending on order, a cookie was set or not...
