### PR TITLE
Remove double margin if an image has no caption or share buttons

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -173,14 +173,14 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
             // content api/ tools sometimes pops a &nbsp; in the blank field
             if (!figcaption.hasText || figcaption.text().length < 2) {
               figcaption.remove()
-              fig.addClass("fig--extra-margin")
+              fig.addClass("fig--no-caption")
             } else {
               figcaption.attr("itemprop", "description")
               fig.addClass("fig--border")
             }
           }
         } else {
-          fig.addClass("fig--extra-margin")
+          fig.addClass("fig--no-caption")
         }
       }
     }
@@ -201,7 +201,7 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
             fig.getElementsByTag("img").foreach { img =>
               val html = views.html.fragments.share.blockLevelSharing(hashSuffix, article.elementShares(Some(hashSuffix), crop.url), article.contentType)
               img.after(html.toString())
-
+              fig.addClass("fig--hasShares")
               img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")
               img.after("<span class='article__fullscreen'><i class='i i-expand-white'></i><i class='i i-expand-black'></i></span>")
             }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -201,7 +201,7 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
             fig.getElementsByTag("img").foreach { img =>
               val html = views.html.fragments.share.blockLevelSharing(hashSuffix, article.elementShares(Some(hashSuffix), crop.url), article.contentType)
               img.after(html.toString())
-              fig.addClass("fig--hasShares")
+              fig.addClass("fig--has-shares")
               img.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")
               img.after("<span class='article__fullscreen'><i class='i i-expand-white'></i><i class='i i-expand-black'></i></span>")
             }

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -371,7 +371,7 @@
         }
     }
 
-    .fig--extra-margin {
+    .fig--no-caption.fig--hasShares {
         padding-bottom: $gs-baseline * 3 !important;
     }
 
@@ -411,4 +411,5 @@
             }
         }
     }
+
 }

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -371,7 +371,7 @@
         }
     }
 
-    .fig--no-caption.fig--hasShares {
+    .fig--no-caption.fig--has-shares {
         padding-bottom: $gs-baseline * 3 !important;
     }
 


### PR DESCRIPTION
Fixes this double margin under an image:

![screen shot 2014-12-10 at 17 31 45](https://cloud.githubusercontent.com/assets/2236852/5380721/6e9ec3b8-8092-11e4-9867-03bce78b70cf.png)
