### PR TITLE
Fixing layout of Soulmates text when page skin is on

### DIFF
--- a/static/src/stylesheets/module/commercial/_soulmates.scss
+++ b/static/src/stylesheets/module/commercial/_soulmates.scss
@@ -218,11 +218,12 @@ $c-soulmates-high: colour(neutral-1);
 
             .commercial__explainer {
                 left: $gs-gutter * 7.5;
+                top: $gs-baseline;
             }
 
             .commercial__head {
                 position: relative;
-                width: auto;
+                width: auto !important;
                 float: none;
             }
             .commercial__cta {


### PR DESCRIPTION
Before;
![screen shot 2014-11-21 at 14 55 42](https://cloud.githubusercontent.com/assets/1303616/5144032/88e8871c-718e-11e4-8df6-203395b85ffb.png)

After;
![screen shot 2014-11-21 at 14 55 49](https://cloud.githubusercontent.com/assets/1303616/5144036/9163ace6-718e-11e4-9201-266cdf9bd79a.png)

cc @paulrobertlloyd Would be great to get rid of the !importants on the width in the Soulmates component.
