### PR TITLE
Fix cutouts inside item--third

### DIFF
--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--third.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--third.scss
@@ -36,8 +36,8 @@ x x x x x x x x
 
         &[class*="fc-item--has-sublinks"] {
             .fc-item__container {
-                @include mq(tablet, desktop) {
-                    padding-bottom: gs-height(5);
+                @include mq(desktop) {
+                    padding-bottom: 0;
                 }
             }
         }
@@ -50,7 +50,11 @@ x x x x x x x x
     }
 
     .fc-item__avatar {
-        height: gs-height(5);
+        height: gs-height(3) + $gs-baseline * 2;
+
+        @include mq(desktop) {
+            height: gs-height(4);
+        }
     }
 
     .fc-item__avatar__media {


### PR DESCRIPTION
The cutouts on `item--third`s weren't playing so nicely. This sorts them out across the breakpoints.

Before:
![screen shot 2014-11-26 at 15 09 27](https://cloud.githubusercontent.com/assets/1607666/5203475/e03cddf8-757e-11e4-9741-1beaf950fe69.png)

After:
![screen shot 2014-11-26 at 15 09 12](https://cloud.githubusercontent.com/assets/1607666/5203478/e3a70cb6-757e-11e4-91e0-7771f14e1717.png)
