### PR TITLE
cAPI fix for class selector

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -71,10 +71,6 @@
     }
 }
 
-.ad-slot--capi-multiple {
-    position: relative;
-}
-
 .fc-container--commercial-capi {
     .fc-item__image-container {
         display: block;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -141,8 +141,8 @@ $header-image-size-desktop: 100px;
         .fc-container__header__description {
             margin-top: 2px;
         }
-        .ad-slot--capi-multiple &,
-        .ad-slot--capi-single &,
+        .fc-container--commercial-capi &,
+        .commercial--dfp-single &,
         .fc-container--tag & {
             border-bottom: 0;
         }


### PR DESCRIPTION
Another small fix of the class selectors of cAPI elements and sponsored logos. The old one were used only on a test page.
