### PR TITLE
Turn on kerning and ligatures

### DIFF
--- a/static/src/stylesheets/base/_type.scss
+++ b/static/src/stylesheets/base/_type.scss
@@ -19,21 +19,14 @@ body {
 
 html,
 body {
-    -webkit-font-feature-settings: normal;
-    -moz-font-feature-settings: "kern" 1, "liga" 1;
-    font-feature-settings: "kern" 1, "liga" 1;
-}
-
-
-/**
- * Turn off kerning and ligatures for monospace type
- */
-
-pre,
-code {
-    -webkit-font-feature-settings: normal;
-    -moz-font-feature-settings: normal;
-    font-feature-settings: normal;
+    text-rendering: optimizeLegibility; // optional: for older browsers
+    -moz-font-feature-settings: 'kern=1'; // pre-Firefox 14+
+    -webkit-font-feature-settings: 'kern';
+    -moz-font-feature-settings: 'kern'; // Firefox 14+
+    font-feature-settings: 'kern';
+    font-kerning: normal; // Safari 7+, Firefox 24+, Chrome 33(?)+, Opera 21
+    -webkit-font-variant-ligatures: common-ligatures; // for iOS and Safari 6
+    font-variant-ligatures: common-ligatures;
 }
 
 


### PR DESCRIPTION
Aware of [this](https://github.com/guardian/frontend/pull/5216), but couldn't reproduce so possibly fixed in latest versions
### Before

![screen shot 2014-11-27 at 17 06 56](https://cloud.githubusercontent.com/assets/74132/5220108/2e73b9ea-7658-11e4-83ad-85ee950dd0eb.png)
### After

![screen shot 2014-11-27 at 17 06 45](https://cloud.githubusercontent.com/assets/74132/5220110/31c1cc54-7658-11e4-8e7f-03f59a5f65c0.png)
