### PR TITLE
Refactoring play icon position.

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -114,6 +114,10 @@ $vjs-progress-inset-bottom: 4px;
             background-color: colour(media-default);
         }
 
+        /**
+         * As arrow is made by using borders we need to use magic numbers
+         * to be able to position it to the center of the button circle.
+         */
         &:before {
             content: '';
             position: absolute;
@@ -125,9 +129,9 @@ $vjs-progress-inset-bottom: 4px;
             border-color: transparent transparent transparent colour(neutral-7);
             -moz-transform: scale(.99999); // fix for diagonal border aliasing in firefox
             top: 50%;
-            left: 0;
-            margin-top: -.9em;
-            margin-left: 2.2em;
+            left: 50%;
+            margin-top: -.9em; /* [1] */
+            margin-left: -.9em; /* [1] */
 
             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
                 @include border-radius(.2em);


### PR DESCRIPTION
Video play icon seems still a little bit off on smaller sizes so this PR is refactoring how we are calculating the position of play icon.

Before:
![screen shot 2014-11-24 at 11 03 00](https://cloud.githubusercontent.com/assets/2579465/5164108/f7dbd514-73ca-11e4-954e-27238c857634.png)

After:
Small size
![screen shot 2014-11-24 at 11 03 31](https://cloud.githubusercontent.com/assets/2579465/5164111/0090fd88-73cb-11e4-9615-812f7dd52549.png)

Large size
![screen shot 2014-11-24 at 11 02 15](https://cloud.githubusercontent.com/assets/2579465/5164115/0c420e42-73cb-11e4-803b-920a34e4594d.png)
