### PR TITLE
Tidy switches, remove underused implicits

### DIFF
--- a/admin/app/controllers/SwitchboardController.scala
+++ b/admin/app/controllers/SwitchboardController.scala
@@ -60,7 +60,7 @@ object SwitchboardController extends Controller with AuthLogging with Logging wi
     }
   }
 
-  private def saveSwitchesOrError(requester: String, updates: List[String]) = try {
+  private def saveSwitchesOrError(requester: String, updates: Seq[String]) = try {
     val current =  Switches.all map { switch =>
       switch.name + "=" + (if (switch.isSwitchedOn) "on" else "off")
     }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -1,7 +1,7 @@
 @(  charts: Seq[tools.AwsLineChart],
     hitMissCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
-    switches: List[conf.Switch],
+    switches: Seq[conf.Switch],
     env: String)
 
 @import org.joda.time.{DateTime, Days}

--- a/applications/app/services/IndexPageGrouping.scala
+++ b/applications/app/services/IndexPageGrouping.scala
@@ -14,7 +14,7 @@ object IndexPageGrouping extends Collections {
   val MinimumPerDayPopOutFrequency = 2
 
   def fromContent(trails: Seq[Content], timezone: DateTimeZone): Seq[IndexPageGrouping] = {
-    val trailsAndDates = trails.zipWith(_.webPublicationDate.withZone(timezone).toLocalDate).map(TrailAndDate.tupled)
+    val trailsAndDates = trails.map(content => TrailAndDate(content, content.webPublicationDate.withZone(timezone).toLocalDate))
 
     trailsAndDates.groupBy(_.date.withDayOfYear(1)).toSeq.sortBy(_._1).reverse flatMap { case (startOfYear, trailsThatYear) =>
       val trailsByMonth = trailsThatYear.groupBy(_.date.withDayOfMonth(1))

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -38,9 +38,16 @@ case class Switch( group: String,
   def daysToExpiry = Days.daysBetween(new DateTime(), sellByDate.toDateTimeAtStartOfDay).getDays
 
   def expiresSoon = daysToExpiry < 7
+
+  Switch.switches.send(this :: _)
 }
 
-object Switches extends Collections {
+object Switch {
+  private val switches = AkkaAgent[List[Switch]](Nil)
+  def allSwitches: Seq[Switch] = switches.get
+}
+
+object Switches {
 
   // Switch names can be letters numbers and hyphens only
 
@@ -374,6 +381,20 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
+  val FootballFeedRecorderSwitch = Switch("Feature", "football-feed-recorder",
+    "If switched on then football matchday feeds will be recorded every minute",
+    safeState = Off, sellByDate = never)
+
+  val CrosswordSvgThumbnailsSwitch = Switch("Feature", "crossword-svg-thumbnails",
+    "If switched on, crossword thumbnails will be accurate SVGs",
+    safeState = Off, sellByDate = never
+  )
+
+  val CricketScoresSwitch = Switch("Feature", "cricket-scores",
+    "If switched on, cricket score and scorecard link will be displayed",
+    safeState = Off, sellByDate = never
+  )
+
   // Facia
 
   val ToolDisable = Switch("Facia", "facia-tool-disable",
@@ -411,99 +432,12 @@ object Switches extends Collections {
     safeState = Off, sellByDate = never
   )
 
-  val FootballFeedRecorderSwitch = Switch("Feature", "football-feed-recorder",
-    "If switched on then football matchday feeds will be recorded every minute",
-    safeState = Off, sellByDate = never)
+  def all: Seq[Switch] = Switch.allSwitches
 
-  val CrosswordSvgThumbnailsSwitch = Switch("Feature", "crossword-svg-thumbnails",
-    "If switched on, crossword thumbnails will be accurate SVGs",
-    safeState = Off, sellByDate = never
-  )
-
-
-  val all: List[Switch] = List(
-    TagPageSizeSwitch,
-    AutoRefreshSwitch,
-    DoubleCacheTimesSwitch,
-    RelatedContentSwitch,
-    FlyerSwitch,
-    AjaxRelatedContentSwitch,
-    DfpCachingSwitch,
-    CommercialSwitch,
-    StandardAdvertsSwitch,
-    CommercialComponentsSwitch,
-    VideoAdvertsSwitch,
-    VpaidAdvertsSwitch,
-    LiveblogAdvertsSwitch,
-    SponsoredSwitch,
-    AudienceScienceSwitch,
-    AudienceScienceGatewaySwitch,
-    CriteoSwitch,
-    DiscussionSwitch,
-    OpenCtaSwitch,
-    FontSwitch,
-    SearchSwitch,
-    ReleaseMessageSwitch,
-    IdentityProfileNavigationSwitch,
-    InlineCriticalCss,
-    FacebookAutoSigninSwitch,
-    FacebookShareUseTrailPicFirstSwitch,
-    IdentityFormstackSwitch,
-    IdentityAvatarUploadSwitch,
-    ToolDisable,
-    ToolSparklines,
-    OphanSwitch,
-    ScrollDepthSwitch,
-    ContentApiPutSwitch,
-    EffectiveMeasureSwitch,
-    ImrWorldwideSwitch,
-    ForeseeSwitch,
-    MediaMathSwitch,
-    KruxSwitch,
-    RemarketingSwitch,
-    OutbrainSwitch,
-    DiagnosticsLogging,
-    TravelOffersFeedSwitch,
-    JobFeedSwitch,
-    MasterclassFeedSwitch,
-    SoulmatesFeedSwitch,
-    MoneysupermarketFeedsSwitch,
-    LCMortgageFeedSwitch,
-    GuBookshopFeedsSwitch,
-    ImageServerSwitch,
-    FaciaToolPressSwitch,
-    ShowAllArticleEmbedsSwitch,
-    FrontPressJobSwitch,
-    EnhanceTweetsSwitch,
-    MemcachedSwitch,
-    MemcachedFallbackSwitch,
-    IncludeBuildNumberInMemcachedKey,
-    GeoMostPopular,
-    FaciaToolCachedContentApiSwitch,
-    FaciaToolDraftContent,
-    GuShiftCookieSwitch,
-    IdentityBlockSpamEmails,
-    IdentityLogRegistrationsFromTor,
-    ABHighCommercialComponent,
-    EnhancedMediaPlayerSwitch,
-    BreakingNewsSwitch,
-    DiscussionPageSizeSwitch,
-    MetricsSwitch,
-    FootballFeedRecorderSwitch,
-    ForceHttpResponseCodeSwitch,
-    CircuitBreakerSwitch,
-    PollPreviewForFreshContentSwitch,
-    PngResizingSwitch,
-    CrosswordSvgThumbnailsSwitch,
-    ZonesAggregationSwitch
-  )
-
-  val httpSwitches: List[Switch] = List(
-  )
-
-  val grouped: List[(String, Seq[Switch])] = all.toList stableGroupBy { _.group }
-
-  def byName(name: String): Option[Switch] = all.find(_.name == name)
+  def grouped: List[(String, Seq[Switch])] = {
+    val sortedSwitches = all.groupBy(_.group).map { case (key, value) => (key, value.sortBy(_.name)) }
+    sortedSwitches.toList.sortBy(_._1)
+  }
 }
 
 class SwitchBoardPlugin(app: Application) extends SwitchBoardAgent(Configuration)

--- a/common/app/implicits/Collections.scala
+++ b/common/app/implicits/Collections.scala
@@ -1,16 +1,13 @@
 package implicits
 
 import language.higherKinds
-import scala.collection.LinearSeq
 import scala.collection.generic.CanBuildFrom
+import collection.mutable.{ HashSet => MutableHashSet }
 
 trait Collections {
 
   // thanks https://gist.github.com/1189097
   implicit class Seq2Distinct[T, C[T] <: Seq[T]](tees: C[T]) {
-    import collection.generic.CanBuildFrom
-    import collection.mutable.{ HashSet => MutableHashSet }
-
     def distinctBy[S](hash: T => S)(implicit cbf: CanBuildFrom[C[T], T, C[T]]): C[T] = {
       val builder = cbf()
       val seen = MutableHashSet[S]()
@@ -23,41 +20,6 @@ trait Collections {
       }
 
       builder.result
-    }
-  }
-
-  implicit class Traversable2ZipWith[T, C[T] <: Traversable[T]](tees: C[T]) {
-    def zipWith[S](f: T => S)(
-      implicit cbf: CanBuildFrom[C[(T, S)], (T, S), C[(T, S)]]): C[(T, S)] = {
-      val builder = cbf()
-
-      val rst = for (t <- tees) yield (t, f(t))
-      rst foreach { builder += _ }
-      builder.result
-    }
-
-    def toMapWith[S](f: T => S)(
-      implicit cbf: CanBuildFrom[C[(T, S)], (T, S), C[(T, S)]]): Map[T, S] = zipWith(f).toMap
-  }
-
-  implicit class Seq2StableGroupBy[T, C[T] <: LinearSeq[T]](tees: C[T]) {
-    import collection.generic.CanBuildFrom
-
-    def stableGroupBy[S](hash: T => S)(implicit cbf: CanBuildFrom[C[(S, LinearSeq[T])], (S, LinearSeq[T]), C[(S, LinearSeq[T])]]): C[(S, LinearSeq[T])] = {
-      val stableKeys: LinearSeq[S] = (tees map { hash }).distinct
-      val groups: Map[S, LinearSeq[T]] = tees groupBy hash
-
-      val rst: LinearSeq[(S, LinearSeq[T])] = Traversable2ZipWith(stableKeys) zipWith { groups(_) }
-
-      val builder = cbf()
-      rst foreach { builder += _ }
-      builder.result
-    }
-  }
-
-  implicit class SeqToStringPimpin(seq: Seq[String]) {
-    def toStringWithRoundBrackets() = {
-      "('" + seq.mkString("', '") + "')"
     }
   }
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -552,7 +552,7 @@ class LiveBlog(content: ApiContentWithMeta) extends Article(content) {
 
   override lazy val hasClassicVersion: Boolean = super.hasClassicVersion && !(section == "football")
 
-  private lazy val cricketMetaData = if (isCricketLiveBlog) {
+  private lazy val cricketMetaData = if (isCricketLiveBlog && conf.Switches.CricketScoresSwitch.isSwitchedOn) {
     Map(("cricketMatch", JsString(webPublicationDate.withZone(DateTimeZone.UTC).toString("yyyy-MM-dd"))))
   } else {
     Map()

--- a/common/app/services/Notification.scala
+++ b/common/app/services/Notification.scala
@@ -52,7 +52,7 @@ trait Notification extends Logging with ExecutionContexts {
 object Notification extends Notification {
   lazy val topic: String = Configuration.aws.notificationSns
 
-  def onSwitchChanges(requester: String, stage: String, changes: List[String]) {
+  def onSwitchChanges(requester: String, stage: String, changes: Seq[String]) {
     val subject = s"${stage.toUpperCase}: Switch changes by ${requester}"
     val message =
       s"""

--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -1,7 +1,6 @@
 @(item: model.MetaData)(implicit request: RequestHeader)
 
 @import common.Edition
-@import dev.HttpSwitch
 @import views.support.{JavaScriptPage, CamelCase}
 @import play.api.libs.json.Json
 
@@ -9,11 +8,7 @@
     {
         "page": @Html(Json.stringify(JavaScriptPage(item).get)),
         "switches" : { @{Html(conf.Switches.all.map{ switch =>
-                if(conf.Switches.httpSwitches.contains(switch))
-                    s""""${CamelCase.fromHyphenated(switch.name)}":${HttpSwitch(switch).isSwitchedOn}"""
-                else
-                    s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""
-            }.mkString(","))}
+            s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}
         },
         "modules": { },
         "images": {


### PR DESCRIPTION
This removes the need for a duplicate switch list, and tidies our Collection implicit.
