### PR TITLE
Changes to article tag placement logic

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -474,15 +474,11 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
   lazy val hasVideoAtTop: Boolean = Jsoup.parseBodyFragment(body).body().children().headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")
 
-  lazy val hasSupportingAtBottom: Boolean = {
+  lazy val hasSupporting: Boolean = {
     val supportingClasses = Set("element--showcase", "element--supporting", "element--thumbnail")
-    var wordCount = 0
-    val lastEls = Jsoup.parseBodyFragment(body).select("body > *").reverseIterator.takeWhile{ el =>
-      wordCount += el.text.length
-      wordCount < 2000
-    }
-    val supportingEls = lastEls.find(_.classNames.intersect(supportingClasses).size > 0)
-    supportingEls.isDefined
+    val leftColElements = Jsoup.parseBodyFragment(body).select("body > *").find(_.classNames.intersect(supportingClasses).size > 0)
+
+    leftColElements.isDefined
   }
 
   lazy val lightbox: JsObject = {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -477,7 +477,6 @@ class Article(content: ApiContentWithMeta) extends Content(content) {
   lazy val hasSupporting: Boolean = {
     val supportingClasses = Set("element--showcase", "element--supporting", "element--thumbnail")
     val leftColElements = Jsoup.parseBodyFragment(body).select("body > *").find(_.classNames.intersect(supportingClasses).size > 0)
-
     leftColElements.isDefined
   }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -689,7 +689,7 @@ object ContentLayout {
     def submetaBreakpoint: Option[String] = {
       content match {
         case a: LiveBlog => None
-        case a: Article if !a.hasSupportingAtBottom => Some("leftcol")
+        case a: Article if !a.hasSupporting => Some("leftcol")
         case v: Video if(v.standfirst.getOrElse("").length > 350) => Some("leftcol")
         case a: Audio if(a.body.getOrElse("").length > 800) => Some("leftcol")
         case i: ImageContent if (i.mainPicture.flatMap(_.largestEditorialCrop).exists(crop => crop.height / crop.width.toFloat > 0.5)) => Some("wide")


### PR DESCRIPTION
The current logic attempts to hide tags when there is supporting content near the bottom of an article where it could conflict with the tags. 
Despite this, we still get the odd conflict, such as on this high profile story:

![screen shot 2014-11-26 at 14 34 44](https://cloud.githubusercontent.com/assets/2236852/5202902/e4ac6c82-7579-11e4-902b-a8e5dabf9e9f.png)
After chatting to Matt, we agreed on hiding the tags whenever there is content placed in the left column. This will hopefully solve the last of our clashing woes.

cc @mattosborn 
