### PR TITLE
Fix copy paste of articles

### DIFF
--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -591,7 +591,7 @@ define([
                 }, {})
                 .value();
 
-            if (this.group.parentType === 'Collection') {
+            if (this.group && this.group.parentType === 'Collection') {
                 cleanMeta.group = this.group.index + '';
             }
 


### PR DESCRIPTION
When using copy paste, the articles from the latest search don't have a group
