### PR TITLE
cAPI multiple css class rename

### DIFF
--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,7 +1,7 @@
 @(items: Seq[model.Content], optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String], optCapiAdFeature: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String])(implicit request: RequestHeader)
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising fc-container--commercial-capi @optSponsorType" data-link-name="merchandising | capi | multiple @optOmnitureId">
+    <section class="fc-container fc-container--paid-for fc-container--special fc-container--merchandising commercial-dfp-multi @optSponsorType" data-link-name="merchandising | capi | multiple @optOmnitureId">
         <div class="fc-container__inner">
         <div class="container__border"></div>
             <div class="fc-container__header">

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -439,7 +439,7 @@
         padding-top: 2px;
         border-top: 1px dotted colour(neutral-5);
 
-        .fc-container--commercial-capi & {
+        .commercial-dfp-multi & {
             position: absolute;
             bottom: $gs-gutter;
         }

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -71,7 +71,7 @@
     }
 }
 
-.fc-container--commercial-capi {
+.commercial-dfp-multi {
     .fc-item__image-container {
         display: block;
     }

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -141,7 +141,7 @@ $header-image-size-desktop: 100px;
         .fc-container__header__description {
             margin-top: 2px;
         }
-        .fc-container--commercial-capi &,
+        .commercial-dfp-multi &,
         .commercial--dfp-single &,
         .fc-container--tag & {
             border-bottom: 0;


### PR DESCRIPTION
There was a need to rename the css class of the cAPI multiple element so it should be more meaningful.
