### PR TITLE
No dedupe on latest-snap cutout images

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -25,12 +25,17 @@ case class ContainerLayoutContext(
     if (hideCutOuts) {
       (card.copy(item = card.item.copy(cutOut = None)), this)
     } else {
-      val newCard = if (card.item.cutOut.exists(cutOutsSeen.contains)) {
-        card.copy(item = card.item.copy(cutOut = None))
+      // Latest snaps are sometimes used to promote journalists, and the cut out should always show on these snaps.
+      if (card.item.snapStuff.snapType == LatestSnap) {
+        (card, this)
       } else {
-        card
+        val newCard = if (card.item.cutOut.exists(cutOutsSeen.contains)) {
+          card.copy(item = card.item.copy(cutOut = None))
+        } else {
+          card
+        }
+        (newCard, addCutOuts(card.item.cutOut.filter(const(card.item.cardTypes.showCutOut)).toSet))
       }
-      (newCard, addCutOuts(card.item.cutOut.filter(const(card.item.cardTypes.showCutOut)).toSet))
     }
   }
 }

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -106,19 +106,30 @@ case class DisplaySettings(
   imageHide: Boolean
 )
 
+sealed trait SnapType
+
+case object LatestSnap extends SnapType
+case object OtherSnap extends SnapType
+
 object SnapStuff {
   def fromTrail(trail: Trail) = SnapStuff(
     SnapData(trail),
     trail match {
       case c: Content => c.snapCss
       case _ => None
+    },
+    if (trail.snapType.exists(_ == "latest")) {
+      LatestSnap
+    } else {
+      OtherSnap
     }
   )
 }
 
 case class SnapStuff(
   dataAttributes: String,
-  snapCss: Option[String]
+  snapCss: Option[String],
+  snapType: SnapType
 ) {
   def cssClasses = Seq(
     "js-snap",


### PR DESCRIPTION
Credits to @robertberry for this. Always show the cutout image on a latest snap (aka dream snap) even if that image has already been rendered on the page.
