### PR TITLE
Video facia

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -102,6 +102,17 @@ $fc-hover-transition: .25s ease;
     }
 }
 
+.fc-item.fc-item--video {
+
+    a {
+        z-index: 0;
+    }
+
+    .u-faux-block-link__promote {
+        z-index: 1;
+    }
+}
+
 .fc-item,
 .item {
     background-color: #ffffff;

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -130,7 +130,7 @@ $fc-hover-transition: .25s ease;
      * The only way how to make it work is to play with the z-index.
      */
     &.fc-item--video {
-        a {
+        .u-faux-block-link__overlay {
             z-index: 0;
         }
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -102,17 +102,6 @@ $fc-hover-transition: .25s ease;
     }
 }
 
-.fc-item.fc-item--video {
-
-    a {
-        z-index: 0;
-    }
-
-    .u-faux-block-link__promote {
-        z-index: 1;
-    }
-}
-
 .fc-item,
 .item {
     background-color: #ffffff;
@@ -133,6 +122,20 @@ $fc-hover-transition: .25s ease;
 
         @include mq($until: desktop) {
             z-index: initial;
+        }
+    }
+
+    /**
+     * The z-index: initial trick above is not working on the webkit browsers.
+     * The only way how to make it work is to play with the z-index.
+     */
+    &.fc-item--video {
+        a {
+            z-index: 0;
+        }
+
+        .u-faux-block-link__promote {
+            z-index: 1;
         }
     }
 


### PR DESCRIPTION
This is fixing [6813](https://github.com/guardian/frontend/issues/6813)

What I think is happening is that webkit has a different approach to calculating z-index stacking context. The only solution is to 'manually' change the z-index for actual link overlay and faux-block-link.

So now we can play video on less than desktop sizes without redirecting user to video detail page:
![screen shot 2014-11-19 at 17 41 37](https://cloud.githubusercontent.com/assets/2579465/5163646/ef28558c-73c5-11e4-9b08-ac6d6620dd79.png)
