### PR TITLE
Add temporary date format helper for AU launch

### DIFF
--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,9 +1,9 @@
 @(webPublicationDate: org.joda.time.DateTime, isLive: Boolean = false, secondary: Boolean = false)(implicit request: RequestHeader)
-@import views.support.Format
+@import views.support.AuFriendlyFormat
 <p class="content__dateline" @if(secondary) { aria-hidden="true"}>
     <time itemprop="datePublished" datetime='@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@webPublicationDate.getMillis">
-        @Format(webPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@Format(webPublicationDate, "HH.mm z")</span>
+        @Format(webPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(webPublicationDate)</span>
     </time>
     @if(!secondary){<span class="js-comment-count"></span>}
 </p>

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -724,6 +724,18 @@ object `package` extends Formats {
   }
 }
 
+object AuFriendlyFormat {
+  def apply(date: DateTime)(implicit request: RequestHeader): String = {
+    val edition = Edition(request)
+    val timezone = edition.timezone
+
+    edition.id match {
+      case "AU" => date.toString(DateTimeFormat.forPattern("HH.mm").withZone(timezone)) + " AEST"
+      case _ => date.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
+    }
+  }
+}
+
 object Format {
   def apply(date: DateTime, pattern: String)(implicit request: RequestHeader): String = {
     apply(date, Edition(request), pattern)


### PR DESCRIPTION
So it turns out there is a bug related to AU timezones in are underlying time date library `Joda DateTime` see this thread for more detail: https://github.com/JodaOrg/joda-time/issues/175

This introduces a temporary `AuFriendlyFormat` helper as a hack around the solution for the AU launch until we can solve more elegantly.

I am only applying this to the main timestamp on content pages.

/cc @rich-nguyen 
