### PR TITLE
Don't share all the gallery images on facebook.

### DIFF
--- a/applications/test/GalleryTemplateTest.scala
+++ b/applications/test/GalleryTemplateTest.scala
@@ -42,6 +42,11 @@ import scala.collection.JavaConversions._
     $("meta[name='twitter:image3:src']").getAttributes("content").head should endWith ("/Bassoons-in-the-Symphony--003.jpg")
   }
 
+  it should "have only ONE opengraph image in a gallery" in goTo("/lifeandstyle/gallery/2014/nov/24/flying-dogs-in-pictures") { browser =>
+    import browser._
+    $("meta[property='og:image']").size() should be(1)
+  }
+
   it should "select the trail picture for the opengraph image when FacebookShareUseTrailPicFirstSwitch is ON" in {
     FacebookShareUseTrailPicFirstSwitch.switchOn()
     goTo("/lifeandstyle/gallery/2014/nov/24/flying-dogs-in-pictures") { browser =>

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -508,6 +508,14 @@ import collection.JavaConversions._
         Then("I should pass Facebook a tracking token")
         browser.findFirst(".social__item[data-link-name=facebook] .social__action").getAttribute("href") should include(fbShareTrackingToken)
       }
+
+      Given("I am going to share an article on Facebook")
+      goTo("/film/2012/nov/11/margin-call-cosmopolis-friends-with-kids-dvd-review") { browser =>
+        import browser._
+        Then("there should only be ONE opengraph image in the metadata")
+        $("meta[property='og:image']").size() should be(1)
+      }
+
     }
 
     // http://www.w3.org/WAI/intro/aria

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -674,8 +674,6 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
       .getOrElse(conf.Configuration.facebook.imageFallback)
   }
 
-  override def openGraphImages: Seq[String] = largestCrops.flatMap(_.url)
-
   override def schemaType = Some("http://schema.org/ImageGallery")
 
   // if you change these rules make sure you update IMAGES.md (in this project)

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -65,8 +65,6 @@ trait MetaData extends Tags {
     "og:url"       -> s"${Configuration.site.host}$url"
   )
 
-  def openGraphImages: Seq[String] = Seq()
-
   def cards: List[(String, String)] = List(
     "twitter:site" -> "@guardian",
     "twitter:app:name:iphone" -> "The Guardian",

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -90,10 +90,6 @@
     <meta name="@key" content="@value" />
 }
 
-@item.openGraphImages.map{ case (imageUrl) =>
-    <meta property="og:image" content="@{imageUrl}" />
-}
-
 @item.pagination.map{ pagination =>
     @pagination.next.map{ next => <link rel="next" href="@LinkTo(item.url+"?page="+next)" /> }
     @pagination.previous.map{ prev => <link rel="prev" href="@LinkTo(item.url+(if(prev != 1){"?page="+prev}else{""}))" /> }


### PR DESCRIPTION
Facebook does a lousy job of selecting the best default image to share when several are available. And we want people to visit our site to see all the lovely gallery pictures, not to stick around in Facebook and have the same benefit.

This PR removes the og:image metadata for all but the trail picture, which we definitely _do_ want to share on the 'book. This change only affects galleries, but I've added a test for a regular article too. 

(Requested by @crifmulholland)
