### PR TITLE
Stop tag pages including themselves in the list of topics

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -36,7 +36,7 @@
             </div>
         }
 
-        @fragments.trendingTopics(index.trails, index.allPath)
+        @fragments.trendingTopics(index.trails, index.page.id, None)
 
         @fragments.commercial.commercialComponent()
     </div>


### PR DESCRIPTION
Fixes a bug where tag pages include themselves in the list of topics
