### PR TITLE
Fixed "trouble loading?" discussion link

### DIFF
--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -108,7 +108,7 @@
                         @toolbar
 
                         <div class="preload-msg discussion__loader">Loading comments… <a href=@{
-                            s"/discussion/$discussionId"
+                            s"/discussion$discussionId"
                         } class="accessible-link">Trouble loading?</a><div class="is-updating"></div></div>
 
                         <div class="discussion__main-comments js-discussion-main-comments"></div>


### PR DESCRIPTION
Removed the extra slash so the "trouble loading?" link doesn't redirect to the article page. 

Currently the link is rendered as: http://www.theguardian.com/discussion//p/43na9
