### PR TITLE
Prevent media list item meta/sublinks indenting out of the item when the image is hidden

### DIFF
--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
@@ -92,6 +92,14 @@ Media list item. Looks a bit like this:
         .fc-item__container {
             padding-left: 0;
         }
+
+        .fc-item__meta {
+            margin-left: 0;
+        }
+
+        .fc-item__footer--vertical {
+            margin-left: 0;
+        }
     }
 
     &.fc-item--has-cutout .fc-item__media-wrapper {
@@ -104,10 +112,6 @@ Media list item. Looks a bit like this:
     }
 
     &.fc-item--has-cutout {
-        .fc-item__meta {
-            margin-left: 0;
-        }
-
         .fc-item__container {
             min-height: gs-height(2) + $gs-baseline;
         }
@@ -123,10 +127,6 @@ Media list item. Looks a bit like this:
                 display: block;
                 right: - $gs-gutter;
             }
-        }
-
-        .fc-item__footer--vertical {
-            margin-left: 0;
         }
     }
 


### PR DESCRIPTION
before
![screen shot 2014-11-21 at 15 22 45](https://cloud.githubusercontent.com/assets/867233/5144436/439ecf96-7192-11e4-9751-1cf9d1a72e1a.png)
after
![screen shot 2014-11-21 at 15 22 27](https://cloud.githubusercontent.com/assets/867233/5144442/513dd0f2-7192-11e4-9fd4-5630157d70e5.png)
