### PR TITLE
Facia tool, line wrap in config and fixed clipboard

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -29,7 +29,7 @@
                 css: {active: !latestArticles.showingDrafts()}">Live content</a>
         </div>
 
-        <div class="col__inner scrollable">
+        <div class="col__inner">
             <div class="title title--clipboard">clipboard</div>
             <div class="clipboard" data-bind="with: clipboard">
                 <div class="droppable" data-bind="
@@ -38,6 +38,9 @@
                     css: {underDrag: underDrag},
                     template: {name: 'template_article', foreach: items}"></div>
             </div>
+        </div>
+
+        <div class="col__inner scrollable">
 
             <div data-bind="with: latestArticles">
                 <div class="search-tools">

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1020,7 +1020,7 @@ button {
 
 .cnf-front .title {
     cursor: pointer;
-    height: 24px;
+    min-height: 24px;
     font-weight: normal;
     font-family: inherit;
     font-size: 20px;


### PR DESCRIPTION
When the front name is long and wraps on two lines, make sure it does not overlap with the next front.

Move the clipboard out of the scrollable area to make easier dragging items from the bottom of the list
