### PR TITLE
Move scrollable MPU over to DFP new world

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
@@ -16,12 +16,12 @@ define([
     expandableTpl
 ) {
 
-    var Creative = function ($adSlot, args) {
-        this.$adSlot        = $adSlot;
-        this.templateParams = args[0];
-        this.isClosed       = true;
-        this.closedHeight   = Math.min(bonzo.viewport().height / 3, 300);
-        this.openedHeight   = Math.min(bonzo.viewport().height * 2 / 3, 600);
+    var Creative = function ($adSlot, params) {
+        this.$adSlot      = $adSlot;
+        this.params       = params;
+        this.isClosed     = true;
+        this.closedHeight = Math.min(bonzo.viewport().height / 3, 300);
+        this.openedHeight = Math.min(bonzo.viewport().height * 2 / 3, 600);
     };
 
     Creative.prototype.listener = function () {
@@ -39,7 +39,7 @@ define([
     };
 
     Creative.prototype.create = function () {
-        var $expandable = $.create(template(expandableTpl, this.templateParams));
+        var $expandable = $.create(template(expandableTpl, this.params));
 
         this.$ad     = $('.ad-exp--expand', $expandable).css('height', this.closedHeight);
         this.$button = $('.ad-exp__close-button', $expandable);

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
@@ -29,6 +29,7 @@ define([
             // expires in 1 week
             var week = 1000 * 60 * 60 * 24 * 7;
 
+            // TODO - needs to have a creative-specific id
             storage.local.set('gu.commercial.expandable.an-expandable', true, { expires: Date.now() + week });
             this.$button.toggleClass('button-spin');
             this.$ad.css('height', this.openedHeight);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -316,7 +316,7 @@ define([
                                 creativeConfig = JSON.parse(breakoutContent);
                                 require(['common/modules/commercial/creatives/' + creativeConfig.name])
                                     .then(function (Creative) {
-                                        new Creative($slot, creativeConfig.args).create();
+                                        new Creative($slot, creativeConfig.params).create();
                                     });
                             } else {
                                 // evil, but we own the returning js snippet

--- a/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu.html
@@ -1,0 +1,5 @@
+<a class="creative--scrollable-mpu"
+    href="{{clickMacro}}{{destination}}"
+    style="background-image: url('{{image}}');"
+    target="_new"></a>
+{{trackingPixelImg}}


### PR DESCRIPTION
General policy now is no css, js or html should live in DFP - it should only serve a json object, e.g. https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10026567, which we then use to construct the html and behaviour

Working through existing templates to use this new style
