### PR TITLE
Facia will now understand all redirects for editionalised fronts

### DIFF
--- a/common/test/implicits/FakeRequests.scala
+++ b/common/test/implicits/FakeRequests.scala
@@ -1,9 +1,13 @@
 package implicits
 
+import common.Edition
+import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 
 trait FakeRequests {
   implicit class FakeRequest2WithHost[A](req: FakeRequest[A]) {
     def withHost(host: String): FakeRequest[A] = req.withHeaders("Host" -> host)
+
+    def from(edition: Edition): FakeRequest[A] = req.withCookies(Cookie("GU_EDITION", edition.id))
   }
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -74,7 +74,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   }
 
   def redirectToEditionalisedVersion(path: String)(implicit request: RequestHeader): Future[Result] = {
-    successful(Found(LinkTo(Editionalise(s"/$path", request))))
+    successful(Cached(60)(Found(LinkTo(Editionalise(s"/$path", request)))))
   }
 
   private def withFaciaPage(path: String)(f: FaciaPage => Result): Future[Result] = {

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -12,6 +12,8 @@ GET        /_agentcontents                                             controlle
 GET        /humans.txt                                                 controllers.Assets.at(path="/public", file="humans.txt")
 
 # Editionalised redirects
+# TODO we should get rid of these. we should not have to add these manually here as routes
+# everything is in place for the fronts, we just have to figure out what to do with RSS
 GET        /                                                           controllers.FaciaController.rootEditionRedirect()
 GET        /$path<(culture|sport|commentisfree|business|money|rss)>    controllers.FaciaController.editionRedirect(path)
 


### PR DESCRIPTION
have left a bit of Tech Debt in there while I think about RSS
