### PR TITLE
Coloured block level share icons in galleries

### DIFF
--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -251,15 +251,19 @@
 
 @function colour($color) {
     @if map-has-key($frontend-palette, $color) {
-        @return map-get($frontend-palette, $color);
+    @return map-get($frontend-palette, $color);
+} @else {
+    @if map-has-key($pasteup-palette, $color) {
+        @return guss-colour($color, $pasteup-palette);
     } @else {
-        @if map-has-key($pasteup-palette, $color) {
-            @return guss-colour($color, $pasteup-palette);
-        } @else {
-            @warn "#{$color} not found in either frontend or pasteup palette";
-            @return false;
-        }
+        @warn "#{$color} not found in either frontend or pasteup palette";
+        @return false;
     }
+}
+}
+
+@function colour-hover($colour) {
+    @return darken(colour($colour), 10%)
 }
 
 @mixin absolute-center {

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -251,15 +251,15 @@
 
 @function colour($color) {
     @if map-has-key($frontend-palette, $color) {
-    @return map-get($frontend-palette, $color);
-} @else {
-    @if map-has-key($pasteup-palette, $color) {
-        @return guss-colour($color, $pasteup-palette);
+        @return map-get($frontend-palette, $color);
     } @else {
-        @warn "#{$color} not found in either frontend or pasteup palette";
-        @return false;
+        @if map-has-key($pasteup-palette, $color) {
+            @return guss-colour($color, $pasteup-palette);
+        } @else {
+            @warn "#{$color} not found in either frontend or pasteup palette";
+            @return false;
+        }
     }
-}
 }
 
 @function colour-hover($colour) {

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -257,7 +257,7 @@
         background-color: colour(social-facebook);
 
         &:hover {
-            background-color: darken(colour(social-facebook), 10%);
+            background-color: colour-hover(social-facebook);
         }
 
         .i {
@@ -269,7 +269,7 @@
         background-color: colour(social-twitter);
 
         &:hover {
-            background-color: darken(colour(social-twitter), 10%);
+            background-color: colour-hover(social-twitter);
         }
 
         .i {
@@ -281,7 +281,7 @@
         background-color: colour(social-gplus);
 
         &:hover {
-            background-color: darken(colour(social-gplus), 10%);
+            background-color: colour-hover(social-gplus);
         }
 
         .i {
@@ -293,7 +293,7 @@
         background-color: colour(social-linkedin);
 
         &:hover {
-            background-color: darken(colour(social-linkedin), 10%);
+            background-color: colour-hover(social-linkedin);
         }
 
         .i {
@@ -305,7 +305,7 @@
         background-color: colour(social-pinterest);
 
         &:hover {
-            background-color: darken(colour(social-pinterest), 10%);
+            background-color: colour-hover(social-pinterest);
         }
 
         .i {

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -251,87 +251,65 @@
 
     .block-share__item {
         @include transition(opacity .15s linear);
-        opacity: .8;
-
-        &:hover {
-            opacity: 1;
-        }
     }
 
     .block-share__item--facebook {
-        border-color: colour(neutral-2);
-        color: colour(neutral-2);
-        .i {
-            @include icon(share-facebook--white);
-        }
+        background-color: colour(social-facebook);
 
         &:hover {
-            border-color: #ffffff;
-            .i {
-                @include icon(share-facebook--white);
-            }
+            background-color: darken(colour(social-facebook), 10%);
+        }
+
+        .i {
+            @include icon(share-facebook--white);
         }
     }
 
     .block-share__item--twitter {
-        border-color: colour(neutral-2);
-        color: colour(neutral-2);
-        .i {
-            @include icon(share-twitter--white);
-        }
+        background-color: colour(social-twitter);
 
         &:hover {
-            border-color: #ffffff;
-            .i {
-                @include icon(share-twitter--white);
-            }
+            background-color: darken(colour(social-twitter), 10%);
+        }
+
+        .i {
+            @include icon(share-twitter--white);
         }
     }
 
     .block-share__item--gplus {
-        border-color: colour(neutral-2);
-        color: colour(neutral-2);
-        .i {
-            @include icon(share-gplus--white);
-        }
+        background-color: colour(social-gplus);
 
         &:hover {
-            border-color: #ffffff;
-            .i {
-                @include icon(share-gplus--white);
-            }
+            background-color: darken(colour(social-gplus), 10%);
+        }
+
+        .i {
+            @include icon(share-gplus--white);
         }
     }
 
     .block-share__item--linkedin {
-        border-color: colour(neutral-2);
-        color: colour(neutral-2);
+        background-color: colour(social-linkedin);
+
+        &:hover {
+            background-color: darken(colour(social-linkedin), 10%);
+        }
 
         .i {
             @include icon(share-linkedin--white);
         }
-
-        &:hover {
-            border-color: #ffffff;
-            .i {
-                @include icon(share-linkedin--white);
-            }
-        }
     }
 
     .block-share__item--pinterest {
-        border-color: colour(neutral-2);
-        color: colour(neutral-2);
+        background-color: colour(social-pinterest);
+
+        &:hover {
+            background-color: darken(colour(social-pinterest), 10%);
+        }
 
         .i {
             @include icon(share-pinterest--white);
-        }
-
-        &:hover {
-            border-color: #ffffff;
-            .i {
-                @include icon(share-pinterest--white);
-            }
         }
     }
 


### PR DESCRIPTION
Coloured in those controversial monochrome share icons on gallery pages:

After:
![screen shot 2014-11-24 at 17 08 44](https://cloud.githubusercontent.com/assets/2236852/5169160/93136232-73fc-11e4-84ed-99db70534604.png)
