### PR TITLE
Regression, ensure background of containers is white when pageskins are present

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -32,6 +32,7 @@ $header-image-size-desktop: 100px;
     @include mq(wide) {
         .has-page-skin & {
             width: gs-span(12);
+            background-color: #ffffff;
         }
     }
 

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -14,6 +14,7 @@ $header-image-size-desktop: 100px;
             margin-left: auto;
             margin-right: auto;
             width: gs-span(12) + ($gs-gutter*2);
+            background-color: #ffffff;
         }
     }
 }


### PR DESCRIPTION
Adds background colour of white if a pageskin is present.

Although most pageskins are correctly formatted sometimes they aren't, this removes the risk.

Tricky to do a before and after with a skin but if you apply background-color instead you can see the issue, (used black below.)

Before;
![screen shot 2014-11-24 at 10 26 04](https://cloud.githubusercontent.com/assets/1303616/5163508/51feb248-73c4-11e4-85f6-eb5c4d9196e0.png)

After;
![screen shot 2014-11-24 at 10 25 17](https://cloud.githubusercontent.com/assets/1303616/5163512/59fdeb94-73c4-11e4-846b-af7fa0c2df0d.png)
