### PR TITLE
Clone articles inside a collection

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -35,7 +35,10 @@
                 <div class="droppable" data-bind="
                     makeDropabble: true,
                     click: pasteItem,
-                    css: {underDrag: underDrag},
+                    css: {
+                        underDrag: underDrag() && !underControlDrag(),
+                        underControlDrag: underDrag() && underControlDrag()
+                    },
                     template: {name: 'template_article', foreach: items}"></div>
             </div>
         </div>
@@ -248,7 +251,10 @@
         <div class="droppable" data-bind="
             makeDropabble: true,
             click: pasteItem,
-            css: {underDrag: underDrag},
+            css: {
+                underDrag: underDrag() && !underControlDrag(),
+                underControlDrag: underDrag() && underControlDrag()
+            },
             template: {name: 'template_article', foreach: items}"></div>
     </script>
 
@@ -272,7 +278,8 @@
             clickBubble: false,
             css: {
                 open: state.isOpen,
-                underDrag: state.underDrag,
+                underDrag: state.underDrag() && !state.underControlDrag(),
+                underControlDrag: state.underDrag() && state.underControlDrag(),
                 imageHidden: meta.imageHide
             }">
 
@@ -298,10 +305,13 @@
                         <div class="droppable" data-bind="
                             makeDropabble: true,
                             click: pasteItem,
-                            css: {underDrag: underDrag},
+                            css: {
+                                underDrag: underDrag() && !underControlDrag(),
+                                underControlDrag: underDrag() && underControlDrag()
+                            },
                             template: {name: 'template_article', foreach: items}"></div>
                     </div>
-                    <span class="supporting-message">Drop content above</span>
+                    <span class="supporting-message">Drop content above, hold Ctrl key to replace item</span>
                 </div>
 
                 <div class="tools">

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -184,6 +184,10 @@ h1 {
     background-color: #999999;
 }
 
+.open .droppable.underControlDrag {
+    background-color: #cdbbfb;
+}
+
 .pending {
     pointer-events: none;
 }

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -274,6 +274,7 @@ define([
             this.state = asObservableProps([
                 'enableContentOverrides',
                 'underDrag',
+                'underControlDrag',
                 'isOpen',
                 'isLoaded',
                 'isEmpty',
@@ -753,7 +754,11 @@ define([
             return false;
         };
 
-        Article.prototype.drop = function (source, targetGroup) {
+        Article.prototype.drop = function (source, targetGroup, alternateAction) {
+            if (alternateAction) {
+                // the drop target for replacing the article ID is the inner group
+                return;
+            }
             mediator.emit('collection:updates', {
                 sourceItem: source.sourceItem,
                 sourceGroup: source.sourceGroup,

--- a/facia-tool/public/js/models/collections/new-items.js
+++ b/facia-tool/public/js/models/collections/new-items.js
@@ -153,11 +153,15 @@ define([
     }
 
     function mergeItems(newItem, oldItem) {
-        var interesting = ['customKicker', 'isBoosted', 'showBoostedHeadline', 'showKickerCustom'];
-        interesting.forEach(function (field) {
-            newItem.meta[field](oldItem.meta[field]());
-        });
-        newItem.meta.supporting = oldItem.meta.supporting;
+        _.chain(oldItem.meta)
+            .keys()
+            .each(function (key) {
+                if (_.isFunction(oldItem.meta[key])) {
+                    newItem.meta[key](oldItem.meta[key]());
+                } else {
+                    newItem.meta[key] = oldItem.meta[key];
+                }
+            });
         newItem.group = oldItem.group;
 
         var sourceGroup = oldItem.group;

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -56,6 +56,7 @@ define([
             'isOpen',
             'isOpenTypePicker',
             'underDrag',
+            'underControlDrag',
             'apiQueryStatus']);
 
         this.state.withinPriority = ko.computed(function() {

--- a/facia-tool/public/js/models/group.js
+++ b/facia-tool/public/js/models/group.js
@@ -17,6 +17,7 @@ define([
 
         this.items = ko.isObservable(opts.items) && opts.items.push ? opts.items : ko.observableArray(opts.items);
         this.underDrag  = ko.observable();
+        this.underControlDrag  = ko.observable();
         this.index      = opts.index || 0;
         this.name       = opts.name || '';
         this.parent     = opts.parent;
@@ -46,26 +47,30 @@ define([
         };
     }
 
-    Group.prototype.setAsTarget = function(targetItem) {
+    Group.prototype.setAsTarget = function(targetItem, alternateAction) {
         this.underDrag(targetItem.constructor === Group);
+        this.underControlDrag(alternateAction);
         _.each(this.items(), function(item) {
             var underDrag = (item === targetItem);
             if (underDrag !== item.state.underDrag()) {
                 item.state.underDrag(underDrag);
             }
+            item.state.underControlDrag(alternateAction);
         });
     };
 
     Group.prototype.unsetAsTarget = function() {
         this.underDrag(false);
+        this.underControlDrag(false);
         _.each(this.items(), function(item) {
             if (item.state.underDrag()) {
                 item.state.underDrag(false);
             }
+            item.state.underControlDrag(false);
         });
     };
 
-    Group.prototype.drop = function(source, targetGroup) {
+    Group.prototype.drop = function(source, targetGroup, alternateAction) {
         var isAfter = false, groups;
         // assume it's to be appended *after* the other items in this group,
         var targetItem = _.last(targetGroup.items());
@@ -89,7 +94,8 @@ define([
             targetItem: targetItem,
             targetGroup: targetGroup,
             isAfter: isAfter,
-            mediaItem: source.mediaItem
+            mediaItem: source.mediaItem,
+            alternateAction: alternateAction
         });
     };
 

--- a/facia-tool/public/js/modules/droppable.js
+++ b/facia-tool/public/js/modules/droppable.js
@@ -25,7 +25,7 @@ define([
             event.preventDefault();
             event.stopPropagation();
 
-            targetGroup.setAsTarget(targetItem);
+            targetGroup.setAsTarget(targetItem, !!event.ctrlKey);
         },
         dragleave: function (element, event) {
             var targetGroup = ko.dataFor(element);
@@ -57,7 +57,7 @@ define([
             copiedArticle.flush();
 
             targetGroup.unsetAsTarget();
-            targetItem.drop(source, targetGroup);
+            targetItem.drop(source, targetGroup, !!event.ctrlKey);
         }
     };
 

--- a/facia-tool/public/js/modules/list-manager.js
+++ b/facia-tool/public/js/modules/list-manager.js
@@ -70,10 +70,34 @@ define([
         });
     }
 
+    function alternateAction (opts) {
+        if (opts.targetGroup.parentType === 'Article') {
+            var id = urlAbsPath(opts.sourceItem.id);
+
+            if (id.indexOf('internal-code/content/') !== 0) {
+                return;
+            }
+
+            var newItems = opts.newItemsConstructor(urlAbsPath(id), null, opts.targetGroup);
+
+            if (!newItems[0]) {
+                alertBadContent();
+                return;
+            }
+
+            opts.mergeItems(newItems[0], opts.targetGroup.parent);
+        }
+    }
+
     return {
         init: _.once(function(newItems) {
             mediator.on('collection:updates', function(opts) {
-                listManager(_.extend(opts, newItems));
+                var options = _.extend(opts, newItems);
+                if (opts.alternateAction) {
+                    alternateAction(options);
+                } else {
+                    listManager(options);
+                }
             });
         })
     };

--- a/facia-tool/public/js/modules/list-manager.js
+++ b/facia-tool/public/js/modules/list-manager.js
@@ -1,9 +1,11 @@
 /* global _: true */
 define([
+    'modules/vars',
     'utils/mediator',
     'utils/url-abs-path',
     'utils/remove-by-id'
 ], function(
+    vars,
     mediator,
     urlAbsPath,
     removeById
@@ -74,7 +76,7 @@ define([
         if (opts.targetGroup.parentType === 'Article') {
             var id = urlAbsPath(opts.sourceItem.id);
 
-            if (id.indexOf('internal-code/content/') !== 0) {
+            if (id.indexOf(vars.CONST.internalContentPrefix) !== 0) {
                 return;
             }
 

--- a/facia-tool/public/js/modules/vars.js
+++ b/facia-tool/public/js/modules/vars.js
@@ -79,7 +79,9 @@ define([
             showHours: 1,
             width: 100,
             height: 35
-        }
+        },
+
+        internalContentPrefix: 'internal-code/content/'
     };
 
     function sparksBaseUrl(args) {

--- a/facia-tool/public/js/utils/internal-content-code.js
+++ b/facia-tool/public/js/utils/internal-content-code.js
@@ -1,7 +1,7 @@
-define(function() {
+define(['modules/vars'], function(vars) {
     return function(content){
         if (content && content.fields && content.fields.internalContentCode) {
-            return 'internal-code/content/' + content.fields.internalContentCode;
+            return vars.CONST.internalContentPrefix + content.fields.internalContentCode;
         }
     };
 });


### PR DESCRIPTION
Holding Ctrl key when dropping an article above another one will replace the old one with the dropped article.
The new article inherits some custom metadata, including the sublinks.

This is a way to replace the id of an article
