### PR TITLE
Only provide a redirect for tag combiners

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -22,7 +22,6 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
 
       // if we do not have a location in the database then follow these rules
       path match {
-        case Decoded(decodedPath)         => redirectTo(decodedPath, "decoded")
         case Gallery(gallery)             => redirectTo(gallery, "gallery")
         case Century(century)             => redirectTo(century, "century")
         case Lowercase(lower)             => redirectTo(lower, "lowercase")
@@ -31,6 +30,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
         // bounce these to the section
         case CombinerSectionRss(section)  => redirectTo(s"$section/rss", "combinerrss")
         case CombinerSection(section)     => redirectTo(section, "combinersection")
+        case Combiner(combiner)           => redirectTo(combiner, "combiner")
 
         case _ =>
           log404(request)
@@ -59,10 +59,11 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
       linksToItself(path, destination.location)
   })
 
-  private object Decoded {
+  private object Combiner {
     def unapply(path: String): Option[String] = {
-        val decodedPath = URLDecoder.decode(path, "UTF-8").replace(" ", "+") // the + is for combiner pages
-        if (decodedPath != path) Some(decodedPath) else None
+        val decodedPath = URLDecoder.decode(path, "UTF-8")
+        val combinerPath = decodedPath.replace(" ", "+") // the + is for combiner pages
+        if (decodedPath != combinerPath) Some(combinerPath) else None
     }
   }
 

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -26,16 +26,15 @@ import scala.concurrent.Future
     controllers.ArchiveController.normalise(path , zeros = "00") should be (expectedPath)
   }
   
-  it should "decode encoded urls" in {
-    val result = controllers.ArchiveController.lookup("www.theguardian.com/foo%2Cfoo")(TestRequest())
-    status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/foo,foo?redirection=decoded")
+  it should "not decode encoded urls" in {
+    val result = controllers.ArchiveController.lookup("www.theguardian.com/foo/%2Cfoo")(TestRequest())
+    status(result) should be (404)
   }
 
   it should "decode encoded spaces as + for tag combiners" in {
     val result = controllers.ArchiveController.lookup("www.theguardian.com/foo%20foo")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/foo+foo?redirection=decoded")
+    location(result) should be ("http://www.theguardian.com/foo+foo?redirection=combiner")
   }
 
   it should "redirect old style galleries" in {


### PR DESCRIPTION
It turned out that our 4XX, redirect looping, encoder endpoint was only worth 4 200 responses every 5 minutes, all of which were tag combiners.

This pr maintains the tag combiner redirect, whilst giving a 404 for other encoded urls.
