### PR TITLE
Fix for showcase image as first image

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -258,8 +258,8 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
             val html = views.html.fragments.share.blockLevelSharing(hashSuffix, article.elementShares(Some(hashSuffix), image.url), article.contentType)
             img.after(html.toString())
 
-            img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='gallery2__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")
-            img.after("<span class='gallery2__fullscreen'><i class='i i-expand-white'></i><i class='i i-expand-black'></i></span>")
+            img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")
+            img.after("<span class='article__fullscreen'><i class='i i-expand-white'></i><i class='i i-expand-black'></i></span>")
           }
         }
 

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -91,6 +91,7 @@ figure.element.element--showcase {
         @include deport-left;
         position: relative;
         margin-bottom: ($gs-baseline/3)*4;
+        clear: both;
     }
 }
 

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -142,7 +142,8 @@
     right: 0;
 }
 
-.gallery2__fullscreen {
+.gallery2__fullscreen,
+.article__fullscreen {
     @include border-radius(50%);
     top: 0;
     right: 0;
@@ -184,7 +185,8 @@
     }
 
     @include mq(desktop) {
-        .gallery2__img-container:hover & {
+        .gallery2__img-container:hover &,
+        .article__img-container:hover & {
             background-color: colour(media-default);
 
             .i-expand-black {


### PR DESCRIPTION
Fixing the fullscreen button placement when a showcase image is used as the first element of an article.
Also removed the use of gallery classes in the article pages.

Before:
![screen shot 2014-11-21 at 10 48 05](https://cloud.githubusercontent.com/assets/2236852/5141300/e6bfefc4-716b-11e4-8250-c6d2cda47615.png)

After:
![screen shot 2014-11-21 at 10 48 32](https://cloud.githubusercontent.com/assets/2236852/5141310/0521a9d0-716c-11e4-9058-5d97f15299c2.png)
