### PR TITLE
Add link to all pages from fronts

### DIFF
--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -82,17 +82,8 @@ case class FrontProperties(
   editorialType: Option[String]
 )
 
-object FrontProperties{
-  implicit val propsFormatter = Json.format[FrontProperties]
+object FrontProperties {
+  implicit val jsonFormat = Json.format[FrontProperties]
 
   val empty = FrontProperties(None, None, None, None, false, None)
-}
-
-object FaciaComponentName {
-  /** TODO remove this once everything is using FaciaContainer */
-  def apply(config: CollectionConfig, collection: Collection): String = {
-    config.displayName.orElse(collection.displayName).map { title =>
-      title.toLowerCase.replace(" ", "-")
-    }.getOrElse("no-name")
-  }
 }

--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -1,4 +1,4 @@
-@(keywords: Seq[model.Tag], visibleKeywords: Int = 5, title: String = "Tags", tone: Option[String] = None)(implicit request: RequestHeader)
+@(keywords: Seq[model.Tag], visibleKeywords: Int = 5, title: String = "Tags", tone: Option[String] = None, allPath: Option[String] = None)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import model.Tag
@@ -18,8 +18,16 @@
 
 @defining(keywords.filterNot(_.isSectionTag).take(visibleKeywords)) { shownKeywords =>
     @defining(keywords.filterNot(_.isSectionTag).drop(visibleKeywords)) { hiddenKeywords =>
-        @if(shownKeywords.nonEmpty) {
+        @if(shownKeywords.nonEmpty || allPath.nonEmpty) {
             <ul class="keyword-list inline-list">
+                @allPath.map { path =>
+                    <li class="inline-list__item">
+                        <a href="@LinkTo(path)"
+                           data-link-name="all"
+                           class="button button--small button--tag button--secondary">All today's stories</a>
+                    </li>
+                }
+
                 @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
                     @renderItem(keyword, row, trailingComma = hiddenKeywords.nonEmpty)
                 }

--- a/common/app/views/fragments/trendingTopics.scala.html
+++ b/common/app/views/fragments/trendingTopics.scala.html
@@ -1,4 +1,4 @@
-@(items: Seq[model.Content], pageId: String)(implicit request: RequestHeader)
+@(items: Seq[model.Content], pageId: String, allPath: Option[String] = None)(implicit request: RequestHeader)
 
 @import views.html.fragments.keywordList
 @import views.support.MostPopularTags.topTags
@@ -8,7 +8,7 @@
     @if(tags.nonEmpty) {
         <div class="submeta" data-link-name="keywords">
             <h2 class="submeta__head">Trending topics</h2>
-            @keywordList(tags, 5, "See also")
+            @keywordList(tags, 5, "See also", allPath = allPath)
         </div>
     }
 }

--- a/common/app/views/fragments/trendingTopics.scala.html
+++ b/common/app/views/fragments/trendingTopics.scala.html
@@ -7,7 +7,7 @@
 @defining(topTags(items).filterNot(_.id == pageId).take(20)) { tags =>
     @if(tags.nonEmpty) {
         <div class="submeta" data-link-name="keywords">
-            <h2 class="submeta__head">Trending topics</h2>
+            <h2 class="submeta__head">Topics</h2>
             @keywordList(tags, 5, "See also", allPath = allPath)
         </div>
     }

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -6,6 +6,7 @@ import dfp.DfpAgent
 import layout.{CollectionEssentials, Front}
 import play.api.libs.json.{JsString, JsValue}
 import services.CollectionConfigWithId
+import scala.language.postfixOps
 
 case class FaciaPage(id: String,
                      seoData: SeoData,
@@ -24,10 +25,18 @@ case class FaciaPage(id: String,
       id <- item.section +: item.tags.map(_.id)
     } yield id
 
-    if (tagAndSectionIds contains id) {
-      Some(s"$id/all")
-    } else {
-      None
+    val idWithoutEdition = id.split("/").toList match {
+      case maybeEdition :: rest if Edition.byId(maybeEdition).isDefined => Some(rest.mkString("/"))
+      case _ => None
+    }
+
+    val validIds = Set(
+      Some(id),
+      idWithoutEdition
+    ).flatten
+
+    tagAndSectionIds.find(validIds contains) map { id =>
+      s"$id/all"
     }
   }
 

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -11,6 +11,25 @@ case class FaciaPage(id: String,
                      seoData: SeoData,
                      frontProperties: FrontProperties,
                      collections: List[(CollectionConfigWithId, Collection)]) extends MetaData with AdSuffixHandlingForFronts {
+  /** If a Facia front is a tag or section page, it ought to exist as a tag or section ID for one of its pieces of
+    * content.
+    *
+    * There are fronts that exist in Facia but have no equivalent tag or section page, which is why we need to make
+    * this check.
+    */
+  def allPath: Option[String] = {
+    val tagAndSectionIds = for {
+      (_, collection) <- collections
+      item <- collection.items
+      id <- item.section +: item.tags.map(_.id)
+    } yield id
+
+    if (tagAndSectionIds contains id) {
+      Some(s"$id/all")
+    } else {
+      None
+    }
+  }
 
   lazy val front = Front.fromConfigs(collections map { case (config, collection) =>
     (config, CollectionEssentials.fromCollection(collection))

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -23,7 +23,7 @@
                 }
             }
 
-            @fragments.trendingTopics(faciaPage.allItems, faciaPage.id)
+            @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
         @if(!faciaPage.isAdvertisementFeature) {
             @fragments.commercial.commercialComponent()


### PR DESCRIPTION
![alllink](https://cloud.githubusercontent.com/assets/1001642/5128078/9dbc2234-70d0-11e4-8f63-01d7ba52f8cf.gif)

Using somewhat hairy logic to determine what the link should be.

The issue is, we currently don't make any requests to Content API when rendering a Facia front, so it's difficult to know whether the front is actually overriding a tag or section, or whether it's its own custom thing that doesn't exist in Content API to begin with.
