### PR TITLE
allow too-long article labels to wrap

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -127,6 +127,7 @@
     position: relative;
     z-index: 1; // bring-to-front fix to make it clickable
     overflow: hidden;
+    word-wrap: break-word;
 
     @include mq(leftCol) {
         border: 0;


### PR DESCRIPTION
before
![screen shot 2014-11-25 at 11 10 50](https://cloud.githubusercontent.com/assets/867233/5181925/5dbf2b06-7493-11e4-8001-9b5fd6da6dac.png)

after
![screen shot 2014-11-25 at 11 10 25](https://cloud.githubusercontent.com/assets/867233/5181926/6163aaf2-7493-11e4-9e50-0551dc0600fc.png)

http://www.browserstack.com/screenshots/4234be98497f027c990ff9372fcaabf5400b2f23
