### PR TITLE
Add request logging to application boxes

### DIFF
--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -3,6 +3,7 @@ package conf
 import common.Assets.Assets
 import common.{ExecutionContexts, GuardianConfiguration}
 import contentapi.ElasticSearchLiveContentApiClient
+import filters.RequestLoggingFilter
 import play.api.mvc._
 import play.filters.gzip.GzipFilter
 import Switches.ForceHttpResponseCodeSwitch
@@ -74,7 +75,13 @@ object BackendHeaderFilter extends Filter with ExecutionContexts {
 }
 
 object Filters {
-                                     // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
-                                     // which effectively means "JsonVaryHeaders goes around Gzipper"
-  lazy val common: List[EssentialFilter] =  ForceHttpResponseFilter :: JsonVaryHeadersFilter :: Gzipper :: BackendHeaderFilter :: Nil
+   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
+   // which effectively means "JsonVaryHeaders goes around Gzipper"
+  lazy val common: List[EssentialFilter] = List(
+    ForceHttpResponseFilter,
+     JsonVaryHeadersFilter,
+     Gzipper,
+     BackendHeaderFilter,
+     RequestLoggingFilter
+   )
 }

--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -75,13 +75,13 @@ object BackendHeaderFilter extends Filter with ExecutionContexts {
 }
 
 object Filters {
-   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
-   // which effectively means "JsonVaryHeaders goes around Gzipper"
+  // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
+  // which effectively means "JsonVaryHeaders goes around Gzipper"
   lazy val common: List[EssentialFilter] = List(
     ForceHttpResponseFilter,
-     JsonVaryHeadersFilter,
-     Gzipper,
-     BackendHeaderFilter,
-     RequestLoggingFilter
-   )
+    JsonVaryHeadersFilter,
+    Gzipper,
+    BackendHeaderFilter,
+    RequestLoggingFilter
+  )
 }

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -23,7 +23,7 @@ object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
         }
 
       case Failure(error) =>
-        log.error(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed}ms", error)
+        log.error(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
     }
 
     result

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -16,10 +16,10 @@ object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
       case Success(response) =>
         response.header.headers.get("X-Accel-Redirect") match {
           case Some(internalRedirect) =>
-            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed}ms and redirected to $internalRedirect")
+            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and redirected to $internalRedirect")
 
           case None =>
-            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed}ms and returned ${response.header.status}")
+            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and returned ${response.header.status}")
         }
 
       case Failure(error) =>

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -1,0 +1,31 @@
+package filters
+
+import common.{ExecutionContexts, Logging, StopWatch}
+import play.api.mvc.{Result, RequestHeader, Filter}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
+  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+    val stopWatch = new StopWatch
+
+    val result = next(rh)
+
+    result onComplete {
+      case Success(response) =>
+        response.header.headers.get("X-Accel-Redirect") match {
+          case Some(internalRedirect) =>
+            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed}ms and redirected to $internalRedirect")
+
+          case None =>
+            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed}ms and returned ${response.header.status}")
+        }
+
+      case Failure(error) =>
+        log.error(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed}ms", error)
+    }
+
+    result
+  }
+}


### PR DESCRIPTION
I think this is a useful thing to have anyway, but I need it to debug what's going on with RSS.

Gives output like

```
2014-12-06 01:49:20,901 [play-akka.actor.default-dispatcher-31] INFO  filters.RequestLoggingFilter$ - GET /uk took 1492ms and returned 200
2014-12-06 01:49:20,928 [play-akka.actor.default-dispatcher-32] INFO  filters.RequestLoggingFilter$ - GET /assets/stylesheets/fdd5d3909fb0c384801d5414c13d97b2/global.css took 1ms and returned 200
2014-12-06 01:49:20,928 [play-akka.actor.default-dispatcher-34] INFO  filters.RequestLoggingFilter$ - GET /assets/stylesheets/f60c940f3a63a997ddb886b78c2556be/head.facia.css took 1ms and returned 200
2014-12-06 01:49:20,929 [play-akka.actor.default-dispatcher-31] INFO  filters.RequestLoggingFilter$ - GET /assets/stylesheets/07037901fa8b88d014f32aae779ef412/print.css took 2ms and returned 200
2014-12-06 01:49:20,972 [play-akka.actor.default-dispatcher-28] INFO  filters.RequestLoggingFilter$ - GET /assets/javascripts/98b1e16296fdfbc97eaa99ee74638e65/core.js took 0ms and returned 200
2014-12-06 01:49:21,109 [play-akka.actor.default-dispatcher-28] INFO  filters.RequestLoggingFilter$ - GET /assets/javascripts/bootstraps/ebf66893f5a849539ea75833fcea876c/app.js took 0ms and returned 200
2014-12-06 01:49:21,109 [play-akka.actor.default-dispatcher-35] INFO  filters.RequestLoggingFilter$ - GET /assets/javascripts/bootstraps/3b1bc75998f3542ad6857091004cd8b5/commercial.js took 0ms and returned 200
2014-12-06 01:49:21,109 [play-akka.actor.default-dispatcher-32] INFO  filters.RequestLoggingFilter$ - GET /assets/javascripts/bootstraps/25db37c5183ac90166be86b65e9bf818/dev.js took 0ms and returned 200
2014-12-06 01:49:21,215 [play-akka.actor.default-dispatcher-34] INFO  filters.RequestLoggingFilter$ - GET /assets/javascripts/bootstraps/5e05cddce74bd4dc0d029a2d64d332b2/facia.js took 0ms and returned 200
2014-12-06 01:49:09,088 [play-akka.actor.default-dispatcher-25] INFO  filters.RequestLoggingFilter$ - GET /sport/cycling took 1047ms and redirected to /applications/sport/cycling
```
