### PR TITLE
Recognise Site Root as a Sponsored Section

### DIFF
--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -8,13 +8,12 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
   val isValid = lineItems.nonEmpty
 
   def sectionsFromAdUnits(adUnits: Seq[GuAdUnit]): Seq[String] = {
-    adUnits map {
-      _.path.drop(1).headOption getOrElse {
-        /*
-         if a line item targets the site root ad unit
-         then a corresponding sponsorship will target any section of the site
-         */
-        ANY_SECTION
+     adUnits map { adUnit =>
+      val pathWithoutSiteRoot = adUnit.path.drop(1)
+
+       pathWithoutSiteRoot match {
+        case section :: restOfAdUnit => section
+        case Nil => ANY_SECTION
       }
     }
   }

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -1,12 +1,23 @@
 package dfp
 
 import common.Edition
+import dfp.Sponsorship.ANY_SECTION
 
 case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
 
   val isValid = lineItems.nonEmpty
 
-  def sectionsFromAdUnits(adUnits: Seq[GuAdUnit]): Seq[String] = adUnits flatMap (_.path.drop(1).headOption)
+  def sectionsFromAdUnits(adUnits: Seq[GuAdUnit]): Seq[String] = {
+    adUnits map {
+      _.path.drop(1).headOption getOrElse {
+        /*
+         if a line item targets the site root ad unit
+         then a corresponding sponsorship will target any section of the site
+         */
+        ANY_SECTION
+      }
+    }
+  }
 
   val sponsorships: Seq[Sponsorship] = {
     lineItems.withFilter { lineItem =>

--- a/admin/app/views/commercial/sponsorships.scala.html
+++ b/admin/app/views/commercial/sponsorships.scala.html
@@ -1,6 +1,8 @@
 @(env: String, sponsoredTags: dfp.SponsorshipReport, advertisementTags: dfp.SponsorshipReport, foundationSupportedTags: dfp.SponsorshipReport)
 @import tools.DfpLink
 
+@sectionName(section: String) = { @if(section.isEmpty) {theguardian.com} else {@section}}
+
 @listItem(sponsorship: dfp.Sponsorship, flagCountries: Boolean = false) = {
     <li class="lineItem">@{sponsorship.tags.mkString(", ")} (<a href="@DfpLink.lineItem(sponsorship.lineItemId)">@sponsorship.lineItemId</a>)
         @if(sponsorship.sponsor.isEmpty) {
@@ -8,7 +10,14 @@
         } else {
             @{sponsorship.sponsor.map(sponsor => <br /><small>[sponsored by <b>{sponsor}</b>]</small>)}
         }
-        @if(sponsorship.sections.nonEmpty){<br /><small>in section <em>@{sponsorship.sections.mkString(", ")}</em></small>}
+        @if(sponsorship.sections.nonEmpty) {
+            <br />
+            @if(sponsorship.sections.size == 1) {
+                in section <em>@{sectionName(sponsorship.sections.head)}</em>
+            } else {
+                in sections <em>@{sponsorship.sections.map(sectionName).mkString(", ")}</em>
+            }
+        }
         @if(sponsorship.countries.nonEmpty && flagCountries) {
             <br /><small><span class="flagged">
                 geotargeted to @{sponsorship.countries.mkString(", ")}</span></small>

--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -21,6 +21,7 @@ object Sponsorship {
 
   implicit val jsonReads = Json.reads[Sponsorship]
 
+  val ANY_SECTION = ""
 }
 
 case class Sponsorship(tags: Seq[String],

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -238,16 +238,14 @@ class DfpAgentTest extends FlatSpec with Matchers {
       Some("sustainable-business/grundfos-partner-zone")) should be(true)
   }
 
-  it should "be true for an article in a partner zone" +
-    "where the partner zone logo targets the entire site and some special ad units" in {
+  it should "be true for an article where the corresponding logo targets the entire site and some special ad units" in {
     testDfpAgent.isAdvertisementFeature(
       tagId = "wsscc-partner-zone/wsscc-partner-zone",
       sectionId = Some("arbitrary section")
     ) should be(true)
   }
 
-  it should "be false for an article in a partner zone" +
-    "where the partner zone logo only targets some special ad units" in {
+  it should "be false for an article where the corresponding logo only targets some special ad units" in {
     testDfpAgent.isAdvertisementFeature(
       tagId = "some-partner-zone/some-partner-zone",
       sectionId = Some("arbitrary section")

--- a/common/test/dfp/DfpAgentTest.scala
+++ b/common/test/dfp/DfpAgentTest.scala
@@ -5,6 +5,7 @@ import com.gu.facia.client.models.CollectionConfig
 import common.Edition.defaultEdition
 import common.editions.{Au, Uk, Us}
 import conf.Configuration.commercial.dfpAdUnitRoot
+import dfp.Sponsorship.ANY_SECTION
 import model.Tag
 import org.scalatest.Inspectors._
 import org.scalatest.{FlatSpec, Matchers}
@@ -61,7 +62,26 @@ class DfpAgentTest extends FlatSpec with Matchers {
       Sponsorship(Seq("film"), sections = Nil, None, Nil, 5),
       Sponsorship(Seq("grundfos-partner-zone", "sustainable-business-grundfos-partner-zone"),
         sections = Seq("sustainable-business"), None, Nil, 8),
-      Sponsorship(Seq("media-network-adobe-partner-zone"), sections = Nil, None, Nil, 9)
+      Sponsorship(Seq("media-network-adobe-partner-zone"), sections = Nil, None, Nil, 9),
+      Sponsorship(
+        tags = Seq("wsscc-partner-zone"),
+        sections = Seq(
+          ANY_SECTION,
+          "global-development-professionals-network",
+          "global-development-professionals-network/front"),
+        sponsor = None,
+        countries = Nil,
+        lineItemId = 12
+      ),
+      Sponsorship(
+        tags = Seq("some-partner-zone"),
+        sections = Seq(
+          "global-development-professionals-network",
+          "global-development-professionals-network/front"),
+        sponsor = None,
+        countries = Nil,
+        lineItemId = 13
+      )
     )
 
     override protected def foundationSupported: Seq[Sponsorship] = Seq(
@@ -216,6 +236,22 @@ class DfpAgentTest extends FlatSpec with Matchers {
     testDfpAgent.isAdvertisementFeature(
       "sustainable-business-grundfos-partner-zone/sustainable-business-grundfos-partner-zone",
       Some("sustainable-business/grundfos-partner-zone")) should be(true)
+  }
+
+  it should "be true for an article in a partner zone" +
+    "where the partner zone logo targets the entire site and some special ad units" in {
+    testDfpAgent.isAdvertisementFeature(
+      tagId = "wsscc-partner-zone/wsscc-partner-zone",
+      sectionId = Some("arbitrary section")
+    ) should be(true)
+  }
+
+  it should "be false for an article in a partner zone" +
+    "where the partner zone logo only targets some special ad units" in {
+    testDfpAgent.isAdvertisementFeature(
+      tagId = "some-partner-zone/some-partner-zone",
+      sectionId = Some("arbitrary section")
+    ) should be(false)
   }
 
   "hasInlineMerchandise" should "be true if tag id has inline merchandising" in {


### PR DESCRIPTION
This is for the case where a line item targets the site root ad unit as well as some special (exclusive) ad units.
