### PR TITLE
Don't sponsor popular containers

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -8,6 +8,7 @@ import services.CollectionConfigWithId
 import slices._
 import views.support.CutOut
 import scala.Function._
+import slices.MostPopular
 
 /** For de-duplicating cutouts */
 object ContainerLayoutContext {
@@ -178,29 +179,26 @@ object FaciaContainer {
     collectionEssentials: CollectionEssentials,
     containerLayout: Option[ContainerLayout],
     componentId: Option[String]
-  ): FaciaContainer = {
-      // rather vague definition of whether this is a popular container
-      val isPopular = config.config.apiQuery.exists { q =>
-        q.contains("show-most-viewed=true") && q.contains("hide-recent-content=true")
-      }
-      FaciaContainer(
-        index,
-        config.id,
-        config.config.displayName orElse collectionEssentials.displayName,
-        config.config.href orElse collectionEssentials.href,
-        componentId,
-        container,
-        collectionEssentials,
-        containerLayout,
-        config.config.showDateHeader.exists(identity),
-        config.config.showLatestUpdate.exists(identity),
-        // popular containers should never be sponsored
-        if (isPopular) ContainerCommercialOptions.empty else ContainerCommercialOptions.fromConfig(config.config),
-        None,
-        None,
-        false
-      )
-  }
+  ): FaciaContainer = FaciaContainer(
+    index,
+    config.id,
+    config.config.displayName orElse collectionEssentials.displayName,
+    config.config.href orElse collectionEssentials.href,
+    componentId,
+    container,
+    collectionEssentials,
+    containerLayout,
+    config.config.showDateHeader.exists(identity),
+    config.config.showLatestUpdate.exists(identity),
+    // popular containers should never be sponsored
+    container match {
+      case MostPopular => ContainerCommercialOptions.empty
+      case _ => ContainerCommercialOptions.fromConfig(config.config)
+    },
+    None,
+    None,
+    false
+  )
 
   def forStoryPackage(dataId: String, items: Seq[Trail], title: String) = {
     FaciaContainer(

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -178,22 +178,29 @@ object FaciaContainer {
     collectionEssentials: CollectionEssentials,
     containerLayout: Option[ContainerLayout],
     componentId: Option[String]
-  ): FaciaContainer = FaciaContainer(
-    index,
-    config.id,
-    config.config.displayName orElse collectionEssentials.displayName,
-    config.config.href orElse collectionEssentials.href,
-    componentId,
-    container,
-    collectionEssentials,
-    containerLayout,
-    config.config.showDateHeader.exists(identity),
-    config.config.showLatestUpdate.exists(identity),
-    ContainerCommercialOptions.fromConfig(config.config),
-    None,
-    None,
-    false
-  )
+  ): FaciaContainer = {
+      // rather vague definition of whether this is a popular container
+      val isPopular = config.config.apiQuery.exists { q =>
+        q.contains("show-most-viewed=true") && q.contains("hide-recent-content=true")
+      }
+      FaciaContainer(
+        index,
+        config.id,
+        config.config.displayName orElse collectionEssentials.displayName,
+        config.config.href orElse collectionEssentials.href,
+        componentId,
+        container,
+        collectionEssentials,
+        containerLayout,
+        config.config.showDateHeader.exists(identity),
+        config.config.showLatestUpdate.exists(identity),
+        // popular containers should never be sponsored
+        if (isPopular) ContainerCommercialOptions.empty else ContainerCommercialOptions.fromConfig(config.config),
+        None,
+        None,
+        false
+      )
+  }
 
   def forStoryPackage(dataId: String, items: Seq[Trail], title: String) = {
     FaciaContainer(


### PR DESCRIPTION
### Before

![screen shot 2014-11-19 at 11 33 19](https://cloud.githubusercontent.com/assets/74132/5105015/e4cae85a-6fdf-11e4-84bc-fb8a71bf73e1.png)
### After

![screen shot 2014-11-19 at 11 33 23](https://cloud.githubusercontent.com/assets/74132/5105016/e907e9ae-6fdf-11e4-855c-b3464ae58bd0.png)

@janua, @robertberry  - is this the best way to achieve this?
