### PR TITLE
debug mode for spacefinder

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -1,20 +1,25 @@
 /* jscs:disable disallowDanglingUnderscores */
 define([
     'qwery',
+    'bonzo',
     'common/utils/_'
 ], function (
     qwery,
+    bonzo,
     _
 ) {
 
     // find spaces in articles for inserting ads and other inline content
 
     var bodySelector = '.js-article__body',
-        // minAbove and minBelow are measured from the top of the paragraph element being tested
+        // minAbove and minBelow are measured in px from the top of the paragraph element being tested
         defaultRules = { // these are written for adverts
-            minAbove: 250,
-            minBelow: 300,
-            selectors: {
+            minAbove: 250, // minimum from para to top of article
+            minBelow: 300, // minimum from (top of) para to bottom of article
+            selectors: { // custom rules using selectors. format:
+                //'.selector': {
+                //   minAbove: <min px above para to bottom of els matching selector>,
+                //   minBelow: <min px below (top of) para to top of els matching selector> }
                 ' > h2': {minAbove: 0, minBelow: 250}, // hug h2s
                 ' > *:not(p):not(h2)': {minAbove: 25, minBelow: 250} // require spacing for all other elements
             }
@@ -22,7 +27,7 @@ define([
         // test one element vs another for the given rules
         _testElem = function (para, other, rules) {
             var isMinAbove = para.top - other.bottom >= rules.minAbove,
-                isMinBelow = other.top - para.bottom >= rules.minBelow;
+                isMinBelow = other.top - para.top >= rules.minBelow;
             return isMinAbove || isMinBelow;
         },
         // test one element vs an array of other elements for the given rules
@@ -40,31 +45,51 @@ define([
         };
     }
 
-    function _enforceRules(slots, rules, bodyHeight) {
+    function _debugErrPara(p, message) {
+        bonzo(p)
+            .addClass('spacefinder--error')
+            .attr('data-spacefinder-msg', message);
+    }
+
+    function _enforceRules(slots, rules, bodyHeight, debug) {
         var filtered = _(slots).filter(function (p) {
-            return p.top >= rules.minAbove && p.top + rules.minBelow <= bodyHeight;
+            var farEnoughFromTopOfBody = p.top >= rules.minAbove,
+                farEnoughFromBottomOfBody = p.top + rules.minBelow <= bodyHeight,
+                valid = farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
+
+            if (debug && !valid) {
+                if (!farEnoughFromTopOfBody) { _debugErrPara(p.element, 'too close to top of body'); }
+                if (!farEnoughFromBottomOfBody) { _debugErrPara(p.element, 'too close to bottom of body'); }
+            }
+
+            return valid;
         });
         _(rules.selectors).forOwn(function (params, selector) {
             var relevantElems = _(qwery(bodySelector + selector)).map(_mapElementToDimensions);
 
-            filtered = filtered.filter(function (slot) {
-                return _testElems(slot, relevantElems, params);
+            filtered = filtered.filter(function (p) {
+                var valid = _testElems(p, relevantElems, params);
+                if (debug && !valid) {
+                    _debugErrPara(p.element, 'too close to selector (' + selector + ')');
+                }
+                return valid;
             });
         });
         return filtered.valueOf();
     }
 
     // getParaWithSpace returns a paragraph that satisfies the given/default rules:
-    function getParaWithSpace(rules) {
+    function getParaWithSpace(rules, debug) {
         rules = rules || defaultRules;
 
         // get all immediate children
         var bodyBottom = qwery(bodySelector)[0].offsetHeight,
-            allElems = _(qwery(bodySelector + ' > *')).map(_mapElementToDimensions),
-            paraElems  = allElems.filter(function (el) {
-                return el.element.tagName.toLowerCase() === 'p';
-            }),
-            slots = _enforceRules(paraElems, rules, bodyBottom);
+            paraElems = _(qwery(bodySelector + ' > p')).map(_mapElementToDimensions),
+            slots = _enforceRules(paraElems, rules, bodyBottom, debug);
+
+        if (debug) {
+            bonzo(slots.map(function (p) { return p.element; })).addClass('spacefinder--valid');
+        }
 
         return slots.length ? slots[0].element : undefined;
     }

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -80,15 +80,24 @@ define([
 
     // getParaWithSpace returns a paragraph that satisfies the given/default rules:
     function getParaWithSpace(rules, debug) {
+        var bodyBottom, paraElems, slots;
         rules = rules || defaultRules;
 
         // get all immediate children
-        var bodyBottom = qwery(bodySelector)[0].offsetHeight,
-            paraElems = _(qwery(bodySelector + ' > p')).map(_mapElementToDimensions),
-            slots = _enforceRules(paraElems, rules, bodyBottom, debug);
+        bodyBottom = qwery(bodySelector)[0].offsetHeight;
+        paraElems = _(qwery(bodySelector + ' > p')).map(_mapElementToDimensions);
+
+        if (debug) { // reset any previous debug messages
+            bonzo(paraElems.pluck('element').valueOf())
+                .attr('data-spacefinder-msg', '')
+                .removeClass('spacefinder--valid')
+                .removeClass('spacefinder--error');
+        }
+
+        slots = _enforceRules(paraElems, rules, bodyBottom, debug);
 
         if (debug) {
-            bonzo(slots.map(function (p) { return p.element; })).addClass('spacefinder--valid');
+            bonzo(_.pluck(slots, 'element')).addClass('spacefinder--valid');
         }
 
         return slots.length ? slots[0].element : undefined;

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -16,7 +16,7 @@ define([
     createAdSlot
 ) {
 
-    var getRules = function() {
+    function getRules() {
         return {
             minAbove: detect.isBreakpoint({ max: 'tablet' }) ? 300 : 700,
             minBelow: 300,
@@ -26,15 +26,14 @@ define([
                 ' .ad-slot': {minAbove: 500, minBelow: 500}
             }
         };
-    };
+    }
 
-    var getLenientRules = function() {
+    function getLenientRules() {
         var lenientRules = cloneDeep(getRules());
         // more lenient rules, closer to the top start of the article
         lenientRules.minAbove = 300;
         return lenientRules;
-    };
-
+    }
 
     var ads = [],
         adNames = [['inline1', 'inline'], ['inline2', 'inline']],

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -16,6 +16,26 @@ define([
     createAdSlot
 ) {
 
+    var getRules = function() {
+        return {
+            minAbove: detect.isBreakpoint({ max: 'tablet' }) ? 300 : 700,
+            minBelow: 300,
+            selectors: {
+                ' > h2': {minAbove: detect.getBreakpoint() === 'mobile' ? 20 : 0, minBelow: 250},
+                ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 400},
+                ' .ad-slot': {minAbove: 500, minBelow: 500}
+            }
+        };
+    };
+
+    var getLenientRules = function() {
+        var lenientRules = cloneDeep(getRules());
+        // more lenient rules, closer to the top start of the article
+        lenientRules.minAbove = 300;
+        return lenientRules;
+    };
+
+
     var ads = [],
         adNames = [['inline1', 'inline'], ['inline2', 'inline']],
         insertAdAtP = function (para) {
@@ -28,7 +48,7 @@ define([
         },
         init = function () {
 
-            var breakpoint, rules, lenientRules;
+            var rules, lenientRules;
 
             // is the switch off, or not an article, or a live blog
             if (
@@ -39,20 +59,8 @@ define([
                 return false;
             }
 
-            breakpoint = detect.getBreakpoint();
-            rules      = {
-                minAbove: detect.isBreakpoint({ max: 'tablet' }) ? 300 : 700,
-                minBelow: 300,
-                selectors: {
-                    ' > h2': {minAbove: breakpoint === 'mobile' ? 20 : 0, minBelow: 250},
-                    ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 400},
-                    ' .ad-slot': {minAbove: 500, minBelow: 500}
-                }
-            },
-            lenientRules = cloneDeep(rules);
-
-            // more lenient rules, closer to the top start of the article
-            lenientRules.minAbove = 300;
+            rules = getRules();
+            lenientRules = getLenientRules();
 
             if (
                 config.page.sponsorshipType === 'foundation-features' &&
@@ -75,6 +83,10 @@ define([
     return {
 
         init: once(init),
+
+        // rules exposed for spacefinder debugging
+        getRules: getRules,
+        getLenientRules: getLenientRules,
 
         destroy: function () {
             ads.forEach(function ($ad) {


### PR DESCRIPTION
- small fix for custom selector checks (see line 30 - all tests should be from the insertion point, e.g. the top of the paragraph)
- added debug argument that annotates paragraphs with classes/attributes to expose debug information (to be used with the bookmarklet [here](https://gist.github.com/mattosborn/c6cc61a69bb049b45446))
## Screenshot

![image](https://cloud.githubusercontent.com/assets/960919/5377148/5a97095a-8076-11e4-9f55-2fb6af79f1b0.png)

// @ironsidevsquincy 
