### PR TITLE
switch smartappbanner to using cookies

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -1,10 +1,12 @@
 define([
+    'common/utils/cookies',
     'common/utils/detect',
     'common/utils/storage',
     'common/utils/template',
     'common/modules/userPrefs',
     'common/modules/ui/message'
 ], function (
+    cookies,
     detect,
     storage,
     template,
@@ -20,7 +22,7 @@ define([
      * Persist close state
      */
 
-    var IMPRESSION_KEY = 'gu.ads.appOnboardCount',
+    var COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER',
         DATA = {
             IOS: {
                 LOGO: 'http://assets.guim.co.uk/images/apps/ios-logo.png',
@@ -35,7 +37,8 @@ define([
                 STORE: 'in Google Play'
             }
         },
-        impressions = (storage.local.get(IMPRESSION_KEY)) ? parseInt(storage.local.get(IMPRESSION_KEY), 10) : 0,
+        cookieVal = cookies.get(COOKIE_IMPRESSION_KEY),
+        impressions = cookieVal && !isNaN(cookieVal) ? parseInt(cookieVal, 10) : 0,
         tmp = '<img src="{{LOGO}}" class="app__logo" alt="Guardian App logo" /><div class="app__cta"><h4 class="app__heading">The Guardian app</h4>' +
             '<p class="app__copy">Instant alerts. Offline reading.<br/>Tailored to you.</p>' +
             '<p class="app__copy"><strong>FREE</strong> – {{STORE}}</p></div><a href="{{LINK}}" class="app__link">View</a>' +
@@ -54,11 +57,11 @@ define([
             msg = new Message(platform);
 
         msg.show(template(tmp, DATA[platform.toUpperCase()]));
-        storage.local.set(IMPRESSION_KEY, impressions + 1);
+        cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);
     }
 
     function init() {
-        if (isDevice() && !detect.isInFacebookApp() && !detect.isInTwitterApp() && canShow()) {
+        if (isDevice() && canShow()) {
             showMessage();
         }
     }

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -58,7 +58,7 @@ define([
     }
 
     function init() {
-        if (isDevice() && canShow()) {
+        if (isDevice() && !detect.isInFacebookApp() && !detect.isInTwitterApp() && canShow()) {
             showMessage();
         }
     }

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -115,6 +115,14 @@ define([
         return navigator.mozApps && !window.locationbar.visible;
     }
 
+    function isInFacebookApp() {
+        return /FBAN\//.test(navigator.userAgent);
+    }
+
+    function isInTwitterApp() {
+        return /Twitter for iPhone/.test(navigator.userAgent);
+    }
+
     function getConnectionSpeed(performance, connection, reportUnknown) {
 
         connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
@@ -336,6 +344,8 @@ define([
         isIOS: isIOS,
         isAndroid: isAndroid,
         isFireFoxOSApp: isFireFoxOSApp,
+        isInFacebookApp: isInFacebookApp,
+        isInTwitterApp: isInTwitterApp,
         isBreakpoint: isBreakpoint,
         initPageVisibility: initPageVisibility,
         pageVisible: pageVisible,

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -115,14 +115,6 @@ define([
         return navigator.mozApps && !window.locationbar.visible;
     }
 
-    function isInFacebookApp() {
-        return /FBAN\//.test(navigator.userAgent);
-    }
-
-    function isInTwitterApp() {
-        return /Twitter for iPhone/.test(navigator.userAgent);
-    }
-
     function getConnectionSpeed(performance, connection, reportUnknown) {
 
         connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
@@ -344,8 +336,6 @@ define([
         isIOS: isIOS,
         isAndroid: isAndroid,
         isFireFoxOSApp: isFireFoxOSApp,
-        isInFacebookApp: isInFacebookApp,
-        isInTwitterApp: isInTwitterApp,
         isBreakpoint: isBreakpoint,
         initPageVisibility: initPageVisibility,
         pageVisible: pageVisible,


### PR DESCRIPTION
so it expires when inside twitter and facebook app.

close button still uses local storage so it will only expire after 4 views.

agree this is a bit shitty so sorry patrick ! :/ 
