### PR TITLE
send png resizer requests for all pngs on 10% of page loads

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1,7 +1,6 @@
 package conf
 
 import common._
-import implicits.Collections
 import org.joda.time.{DateTime, Days, LocalDate}
 import play.api.Play.current
 import play.api.libs.ws.WS
@@ -147,8 +146,9 @@ object Switches {
   )
 
   val PngResizingSwitch = Switch("Performance", "png-resizing",
-    "If this switch is on png images will be resized via the png-resizing server",
-    safeState = Off, sellByDate = never
+    //"If this switch is on png images will be resized via the png-resizing server",
+    "If on, 10% of client requests for PNGs will also GET a resized one - for load testing (JD)",
+    safeState = Off, sellByDate = new LocalDate(2014, 12, 10)
   )
 
   // Commercial

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -111,7 +111,7 @@ object ImgSrc {
   def apply(url: String, imageType: ElementProfile): String = {
     val uri = new URI(url.trim)
 
-    val supportedImages = if(PngResizingSwitch.isSwitchedOn) Seq(".jpg", ".jpeg", ".png") else Seq(".jpg", ".jpeg")
+    val supportedImages = if(PngResizingSwitch.isSwitchedOn) Seq(".jpg", ".jpeg"/*, ".png" rewritten in the browser for now*/) else Seq(".jpg", ".jpeg")
     val isSupportedImage = supportedImages.exists(extension => uri.getPath.toLowerCase.endsWith(extension))
 
     hostPrefixMapping.get(uri.getHost)

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -1,11 +1,10 @@
 package views.support
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
-import model.{ImageContainer, ImageAsset}
 import com.gu.contentapi.client.model.Asset
-import conf.Switches.{ImageServerSwitch, PngResizingSwitch}
 import conf.Configuration
+import conf.Switches.ImageServerSwitch
+import model.{ImageAsset, ImageContainer}
+import org.scalatest.{FlatSpec, Matchers}
 
 
 class ImgSrcTest extends FlatSpec with Matchers  {
@@ -48,12 +47,13 @@ class ImgSrcTest extends FlatSpec with Matchers  {
     GalleryLargeTrail.bestFor(image) should be (Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"))
   }
 
-  it should "convert the URL of the image if it is a PNG" in {
-    ImageServerSwitch.switchOn()
-    PngResizingSwitch.switchOn()
-    val pngImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)), null, 0)
-    GalleryLargeTrail.bestFor(pngImage) should be (Some(s"${imageHost}/static/w-480/h-288/q-95/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png"))
-  }
+  // removed temporarily because the PNG is converted on the client side for 10% of users for an extra hidden img element
+//  it should "convert the URL of the image if it is a PNG" in {
+//    ImageServerSwitch.switchOn()
+//    PngResizingSwitch.switchOn()
+//    val pngImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)), null, 0)
+//    GalleryLargeTrail.bestFor(pngImage) should be (Some(s"${imageHost}/static/w-480/h-288/q-95/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png"))
+//  }
 
   it should "not convert the URL of the image if it is a GIF (we do not support animated GIF)" in {
     ImageServerSwitch.switchOn()

--- a/static/src/javascripts/components/imager.js/imager.js
+++ b/static/src/javascripts/components/imager.js/imager.js
@@ -36,6 +36,8 @@ ImagerStrategyOptions;
 function Imager (collection, options) {
     options = options || {};
 
+    this.matchingClassName = (options.placeholder && options.placeholder.matchingClassName) || 'none' // TODO temporary code
+
     this.update(collection);
     options.strategy = options.strategy || 'replacer';
     this.replacementDelay = (options.hasOwnProperty('replacementDelay')) ? options.replacementDelay : 200;
@@ -94,17 +96,44 @@ Imager.prototype.update = function updateNodes (collection) {
 };
 
 /**
+ * change
+ * http://static.guim.co.uk /sys-images/Guardian/Pix/pictures/2014/3/13/1394733741000/JonathanJones.png
+ * http://i.guim.co.uk/static/w-10/h--/q-95 /sys-images/Guardian/Pix/pictures/2014/3/13/1394733741000/JonathanJones.png
+ * @param url
+ * @returns {*}
+ */
+Imager.changeToResizer = function changeToResizer (url) {
+
+    if ((url.slice(-'.png'.length) == '.png') && (url.indexOf('http://static.guim.co.uk/') === 0)) {
+        return url.replace('http://static.guim.co.uk', 'http://i.guim.co.uk/static/w-10/h--/q-95');
+    }
+    return undefined;
+};
+
+/**
  * Updates the responsive image source with a better URI
  */
 Imager.prototype.updateImagesSource = function updateImagesSource () {
     var i = this.nodes.length,
         self = this,
-        strategy = self.strategy;
+        strategy = self.strategy,
+        srcUrl,
+        updatedUrl;
 
     while (i--) {
-        strategy.updatePlaceholderUri(this.nodes[i], Imager.replaceUri(this.nodes[i].getAttribute('data-src'), {
-            'width': self.getBestWidth(this.nodes[i].clientWidth, this.nodes[i].getAttribute('data-width'))
-        }));
+        // TODO temp code to put some load on the PNG resizer
+        if (this.matchingClassName && this.matchingClassName === 'resized-png-img') {
+            srcUrl = this.nodes[i].getAttribute('data-src');
+            updatedUrl = Imager.changeToResizer(srcUrl);
+            if (updatedUrl) {
+                strategy.updatePlaceholderUri(this.nodes[i], updatedUrl);
+            }
+        } else {
+            // END temp code
+            strategy.updatePlaceholderUri(this.nodes[i], Imager.replaceUri(this.nodes[i].getAttribute('data-src'), {
+                'width': self.getBestWidth(this.nodes[i].clientWidth, this.nodes[i].getAttribute('data-width'))
+            }));
+        }
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -5,6 +5,7 @@ define([
     'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/$css',
+    'common/utils/config',
     'common/utils/mediator'
 ],
 function (
@@ -14,6 +15,7 @@ function (
     debounce,
     $,
     $css,
+    config,
     mediator
 ) {
 
@@ -28,6 +30,19 @@ function (
                     strategy: 'container',
                     replacementDelay: 0
                 },
+                optionsTemp = {
+                    availableWidths: images.availableWidths,
+                    strategy: 'container',
+                    replacementDelay: 0,
+                    placeholder: {
+                        element: (function () {
+                            var img = document.createElement('img');
+                            img.style.display = 'none';
+                            return img;
+                        })(),
+                        matchingClassName: 'resized-png-img'
+                    }
+                },
                 containers = $('.js-image-upgrade', context).map(
                     function (container) {
                         return container;
@@ -36,8 +51,22 @@ function (
                     function (container) {
                         return $css(bonzo(container), 'display') !== 'none';
                     }
+                ),
+                containersTemp = $('.js-image-upgrade', context).map(
+                    function (container) {
+                        return container;
+                    },
+                    // this is an optional filter function
+                    function (container) {
+                        return $css(bonzo(container), 'display') !== 'none' && container.getAttribute('data-src') && container.getAttribute('data-src').slice(-'.png'.length) === '.png';
+                    }
                 );
             imager.init(containers, options);
+            // TODO temp code to put some load on the PNG resizer
+            if (config.switches.pngResizing && Math.random() < 0.1) {
+                imager.init(containersTemp, optionsTemp);
+            }
+            // END temp code
             // add empty alts if none exist
             forEach(containers, function (container) {
                 $('img', container).each(function (img) {


### PR DESCRIPTION
The PNG resizer was getting unhealthy when we were using it in production.  We are not sure why as it works ok with light load.

This is to add some load to the resizer without affecting the user experience if it dies.  The browser will just GET a small image and store it in a hidden img element.

It's pretty hacky as the existing code's not really designed with this in mind, but I didn't want to rewrite it all just for a short term test.

I will turn on for short periods during the day and monitor the servers for response time etc.

@robertberry @phamann any comments?
