### PR TITLE
Email preferences: Themes: add Comment Theme

### DIFF
--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -29,8 +29,8 @@ object EmailSubscriptions {
     EmailSubscription(
       "Morning Mail",
       "news",
+      "Guardian Australia's morning news briefing from around the web",
       "A brief mobile-friendly roundup of all the news you need to know in Australia, sent first thing in the morning",
-      "Subscribe to First Dog on the Moon to get his cartoons straight to your inbox every time they're published",
       "Every weekday",
       "2636",
       11,

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -39,7 +39,7 @@
               <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
             }
             <div class="email-subscriptions">
-                @List("news", "sport", "culture", "lifestyle").zipWithIndex.map { case(theme, index) =>
+                @List("news", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
                   @emailListCategoryList(theme, emailSubscriptions.subscriptions.filter(_.theme == theme), index == 0)
                 }
             </div>


### PR DESCRIPTION
I failed to understand how themes work so for now this explicitly adds the Comment theme to the list in the template while I figure out how they should work.

Also one of the descriptions was wrong.
