### PR TITLE
make integration tests runnable locally with firefox

### DIFF
--- a/integrated-tests/src/test/scala/driver/Driver.scala
+++ b/integrated-tests/src/test/scala/driver/Driver.scala
@@ -11,7 +11,7 @@ import org.scalatest.{BeforeAndAfterAll, Retries, Suite}
 
 trait Driver extends Suite with WebBrowser with BeforeAndAfterAll with Retries {
 
-  private val url: String = s"http://${stack.userName}:${stack.automateKey}@ondemand.saucelabs.com:80/wd/hub"
+  private lazy val url: String = s"http://${stack.userName}:${stack.automateKey}@ondemand.saucelabs.com:80/wd/hub"
 
   private lazy val remoteBrowser = {
     val capabilities = DesiredCapabilities.firefox()


### PR DESCRIPTION
According the the README you can run them locally by omitting some variables.  However the val was evaluating the stack.userName regardless.  Fixing to make it a lazy val.
