### PR TITLE
Do not strip valid Unicode characters from RSS

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -19,14 +19,6 @@ object TrailsToRss extends implicits.Collections {
     TrailsToRss(Some(metaData.webTitle), trails, Some(metaData.url), metaData.description)
 
   def apply(title: Option[String], trails: Seq[Trail], url: Option[String] = None, description: Option[String] = None)(implicit request: RequestHeader): String = {
-
-    // http://stackoverflow.com/questions/9710185/how-to-deal-with-invalid-characters-in-a-ws-output-when-using-cxf
-    // subjects … Philip Hoare
-    def cleanInvalidXmlChars(text: String): String = {
-      val re = "[^\\x09\\x0A\\x0D\\x20-\\xD7FF\\xE000-\\xFFFD\\x10000-x10FFFF]".r;
-      re.replaceAllIn(text, "")
-    }
-
     val feedTitle = title.map(t => s"$t | The Guardian").getOrElse("The Guardian")
 
     // Feed: image
@@ -71,7 +63,7 @@ object TrailsToRss extends implicits.Collections {
           case _ => ""
         }
       val readMore = s""" <a href="${trail.webUrl}">Continue reading...</a>"""
-      description.setValue(cleanInvalidXmlChars(standfirst + intro + readMore))
+      description.setValue(standfirst + intro + readMore)
 
       val images: Seq[ImageAsset] = (trail.bodyImages ++ trail.mainPicture ++ trail.thumbnail).map{ i =>
         i.imageCrops.filter(c => (c.width == 140 && c.height == 84) || (c.width == 460 && c.height == 276))
@@ -85,9 +77,9 @@ object TrailsToRss extends implicits.Collections {
         i.mimeType.map(image.setType)
         // create image's metadata
         val imageMetadata = new Metadata()
-        i.caption.map(d => { imageMetadata.setDescription(cleanInvalidXmlChars(d)) })
+        i.caption.map(d => { imageMetadata.setDescription(d) })
         i.credit.map{ creditName =>
-          val credit = new Credit(null, null, cleanInvalidXmlChars(creditName))
+          val credit = new Credit(null, null, creditName)
           imageMetadata.setCredits(Seq(credit).toArray)
         }
         image.setMetadata(imageMetadata)
@@ -97,14 +89,14 @@ object TrailsToRss extends implicits.Collections {
         module
       }
 
-      // Entry: DublinCore 
+      // Entry: DublinCore
       val dc = new DCModuleImpl
-      dc.setDate(trail.webPublicationDate.toDate);
-      dc.setCreator(trail.byline.getOrElse("Guardian Staff"));
-  
+      dc.setDate(trail.webPublicationDate.toDate)
+      dc.setCreator(trail.byline.getOrElse("Guardian Staff"))
+
       // Entry
       val entry = new SyndEntryImpl
-      entry.setTitle(cleanInvalidXmlChars(trail.linkText))
+      entry.setTitle(trail.linkText)
       entry.setLink(trail.webUrl)
       entry.setDescription(description)
       entry.setCategories(categories)
@@ -118,7 +110,7 @@ object TrailsToRss extends implicits.Collections {
     val writer = new StringWriter()
     val output = new SyndFeedOutput()
     output.output(feed, writer)
-    writer.close
+    writer.close()
     writer.toString
   }
 }

--- a/common/test/common/TrailsToRss.scala
+++ b/common/test/common/TrailsToRss.scala
@@ -4,6 +4,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import play.api.test.FakeRequest
 import org.joda.time.DateTime
+import scala.util.Try
 import scala.xml._
 import model.{FaciaImageElement, Trail}
 
@@ -14,43 +15,56 @@ class TrailsToRssTest extends FlatSpec with Matchers {
 
   "TrailsToRss" should "produce a valid RSS feed" in {
     val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
-    ((rss \ "channel" \ "title").text) should be("foo | The Guardian")
+    (rss \ "channel" \ "title").text should be("foo | The Guardian")
   }
 
   "TrailsToRss" should "create an RSS entry per given trail" in {
     val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
-    ((rss \ "channel" \ "item").size) should be(2)
+    (rss \ "channel" \ "item").size should be(2)
   }
 
   "TrailsToRss" should "not strip valid Unicode characters from XML" in {
     val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
-    ((rss \\ "item" \\ "title" )(1).text) should be("hello …")
+    (rss \\ "item" \\ "title" )(1).text should be("hello …")
+  }
+
+  "TrailsToRss" should "escape special XML characters" in {
+    isWellFormedXML(TrailsToRss(Option("foo"), Seq(
+      TestTrail("c", customTitle = Some("TV & Radio")),
+      TestTrail("d", customTitle = Some("Scala < Haskell")),
+      TestTrail("e", customTitle = Some("Scala > JavaScript")),
+      TestTrail("f", customTitle = Some("Let's get a pizza")),
+      TestTrail("g", customTitle = Some(""" "No, let's not." """))
+    ))(request)) shouldBe true
   }
 
   "TrailsToRss" should "should include published date and byline" in {
     val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
-    ((rss \\ "item" \\ "creator" ).filter(_.prefix == "dc").head.text) should be("Chadders")
-    ((rss \\ "item" \\ "pubDate" ).size) should be(2)
+    (rss \\ "item" \\ "creator" ).filter(_.prefix == "dc").head.text should be("Chadders")
+    (rss \\ "item" \\ "pubDate" ).size should be(2)
   }
 
+  def isWellFormedXML(s: String) =
+    Try {
+      scala.xml.XML.loadString(s)
+    }.isSuccess
 
-case class TestTrail(url: String) extends Trail {
+  case class TestTrail(url: String, customTitle: Option[String] = None) extends Trail {
+    override def customImageCutout: Option[FaciaImageElement] = None
 
-  override def customImageCutout: Option[FaciaImageElement] = None
+    def webPublicationDate: DateTime = DateTime.now
+    def shortUrl: String = ""
+    def linkText: String = customTitle getOrElse "hello …"
+    def headline: String = ""
+    def webUrl: String = ""
+    def trailText: Option[String] = None
+    def section: String = ""
+    def sectionName: String = ""
+    def isLive: Boolean = true
+    override def byline: Option[String] = Some("Chadders") // this is how I'd like to be remembered
 
-  def webPublicationDate: DateTime = DateTime.now
-  def shortUrl: String = ""
-  def linkText: String = "hello …"
-  def headline: String = ""
-  def webUrl: String = ""
-  def trailText: Option[String] = None
-  def section: String = ""
-  def sectionName: String = ""
-  def isLive: Boolean = true
-  override def byline: Option[String] = Some("Chadders") // this is how I'd like to be remembered
-
-  val snapUri: Option[String] = None
-  val snapType: Option[String] = None
-}
+    val snapUri: Option[String] = None
+    val snapType: Option[String] = None
+  }
 
 }

--- a/common/test/common/TrailsToRss.scala
+++ b/common/test/common/TrailsToRss.scala
@@ -28,6 +28,12 @@ class TrailsToRssTest extends FlatSpec with Matchers {
     (rss \\ "item" \\ "title" )(1).text should be("hello …")
   }
 
+  it should "strip invalid Unicode characters from XML" in {
+    isWellFormedXML(TrailsToRss(Option("foo"), Seq(
+      TestTrail("h", customTitle = Some("\0LOL"))
+    ))(request)) shouldBe true
+  }
+
   "TrailsToRss" should "escape special XML characters" in {
     isWellFormedXML(TrailsToRss(Option("foo"), Seq(
       TestTrail("c", customTitle = Some("TV & Radio")),

--- a/common/test/common/TrailsToRss.scala
+++ b/common/test/common/TrailsToRss.scala
@@ -22,9 +22,9 @@ class TrailsToRssTest extends FlatSpec with Matchers {
     ((rss \ "channel" \ "item").size) should be(2)
   }
 
-  "TrailsToRss" should "clean invalid XML characters" in {
+  "TrailsToRss" should "not strip valid Unicode characters from XML" in {
     val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
-    ((rss \\ "item" \\ "title" )(1).text) should be("hello")
+    ((rss \\ "item" \\ "title" )(1).text) should be("hello …")
   }
 
   "TrailsToRss" should "should include published date and byline" in {


### PR DESCRIPTION
As we encode our RSS feeds in UTF-8 anyway, I don't understand why we're stripping Unicode characters from our XML. This is what's causing missing n dashes, etc.

If I'm doing something stupid please let me know @gklopper @rich-nguyen @phamann 
