### PR TITLE
Removing min-height from commercial components

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -255,10 +255,8 @@
  */
 .ad-slot--commercial-component,
 .ad-slot--commercial-component-high {
-    min-height: 88px;
-
-    @include mq(wide) {
-        .has-page-skin & {
+    .has-page-skin & {
+        @include mq(wide) {
             margin-left: auto;
             margin-right: auto;
             width: gs-span(12) + ($gs-gutter*2);


### PR DESCRIPTION
Kinda pointless, as they're never 88px high
