### PR TITLE
make adverts test use ie8 compatible javascript

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -102,7 +102,7 @@ define([
                 !userPrefs.isOff('adverts') &&
                 !config.page.shouldHideAdverts &&
                 (!config.page.isSSL || config.page.section === 'admin') &&
-                window.location.hash.substr(1).split('&').indexOf('noads') === -1
+                !window.location.hash.match(/[#&]noads(&.*)?$/)
             ) {
                 modules.commercialLoaderHelper();
                 modules.tagContainer();


### PR DESCRIPTION
indexOf isnt' supported in ie8, so ie8 users were getting errors and not seeing any adverts

sorry @ironsidevsquincy ! here's the fix =)
