### PR TITLE
Zero top and bottom margins for live blog thumbnails or captionless pics

### DIFF
--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -355,54 +355,57 @@
 
 // Inline embeds
 
-.block-share--article,
-.block-share--article-mobile {
-    position: absolute;
-    right: -$gs-gutter/4;
-    margin-top: ($gs-baseline/3)*2;
+.content--article {
 
-    .element--thumbnail &,
-    .img--base & {
-        display: none !important;
-    }
-}
+    .block-share--article,
+    .block-share--article-mobile {
+        position: absolute;
+        right: -$gs-gutter/4;
+        margin-top: ($gs-baseline/3)*2;
 
-.fig--extra-margin {
-    padding-bottom: $gs-baseline * 3 !important;
-}
-
-.fig--border {
-    @include mq(leftCol) {
-        border-bottom: 1px dotted colour(neutral-5) !important;
-    }
-
-    &.element--thumbnail {
-        border: 0 !important;
-    }
-}
-
-.fig--narrow-caption {
-    figcaption {
-        @include mq(tablet) {
-            max-width: gs-span(6);
+        .element--thumbnail &,
+        .img--base & {
+            display: none !important;
         }
     }
 
-    &.element--supporting {
-        figcaption {
-            @include mq(desktop) {
-                max-width: gs-span(3) - 10;
-            }
-            @include mq(wide) {
-                max-width: gs-span(4) - 10;
-            }
+    .fig--extra-margin {
+        padding-bottom: $gs-baseline * 3 !important;
+    }
+
+    .fig--border {
+        @include mq(leftCol) {
+            border-bottom: 1px dotted colour(neutral-5) !important;
+        }
+
+        &.element--thumbnail {
+            border: 0 !important;
         }
     }
 
-    &.element--showcase {
+    .fig--narrow-caption {
         figcaption {
-            @include mq(leftCol) {
-                max-width: gs-span(9);
+            @include mq(tablet) {
+                max-width: gs-span(6);
+            }
+        }
+
+        &.element--supporting {
+            figcaption {
+                @include mq(desktop) {
+                    max-width: gs-span(3) - 10;
+                }
+                @include mq(wide) {
+                    max-width: gs-span(4) - 10;
+                }
+            }
+        }
+
+        &.element--showcase {
+            figcaption {
+                @include mq(leftCol) {
+                    max-width: gs-span(9);
+                }
             }
         }
     }

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -265,7 +265,7 @@ $block-padding-right: $gs-gutter;
         margin-top: ($gs-baseline/4)*-1;
         margin-bottom: $gs-baseline;
 
-        & + .block-elements .element-image:first-child,
+        & + .block-elements .element-image:first-child:not(.element--thumbnail),
         & + .block-elements .element-video:first-child {
             margin-top: 34px; // Extra margin top to position media below block-time
         }


### PR DESCRIPTION
Before (an image which is both captionless and thumbnail):
![screen shot 2014-12-01 at 10 59 43](https://cloud.githubusercontent.com/assets/4549425/5244585/c50323bc-7948-11e4-9947-83bf66682b7a.png)

After:
![screen shot 2014-12-01 at 10 58 32](https://cloud.githubusercontent.com/assets/4549425/5244576/ad5c1890-7948-11e4-9c1c-570404412024.png)
