### PR TITLE
Remove complaints and corrections from footer for Aus

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -56,56 +56,80 @@
 
     <div class="l-footer__secondary gs-container" role="contentinfo">
         <ul class="colophon u-cf">
-        @if(Edition(request) == Uk) {
-            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">membership</a></li>
-            <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">jobs</a></li>
-            <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">soulmates</a></li>
-            <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES">masterclasses</a></li>
-            <li class="colophon__item"><a data-link-name="uk : footer : subscribe" target="_blank" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">subscribe</a></li>
-        }
+        @defining(Edition(request)) { currentEdition =>
+            @if(currentEdition == Uk) {
+                <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
+                    membership</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
+                    jobs</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
+                    soulmates</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES">
+                    masterclasses</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : subscribe" target="_blank" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
+                    subscribe</a></li>
+            }
 
-        @if(Edition(request) == Us) {
-            <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">jobs</a></li>
-            <li class="colophon__item"><a data-link-name="us : footer : subscribe" target="_blank" href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA15&INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE&CMP=dis_2311">subscribe</a></li>
-        }
+            @if(currentEdition == Us) {
+                <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
+                    jobs</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : subscribe" target="_blank" href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA15&INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE&CMP=dis_2311">
+                    subscribe</a></li>
+            }
 
-        @if(Edition(request) == Au) {
-            <li class="colophon__item"><a data-link-name="au : footer : advertising" href="/advertising/guardian-australia-advertising">advertising</a></li>
-            <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="/guardian-masterclasses/guardian-masterclasses-australia">masterclasses</a></li>
-            <li class="colophon__item"><a data-link-name="au : footer : subscribe" target="_blank" href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA15&INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE&CMP=dis_2311">subscribe</a></li>
-        }
-            <li class="colophon__item"><a data-link-name="all topics" href="/index/subjects/a">all topics</a></li>
-            <li class="colophon__item"><a data-link-name="all contributors" href="/index/contributors">all contributors</a></li>
+            @if(currentEdition == Au) {
+                <li class="colophon__item"><a data-link-name="au : footer : advertising" href="/advertising/guardian-australia-advertising">
+                    advertising</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="/guardian-masterclasses/guardian-masterclasses-australia">
+                    masterclasses</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : subscribe" target="_blank" href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA15&INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE&CMP=dis_2311">
+                    subscribe</a></li>
+            }
+        <li class="colophon__item"><a data-link-name="all topics" href="/index/subjects/a">all topics</a></li>
+        <li class="colophon__item"><a data-link-name="all contributors" href="/index/contributors">all contributors</a></li>
 
-        @if(Edition(request) == Uk) {
-            <li class="colophon__item"><a data-link-name="uk : footer : info and resources" target="_blank" href="/info">info and resources</a></li>
-            <li class="colophon__item"><a data-link-name="uk : footer : contact us" target="_blank" href="/help/contact-us">contact us</a></li>
-            <li class="colophon__item"><a data-link-name="uk : footer : feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-uk-edition-feedback">feedback</a></li>
-        }
+            @if(currentEdition == Uk) {
+                <li class="colophon__item"><a data-link-name="uk : footer : info and resources" target="_blank" href="/info">
+                    info and resources</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : contact us" target="_blank" href="/help/contact-us">
+                    contact us</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-uk-edition-feedback">
+                    feedback</a></li>
+            }
 
-        @if(Edition(request) == Us) {
-            <li class="colophon__item"><a data-link-name="us : footer : info and resources" target="_blank" href="/info/about-guardian-us">info and resources</a></li>
-            <li class="colophon__item"><a data-link-name="us : footer : contact us" target="_blank" href="/info/about-guardian-us/contact">contact us</a></li>
-            <li class="colophon__item"><a data-link-name="us : footer : feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-us-edition-feedback">feedback</a></li>
-        }
-        @if(Edition(request) == Au) {
-            <li class="colophon__item"><a data-link-name="au : footer : about us" href="/info/about-guardian-australia">about us</a></li>
-            <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="/info/2014/aug/11/guardian-australia-vacancies">vacancies</a></li>
-            <li class="colophon__item"><a data-link-name="au : footer : info and resources" target="_blank" href="/info">info and resources</a></li>
-            <li class="colophon__item"><a data-link-name="au : footer : contact us" target="_blank" href="/info/2013/may/26/contact-guardian-australia">contact us</a></li>
-            <li class="colophon__item"><a data-link-name="au : footer : feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-au-edition-feedback">feedback</a></li>
-        }
-        @if(Edition(request) != Au) {
-            <li class="colophon__item"><a data-link-name="complaints" href="/info/complaints-and-corrections">complaints &amp; corrections</a></li>
-        }
+            @if(currentEdition == Us) {
+                <li class="colophon__item"><a data-link-name="us : footer : info and resources" target="_blank" href="/info/about-guardian-us">
+                    info and resources</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : contact us" target="_blank" href="/info/about-guardian-us/contact">
+                    contact us</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-us-edition-feedback">
+                    feedback</a></li>
+            }
+            @if(currentEdition == Au) {
+                <li class="colophon__item"><a data-link-name="au : footer : about us" href="/info/about-guardian-australia">
+                    about us</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="/info/2014/aug/11/guardian-australia-vacancies">
+                    vacancies</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : info and resources" target="_blank" href="/info">
+                    info and resources</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : contact us" target="_blank" href="/info/2013/may/26/contact-guardian-australia">
+                    contact us</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-au-edition-feedback">
+                    feedback</a></li>
+            }
+            @if(currentEdition != Au) {
+                <li class="colophon__item"><a data-link-name="complaints" href="/info/complaints-and-corrections">
+                    complaints &amp; corrections</a></li>
+            }
             <li class="colophon__item"><a data-link-name="terms" href="/help/terms-of-service">terms &amp; conditions</a></li>
             <li class="colophon__item"><a data-link-name="privacy" href="/help/privacy-policy">privacy policy</a></li>
             <li class="colophon__item"><a data-link-name="cookie" href="/info/cookies">cookie policy</a></li>
             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">securedrop</a></li>
 
-        @if(HasClassicVersion(page)) {
-            <li class="colophon__item hide-on-mobile">@fragments.mainSiteLink(page, label = "use current version")</li>
-            <li class="colophon__item mobile-only">@fragments.mainSiteLink(page, label = "desktop site")</li>
+            @if(HasClassicVersion(page)) {
+                <li class="colophon__item hide-on-mobile">@fragments.mainSiteLink(page, label = "use current version")</li>
+                <li class="colophon__item mobile-only">@fragments.mainSiteLink(page, label = "desktop site")</li>
+            }
         }
         </ul>
         <div class="l-footer__misc">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -95,7 +95,9 @@
             <li class="colophon__item"><a data-link-name="au : footer : contact us" target="_blank" href="/info/2013/may/26/contact-guardian-australia">contact us</a></li>
             <li class="colophon__item"><a data-link-name="au : footer : feedback" target="_blank" href="https://www.surveymonkey.com/s/theguardian-au-edition-feedback">feedback</a></li>
         }
+        @if(Edition(request) != Au) {
             <li class="colophon__item"><a data-link-name="complaints" href="/info/complaints-and-corrections">complaints &amp; corrections</a></li>
+        }
             <li class="colophon__item"><a data-link-name="terms" href="/help/terms-of-service">terms &amp; conditions</a></li>
             <li class="colophon__item"><a data-link-name="privacy" href="/help/privacy-policy">privacy policy</a></li>
             <li class="colophon__item"><a data-link-name="cookie" href="/info/cookies">cookie policy</a></li>


### PR DESCRIPTION
The main changes here are

```
@if(currentEdition != Au) {
                <li class="colophon__item"><a data-link-name="complaints" href="/info/complaints-and-corrections">
                    complaints &amp; corrections</a></li>
            }
```

```
@defining(Edition(request)) { currentEdition =>
```

In Aus, complaints and corrections are dealt with differently, so we don't want this in the footer.
