### PR TITLE
Keep the header fixed even for smaller breakpoints

### DIFF
--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1328,9 +1328,6 @@ button {
         right: inherit;
         left: 0;
     }
-    .scrollable {
-        overflow-y: inherit
-    }
 }
 
 @media (max-width: 550px) {


### PR DESCRIPTION
The list of collections scrolls but the header stays fixed so it's aligned with other headers when using multiple panes
