### PR TITLE
Fix calls to /undefined

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -272,7 +272,7 @@
             }">
 
             <a class="thumb" data-bind="
-                style: {backgroundImage: 'url(' + (meta.imageReplace() && meta.imageSrc() ? meta.imageSrc() : meta.imageCutoutReplace() ? meta.imageCutoutSrc() || state.imageCutoutSrcFromCapi() || fields.thumbnail() : fields.thumbnail() ) + ')'},
+                style: {backgroundImage: thumbImage() ? 'url(' + thumbImage() + ')' : ''},
                 attr: {href: id}"></a>
 
             <!-- ko if: state.imageCutoutSrcFromCapi() && !meta.imageCutoutReplace() -->

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -338,6 +338,20 @@ define([
             } else {
                 this.updateEditorsDisplay();
             }
+
+            this.thumbImage = ko.computed(function () {
+                var meta = this.meta,
+                    fields = this.fields,
+                    state = this.state;
+
+                if (meta.imageReplace() && meta.imageSrc()) {
+                    return meta.imageSrc();
+                } else if (meta.imageCutoutReplace()) {
+                    return meta.imageCutoutSrc() || state.imageCutoutSrcFromCapi() || fields.thumbnail();
+                } else {
+                    return fields.thumbnail();
+                }
+            }, this);
         }
 
         Article.prototype.copy = function() {


### PR DESCRIPTION
Articles without image cause a 404 for the background image /undefined

Only set the background if there's an image
