### PR TITLE
Fix for social button clash on thumbnail images

### DIFF
--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -362,9 +362,11 @@
         position: absolute;
         right: -$gs-gutter/4;
         margin-top: ($gs-baseline/3)*2;
+    }
 
-        .element--thumbnail &,
-        .img--base & {
+    .element--thumbnail,
+    .img--base {
+        .block-share--article {
             display: none !important;
         }
     }


### PR DESCRIPTION
Fix for:
![screen shot 2014-12-03 at 18 34 27](https://cloud.githubusercontent.com/assets/2236852/5286310/15f7574c-7b1b-11e4-9a54-af552f08ecda.png)
