### PR TITLE
dont use cif as a series identifier

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -91,7 +91,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     .map(_.id).map(Reference(_)).map(_._2)
 
   lazy val seriesMeta = {
-    blogsAndSeries.headOption.map( series =>
+    blogsAndSeries.filterNot{ tag => tag.id == "commentisfree/commentisfree"}.headOption.map( series =>
       Seq(("series", JsString(series.name)), ("seriesId", JsString(series.id)))
     ) getOrElse Nil
   }


### PR DESCRIPTION
This is a result of putting blogs into the series container here: https://github.com/guardian/frontend/pull/7279 and treplicates the logic we use to populate the left -hand meta data where cif is a special case. Essentially what this boils down to is - don't use cif as a series identifier in and of its self but the first non cif blog or series tag,

So (I've screwed up on my cropping here, but the only thing thats changes is the label link)

Before: 
![series-before](https://cloud.githubusercontent.com/assets/986155/5266760/b7fb4072-7a43-11e4-8f45-63c2d978f126.png)

After: 
![series-after](https://cloud.githubusercontent.com/assets/986155/5266775/ca817798-7a43-11e4-96b2-499c57d1767a.png)
