### PR TITLE
Video play icon fix

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -172,7 +172,7 @@ $fc-hover-transition: .25s ease;
     }
 
     .vjs-big-play-button > span {
-        @include video-play-button-size($vjs-x-small-button-size);
+        @include video-play-button-size($vjs-small-button-size);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--mega-full.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--mega-full.scss
@@ -85,12 +85,4 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
     .fc-item__footer--horizontal {
         @include flex-basis(auto);
     }
-
-    .vjs-big-play-button > span {
-        @include video-play-button-size($vjs-small-button-size);
-
-        @include mq(desktop) {
-            @include video-play-button-size($vjs-large-button-size);
-        }
-    }
 }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--mega-full.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--mega-full.scss
@@ -85,4 +85,12 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
     .fc-item__footer--horizontal {
         @include flex-basis(auto);
     }
+
+    .vjs-big-play-button > span {
+        @include video-play-button-size($vjs-small-button-size);
+
+        @include mq(desktop) {
+            @include video-play-button-size($vjs-large-button-size);
+        }
+    }
 }


### PR DESCRIPTION
There was a 'bug' causing play icon to appear broken on the large items:
![screen shot 2014-11-19 at 15 05 37](https://cloud.githubusercontent.com/assets/2579465/5112170/b55e3480-701d-11e4-865c-0a1ac5be2096.png)

It seems that we were not using the default x-small icon so I've changed it to the small version. @michaelwmcnamara looked at it to and it seems to be ok.

The main reason why I did that instead of adding breakpoints for `mega-full` class, is to not add more css if it's not really necessary. 

CC @sndrs 
