### PR TITLE
Do not dedup thrashers

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -74,6 +74,10 @@ object Front extends implicits.Collections {
           (seen, trails)
         }
 
+      /** Singleton containers (such as the eyewitness one or the thrasher one) do not participate in deduplication */
+      case Fixed(containerDefinition) if containerDefinition.isSingleton =>
+        (seen, trails)
+
       case Fixed(containerDefinition) =>
         /** Fixed Containers participate in de-duplication.
           */

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -46,9 +46,8 @@ object Front extends implicits.Collections {
   def itemsVisible(containerDefinition: ContainerDefinition) =
     containerDefinition.slices.flatMap(_.layout.columns.map(_.numItems)).sum
 
-  // Dream on.
-  def participatesInDeduplication(trail: Trail) =
-    !trail.snapType.exists(_ == "latest")
+  // Never de-duplicate snaps.
+  def participatesInDeduplication(trail: Trail) = !trail.snapType.isDefined
 
   /** Given a set of already seen trail URLs, a container type, and a set of trails, returns a new set of seen urls
     * for further de-duplication and the sequence of trails in the order that they ought to be shown for that

--- a/common/app/slices/ContainerDefinition.scala
+++ b/common/app/slices/ContainerDefinition.scala
@@ -54,4 +54,6 @@ case class ContainerDefinition(
   slices: Seq[Slice],
   mobileShowMore: MobileShowMore,
   customCssClasses: Set[String]
-)
+) {
+  def isSingleton = slices.length == 1 && slices.headOption.exists(_.layout.columns.map(_.numItems).sum == 1)
+}

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -63,6 +63,8 @@ object FixedContainers {
   val slowIndexPageMpuV = slices(TTT, TTMpu)
   val slowIndexPageMpuVII = slices(HalfHalf2, TTT, TTMpu)
 
+  val thrasher = slices(FullMedia75).copy(customCssClasses = Set("fc-container--thrasher"))
+
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),
     ("fixed/small/slow-II", slices(HalfHalf)),
@@ -82,7 +84,7 @@ object FixedContainers {
     ("fixed/medium/fast-XII", fixedMediumFastXII),
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/large/fast-XV", slices(HalfQQ, Ql3Ql3Ql3Ql3)),
-    ("fixed/thrasher", slices(FullMedia75).copy(customCssClasses = Set("fc-container--thrasher")))
+    ("fixed/thrasher", thrasher)
   )
 
   def unapply(collectionType: Option[String]): Option[ContainerDefinition] =

--- a/common/test/layout/FrontTest.scala
+++ b/common/test/layout/FrontTest.scala
@@ -104,6 +104,22 @@ class FrontTest extends FlatSpec with Matchers {
     dedupedTrails.map(_.webUrl) shouldEqual Seq("one", "two", "three")
   }
 
+  it should "not include items seen in a singleton container in the set of urls for further deduplication" in {
+    val (nowSeen, _) = Front.deduplicate(Set.empty, Fixed(FixedContainers.thrasher), Seq(
+      trailWithUrl("one")
+    ))
+
+    nowSeen shouldEqual Set.empty
+  }
+
+  it should "not remove items from a singleton container" in {
+    val (_, dedupedTrails) = Front.deduplicate(Set("one"), Fixed(FixedContainers.thrasher), Seq(
+      trailWithUrl("one")
+    ))
+
+    dedupedTrails.map(_.webUrl) shouldEqual Seq("one")
+  }
+
   it should "not include items seen in a nav media list in the set of urls for further deduplication" in {
     val (nowSeen, _) = Front.deduplicate(Set("one", "two"), NavMediaList, Seq(
       trailWithUrl("one"),


### PR DESCRIPTION
A couple of new de-duping rules:
- Don't dedup snaps ever (previously we just didn't dedup dream snaps)
- Don't dedup a container that only houses one item. These are typically big image containers, like the eyewitness container, or a thrasher, so we ought not to dedup the only item in them.
