### PR TITLE
Fix deduping issue with dream snaps

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -79,9 +79,9 @@ object Front extends implicits.Collections {
         /** Fixed Containers participate in de-duplication.
           */
         val nToTake = itemsVisible(containerDefinition)
-        val notUsed = trails.filterNot(trail => participatesInDeduplication(trail) && seen.contains(trail.url))
+        val notUsed = trails.filter(trail => !seen.contains(trail.url) || !participatesInDeduplication(trail))
           .distinctBy(_.url)
-        (seen ++ notUsed.filter(participatesInDeduplication).take(nToTake).map(_.url), notUsed)
+        (seen ++ notUsed.take(nToTake).filter(participatesInDeduplication).map(_.url), notUsed)
 
       case _ =>
         /** Nav lists and most popular do not participate in de-duplication at all */

--- a/common/test/layout/FrontTest.scala
+++ b/common/test/layout/FrontTest.scala
@@ -142,6 +142,19 @@ class FrontTest extends FlatSpec with Matchers {
     dedupedTrails.map(_.webUrl) shouldEqual Seq("one")
   }
 
+  it should "not skip dream snaps when considering items visible to be added to the set of seen urls" in {
+    val (nowSeen, _) = Front.deduplicate(Set.empty, Fixed(FixedContainers.fixedSmallSlowIV), Seq(
+      dreamSnapWithUrl("one"),
+      dreamSnapWithUrl("two"),
+      trailWithUrl("three"),
+      trailWithUrl("four"),
+      trailWithUrl("five"),
+      trailWithUrl("six")
+    ))
+
+    nowSeen shouldEqual Set("three", "four")
+  }
+
   it should "not include dream snaps in the seen urls" in {
     val (nowSeen, _) = Front.deduplicate(Set.empty, Fixed(FixedContainers.fixedMediumFastXI), Seq(
       dreamSnapWithUrl("one")


### PR DESCRIPTION
Dream snaps are causing deduping issues on the fronts ... basically, if you have n dream snaps in a container, it considers n more urls past the 'show more' border to have been 'seen'. This fixes that.

CC @johnduffell @stephanfowler @rich-nguyen @phamann Could one of you please take a look? This is a PROD issue and we need to get it out ASAP.
