### PR TITLE
Automatically add blog and series kickers on tag pages when no other kicker

### DIFF
--- a/applications/app/services/repositories.scala
+++ b/applications/app/services/repositories.scala
@@ -63,10 +63,14 @@ object IndexPage {
           (ContainerDefinition.forNumberOfItems(grouping.items.length), mpuState)
         }
 
-        (newMpuState, ((CollectionConfigWithId(grouping.dateHeadline.displayString, CollectionConfig.emptyConfig.copy(
-          displayName = Some(grouping.dateHeadline.displayString)
-        )), collection),
-          Fixed(container)))
+        val containerConfig = ContainerDisplayConfig(
+          CollectionConfigWithId(grouping.dateHeadline.displayString, CollectionConfig.emptyConfig.copy(
+            displayName = Some(grouping.dateHeadline.displayString)
+          )),
+          showSeriesAndBlogKickers = true
+        )
+
+        (newMpuState, ((containerConfig, collection), Fixed(container)))
     }._2.toSeq
 
     val front = Front.fromConfigsAndContainers(

--- a/applications/app/views/all.scala.html
+++ b/applications/app/views/all.scala.html
@@ -2,7 +2,7 @@
 
 @import com.gu.facia.client.models.CollectionConfig
 @import views.support.PreviousAndNext
-@import layout.ContainerLayout
+@import layout.{ContainerLayout, ContainerDisplayConfig}
 @import model.Collection
 
 @main(index.page, projectName = Option("facia")){  }{
@@ -12,7 +12,7 @@
             Collection(index.trails),
             ContainerLayout.singletonFromContainerDefinition(
                 slices.TagContainers.allTagPage,
-                CollectionConfig.emptyConfig,
+                ContainerDisplayConfig.empty,
                 index.trails
             ),
             0,

--- a/applications/test/AllIndexTemplateTest.scala
+++ b/applications/test/AllIndexTemplateTest.scala
@@ -14,6 +14,6 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 
     $("[rel=prev]").first.click()
     $("[rel=prev]").first.click()
-    url() should endWith("/world/2014/sep/30/all")
+    url() should endWith("/world/2014/oct/01/all")
   }
 }

--- a/applications/test/AllIndexTemplateTest.scala
+++ b/applications/test/AllIndexTemplateTest.scala
@@ -14,6 +14,6 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 
     $("[rel=prev]").first.click()
     $("[rel=prev]").first.click()
-    url() should endWith("/world/2014/oct/01/all")
+    url() should endWith("/world/2014/sep/30/all")
   }
 }

--- a/common/app/contentapi/Paths.scala
+++ b/common/app/contentapi/Paths.scala
@@ -1,0 +1,10 @@
+package contentapi
+
+import common.Edition
+
+object Paths {
+  def withoutEdition(path: String) = (path.split("/").toList match {
+    case maybeEdition :: rest if Edition.byId(maybeEdition).isDefined => Some(rest.mkString("/"))
+    case _ => None
+  }).filter(_.nonEmpty)
+}

--- a/common/app/layout/Column.scala
+++ b/common/app/layout/Column.scala
@@ -67,7 +67,8 @@ object SliceWithCards {
     layout: SliceLayout,
     context: ContainerLayoutContext,
     config: CollectionConfig,
-    mobileShowMore: MobileShowMore
+    mobileShowMore: MobileShowMore,
+    showSeriesAndBlogKickers: Boolean
   ): (SliceWithCards, Seq[IndexedTrail], ContainerLayoutContext) = {
     val (columns, unconsumed, endContext) = layout.columns.foldLeft((Seq.empty[ColumnAndCards], items, context)) {
       case ((acc, itemsRemaining, currentContext), column) =>
@@ -81,7 +82,8 @@ object SliceWithCards {
                 FaciaCard.fromTrail(
                   trail,
                   config,
-                  Column.cardStyle(column, positionInColumn).getOrElse(ItemClasses.showMore)
+                  Column.cardStyle(column, positionInColumn).getOrElse(ItemClasses.showMore),
+                  showSeriesAndBlogKickers
                 ),
                 mobileShowMore match {
                   case RestrictTo(nToShowOnMobile) if index >= nToShowOnMobile => Some(Mobile)

--- a/common/app/layout/ContainerDisplayConfig.scala
+++ b/common/app/layout/ContainerDisplayConfig.scala
@@ -1,0 +1,24 @@
+package layout
+
+import com.gu.facia.client.models.CollectionConfig
+import services.CollectionConfigWithId
+
+object ContainerDisplayConfig {
+  val empty = ContainerDisplayConfig(
+    CollectionConfigWithId(
+      "",
+      CollectionConfig.emptyConfig
+    ),
+    false
+  )
+
+  def withDefaults(collectionConfigWithId: CollectionConfigWithId) = ContainerDisplayConfig(
+    collectionConfigWithId,
+    false
+  )
+}
+
+case class ContainerDisplayConfig(
+  collectionConfigWithId: CollectionConfigWithId,
+  showSeriesAndBlogKickers: Boolean
+)

--- a/common/app/layout/ContainerLayout.scala
+++ b/common/app/layout/ContainerLayout.scala
@@ -1,6 +1,5 @@
 package layout
 
-import com.gu.facia.client.models.CollectionConfig
 import model.{Content, Trail}
 import slices._
 
@@ -11,7 +10,7 @@ object ContainerLayout extends implicits.Collections {
       sliceDefinitions: Seq[Slice],
       items: Seq[Trail],
       initialContext: ContainerLayoutContext,
-      config: CollectionConfig,
+      config: ContainerDisplayConfig,
       mobileShowMore: MobileShowMore
   ): (ContainerLayout, ContainerLayoutContext) = {
     val indexedTrails = items.zipWithIndex.map((IndexedTrail.apply _).tupled)
@@ -25,8 +24,9 @@ object ContainerLayout extends implicits.Collections {
           trailsForUse,
           sliceDefinition.layout,
           context,
-          config,
-          mobileShowMore
+          config.collectionConfigWithId.config,
+          mobileShowMore,
+          config.showSeriesAndBlogKickers
         )
         (slicesSoFar :+ slice, remainingTrails, newContext)
     }
@@ -34,7 +34,12 @@ object ContainerLayout extends implicits.Collections {
     (ContainerLayout(slices, showMore map { case IndexedTrail(trail, index) =>
       FaciaCardAndIndex(
         index,
-        FaciaCard.fromTrail(trail, config, ItemClasses.showMore),
+        FaciaCard.fromTrail(
+          trail,
+          config.collectionConfigWithId.config,
+          ItemClasses.showMore,
+          config.showSeriesAndBlogKickers
+        ),
         hideUpTo = Some(Desktop)
       )
     }), finalContext)
@@ -42,7 +47,7 @@ object ContainerLayout extends implicits.Collections {
 
   def singletonFromContainerDefinition(
     containerDefinition: ContainerDefinition,
-    config: CollectionConfig,
+    config: ContainerDisplayConfig,
     items: Seq[Trail]
   ) = fromContainerDefinition(
     containerDefinition,
@@ -54,7 +59,7 @@ object ContainerLayout extends implicits.Collections {
   def fromContainerDefinition(
       containerDefinition: ContainerDefinition,
       containerLayoutContext: ContainerLayoutContext,
-      config: CollectionConfig,
+      config: ContainerDisplayConfig,
       items: Seq[Trail]
   ) = apply(
       containerDefinition.slices,
@@ -67,7 +72,7 @@ object ContainerLayout extends implicits.Collections {
   def fromContainer(
       container: Container,
       containerLayoutContext: ContainerLayoutContext,
-      config: CollectionConfig,
+      config: ContainerDisplayConfig,
       items: Seq[Trail]
   ) =
     ContainerDefinition.fromContainer(container, items collect { case c: Content => c }) map {

--- a/common/app/layout/FaciaCardAndIndex.scala
+++ b/common/app/layout/FaciaCardAndIndex.scala
@@ -12,7 +12,12 @@ object FaciaCardAndIndex {
   /** If creating a Card off the cuff (i.e., outside of the normal Facia front construction code */
   def fromTrail(trail: Trail, itemClasses: ItemClasses, index: Int) = FaciaCardAndIndex(
     index,
-    FaciaCard.fromTrail(trail, CollectionConfig.emptyConfig, itemClasses),
+    FaciaCard.fromTrail(
+      trail,
+      CollectionConfig.emptyConfig,
+      itemClasses,
+      showSeriesAndBlogKickers = false
+    ),
     None
   )
 }

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -90,7 +90,7 @@ object Front extends implicits.Collections {
   }
 
   def fromConfigsAndContainers(
-      configs: Seq[((CollectionConfigWithId, CollectionEssentials), Container)],
+      configs: Seq[((ContainerDisplayConfig, CollectionEssentials), Container)],
       initialContext: ContainerLayoutContext = ContainerLayoutContext.empty
   ) = {
     import scalaz.syntax.traverse._
@@ -102,11 +102,11 @@ object Front extends implicits.Collections {
       ) { case ((seenTrails, context), (((config, collection), container), index)) =>
         val (newSeen, newItems) = deduplicate(seenTrails, container, collection.items)
 
-        ContainerLayout.fromContainer(container, context, config.config, newItems) map {
+        ContainerLayout.fromContainer(container, context, config, newItems) map {
           case (containerLayout, newContext) => ((newSeen, newContext), FaciaContainer.fromConfig(
             index,
             container,
-            config,
+            config.collectionConfigWithId,
             collection.copy(items = newItems),
             Some(containerLayout),
             None
@@ -115,7 +115,7 @@ object Front extends implicits.Collections {
           ((newSeen, context), FaciaContainer.fromConfig(
             index,
             container,
-            config,
+            config.collectionConfigWithId,
             collection.copy(items = newItems),
             None,
             None
@@ -126,7 +126,10 @@ object Front extends implicits.Collections {
   }
 
   def fromConfigs(configs: Seq[(CollectionConfigWithId, CollectionEssentials)]) = {
-    fromConfigsAndContainers(configs.zipWith({ case (config, _) => Container.fromConfig(config.config) }))
+    fromConfigsAndContainers(configs.map {
+      case (config, collectionEssentials) =>
+        ((ContainerDisplayConfig.withDefaults(config), collectionEssentials), Container.fromConfig(config.config))
+    })
   }
 }
 
@@ -163,15 +166,31 @@ object FaciaContainer {
     config: CollectionConfigWithId,
     collectionEssentials: CollectionEssentials,
     componentId: Option[String] = None
+  ): FaciaContainer = {
+    apply(
+      index,
+      container,
+      ContainerDisplayConfig.withDefaults(config),
+      collectionEssentials,
+      componentId
+    )
+  }
+
+  def apply(
+    index: Int,
+    container: Container,
+    config: ContainerDisplayConfig,
+    collectionEssentials: CollectionEssentials,
+    componentId: Option[String]
   ): FaciaContainer = fromConfig(
     index,
     container,
-    config,
+    config.collectionConfigWithId,
     collectionEssentials,
     ContainerLayout.fromContainer(
       container,
       ContainerLayoutContext.empty,
-      config.config,
+      config,
       collectionEssentials.items
     ).map(_._1),
     componentId
@@ -211,7 +230,7 @@ object FaciaContainer {
     FaciaContainer(
       index = 2,
       container = Fixed(ContainerDefinition.forNumberOfItems(items.size)),
-      config = CollectionConfigWithId(dataId, CollectionConfig.emptyConfig),
+      config = ContainerDisplayConfig.withDefaults(CollectionConfigWithId(dataId, CollectionConfig.emptyConfig)),
       collectionEssentials = CollectionEssentials(items take 8, Some(title), None, None, None),
       componentId = None
     ).withTimeStamps

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -139,9 +139,15 @@ case class SnapStuff(
 }
 
 object FaciaCardHeader {
-  def fromTrail(trail: Trail, config: Option[CollectionConfig]) = FaciaCardHeader(
-    trail.showQuotedHeadline,
+  def fromTrail(trail: Trail, config: Option[CollectionConfig]) = fromTrailAndKicker(
+    trail,
     ItemKicker.fromTrail(trail, config),
+    config
+  )
+
+  def fromTrailAndKicker(trail: Trail, itemKicker: Option[ItemKicker], config: Option[CollectionConfig]) = FaciaCardHeader(
+    trail.showQuotedHeadline,
+    itemKicker,
     trail.headline,
     EditionalisedLink.fromTrail(trail)
   )
@@ -181,13 +187,19 @@ object FaciaCard {
     Byline(byline, content.contributors)
   }
 
-  def fromTrail(trail: Trail, config: CollectionConfig, cardTypes: ItemClasses) = {
+  def fromTrail(trail: Trail, config: CollectionConfig, cardTypes: ItemClasses, showSeriesAndBlogKickers: Boolean) = {
     val content = trail match {
       case c: Content => Some(c)
       case _ => None
     }
 
-    val maybeKicker = ItemKicker.fromTrail(trail, Some(config))
+    val maybeKicker = ItemKicker.fromTrail(trail, Some(config)) orElse {
+      if (showSeriesAndBlogKickers) {
+        ItemKicker.seriesOrBlogKicker(trail)
+      } else {
+        None
+      }
+    }
 
     /** If the kicker contains the byline, don't display it */
     val suppressByline = (for {
@@ -199,7 +211,7 @@ object FaciaCard {
     FaciaCard(
       content.map(_.id),
       trail.headline,
-      FaciaCardHeader.fromTrail(trail, Some(config)),
+      FaciaCardHeader.fromTrailAndKicker(trail, maybeKicker, Some(config)),
       content.flatMap(getByline).filterNot(Function.const(suppressByline)),
       FaciaDisplayElement.fromTrail(trail),
       CutOut.fromTrail(trail),

--- a/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/sublink.scala.html
@@ -34,7 +34,7 @@
       <span class="fc-sublink__kicker">Review</span>
     }
 
-    case TagKicker(tagName, tagLink) => {
+    case TagKicker(tagName, tagLink, _) => {
       <a href="@LinkTo(tagLink)" data-link-name="kicker" class="fc-sublink__kicker">@Html(tagName)</a>
     }
 

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -34,7 +34,7 @@
             <span class="fc-item__kicker">Review</span>
         }
 
-        case TagKicker(tagName, tagLink) => {
+        case TagKicker(tagName, tagLink, _) => {
             <a href="@LinkTo(tagLink)" data-link-name="kicker" class="fc-item__kicker">@Html(tagName)</a>
         }
 

--- a/common/app/views/support/ItemKicker.scala
+++ b/common/app/views/support/ItemKicker.scala
@@ -9,9 +9,7 @@ object ItemKicker {
   def fromTrail(trail: Trail, config: Option[CollectionConfig]): Option[ItemKicker] = {
     lazy val maybeTag = firstTag(trail)
 
-    def tagKicker = maybeTag map { tag =>
-      TagKicker(tag.name, tag.webUrl)
-    }
+    def tagKicker = maybeTag.map(TagKicker.fromTag)
 
     def sectionKicker = Some(SectionKicker(trail.sectionName.capitalize, "/" + trail.section))
 
@@ -58,6 +56,9 @@ object ItemKicker {
     }
   }
 
+  def seriesOrBlogKicker(item: Trail) =
+    item.tags.find(Set("series", "blog") contains _.tagType).map(TagKicker.fromTag)
+
   /** Used for de-duping bylines */
   def kickerText(itemKicker: ItemKicker): Option[String] = itemKicker match {
     case PodcastKicker(Some(series)) => Some(series.name)
@@ -79,7 +80,13 @@ case object AnalysisKicker extends ItemKicker
 case object ReviewKicker extends ItemKicker
 case object CartoonKicker extends ItemKicker
 case class PodcastKicker(series: Option[Series]) extends ItemKicker
+
+object TagKicker {
+  def fromTag(tag: Tag) = TagKicker(tag.name, tag.webUrl)
+}
+
 case class TagKicker(name: String, url: String) extends ItemKicker
+
 case class SectionKicker(name: String, url: String) extends ItemKicker
 case class FreeHtmlKicker(body: String) extends ItemKicker
 case class FreeHtmlKickerWithLink(body: String, url: String) extends ItemKicker

--- a/common/app/views/support/ItemKicker.scala
+++ b/common/app/views/support/ItemKicker.scala
@@ -62,7 +62,7 @@ object ItemKicker {
   /** Used for de-duping bylines */
   def kickerText(itemKicker: ItemKicker): Option[String] = itemKicker match {
     case PodcastKicker(Some(series)) => Some(series.name)
-    case TagKicker(name, _) => Some(name)
+    case TagKicker(name, _, _) => Some(name)
     case SectionKicker(name, _) => Some(name)
     case FreeHtmlKicker(body) => Some(body)
     case FreeHtmlKickerWithLink(body, _) => Some(body)
@@ -82,10 +82,10 @@ case object CartoonKicker extends ItemKicker
 case class PodcastKicker(series: Option[Series]) extends ItemKicker
 
 object TagKicker {
-  def fromTag(tag: Tag) = TagKicker(tag.name, tag.webUrl)
+  def fromTag(tag: Tag) = TagKicker(tag.name, tag.webUrl, tag.id)
 }
 
-case class TagKicker(name: String, url: String) extends ItemKicker
+case class TagKicker(name: String, url: String, id: String) extends ItemKicker
 
 case class SectionKicker(name: String, url: String) extends ItemKicker
 case class FreeHtmlKicker(body: String) extends ItemKicker

--- a/common/test/layout/SliceWithCardsTest.scala
+++ b/common/test/layout/SliceWithCardsTest.scala
@@ -46,7 +46,8 @@ class SliceWithCardsTest extends FlatSpec with Matchers with GeneratorDrivenProp
         layout,
         ContainerLayoutContext.empty,
         CollectionConfig.emptyConfig,
-        DesktopBehaviour
+        DesktopBehaviour,
+        showSeriesAndBlogKickers = false
       )._2.length shouldEqual
         (0 max (NumberOfFixtures - layout.columns.map(SliceWithCards.itemsToConsume).sum))
     }
@@ -59,7 +60,8 @@ class SliceWithCardsTest extends FlatSpec with Matchers with GeneratorDrivenProp
         layout,
         ContainerLayoutContext.empty,
         CollectionConfig.emptyConfig,
-        DesktopBehaviour
+        DesktopBehaviour,
+        showSeriesAndBlogKickers = false
       )
 
       def idFromTrail(trail: Trail) = trail match {
@@ -78,7 +80,8 @@ class SliceWithCardsTest extends FlatSpec with Matchers with GeneratorDrivenProp
         layout,
         ContainerLayoutContext.empty,
         CollectionConfig.emptyConfig,
-        DesktopBehaviour
+        DesktopBehaviour,
+        showSeriesAndBlogKickers = false
       )._1
 
       for (column <- slice.columns) {

--- a/common/test/views/support/ItemKickerTest.scala
+++ b/common/test/views/support/ItemKickerTest.scala
@@ -58,7 +58,7 @@ class ItemKickerTest extends FlatSpec with Matchers with OptionValues {
     ItemKicker.fromTrail(
       createTrailFixture(showTag = true, showSection = false),
       Option(CollectionConfig.withDefaults(showSections = Option(true)))
-    ).value shouldEqual TagKicker("Test Tag", "testtag")
+    ).value shouldEqual TagKicker("Test Tag", "testtag", "testTag")
   }
 
   it should "prefer item level section kicker to collection level tag kicker" in {

--- a/facia/app/model/FaciaPage.scala
+++ b/facia/app/model/FaciaPage.scala
@@ -2,6 +2,7 @@ package model
 
 import common.{Edition, NavItem}
 import conf.Configuration
+import contentapi.Paths
 import dfp.DfpAgent
 import layout.{CollectionEssentials, Front}
 import play.api.libs.json.{JsString, JsValue}
@@ -25,14 +26,9 @@ case class FaciaPage(id: String,
       id <- item.section +: item.tags.map(_.id)
     } yield id
 
-    val idWithoutEdition = id.split("/").toList match {
-      case maybeEdition :: rest if Edition.byId(maybeEdition).isDefined => Some(rest.mkString("/"))
-      case _ => None
-    }
-
     val validIds = Set(
       Some(id),
-      idWithoutEdition.filter(_.nonEmpty)
+      Paths.withoutEdition(id)
     ).flatten
 
     tagAndSectionIds.find(validIds contains) map { id =>


### PR DESCRIPTION
Examples --

Before:

![screen shot 2014-11-24 at 10 10 45](https://cloud.githubusercontent.com/assets/1001642/5163355/7bf3dee0-73c2-11e4-9c26-4336603af6d9.png)

After:

![screen shot 2014-11-24 at 10 10 56](https://cloud.githubusercontent.com/assets/1001642/5163358/859bee92-73c2-11e4-8037-2509e151f842.png)

Before:

![screen shot 2014-11-24 at 10 10 02](https://cloud.githubusercontent.com/assets/1001642/5163359/8defdc52-73c2-11e4-97a0-c4a7bbe49124.png)

After:

![screen shot 2014-11-24 at 10 10 14](https://cloud.githubusercontent.com/assets/1001642/5163361/95b890e6-73c2-11e4-8840-f2e83385e8de.png)
