### PR TITLE
Add a redirection identifier to archive controller

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -22,15 +22,15 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
 
       // if we do not have a location in the database then follow these rules
       path match {
-        case Decoded(decodedPath)         => redirectTo(decodedPath)
-        case Gallery(gallery)             => redirectTo(gallery)
-        case Century(century)             => redirectTo(century)
-        case Lowercase(lower)             => redirectTo(lower)
+        case Decoded(decodedPath)         => redirectTo(decodedPath, "decoded")
+        case Gallery(gallery)             => redirectTo(gallery, "gallery")
+        case Century(century)             => redirectTo(century, "century")
+        case Lowercase(lower)             => redirectTo(lower, "lowercase")
 
         // Googlebot hits a bunch of really old combiners and combiner RSS
         // bounce these to the section
-        case CombinerSectionRss(section)  => redirectTo(s"$section/rss")
-        case CombinerSection(section)     => redirectTo(section)
+        case CombinerSectionRss(section)  => redirectTo(s"$section/rss", "combinerrss")
+        case CombinerSection(section)     => redirectTo(section, "combinersection")
 
         case _ =>
           log404(request)
@@ -95,9 +95,9 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
     }
   }
 
-  private def redirectTo(path: String)(implicit request: RequestHeader): Result = {
-    log.info(s"301,${RequestLog(request)}")
-    Cached(300)(Redirect(s"http://$path", 301))
+  private def redirectTo(path: String, identifier: String)(implicit request: RequestHeader): Result = {
+    log.info(s"301, $identifier, ${RequestLog(request)}")
+    Cached(300)(Redirect(s"http://$path?redirection=$identifier", 301))
   }
 
   private def logDestination(path: String, msg: String, destination: String) {

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -29,19 +29,19 @@ import scala.concurrent.Future
   it should "decode encoded urls" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/foo%2Cfoo")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/foo,foo")
+    location(result) should be ("http://www.theguardian.com/foo,foo?redirection=decoded")
   }
 
   it should "decode encoded spaces as + for tag combiners" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/foo%20foo")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/foo+foo")
+    location(result) should be ("http://www.theguardian.com/foo+foo?redirection=decoded")
   }
 
   it should "redirect old style galleries" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/arts/gallery/0,")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/arts/pictures/0,")
+    location(result) should be ("http://www.theguardian.com/arts/pictures/0,?redirection=gallery")
   }
 
   it should "test a redirect doesn't not link to itself" in {
@@ -53,25 +53,25 @@ import scala.concurrent.Future
   it should "lowercase the section of the url" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/Football/News_Story/0,1563,1655638,00.html")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/football/News_Story/0,1563,1655638,00.html")
+    location(result) should be ("http://www.theguardian.com/football/News_Story/0,1563,1655638,00.html?redirection=lowercase")
   }
 
   it should "redirect century urls correctly" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/century")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
+    location(result) should be ("http://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century?redirection=century")
   }
 
   it should "redirect century decade urls correctly" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/1899-1909")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
+    location(result) should be ("http://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century?redirection=century")
   }
 
   it should "redirect an R1 century article to a corrected decade story endpoint" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/1899-1909/Story/0,,126404,00.html")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/century/1899-1909/Story/0,,126404,00.html")
+    location(result) should be ("http://www.theguardian.com/century/1899-1909/Story/0,,126404,00.html?redirection=century")
   }
 
   it should "not redirect a random URL that contains the word century" in {
@@ -82,21 +82,21 @@ import scala.concurrent.Future
   it should "redirect failed combiners to the section" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/tv-and-radio/tvandradioblog+media/chris-evans")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/tv-and-radio")
+    location(result) should be ("http://www.theguardian.com/tv-and-radio?redirection=combinersection")
 
     val result2 = controllers.ArchiveController.lookup("www.theguardian.com/tv-and-radio+media/chris-evans")(TestRequest())
     status(result2) should be (301)
-    location(result2) should be ("http://www.theguardian.com/tv-and-radio")
+    location(result2) should be ("http://www.theguardian.com/tv-and-radio?redirection=combinersection")
   }
 
   it should "redirect failed combiners RSS to the section RSS" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/tv-and-radio/tvandradioblog+media/chris-evans/rss")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/tv-and-radio/rss")
+    location(result) should be ("http://www.theguardian.com/tv-and-radio/rss?redirection=combinerrss")
 
     val result2 = controllers.ArchiveController.lookup("www.theguardian.com/tv-and-radio+media/chris-evans/rss")(TestRequest())
     status(result2) should be (301)
-    location(result2) should be ("http://www.theguardian.com/tv-and-radio/rss")
+    location(result2) should be ("http://www.theguardian.com/tv-and-radio/rss?redirection=combinerrss")
   }
 
   private def location(result: Future[Result]): String = header("Location", result).head


### PR DESCRIPTION
This works towards reducing some 3XX loops that could be contributing to our 4XX alarms (they appear as 400 in the fastly logs, with a (null) backend server). The redirect loop will hit Article once per loop, resulting in a 404 response from article, then a router-based recovery request to archive, then a db lookup failure, then a 301 from archive.

Ideally, we should not redirect if there are not a lot of invalid urls coming through to our 'archive url rescue' system. Specifically, we permit a request that has encoded characters. A redirect with decoded characters could get re-encoded, resulting in a loop. Maybe we could whitelist encoded characters worth saving (like the R1 comma), or be honest, and give a 404.

I will remove the encoding-based redirect if the identifier added in this PR shows little traffic being redirected successfully.
