### PR TITLE
allow plus sign in fronts

### DIFF
--- a/facia-tool/app/controllers/FrontController.scala
+++ b/facia-tool/app/controllers/FrontController.scala
@@ -10,7 +10,7 @@ import com.gu.googleauth.UserIdentity
 import auth.ExpiringActions
 
 object CreateFront {
-  implicit val jsonFormat = Json.format[CreateFront]
+  implicit val jsonFormat = Json.format[CreateFront].filter(_.id.matches("""^[a-z0-9\/\-+]*$"""))
 }
 
 case class CreateFront(

--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -154,7 +154,7 @@ define([
             .toLowerCase()
             .replace(/\/+/g, '/')
             .replace(/^\/|\/$/g, '')
-            .replace(/[^a-z0-9\/\-]*/g, '')
+            .replace(/[^a-z0-9\/\-+]*/g, '')
             .split('/')
             .slice(0,3)
             .join('/')

--- a/facia-tool/public/js/models/config/persistence.js
+++ b/facia-tool/public/js/models/config/persistence.js
@@ -15,7 +15,7 @@ define([
 
         authedAjax.request(_.extend({
             type: 'POST'
-        }, opts)).then(function () {
+        }, opts)).always(function () {
             _.each(onUpdateCallbacks, function (callback) {
                 callback();
             });

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -58,7 +58,7 @@ trait FrontJson extends ExecutionContexts with Logging {
   val stage: String = Configuration.facia.stage.toUpperCase
   val bucketLocation: String
 
-  private def getAddressForPath(path: String): String = s"$bucketLocation/$path/pressed.json"
+  private def getAddressForPath(path: String): String = s"$bucketLocation/${path.replaceAll("""\+""","%2B")}/pressed.json"
 
   def get(path: String): Future[Option[FaciaPage]] = {
     val response = SecureS3Request.urlGet(getAddressForPath(path)).get()


### PR DESCRIPTION
on r2 we could have fronts with + in the name (tag combiners)  however on ngw the plus is stripped out, so we need to add the plus as a possibility.

if we do create a front with a plus in the name, the pressed file is in a directory on s3 with a plus in the name.  if we want to gET it with http we need to escape the plus as a %2b otherwise it won't find it.  We can't just do a general escaping of all characters invalid in a path segment as forward slashes are actually used in S3 with their semantic meaning not just as a character, so just escaping the plus alone for now.
