### PR TITLE
Ensure series container isn't loaded when showRelatedContent is false

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -174,7 +174,7 @@ define([
             },
 
             transcludeOnwardContent: function () {
-                if ('seriesId' in config.page) {
+                if ('seriesId' in config.page && 'showRelatedContent' in config.page && config.page.showRelatedContent) {
                     new Onward(qwery('.js-onward'));
                 } else if (config.page.tones !== '') {
                     $('.js-onward').each(function (c) {


### PR DESCRIPTION
This is a mistake and needs to be fixed by tomorrow morning as requested by editorial.
