### PR TITLE
Additional styling for related content on galleries and liveblogs 

### DIFF
--- a/static/src/stylesheets/module/content/_gallery-lightbox.scss
+++ b/static/src/stylesheets/module/content/_gallery-lightbox.scss
@@ -397,10 +397,8 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
 
     .fc-container__header {
         width: 100%;
-        border-bottom: 1px solid colour(neutral-2);
-        margin-bottom: $gs-baseline * 2;
+        margin-bottom: $gs-baseline;
     }
-
     .fc-container__inner {
         width: auto;
         border-top: 0 !important;

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -238,3 +238,17 @@
         }
     }
 }
+
+//disable hover state for lightbox and related content as they're on dark backgrounds
+.gallery__most-popular,
+.gallery-lightbox--endslate {
+    .tone-media--item {
+        .u-faux-block-link--hover {
+            background-color: colour(media-background) !important;
+
+            .responsive-img {
+                opacity: 1 !important;
+            }
+        }
+    }
+}

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -249,6 +249,10 @@
             .responsive-img {
                 opacity: 1 !important;
             }
+
+            .fc-item__link {
+                text-decoration: underline !important;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -704,8 +704,13 @@ $timeline-width: 15px;
 
     .tone-news--item {
         .fc-item__content {
-            padding-left: 0;
-            padding-right: 0;
+            background-color: darken(colour(neutral-8), 3%);
+        }
+
+        .u-faux-block-link--hover {
+            .fc-item__content {
+                background-color: darken(colour(neutral-8), 8%);
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -609,7 +609,7 @@ $vjs-progress-inset-bottom: 4px;
     right: 0;
     margin: auto;
     @include box-sizing(border-box);
-    background-color: rgba(25, 25, 25, .8);
+    background-color: rgba(25, 25, 25, .9);
     color: colour(neutral-7);
     top: $gs-baseline*4;
     padding-left: $gs-gutter/4;


### PR DESCRIPTION
Fix for:

![screen shot 2014-11-26 at 13 03 42](https://cloud.githubusercontent.com/assets/2236852/5201625/ad16914c-756c-11e4-8367-9cd44be0607c.png)

![screen shot 2014-11-26 at 13 04 05](https://cloud.githubusercontent.com/assets/2236852/5201630/bad7f06e-756c-11e4-8412-eaef5fa937ce.png)

And removing the extra grey line:
![screen shot 2014-11-26 at 13 04 46](https://cloud.githubusercontent.com/assets/2236852/5201640/d5af1232-756c-11e4-996b-fac48a76aa59.png)
