### PR TITLE
Navigation change soulmates to dating

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -63,7 +63,7 @@
                 <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
                     jobs</a></li>
                 <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
-                    soulmates</a></li>
+                    dating</a></li>
                 <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES">
                     masterclasses</a></li>
                 <li class="colophon__item"><a data-link-name="uk : footer : subscribe" target="_blank" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -12,7 +12,7 @@
         </div>
         <div class="brand-bar__item hide-on-mobile hide-on-tablet">
             <a class="brand-bar__item--action" data-link-name="uk : topNav : soulmates"
-               href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
+               href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">dating</a>
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control">
             <a href="#guardian-services-top-menu" class="brand-bar__item--action popup__toggle"
@@ -34,7 +34,7 @@
                     </li>
                     <li class="popup__item hide-on-desktop">
                         <a class="brand-bar__item--action" data-link-name="uk : topNav : soulmates"
-                           href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">soulmates</a>
+                           href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">dating</a>
                     </li>
                     <li class="popup__item">
                         <a class="brand-bar__item--action" data-link-name="uk : topNav : masterclasses"


### PR DESCRIPTION
According to tests people like 'dating' more than 'soulmates'. We will be still tracking it as 'soulmates'.

Before:
![screen shot 2014-12-08 at 15 38 36](https://cloud.githubusercontent.com/assets/2579465/5341820/02da2f2a-7ef1-11e4-806f-24211ff538aa.png)

After:
![screen shot 2014-12-08 at 15 38 07](https://cloud.githubusercontent.com/assets/2579465/5341829/0b0b6510-7ef1-11e4-90f3-4bc698683177.png)
