### PR TITLE
Extra fields for commercial expandable template

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
@@ -51,7 +51,7 @@ define([
         $('.ad-exp-collapse__slide', $expandable).css('height', this.closedHeight);
 
         if (this.params.trackingPixel) {
-            this.$adSlot.before('<img src="' + this.params.trackingPixel + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
+            this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
         }
 
         $expandable.appendTo(this.$adSlot);

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
@@ -49,6 +49,10 @@ define([
         this.$button = $('.ad-exp__close-button', $expandable);
 
         $('.ad-exp-collapse__slide', $expandable).css('height', this.closedHeight);
+        
+        if (this.params.trackingPixel) {
+            this.$adSlot.before('<img src="' + this.params.trackingPixel + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
+        }
 
         $expandable.appendTo(this.$adSlot);
 

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
@@ -49,7 +49,7 @@ define([
         this.$button = $('.ad-exp__close-button', $expandable);
 
         $('.ad-exp-collapse__slide', $expandable).css('height', this.closedHeight);
-        
+
         if (this.params.trackingPixel) {
             this.$adSlot.before('<img src="' + this.params.trackingPixel + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
         }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250.js
@@ -25,7 +25,7 @@ define([
         $.create(template(fluid250Tpl, this.params)).appendTo(this.$adSlot);
 
         if (this.params.trackingPixel) {
-            this.$adSlot.before('<img src="' + this.params.trackingPixel + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
+            this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
         }
         this.$adSlot.addClass('ad-slot__fluid250');
     };

--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
@@ -1,14 +1,13 @@
 <div class="creative--expandable">
     <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
         <div class="facia-container__inner">Advertisement</div>
-        <img src="https://ad.doubleclick.net/ad/N5295.133705.GUARDIAN.CO.UK/B8333982.112985966;sz=1x1;ord=%%CACHEBUSTER%%"/>
     </div>
     <div class="ad-exp--expand l-side-margins">
         <div class="facia-container__inner facia-container__inner--full-span">
             <button class="ad-exp__close-button">
                 <i class="i i-close-icon-white-small"></i>
             </button>
-            <a href="{{clickMacro}}https://ad.doubleclick.net/ddm/clk/285734502;112985966;s"  target="_new">
+            <a href="{{link}}" target="_new">
                 <div class="ad-exp-collapse__slide slide-1" style="background-image: url('{{slide1}}');">
                     <div class="ad-exp__cta" style="background-image: url('{{cta}}');"></div>
                     <div class="ad-exp__logo" style="background-image: url('{{logo}}');"></div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
@@ -7,7 +7,7 @@
             <button class="ad-exp__close-button">
                 <i class="i i-close-icon-white-small"></i>
             </button>
-            <a href="{{link}}" target="_new">
+            <a href="{{clickMacro}}{{link}}" target="_new">
                 <div class="ad-exp-collapse__slide slide-1" style="background-image: url('{{slide1}}');">
                     <div class="ad-exp__cta" style="background-image: url('{{cta}}');"></div>
                     <div class="ad-exp__logo" style="background-image: url('{{logo}}');"></div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fluid250.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fluid250.html
@@ -7,7 +7,7 @@
         background-position: {{backgroundPosition}};
         background-repeat: {{backgroundRepeat}};
     ">
-    <a href="{{link}}" target="_blank">
+    <a href="{{clickMacro}}{{link}}" target="_blank">
         <div class="gs-container">
             <div class="fluid250_layer fluid250_layer1" style="
                 background-image: url({{layerOneBGImage}});

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -164,7 +164,11 @@
     $expandable-colour: #f3f3f3;
 
     margin-bottom: $gs-baseline;
-
+    
+    .facia-container__inner {
+        border-top: 0;
+        padding-top: 0;
+    }
     .ad-slot__label--wrapper {
         @include mq($until: tablet) {
             width: auto;


### PR DESCRIPTION
This adds tracking pixel and url fields for the expandable DFP template.

DFP template output as below;

```
<script type="application/json" class="breakout__script">
    {
        "name": "expandable",
        "params": {
            "slide1": "[%Slide1%]",
            "slide2": "[%Slide2%]",
            "cta": "[%CTA%]",
            "logo": "[%Logo%]",
            "text": "[%Text%]",
            "textMobile": "[%TextMobile%]",
            "clickMacro": "%%CLICK_URL_ESC%%",
            "trackingPixel": "[%Trackingpixel%]%%CACHEBUSTER%%",
            "link": "%%CLICK_URL_ESC%%[%Link%]"
        }
    }
</script>
```
