### PR TITLE
Merchandising cAPI components use JSON instead of a script in the DFP template 

### DIFF
--- a/commercial/app/controllers/commercial/ContentApiOffers.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffers.scala
@@ -50,7 +50,7 @@ object ContentApiOffers extends Controller with ExecutionContexts with implicits
         )
     val optSponsorLabel: Option[String] = optCapiAdFeature flatMap (feature => sponsorTypeToLabel.get(feature))
 
-    val optClickMacro = request.getParameter("clickMacro").get
+    val optClickMacro = request.getParameter("clickMacro")
 
     val optOmnitureId = request.getParameter("omnitureId")
 

--- a/commercial/app/controllers/commercial/ContentApiOffers.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffers.scala
@@ -50,6 +50,10 @@ object ContentApiOffers extends Controller with ExecutionContexts with implicits
         )
     val optSponsorLabel: Option[String] = optCapiAdFeature flatMap (feature => sponsorTypeToLabel.get(feature))
 
+    val optClickMacro = request.getParameter("clickMacro").get
+
+    val optOmnitureId = request.getParameter("omnitureId")
+
     val futureLatestByKeyword = optKeyword.map { keyword =>
       // getting twice as many, as we filter out content without images
       Lookup.latestContentByKeyword(keyword, 8)

--- a/commercial/app/controllers/commercial/ContentApiOffers.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffers.scala
@@ -32,6 +32,10 @@ object ContentApiOffers extends Controller with ExecutionContexts with implicits
 
     val optCapiSupportedBy = request.getParameter("sb")
 
+    val optClickMacro = request.getParameter("clickMacro")
+
+    val optOmnitureId = request.getParameter("omnitureId")
+
     val sponsorTypeToClass = Map (
         "sponsored" -> ("fc-container--sponsored"),
         "advertisement-feature" -> ("fc-container--advertisement-feature"),
@@ -60,7 +64,7 @@ object ContentApiOffers extends Controller with ExecutionContexts with implicits
       case Nil => NoCache(format.nilResult)
       case contents => Cached(componentMaxAge) {
         if (isMulti) {
-          format.result(views.html.contentapi.items(contents, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optCapiAdFeature, optSponsorType, optSponsorLabel))
+          format.result(views.html.contentapi.items(contents, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optClickMacro, optOmnitureId, optCapiAdFeature, optSponsorType, optSponsorLabel))
         } else {
           format.result(views.html.contentapi.item(contents.head, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optCapiButtonText, optCapiReadMoreUrl, optCapiReadMoreText, optCapiAdFeature, optCapiSupportedBy))
         }

--- a/commercial/app/controllers/commercial/ContentApiOffers.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffers.scala
@@ -66,7 +66,7 @@ object ContentApiOffers extends Controller with ExecutionContexts with implicits
         if (isMulti) {
           format.result(views.html.contentapi.items(contents, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optClickMacro, optOmnitureId, optCapiAdFeature, optSponsorType, optSponsorLabel))
         } else {
-          format.result(views.html.contentapi.item(contents.head, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optCapiButtonText, optCapiReadMoreUrl, optCapiReadMoreText, optCapiAdFeature, optCapiSupportedBy))
+          format.result(views.html.contentapi.item(contents.head, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optCapiButtonText, optCapiReadMoreUrl, optCapiReadMoreText, optCapiAdFeature, optCapiSupportedBy, optClickMacro, optOmnitureId))
         }
       }
     }

--- a/commercial/app/controllers/commercial/ContentApiOffers.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffers.scala
@@ -32,10 +32,6 @@ object ContentApiOffers extends Controller with ExecutionContexts with implicits
 
     val optCapiSupportedBy = request.getParameter("sb")
 
-    val optClickMacro = request.getParameter("clickMacro")
-
-    val optOmnitureId = request.getParameter("omnitureId")
-
     val sponsorTypeToClass = Map (
         "sponsored" -> ("fc-container--sponsored"),
         "advertisement-feature" -> ("fc-container--advertisement-feature"),

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -1,12 +1,12 @@
-@(item: model.Content, optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optCapiButtonText: Option[String], optCapiReadMoreUrl: Option[String], optCapiReadMoreText: Option[String], optCapiAdFeature: Option[String], optCapiSupportedBy: Option[String])(implicit request: RequestHeader)
+@(item: model.Content, optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optCapiButtonText: Option[String], optCapiReadMoreUrl: Option[String], optCapiReadMoreText: Option[String], optCapiAdFeature: Option[String], optCapiSupportedBy: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String])(implicit request: RequestHeader)
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    <section class="fc-container fc-container--paid-for @for(adFeature <- optCapiAdFeature) {@adFeature} commercial commercial--dfp commercial--dfp-single" data-link-name="merchandising | capi | single">
+    <section class="fc-container fc-container--paid-for @for(adFeature <- optCapiAdFeature) {@adFeature} commercial commercial--dfp commercial--dfp-single" data-link-name="merchandising | capi | single @optOmnitureId">
         <div class="fc-container__inner">
             <div class="fc-container__header">
                 <h3 class="fc-container__header__title">
                     @optCapiLink.map { linkUrl =>
-                        <a href="%OASToken%@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
                     }.getOrElse {
                         <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
                     }
@@ -15,11 +15,11 @@
             <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
                 <div class="ad-slot--paid-for-badge__inner">
                     <h3 class="ad-slot--paid-for-badge__header">@for(broughtBy <- optCapiSupportedBy) {@broughtBy}</h3>
-                    <a href="%OASToken%@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
+                    <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
                         @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
                     </a>
                     @for(aboutLinkUrl <- optCapiAbout) {
-                        <a href="%OASToken%@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
+                        <a href="@optClickMacro@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
                     }
                 </div>
             </div>
@@ -27,7 +27,7 @@
                 <div class="lineitems">
                     <div class="lineitem lineitem--dfp-single">
                         <div class="lineitem--dfp-single__offer">
-                            <a href="%OASToken%@AdLink{@item.webUrl}" data-link-name="merchandising-capi-single-v@{version}_@{date}-@item.webTitle">
+                            <a href="@optClickMacro@AdLink{@item.webUrl}" data-link-name="merchandising-capi-single-v@{version}_@{date}-@item.webTitle">
                                 @item.trailPicture.map { trailPictureContainer =>
                                     @Item300.bestFor(trailPictureContainer).map{ url => <img src="@url" alt="" class="lineitem__image" /> }
                                 }
@@ -36,7 +36,7 @@
                                     <p class="fc-item__standfirst lineitem__desc">@Html(trailText)</p>
                                 }
                                 @for(buttonText <- optCapiButtonText) {
-                                    <a href="%OASToken%@AdLink{@item.webUrl}" class="lineitem__cta button button--tertiary button--small">
+                                    <a href="@optClickMacro@AdLink{@item.webUrl}" class="lineitem__cta button button--tertiary button--small">
                                         @buttonText
                                         <i class="i i-arrow-black-right i-right"></i>
                                     </a>
@@ -45,7 +45,7 @@
                         </div>
                         <div class="lineitem--dfp-single__cta hide-on-mobile">
                             @for(moreButton <- optCapiReadMoreText) {
-                                <a href="%OASToken%@for(moreUrl <- optCapiReadMoreUrl) {@moreUrl}" class="commercial__cta button button--primary button--large" data-link-name="merchandising-single-more">
+                                <a href="@optClickMacro@for(moreUrl <- optCapiReadMoreUrl) {@moreUrl}" class="commercial__cta button button--primary button--large" data-link-name="merchandising-single-more">
                                     @moreButton
                                     <i class="i i-arrow-white-right i-right"></i>
                                 </a>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,7 +1,7 @@
 @(items: Seq[model.Content], optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String], optCapiAdFeature: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String])(implicit request: RequestHeader)
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising fc-container--commercial-capi" data-link-name="merchandising | capi | multiple @optOmnitureId">
+    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising fc-container--commercial-capi @optSponsorType" data-link-name="merchandising | capi | multiple @optOmnitureId">
         <div class="fc-container__inner">
         <div class="container__border"></div>
             <div class="fc-container__header">

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,13 +1,13 @@
-@(items: Seq[model.Content], optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optCapiAdFeature: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String])(implicit request: RequestHeader)
+@(items: Seq[model.Content], optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String], optCapiAdFeature: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String])(implicit request: RequestHeader)
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising  fc-container--commercial-capi @optSponsorType" data-link-name="merchandising | capi | multiple">
+    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising fc-container--commercial-capi" data-link-name="merchandising | capi | multiple @optOmnitureId">
         <div class="fc-container__inner">
         <div class="container__border"></div>
             <div class="fc-container__header">
                 <h2 class="fc-container__header__title">
                     @optCapiLink.map { linkUrl =>
-                        <a href="%OASToken%@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
                     }.getOrElse {
                         <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
                     }
@@ -16,11 +16,11 @@
             <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
                 <div class="ad-slot--paid-for-badge__inner">
                     <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
-                    <a href="%OASToken%@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
+                    <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
                         @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
                     </a>
                     @for(aboutLinkUrl <- optCapiAbout) {
-                        <a href="%OASToken%@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
+                        <a href="@optClickMacro@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
                     }
                 </div>
             </div>
@@ -58,7 +58,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <a href="%OASToken%@AdLink{@item.webUrl}" class="u-faux-block-link__overlay" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle" tabindex="-1">
+                                    <a href="@optClickMacro@AdLink{@item.webUrl}" class="u-faux-block-link__overlay" data-link-name="merchandising-capi-v@{version}_@{date}-@item.webTitle" tabindex="-1">
                                         @item.webTitle
                                     </a>
                                 </div>

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -680,7 +680,6 @@ jQuery(function($) {
                                 "cal": "http://theguardian.com/about",
                                 "t": ["p/43945","p/43945"],
                                 "k": "music/pinkfloyd",
-                                "sb": "Brought to you by:",
                                 "af": "advertisement-feature",
                                 "omnitureId": "omnitureId"
                             }).create();
@@ -699,22 +698,26 @@ jQuery(function($) {
             </div>
             <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi-s"></div>
             <script>
-            require(['core'], function(core) {
-            require(['bootstraps/commercial'], function(core) {
-            require(['common/modules/commercial/loader'], function(CommercialComponent) {
-            new CommercialComponent({
-            oastoken: '%%CLICK_URL_ESC%%',
-            t: ['p/43b2q','p/43945'],
-            l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-            ct: 'Led Zeppelin special',
-            cl: 'http://theguardian.com/music/ledzeppelin',
-            cal: 'http://theguardian.com/about',
-            k: 'music/ledzeppelin',
-            af: 'sponsored'
-            }).init('capi', document.querySelector('[data-name="merchandising-capi-s"]'));
-            });
-            });
-            });
+                require(['core'], function(core) {
+                    require(['bootstraps/commercial'], function(core) {
+                        var $slot = document.querySelector('[data-name="merchandising-capi-s"]');
+                        require(['common/modules/commercial/creatives/commercial-component'])
+                        .then(function (Creative) {
+                            new Creative($slot, {
+                            "type": "capi",
+                            "clickMacro": "%%CLICK_URL_UNESC%%",
+                            "l": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
+                            "ct": "This is title",
+                            "cl": "http%3A%2F%2Ftheguardian.com%2Fmusic%2Fledzeppelin",
+                            "cal": "http://theguardian.com/about",
+                            "t": ["p/43945","p/43945"],
+                            "k": "music/pinkfloyd",
+                            "af": "sponsored",
+                            "omnitureId": "omnitureId"
+                            }).create();
+                        });
+                    });
+                });
             </script>
         </div>
 
@@ -727,23 +730,24 @@ jQuery(function($) {
             <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi-multi"></div>
             <script>
             require(['core'], function(core) {
-            require(['bootstraps/commercial'], function(core) {
-            require(['common/modules/commercial/loader'], function(CommercialComponent) {
-            new CommercialComponent({
-            oastoken: '%%CLICK_URL_ESC%%',
-            capi: ['p/4xv7c','','',''],
-            logo: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-            capiTitle: 'Pink Floyd special',
-            capiLinkUrl: 'http://theguardian.com/music/pinkfloyd',
-            capiAboutLinkUrl: 'http://theguardian.com/about',
-            capiKeywords: 'music/pinkfloyd',
-
-            t: ['p/43akg','p/43945'],
-            k: 'music/pinkfloyd',
-            af: 'foundation-supported'
-            }).init('capi', document.querySelector('[data-name="merchandising-capi-multi"]'));
-            });
-            });
+                require(['bootstraps/commercial'], function(core) {
+                    var $slot = document.querySelector('[data-name="merchandising-capi-multi"]');
+                    require(['common/modules/commercial/creatives/commercial-component'])
+                    .then(function (Creative) {
+                        new Creative($slot, {
+                        "type": "capi",
+                        "clickMacro": "%%CLICK_URL_UNESC%%",
+                        "l": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
+                        "ct": "This is title",
+                        "cl": "http%3A%2F%2Ftheguardian.com%2Fmusic%2Fledzeppelin",
+                        "cal": "http://theguardian.com/about",
+                        "t": ["p/43945","p/43945"],
+                        "k": "music/pinkfloyd",
+                        "af": "foundation-supported",
+                        "omnitureId": "omnitureId"
+                        }).create();
+                    });
+                });
             });
             </script>
         </div>

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -663,85 +663,92 @@ jQuery(function($) {
                 <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207">CMerchandising: cAPI multiple (advertorial) - advertisement option</a>
             </h2>
         </div>
-        <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi"></div>
-        <script>
-        require(['core'], function(core) {
-            require(['bootstraps/commercial'], function(core) {
-                require(['common/modules/commercial/loader'], function(CommercialComponent) {
-                    new CommercialComponent({
-                        oastoken: '%%CLICK_URL_ESC%%',
-                        t: ['p/43b2q','p/43945'],
-                        l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-                        ct: 'Led Zeppelin special',
-                        cl: 'http://theguardian.com/music/ledzeppelin',
-                        cal: 'http://theguardian.com/about',
-                        k: 'music/ledzeppelin',
-                        af: 'advertisement-feature'
-                    }).init('capi', document.querySelector('[data-name="merchandising-capi"]'));
-                });
-            });
-        });
-        </script>
-    </div>
-    
-    <div class="fc-container">
-        <div class="fc-container__inner">
-            <h2 class="test-page-head">
-                <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207">CMerchandising: cAPI multiple (advertorial) - sponsored option</a>
-            </h2>
-        </div>
-        <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi-s"></div>
-        <script>
-        require(['core'], function(core) {
-            require(['bootstraps/commercial'], function(core) {
-                require(['common/modules/commercial/loader'], function(CommercialComponent) {
-                    new CommercialComponent({
-                        oastoken: '%%CLICK_URL_ESC%%',
-                        t: ['p/43b2q','p/43945'],
-                        l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-                        ct: 'Led Zeppelin special',
-                        cl: 'http://theguardian.com/music/ledzeppelin',
-                        cal: 'http://theguardian.com/about',
-                        k: 'music/ledzeppelin',
-                        af: 'sponsored'
-                    }).init('capi', document.querySelector('[data-name="merchandising-capi-s"]'));
-                });
-            });
-        });
-        </script>
-    </div>
-    
-    <div class="fc-container">
-        <div class="fc-container__inner">
-            <h2 class="test-page-head">
-                <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207">CMerchandising: cAPI multiple (advertorial) - supported option</a>
-            </h2>
-        </div>
-        <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi-multi"></div>
-        <script>
-        require(['core'], function(core) {
-            require(['bootstraps/commercial'], function(core) {
-                require(['common/modules/commercial/loader'], function(CommercialComponent) {
-                    new CommercialComponent({
-                        oastoken: '%%CLICK_URL_ESC%%',
-                        capi: ['p/4xv7c','','',''],
-                        logo: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-                        capiTitle: 'Pink Floyd special',
-                        capiLinkUrl: 'http://theguardian.com/music/pinkfloyd',
-                        capiAboutLinkUrl: 'http://theguardian.com/about',
-                        capiKeywords: 'music/pinkfloyd',
 
-                        t: ['p/43akg','p/43945'],
-                        k: 'music/pinkfloyd',
-                        af: 'foundation-supported'
-                    }).init('capi', document.querySelector('[data-name="merchandising-capi-multi"]'));
+        <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi">
+            <script>
+                require(['core'], function(core) {
+                    require(['bootstraps/commercial'], function(core) {
+                        var $slot = document.querySelector('[data-name="merchandising-capi"]');
+                        require(['common/modules/commercial/creatives/commercial-component'])
+                        .then(function (Creative) {
+                            new Creative($slot, {
+                                "type": "capi",
+                                "clickMacro": "%%CLICK_URL_UNESC%%",
+                                "l": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
+                                "ct": "This is title",
+                                "cl": "http%3A%2F%2Ftheguardian.com%2Fmusic%2Fledzeppelin",
+                                "cal": "http://theguardian.com/about",
+                                "t": ["p/43945","p/43945"],
+                                "k": "music/pinkfloyd",
+                                "sb": "Brought to you by:",
+                                "af": "advertisement-feature",
+                                "omnitureId": "omnitureId"
+                            }).create();
+                        });
+                    });
                 });
-            });
-        });
-        </script>
+            </script>
+        </div>
     </div>
 
-    <hr/>
+        <div class="fc-container">
+            <div class="fc-container__inner">
+                <h2 class="test-page-head">
+                    <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207">CMerchandising: cAPI multiple (advertorial) - sponsored option</a>
+                </h2>
+            </div>
+            <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi-s"></div>
+            <script>
+            require(['core'], function(core) {
+            require(['bootstraps/commercial'], function(core) {
+            require(['common/modules/commercial/loader'], function(CommercialComponent) {
+            new CommercialComponent({
+            oastoken: '%%CLICK_URL_ESC%%',
+            t: ['p/43b2q','p/43945'],
+            l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
+            ct: 'Led Zeppelin special',
+            cl: 'http://theguardian.com/music/ledzeppelin',
+            cal: 'http://theguardian.com/about',
+            k: 'music/ledzeppelin',
+            af: 'sponsored'
+            }).init('capi', document.querySelector('[data-name="merchandising-capi-s"]'));
+            });
+            });
+            });
+            </script>
+        </div>
+
+        <div class="fc-container">
+            <div class="fc-container__inner">
+                <h2 class="test-page-head">
+                    <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207">CMerchandising: cAPI multiple (advertorial) - supported option</a>
+                </h2>
+            </div>
+            <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component" data-name="merchandising-capi-multi"></div>
+            <script>
+            require(['core'], function(core) {
+            require(['bootstraps/commercial'], function(core) {
+            require(['common/modules/commercial/loader'], function(CommercialComponent) {
+            new CommercialComponent({
+            oastoken: '%%CLICK_URL_ESC%%',
+            capi: ['p/4xv7c','','',''],
+            logo: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
+            capiTitle: 'Pink Floyd special',
+            capiLinkUrl: 'http://theguardian.com/music/pinkfloyd',
+            capiAboutLinkUrl: 'http://theguardian.com/about',
+            capiKeywords: 'music/pinkfloyd',
+
+            t: ['p/43akg','p/43945'],
+            k: 'music/pinkfloyd',
+            af: 'foundation-supported'
+            }).init('capi', document.querySelector('[data-name="merchandising-capi-multi"]'));
+            });
+            });
+            });
+            </script>
+        </div>
+
+        <hr/>
 
     <div class="fc-container">
         <div class="fc-container__inner">
@@ -753,22 +760,29 @@ jQuery(function($) {
         <script>
         require(['core'], function(core) {
             require(['bootstraps/commercial'], function(core) {
-                require(['common/modules/commercial/loader'], function(CommercialComponent) {
-                    new CommercialComponent({
-                        oastoken: 'CLICK_URL_UNESC',
-                        t: ['p/4xv7c'],
-                        l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-                        ct: 'Led Zeppelin special',
-                        cl: 'http://theguardian.com/music/ledzeppelin',
-                        clt: 'Readmore link text',
-                        cal: 'http://theguardian.com/about',
-                        k: 'music/pinkfloyd',
-                        rmd: 'www.theguardina.com',
-                        rmt: 'See more over here',
-                        sb: 'Brought to you by:',
-                        af: 'fc-container--advertisement-feature'
-                    }).init('capiSingle', document.querySelector('[data-name="merchandising-capi-single"]'));
-                });
+                var $slot = document.querySelector('[data-name="merchandising-capi-single"]');
+                require(['common/modules/commercial/creatives/commercial-component'])
+                    .then(function (Creative) {
+                        new Creative($slot, {
+                            "type": "capiSingle",
+                            "clickMacro": "%%CLICK_URL_UNESC%%",
+                            "l": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
+                            "ct": "This is title",
+                            "cl": "http%3A%2F%2Ftheguardian.com%2Fmusic%2Fledzeppelin",
+                            "clt": "Read more link text",
+                            "cal": "http://theguardian.com/about",
+                            "t": [
+                            "p/43945",
+                            "p/43945"
+                            ],
+                            "k": "music/pinkfloyd",
+                            "rmd": "www.theguardina.com",
+                            "rmt": "Seemoreoverhere",
+                            "sb": "Brought to you by:",
+                            "af": "fc-container--advertisement-feature",
+                            "omnitureId": "omnitureId"
+                        }).create();
+                    });
             });
         });
         </script>
@@ -956,21 +970,28 @@ jQuery(function($) {
         <script>
         require(['core'], function(core) {
             require(['bootstraps/commercial'], function(core) {
-                require(['common/modules/commercial/loader'], function(CommercialComponent) {
-                    new CommercialComponent({
-                        oastoken: '%%CLICK_URL_ESC%%',
-                        t: ['p/43akg'],
-                        l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-                        ct: 'Led Zeppelin special',
-                        cl: 'http://theguardian.com/music/ledzeppelin',
-                        clt: 'Readmore link text',
-                        cal: 'http://theguardian.com/about',
-                        k: 'music/pinkfloyd',
-                        rmd: 'www.theguardina.com',
-                        rmt: 'See more over here',
-                        sb: 'Sponsored by:',
-                        af: 'fc-container--merchandising-feature'
-                    }).init('capiSingleMerch', document.querySelector('[data-name="merchandising-capi-single-merch"]'));
+                var $slot = document.querySelector('[data-name="merchandising-capi-single-merch"]');
+                require(['common/modules/commercial/creatives/commercial-component'])
+                    .then(function (Creative) {
+                        new Creative($slot, {
+                        "type": "capiSingleMerch",
+                        "clickMacro": "%%CLICK_URL_UNESC%%",
+                        "l": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
+                        "ct": "This is title",
+                        "cl": "http%3A%2F%2Ftheguardian.com%2Fmusic%2Fledzeppelin",
+                        "clt": "Readmorelinktext",
+                        "cal": "http://theguardian.com/about",
+                        "t": [
+                        "p/43945",
+                        "p/43945"
+                        ],
+                        "k": "music/pinkfloyd",
+                        "rmd": "www.theguardina.com",
+                        "rmt": "See more over here",
+                        "sb": "Sponsored by:",
+                        "af": "fc-container--merchandising-feature",
+                        "omnitureId": "omnitureId"
+                    }).create();
                 });
             });
         });

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -18,6 +18,7 @@ define([
 
     // modules for creatives - need to be included so they're available, as they're required dynamically
     'common/modules/commercial/creatives/branded-component',
+    'common/modules/commercial/creatives/commercial-component',
     'common/modules/commercial/creatives/expandable',
     'common/modules/commercial/creatives/scrollable-mpu',
     'common/modules/commercial/creatives/template'

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -79,24 +79,13 @@ define([
          *
          * @constructor
          * @extends Component
-         * @param {Object=} options
+         * @param {Object=} params
          */
-        Loader = function (options) {
-            var opts = defaults(options || {}, {
-                    capi:             [],
-                    capiAboutLinkUrl: '',
-                    capiKeywords:     '',
-                    capiLinkUrl:      '',
-                    capiTitle:        '',
-                    components:       [],
-                    jobIds:           '',
-                    logo:             '',
-                    oastoken:         ''
-                }),
-                section = config.page.section,
-                jobs    = opts.jobIds ? opts.jobIds.split(',') : [];
+        Loader = function ($adSlot, params) {
+            var section = config.page.section,
+                jobs    = params.jobIds ? params.jobIds.split(',') : [];
 
-            this.oastoken   = opts.oastoken;
+            this.$adSlot = $adSlot;
             this.components = {
                 bestbuy:           buildComponentUrl('money/bestbuys'),
                 bestbuyHigh:       buildComponentUrl('money/bestbuys-high'),
@@ -112,22 +101,23 @@ define([
                 soulmatesHigh:     buildComponentUrl('soulmates/mixed-high'),
                 travel:            buildComponentUrl('travel/offers', { s: section }),
                 travelHigh:        buildComponentUrl('travel/offers-high', { s: section }),
-                multi:             buildComponentUrl('multi', { c: opts.components }),
-                capiSingle:        buildComponentUrl('capi-single', defaults(options, { s: section })),
-                capiSingleMerch:   buildComponentUrl('capi-single-merch', defaults(options, { s: section })),
-                capi:              buildComponentUrl('capi', defaults(options, {
-                    s:   section,
-                    t:   opts.capi,
-                    k:   opts.capiKeywords.split(','),
-                    l:   opts.logo,
-                    ct:  opts.capiTitle,
-                    cl:  opts.capiLinkUrl,
-                    cal: opts.capiAboutLinkUrl
-                }))
+                multi:             buildComponentUrl('multi', { c: params.components }),
+                capiSingle:        buildComponentUrl('capi-single', defaults(params, { s: section })),
+                capiSingleMerch:   buildComponentUrl('capi-single-merch', defaults(params, { s: section })),
+                capi:              buildComponentUrl('capi', defaults(params, { s: section }))
+                //
+                //    s:   section,
+                //    t:   opts.capi,
+                //    k:   opts.capiKeywords.split(','),
+                //    l:   opts.logo,
+                //    ct:  opts.capiTitle,
+                //    cl:  opts.capiLinkUrl,
+                //    cal: opts.capiAboutLinkUrl,
+                //    omnitureId: opts.omnitureId,
+                //    clockMacro: opts.clickMacro
+                //})
             };
         };
-
-    Component.define(Loader);
 
     Loader.prototype.postLoadEvents = {
         bestbuy: function (el) {
@@ -138,15 +128,10 @@ define([
     /**
      * @param {Element} target
      */
-    Loader.prototype.load = function (name, target) {
+    Loader.prototype.load = function () {
         new LazyLoad({
             url: this.components[name],
-            container: target,
-            beforeInsert: function (html) {
-                // Currently we are replacing the OmnitureToken with nothing. This will change once
-                // commercial components have properly been setup in the lovely mess that is Omniture!
-                return html ? html.replace(/%OASToken%/g, this.oastoken).replace(/%OmnitureToken%/g, '') : html;
-            }.bind(this),
+            container: this.$adSlot,
             success: function () {
                 this.postLoadEvents[name] && this.postLoadEvents[name](target);
 
@@ -161,14 +146,14 @@ define([
      * @param {String}  name
      * @param {Element} el
      */
-    Loader.prototype.init = function (name, el) {
+    Loader.prototype.create = function () {
 
         if (this.components[name] === undefined) {
             raven.captureMessage('Unknown commercial component: ' + name);
             return false;
         }
 
-        return this.load(name, el);
+        return this.load();
     };
 
     return Loader;

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -119,12 +119,11 @@ define([
      * @param {Element} target
      */
     CommercialComponent.prototype.load = function () {
-        console.log('CommercialComponent.prototype.load');
         new LazyLoad({
             url: this.components[this.params.type],
             container: this.$adSlot,
             success: function () {
-                this.postLoadEvents[this.params.type] && this.postLoadEvents[this.params.type](target);
+                this.postLoadEvents[this.params.type] && this.postLoadEvents[this.params.type](this.$adSlot);
 
                 mediator.emit('modules:commercial:creatives:commercial-component:loaded');
             }.bind(this)
@@ -138,8 +137,6 @@ define([
      * @param {Element} el
      */
     CommercialComponent.prototype.create = function () {
-
-        console.log('CommercialComponent.prototype.create');
         if (this.components[this.params.type] === undefined) {
             raven.captureMessage('Unknown commercial component: ' + name);
             return false;

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -68,17 +68,11 @@ define([
         /**
          * Loads commercial components.
          *
-         * BEWARE that this code is depended upon by the ad server.
-         *
-         * ```
-         * require(['common/modules/commercial/loader'], function (CommercialComponent) {
-         *     var slot = document.querySelector('[data-base="SLOT_NAME"]');
-         *     var c = new CommercialComponent({config: guardian, oastoken: '%%C%%?'}).init('COMPONENT_NAME', slot);
-         * })
-         * ```
+         * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207
          *
          * @constructor
          * @extends Component
+         * @param (Object=) $adSlot
          * @param {Object=} params
          */
         CommercialComponent = function ($adSlot, params) {
@@ -87,6 +81,7 @@ define([
 
             this.params = params;
             this.$adSlot = $adSlot;
+            this.type = params.type;
             this.components = {
                 bestbuy:           buildComponentUrl('money/bestbuys'),
                 bestbuyHigh:       buildComponentUrl('money/bestbuys-high'),
@@ -120,10 +115,10 @@ define([
      */
     CommercialComponent.prototype.load = function () {
         new LazyLoad({
-            url: this.components[this.params.type],
+            url: this.components[this.type],
             container: this.$adSlot,
             success: function () {
-                this.postLoadEvents[this.params.type] && this.postLoadEvents[this.params.type](this.$adSlot);
+                this.postLoadEvents[this.type] && this.postLoadEvents[this.type](this.$adSlot);
 
                 mediator.emit('modules:commercial:creatives:commercial-component:loaded');
             }.bind(this)
@@ -137,7 +132,7 @@ define([
      * @param {Element} el
      */
     CommercialComponent.prototype.create = function () {
-        if (this.components[this.params.type] === undefined) {
+        if (this.components[this.type] === undefined) {
             raven.captureMessage('Unknown commercial component: ' + name);
             return false;
         }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -1,5 +1,5 @@
 /*
- Module: commercial/loader.js
+ Module: commercial/creatives/commercial-component.js
  Description: Loads our commercial components
  */
 define([
@@ -81,10 +81,11 @@ define([
          * @extends Component
          * @param {Object=} params
          */
-        Loader = function ($adSlot, params) {
+        CommercialComponent = function ($adSlot, params) {
             var section = config.page.section,
                 jobs    = params.jobIds ? params.jobIds.split(',') : [];
 
+            this.params = params;
             this.$adSlot = $adSlot;
             this.components = {
                 bestbuy:           buildComponentUrl('money/bestbuys'),
@@ -105,21 +106,10 @@ define([
                 capiSingle:        buildComponentUrl('capi-single', defaults(params, { s: section })),
                 capiSingleMerch:   buildComponentUrl('capi-single-merch', defaults(params, { s: section })),
                 capi:              buildComponentUrl('capi', defaults(params, { s: section }))
-                //
-                //    s:   section,
-                //    t:   opts.capi,
-                //    k:   opts.capiKeywords.split(','),
-                //    l:   opts.logo,
-                //    ct:  opts.capiTitle,
-                //    cl:  opts.capiLinkUrl,
-                //    cal: opts.capiAboutLinkUrl,
-                //    omnitureId: opts.omnitureId,
-                //    clockMacro: opts.clickMacro
-                //})
             };
         };
 
-    Loader.prototype.postLoadEvents = {
+    CommercialComponent.prototype.postLoadEvents = {
         bestbuy: function (el) {
             new Tabs().init(el);
         }
@@ -128,14 +118,15 @@ define([
     /**
      * @param {Element} target
      */
-    Loader.prototype.load = function () {
+    CommercialComponent.prototype.load = function () {
+        console.log('CommercialComponent.prototype.load');
         new LazyLoad({
-            url: this.components[name],
+            url: this.components[this.params.type],
             container: this.$adSlot,
             success: function () {
-                this.postLoadEvents[name] && this.postLoadEvents[name](target);
+                this.postLoadEvents[this.params.type] && this.postLoadEvents[this.params.type](target);
 
-                mediator.emit('modules:commercial:loader:loaded');
+                mediator.emit('modules:commercial:creatives:commercial-component:loaded');
             }.bind(this)
         }).load();
 
@@ -146,9 +137,10 @@ define([
      * @param {String}  name
      * @param {Element} el
      */
-    Loader.prototype.create = function () {
+    CommercialComponent.prototype.create = function () {
 
-        if (this.components[name] === undefined) {
+        console.log('CommercialComponent.prototype.create');
+        if (this.components[this.params.type] === undefined) {
             raven.captureMessage('Unknown commercial component: ' + name);
             return false;
         }
@@ -156,5 +148,5 @@ define([
         return this.load();
     };
 
-    return Loader;
+    return CommercialComponent;
 });

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -67,8 +67,7 @@ define([
         },
         /**
          * Loads commercial components.
-         *
-         * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207
+         *         * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10023207
          *
          * @constructor
          * @extends Component

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -294,7 +294,7 @@ define([
                 $iFrame            = bonzo(iFrame),
                 iFrameBody         = iFrame.contentDocument.body,
                 $iFrameParent      = $iFrame.parent();
-console.log('iFrameBody');
+
             if (iFrameBody) {
                 forEach(breakoutClasses, function (breakoutClass) {
                     $('.' + breakoutClass, iFrameBody).each(function (breakoutEl) {
@@ -305,7 +305,6 @@ console.log('iFrameBody');
                         if (breakoutClass === 'breakout__script') {
                             // new way of passing data from DFP
                             if ($breakoutEl.attr('type') === 'application/json') {
-                                console.log(breakoutContent);
                                 creativeConfig = JSON.parse(breakoutContent);
                                 require(['common/modules/commercial/creatives/' + creativeConfig.name])
                                     .then(function (Creative) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -294,7 +294,7 @@ define([
                 $iFrame            = bonzo(iFrame),
                 iFrameBody         = iFrame.contentDocument.body,
                 $iFrameParent      = $iFrame.parent();
-
+console.log('iFrameBody');
             if (iFrameBody) {
                 forEach(breakoutClasses, function (breakoutClass) {
                     $('.' + breakoutClass, iFrameBody).each(function (breakoutEl) {
@@ -305,6 +305,7 @@ define([
                         if (breakoutClass === 'breakout__script') {
                             // new way of passing data from DFP
                             if ($breakoutEl.attr('type') === 'application/json') {
+                                console.log(breakoutContent);
                                 creativeConfig = JSON.parse(breakoutContent);
                                 require(['common/modules/commercial/creatives/' + creativeConfig.name])
                                     .then(function (Creative) {


### PR DESCRIPTION
Merchandising cAPI components (multiple, single and single - sponsored) stores now JSON instead of a script in a template. In the DFP we will now use the JSON format, load a proper module (CommercialComponent in this case) and fire 'create' method. The old method used ugly eval() on a script inside a creative template. 
