### PR TITLE
Removing negative margin from commercial component slots

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -258,8 +258,6 @@
  */
 .ad-slot--commercial-component,
 .ad-slot--commercial-component-high {
-    margin-bottom: -$gs-baseline;
-    
     .has-page-skin & {
         @include mq(wide) {
             margin-left: auto;


### PR DESCRIPTION
This removes a negative margin that was put in to close a gap that isn't there any more!

Before;
![screen shot 2014-12-03 at 17 21 16](https://cloud.githubusercontent.com/assets/1303616/5285069/e3f18358-7b10-11e4-951a-4fdf96e61289.png)

After;
![screen shot 2014-12-03 at 17 21 31](https://cloud.githubusercontent.com/assets/1303616/5285071/e96b384c-7b10-11e4-850d-cb5534353579.png)
