### PR TITLE
Fix link to all pages in pagination

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.pagination
 @import services.IndexPage
 @import model.FrontProperties.empty
-@import common.Edition
+@import common.{Edition, PagePaths}
 @import fragments.containers.facia_cards.container
 
 <div class="l-side-margins">
@@ -30,9 +30,9 @@
             }
         }
 
-        @index.page.pagination.map { paginate =>
+        @index.page.pagination.map { paginationInstance =>
             <div class="fc-container__pagination">
-                @pagination(index.page, paginate)
+                @pagination(index.page.webTitle, paginationInstance, PagePaths.fromId(index.page.id))
             </div>
         }
 

--- a/common/app/common/PagePaths.scala
+++ b/common/app/common/PagePaths.scala
@@ -1,0 +1,32 @@
+package common
+
+import services.ConfigAgent
+
+object PagePaths {
+  def fromId(id: String) = if (ConfigAgent.shouldServeFront(id)) {
+    AllPagePaths(s"/$id")
+  } else {
+    SimplePagePaths(s"/$id")
+  }
+}
+
+trait PagePaths {
+  def pathFor(page: Int): String
+}
+
+case class SimplePagePaths(basePath: String) extends PagePaths {
+  override def pathFor(page: Int): String = if (page <= 1) {
+    basePath
+  } else {
+    s"$basePath?page=$page"
+  }
+}
+
+/** If a front, page 1 should link to the all page, not the front */
+case class AllPagePaths(basePath: String) extends PagePaths {
+  override def pathFor(page: Int): String = if (page <= 1) {
+    s"$basePath/all"
+  } else {
+    s"$basePath?page=$page"
+  }
+}

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -1,20 +1,20 @@
-@(  page: MetaData,
-    pagination: Pagination,
-    actionClass: Option[String] = None,
-    showFull: Boolean = true,
-    ariaContext: Option[String] = None)(implicit request: RequestHeader)
+@(title: String,
+  pagination: Pagination,
+  pagePaths: PagePaths,
+  actionClass: Option[String] = None,
+  showFull: Boolean = true,
+  ariaContext: Option[String] = None)(implicit request: RequestHeader)
 
-@import model._
 @import common._
 @import views.support.Format
 
-@paginated(url: String, pageNum: Int) = {@common.LinkTo(url+(if(pageNum > 1){"?page="+pageNum}else{""}))}
-@paginationPointer(pageNo: Option[Int], dir: String, url: String) = {
+@paginated(pageNum: Int) = {@common.LinkTo(pagePaths.pathFor(pageNum))}
+@paginationPointer(pageNo: Option[Int], dir: String) = {
     @pageNo.map { p =>
         <a class="button button--small button--tertiary pagination__action--static @actionClass"
             data-page="@p"
             rel="@dir"
-            href="@paginated(url, p)"
+            href="@paginated(p)"
             data-link-name="Pagination view @dir"
             aria-label="@ariaContext @dir page">
             @if(dir == "next") {
@@ -30,14 +30,14 @@
     <span class="pagination__text">…</span>
 }
 
-@paginationExtreme(pageNo: Option[Int], dir: String, url: String) = {
+@paginationExtreme(pageNo: Option[Int], dir: String) = {
     @pageNo.map { p =>
         @if(dir == "last") {
             @paginationDivider
         }
 
         <a class="button button--small button--tertiary pagination__action pagination__action--@dir @actionClass"
-        href="@paginated(url, p)"
+        href="@paginated(p)"
         data-page="@p"
         data-link-name="Pagination view page @p"
         aria-label="@ariaContext @dir page">@p</a>
@@ -52,16 +52,16 @@
 @if(pagination.lastPage > 1) {
     @if(showFull) {
     <div class="pagination pagination--full u-cf">
-        <span class="pagination__legend hide-on-mobile-inline">About @Format(pagination.totalContent) results for @Html(page.webTitle)</span>
+        <span class="pagination__legend hide-on-mobile-inline">About @Format(pagination.totalContent) results for @Html(title)</span>
     } else {
     <div class="pagination u-cf">
     }
         <div class="pagination__list">
         @if(pagination.lastPage > 5) {
-            @paginationPointer(pagination.previous, "prev", page.url)
+            @paginationPointer(pagination.previous, "prev")
 
             @if(pagination.currentPage - 2 > 1) {
-                @paginationExtreme(pagination.previous.map(_ => 1), "first", page.url)
+                @paginationExtreme(pagination.previous.map(_ => 1), "first")
             }
         }
 
@@ -72,7 +72,7 @@
             } else {
                 <a class="button button--small button--tertiary pagination__action @actionClass"
                 data-page="@pageNum"
-                href="@paginated(page.url, pageNum)"
+                href="@paginated(pageNum)"
                 data-link-name="Pagination view page @pageNum"
                 aria-label="@ariaContext page @pageNum">@pageNum</a>
             }
@@ -80,10 +80,10 @@
 
         @if(pagination.lastPage > 5) {
             @if(pagination.currentPage + 2 < pagination.lastPage) {
-                @paginationExtreme(Some(pagination.lastPage), "last", page.url)
+                @paginationExtreme(Some(pagination.lastPage), "last")
             }
 
-            @paginationPointer(pagination.next, "next", page.url)
+            @paginationPointer(pagination.next, "next")
         }
         </div>
     </div>

--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -1,4 +1,9 @@
-@(page: CommentPage, blankComment: Comment = null, isTopComments: Boolean = false)(implicit request: RequestHeader)
+@(page: discussion.CommentPage, blankComment: discussion.model.Comment = null, isTopComments: Boolean = false)(implicit request: RequestHeader)
+
+@** TODO: WTF? NULL? SERIOUSLY? ARGH! *@
+
+@import common.SimplePagePaths
+
 <div
     class="d-discussion @if(isTopComments){d-discussion--top-comments} @if(!page.isClosedForRecommendation){d-discussion--recommendations-open} u-cf"
     @page.switches.map{ switch =>
@@ -28,7 +33,7 @@
 
     @if(!isTopComments) {
     <div class="discussion__pagination discussion__pagination--bottom js-discussion-pagination">
-        @page.pagination.map{ paginate => @fragments.pagination(page, paginate, Some("js-discussion-change-page"), false, Some("Comments")) }
+        @page.pagination.map{ paginate => @fragments.pagination(page.webTitle, paginate, SimplePagePaths(page.url), Some("js-discussion-change-page"), false, Some("Comments")) }
     </div>
     @fragments.reportComment()
     }

--- a/discussion/app/views/profileActivity/comments.scala.html
+++ b/discussion/app/views/profileActivity/comments.scala.html
@@ -1,4 +1,7 @@
-@(page: Page, profileComments: discussion.model.ProfileComments)(implicit request: RequestHeader)
+@(page: _root_.model.Page, profileComments: discussion.model.ProfileComments)(implicit request: RequestHeader)
+
+@import common.SimplePagePaths
+@import views.support.Seq2zipWithRowInfo
 
 <div class="activity-stream activity-stream--replies" itemprop itemtype="http://schema.org/UserComments" data-link-name="User activity replies">
     @if(profileComments.comments.isEmpty){
@@ -24,7 +27,7 @@
             }
         </div>
         <div class="activity-stream__pagination u-cf">
-            @fragments.pagination(page, profileComments.pagination, Some("js-activity-stream-page-change"), false, Some("Comments"))
+            @fragments.pagination(page.webTitle, profileComments.pagination, SimplePagePaths(page.url), Some("js-activity-stream-page-change"), false, Some("Comments"))
         </div>
     }
 </div>

--- a/discussion/app/views/profileActivity/discussions.scala.html
+++ b/discussion/app/views/profileActivity/discussions.scala.html
@@ -1,4 +1,8 @@
-@(page: Page, profileDiscussions: discussion.model.ProfileDiscussions)(implicit request: RequestHeader)
+@(page: _root_.model.Page, profileDiscussions: discussion.model.ProfileDiscussions)(implicit request: RequestHeader)
+
+@import common.SimplePagePaths
+@import conf.Configuration
+@import views.support.Seq2zipWithRowInfo
 
 <div class="activity-stream activity-stream--discussions" itemprop itemtype="http://schema.org/UserComments" data-link-name="User activity discussions">
     @if(profileDiscussions.discussions.isEmpty){
@@ -29,7 +33,7 @@
             </div>
         }
         <div class="activity-stream__pagination u-cf">
-            @fragments.pagination(page, profileDiscussions.pagination, Some("js-activity-stream-page-change"), false, Some("Comments"))
+            @fragments.pagination(page.webTitle, profileDiscussions.pagination, SimplePagePaths(page.url), Some("js-activity-stream-page-change"), false, Some("Comments"))
         </div>
     }
 </div>


### PR DESCRIPTION
Page 1 links on index pages don't always work properly. (i.e., they sometimes link back to the front rather than the first page of the index page.) This fixes that.
