### PR TITLE
Add fc-container classes to merchandising components and fix spacing

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -37,7 +37,8 @@
         }
 
         @fragments.trendingTopics(index.trails, index.page.id, None)
-
-        @fragments.commercial.commercialComponent()
+        <div class="fc-container fc-container--merchandising">
+            @fragments.commercial.commercialComponent()
+        </div>
     </div>
 </div>

--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -37,7 +37,7 @@
         }
 
         @fragments.trendingTopics(index.trails, index.page.id, None)
-        <div class="fc-container fc-container--merchandising">
+        <div class="fc-container fc-container--commercial">
             @fragments.commercial.commercialComponent()
         </div>
     </div>

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -176,12 +176,10 @@
             </script>
     </article>
 
-    <div class="fc-container">
-        <div class="fc-container__inner">
-            <h2 class="test-page-head">
-                <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10028487">Merchandising: commercial component</a>
-            </h2>
-        </div>
+    <div class="fc-container__inner">
+        <h2 class="test-page-head">
+            <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10028487">Merchandising: commercial component</a>
+        </h2>
     </div>
 
     @Seq(
@@ -192,60 +190,56 @@
         Map(("name", "Soulmates"), ("type", "soulmates"), ("hasMedium" -> false)),
         Map(("name", "Travel"), ("type", "travel"), ("hasMedium" -> false))
     ).map { component =>
-        <div class="fc-container">
-            <div class="fc-container__inner">
-                <h2 class="test-page-head">@component("name")</h2>
-            </div>
-            @Seq("low", "medium", "high").map { relevance =>
-                @if(relevance != "medium" || (relevance == "medium" && component("hasMedium") == true)) {
-                    <div class="fc-container__inner">
-                        <div class="fc-container__header">
-                            <h3 class="fc-container__header__description">@relevance.capitalize relevance</h3>
-                        </div>
-                    </div>
-                    <div class="ad-slot ad-slot--merchandising ad-slot--commercial-component dfp-ad--merchandising-@component("type")-@relevance"></div>
-                    <script>
-                        loadCommercial(function () {
-                            require(['common/modules/commercial/creatives/commercial-component'])
-                                .then(function(
-                                    CommercialComponent
-                                ) {
-                                    new CommercialComponent(document.querySelector('.dfp-ad--merchandising-@component("type")-@relevance'), {
-                                        type: '@component("type")@if(relevance != "low"){@relevance.capitalize}',
-                                        clickMacro: '%%CLICK_URL_ESC%%',
-                                        omnitureId: 'omnitureId'
-                                    }).create();
-                                });
-                        });
-                    </script>
-                }
-            }
+        <div class="fc-container__inner">
+            <h2 class="test-page-head">@component("name")</h2>
         </div>
+        @Seq("low", "medium", "high").map { relevance =>
+            @if(relevance != "medium" || (relevance == "medium" && component("hasMedium") == true)) {
+                <div class="fc-container__inner">
+                    <div class="fc-container__header">
+                        <h3 class="fc-container__header__description">@relevance.capitalize relevance</h3>
+                    </div>
+                </div>
+                <div class="ad-slot ad-slot--merchandising ad-slot--commercial-component dfp-ad--merchandising-@component("type")-@relevance"></div>
+                <script>
+                    loadCommercial(function () {
+                        require(['common/modules/commercial/creatives/commercial-component'])
+                            .then(function(
+                                CommercialComponent
+                            ) {
+                                new CommercialComponent(document.querySelector('.dfp-ad--merchandising-@component("type")-@relevance'), {
+                                    type: '@component("type")@if(relevance != "low"){@relevance.capitalize}',
+                                    clickMacro: '%%CLICK_URL_ESC%%',
+                                    omnitureId: 'omnitureId'
+                                }).create();
+                            });
+                    });
+                </script>
+            }
+        }
     }
 
-    <div class="fc-container">
-        <div class="fc-container__inner">
-            <h2 class="test-page-head">
-                <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10022487">Merchandising: blended component</a>
-            </h2>
-        </div>
-        <div class="ad-slot ad-slot--merchandising ad-slot--commercial-component dfp-ad--merchandising-multi"></div>
-        <script>
-            loadCommercial(function () {
-                require(['common/modules/commercial/creatives/commercial-component'])
-                    .then(function(
-                        CommercialComponent
-                    ) {
-                    new CommercialComponent(document.querySelector('.dfp-ad--merchandising-multi'), {
-                        type: 'multi',
-                        components: ['jobs', 'masterclasses', 'books', 'soulmates'],
-                        clickMacro: '%%CLICK_URL_ESC%%',
-                        omnitureId: 'omnitureId'
-                    }).create();
-                });
+    <div class="fc-container__inner">
+        <h2 class="test-page-head">
+            <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10022487">Merchandising: blended component</a>
+        </h2>
+    </div>
+    <div class="ad-slot ad-slot--merchandising ad-slot--commercial-component dfp-ad--merchandising-multi"></div>
+    <script>
+        loadCommercial(function () {
+            require(['common/modules/commercial/creatives/commercial-component'])
+                .then(function(
+                    CommercialComponent
+                ) {
+                new CommercialComponent(document.querySelector('.dfp-ad--merchandising-multi'), {
+                    type: 'multi',
+                    components: ['jobs', 'masterclasses', 'books', 'soulmates'],
+                    clickMacro: '%%CLICK_URL_ESC%%',
+                    omnitureId: 'omnitureId'
+                }).create();
             });
-        </script>
-        </div>
+        });
+    </script>
     </div>
 
     @Seq(
@@ -258,67 +252,65 @@
             ("creativeId", "10023207")
         )
     ).map { component =>
-        <div class="fc-container">
-            <div class="fc-container__inner">
-                <h2 class="test-page-head">
-                    <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=@component("creativeId")">
-                        Merchandising: cAPI @component("type")
-                    </a>
-                </h2>
-                <form class="capi-@component("type")-paid-for-type">
-                    <label>Type:
-                        <select>
-                            <option value="advertisement-feature" selected>Advertisement Feature</option>
-                            <option value="sponsored">Sponsored</option>
-                            <option value="foundation-supported">Foundation Supported</option>
-                        </select>
-                    </label>
-                </form>
-            </div>
-            <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component ad-slot--capi-@component("type")"></div>
-            <script>
-                loadCommercial(function () {
-                    require([
-                        'bean',
-                        'qwery',
-                        'common/utils/$',
-                        'common/modules/commercial/creatives/commercial-component'
-                    ])
-                        .then(function (
-                            bean,
-                            qwery,
-                            $,
-                            CommercialComponent
-                        ) {
-                            var $capiMultiple = $('.ad-slot--capi-@component("type")');
+        <div class="fc-container__inner">
+            <h2 class="test-page-head">
+                <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=@component("creativeId")">
+                    Merchandising: cAPI @component("type")
+                </a>
+            </h2>
+            <form class="capi-@component("type")-paid-for-type">
+                <label>Type:
+                    <select>
+                        <option value="advertisement-feature" selected>Advertisement Feature</option>
+                        <option value="sponsored">Sponsored</option>
+                        <option value="foundation-supported">Foundation Supported</option>
+                    </select>
+                </label>
+            </form>
+        </div>
+        <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component ad-slot--capi-@component("type")"></div>
+        <script>
+            loadCommercial(function () {
+                require([
+                    'bean',
+                    'qwery',
+                    'common/utils/$',
+                    'common/modules/commercial/creatives/commercial-component'
+                ])
+                    .then(function (
+                        bean,
+                        qwery,
+                        $,
+                        CommercialComponent
+                    ) {
+                        var $capiMultiple = $('.ad-slot--capi-@component("type")');
 
-                            bean.on(qwery('.capi-multiple-paid-for-type')[0], 'change', function (event) {
-                                var commercialComponent = new CommercialComponent($capiMultiple[0], {
-                                    type: 'capi@if(component("type") == "single"){Single}',
-                                    t: ['p/43b2q','p/43945'],
-                                    l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
-                                    ct: 'Led Zeppelin special',
-                                    cl: 'http://theguardian.com/music/ledzeppelin',
-                                    cal: 'http://theguardian.com/about',
-                                    k: 'music/ledzeppelin',
-                                    rmd: 'www.theguardina.com',
-                                    rmt: 'Seemoreoverhere',
-                                    af: $(event.srcElement).val(),
-                                    clickMacro: '%%CLICK_URL_ESC%%',
-                                    omnitureId: "omnitureId"
-                                });
-
-                                commercialComponent.postLoadEvents.capi = function () {
-                                    $capiMultiple.removeClass('lazyloaded');
-                                };
-                                commercialComponent.create();
+                        bean.on(qwery('.capi-multiple-paid-for-type')[0], 'change', function (event) {
+                            var commercialComponent = new CommercialComponent($capiMultiple[0], {
+                                type: 'capi@if(component("type") == "single"){Single}',
+                                t: ['p/43b2q','p/43945'],
+                                l: 'http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8',
+                                ct: 'Led Zeppelin special',
+                                cl: 'http://theguardian.com/music/ledzeppelin',
+                                cal: 'http://theguardian.com/about',
+                                k: 'music/ledzeppelin',
+                                rmd: 'www.theguardina.com',
+                                rmt: 'Seemoreoverhere',
+                                af: $(event.srcElement).val(),
+                                clickMacro: '%%CLICK_URL_ESC%%',
+                                omnitureId: "omnitureId"
                             });
 
-                            bean.fire(qwery('.capi-@component("type")-paid-for-type select')[0], 'change');
+                            commercialComponent.postLoadEvents.capi = function () {
+                                $capiMultiple.removeClass('lazyloaded');
+                            };
+                            commercialComponent.create();
                         });
-                });
-            </script>
-        </div>
+
+                        bean.fire(qwery('.capi-@component("type")-paid-for-type select')[0], 'change');
+                    });
+            });
+        </script>
     }
 
     @Seq(
@@ -376,30 +368,28 @@
             ))
         )
     ).map { component =>
-        <div class="fc-container">
-            <div class="fc-container__inner">
-                <h2 class="test-page-head">
-                    <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=@component("creativeId")">
-                        Merchandising: manual @component("type")
-                    </a>
-                </h2>
-            </div>
-            <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component ad-slot--@component("type")-manual"></div>
-            <script>
-                @component("args") match {
-                    case args: JsObject => {
-                        loadCommercial(function () {
-                            require(['common/modules/commercial/creatives/template'])
-                                .then(function (Template) {
-                                    new Template(document.querySelector('.ad-slot--@component("type")-manual'), @Html(Json.stringify(args)))
-                                        .create();
-                            });
-                        });
-                    }
-                    case _ => { }
-                }
-            </script>
+        <div class="fc-container__inner">
+            <h2 class="test-page-head">
+                <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=@component("creativeId")">
+                    Merchandising: manual @component("type")
+                </a>
+            </h2>
         </div>
+        <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component ad-slot--@component("type")-manual"></div>
+        <script>
+            @component("args") match {
+                case args: JsObject => {
+                    loadCommercial(function () {
+                        require(['common/modules/commercial/creatives/template'])
+                            .then(function (Template) {
+                                new Template(document.querySelector('.ad-slot--@component("type")-manual'), @Html(Json.stringify(args)))
+                                    .create();
+                        });
+                    });
+                }
+                case _ => { }
+            }
+        </script>
     }
 
 </div>

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -30,7 +30,7 @@
         }
 
         @if(!content.shouldHideAdverts) {
-            <div class="fc-container fc-container--merchandising">
+            <div class="fc-container fc-container--commercial">
                 @fragments.commercial.commercialComponent()
             </div>
         }

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -8,7 +8,7 @@
     @if(!content.isAdvertisementFeature) {
 
         @if(!content.shouldHideAdverts) {
-            <div class="fc-container fc-container--commercial">
+            <div class="fc-container fc-container--commercial-high">
                 @fragments.commercial.commercialComponentHigh()
             </div>
         }
@@ -30,7 +30,7 @@
         }
 
         @if(!content.shouldHideAdverts) {
-            <div class="fc-container fc-container--commercial">
+            <div class="fc-container fc-container--merchandising">
                 @fragments.commercial.commercialComponent()
             </div>
         }

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -26,7 +26,9 @@
             @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
         @if(!faciaPage.isAdvertisementFeature) {
-            @fragments.commercial.commercialComponent()
+            <div class="fc-container fc-container--merchandising">
+                @fragments.commercial.commercialComponent()
+            </div>
         }
         </div>
     </div>

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -26,7 +26,7 @@
             @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
         @if(!faciaPage.isAdvertisementFeature) {
-            <div class="fc-container fc-container--merchandising">
+            <div class="fc-container fc-container--commercial">
                 @fragments.commercial.commercialComponent()
             </div>
         }

--- a/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
+++ b/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
@@ -18,8 +18,9 @@ define([
         }
 
         var containerIndex,
-            $adSlot     = bonzo(createAdSlot('merchandising-high', 'commercial-component-high')),
-            $containers = $('.fc-container');
+            $adSlotWrapper = $.create('<div class="fc-container"></div>'),
+            $adSlot        = bonzo(createAdSlot('merchandising-high', 'commercial-component-high')),
+            $containers    = $('.fc-container');
 
         if ($containers.length >= 2) {
             containerIndex = 0;
@@ -28,7 +29,9 @@ define([
                 containerIndex = config.page.contentType === 'Network Front' ? 3 : 2;
             }
 
-            return $adSlot.insertAfter($containers[containerIndex]);
+            return $adSlotWrapper
+                .append($adSlot)
+                .insertAfter($containers[containerIndex]);
         }
 
     }

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -293,7 +293,6 @@
 
 .ad-slot--dfp.ad-slot__fluid250 {
     height: auto;
-    padding: 0;
     width: 100%;
     margin-left: 0;
 

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -472,6 +472,10 @@ $header-image-size-desktop: 100px;
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
     margin-top: $gs-baseline;
+    
+    .has-page-skin & {
+        width: gs-span(12);
+    }
 }
 
 .index-page-header__content {
@@ -480,7 +484,7 @@ $header-image-size-desktop: 100px;
     @include mq(wide) {
         width: $left-column-wide + $gs-gutter + gs-span(12);
 
-        .has-page-skin {
+        .has-page-skin & {
             width: 100%;
         }
     }

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -17,6 +17,10 @@ $header-image-size-desktop: 100px;
             background-color: #ffffff;
         }
     }
+    
+    &.fc-container--merchandising {
+        padding-bottom: 0;
+    }
 }
 
 .fc-container--outbrain {

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -18,7 +18,7 @@ $header-image-size-desktop: 100px;
         }
     }
     
-    &.fc-container--merchandising {
+    &.fc-container--commercial {
         padding-bottom: 0;
     }
 }

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -17,10 +17,10 @@ $header-image-size-desktop: 100px;
             background-color: #ffffff;
         }
     }
-    
-    &.fc-container--commercial {
-        padding-bottom: 0;
-    }
+}    
+
+.fc-container--commercial {
+    padding-bottom: 0;
 }
 
 .fc-container--outbrain {

--- a/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
+++ b/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
@@ -60,8 +60,6 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    var adSlot = $('#' + fixturesConfig.id + ' > *').get(3);
-                    expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );
 
@@ -74,7 +72,7 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    var adSlot = $('#' + fixturesConfig.id + ' > *').get(1);
+                    var adSlot = $('#' + fixturesConfig.id + ' > .fc-container > *');
                     expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );
@@ -90,7 +88,8 @@ define([
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
-                    var adSlot = $('#' + fixturesConfig.id + ' > *').get(4);
+                    var adSlot = $('#' + fixturesConfig.id + ' > .fc-container > *');
+                    
                     expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 }
             );


### PR DESCRIPTION
This adds puts the commercial components in fc-container classes to correct the spacing issues.

We then remove the bottom padding for the low commercial component so it sits correctly above the footer.

Before;
![screen shot 2014-12-09 at 10 22 12](https://cloud.githubusercontent.com/assets/1303616/5355682/64c30fb2-7f8d-11e4-9507-346ef3b59d16.png)

After;
![screen shot 2014-12-09 at 10 22 56](https://cloud.githubusercontent.com/assets/1303616/5355686/69a58730-7f8d-11e4-829a-2e668e92b2a6.png)
