### PR TITLE
add config.page.sectionName to Facia and Section pages

### DIFF
--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -27,7 +27,8 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
   override lazy val metaData: Map[String, JsValue] = super.metaData ++ Map(
     "keywords" -> JsString(webTitle),
     "keywordIds" -> JsString(keywordIds.mkString(",")),
-    "content-type" -> JsString("Section")
+    "contentType" -> JsString("Section"),
+    "sectionName" -> JsString(delegate.webTitle)
   )
 
   override lazy val isSponsored: Boolean = keywordIds exists (DfpAgent.isSponsored(_, Some(id)))

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -31,7 +31,8 @@ case class FaciaPage(id: String,
   lazy val faciaPageMetaData: Map[String, JsValue] = Map(
     "keywords" -> JsString(webTitle.capitalize),
     "keywordIds" -> JsString(keywordIds.mkString(",")),
-    "contentType" -> JsString(contentType)
+    "contentType" -> JsString(contentType),
+    "sectionName" -> JsString(seoData.webTitle)
   )
 
   val isNetworkFront: Boolean = Edition.all.exists(edition => id.toLowerCase.endsWith(edition.id.toLowerCase))


### PR DESCRIPTION
I noticed it was missing which meant that the reader history wouldn't count visits to section and facia pages towards the "my popular history" bar that I'm adding.
