### PR TITLE
Article lightbox changes

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -473,9 +473,9 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
   }
 
   lazy val lightbox: JsObject = {
-    val imageContainers = bodyImages
+    val imageContainers = bodyImages.filter(_.largestEditorialCrop.nonEmpty)
     val imageJson = imageContainers.map{ imgContainer =>
-      imgContainer.largestEditorialCrop.map { img =>
+      imgContainer.largestEditorialCrop.filter(_.width > 620).map { img =>
         JsObject(Seq(
           "caption" -> JsString(img.caption.getOrElse("")),
           "credit" -> JsString(img.credit.getOrElse("")),
@@ -684,8 +684,8 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
   }.flatten
 
   lazy val lightbox: JsObject = {
-    val imageContainers = galleryImages.filter(_.isGallery)
-    val imageJson = imageContainers.map{ imgContainer =>
+    val imageContainers = galleryImages
+    val imageJson = imageContainers.map { imgContainer =>
       imgContainer.largestEditorialCrop.map { img =>
         JsObject(Seq(
           "caption" -> JsString(img.caption.getOrElse("")),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -495,6 +495,11 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
     ))
   }
 
+  lazy val lightboxImages = bodyImages.zip(bodyImages.map(_.largestEditorialCrop)).filter({
+    case (_, Some(crop)) => crop.width > 620
+    case _ => false
+  })
+
   lazy val linkCounts = LinkTo.countLinks(body) + standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
 
   override def metaData: Map[String, JsValue] = {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -234,6 +234,7 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
           // content api/ tools sometimes pops a &nbsp; in the blank field
           if (!figcaption.hasText || figcaption.text().length < 2) {
             figcaption.remove()
+            fig.addClass("fig-no-border")
           } else {
             figcaption.attr("itemprop", "description")
           }
@@ -245,30 +246,25 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
 
   def addSharesAndFullscreen(body: Document): Document = {
     if(!article.isLiveBlog) {
-      val imageElements = body.getElementsByClass("element-image").view.zipWithIndex
-      imageElements foreach { case (fig, index) =>
-        val linkIndex = (index + 1).toString
-        val hashSuffix = "img-" + linkIndex
-        fig.attr("id", hashSuffix)
-        val mediaId = fig.attr("data-media-id")
-        val asset = findImageFromId(mediaId)
 
-        fig.getElementsByTag("img").foreach { img =>
-          asset.map { image =>
-            val html = views.html.fragments.share.blockLevelSharing(hashSuffix, article.elementShares(Some(hashSuffix), image.url), article.contentType)
+      article.bodyImages.zip(article.bodyImages.map(_.largestEditorialCrop)).filter({
+        case (_, Some(crop)) => crop.width > 620
+        case _ => false
+      }).zipWithIndex map {
+        case ((imageElement, Some(crop)), index) =>
+          val fig = body.select("[data-media-id=" + imageElement.id + "]").first()
+          val linkIndex = (index + 1).toString
+          val hashSuffix = "img-" + linkIndex
+          fig.attr("id", hashSuffix)
+          fig.addClass("fig-narrow-caption")
+
+          fig.getElementsByTag("img").foreach { img =>
+            val html = views.html.fragments.share.blockLevelSharing(linkIndex, article.elementShares(Some(linkIndex), crop.url), article.contentType)
             img.after(html.toString())
 
-            img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")
+            img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-nxame='Launch Article Lightbox' data-is-ajax></a>")
             img.after("<span class='article__fullscreen'><i class='i i-expand-white'></i><i class='i i-expand-black'></i></span>")
           }
-        }
-
-        val figcaption = fig.getElementsByTag("figcaption")
-
-        //if there's no caption then a larger margin-bottom is needed to fit the share buttons in
-        if (figcaption.length < 1) {
-          fig.addClass("fig-extra-margin")
-        }
       }
     }
     body
@@ -287,10 +283,11 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
     }
 
     body
+
   }
 
   def clean(body: Document): Document = {
-    cleanShowcasePictures(cleanStandardPictures(addSharesAndFullscreen(body)))
+    cleanShowcasePictures(addSharesAndFullscreen(cleanStandardPictures(body)))
   }
 
   def findImageFromId(id:String): Option[ImageAsset] = {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -136,10 +136,8 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
           // add extra margin if there is no caption to fit the share buttons
           val figcaption = element.getElementsByTag("figcaption")
           if(figcaption.length < 1) {
-            element.addClass("fig-extra-margin")
+            element.addClass("fig--extra-margin")
           }
-        } else {
-          element.addClass("fig-full-width")
         }
       })
     }
@@ -234,9 +232,10 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
           // content api/ tools sometimes pops a &nbsp; in the blank field
           if (!figcaption.hasText || figcaption.text().length < 2) {
             figcaption.remove()
-            fig.addClass("fig-no-border")
+            fig.addClass("fig--extra-margin")
           } else {
             figcaption.attr("itemprop", "description")
+            fig.addClass("fig--border")
           }
         }
       }
@@ -247,16 +246,13 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
   def addSharesAndFullscreen(body: Document): Document = {
     if(!article.isLiveBlog) {
 
-      article.bodyImages.zip(article.bodyImages.map(_.largestEditorialCrop)).filter({
-        case (_, Some(crop)) => crop.width > 620
-        case _ => false
-      }).zipWithIndex map {
+      article.lightboxImages.zipWithIndex map {
         case ((imageElement, Some(crop)), index) =>
           val fig = body.select("[data-media-id=" + imageElement.id + "]").first()
           val linkIndex = (index + 1).toString
           val hashSuffix = "img-" + linkIndex
           fig.attr("id", hashSuffix)
-          fig.addClass("fig-narrow-caption")
+          fig.addClass("fig--narrow-caption")
 
           fig.getElementsByTag("img").foreach { img =>
             val html = views.html.fragments.share.blockLevelSharing(linkIndex, article.elementShares(Some(linkIndex), crop.url), article.contentType)

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -262,7 +262,7 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
             val html = views.html.fragments.share.blockLevelSharing(linkIndex, article.elementShares(Some(linkIndex), crop.url), article.contentType)
             img.after(html.toString())
 
-            img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-nxame='Launch Article Lightbox' data-is-ajax></a>")
+            img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")
             img.after("<span class='article__fullscreen'><i class='i i-expand-white'></i><i class='i i-expand-black'></i></span>")
           }
       }

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -428,7 +428,7 @@ define([
     };
 
     GalleryLightbox.prototype.close = function () {
-        //url.hasHistorySupport ? url.back() :
+        url.hasHistorySupport ? url.back() : this.trigger('close');
         this.trigger('close');
     };
 

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -428,7 +428,8 @@ define([
     };
 
     GalleryLightbox.prototype.close = function () {
-        url.hasHistorySupport ? url.back() : this.trigger('close');
+        //url.hasHistorySupport ? url.back() :
+        this.trigger('close');
     };
 
     GalleryLightbox.prototype.hide = function () {

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -96,10 +96,8 @@ figure.element.element--showcase {
 }
 
 figure.element.element--supporting {
-    @include mq(desktop) {
-        figcaption {
-            max-width: gs-span(3);
-        }
+    figcaption {
+        padding-top: ($gs-baseline/3)*2;
     }
     @include mq(leftCol) {
         padding-bottom: $gs-baseline * 2;
@@ -109,15 +107,6 @@ figure.element.element--supporting {
             background: #ffffff;
             padding-left: 0;
             top: 100%;
-            padding-top: ($gs-baseline/3)*2;
-            max-width: gs-span(3);
-        }
-    }
-    @include mq(wide) {
-        max-width: gs-span(4);
-
-        figcaption {
-            padding-right: $gs-gutter/2;
         }
     }
 }
@@ -128,7 +117,6 @@ figure.element.element--showcase {
             background: #ffffff;
             padding-left: 0;
             top: 100%;
-            max-width: gs-span(9);
         }
     }
 }

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -95,13 +95,13 @@ figure.element.element--showcase {
     }
 }
 
-figure.element.element--supporting {
+figure.element.element--supporting,
+figure.element-video {
     figcaption {
         padding-top: ($gs-baseline/3)*2;
     }
     @include mq(leftCol) {
         padding-bottom: $gs-baseline * 2;
-        border-bottom: 1px dotted colour(neutral-5);
 
         figcaption {
             background: #ffffff;
@@ -121,10 +121,10 @@ figure.element.element--showcase {
     }
 }
 
-figure.img--extended {
+figure.img--extended,
+figure.element-video {
     @include mq(leftCol) {
         padding-bottom: $gs-baseline * 2;
-        border-bottom: 1px dotted colour(neutral-5);
 
         &.element--thumbnail {
             padding-bottom: 0;

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -387,21 +387,23 @@
     .img--base & {
         display: none !important;
     }
-
-    .element-video & {
-        margin-top: 2px;
-    }
 }
 
-.fig-extra-margin {
+.fig--extra-margin {
     padding-bottom: $gs-baseline * 3 !important;
 }
 
-.fig-no-border {
-    border: 0 !important;
+.fig--border {
+    @include mq(leftCol) {
+        border-bottom: 1px dotted colour(neutral-5) !important;
+    }
+
+    &.element--thumbnail {
+        border: 0 !important;
+    }
 }
 
-.fig-narrow-caption {
+.fig--narrow-caption {
     figcaption {
         @include mq(leftCol) {
             max-width: gs-span(6);

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -397,8 +397,33 @@
     padding-bottom: $gs-baseline * 3 !important;
 }
 
-.fig-full-width {
+.fig-no-border {
+    border: 0 !important;
+}
+
+.fig-narrow-caption {
     figcaption {
-        max-width: 100% !important;
+        @include mq(leftCol) {
+            max-width: gs-span(6);
+        }
+    }
+
+    &.element--supporting {
+        figcaption {
+            @include mq(desktop) {
+                max-width: gs-span(3) - 10;
+            }
+            @include mq(wide) {
+                max-width: gs-span(4) - 10;
+            }
+        }
+    }
+
+    &.element--showcase {
+        figcaption {
+            @include mq(leftCol) {
+                max-width: gs-span(9);
+            }
+        }
     }
 }

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -17,11 +17,6 @@ $vjs-progress-inset-bottom: 4px;
 .gu-media-wrapper {
     background: #000000;
     -webkit-transform: translateZ(0); // fixes iOS hover bug
-    margin-bottom: ($gs-baseline / 3) * 2;
-
-    .element--supporting & {
-        margin-bottom: 0;
-    }
 }
 .gu-media-wrapper--audio {
     background-color: $vjs-control-colour;

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -176,9 +176,6 @@ figure {
         position: relative;
         figcaption {
             padding-top: ($gs-baseline/6)*4;
-            @include mq(tablet) {
-                max-width: gs-span(6);
-            }
         }
     }
     &.element-video {


### PR DESCRIPTION
A number of changes regarding the image lightbox for article pages.

Main changes:
- Lightbox only launches for images larger than 620px wide now
- Refactor of the figcaption logic to ensure captions go fullwidth when there are no block sharing options
