### PR TITLE
Read Commercial Feeds After Switches Have Been Initialized

### DIFF
--- a/commercial/app/model/commercial/FeedReader.scala
+++ b/commercial/app/model/commercial/FeedReader.scala
@@ -18,60 +18,62 @@ object FeedReader extends ExecutionContexts with Logging {
 
   def read[T](request: FeedRequest)(parse: String => T): Future[Option[T]] = {
 
-    def recordLoad(duration: Long) {
-      val feedName = request.feedName.toLowerCase.replaceAll("\\s+", "-")
-      val key = s"$feedName-feed-load-time"
-      CloudWatch.put("Commercial", Map(s"$key" -> duration.toDouble))
-    }
+    def readUrl(url: String): Future[Option[T]] = {
 
-    def parseBody(url: String, body: String): Option[T] = {
-      Try(parse(body)).map(Some(_)).recover {
-        case e: Exception =>
-          log.error(s"Parsing ${request.feedName} feed from $url failed: ${e.getMessage}")
-          None
-      }.get
-    }
+      def recordLoad(duration: Long):Unit= {
+        val feedName = request.feedName.toLowerCase.replaceAll("\\s+", "-")
+        val key = s"$feedName-feed-load-time"
+        CloudWatch.put("Commercial", Map(s"$key" -> duration.toDouble))
+      }
 
-    if (request.switch.isSwitchedOn) {
-      request.url map { url =>
-        val start = System.currentTimeMillis
-        val futureResponse = WS.url(url)
-          .withRequestTimeout(request.timeout.toMillis.toInt)
-          .get()
-
-        futureResponse map { response =>
-          response.status match {
-            case 200 =>
-              recordLoad(System.currentTimeMillis - start)
-
-              val body = request.responseEncoding map {
-                response.underlying[AHCResponse].getResponseBody
-              } getOrElse {
-                response.body
-              }
-
-              parseBody(url, body)
-
-            case other =>
-              recordLoad(-1)
-              log.error(s"Reading ${request.feedName} feed from $url failed: Response status $other: ${response.statusText}")
-              None
-          }
-        } recover {
+      def parseBody(url: String, body: String): Option[T] = {
+        Try(parse(body)).map(Some(_)).recover {
           case e: Exception =>
+            log.error(s"Parsing ${request.feedName} feed from $url failed: ${e.getMessage}")
+            None
+        }.get
+      }
+
+      val start = System.currentTimeMillis
+      val futureResponse = WS.url(url)
+        .withRequestTimeout(request.timeout.toMillis.toInt)
+        .get()
+
+      futureResponse map { response =>
+        response.status match {
+          case 200 =>
+            recordLoad(System.currentTimeMillis - start)
+            val body = request.responseEncoding map {
+              response.underlying[AHCResponse].getResponseBody
+            } getOrElse response.body
+            parseBody(url, body)
+          case other =>
             recordLoad(-1)
-            log.error(s"Reading ${request.feedName} feed from $url failed: ${e.getMessage}")
+            val feedName = request.feedName
+            val statusText = response.statusText
+            log.error(s"Reading $feedName feed from $url failed: $other: $statusText")
             None
         }
+      } recover {
+        case e: Exception =>
+          recordLoad(-1)
+          log.error(s"Reading ${request.feedName} feed from $url failed: ${e.getMessage}")
+          None
+      }
+    }
 
-      } getOrElse {
-        log.warn(s"Missing URL for ${request.feedName} feed")
+     request.switch.onInitialized flatMap { switch =>
+       if (switch.isSwitchedOn) {
+        request.url map readUrl getOrElse {
+          log.warn(s"Missing URL for ${request.feedName} feed")
+          Future.successful(None)
+        }
+      } else {
+        log.warn(s"Reading ${request.feedName} feed failed: Switch is off")
         Future.successful(None)
       }
-    } else {
-      log.warn(s"Reading ${request.feedName} feed failed: Switch is off")
-      Future.successful(None)
     }
+
   }
 
   def readSeq[T](request: FeedRequest)(parse: String => Seq[T]): Future[Seq[T]] = {

--- a/common/app/conf/Initializable.scala
+++ b/common/app/conf/Initializable.scala
@@ -1,0 +1,31 @@
+package conf
+
+import java.util.concurrent.TimeoutException
+
+import common.{ExecutionContexts, Logging}
+import play.api.Play.current
+import play.api.libs.concurrent.Akka
+
+import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
+
+trait Initializable[T] extends ExecutionContexts with Logging {
+
+  private val initialized = Promise[T]()
+
+  protected val initializationTimeout: FiniteDuration = 1.minute
+
+  Akka.system.scheduler.scheduleOnce(initializationTimeout) {
+    initialized.tryFailure {
+      new TimeoutException(s"Initialization timed out after $initializationTimeout")
+    }
+  }
+
+  initialized.future.onFailure {
+    case e: Exception => log.error(s"Initialization failed: ${e.getMessage}")
+  }
+
+  def initialized(t: T): Unit = initialized.trySuccess(t)
+
+  def onInitialized: Future[T] = initialized.future
+}

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -22,7 +22,7 @@ case class Switch( group: String,
 
   val delegate = DefaultSwitch(name, description, initiallyOn = safeState == On)
 
-  protected val initialized = Promise[Switch]()
+  private val initialized = Promise[Switch]()
 
   def isSwitchedOn: Boolean = delegate.isSwitchedOn && new LocalDate().isBefore(sellByDate)
 


### PR DESCRIPTION
This fixes a bug where the soulmates feed was always failing on the first read because it depended on an uninitialized switch.

Before the switchboard is read, switches are in their safe state.  This means that if a switch is on in the switchboard but has a safe state of off, anything expecting it to be on will not work.

This change provides an `onInitialized` event in each switch that allows client code to wait until the switch is in the state determined by the switchboard.
