### PR TITLE
Add launch banner for AU

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -55,7 +55,8 @@ define([
     'bootstraps/identity',
 
     'text!common/views/release-message.html',
-    'text!common/views/release-message-compulsory.html'
+    'text!common/views/release-message-compulsory.html',
+    'text!common/views/release-message-launched.html'
 ], function (
     bean,
     bonzo,
@@ -110,7 +111,8 @@ define([
     identity,
 
     releaseMessageTpl,
-    releaseMessageCompulsoryTpl
+    releaseMessageCompulsoryTpl,
+    releaseMessageLaunchedTpl
 ) {
 
     var modules = {
@@ -280,6 +282,13 @@ define([
                     if (config.page.edition === 'US' || /in\|/.test(shift)) {
                         releaseMessage.show(template(
                             releaseMessageCompulsoryTpl,
+                            {
+                                feedbackLink: feedbackLink
+                            }
+                        ));
+                    } else if (config.page.edition === 'AU' &&  config.page.section === 'commentisfree') {
+                        releaseMessage.show(template(
+                            releaseMessageLaunchedTpl,
                             {
                                 feedbackLink: feedbackLink
                             }

--- a/static/src/javascripts/projects/common/views/release-message-launched.html
+++ b/static/src/javascripts/projects/common/views/release-message-launched.html
@@ -1,0 +1,8 @@
+<p class="site-message__message" id="site-message__message">
+    You're viewing the Guardian's new website. We’d love to hear what you think.</p>
+<ul class="site-message__actions u-unstyled">
+    <li class="site-message__actions__item">
+        <i class="i i-arrow-white-right"></i>
+        <a href="{{feedbackLink}}" target="_blank">Leave feedback</a>
+    </li>
+</ul>


### PR DESCRIPTION
Adds a launch message for AU. Currently only targeted to CIF but will change throughout the week, a "find out more" button with a link to a new blog post will also be added on Wednesday.

/cc @rich-nguyen @cantlin 
