### PR TITLE
Adding logo related DFP templates to Frontend

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-ad-feature.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-ad-feature.html
@@ -1,0 +1,8 @@
+<div class="ad-slot--paid-for-badge__inner">
+    <h3 class="ad-slot--paid-for-badge__header">Brought to you by:</h3>
+    <a href="{{clickMacro}}{{logoUrl}}" class="ad-slot--paid-for-badge__link">
+        <img class="ad-slot--paid-for-badge__logo" src="{{logoImage}}" />
+    </a>
+    <a href="{{clickMacro}}{{infoUrl}}" class="ad-slot--paid-for-badge__help u-h">About this content</a>
+    <a href="{{clickMacro}}http://theguardian.com/paid-for-content" class="ad-slot--paid-for-badge__help">About this content</a>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded-partners.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded-partners.html
@@ -1,0 +1,14 @@
+<div class="ad-slot--paid-for-badge__inner">
+    <h3 class="ad-slot--paid-for-badge__header">Supported by:</h3>
+    <a href="{{clickMacro}}{{logoUrl}}" class="ad-slot--paid-for-badge__link">
+        <img class="ad-slot--paid-for-badge__logo" src="{{logoImage}}" />
+    </a>
+    <h3 class="ad-slot--paid-for-badge__header">In partnership with:</h3>
+    <a href="{{clickMacro}}{{partnerOneLogoUrl}}" class="ad-slot--paid-for-badge__link">
+        <img class="ad-slot--paid-for-badge__logo" src="{{partnerOneLogoImage}}" />
+    </a>
+    <a href="{{clickMacro}}{{partnerTwoLogoUrl}}" class="ad-slot--paid-for-badge__link">
+        <img class="ad-slot--paid-for-badge__logo" src="{{partnerTwoLogoImage}}" />
+    </a>
+    <a href="{{clickMacro}}{{infoUrl}}" class="ad-slot--paid-for-badge__help">About this content</a>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded.html
@@ -1,0 +1,7 @@
+<div class="ad-slot--paid-for-badge__inner">
+    <h3 class="ad-slot--paid-for-badge__header">Supported by:</h3>
+    <a href="{{clickMacro}}{{logoUrl}}" class="ad-slot--paid-for-badge__link">
+        <img class="ad-slot--paid-for-badge__logo" src="{{logoImage}}" />
+    </a>
+    <a href="{{clickMacro}}{{infoUrl}}" class="ad-slot--paid-for-badge__help">About this content</a>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-sponsored.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-sponsored.html
@@ -1,0 +1,7 @@
+<div class="ad-slot--paid-for-badge__inner">
+    <h3 class="ad-slot--paid-for-badge__header">Sponsored by:</h3>
+    <a href="{{clickMacro}}{{logoUrl}}" class="ad-slot--paid-for-badge__link">
+        <img class="ad-slot--paid-for-badge__logo" src="{{logoImage}}" />
+    </a>
+    <a href="{{clickMacro}}{{infoUrl}}" class="ad-slot--paid-for-badge__help">About this content</a>
+</div>


### PR DESCRIPTION
So we can move the HTML out of DFP, e.g. https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10026327
