### PR TITLE
Fix for inline sharing clashes on thumbnails

### DIFF
--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -384,7 +384,8 @@
     margin-top: ($gs-baseline/3)*2;
 
     .element--supporting &,
-    .element--thumbnail & {
+    .element--thumbnail &,
+    .img--base & {
         display: none !important;
     }
 


### PR DESCRIPTION
Fix for:
![screen shot 2014-11-17 at 16 19 25](https://cloud.githubusercontent.com/assets/2236852/5072868/8ef711d0-6e75-11e4-9e9f-2c1ced596faf.png)
