### PR TITLE
Embeds now have correct padding

### DIFF
--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -101,8 +101,6 @@ figure.element-video {
         padding-top: ($gs-baseline/3)*2;
     }
     @include mq(leftCol) {
-        padding-bottom: $gs-baseline * 2;
-
         figcaption {
             background: #ffffff;
             padding-left: 0;
@@ -124,8 +122,6 @@ figure.element.element--showcase {
 figure.img--extended,
 figure.element-video {
     @include mq(leftCol) {
-        padding-bottom: $gs-baseline * 2;
-
         &.element--thumbnail {
             padding-bottom: 0;
             border-bottom: 0;

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -383,7 +383,7 @@
 
 .fig--narrow-caption {
     figcaption {
-        @include mq(leftCol) {
+        @include mq(tablet) {
             max-width: gs-span(6);
         }
     }

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -143,6 +143,12 @@
     color: colour(neutral-2);
 }
 
+.caption--img {
+    @include mq(leftCol) {
+        padding-bottom: $gs-baseline * 2;
+    }
+}
+
 .caption--main {
     padding: ($gs-baseline/3)*2 $gs-gutter/2 $gs-baseline*2;
 


### PR DESCRIPTION
Quick fix for embeds not getting the correct padding if they have a caption:
e.g.
![screen shot 2014-11-27 at 12 22 41](https://cloud.githubusercontent.com/assets/2236852/5216780/2a93ef16-7630-11e4-916c-6cf8342dadfd.png)
