### PR TITLE
minor fixes in rh ads links

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
@@ -35,13 +35,15 @@ define([
 
     return {
 
-        run: function (type) {
+        run: function (type, clickMacro) {
             var templateConfig = templates[type],
                 $rightHandCol  = $('.content__secondary-column');
 
             if (!templateConfig || $rightHandCol.css('display') === 'none') {
                 return false;
             }
+
+            templateConfig.config.clickMacro = clickMacro;
 
             if ($rightHandCol.dim().height > 1000 && config.page.section !== 'football') {
 

--- a/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-jobs.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-jobs.html
@@ -1,11 +1,13 @@
 <div class="creative--branded-component creative--jobs" data-link-name="creative | branded component | jobs">
     <div class="creative__inner">
-        <i class="creative__marque i i-marque-36-333"></i>
+        <a href="{{clickMacro}}http://jobs.theguardian.com/" data-link-name="logo link">
+            <i class="creative__marque i i-marque-36-333"></i>
+        </a>
         <h3 class="creative__marque-title">Jobs</h3>
         <img src="{{imgUrl}}" width="198" height="137" />
         <p class="creative__title">Finding quality jobs just got easier</p>
         <p class="creative__text">Introducing the next-generation Guardian Jobs website, designed to work whatever your device</p>
-        <a class="button button--primary" href="http://jobs.theguardian.com/" data-link-name="link">
+        <a class="button button--primary" href="{{clickMacro}}http://jobs.theguardian.com/" data-link-name="link">
             Browse jobs<i class="i i-arrow-white-right i-right"></i>
         </a>
     </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-membership.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-membership.html
@@ -1,10 +1,12 @@
 <div class="creative--branded-component creative--membership" data-link-name="creative | branded component | membership">
     <div class="creative__inner">
-        <i class="creative__marque i i-marque-36-333"></i>
+        <a href="{{clickMacro}}https://membership.theguardian.com/" data-link-name="logo link">
+            <i class="creative__marque i i-marque-36-333"></i>
+        </a>
         <h3 class="creative__marque-title">Membership</h3>
         <p class="creative__title">The open exchange of ideas and opinions has the power to change the world</p>
         <p class="creative__text">Join the community for those who share this belief</p>
-        <a class="button" href="https://membership.theguardian.com/?CMP=ppc_mem_12" data-link-name="link">
+        <a class="button" href="{{clickMacro}}https://membership.theguardian.com/" data-link-name="link">
             Find out more<i class="i i-arrow-white-right i-right"></i>
         </a>
     </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-soulmates.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-soulmates.html
@@ -3,7 +3,7 @@
         <p class="creative__title">Meet someone <em>worth</em> meeting</p>
         <p class="creative__text">Thousands of new members sign up to Soulmates every month</p>
         <div class="creative__link-wrapper">
-            <a class="creative__link" href="https://soulmates.theguardian.com/" data-link-name="link">
+            <a class="creative__link" href="{{clickMacro}}https://soulmates.theguardian.com/" data-link-name="link">
                 Join now
                 <span class="creative__link__button button button--small">
                     <span class="i i-arrow-white-right" />
@@ -13,8 +13,10 @@
         <div class="i--commercial i-soulmates-title-background soulmates-logo">
             <span class="u-h">The Guardian</span>
             <h4 class="soulmates-logo__title">
-                <span class="i i--commercial i-soulmates-logo"></span>
-                <span class="u-h">Soulmates</span>
+                <a href="{{clickMacro}}https://soulmates.theguardian.com/" data-link-name="logo link">
+                    <span class="i i--commercial i-soulmates-logo"></span>
+                    <span class="u-h">Soulmates</span>
+                </a>
             </h4>
         </div>
     </div>


### PR DESCRIPTION
- Click macro added to all links.
- All logos (Ie G for Jobs and Masterclass and Soulmates for Soulmates comp) are links now.
- The query string on the end of the Membership URL (?CMP=ppc_mem_12) is removed.
- Added data-link-name so the Omniture nav interaction evar is firing correctly. 
