### PR TITLE
put blogs in series container

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -82,7 +82,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     .map(_.id).map(Reference(_)).map(_._2)
 
   lazy val seriesMeta = {
-    series.headOption.map( series =>
+    blogsAndSeries.headOption.map( series =>
       Seq(("series", JsString(series.name)), ("seriesId", JsString(series.id)))
     ) getOrElse Nil
   }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -232,6 +232,7 @@ trait Tags {
   lazy val blogs: Seq[Tag] = tagsOfType("blog")
   lazy val tones: Seq[Tag] = tagsOfType("tone")
   lazy val types: Seq[Tag] = tagsOfType("type")
+  lazy val blogsAndSeries: Seq[Tag] = tags.filter{ tag => tag.tagType == "series" || tag.tagType == "blog"}
 
   def isSponsored: Boolean
   def hasMultipleSponsors: Boolean = DfpAgent.hasMultipleSponsors(tags)


### PR DESCRIPTION
Further to https://github.com/guardian/frontend/pull/7264: Where a blog tag is first in the tag sequence, use this tag to populate the 'Series' container: 

Before:
![series-container-before](https://cloud.githubusercontent.com/assets/986155/5182971/053ae8c2-74a1-11e4-8c8a-b8e3babbb1a2.png)

After: 
![series-container-after](https://cloud.githubusercontent.com/assets/986155/5182974/16c11044-74a1-11e4-83ec-27b1a151ac10.png)
