### PR TITLE
Do not dedup dream snaps

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -62,21 +62,20 @@ object Front extends implicits.Collections {
         dynamicContainer.containerDefinitionFor(
           trails.collect({ case content: Content => content }).map(Story.fromContent)
         ) map { containerDefinition =>
-          (seen ++ trails.map(_.url).take(itemsVisible(containerDefinition)), trails)
+          (seen ++ trails
+            .map(_.url)
+            .take(itemsVisible(containerDefinition)), trails)
         } getOrElse {
           (seen, trails)
         }
 
       case Fixed(containerDefinition) =>
         /** Fixed Containers participate in de-duplication.
-          *
-          * If any items in the container have appeared previously, they're shoved to the end of the container (the idea
-          * being that they disappear beyond the fold, i.e., after the 'show more' button).
           */
         val nToTake = itemsVisible(containerDefinition)
         val notUsed = trails.filterNot(trail => participatesInDeduplication(trail) && seen.contains(trail.url))
           .distinctBy(_.url)
-        (seen ++ notUsed.take(nToTake).map(_.url), notUsed)
+        (seen ++ notUsed.filter(participatesInDeduplication).take(nToTake).map(_.url), notUsed)
 
       case _ =>
         /** Nav lists and most popular do not participate in de-duplication at all */

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -40,6 +40,10 @@ object Front extends implicits.Collections {
   def itemsVisible(containerDefinition: ContainerDefinition) =
     containerDefinition.slices.flatMap(_.layout.columns.map(_.numItems)).sum
 
+  // Dream on.
+  def participatesInDeduplication(trail: Trail) =
+    !trail.snapType.exists(_ == "latest")
+
   /** Given a set of already seen trail URLs, a container type, and a set of trails, returns a new set of seen urls
     * for further de-duplication and the sequence of trails in the order that they ought to be shown for that
     * container.
@@ -70,7 +74,8 @@ object Front extends implicits.Collections {
           * being that they disappear beyond the fold, i.e., after the 'show more' button).
           */
         val nToTake = itemsVisible(containerDefinition)
-        val notUsed = trails.filterNot(trail => seen.contains(trail.url)).distinctBy(_.url)
+        val notUsed = trails.filterNot(trail => participatesInDeduplication(trail) && seen.contains(trail.url))
+          .distinctBy(_.url)
         (seen ++ notUsed.take(nToTake).map(_.url), notUsed)
 
       case _ =>


### PR DESCRIPTION
Dream snaps ain't supposed to participate in that there deduplication

Before:

![screen shot 2014-11-17 at 15 01 25](https://cloud.githubusercontent.com/assets/1001642/5073471/075146b0-6e7a-11e4-9454-c3c76ff0c8f9.png)

After:

![screen shot 2014-11-17 at 15 01 32](https://cloud.githubusercontent.com/assets/1001642/5073473/0bd4bd3e-6e7a-11e4-97bc-08df342d44b3.png)
