### PR TITLE
Gallery twitter:image:src values should begin with http://

### DIFF
--- a/applications/test/GalleryTemplateTest.scala
+++ b/applications/test/GalleryTemplateTest.scala
@@ -37,6 +37,7 @@ import scala.collection.JavaConversions._
     import browser._
     $("meta[name='twitter:card']").getAttributes("content").head should be ("gallery")
     $("meta[name='twitter:title']").getAttributes("content").head should be ("Southbank Centre's Sounds Venezuela festival - in pictures")
+    $("meta[name='twitter:image3:src']").getAttributes("content").head should startWith ("http://")
     $("meta[name='twitter:image3:src']").getAttributes("content").head should endWith ("/Bassoons-in-the-Symphony--003.jpg")
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -646,7 +646,12 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
     "twitter:card" -> "gallery",
     "twitter:title" -> linkText
   ) ++ largestCrops.sortBy(_.index).take(5).zipWithIndex.map { case (image, index) =>
-    image.path.map(s"twitter:image$index:src" ->)
+    image.path.map( i =>
+      if(i.startsWith("//")){
+        s"twitter:image$index:src" -> s"http:$i"
+      } else {
+        s"twitter:image$index:src" -> i
+      })
   }.flatten
 
   lazy val lightbox: JsObject = {


### PR DESCRIPTION
If the link to an image used in a twitter:image:src meta element begins with `//` ensure we prefix with `http:`
