### PR TITLE
Parameter for Setting adtest Cookie

### DIFF
--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -18,15 +18,9 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
   val insignificantParams = Seq(
     "view",
     "_edition", //allows us to spoof edition in tests
-    "k", // keywords in commercial component requests
-    "s", // section in commercial component requests
     "c", // used for counts in the Diagnostics server
-    "seg", // user segments in commercial component requests
     "build", // used by Forsee surveys
-    "google_console", // two params for dfp console
-    "googfc",
     "shortUrl", // Used by series component in onwards journeys
-    "t", // specific item targetting
     "switchesOn", // turn switches on for non-prod, http requests
     "switchesOff", // turn switches off for non-prod, http requests
     "test", // used for integration tests
@@ -37,7 +31,17 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
     "oauth_verifier" // for generating Magento tokens for bookshop service
   )
 
-  val allowedParams = CanonicalLink.significantParams ++ insignificantParams
+  val commercialParams = Seq(
+    "adtest", // used to set ad-test cookie from admin domain
+    "google_console", // two params for dfp console
+    "googfc",
+    "k", // keywords in commercial component requests
+    "s", // section in commercial component requests
+    "seg", // user segments in commercial component requests
+    "t" // specific item targetting
+  )
+
+  val allowedParams = CanonicalLink.significantParams ++ commercialParams ++ insignificantParams
 
   override def onRouteRequest(request: RequestHeader) = {
 

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -407,6 +407,15 @@ define([
                 }
             },
 
+            adTestCookie: function () {
+                var queryParams = url.getUrlVars();
+                if (queryParams.adtest === 'clear') {
+                    cookies.remove('adtest');
+                } else if (queryParams.adtest) {
+                    cookies.add('adtest', encodeURIComponent(queryParams.adtest), 10);
+                }
+            },
+
             initReleaseMessage: function () {
                 releaseMessage.init();
             },
@@ -448,6 +457,7 @@ define([
             modules.initDiscussion();
             modules.initFastClick();
             modules.testCookie();
+            modules.adTestCookie();
             modules.windowEventListeners();
             modules.initShareCounts();
             modules.initialiseFauxBlockLink();

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -78,7 +78,7 @@ define([
             su:      page.isSurging,
             bp:      detect.getBreakpoint(),
             a:       audienceScience.getSegments(),
-            at:      cookies.get('adtest') || cookies.get('GU_TEST') || '',
+            at:      cookies.get('adtest') || '',
             gdncrm:  userAdTargeting.getUserSegments(),
             ab:      abParam(),
             co:      parseTargets(page.authorIds),

--- a/static/src/javascripts/projects/common/utils/cookies.js
+++ b/static/src/javascripts/projects/common/utils/cookies.js
@@ -44,9 +44,7 @@ define([
 
     function add(name, value, daysToLive) {
 
-        var expires = new Date(),
-            cookie = name + '=' + value + '; path=/; expires=' + expires.toUTCString() + ';',
-            domain = getShortDomain();
+        var expires = new Date();
 
         if (daysToLive) {
             expires.setDate(expires.getDate() + daysToLive);
@@ -55,11 +53,8 @@ define([
             expires.setDate(1);
         }
 
-        if (domain !== 'localhost') {
-            cookie += 'domain=' + getShortDomain() + ';';
-        }
-
-        getDocument().cookie = cookie;
+        getDocument().cookie =
+            name + '=' + value + '; path=/; expires=' + expires.toUTCString() + '; domain=' + getShortDomain() + ';';
     }
 
     function addForMinutes(name, value, minutesToLive) {

--- a/static/src/javascripts/projects/common/utils/cookies.js
+++ b/static/src/javascripts/projects/common/utils/cookies.js
@@ -53,8 +53,13 @@ define([
             expires.setDate(1);
         }
 
-        getDocument().cookie =
-            name + '=' + value + '; path=/; expires=' + expires.toUTCString() + '; domain=' + getShortDomain() + ';';
+        var cookie = name + '=' + value + '; path=/; expires=' + expires.toUTCString() + ';';
+        var domain = getShortDomain();
+        if (domain !== 'localhost') {
+            cookie += 'domain=' + getShortDomain() + ';';
+        }
+
+        getDocument().cookie = cookie;
     }
 
     function addForMinutes(name, value, minutesToLive) {

--- a/static/src/javascripts/projects/common/utils/cookies.js
+++ b/static/src/javascripts/projects/common/utils/cookies.js
@@ -44,7 +44,9 @@ define([
 
     function add(name, value, daysToLive) {
 
-        var expires = new Date();
+        var expires = new Date(),
+            cookie = name + '=' + value + '; path=/; expires=' + expires.toUTCString() + ';',
+            domain = getShortDomain();
 
         if (daysToLive) {
             expires.setDate(expires.getDate() + daysToLive);
@@ -53,8 +55,6 @@ define([
             expires.setDate(1);
         }
 
-        var cookie = name + '=' + value + '; path=/; expires=' + expires.toUTCString() + ';';
-        var domain = getShortDomain();
         if (domain !== 'localhost') {
             cookie += 'domain=' + getShortDomain() + ';';
         }


### PR DESCRIPTION
For setting and clearing the _adtest_ cookie from the admin domain.

This decouples the parameter called _test_, that may be being used in integration tests.  It also stops using the _GU_TEST_ cookie in ad calls, so that this cookie is now specifically for integration tests.

@ironsidevsquincy @mattosborn 
