### PR TITLE
Tweak static asset monitoring graphs

### DIFF
--- a/admin/app/views/staticAssets.scala.html
+++ b/admin/app/views/staticAssets.scala.html
@@ -14,6 +14,11 @@
         vAxis: {
             title: 'Kb',
             textPosition: 'in',
+            viewWindowMode: 'pretty'
+//            viewWindow: {
+//                max: 100,
+//                min: 0
+//            }
         },
         fontName : 'Helvetica'
     });
@@ -28,12 +33,12 @@
             <table class="table table-bordered table--asset">
                 <thead>
                     <tr>
-                        <th class="table__head" colspan="4">Size in Kb (last 14 days)</th>
+                        <th class="table__head" colspan="4">GZipped size in Kb (last 14 days)</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td colspan="4">@chart(asset.raw)</td>
+                        <td colspan="4">@chart(asset.zipped)</td>
                     </tr>
                 </tbody>
             </table>
@@ -64,9 +69,9 @@
                             <th>Average Selectors</th>
                         </tr>
                         <tr>
-                            <td>@asset.rules.latest</td>
-                            <td>@asset.selectors.latest</td>
-                            <td></td>
+                            <td>@asset.rules.latest.toInt</td>
+                            <td>@asset.selectors.latest.toInt</td>
+                            <td>@{ "%.2f".format(asset.selectors.latest / asset.rules.latest) }</td>
                         </tr>
                     }
                 </tbody>

--- a/admin/app/views/staticAssets.scala.html
+++ b/admin/app/views/staticAssets.scala.html
@@ -15,10 +15,6 @@
             title: 'Kb',
             textPosition: 'in',
             viewWindowMode: 'pretty'
-//            viewWindow: {
-//                max: 100,
-//                min: 0
-//            }
         },
         fontName : 'Helvetica'
     });


### PR DESCRIPTION
This changes the data displayed on our asset-monitoring graphs found [here](https://frontend.gutools.co.uk/metrics/assets).
- Show GZipped rather than raw in main graphs
- Format CSS stats to 2 decimal places
- Show average CSS selector count

/cc @sndrs 
