### PR TITLE
making share counts protocol relative as they are available over HTTPS

### DIFF
--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -76,7 +76,7 @@ define([
             var url = 'http://www.theguardian.com/' + config.page.pageId;
             try {
                 ajax({
-                    url: 'http://graph.facebook.com/' + url,
+                    url: '//graph.facebook.com/' + url,
                     type: 'json',
                     method: 'get',
                     crossOrigin: true
@@ -87,7 +87,7 @@ define([
                     updateTooltip();
                 });
                 ajax({
-                    url: 'http://urls.api.twitter.com/1/urls/count.json?url=' + url,
+                    url: '//urls.api.twitter.com/1/urls/count.json?url=' + url,
                     type: 'jsonp',
                     method: 'get',
                     crossOrigin: true


### PR DESCRIPTION
This fixes one of the mixed content errors:
![screen shot 2014-11-17 at 11 40 20](https://cloud.githubusercontent.com/assets/1764158/5069157/96bf9d14-6e4e-11e4-84be-dc64d014e7bf.png)
 when fetching over HTTPS (e.g. Preview)
