### PR TITLE
Create a new training type/priority

### DIFF
--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -29,12 +29,16 @@ GET           /assets/fonts/*path        dev.DevAssetsController.atFonts(path)
 GET           /                          controllers.FaciaToolController.priorities()
 GET           /editorial                 controllers.FaciaToolController.collectionEditor(priority="editorial")
 GET           /commercial                controllers.FaciaToolController.collectionEditor(priority="commercial")
+GET           /training                  controllers.FaciaToolController.collectionEditor(priority="training")
+
 
 GET           /editorial/2               controllers.FaciaToolController.multiPane(panes:Int=2)
 GET           /editorial/3               controllers.FaciaToolController.multiPane(panes:Int=3)
 
 GET           /editorial/config          controllers.FaciaToolController.configEditor(priority="editorial")
 GET           /commercial/config         controllers.FaciaToolController.configEditor(priority="commercial")
+GET           /training/config           controllers.FaciaToolController.configEditor(priority="training")
+
 
 GET           /publish-all               controllers.ContentApiPressController.publishAll()
 GET           /publish-all/comet         controllers.ContentApiPressController.publishAllStream()

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -195,7 +195,8 @@
                     <div class="cnf-form">
                         <label>Hidden</label>
                         <input type="checkbox" data-bind="
-                            checked: props.isHidden" />
+                            checked: props.isHidden,
+                            disable: state.isTypeLocked" />
 
                         <label>Nav section</label>
                         <select data-bind="
@@ -234,10 +235,19 @@
                             enable: props.imageUrl" />
 
                         <label>Type</label>
-                        <input type="radio" name="group02" data-bind="checkedValue: undefined, checked: props.priority" />
+                        <input type="radio" name="group02" data-bind="
+                            checkedValue: undefined,
+                            checked: props.priority,
+                            disable: state.isTypeLocked" />
                         <span class="radio-label">editorial</span>
-                        <input type="radio" name="group02" value="commercial" data-bind="checked: props.priority" />
+                        <input type="radio" name="group02" value="commercial" data-bind="
+                            checked: props.priority,
+                            disable: state.isTypeLocked" />
                         <span class="radio-label">commercial</span>
+                        <input type="radio" name="group02" value="training" data-bind="
+                            checked: props.priority,
+                            disable: state.isTypeLocked" />
+                        <span class="radio-label">training</span>
 
                         <div class="tools">
                             <span class="tool" data-bind="click: saveProps">Save metadata</span>
@@ -247,7 +257,7 @@
 
                  <!-- ko if: id -->
                     <div class="instructions">
-                        <!-- ko if: !state.isOpenProps() -->
+                        <!-- ko if: !state.isOpenProps() && collections.items().length -->
                             <span class="linky tool--metadata" data-bind="click: openProps">edit metadata</span>
                             &middot;
                             <a class='tool--content' data-bind="attr: {href: '/@{priority}?front=' + id()}">edit content</a>

--- a/facia-tool/app/views/priority.scala.html
+++ b/facia-tool/app/views/priority.scala.html
@@ -11,6 +11,9 @@
     <div class="front-priorities--priority">
         <a href="/commercial">Commercial Fronts</a>
     </div>
+    <div class="front-priorities--priority">
+        <a href="/training">Training Fronts</a>
+    </div>
     <div class="front-priorities--extra">
         Bookmarklets:
         <a href="javascript:window.location.href='https://fronts.gutools.co.uk/editorial?front='+window.location.pathname.replace(/^\/|\/$/g,'');">Edit PROD front</a> ·

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -21,12 +21,14 @@ GET           /assets/*file              controllers.UncachedAssets.at(file)
 GET           /                          controllers.FaciaToolController.priorities()
 GET           /editorial                 controllers.FaciaToolController.collectionEditor(priority="editorial")
 GET           /commercial                controllers.FaciaToolController.collectionEditor(priority="commercial")
+GET           /training                  controllers.FaciaToolController.collectionEditor(priority="training")
 
 GET           /editorial/2               controllers.FaciaToolController.multiPane(panes:Int=2)
 GET           /editorial/3               controllers.FaciaToolController.multiPane(panes:Int=3)
 
 GET           /editorial/config          controllers.FaciaToolController.configEditor(priority="editorial")
 GET           /commercial/config         controllers.FaciaToolController.configEditor(priority="commercial")
+GET           /training/config           controllers.FaciaToolController.configEditor(priority="training")
 
 GET           /publish-all               controllers.ContentApiPressController.publishAll()
 GET           /publish-all/comet         controllers.ContentApiPressController.publishAllStream()

--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -59,6 +59,8 @@ define([
             return this.props.priority() === vars.priority || this.state.isOpenProps(); // last clause allows priority change
         }, this);
 
+        this.applyConstraints();
+
         this.collections = new Group({
             parent: self,
             parentType: 'Front',
@@ -191,6 +193,7 @@ define([
     };
 
     Front.prototype.saveProps = function() {
+        this.applyConstraints();
         persistence.front.update(this);
         this.state.isOpenProps(false);
     };
@@ -209,6 +212,13 @@ define([
         collection.parents.remove(this);
         this.collections.items.remove(collection);
         this.saveProps();
+    };
+
+    Front.prototype.applyConstraints = function () {
+        if (this.props.priority() === 'training') {
+            this.state.isTypeLocked = true;
+            this.props.isHidden(true);
+        }
     };
 
     function toTitleCase(str) {


### PR DESCRIPTION
Fronts with priority training are hidden by default and cannot be modified.

There's no link for the training type on the front page, but the tool is accessible at `/training` and `/training/config`
