### PR TITLE
Sponsorship feature logo

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -383,10 +383,8 @@
     }
     .ad-slot--paid-for-badge__link {
         position: relative;
-        float: right;
-
         @include mq(mobile, $until: leftCol) {
-            margin-top: get-line-height(data, 3)*-1;
+            margin-top: 0;
         }
     }
 
@@ -397,13 +395,18 @@
         float: left;
         min-height: 0;
         margin-top: 4px;
+        padding-top: 2px;
+        border-top: 1px dotted colour(neutral-5);
 
         .ad-slot--paid-for-badge__link {
             float: none;
             margin-top: $gs-row-height/4;
         }
     }
-
+    @include mq(tablet, $until: leftCol) {
+        float: right;
+        clear: right;
+    }
     @include mq(wide) {
         .has-page-skin & {
             margin-left: 50%;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -383,6 +383,19 @@
     }
     .ad-slot--paid-for-badge__link {
         position: relative;
+        &:after {
+            display: block;
+            height: 0;
+            width: $left-column + $gs-gutter;
+            content: '';
+            border-bottom: 1px dotted colour(neutral-5);
+            @include mq(leftCol) {
+                width: $left-column;
+            }
+            @include mq(wide) {
+                width: $left-column-wide;
+            }
+        }
         @include mq(mobile, $until: leftCol) {
             margin-top: 0;
         }
@@ -406,8 +419,10 @@
     @include mq(tablet, $until: leftCol) {
         float: right;
         clear: right;
+        width: $left-column + $gs-gutter;
     }
     @include mq(wide) {
+        width: $left-column-wide;
         .has-page-skin & {
             margin-left: 50%;
             width: auto;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -411,6 +411,11 @@
         padding-top: 2px;
         border-top: 1px dotted colour(neutral-5);
 
+        .ad-slot--capi-multiple & {
+            position: absolute;
+            bottom: $gs-gutter;
+        }
+
         .ad-slot--paid-for-badge__link {
             float: none;
             margin-top: $gs-row-height/4;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -352,12 +352,14 @@
         border-bottom-width: 0;
         border-top: 1px dotted colour(neutral-5);
     }
+
     @include mq(mobile, $until: leftCol) {
-        padding-bottom: $gs-baseline/2;
+        padding-bottom: $gs-baseline / 2;
         .ad-slot--paid-for-badge__link {
             margin-top: 6px;
         }
     }
+
     .ad-slot--paid-for-badge__logo {
         @include mq(mobile, $until: leftCol) {
             max-height: 60px;
@@ -389,6 +391,7 @@
     @include mq(tablet) {
         padding-left: $gs-gutter / 2;
     }
+
     .container--has-toggle & {
         @include mq(tablet, $until: leftCol) {
             margin-right: gs-span(1);
@@ -399,19 +402,23 @@
     }
     .ad-slot--paid-for-badge__link {
         position: relative;
+
         &:after {
             display: block;
             height: 0;
             width: $left-column + $gs-gutter;
             content: '';
             border-bottom: 1px dotted colour(neutral-5);
+
             @include mq(leftCol) {
                 width: $left-column;
             }
+
             @include mq(wide) {
                 width: $left-column-wide;
             }
         }
+
         @include mq(mobile, $until: leftCol) {
             margin-top: 0;
         }
@@ -449,6 +456,7 @@
     }
     @include mq(wide) {
         width: $left-column-wide;
+
         .has-page-skin & {
             margin-left: 50%;
             width: auto;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -291,6 +291,9 @@
         @include fs-textSans(1);
         color: colour(neutral-2);
     }
+    .ad-slot--paid-for-badge__help {
+        @include font-size(11, 14);
+    }
     .ad-slot--paid-for-badge__header {
         margin: 0;
         padding-top: $gs-baseline / 2;
@@ -343,12 +346,22 @@
 .ad-slot--paid-for-badge--article {
     padding-bottom: $gs-baseline * 2;
     border-bottom: 1px dotted colour(neutral-5);
-    min-height: 135px;
 
     @include mq(leftCol) {
         min-height: 0;
         border-bottom-width: 0;
         border-top: 1px dotted colour(neutral-5);
+    }
+    @include mq(mobile, $until: leftCol) {
+        padding-bottom: $gs-baseline/2;
+        .ad-slot--paid-for-badge__link {
+            margin-top: 6px;
+        }
+    }
+    .ad-slot--paid-for-badge__logo {
+        @include mq(mobile, $until: leftCol) {
+            max-height: 60px;
+        }
     }
     .content--media--video & {
         min-height: 0;
@@ -381,6 +394,9 @@
             margin-right: gs-span(1);
         }
     }
+    .ad-slot--capi-single & {
+        margin: 0;
+    }
     .ad-slot--paid-for-badge__link {
         position: relative;
         &:after {
@@ -398,6 +414,11 @@
         }
         @include mq(mobile, $until: leftCol) {
             margin-top: 0;
+        }
+    }
+    .ad-slot--paid-for-badge__logo {
+        @include mq(mobile, $until: leftCol) {
+            max-height: 60px;
         }
     }
 
@@ -441,6 +462,9 @@
         .has-page-skin .container--has-toggle & {
             margin-right: gs-span(1);
         }
+    }
+    @include mq($until: tablet) {
+        clear: both;
     }
 }
 .fc-container--sponsored .fc-container:first-child,

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -71,10 +71,14 @@
     }
 }
 
+.ad-slot--capi-multiple {
+    position: relative;
+}
+
 .fc-container--commercial-capi {
     .fc-item__image-container {
         display: block;
-    }    
+    }
 }
 
 .fc-container--advertisement-feature {
@@ -85,7 +89,7 @@
     .item__link:visited .item__title {
         color: colour(neutral-2-contrasted);
     }
-    
+
     .fc-item__header,
     .fc-item__title,
     .fc-item__standfirst,

--- a/static/src/stylesheets/module/commercial/_lineitem.scss
+++ b/static/src/stylesheets/module/commercial/_lineitem.scss
@@ -5,7 +5,6 @@
     .lineitems {
         padding: 0;
         margin: 0;
-        overflow: hidden;
     }
     .lineitem {
         @include box-sizing(border-box);

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -128,7 +128,30 @@ $header-image-size-desktop: 100px;
 
 .fc-container__header {
     @include mq($until: tablet) {
+        overflow: hidden;
         border-bottom: 1px dotted colour(neutral-5);
+
+        .fc-container__header__title,
+        .fc-container__header__description {
+            float: left;
+        }
+        .fc-container__header__title {
+            padding-right: $gs-baseline/2;
+        }
+        .fc-container__header__description {
+            margin-top: 2px;
+        }
+        .ad-slot--capi-multiple &,
+        .ad-slot--capi-single &,
+        .fc-container--tag & {
+            border-bottom: 0;
+        }
+    }
+    @include mq(tablet, $until: leftCol) {
+        .fc-container--tag & {
+            float: left;
+            clear: left;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -136,7 +136,7 @@ $header-image-size-desktop: 100px;
             float: left;
         }
         .fc-container__header__title {
-            padding-right: $gs-baseline/2;
+            padding-right: $gs-gutter/4;
         }
         .fc-container__header__description {
             margin-top: 2px;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -126,6 +126,12 @@ $header-image-size-desktop: 100px;
     }
 }
 
+.fc-container__header {
+    @include mq($until: tablet) {
+        border-bottom: 1px dotted colour(neutral-5);
+    }
+}
+
 .fc-container__header__title,
 .container__title {
     position: relative;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -136,7 +136,7 @@ $header-image-size-desktop: 100px;
             float: left;
         }
         .fc-container__header__title {
-            padding-right: $gs-gutter/4;
+            padding-right: $gs-gutter / 4;
         }
         .fc-container__header__description {
             margin-top: 2px;


### PR DESCRIPTION
The sponsorship feature logo visual fixes:

Position of the whole feature logo, smaller font size, max-height on a logo image in cAPI single and multiple components
![screen shot 2014-12-05 at 11 25 37](https://cloud.githubusercontent.com/assets/489567/5315130/6faea176-7c71-11e4-9e0e-f06998036c91.png)

Position of the whole feature logo, headers in one line (if text is not too long), border under headers on a front page
![screen shot 2014-12-05 at 11 29 14](https://cloud.githubusercontent.com/assets/489567/5315162/e9ce7954-7c71-11e4-81b7-02f8c3d22e15.png)

Position of the whole feature logo, additional border under the logo, no additional spaces on a tags page
![screen shot 2014-12-05 at 11 33 41](https://cloud.githubusercontent.com/assets/489567/5315214/8ce96d88-7c72-11e4-90f4-603adb05c1bb.png)

Smaller font size, max-height on a logo image on an article page
![screen shot 2014-12-05 at 11 36 08](https://cloud.githubusercontent.com/assets/489567/5315236/e118e5fa-7c72-11e4-8a20-5a766015c464.png)

Smaller font size on an interactive page
![screen shot 2014-12-05 at 11 36 57](https://cloud.githubusercontent.com/assets/489567/5315250/fe1bd8a6-7c72-11e4-899c-ac7f19dab9b9.png)
