### PR TITLE
Updating admin responsive ads page

### DIFF
--- a/admin/app/views/commercial/fluidAds.scala.html
+++ b/admin/app/views/commercial/fluidAds.scala.html
@@ -6,30 +6,41 @@
 
     <h1>Commercial</h1>
 
-    <h3>Fluid 250 ads</h3>
+    <h3>Responsive advertising</h3>
     
-    <p>These are links to the "fluid 250" ads that we have created so far. All are served from DFP and are hidden behind cookies.</p>
+    <p>These are links to the responsive ads that we have created so far. All are served from DFP and are hidden behind cookies.</p>
+    <p><a href="http://www.theguardian.com?adtest=clear&view=mobile">Click here to clear the cookie.</a></p>
     
     <ul class="list-group">
         <li class="list-group-item">
-            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng101&view=mobile">Live Better</a></h4>
+            <h4><a href="http://www.theguardian.com/technology?adtest=ng101&view=mobile">Live Better</a></h4>
             <small>Fluid250</small>
+            <p><a href="https://www.google.com/dfp/59666047#delivery/PreviewCreative/orderId=191567367&lineItemId=71342607&creativeId=44634448407">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng102&view=mobile">Nissan</a></h4>
+            <h4><a href="http://www.theguardian.com/technology?adtest=ng102&view=mobile">Nissan</a></h4>
             <small>Fluid250 with basic animation</small>
+            <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=191567367&lineItemId=73829127">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng103&view=mobile">Own the Weekend</a></h4>
+            <h4><a href="http://www.theguardian.com/technology?adtest=ng103&view=mobile">Own the Weekend</a></h4>
             <small>Fluid250 with animation</small>
+            <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=191567367&lineItemId=74480367">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng104&view=mobile">ITV - Grantchester</a></h4>
+            <h4><a href="http://www.theguardian.com/technology?adtest=ng104&view=mobile">ITV - Grantchester</a></h4>
             <small>Fluid250, Expandable, scrollable MPU</small>
+            <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=206037807&lineItemId=76437927">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://m.code.dev-theguardian.com/technology?test=ng105&view=mobile">Google Android</a></h4>
+            <h4><a href="http://www.theguardian.com/technology?adtest=ng105&view=mobile">Google Android</a></h4>
             <small>Fluid250, Expandable, scrollable MPU + all on mobile</small>
+            <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=208612407&lineItemId=77324247">DFP Line item</a></p>
+        </li>
+        <li class="list-group-item">
+            <h4><a href="http://www.theguardian.com/technology?adtest=ng107&view=mobile">Hyundai</a></h4>
+            <small>Fluid250, Expandable, scrollable MPU + all on mobile</small>
+            <p><a href="https://www.google.com/dfp/59666047#delivery/OrderDetail/orderId=210091887">DFP Line item</a></p>
         </li>
     </ul>
 }


### PR DESCRIPTION
This updates the responsive ads list:
- Adds Hyundai campaign for Australia launch
- Updates links for new cookie setting technique
- Add links to DFP line items for each campaign

Before;
![screen shot 2014-11-26 at 14 48 28](https://cloud.githubusercontent.com/assets/1303616/5203073/572f1d26-757b-11e4-90f2-c4b1ba8dad15.png)

After;
![screen shot 2014-11-26 at 14 48 32](https://cloud.githubusercontent.com/assets/1303616/5203082/625b49ae-757b-11e4-9d09-8c235484e1aa.png)
