### PR TITLE
Add artanddesign/photography to image rich tag pages

### DIFF
--- a/common/app/layout/SlowOrFastByTrails.scala
+++ b/common/app/layout/SlowOrFastByTrails.scala
@@ -26,7 +26,8 @@ object SlowOrFastByTrails {
     "type/cartoon",
     "type/gallery",
     "type/picture",
-    "lifeandstyle/series/last-bites"
+    "lifeandstyle/series/last-bites",
+    "artanddesign/photography"
   )
 
   val FrequencyThreshold = 0.8


### PR DESCRIPTION
On request of that desk

Before:

![screen shot 2014-12-02 at 14 06 25](https://cloud.githubusercontent.com/assets/1001642/5263744/9731f582-7a2c-11e4-8488-f5c41c08774d.png)

After:

![screen shot 2014-12-02 at 14 06 44](https://cloud.githubusercontent.com/assets/1001642/5263746/9d9f7d04-7a2c-11e4-8bfc-76f89a2c9482.png)
