### PR TITLE
Fix unsafe divide

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -481,7 +481,7 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
           "credit" -> JsString(img.credit.getOrElse("")),
           "displayCredit" -> JsBoolean(img.displayCredit),
           "src" -> JsString(ImgSrc(img.url.getOrElse(""), ImgSrc.Imager)),
-          "ratio" -> JsNumber(img.width.toDouble / img.height.toDouble),
+          "ratio" -> Try(JsNumber(img.width.toDouble / img.height.toDouble)).getOrElse(JsNumber(1)),
           "role" -> JsString(img.role.toString)
         ))
       }


### PR DESCRIPTION
There is an unsafe division within `content.scala`.
Image `width` and `height` have the potential to be zero.

I am not sure what the best ratio to fallback to is, but `1` is definitely better than an `exception` which will break the whole article.

@Jholder112233 @phamann 
