### PR TITLE
Tolerance for image aspect ratio

### DIFF
--- a/common/app/contentapi/FixtureTemplates.scala
+++ b/common/app/contentapi/FixtureTemplates.scala
@@ -1,6 +1,6 @@
 package contentapi
 
-import com.gu.contentapi.client.model.{Content => ApiContent, Tag => ApiTag}
+import com.gu.contentapi.client.model.{Content => ApiContent, Tag => ApiTag, Element => ApiElement, Asset => ApiAsset}
 
 /** Quite often we base tests on pieces of content from Content API, where we only care that a few of the fields are
   * set.
@@ -28,5 +28,20 @@ object FixtureTemplates {
     "",
     "",
     ""
+  )
+
+  val emptyElement = ApiElement(
+    "",
+    "",
+    "",
+    None,
+    Nil
+  )
+
+  val emptyAsset = ApiAsset(
+    "",
+    None,
+    None,
+    Map.empty
   )
 }

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -6,15 +6,7 @@ import views.support.{Naked, ImgSrc}
 import scala.util.matching.Regex
 
 case class ImageAsset(delegate: Asset, index: Int) {
-
-  private lazy val fields: Map[String,String] = delegate.typeData
-  private lazy val aspectRatio: Fraction = {
-    val heightAsRatio: Int = height match {
-      case 0 => 1
-      case denom:Int => denom
-    }
-    new Fraction(width, heightAsRatio)
-  }
+  private lazy val fields: Map[String, String] = delegate.typeData
 
   lazy val mediaType: String = delegate.`type`
   lazy val mimeType: Option[String] = delegate.mimeType
@@ -36,9 +28,6 @@ case class ImageAsset(delegate: Asset, index: Int) {
   lazy val photographer: Option[String] = fields.get("photographer")
   lazy val credit: Option[String] = fields.get("credit")
   lazy val displayCredit: Boolean = fields.get("displayCredit").exists(_=="true")
-
-  lazy val aspectRatioWidth: Int = aspectRatio.getNumerator
-  lazy val aspectRatioHeight: Int = aspectRatio.getDenominator
 }
 
 case class VideoAsset(private val delegate: Asset, image: Option[ImageContainer]) {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -129,17 +129,25 @@ trait Elements {
 
   private val trailPicMinDesiredSize = 460
 
+  val AspectRatioThreshold = 0.01
+
   // Find a main picture crop which matches this aspect ratio.
-  def trailPictureAll(aspectWidth: Int, aspectHeight: Int): List[ImageContainer] =
+  def trailPictureAll(aspectWidth: Int, aspectHeight: Int): List[ImageContainer] = {
+    val desiredAspectRatio = aspectWidth.toDouble / aspectHeight
+
     (thumbnail.find(_.imageCrops.exists(_.width >= trailPicMinDesiredSize)) ++ mainPicture ++ thumbnail)
-      .map{ image =>
-        image.imageCrops.filter{ crop => crop.aspectRatioWidth == aspectWidth && crop.aspectRatioHeight == aspectHeight } match {
-          case Nil   => None
-          case crops => Option(ImageContainer(crops, image.delegate, image.index))
-        }
+      .map { image =>
+      image.imageCrops.filter { crop =>
+        aspectHeight.toDouble * crop.width != 0 &&
+          Math.abs((aspectWidth.toDouble * crop.height) / (aspectHeight.toDouble * crop.width) - 1 ) <= AspectRatioThreshold
+      } match {
+        case Nil => None
+        case crops => Option(ImageContainer(crops, image.delegate, image.index))
       }
+    }
       .flatten
       .toList
+  }
 
   def trailPicture(aspectWidth: Int, aspectHeight: Int): Option[ImageContainer] = trailPictureAll(aspectWidth, aspectHeight).headOption
 

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -473,8 +473,8 @@ define([
                 {
                     maxWidth: 1000,
                     minWidth: 400,
-                    widthAspectRatio: 3,
-                    heightAspectRatio: 5
+                    widthAspectRatio: 5,
+                    heightAspectRatio: 3
                 }
             );
         };

--- a/facia-tool/public/js/utils/validate-image-src.js
+++ b/facia-tool/public/js/utils/validate-image-src.js
@@ -44,8 +44,6 @@ define([
                             'Images must have a ' + criteria.widthAspectRatio + 'x' + criteria.heightAspectRatio + ' aspect ratio'
                             : false;
 
-                console.log(Math.abs((height * criteria.widthAspectRatio) / (width * criteria.heightAspectRatio) - 1));
-
                 if (err) {
                     defer.reject(err);
                 } else {

--- a/facia-tool/public/js/utils/validate-image-src.js
+++ b/facia-tool/public/js/utils/validate-image-src.js
@@ -40,9 +40,11 @@ define([
                         (criteria.minWidth !== undefined && width < criteria.minWidth) ?
                             'Images cannot be less than ' + criteria.minWidth + ' pixels wide' :
                         (criteria.widthAspectRatio !== undefined && criteria.heightAspectRatio !== undefined
-                          && Math.abs((width * criteria.widthAspectRatio) / (height * criteria.heightAspectRatio) - 1) > 0.01) ?
+                          && Math.abs((height * criteria.widthAspectRatio) / (width * criteria.heightAspectRatio) - 1) > 0.01) ?
                             'Images must have a ' + criteria.widthAspectRatio + 'x' + criteria.heightAspectRatio + ' aspect ratio'
                             : false;
+
+                console.log(Math.abs((height * criteria.widthAspectRatio) / (width * criteria.heightAspectRatio) - 1));
 
                 if (err) {
                     defer.reject(err);


### PR DESCRIPTION
Instead of rejecting an image whose aspect ratio is not exact, accept it if it is within 1% of the desired ratio.

Mostly the work of Monseigneur @robertberry 
