### PR TITLE
Style the new Thrasher container

### DIFF
--- a/static/src/stylesheets/global.scss
+++ b/static/src/stylesheets/global.scss
@@ -106,6 +106,7 @@
 
 @import 'module/facia/_l-list';
 @import 'module/facia/_container';
+@import 'module/facia/_container--thrasher';
 @import 'module/facia/_slices';
 @import 'module/facia/_sublinks';
 @import 'module/facia/_item';

--- a/static/src/stylesheets/global.scss
+++ b/static/src/stylesheets/global.scss
@@ -106,7 +106,7 @@
 
 @import 'module/facia/_l-list';
 @import 'module/facia/_container';
-@import 'module/facia/_container--thrasher';
+@import 'module/facia/_containers';
 @import 'module/facia/_slices';
 @import 'module/facia/_sublinks';
 @import 'module/facia/_item';

--- a/static/src/stylesheets/module/facia/_container--thrasher.scss
+++ b/static/src/stylesheets/module/facia/_container--thrasher.scss
@@ -1,0 +1,55 @@
+.fc-container--thrasher {
+    border-top: 0;
+    margin-top: 0;
+    margin-bottom: 24px;
+    padding-bottom: 0;
+
+    .fc-container__inner {
+        border-top: 0;
+        padding-top: 0;
+
+        @include mq($until: tablet) {
+            margin-left: 0;
+            margin-right: 0;
+            width: 100%;
+        }
+    }
+
+    .fc-container__header {
+        display: none;
+    }
+
+    .fc-container__body {
+        margin-left: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        width: 100%;
+        overflow: initial;
+    }
+
+    .fc-slice-wrapper {
+        margin-left: 0;
+        margin-right: 0;
+
+        @include mq(tablet) {
+            margin-left: -20px;
+            margin-right: -20px;
+        }
+    }
+
+    .fc-slice {
+        margin: 0;
+        width: 100%;
+    }
+
+    .fc-slice__item {
+        margin-bottom: 0;
+        width: 100%;
+    }
+
+    .fc-item {
+        margin: 0;
+        overflow: auto;
+        width: 100%;
+    }
+}

--- a/static/src/stylesheets/module/facia/_container--thrasher.scss
+++ b/static/src/stylesheets/module/facia/_container--thrasher.scss
@@ -20,9 +20,9 @@
     }
 
     .fc-container__body {
-        margin-left: 0;
         padding-top: 0;
         padding-bottom: 0;
+        margin-left: 0;
         width: 100%;
         overflow: initial;
     }

--- a/static/src/stylesheets/module/facia/_container--thrasher.scss
+++ b/static/src/stylesheets/module/facia/_container--thrasher.scss
@@ -1,7 +1,7 @@
 .fc-container--thrasher {
     border-top: 0;
     margin-top: 0;
-    margin-bottom: 24px;
+    margin-bottom: $gs-baseline * 2;
     padding-bottom: 0;
 
     .fc-container__inner {
@@ -32,8 +32,8 @@
         margin-right: 0;
 
         @include mq(tablet) {
-            margin-left: -20px;
-            margin-right: -20px;
+            margin-left: -$gs-gutter;
+            margin-right: -$gs-gutter;
         }
     }
 

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -19,10 +19,6 @@ $header-image-size-desktop: 100px;
     }
 }
 
-.fc-container--outbrain {
-    background-color: colour(neutral-8);
-}
-
 .fc-container__inner,
 .facia-container__inner {
     padding-top: $gs-baseline / 4;
@@ -50,34 +46,6 @@ $header-image-size-desktop: 100px;
 
 .fc-container--rolled-up .fc-container--rolled-up-hide {
     display: none;
-}
-
-.fc-container--first {
-    margin-top: 0;
-    padding-top: 0;
-
-    .fc-container__inner {
-        border: 0;
-    }
-
-    @include mq(tablet) {
-        padding-top: $gs-baseline/2;
-    }
-    @include mq(leftCol) {
-        .fc-container__header__title {
-            border-top: 1px solid colour(news-accent);
-            padding-top: $gs-baseline / 4;
-        }
-
-        .fc-container__body {
-            padding-top: 0;
-        }
-    }
-    @include mq(leftCol, wide) {
-        .fc-slice-wrapper:first-child {
-            padding-top: 0;
-        }
-    }
 }
 
 .fc-slice-wrapper {

--- a/static/src/stylesheets/module/facia/_containers.scss
+++ b/static/src/stylesheets/module/facia/_containers.scss
@@ -1,3 +1,35 @@
+.fc-container--first {
+    margin-top: 0;
+    padding-top: 0;
+
+    .fc-container__inner {
+        border: 0;
+    }
+
+    @include mq(tablet) {
+        padding-top: $gs-baseline/2;
+    }
+    @include mq(leftCol) {
+        .fc-container__header__title {
+            border-top: 1px solid colour(news-accent);
+            padding-top: $gs-baseline / 4;
+        }
+
+        .fc-container__body {
+            padding-top: 0;
+        }
+    }
+    @include mq(leftCol, wide) {
+        .fc-slice-wrapper:first-child {
+            padding-top: 0;
+        }
+    }
+}
+
+.fc-container--outbrain {
+    background-color: colour(neutral-8);
+}
+
 .fc-container--thrasher {
     border-top: 0;
     margin-top: 0;


### PR DESCRIPTION
Now that @robertberry has added a `.fc-container--thrasher` class, we can move a lot of the repeating code added to every thrasher and move it into frontend. Basically it's a slimmed down version of [this mixin](https://github.com/guardian/thrashers/blob/master/shared/_mixins.scss#L3).

A few properties will still have to be declared in the thrasher itself, but this massively reduces repeating code and keeps 99% of the global properties next to the originals.

![200](https://cloud.githubusercontent.com/assets/1607666/5339199/419fbe08-7ed5-11e4-89c9-ba52972f45bf.gif)
