### PR TITLE
suppress series tags in meta for childrens books site

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -45,6 +45,8 @@ case class Tag(private val delegate: ApiTag, override val pagination: Option[Pag
     !idParts.exists(_ != section)
   }
 
+  lazy val showSeriesInMeta = id != "commentisfree/commentisfree"  &&  id != "childrens-books-site/childrens-books-site"
+
   lazy val isKeyword = tagType == "keyword"
 
   override lazy val tags = Seq(this)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -245,10 +245,10 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
 
   override lazy val adUnitSuffix: String = super.adUnitSuffix + "/" + contentType.toLowerCase
 
-  lazy val isCommentIsFree: Boolean = tags.exists{ tag => tag.id == "commentisfree/commentisfree" && tag.tagType == "blog" }
+  lazy val showSectionNotTag: Boolean = tags.exists{ tag => (tag.id == "commentisfree/commentisfree" || tag.id == "childrens-books-site/childrens-books-site") && tag.tagType == "blog" }
 
   lazy val sectionLabelLink : String = {
-    if (isCommentIsFree || DfpAgent.isAdvertisementFeature(tags, Some(section))) {
+    if (showSectionNotTag || DfpAgent.isAdvertisementFeature(tags, Some(section))) {
       section
     } else tags.find(_.isKeyword) match {
       case Some(tag) => tag.id
@@ -257,14 +257,14 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   }
 
   lazy val sectionLabelName : String = {
-    if(this.isCommentIsFree) sectionName else tags.find(_.isKeyword) match {
+    if(this.showSectionNotTag) sectionName else tags.find(_.isKeyword) match {
       case Some(tag) => tag.webTitle
       case _ => ""
     }
   }
 
   lazy val blogOrSeriesTag: Option[Tag] = {
-    tags.find( tag => tag.id != "commentisfree/commentisfree" && (tag.isBlog || tag.isSeries )).headOption
+    tags.find( tag => tag.showSeriesInMeta && (tag.isBlog || tag.isSeries )).headOption
   }
 
   lazy val seriesTag: Option[Tag] = {


### PR DESCRIPTION
Apply the same meta logic as per comment is free to articles in the http://www.theguardian.com/childrens-books-site - don't show the series or blog tag,just a link to children's books: 

Before: 
![childrens-books-after](https://cloud.githubusercontent.com/assets/986155/5246812/c9ec88ac-7964-11e4-9cb4-08cccd7b5f8c.png)

After:
![children s-books-after](https://cloud.githubusercontent.com/assets/986155/5246819/db787d7e-7964-11e4-8279-e70af916b212.png)
