### PR TITLE
Cap the byline width on interactive pieces

### DIFF
--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -124,7 +124,11 @@
         }
     }
     .byline {
+        @include mq(desktop) {
+            width: gs-span(7);
+        }
         @include mq(leftCol) {
+            width: gs-span(8);
             border-top: 0;
             padding-bottom: 0;
             min-height: $gs-baseline * 2;


### PR DESCRIPTION
Fix for:
![screen shot 2014-12-09 at 17 39 34](https://cloud.githubusercontent.com/assets/2236852/5362382/691a2284-7fca-11e4-9fcc-f919d48d08b9.png)

Now looks like:
![screen shot 2014-12-09 at 17 39 26](https://cloud.githubusercontent.com/assets/2236852/5362391/709696dc-7fca-11e4-9fb0-11ef31d913e3.png)
