### PR TITLE
Fix for jumping trails

### DIFF
--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -736,6 +736,17 @@ define([
             return false;
         };
 
+        Article.prototype.drop = function (source, targetGroup) {
+            mediator.emit('collection:updates', {
+                sourceItem: source.sourceItem,
+                sourceGroup: source.sourceGroup,
+                targetItem: this,
+                targetGroup: targetGroup,
+                isAfter: false,
+                mediaItem: source.mediaItem
+            });
+        };
+
         function getMainMediaType(contentApiArticle) {
             return _.chain(contentApiArticle.elements).where({relation: 'main'}).pluck('type').first().value();
         }

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -9,6 +9,7 @@ define([
     'utils/as-observable-props',
     'utils/populate-observables',
     'utils/full-trim',
+    'utils/mediator',
     'utils/url-abs-path',
     'utils/identity'
 ], function(
@@ -21,6 +22,7 @@ define([
     asObservableProps,
     populateObservables,
     fullTrim,
+    mediator,
     urlAbsPath,
     identity
 ) {
@@ -185,6 +187,17 @@ define([
                 self.capiResults(results || []);
                 self.state.apiQueryStatus(results && results.length ? 'valid' : 'invalid');
             }
+        });
+    };
+
+    Collection.prototype.drop = function (source, targetGroup) {
+        mediator.emit('collection:updates', {
+            sourceItem: source.sourceItem,
+            sourceGroup: source.sourceGroup,
+            targetItem: this,
+            targetGroup: targetGroup,
+            isAfter: false,
+            mediaItem: null
         });
     };
 

--- a/facia-tool/public/js/models/group.js
+++ b/facia-tool/public/js/models/group.js
@@ -43,5 +43,52 @@ define([
         };
     }
 
+    Group.prototype.setAsTarget = function(targetItem) {
+        this.underDrag(targetItem.constructor === Group);
+        _.each(this.items(), function(item) {
+            var underDrag = (item === targetItem);
+            if (underDrag !== item.state.underDrag()) {
+                item.state.underDrag(underDrag);
+            }
+        });
+    };
+
+    Group.prototype.unsetAsTarget = function() {
+        this.underDrag(false);
+        _.each(this.items(), function(item) {
+            if (item.state.underDrag()) {
+                item.state.underDrag(false);
+            }
+        });
+    };
+
+    Group.prototype.drop = function(source, targetGroup) {
+        var isAfter = false, groups;
+        // assume it's to be appended *after* the other items in this group,
+        var targetItem = _.last(targetGroup.items());
+        if (targetItem) {
+            isAfter = true;
+        // or if there arent't any other items, after those in the first preceding group that contains items.
+        } else if (targetGroup.parentType === 'Collection') {
+            groups = targetGroup.parent.groups;
+            for (var i = groups.indexOf(targetGroup) - 1; i >= 0; i -= 1) {
+                targetItem = _.last(groups[i].items());
+                if (targetItem) {
+                    isAfter = true;
+                    break;
+                }
+            }
+        }
+
+        mediator.emit('collection:updates', {
+            sourceItem: source.sourceItem,
+            sourceGroup: source.sourceGroup,
+            targetItem: targetItem,
+            targetGroup: targetGroup,
+            isAfter: isAfter,
+            mediaItem: source.mediaItem
+        });
+    };
+
     return Group;
 });

--- a/facia-tool/public/js/modules/droppable.js
+++ b/facia-tool/public/js/modules/droppable.js
@@ -2,17 +2,11 @@
 define([
     'knockout',
     'modules/copied-article',
-    'models/group',
-    'utils/mediator',
-    'utils/deep-get',
-    'utils/parse-query-params'
+    'utils/draggable-element'
 ], function(
     ko,
     copiedArticle,
-    Group,
-    mediator,
-    deepGet,
-    parseQueryParams
+    draggableElement
 ) {
     var sourceGroup;
     var listeners = {
@@ -26,18 +20,12 @@ define([
         },
         dragover: function (element, event) {
             var targetGroup = ko.dataFor(element),
-                targetItem = ko.dataFor(event.target);
+                targetItem = getTargetItem(event.target);
 
             event.preventDefault();
             event.stopPropagation();
 
-            targetGroup.underDrag(targetItem.constructor === Group);
-            _.each(targetGroup.items(), function(item) {
-                var underDrag = (item === targetItem);
-                if (underDrag !== item.state.underDrag()) {
-                    item.state.underDrag(underDrag);
-                }
-            });
+            targetGroup.setAsTarget(targetItem);
         },
         dragleave: function (element, event) {
             var targetGroup = ko.dataFor(element);
@@ -45,119 +33,44 @@ define([
             event.preventDefault();
             event.stopPropagation();
 
-            targetGroup.underDrag(false);
-            _.each(targetGroup.items(), function(item) {
-                if (item.state.underDrag()) {
-                    item.state.underDrag(false);
-                }
-            });
+            targetGroup.unsetAsTarget();
         },
         drop: function (element, event) {
             var targetGroup = ko.dataFor(element),
-                targetItem = ko.dataFor(event.target),
-                id = event.dataTransfer.getData('Text'),
-                mediaItem = event.dataTransfer.getData('application/vnd.mediaservice.crops+json'),
-                knownQueryParams = parseQueryParams(id, {
-                    namespace: 'gu-',
-                    excludeNamespace: false,
-                    stripNamespace: true
-                }),
-                unknownQueryParams = parseQueryParams(id, {
-                    namespace: 'gu-',
-                    excludeNamespace: true
-                }),
-                sourceItem,
-                groups,
-                isAfter = false;
+                targetItem = getTargetItem(event.target),
+                source;
+
+            if (!targetGroup) {
+                return;
+            }
+
+            try {
+                source = draggableElement(event.dataTransfer, sourceGroup);
+            } catch (ex) {
+                window.alert(ex.message);
+                return;
+            }
 
             event.preventDefault();
             event.stopPropagation();
 
             copiedArticle.flush();
 
-            if (mediaItem) {
-                try {
-                    mediaItem = JSON.parse(mediaItem);
-                } catch(e) {
-                    mediaItem = undefined;
-                }
-
-                if (!mediaItem) {
-                    window.alert('Sorry, that image could not be understood.');
-                    return;
-                } else {
-                    mediaItem = _.chain(mediaItem.assets)
-                        .filter(function(asset) { return deepGet(asset, '.dimensions.width') <= 1000; })
-                        .sortBy(function(asset) { return deepGet(asset, '.dimensions.width') * -1; })
-                        .first()
-                        .value();
-                }
-
-                if (!mediaItem) {
-                    window.alert('Sorry, a suitable crop size does not exist for this image');
-                    return;
-                }
-
-            } else if (!targetGroup) {
-                return;
-
-            } else if (!id) {
-                window.alert('Sorry, you can\'t add that to a front');
-                return;
-            }
-
-            targetGroup.underDrag(false);
-            _.each(targetGroup.items(), function(item) {
-                item.state.underDrag(false);
-            });
-
-            // If the item isn't dropped onto an item, assume it's to be appended *after* the other items in this group,
-            if (targetItem.constructor === Group) {
-                targetItem = _.last(targetGroup.items());
-                if (targetItem) {
-                    isAfter = true;
-                // or if there arent't any other items, after those in the first preceding group that contains items.
-                } else if (targetGroup.parentType === 'Collection') {
-                    groups = targetGroup.parent.groups;
-                    for (var i = groups.indexOf(targetGroup) - 1; i >= 0; i -= 1) {
-                        targetItem = _.last(groups[i].items());
-                        if (targetItem) {
-                            isAfter = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            sourceItem = event.dataTransfer.getData('sourceItem');
-
-            if (sourceItem) {
-                sourceItem = JSON.parse(sourceItem);
-
-            } else if (unknownQueryParams.url) {
-                sourceItem = { id: unknownQueryParams.url };
-                sourceGroup = undefined;
-
-            } else {
-                sourceItem = {
-                    id: id.split('?')[0] + (_.isEmpty(unknownQueryParams) ? '' : '?' + _.map(unknownQueryParams, function(val, key) {
-                        return key + (val ? '=' + val : '');
-                    }).join('&')),
-                    meta: knownQueryParams
-                };
-                sourceGroup = undefined;
-            }
-
-            mediator.emit('collection:updates', {
-                sourceItem: sourceItem,
-                sourceGroup: sourceGroup,
-                targetItem: targetItem,
-                targetGroup: targetGroup,
-                isAfter: isAfter,
-                mediaItem: mediaItem
-            });
+            targetGroup.unsetAsTarget();
+            targetItem.drop(source, targetGroup);
         }
     };
+
+    function getTargetItem (target, context) {
+        context = context || ko.contextFor(target);
+        var data = context.$data || {};
+        if (!data.drop && context.$parentContext) {
+            return getTargetItem(null, context.$parentContext);
+        } else {
+            return data;
+        }
+    }
+
     function getListener (name, element) {
         return function (event) {
             listeners[name](element, event);

--- a/facia-tool/public/js/utils/draggable-element.js
+++ b/facia-tool/public/js/utils/draggable-element.js
@@ -1,0 +1,73 @@
+/* globals _ */
+define([
+    'utils/deep-get',
+    'utils/parse-query-params'
+], function (
+    deepGet,
+    parseQueryParams
+) {
+    function getItem(dataTransfer, sourceGroup) {
+        var id = dataTransfer.getData('Text'),
+            mediaItem = dataTransfer.getData('application/vnd.mediaservice.crops+json'),
+            sourceItem = dataTransfer.getData('sourceItem'),
+            knownQueryParams = parseQueryParams(id, {
+                namespace: 'gu-',
+                excludeNamespace: false,
+                stripNamespace: true
+            }),
+            unknownQueryParams = parseQueryParams(id, {
+                namespace: 'gu-',
+                excludeNamespace: true
+            });
+
+        if (mediaItem) {
+            try {
+                mediaItem = JSON.parse(mediaItem);
+            } catch(e) {
+                mediaItem = undefined;
+            }
+
+            if (!mediaItem) {
+                throw new Error('Sorry, that image could not be understood.');
+            } else {
+                mediaItem = _.chain(mediaItem.assets)
+                    .filter(function(asset) { return deepGet(asset, '.dimensions.width') <= 1000; })
+                    .sortBy(function(asset) { return deepGet(asset, '.dimensions.width') * -1; })
+                    .first()
+                    .value();
+            }
+
+            if (!mediaItem) {
+                throw new Error('Sorry, a suitable crop size does not exist for this image');
+            }
+
+        } else if (!id) {
+            throw new Error('Sorry, you can\'t add that to a front');
+        }
+
+        if (sourceItem) {
+            sourceItem = JSON.parse(sourceItem);
+
+        } else if (unknownQueryParams.url) {
+            sourceItem = { id: unknownQueryParams.url };
+            sourceGroup = undefined;
+
+        } else {
+            sourceItem = {
+                id: id.split('?')[0] + (_.isEmpty(unknownQueryParams) ? '' : '?' + _.map(unknownQueryParams, function(val, key) {
+                    return key + (val ? '=' + val : '');
+                }).join('&')),
+                meta: knownQueryParams
+            };
+            sourceGroup = undefined;
+        }
+
+        return {
+            mediaItem: mediaItem,
+            sourceItem: sourceItem,
+            sourceGroup: sourceGroup
+        };
+    }
+
+    return getItem;
+});


### PR DESCRIPTION
When an article is dragged over parts of another article that have their own context (like the boolean states) a request is sent to add the new article at the bottom of the parent group instead of above the article.

There's also some refactoring to split the view/action from the drop/position logic.
