### PR TITLE
Add internal redirects to RSS server

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -186,6 +186,11 @@ object FaciaMetrics {
     "redirects-to-applications",
     "Number of requests to facia that have been redirected to Applications via X-Accel-Redirect"
   )
+
+  object FaciaToRssRedirectMetric extends CountMetric(
+    "redirects-to-rss",
+    "Number of requests to Facia that have been redirected to RSS via X-Accel-Redirect"
+  )
 }
 
 object FaciaPressMetrics {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -59,6 +59,12 @@ object Switches {
     sellByDate = never
   )
 
+  val RssServerSwitch = Switch("Performance", "rss-server",
+    "If this switch is on then RSS traffic will be redirected to RSS server",
+    safeState = Off,
+    sellByDate = new LocalDate(2014, 2, 1)
+  )
+
   val CircuitBreakerSwitch = Switch("Performance", "circuit-breaker",
     "If this switch is switched on then the Content API circuit breaker will be operational",
     safeState = Off,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -62,7 +62,7 @@ object Switches {
   val RssServerSwitch = Switch("Performance", "rss-server",
     "If this switch is on then RSS traffic will be redirected to RSS server",
     safeState = Off,
-    sellByDate = new LocalDate(2014, 2, 1)
+    sellByDate = new LocalDate(2015, 2, 1)
   )
 
   val CircuitBreakerSwitch = Switch("Performance", "circuit-breaker",

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -20,6 +20,7 @@ object Global extends WithFilters(Filters.common: _*)
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
     S3Metrics.S3AuthorizationError,
     FaciaMetrics.FaciaToApplicationRedirectMetric,
+    FaciaMetrics.FaciaToRssRedirectMetric,
     ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric
   )
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -3,20 +3,20 @@ package controllers
 import com.gu.facia.client.models.CollectionConfig
 import common._
 import common.editions.EditionalisedSections
+import conf.Switches
 import front._
 import layout.{CollectionEssentials, FaciaContainer}
 import model._
 import play.api.mvc._
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.Json
 import slices.Container
 import scala.concurrent.Future
 import play.twirl.api.Html
 import performance.MemcachedAction
 import services.{CollectionConfigWithId, ConfigAgent}
-import common.FaciaMetrics.FaciaToApplicationRedirectMetric
+import common.FaciaMetrics._
 import views.html.fragments.containers.facia_cards.container
 import scala.concurrent.Future.successful
-
 
 trait FaciaController extends Controller with Logging with ExecutionContexts with implicits.Collections with implicits.Requests {
 
@@ -43,9 +43,22 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     }
   }
 
-  def applicationsRedirect(path: String)(implicit request : RequestHeader) = {
+  def applicationsRedirect(path: String)(implicit request: RequestHeader) = {
     FaciaToApplicationRedirectMetric.increment()
     Future.apply(InternalRedirect.internalRedirect("applications", path, if (request.queryString.nonEmpty) Option(s"?${request.rawQueryString}") else None))
+  }
+
+  def rssRedirect(path: String)(implicit request: RequestHeader) = {
+    if (Switches.RssServerSwitch.isSwitchedOn) {
+      FaciaToRssRedirectMetric.increment()
+      Future.apply(InternalRedirect.internalRedirect(
+        "rss_server",
+        path,
+        if (request.queryString.nonEmpty) Option(s"?${request.rawQueryString}") else None
+      ))
+    } else {
+      applicationsRedirect(path)
+    }
   }
 
   //Only used by dev-build for rending special urls such as lifeandstyle/home-and-garden
@@ -58,7 +71,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   def renderFrontRss(path: String) = MemcachedAction { implicit  request =>
   log.info(s"Serving RSS Path: $path")
     if (!ConfigAgent.shouldServeFront(path))
-      applicationsRedirect(s"$path/rss")
+      rssRedirect(s"$path/rss")
     else
       renderFrontPressResult(path)
   }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -51,7 +51,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   def rssRedirect(path: String)(implicit request: RequestHeader) = {
     if (Switches.RssServerSwitch.isSwitchedOn) {
       FaciaToRssRedirectMetric.increment()
-      Future.apply(InternalRedirect.internalRedirect(
+      Future.successful(InternalRedirect.internalRedirect(
         "rss_server",
         path,
         if (request.queryString.nonEmpty) Option(s"?${request.rawQueryString}") else None


### PR DESCRIPTION
All RSS endpoints are sent to Facia, as at the time of serving we do not know whether they are fronts (in which case Facia serves the RSS) or index pages (in which case historically Applications has served the RSS, but now the RSS server will).

This sends appropriate internal redirects for RSS pages. I've also added a switch so that we can roll this back if there's any issues.
