### PR TITLE
Add Logging to Memory Leak Plug

### DIFF
--- a/admin/app/dfp/MemoryLeakPlug.scala
+++ b/admin/app/dfp/MemoryLeakPlug.scala
@@ -11,14 +11,19 @@ import common.Logging
  */
 object MemoryLeakPlug extends Logging {
 
-  def apply() {
+  def apply(): Unit = {
     log.info("Plugging memory leak")
-    val queueHolderClass = Class.forName("com.google.inject.internal.util.$MapMaker$QueueHolder")
-    val queueField = queueHolderClass.getDeclaredField("queue")
-    queueField.setAccessible(true)
-    val modifiersField = classOf[Field].getDeclaredField("modifiers")
-    modifiersField.setAccessible(true)
-    modifiersField.setInt(queueField, queueField.getModifiers & ~Modifier.FINAL)
-    queueField.set(null, null)
+    try {
+      val queueHolderClass = Class.forName("com.google.inject.internal.util.$MapMaker$QueueHolder")
+      val queueField = queueHolderClass.getDeclaredField("queue")
+      queueField.setAccessible(true)
+      val modifiersField = classOf[Field].getDeclaredField("modifiers")
+      modifiersField.setAccessible(true)
+      modifiersField.setInt(queueField, queueField.getModifiers & ~Modifier.FINAL)
+      queueField.set(null, null)
+      log.info("Memory leak plugged")
+    } catch {
+      case e: Exception => log.error(e.getMessage)
+    }
   }
 }


### PR DESCRIPTION
It behaves differently in Prod would you believe.
Effect should be that there is no longer a thread local in the finalizer thread.

MAT finalizer overview locally:
![image](https://cloud.githubusercontent.com/assets/1722550/5319387/c62800c2-7ca0-11e4-843e-9d815a45c6aa.png)

on Prod:
![image](https://cloud.githubusercontent.com/assets/1722550/5319400/e6ccf274-7ca0-11e4-92f4-2d15b5fd5d6c.png)
