### PR TITLE
remove min-height on standard items with cutout

### DIFF
--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--standard.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--standard.scss
@@ -27,12 +27,6 @@ x x x x x x x x
 
 
 @mixin fc-item--standard {
-    &.fc-item--has-cutout {
-        .fc-item__container {
-            min-height: gs-height(4);
-        }
-    }
-
     .fc-item__image-container {
         display: block;
     }


### PR DESCRIPTION
space is handled by bottom padding - looks as though it was not removed during an earlier change

before 
![screen shot 2014-11-24 at 11 08 30](https://cloud.githubusercontent.com/assets/867233/5164017/f71cfd7a-73c9-11e4-9159-040baac06fb8.png)

after
![screen shot 2014-11-24 at 11 08 41](https://cloud.githubusercontent.com/assets/867233/5164022/fc9db730-73c9-11e4-89e1-5107d56f6e4e.png)
