### PR TITLE
Fix /all page redirects for tag (not section) pages

### DIFF
--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -55,7 +55,7 @@ private object ItemOrRedirect extends ItemResponses with Logging {
 
   private def needsRedirect[T](itemPath: String)(implicit request: RequestHeader): Boolean = {
     // redirect if itemPath is not the same as request's, and this isn't an all page, a JSON or an RSS request
-    itemPath != request.path && !(request.isJson || request.isRss)
+    itemPath != request.path.stripSuffix("/all") && !(request.isJson || request.isRss)
   }
 }
 


### PR DESCRIPTION
/all pages for tag pages (not section pages) currently always redirect, which is wrong, as we override some tags with Facia fronts.
