### PR TITLE
Fix the snap fallback link

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -48,8 +48,7 @@ trait LinkTo extends Logging {
   }
 
   def apply(trail: Trail)(implicit request: RequestHeader): Option[String] = trail match {
-    //TODO: legacy-snaps: Remove href after we move away from href in favour of snapUri
-    case snap: Snap => snap.snapUri.filter(_.nonEmpty).orElse(snap.href).map(apply(_))
+    case snap: Snap => snap.snapHref.filter(_.nonEmpty).map(apply(_))
     case t: Trail => Option(apply(t.url))
   }
 

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -27,8 +27,7 @@ case object Audio extends MediaType
 object EditionalisedLink {
   def fromTrail(trail: Trail) = EditionalisedLink {
     trail match {
-      case snap: Snap if snap.snapUri.exists(_.nonEmpty) => snap.snapUri.get
-      case snap: Snap if snap.href.exists(_.nonEmpty) => snap.href.get
+      case snap: Snap if snap.snapHref.exists(_.nonEmpty) => snap.snapHref.get
       case _ => trail.url
     }
   }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -28,6 +28,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   lazy val snapType: Option[String] = apiContent.metaData.flatMap(_.snapType).filter(_.nonEmpty)
   lazy val snapCss: Option[String] = apiContent.metaData.flatMap(_.snapCss).filter(_.nonEmpty)
   lazy val snapUri: Option[String]  = apiContent.metaData.flatMap(_.snapUri).filter(_.nonEmpty)
+  lazy val snapHref: Option[String] = apiContent.metaData.flatMap(_.href).filter(_.nonEmpty)
 
   lazy val publication: String = fields.getOrElse("publication", "")
   lazy val lastModified: DateTime = fields.get("lastModified").map(_.parseISODateTime).getOrElse(DateTime.now)

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -39,7 +39,7 @@ trait Trail extends Elements with Tags with FaciaFields with Dates {
   override def isFoundationSupported: Boolean = DfpAgent.isFoundationSupported(tags, Some(section))
 
   def faciaUrl: Option[String] = this match {
-    case snap: Snap => snap.snapUri.filter(_.nonEmpty)
+    case snap: Snap => snap.snapHref.filter(_.nonEmpty)
     case t: Trail => Option(t.url)
   }
 }

--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -365,14 +365,13 @@
                             <!-- /ko -->
 
                             <!-- ko if: meta.snapType -->
-                                <span class="label label--snap">snap: </span>
+                                <span class="label label--snap">snap</span>
                                 <span class="label label--snap" data-bind="text: meta.snapCss() || meta.snapType()"></span>
                                 <span class="label label--snap-uri" data-bind="text: meta.snapUri"></span>
                             <!-- /ko -->
 
-                            <!-- legacy-snaps -->
                             <!-- ko if: meta.href -->
-                                <span class="label label--snap">snap: NEEDS UPGRADE!</span>
+                                <span class="label label--snap">url</span>
                                 <span class="label label--snap-uri" data-bind="text: meta.href"></span>
                             <!-- /ko -->
 

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -594,14 +594,6 @@ define([
         };
 
         Article.prototype.save = function() {
-
-            // legacy-snaps
-            if (this.meta.href()) {
-                this.meta.snapType('link');
-                this.meta.snapUri(this.meta.href());
-                this.meta.href(undefined);
-            }
-
             if (!this.group.parent) {
                 return;
             }
@@ -628,6 +620,7 @@ define([
         };
 
         Article.prototype.convertToSnap = function() {
+            this.meta.href(this.id());
             this.id(snap.generateId());
             this.updateEditorsDisplay();
         };
@@ -638,7 +631,6 @@ define([
             }
 
             this.meta.snapType('link');
-            this.meta.snapUri(this.id());
 
             this.convertToSnap();
         }


### PR DESCRIPTION
- Reinstate the `href` metadata property for link-type snaps, or as the fallback in case of embed-type snaps. 
- Only use `snapUri` for the actual embed callout.

@janua 
