### PR TITLE
Remove foundation-supported class from top level container

### DIFF
--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -8,7 +8,6 @@
                 "fc-container--layout-front" -> true,
                 "fc-container--sponsored" -> faciaPage.isSponsored,
                 "fc-container--advertisement-feature" -> faciaPage.isAdvertisementFeature,
-                "fc-container--foundation-supported" -> faciaPage.isFoundationSupported,
                 "js-sponsored-front" -> (faciaPage.isSponsored || faciaPage.isAdvertisementFeature || faciaPage.isFoundationSupported)))"
             data-link-name="Front | @request.path"
             @faciaPage.sponsor.map { sponsor =>


### PR DESCRIPTION
This is not needed at the top level as is now applied at a container level instead.
