### PR TITLE
Refactor video embed logic to enable in article video embeds

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -93,7 +93,7 @@
                     document.documentElement.className = docClass;
 
                     var curl = {
-                        baseUrl: '@{Configuration.assets.path}javascripts',
+                        baseUrl: '@{Configuration.assets.securePath}javascripts',
                         apiName: 'require',
                         paths: {
                             core: '@StaticSecure("javascripts/core.js")',

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -15,7 +15,7 @@
             ("js-gu-media", true)
         ))" data-title="@player.title" data-auto-play="@player.autoPlay" data-show-end-slate="@player.showEndSlate"
             poster="@player.poster" data-duration="@player.video.duration.toString()" data-media-id="@player.video.id"
-            data-end-slate="@player.endSlatePath" data-block-video-ads="@player.blockVideoAds">
+            data-end-slate="@player.endSlatePath" data-block-video-ads="@player.blockVideoAds" data-embeddable="@player.video.embeddable">
 
             @player.video.encodings.map { encoding =>
                 <source src="@encoding.url" type="@encoding.format" />

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -1,5 +1,6 @@
 package views.support
 
+import java.net.URL
 import java.util.regex.{Matcher, Pattern}
 
 import common.{Edition, LinkTo}
@@ -105,6 +106,8 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
       findVideoApiElement(mediaId).foreach( videoElement => {
         element.attr("data-block-video-ads", videoElement.blockVideoAds.toString)
+        element.attr("data-embeddable", videoElement.embeddable.toString)
+        element.attr("data-embed-path", new URL(element.parent().parent().attr("data-canonical-url")).getPath.stripPrefix("/"))
       })
     }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -66,49 +66,55 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
       })
     }
 
-    document.getElementsByClass("gu-video").foreach { element: Element =>
+    document.getElementsByClass("element-video").foreach { figure: Element =>
+      val canonicalUrl = figure.attr("data-canonical-url")
 
-      element
-        .removeClass("gu-video")
-        .addClass("js-gu-media gu-media gu-media--video")
-        .wrap("<div class=\"gu-media-wrapper gu-media-wrapper--video u-responsive-ratio u-responsive-ratio--hd\"></div>")
+      figure.getElementsByClass("gu-video").foreach { element: Element =>
 
-      val flashMediaElement = conf.Static("flash/components/mediaelement/flashmediaelement.swf").path
+        element
+          .removeClass("gu-video")
+          .addClass("js-gu-media gu-media gu-media--video")
+          .wrap("<div class=\"gu-media-wrapper gu-media-wrapper--video u-responsive-ratio u-responsive-ratio--hd\"></div>")
 
-      val mediaId = element.attr("data-media-id")
-      val asset = findVideoFromId(mediaId)
+        val flashMediaElement = conf.Static("flash/components/mediaelement/flashmediaelement.swf").path
 
-      element.getElementsByTag("source").remove()
+        val mediaId = element.attr("data-media-id")
+        val asset = findVideoFromId(mediaId)
 
-      val sourceHTML: String = getVideoAssets(mediaId).map { videoAsset =>
-        videoAsset.encoding.map { encoding =>
-          s"""<source src="${encoding.url}" type="${encoding.format}"></source>"""
-        }.getOrElse("")
-      }.mkString("")
+        element.getElementsByTag("source").remove()
 
-      element.append(sourceHTML)
+        val sourceHTML: String = getVideoAssets(mediaId).map { videoAsset =>
+          videoAsset.encoding.map { encoding =>
+            s"""<source src="${encoding.url}" type="${encoding.format}"></source>"""
+          }.getOrElse("")
+        }.mkString("")
 
-      // add the poster url
-      asset.flatMap(_.image).flatMap(Item640.bestFor).map(_.toString()).foreach{ url =>
-        element.attr("poster", url)
-      }
+        element.append(sourceHTML)
 
-      asset.foreach( video => {
-        element.append(
-          s"""<object type="application/x-shockwave-flash" data="$flashMediaElement" width="620" height="350">
+        // add the poster url
+        asset.flatMap(_.image).flatMap(Item640.bestFor).map(_.toString()).foreach { url =>
+          element.attr("poster", url)
+        }
+
+        asset.foreach(video => {
+          element.append(
+            s"""<object type="application/x-shockwave-flash" data="$flashMediaElement" width="620" height="350">
                 <param name="allowFullScreen" value="true" />
                 <param name="movie" value="$flashMediaElement" />
                 <param name="flashvars" value="controls=true&amp;file=${video.url.getOrElse("")}" />
                 Sorry, your browser is unable to play this video.
               </object>""")
 
-      })
+        })
 
-      findVideoApiElement(mediaId).foreach( videoElement => {
-        element.attr("data-block-video-ads", videoElement.blockVideoAds.toString)
-        element.attr("data-embeddable", videoElement.embeddable.toString)
-        element.attr("data-embed-path", new URL(element.parent().parent().attr("data-canonical-url")).getPath.stripPrefix("/"))
-      })
+        findVideoApiElement(mediaId).foreach{ videoElement =>
+          element.attr("data-block-video-ads", videoElement.blockVideoAds.toString)
+          element.attr("data-embeddable", videoElement.embeddable.toString)
+          if(!canonicalUrl.isEmpty) {
+            element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))
+          }
+        }
+      }
     }
 
     document.getElementsByClass("element-witness--main").foreach { element: Element =>

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -287,12 +287,14 @@ define([
                     preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35
                     plugins: {
                         embed: {
-                            embedable: config.switches.externalVideoEmbeds && $el.attr('data-block-video-ads') === 'true',
+                            embeddable: config.switches.externalVideoEmbeds && $el.attr('data-embeddable') === 'true',
                             location: config.page.externalEmbedHost + (embedPath ? embedPath : config.page.pageId)
                         }
                     }
                 }),
                 mouseMoveIdle;
+
+            console.log($el.attr('data-embeddable'));
 
             player.guMediaType = mediaType;
 

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -280,14 +280,15 @@ define([
                 blockVideoAds = $el.attr('data-block-video-ads') === 'true',
                 showEndSlate = $el.attr('data-show-end-slate') === 'true',
                 endSlateUri = $el.attr('data-end-slate'),
+                embedPath = $el.attr('data-embed-path'),
                 player = createVideoPlayer(el, {
                     controls: true,
                     autoplay: false,
                     preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35
                     plugins: {
                         embed: {
-                            embedable: config.switches.externalVideoEmbeds && config.page.embeddable,
-                            location: config.page.externalEmbedHost + config.page.pageId
+                            embedable: config.switches.externalVideoEmbeds && $el.attr('data-block-video-ads') === 'true',
+                            location: config.page.externalEmbedHost + (embedPath ? embedPath : config.page.pageId)
                         }
                     }
                 }),

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -294,8 +294,6 @@ define([
                 }),
                 mouseMoveIdle;
 
-            console.log($el.attr('data-embeddable'));
-
             player.guMediaType = mediaType;
 
             //Location of this is important

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -77,7 +77,7 @@ define([
                     preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35
                     plugins: {
                         embed: {
-                            embedable: guardian.config.switches.externalVideoEmbeds && guardian.config.page.embeddable,
+                            embeddable: guardian.config.switches.externalVideoEmbeds && guardian.config.page.embeddable,
                             location: 'https://embed.theguardian.com/embed/video/' + guardian.config.page.pageId
                         }
                     }

--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -24,7 +24,7 @@
     "fastclick": "guardian/fastclick#master",
     "requirejs-text": "~2.0.12",
     "native-promise-only": "guardian/native-promise-only#master",
-    "videojs-embed": "~0.3.0"
+    "videojs-embed": "~0.3.1"
   },
   "resolutions": {
     "videojs-contrib-ads": "af69a79e52b95a2c997e9c76a4a0e92db9a1b4a3",

--- a/static/src/javascripts/components/videojs-embed/videojs.embed.js
+++ b/static/src/javascripts/components/videojs-embed/videojs.embed.js
@@ -2,7 +2,7 @@
 
     videojs.plugin('embed', function(options) {
 
-        if (!options.embedable) { return false; }
+        if (!options.embeddable) { return false; }
 
         var player = this;
 


### PR DESCRIPTION
Adds the `data-embeddable` and `data-embed-path` data attributes to in-content video embeds, to enable correct player embed functionality.

/cc @rich-nguyen 
