### PR TITLE
Lower number of items on tag pages to 35

### DIFF
--- a/applications/app/services/repositories.scala
+++ b/applications/app/services/repositories.scala
@@ -23,7 +23,7 @@ import scalaz.std.list._
 import Function.const
 
 object IndexPagePagination {
-  def pageSize: Int = 50 //have a good think before changing this
+  def pageSize: Int = 35 //have a good think before changing this
 }
 
 case class MpuState(injected: Boolean)

--- a/applications/app/services/repositories.scala
+++ b/applications/app/services/repositories.scala
@@ -3,7 +3,7 @@ package services
 import com.gu.facia.client.models.CollectionConfig
 import layout._
 import model._
-import conf.{InlineRelatedContentSwitch, LiveContentApi}
+import conf.{Switches, InlineRelatedContentSwitch, LiveContentApi}
 import model.Section
 import common._
 import com.gu.contentapi.client.model.{SearchResponse, ItemResponse}
@@ -23,7 +23,11 @@ import scalaz.std.list._
 import Function.const
 
 object IndexPagePagination {
-  def pageSize: Int = 35 //have a good think before changing this
+  def pageSize: Int = if (Switches.TagPageSizeSwitch.isSwitchedOn) {
+    35
+  } else {
+    20
+  }
 }
 
 case class MpuState(injected: Boolean)

--- a/applications/test/TagFeatureTest.scala
+++ b/applications/test/TagFeatureTest.scala
@@ -1,6 +1,7 @@
 package test
 
 import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import services.IndexPagePagination
 import collection.JavaConversions._
 import conf.Switches
 import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
@@ -15,7 +16,7 @@ import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
 
       goTo("/technology/askjack") { browser =>
         val trails = browser.$(".fc-item__container")
-        trails.length should be(35)
+        trails.length should be(IndexPagePagination.pageSize)
       }
     }
   }

--- a/applications/test/TagFeatureTest.scala
+++ b/applications/test/TagFeatureTest.scala
@@ -15,7 +15,7 @@ import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
 
       goTo("/technology/askjack") { browser =>
         val trails = browser.$(".fc-item__container")
-        trails.length should be(50)
+        trails.length should be(35)
       }
     }
   }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -45,6 +45,12 @@ object Switches extends Collections {
   private lazy val never = new LocalDate(2100, 1, 1)
 
   // Performance
+  val TagPageSizeSwitch = Switch("Performance", "tag-page-size",
+    "If this switch is on then we will request more items for larger tag pages",
+    safeState = Off,
+    sellByDate = never
+  )
+
   val CircuitBreakerSwitch = Switch("Performance", "circuit-breaker",
     "If this switch is switched on then the Content API circuit breaker will be operational",
     safeState = Off,
@@ -391,6 +397,7 @@ object Switches extends Collections {
   )
 
   val all: List[Switch] = List(
+    TagPageSizeSwitch,
     AutoRefreshSwitch,
     DoubleCacheTimesSwitch,
     RelatedContentSwitch,


### PR DESCRIPTION
CC @gklopper @rich-nguyen 

50 was causing us issues. Content API have upped their number of boxes.
