### PR TITLE
don't display ads in responsive viewer

### DIFF
--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -97,7 +97,7 @@
                     html += '<div style="left:' + leftAcc + 'px">' +
                             '<h2>' + bp.name + '</h2>' +
                             '<iframe frameBorder="0" sandbox="allow-same-origin allow-forms allow-scripts" seamless ' +
-                            'src="' + src + '" ' +
+                            'src="' + src + '#noads" ' +
                             'width="' + ( bp.width + sbWidth ) + '"></iframe>' +
                             '</div>' ;
                     leftAcc += bp.width + sbWidth + 15 ;

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -107,7 +107,8 @@ define([
             if (
                 !userPrefs.isOff('adverts') &&
                 !config.page.shouldHideAdverts &&
-                (!config.page.isSSL || config.page.section === 'admin')
+                (!config.page.isSSL || config.page.section === 'admin') &&
+                !/#noads/.test(window.location.hash)
             ) {
                 modules.commercialLoaderHelper();
                 modules.tagContainer();

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -108,7 +108,7 @@ define([
                 !userPrefs.isOff('adverts') &&
                 !config.page.shouldHideAdverts &&
                 (!config.page.isSSL || config.page.section === 'admin') &&
-                !/#noads/.test(window.location.hash)
+                window.location.hash !== '#noads'
             ) {
                 modules.commercialLoaderHelper();
                 modules.tagContainer();


### PR DESCRIPTION
This is to keep ads in general but disable them only when in the responsive viewer.  This is because when people are previewing things they don't usually want to see the ads.  Also ads sometimes break in an iframe.

Because this is done via a hash, when people click other links in the responsive-viewer page, they will see an advert.  However we can deal with this if it's a problem via other methods.

@stephanfowler @ironsidevsquincy any comments?
