### PR TITLE
fix media meta number border colour

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -47,7 +47,7 @@
     .commentcount,
     .meta__numbers,
     .meta__social,
-    .meta__number {
+    .meta__number:not(u-h) + .meta__number {
         border-color: colour(neutral-2);
     }
 


### PR DESCRIPTION
fixing this:
![image](https://cloud.githubusercontent.com/assets/960919/5108011/9be39730-6ffe-11e4-920d-544512360adc.png)
