### PR TITLE
Stop sharing all gallery images on Facebook (2nd PR)

### DIFF
--- a/applications/test/GalleryTemplateTest.scala
+++ b/applications/test/GalleryTemplateTest.scala
@@ -42,6 +42,11 @@ import scala.collection.JavaConversions._
     $("meta[name='twitter:image3:src']").getAttributes("content").head should endWith ("/Bassoons-in-the-Symphony--003.jpg")
   }
 
+  it should "have only ONE opengraph image in a gallery" in goTo("/lifeandstyle/gallery/2014/nov/24/flying-dogs-in-pictures") { browser =>
+    import browser._
+    $("meta[property='og:image']").size() should be(1)
+  }
+
   it should "select the trail picture for the opengraph image when FacebookShareUseTrailPicFirstSwitch is ON" in {
     FacebookShareUseTrailPicFirstSwitch.switchOn()
     goTo("/lifeandstyle/gallery/2014/nov/24/flying-dogs-in-pictures") { browser =>

--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -16,12 +16,11 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
       item.content.map { apiContent =>
         val pageShares = model.Content(apiContent).pageShares
 
-        pageShares.map(_.text) should be (List("Facebook", "Twitter", "Email", "Pinterest", "Google plus", "WhatsApp"))
+        pageShares.map(_.text) should be (List("Facebook", "Twitter", "Email", "Google plus", "WhatsApp"))
         pageShares.map(_.href) should be (List(
           "https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsfb&ref=responsive",
           "https://twitter.com/intent/tweet?text=2014+Wildlife+photographer+of+the+Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fstw",
           "mailto:?subject=2014%20Wildlife%20photographer%20of%20the%20Year&body=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsbl",
-          "http://www.pinterest.com/pin/find/?url=http%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year",
           "https://plus.google.com/share?url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsgp&amp;hl=en-GB&amp;wwc=1",
           "whatsapp://send?text=%222014%20Wildlife%20photographer%20of%20the%20Year%22%20http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fswa"))
       }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -508,6 +508,14 @@ import collection.JavaConversions._
         Then("I should pass Facebook a tracking token")
         browser.findFirst(".social__item[data-link-name=facebook] .social__action").getAttribute("href") should include(fbShareTrackingToken)
       }
+
+      Given("I am going to share an article on Facebook")
+      goTo("/film/2012/nov/11/margin-call-cosmopolis-friends-with-kids-dvd-review") { browser =>
+        import browser._
+        Then("there should only be ONE opengraph image in the metadata")
+        $("meta[property='og:image']").size() should be(1)
+      }
+
     }
 
     // http://www.w3.org/WAI/intro/aria

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -674,8 +674,6 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
       .getOrElse(conf.Configuration.facebook.imageFallback)
   }
 
-  override def openGraphImages: Seq[String] = largestCrops.flatMap(_.url)
-
   override def schemaType = Some("http://schema.org/ImageGallery")
 
   // if you change these rules make sure you update IMAGES.md (in this project)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -657,7 +657,7 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) {
   lazy val landscapes = largestCrops.filter(i => i.width > i.height).sortBy(_.index)
   lazy val portraits = largestCrops.filter(i => i.width < i.height).sortBy(_.index)
   lazy val isInPicturesSeries = tags.exists(_.id == "lifeandstyle/series/in-pictures")
-  override protected lazy val pageShareOrder = List("facebook", "twitter", "email", "pinterestPage", "gplus", "whatsapp")
+  override protected lazy val pageShareOrder = List("facebook", "twitter", "email", "gplus", "whatsapp")
   override protected lazy val elementShareOrder = List("facebook", "twitter", "pinterestBlock")
 
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -65,8 +65,6 @@ trait MetaData extends Tags {
     "og:url"       -> s"${Configuration.site.host}$url"
   )
 
-  def openGraphImages: Seq[String] = Seq()
-
   def cards: List[(String, String)] = List(
     "twitter:site" -> "@guardian",
     "twitter:app:name:iphone" -> "The Guardian",

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -90,10 +90,6 @@
     <meta name="@key" content="@value" />
 }
 
-@item.openGraphImages.map{ case (imageUrl) =>
-    <meta property="og:image" content="@{imageUrl}" />
-}
-
 @item.pagination.map{ pagination =>
     @pagination.next.map{ next => <link rel="next" href="@LinkTo(item.url+"?page="+next)" /> }
     @pagination.previous.map{ prev => <link rel="prev" href="@LinkTo(item.url+(if(prev != 1){"?page="+prev}else{""}))" /> }


### PR DESCRIPTION
Following on from the previous PR (https://github.com/guardian/frontend/pull/7320) to prevent Facebook sharing from using poor auto-cropped portrait images from galleries, @Jholder112233 commented that this change would have a major fail situation with Pinterest.

The decision has been made by @crifmulholland to sacrifice Pinterest gallery page shares in order to save Facebook sharing for galleries, until we can devise a better way of feeding the image we want used as the default to Facebook.
