### PR TITLE
Element level share link fix

### DIFF
--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -264,7 +264,7 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
           fig.addClass("fig--narrow-caption")
 
           fig.getElementsByTag("img").foreach { img =>
-            val html = views.html.fragments.share.blockLevelSharing(linkIndex, article.elementShares(Some(linkIndex), crop.url), article.contentType)
+            val html = views.html.fragments.share.blockLevelSharing(hashSuffix, article.elementShares(Some(hashSuffix), crop.url), article.contentType)
             img.after(html.toString())
 
             img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")


### PR DESCRIPTION
Previous pull request reverted the link prefix of "img-" for element level shares. This prefixes them, as required.

cc @mattosborn 
