### PR TITLE
Style fixes for recommend button and video icon

### DIFF
--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -661,6 +661,7 @@ $comment-recommend-button-size: 19px;
     i {
         width: 13px !important;
         height: 13px !important;
+        left: 2px;
     }
 
     .id--signed-in .d-discussion--recommendations-open & {

--- a/static/src/stylesheets/module/_icons.scss
+++ b/static/src/stylesheets/module/_icons.scss
@@ -25,7 +25,7 @@ blockquote.quoted:before {
     @include icon(image);
 
     .element-video & {
-        @include icon(video-icon-black);
+        @include icon(video-icon-grey);
         width: 16px !important;
         height: 12px !important;
         margin-top: $gs-baseline/6;


### PR DESCRIPTION
Minor style fixes for:

![screen shot 2014-11-20 at 11 49 25](https://cloud.githubusercontent.com/assets/2236852/5124115/4ec6549e-70ab-11e4-8f64-d180383c59d2.png)
Being black instead of grey

---

![screen shot 2014-11-20 at 11 49 03](https://cloud.githubusercontent.com/assets/2236852/5124125/57a93f9a-70ab-11e4-9882-41a7bdcf701d.png)
Being off centre 

cc @mattosborn 
