### PR TITLE
Ability to override the adunit

### DIFF
--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -32,6 +32,7 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
   )
 
   val commercialParams = Seq(
+    "ad-unit", // allows overriding of the ad unit
     "adtest", // used to set ad-test cookie from admin domain
     "google_console", // two params for dfp console
     "googfc",

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -18,6 +18,7 @@ define([
     'common/utils/config',
     'common/utils/detect',
     'common/utils/mediator',
+    'common/utils/url',
     'common/modules/commercial/build-page-targeting',
     'common/modules/onward/geo-most-popular',
     'common/modules/ui/sticky'
@@ -40,6 +41,7 @@ define([
     config,
     detect,
     mediator,
+    urlUtils,
     buildPageTargeting,
     geoMostPopular,
     Sticky
@@ -224,12 +226,15 @@ define([
          * Private functions
          */
         defineSlot = function ($adSlot) {
-            var slotTarget  = $adSlot.data('slot-target') || $adSlot.data('name'),
-                adUnit      = config.page.adUnit,
-                id          = $adSlot.attr('id'),
-                sizeMapping = defineSlotSizes($adSlot),
+            var slotTarget     = $adSlot.data('slot-target') || $adSlot.data('name'),
+                adUnitOverride = urlUtils.getUrlVars()['ad-unit'],
+                // if ?ad-unit=x, use that
+                adUnit         = adUnitOverride ?
+                    ['/', config.page.dfpAccountId, '/', adUnitOverride].join('') : config.page.adUnit,
+                id             = $adSlot.attr('id'),
+                sizeMapping    = defineSlotSizes($adSlot),
                 // as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
-                size        = uniq(
+                size           = uniq(
                     flatten(sizeMapping, true, function (map) {
                         return map[1];
                     }),


### PR DESCRIPTION
Ad rules are on a per-ad-unit basis, making it hard to test out any rules as it will effect all the ad units

This gives the ability to set the ad unit, so they can change it to something unique (e.g. test), to test out the ad rules
