### PR TITLE
can leave ads off in integrated tests for better reliability

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -459,11 +459,6 @@ object Switches {
     safeState = Off, sellByDate = never
   )
 
-  val IntegratedTestsNoAds = Switch("Facia", "integrated-tests-no-ads",
-    "The tests are running without adverts, we need to decide if it's helping reliability before this expires",
-    safeState = Off, sellByDate = new LocalDate(2015, 1, 31)
-  )
-
   def all: Seq[Switch] = Switch.allSwitches
 
   def grouped: List[(String, Seq[Switch])] = {


### PR DESCRIPTION
having switched off ads in the tests, things got a lot more reliable (although not 100% of runs pass due to another issue that needs investigation)

This PR is to remove the switch as it was only added to make sure we checked back on this.
