### PR TITLE
Commercial admin add google

### DIFF
--- a/admin/app/views/commercial/fluidAds.scala.html
+++ b/admin/app/views/commercial/fluidAds.scala.html
@@ -13,18 +13,23 @@
     <ul class="list-group">
         <li class="list-group-item">
             <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng101&view=mobile">Live Better</a></h4>
+            <small>Fluid250</small>
         </li>
         <li class="list-group-item">
             <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng102&view=mobile">Nissan</a></h4>
+            <small>Fluid250 with basic animation</small>
         </li>
         <li class="list-group-item">
             <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng103&view=mobile">Own the Weekend</a></h4>
+            <small>Fluid250 with animation</small>
         </li>
         <li class="list-group-item">
             <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng104&view=mobile">ITV - Grantchester</a></h4>
+            <small>Fluid250, Expandable, scrollable MPU</small>
         </li>
         <li class="list-group-item">
             <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng105&view=mobile">Google Android</a></h4>
+            <small>Fluid250, Expandable, scrollable MPU + all on mobile</small>
         </li>
     </ul>
 }

--- a/admin/app/views/commercial/fluidAds.scala.html
+++ b/admin/app/views/commercial/fluidAds.scala.html
@@ -23,5 +23,8 @@
         <li class="list-group-item">
             <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng104&view=mobile">ITV - Grantchester</a></h4>
         </li>
+        <li class="list-group-item">
+            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng105&view=mobile">Google Android</a></h4>
+        </li>
     </ul>
 }


### PR DESCRIPTION
Updates the list of example Fluid 250 / Expandable campaigns.

Also adds explanations of what each example shows.

Before;
![screen shot 2014-11-13 at 10 25 47](https://cloud.githubusercontent.com/assets/1303616/5026786/7e5db7d8-6b1f-11e4-97ec-cbcce76ff1f6.png)

After;
![screen shot 2014-11-13 at 10 25 57](https://cloud.githubusercontent.com/assets/1303616/5026788/860a79bc-6b1f-11e4-93ad-fb1b6557980e.png)
