### PR TITLE
Merchandising components bugfix

### DIFF
--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -1,12 +1,12 @@
 @(item: model.Content, optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optCapiButtonText: Option[String], optCapiReadMoreUrl: Option[String], optCapiReadMoreText: Option[String], optCapiAdFeature: Option[String], optCapiSupportedBy: Option[String])(implicit request: RequestHeader)
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    <section class="fc-container fc-container--paid-for @for(adFeature <- optCapiAdFeature) {@adFeature} commercial commercial--dfp commercial--dfp-single">
+    <section class="fc-container fc-container--paid-for @for(adFeature <- optCapiAdFeature) {@adFeature} commercial commercial--dfp commercial--dfp-single" data-link-name="merchandising | capi | single">
         <div class="fc-container__inner">
             <div class="fc-container__header">
                 <h3 class="fc-container__header__title">
                     @optCapiLink.map { linkUrl =>
-                        <a href="@linkUrl" class="fc-container__header__link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        <a href="@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
                     }.getOrElse {
                         <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
                     }

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -6,7 +6,7 @@
             <div class="fc-container__header">
                 <h3 class="fc-container__header__title">
                     @optCapiLink.map { linkUrl =>
-                        <a href="@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        <a href="%OASToken%@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
                     }.getOrElse {
                         <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
                     }
@@ -15,11 +15,11 @@
             <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
                 <div class="ad-slot--paid-for-badge__inner">
                     <h3 class="ad-slot--paid-for-badge__header">@for(broughtBy <- optCapiSupportedBy) {@broughtBy}</h3>
-                    <a href=" @for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link">
+                    <a href="%OASToken%@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
                         @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
                     </a>
                     @for(aboutLinkUrl <- optCapiAbout) {
-                        <a href="@aboutLinkUrl" class="ad-slot--paid-for-badge__help">About this content</a>
+                        <a href="%OASToken%@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
                     }
                 </div>
             </div>
@@ -27,7 +27,7 @@
                 <div class="lineitems">
                     <div class="lineitem lineitem--dfp-single">
                         <div class="lineitem--dfp-single__offer">
-                            <a href="@AdLink{@item.webUrl}" data-link-name="merchandising-capi-single-v@{version}_@{date}-@item.webTitle">
+                            <a href="%OASToken%@AdLink{@item.webUrl}" data-link-name="merchandising-capi-single-v@{version}_@{date}-@item.webTitle">
                                 @FaciaDisplayElement.fromTrail(item) match {
                                     case Some(InlineVideo(_, _, _, Some(fallbackImage))) => {
                                         @Item300.bestFor(fallbackImage.imageContainer).map{ url => <img src="@url" alt="" class="lineitem__image" /> }
@@ -42,7 +42,7 @@
                                     <p class="fc-item__standfirst lineitem__desc">@Html(trailText)</p>
                                 }
                                 @for(buttonText <- optCapiButtonText) {
-                                    <a href="@AdLink{@item.webUrl}" class="lineitem__cta button button--tertiary button--small">
+                                    <a href="%OASToken%@AdLink{@item.webUrl}" class="lineitem__cta button button--tertiary button--small">
                                         @buttonText
                                         <i class="i i-arrow-black-right i-right"></i>
                                     </a>
@@ -51,7 +51,7 @@
                         </div>
                         <div class="lineitem--dfp-single__cta hide-on-mobile">
                             @for(moreButton <- optCapiReadMoreText) {
-                                <a href="@for(moreUrl <- optCapiReadMoreUrl) {@moreUrl}" class="commercial__cta button button--primary button--large">
+                                <a href="%OASToken%@for(moreUrl <- optCapiReadMoreUrl) {@moreUrl}" class="commercial__cta button button--primary button--large" data-link-name="merchandising-single-more">
                                     @moreButton
                                     <i class="i i-arrow-white-right i-right"></i>
                                 </a>

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -5,7 +5,11 @@
         <div class="fc-container__inner">
             <div class="fc-container__header">
                 <h3 class="fc-container__header__title">
-                    <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
+                    @optCapiLink.map { linkUrl =>
+                        <a href="@linkUrl" class="fc-container__header__link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                    }.getOrElse {
+                        <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
+                    }
                 </h3>
             </div>
             <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -6,7 +6,11 @@
         <div class="container__border"></div>
             <div class="fc-container__header">
                 <h2 class="fc-container__header__title">
-                    <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
+                    @optCapiLink.map { linkUrl =>
+                        <a href="@linkUrl" class="fc-container__header__link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                    }.getOrElse {
+                        <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
+                    }
                 </h2>
             </div>
             <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -7,7 +7,7 @@
             <div class="fc-container__header">
                 <h2 class="fc-container__header__title">
                     @optCapiLink.map { linkUrl =>
-                        <a href="@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        <a href="%OASToken%@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
                     }.getOrElse {
                         <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
                     }
@@ -16,11 +16,11 @@
             <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
                 <div class="ad-slot--paid-for-badge__inner">
                     <h3 class="ad-slot--paid-for-badge__header">Brought to you by:</h3>
-                    <a href=" @for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link">
+                    <a href="%OASToken%@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
                         @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
                     </a>
                     @for(aboutLinkUrl <- optCapiAbout) {
-                        <a href="@aboutLinkUrl" class="ad-slot--paid-for-badge__help">About this content</a>
+                        <a href="%OASToken%@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
                     }
                 </div>
             </div>
@@ -64,7 +64,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <a href="@AdLink{@item.webUrl}" class="u-faux-block-link__overlay" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle" tabindex="-1">
+                                    <a href="%OASToken%@AdLink{@item.webUrl}" class="u-faux-block-link__overlay" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle" tabindex="-1">
                                         @item.webTitle
                                     </a>
                                 </div>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,13 +1,13 @@
 @(items: Seq[model.Content], optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String])(implicit request: RequestHeader)
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising fc-container--advertisement-feature fc-container--commercial-capi">
+    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising fc-container--advertisement-feature fc-container--commercial-capi" data-link-name="merchandising | capi | multiple">
         <div class="fc-container__inner">
         <div class="container__border"></div>
             <div class="fc-container__header">
                 <h2 class="fc-container__header__title">
                     @optCapiLink.map { linkUrl =>
-                        <a href="@linkUrl" class="fc-container__header__link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        <a href="@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
                     }.getOrElse {
                         <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
                     }

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -666,13 +666,22 @@ jQuery(function($) {
 
         <div id="dfp-ad--merchandising" class="dfp-ad--merchandising-capi ad-slot ad-slot--merchandising ad-slot--commercial-component">
             <script>
-                $.getJSON(
-                    '/commercial/capi.json?s=books&t=p%2F43b2q&t=p%2F43945&k=music%2Fledzeppelin&' +
-                    'k=music%2Fpinkfloyd&l=http%3A%2F%2Fpagead2.googlesyndication.com%2Fpagead%2Fimgad%3Fid%3DCICAgKDjnfPJbBABGAEyCHbj_OBIEKp8&' +
-                    'ct=Led%20Zeppelin%20special&cl=http%3A%2F%2Ftheguardian.com%2Fmusic%2Fledzeppelin&' +
-                    'cal=http%3A%2F%2Ftheguardian.com%2Fabout',
-                    function(json) { $('.dfp-ad--merchandising-capi').html(json.html); }
-                );
+                require(['core'], function(core) {
+                    require(['bootstraps/commercial'], function(core) {
+                        require(['common/modules/commercial/loader'], function(CommercialComponent) {
+                            var slot = document.querySelector('.dfp-ad--merchandising-capi');
+                            new CommercialComponent({
+                                oastoken: 'CLICK_URL_UNESC',
+                                capi: ['p/43945','p/43945'],
+                                logo: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
+                                capiTitle: 'Led Zeppelin special',
+                                capiLinkUrl: 'http%3A%2F%2Ftheguardian.com%2Fmusic%2Fledzeppelin',
+                                capiAboutLinkUrl: 'http://theguardian.com/about',
+                                capiKeywords: 'music/ledzeppelin'
+                            }).init('capi', slot);
+                            });
+                        });
+                    });
             </script>
         </div>
     </div>
@@ -689,7 +698,7 @@ jQuery(function($) {
             require(['bootstraps/commercial'], function(core) {
                 require(['common/modules/commercial/loader'], function(CommercialComponent) {
                     new CommercialComponent({
-                        oastoken: '%%CLICK_URL_ESC%%',
+                        oastoken: 'CLICK_URL_UNESC',
                         t: ['p/4xv7c'],
                         l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
                         ct: 'Led Zeppelin special',

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -73,7 +73,7 @@
 
 .container--merchandising-feature {
     background-color: transparent;
-    
+
     .fc-container__inner {
         padding-top: $gs-baseline/2;
         border-top: 1px solid colour(neutral-4);
@@ -92,6 +92,12 @@
 
     .fc-container__header__title {
         color: colour(neutral-1);
+        .fc-container__header__link {
+            color: colour(guardian-brand);
+            &:hover {
+                color: colour(news-accent);
+            }
+        }
     }
 
     .fc-item__container {

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -92,8 +92,10 @@
 
     .fc-container__header__title {
         color: colour(neutral-1);
+
         .fc-container__header__link {
             color: colour(guardian-brand);
+
             &:hover {
                 color: colour(news-accent);
             }

--- a/static/src/stylesheets/module/commercial/_dfp.scss
+++ b/static/src/stylesheets/module/commercial/_dfp.scss
@@ -49,6 +49,10 @@
 
     /* Multiple */
     &.commercial--dfp-multiple {
+        .container__header__inner {
+            min-height: 36px;
+        }
+
         .lineitem {
             width: percentage(1/2);
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -105,7 +105,6 @@ $fc-hover-transition: .25s ease;
 
 .fc-item,
 .item {
-    background-color: #ffffff;
     margin-left: $gs-gutter * .5;
     margin-right: $gs-gutter * .5;
 


### PR DESCRIPTION
Fixes like:
- removed white background from the Advertisement feature 
- fixed mobile breakpoint in the Merchandising: cAPI multiple (advertorial) - right arrow is no longer cut
- added link on the title of the Merchandising: cAPI multiple and single components
- added clickMacro and proper data-link-name on every link in the Merchandising: cAPI multiple and single components
