### PR TITLE
Add 'data-discussion-closed' attribute to top comment count

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -22,7 +22,7 @@
         <div class="meta__numbers modern-visible">
             <div class="u-h meta__number js-sharecount">
             </div>
-            <div class="u-h meta__number" data-discussion-id="@content.discussionId" data-commentcount-format="content">
+            <div class="u-h meta__number" data-discussion-id="@content.discussionId" data-commentcount-format="content" data-discussion-closed="@content.isCommentable">
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is a fix for the comment count erroneously showing on articles where the comments were closed after the article was already published. 

e.g. http://localhost:9000/artanddesign/gallery/2014/dec/01/the-beauty-of-a-red-headed-man-in-pictures
