### PR TITLE
add json endpoints to the playercard controller

### DIFF
--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -3,6 +3,7 @@ package controllers.admin
 import play.api.mvc._
 import football.services.GetPaClient
 import pa.{StatsSummary, PlayerProfile, PlayerAppearances}
+import implicits.Requests
 import common.{JsonComponent, ExecutionContexts}
 import org.joda.time.LocalDate
 import football.model.PA
@@ -10,9 +11,10 @@ import scala.concurrent.Future
 import model.{Cors, NoCache, Cached}
 import play.api.libs.json.{JsString, JsArray, JsObject}
 import org.joda.time.format.DateTimeFormat
+import play.twirl.api.HtmlFormat
 
 
-object PlayerController extends Controller with ExecutionContexts with GetPaClient {
+object PlayerController extends Controller with ExecutionContexts with GetPaClient with Requests {
 
   def playerIndex =AuthActions.AuthActionTest.async { request =>
     for {
@@ -38,6 +40,8 @@ object PlayerController extends Controller with ExecutionContexts with GetPaClie
     }
     result
   }
+  def playerCardCompetitionJson(cardType: String, playerId: String, teamId: String, competitionId: String)
+        = playerCardCompetition(cardType, playerId, teamId, competitionId)
 
   def playerCardCompetition(cardType: String, playerId: String, teamId: String, competitionId: String) =AuthActions.AuthActionTest.async { implicit request =>
     client.competitions.map(PA.filterCompetitions).flatMap { competitions =>
@@ -47,33 +51,53 @@ object PlayerController extends Controller with ExecutionContexts with GetPaClie
           playerStats <- client.playerStats(playerId, competition.startDate, LocalDate.now(), teamId, competitionId)
           playerAppearances <- client.appearances(playerId, competition.startDate, LocalDate.now(), teamId, competitionId)
         } yield {
-          val result = renderPlayerCard(cardType, playerId, playerProfile, playerStats, playerAppearances)
-          Cors(NoCache(result))
+          val result = createPlayerCard(cardType, playerId, playerProfile, playerStats, playerAppearances)
+          result.map(renderPlayerCard).getOrElse(renderNotFound)
         }
       }
     }
   }
 
-  def playerCardDate(cardType: String, playerId: String, teamId: String, startDateStr: String) =AuthActions.AuthActionTest.async { implicit request =>
+  def playerCardDateJson(cardType: String, playerId: String, teamId: String, startDateStr: String)
+
+      = playerCardDate(cardType, playerId, teamId, startDateStr)
+
+
+  def playerCardDate(cardType: String, playerId: String, teamId: String, startDateStr: String) = AuthActions.AuthActionTest.async { implicit request =>
     val startDate = LocalDate.parse(startDateStr, DateTimeFormat.forPattern("yyyyMMdd"))
     for {
       playerProfile <- client.playerProfile(playerId)
       playerStats <- client.playerStats(playerId, startDate, LocalDate.now(), teamId)
       playerAppearances <- client.appearances(playerId, startDate, LocalDate.now(), teamId)
     } yield {
-      val result = renderPlayerCard(cardType, playerId, playerProfile, playerStats, playerAppearances)
-      Cors(NoCache(result))
+      val result = createPlayerCard(cardType, playerId, playerProfile, playerStats, playerAppearances)
+      result.map(renderPlayerCard).getOrElse(renderNotFound)
     }
   }
 
-  private def renderPlayerCard(cardType: String, playerId: String, playerProfile: PlayerProfile, playerStats: StatsSummary, playerAppearances: PlayerAppearances) = {
+  private def renderPlayerCard(card: HtmlFormat.Appendable)(implicit request: RequestHeader) = {
+    if(!request.isJson) Cors(NoCache(Ok(card)))
+    else NoCache {
+      JsonComponent(
+          "html" -> card
+      )
+    }
+  }
+
+  private def renderNotFound()(implicit request: RequestHeader) = {
+    if(!request.isJson) Cors(NotFound(views.html.football.error("Unknown card type")))
+    else NotFound
+  }
+
+  private def createPlayerCard(cardType: String, playerId: String, playerProfile: PlayerProfile, playerStats: StatsSummary, playerAppearances: PlayerAppearances):
+    Option[HtmlFormat.Appendable] = {
     cardType match {
-      case "attack" => Ok(views.html.football.player.cards.attack(playerId, playerProfile, playerStats, playerAppearances))
-      case "assist" => Ok(views.html.football.player.cards.assist(playerId, playerProfile, playerStats, playerAppearances))
-      case "discipline" => Ok(views.html.football.player.cards.discipline(playerId, playerProfile, playerStats, playerAppearances))
-      case "defence" => Ok(views.html.football.player.cards.defence(playerId, playerProfile, playerStats, playerAppearances))
-      case "goalkeeper" => Ok(views.html.football.player.cards.goalkeeper(playerId, playerProfile, playerStats, playerAppearances))
-      case _ => NotFound(views.html.football.error("Unknown card type"))
+      case "attack" => Some(views.html.football.player.cards.attack(playerId, playerProfile, playerStats, playerAppearances))
+      case "assist" => Some(views.html.football.player.cards.assist(playerId, playerProfile, playerStats, playerAppearances))
+      case "discipline" => Some(views.html.football.player.cards.discipline(playerId, playerProfile, playerStats, playerAppearances))
+      case "defence" => Some(views.html.football.player.cards.defence(playerId, playerProfile, playerStats, playerAppearances))
+      case "goalkeeper" => Some(views.html.football.player.cards.goalkeeper(playerId, playerProfile, playerStats, playerAppearances))
+      case _ => None
     }
   }
 

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -59,7 +59,6 @@ object PlayerController extends Controller with ExecutionContexts with GetPaClie
   }
 
   def playerCardDateJson(cardType: String, playerId: String, teamId: String, startDateStr: String)
-
       = playerCardDate(cardType, playerId, teamId, startDateStr)
 
 

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -93,7 +93,9 @@ POST        /admin/football/browserRedirect                                     
 GET         /admin/football/browser/*query                                                     controllers.admin.PaBrowserController.browser(query)
 GET         /admin/football/player                                                             controllers.admin.PlayerController.playerIndex
 POST        /admin/football/player/card                                                        controllers.admin.PlayerController.redirectToCard
+GET         /admin/football/player/card/competition/:cardType/:playerId/:teamId/:compId.json   controllers.admin.PlayerController.playerCardCompetitionJson(cardType: String, playerId: String, teamId: String, compId: String)
 GET         /admin/football/player/card/competition/:cardType/:playerId/:teamId/:compId        controllers.admin.PlayerController.playerCardCompetition(cardType: String, playerId: String, teamId: String, compId: String)
+GET         /admin/football/player/card/date/:cardType/:playerId/:teamId/:startDate.json       controllers.admin.PlayerController.playerCardDateJson(cardType: String, playerId: String, teamId: String, startDate: String)
 GET         /admin/football/player/card/date/:cardType/:playerId/:teamId/:startDate            controllers.admin.PlayerController.playerCardDate(cardType: String, playerId: String, teamId: String, startDate: String)
 GET         /admin/football/tables                                                             controllers.admin.TablesController.tablesIndex
 POST        /admin/football/tables/league                                                      controllers.admin.TablesController.redirectToTable

--- a/admin/test/football/PlayerControllerTest.scala
+++ b/admin/test/football/PlayerControllerTest.scala
@@ -39,4 +39,22 @@ import test.ConfiguredTestSuite
     val content = contentAsJson(result)
     (content \ "players").as[List[JsObject]] should contain(JsObject(Seq("label" -> JsString("Heurelho Gomes"), "value" -> JsString("283600"))))
   }
+
+  "test can return json when json format supplied" in {
+    val Some(result) = route(FakeRequest(GET, "/admin/football/player/card/date/attack/237670/19/20140101.json"))
+    status(result) should equal(OK)
+    contentType(result).get should be("application/json")
+    contentAsString(result) should startWith("{\"html\"")
+  }
+
+  "test can return jsonp when callback supplied" in {
+    val callbackName = "theCallbackName"
+    val fakeRequest = FakeRequest(GET, s"/admin/football/player/card/date/attack/237670/19/20140101?callback=${callbackName}")
+      .withHeaders("host" -> "localhost:9000")
+      .withHeaders("Origin" -> "www.theguorigin.com")
+    val Some(result) = route(fakeRequest)
+    status(result) should equal(OK)
+    contentType(result).get should be ("application/javascript")
+    contentAsString(result) should startWith(s"""${callbackName}({\"html\"""") // the callback
+  }
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -190,7 +190,9 @@ POST        /admin/football/browserRedirect                                     
 GET         /admin/football/browser/*query                                                                           controllers.admin.PaBrowserController.browser(query)
 GET         /admin/football/player                                                                                   controllers.admin.PlayerController.playerIndex
 POST        /admin/football/player/card                                                                              controllers.admin.PlayerController.redirectToCard
+GET         /admin/football/player/card/competition/:cardType/:playerId/:teamId/:compId.json                         controllers.admin.PlayerController.playerCardCompetitionJson(cardType: String, playerId: String, teamId: String, compId: String)
 GET         /admin/football/player/card/competition/:cardType/:playerId/:teamId/:compId                              controllers.admin.PlayerController.playerCardCompetition(cardType: String, playerId: String, teamId: String, compId: String)
+GET         /admin/football/player/card/date/:cardType/:playerId/:teamId/:startDate.json                             controllers.admin.PlayerController.playerCardDateJson(cardType: String, playerId: String, teamId: String, startDate: String)
 GET         /admin/football/player/card/date/:cardType/:playerId/:teamId/:startDate                                  controllers.admin.PlayerController.playerCardDate(cardType: String, playerId: String, teamId: String, startDate: String)
 GET         /admin/football/tables                                                                                   controllers.admin.TablesController.tablesIndex
 POST        /admin/football/tables/league                                                                            controllers.admin.TablesController.redirectToTable


### PR DESCRIPTION
Further to https://github.com/guardian/frontend/pull/7348
This adds json endpoints to supplant the existing corsified non json endpoints at a future date
