### PR TITLE
Add temporary StaticSecure method to explicity fetch secure asset paths

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -13,7 +13,7 @@
             * { margin: 0; padding: 0; }
             figure { margin: 0 !important; }
         </style>
-        <link rel="stylesheet" href="@Static("stylesheets/media-player.css")"/>
+        <link rel="stylesheet" href="@StaticSecure("stylesheets/media-player.css")"/>
     </head>
     <body>
 
@@ -96,13 +96,13 @@
                         baseUrl: '@{Configuration.assets.path}javascripts',
                         apiName: 'require',
                         paths: {
-                            core: '@Static("javascripts/core.js")',
+                            core: '@StaticSecure("javascripts/core.js")',
                             text: 'text', // noop
-                            'bootstraps/video-embed': '@Static("javascripts/bootstraps/video-embed.js")'
+                            'bootstraps/video-embed': '@StaticSecure("javascripts/bootstraps/video-embed.js")'
                         }
                     };
 
-                    @Html(Static.js.curl)
+                    @Html(StaticSecure.js.curl)
 
                     require(['bootstraps/video-embed'], function(bootstrap) {
                         bootstrap.init();

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -198,6 +198,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val path =
       if (environment.secure) configuration.getMandatoryStringProperty("assets.securePath")
       else configuration.getMandatoryStringProperty("assets.path")
+    lazy val securePath = configuration.getMandatoryStringProperty("assets.securePath")
   }
 
   object staticSport {

--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -14,6 +14,7 @@ object Configuration extends GuardianConfiguration("frontend", webappConfDirecto
 object LiveContentApi extends ElasticSearchLiveContentApiClient
 
 object Static extends Assets(Configuration.assets.path)
+object StaticSecure extends Assets(Configuration.assets.securePath)
 
 object Gzipper extends GzipFilter(
   shouldGzip = (req, resp) => !resp.headers.get("Content-Type").exists(_.startsWith("image/"))


### PR DESCRIPTION
Our current implementation of `Static` assumes that your entire environment is secure to return secure paths. This doesn't enable us to change the paths on a per route/action or individual asset basis, which we require for the new embed work.

After discussing with @gklopper this is a temporary solution until we discuss with Level3 the possibility of serving both protocols over the same host, which in-turn would negate the need for any of this and we can just use a single protocol relative path.

/cc @mattosborn 
