### PR TITLE
Lightbox fixes

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -240,7 +240,7 @@ define([
 
                     $img.attr('src', imgSrc); // src can change with width so overwrite every time
 
-                    bean.on($img[0], 'load', function () {
+                    bean.one($img[0], 'load', function () {
                         $('.js-loader').remove();
                     });
 

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -240,8 +240,8 @@ define([
 
                     $img.attr('src', imgSrc); // src can change with width so overwrite every time
 
-                    bean.one($img[0], 'load', function () {
-                        $('.js-loader', $parent[0]).remove();
+                    bean.on($img[0], 'load', function () {
+                        $('.js-loader').remove();
                     });
 
                 }
@@ -522,7 +522,7 @@ define([
                 url.pushUrl(null, document.title, galleryId, true); // lets back work properly
                 lightbox.loadGalleryfromJson(images, parseInt(match[1], 10));
             } else {
-                res = /^#(?:img-)?(\d)+$/.exec(galleryHash);
+                res = /^#(?:img-)?(\d+)$/.exec(galleryHash);
                 if (res) {
                     lightbox.loadGalleryfromJson(images, parseInt(res[1], 10));
                 }


### PR DESCRIPTION
Two minor fixes:
1. The loading button now goes away once the image has loaded. This fixes a bug where it was still visible when the lightbox image was small.
2. Improved regex for the lightbox opening logic. This allows it to match double digit indexes.
