### PR TITLE
Lightbox enabled for ImageContent

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -645,7 +645,7 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) with Lightbo
   override lazy val metaData: Map[String, JsValue] = super.metaData ++ Map(
     "contentType" -> JsString(contentType),
     "gallerySize" -> JsNumber(size),
-    "galleryLightbox" -> lightbox
+    "lightboxImages" -> lightbox
   )
 
   override lazy val openGraphImage: String = {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -190,7 +190,7 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
   def addSharesAndFullscreen(body: Document): Document = {
     if(!article.isLiveBlog) {
 
-      article.lightboxImages.zipWithIndex map {
+      article.bodyLightboxImages.zipWithIndex map {
         case ((imageElement, Some(crop)), index) =>
           body.select("[data-media-id=" + imageElement.id + "]").map { fig =>
             val linkIndex = (index + (if(article.isMainImageLightboxable) 2 else 1) ).toString

--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -9,6 +9,7 @@ define([
     'bootstraps/common',
     'bootstraps/football',
     'bootstraps/gallery',
+    'bootstraps/image-content',
     'bootstraps/liveblog',
     'bootstraps/media',
     'bootstraps/profile',
@@ -26,6 +27,7 @@ define([
     common,
     football,
     gallery,
+    imageContent,
     liveBlog,
     media,
     profile,
@@ -74,6 +76,10 @@ define([
 
             if (config.page.contentType === 'Gallery') {
                 bootstrapContext('gallery', gallery);
+            }
+
+            if (config.page.contentType === 'ImageContent') {
+                bootstrapContext('image-content', imageContent);
             }
 
             if (config.page.contentType === 'Tag') {

--- a/static/src/javascripts/bootstraps/article.js
+++ b/static/src/javascripts/bootstraps/article.js
@@ -65,7 +65,7 @@ define([
             },
 
             initLightbox: function () {
-                if ('lightboxImages' in config.page) {
+                if ('lightboxImages' in config.page && config.page.lightboxImages.images.length > 0) {
                     Lightbox.init();
                 }
             }

--- a/static/src/javascripts/bootstraps/article.js
+++ b/static/src/javascripts/bootstraps/article.js
@@ -65,9 +65,7 @@ define([
             },
 
             initLightbox: function () {
-                if ('lightboxImages' in config.page && config.page.lightboxImages.images.length > 0) {
-                    Lightbox.init();
-                }
+                Lightbox.init();
             }
         },
 

--- a/static/src/javascripts/bootstraps/image-content.js
+++ b/static/src/javascripts/bootstraps/image-content.js
@@ -1,0 +1,15 @@
+define([
+    'common/modules/gallery/lightbox'
+], function (
+    Lightbox
+) {
+
+    var ready = function () {
+            Lightbox.init();
+        };
+
+    return {
+        init: ready
+    };
+
+});

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -494,27 +494,27 @@ define([
     };
 
     function bootstrap() {
-        var lightbox,
-            galleryId,
-            match,
-            galleryHash = window.location.hash,
-            images = config.page.lightboxImages,
-            res;
-
-        bean.on(document.body, 'click', '.js-gallerythumbs', function (e) {
-            e.preventDefault();
-
-            var $el = bonzo(e.currentTarget),
-                galleryHref = $el.attr('href') || $el.attr('data-gallery-url'),
-                galleryHrefParts = galleryHref.split('#img-'),
-                parsedGalleryIndex = parseInt(galleryHrefParts[1], 10),
-                galleryIndex = isNaN(parsedGalleryIndex) ? 1 : parsedGalleryIndex;// 1-based index
-            lightbox = lightbox || new GalleryLightbox();
-
-            lightbox.loadGalleryfromJson(images, galleryIndex);
-        });
-
         if ('lightboxImages' in config.page && config.page.lightboxImages.images.length > 0) {
+            var lightbox,
+                galleryId,
+                match,
+                galleryHash = window.location.hash,
+                images = config.page.lightboxImages,
+                res;
+
+            bean.on(document.body, 'click', '.js-gallerythumbs', function (e) {
+                e.preventDefault();
+
+                var $el = bonzo(e.currentTarget),
+                    galleryHref = $el.attr('href') || $el.attr('data-gallery-url'),
+                    galleryHrefParts = galleryHref.split('#img-'),
+                    parsedGalleryIndex = parseInt(galleryHrefParts[1], 10),
+                    galleryIndex = isNaN(parsedGalleryIndex) ? 1 : parsedGalleryIndex;// 1-based index
+                lightbox = lightbox || new GalleryLightbox();
+
+                lightbox.loadGalleryfromJson(images, galleryIndex);
+            });
+
             lightbox = lightbox || new GalleryLightbox();
             galleryId = '/' + config.page.pageId;
             match = /\?index=(\d+)/.exec(document.location.href);

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -514,7 +514,7 @@ define([
             lightbox.loadGalleryfromJson(images, galleryIndex);
         });
 
-        if (config.page.contentType === 'Gallery' || config.page.contentType === 'Article') {
+        if (config.page.contentType === 'Gallery' || config.page.contentType === 'Article' || config.page.contentType === 'ImageContent') {
             lightbox = lightbox || new GalleryLightbox();
             galleryId = '/' + config.page.pageId;
             match = /\?index=(\d+)/.exec(document.location.href);

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -498,7 +498,7 @@ define([
             galleryId,
             match,
             galleryHash = window.location.hash,
-            images = config.page[(config.page.contentType === 'Gallery') ? 'galleryLightbox' : 'lightboxImages'],
+            images = config.page.lightboxImages,
             res;
 
         bean.on(document.body, 'click', '.js-gallerythumbs', function (e) {
@@ -514,7 +514,7 @@ define([
             lightbox.loadGalleryfromJson(images, galleryIndex);
         });
 
-        if (config.page.contentType === 'Gallery' || config.page.contentType === 'Article' || config.page.contentType === 'ImageContent') {
+        if ('lightboxImages' in config.page && config.page.lightboxImages.images.length > 0) {
             lightbox = lightbox || new GalleryLightbox();
             galleryId = '/' + config.page.pageId;
             match = /\?index=(\d+)/.exec(document.location.href);


### PR DESCRIPTION
This enables the lightbox for articles of a content type of "ImageContent" such as EyeWitness and cartoons.

cc @mattosborn 
