### PR TITLE
Remove top padding from logo on live blogs

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -346,11 +346,6 @@
         min-height: 0;
     }
 }
-.ad-slot--paid-for-badge--live-blog {
-    @include mq(desktop) {
-        padding-top: $gs-baseline*2;
-    }
-}
 .ad-slot--paid-for-badge--interactive {
     min-width: 140px;
     min-height: 135px;


### PR DESCRIPTION
### Before

![screen shot 2014-11-28 at 14 59 49](https://cloud.githubusercontent.com/assets/74132/5229447/6c3bd8c2-770f-11e4-9083-28281c68050e.png)
### After

![screen shot 2014-11-28 at 14 59 40](https://cloud.githubusercontent.com/assets/74132/5229448/6f675c06-770f-11e4-9b6c-62d7e166edc6.png)

cc: @Pearson82 
