### PR TITLE
Specify charset on a per-font basis

### DIFF
--- a/static/src/stylesheets/bower.json
+++ b/static/src/stylesheets/bower.json
@@ -10,6 +10,9 @@
     "guss-layout": "~1.3.3",
     "guss-rem": "~1.2.0",
     "guss-typography": "~3.1.0",
-    "guss-webfonts": "~3.0.0"
+    "guss-webfonts": "~3.1.0"
+  },
+  "resolutions": {
+    "guss-webfonts": "~3.1.0"
   }
 }

--- a/static/src/stylesheets/components/guss-webfonts/.bower.json
+++ b/static/src/stylesheets/components/guss-webfonts/.bower.json
@@ -1,7 +1,7 @@
 {
   "name": "guss-webfonts",
   "description": "Guardian web fonts, for your prototyping needs",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": [
     "src/_webfonts.scss"
   ],
@@ -10,13 +10,13 @@
     "type": "git",
     "url": "http://github.com/guardian/guss-webfonts.git"
   },
-  "_release": "3.0.1",
+  "_release": "3.1.0",
   "_resolution": {
     "type": "version",
-    "tag": "3.0.1",
-    "commit": "76411109b5b9c6b4c883c7e043f2c41889948adb"
+    "tag": "3.1.0",
+    "commit": "b9a4ffe0699ae222c23cd4881e58fadec6db73e4"
   },
   "_source": "git://github.com/guardian/guss-webfonts.git",
-  "_target": "~3.0.0",
+  "_target": "~3.1.0",
   "_originalSource": "guss-webfonts"
 }

--- a/static/src/stylesheets/components/guss-webfonts/.gitignore
+++ b/static/src/stylesheets/components/guss-webfonts/.gitignore
@@ -2,6 +2,6 @@
 .DS_Store
 .sass-cache
 
-demo/demo.css
+demo/*.css
 docs
 node_modules

--- a/static/src/stylesheets/components/guss-webfonts/README.md
+++ b/static/src/stylesheets/components/guss-webfonts/README.md
@@ -107,23 +107,23 @@ You can curate your own list of @font-face rules like so:
     (
         'Guardian Agate Sans 1 Web': (
             (weight: 'regular', style: 'normal'),
-            (weight: 'bold',    style: 'normal'),
+            (weight: 'bold',    style: 'normal', charset: 'original'),
         ),
         'Guardian Text Egyptian Web': (
             (weight: 'regular',  style: 'normal'),
             (weight: 'regular',  style: 'italic'),
-            (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
-            (weight: 'medium',   style: 'italic', use-as: (weight: 'bold', style: 'italic')),
+            (weight: 'medium',   style: 'normal', version: '0.2.0', use-as: (weight: 'bold')),
+            (weight: 'medium',   style: 'italic', hinting: 'off', use-as: (weight: 'bold', style: 'normal')),
         ),
         'Guardian Egyptian Web': (
-            (weight: 'light',    style: 'normal'),
+            (weight: 'light',    style: 'normal', kerning: 'off'),
             (weight: 'regular',  style: 'normal'),
-            (weight: 'semibold', style: 'normal', use-as: (weight: 'ultrablack', style: 'normal')),
+            (weight: 'semibold', style: 'normal', use-as: (weight: 'ultrablack')),
         ),
         'Guardian Text Sans Web': (
             (weight: 'regular',  style: 'normal'),
             (weight: 'regular',  style: 'italic'),
-            (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
+            (weight: 'medium',   style: 'normal', use-as: (weight: 'bold')),
             (weight: 'medium',   style: 'italic', use-as: (weight: 'bold', style: 'italic')),
         ),
         'Guardian Sans Web': (
@@ -131,6 +131,53 @@ You can curate your own list of @font-face rules like so:
         )
     )
 );
+```
+
+## Development
+
+You will need
+
+ * [Node.js](http://nodejs.org/)
+ * [Ruby](https://www.ruby-lang.org/en/)
+ * [Bundler](http://bundler.io/)
+```
+$ gem install bundler
+```
+ * [Grunt CLI](http://gruntjs.com/getting-started#installing-the-cli)
+```
+$ npm install -g grunt-cli
+```
+
+Then, in root, install the dependecies
+
+```
+$ bundle install
+$ npm install
+$ bower install
+```
+
+To build the component
+
+```
+$ grunt build:demo
+```
+
+To build the docs (output to the `docs` dir)
+
+```
+$ grunt docs
+```
+
+To release the component
+
+```
+$ grunt release
+```
+
+By default a patch release. Also `major` and `minor` targets available, e.g.
+
+```
+$ grunt release:minor
 ```
 
 ## Uploading fonts

--- a/static/src/stylesheets/components/guss-webfonts/bower.json
+++ b/static/src/stylesheets/components/guss-webfonts/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "guss-webfonts",
   "description": "Guardian web fonts, for your prototyping needs",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "main": [
     "src/_webfonts.scss"
   ],

--- a/static/src/stylesheets/components/guss-webfonts/demo/demo.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/demo.scss
@@ -1,8 +1,4 @@
-$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
-
 @import '../src/_webfonts';
-
-@include guss-webfonts();
 
 @mixin font-family-helper-classes {
     $current-font: null;
@@ -35,27 +31,18 @@ body {
     margin: 0 auto;
     max-width: 620px;
 }
-
 [class*=family] {
     margin: 1em 0 4em;
-}
-
-h1 {
-    font-family: 'Guardian Titlepiece Web';
-}
-
-h2,
-h3 {
-    font-family: 'Guardian Egyptian Web';
-    font-weight: 200;
 }
 h2 {
     border-top: 2px solid #dfdfdf;
     padding-top: 4px;
+    font-weight: 200;
 }
 h3 {
     margin-top: 2em;
     margin-bottom: .5em;
+    font-weight: inherit;
 }
 
 @include font-family-helper-classes;

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-off-ascii.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-off-ascii.scss
@@ -1,0 +1,8 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-hinting: 'off';
+$guss-webfonts-kerning: 'off';
+$guss-webfonts-charset: 'ascii';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-off-latin1.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-off-latin1.scss
@@ -1,0 +1,8 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-hinting: 'off';
+$guss-webfonts-kerning: 'off';
+$guss-webfonts-charset: 'latin1';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-off-original.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-off-original.scss
@@ -1,0 +1,7 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-hinting: 'off';
+$guss-webfonts-kerning: 'off';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-on-ascii.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-on-ascii.scss
@@ -1,0 +1,7 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-hinting: 'off';
+$guss-webfonts-charset: 'ascii';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-on-latin1.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-on-latin1.scss
@@ -1,0 +1,7 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-hinting: 'off';
+$guss-webfonts-charset: 'latin1';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-on-original.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-off-kerning-on-original.scss
@@ -1,0 +1,6 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-hinting: 'off';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-off-ascii.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-off-ascii.scss
@@ -1,0 +1,7 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-kerning: 'off';
+$guss-webfonts-charset: 'ascii';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-off-latin1.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-off-latin1.scss
@@ -1,0 +1,7 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-kerning: 'off';
+$guss-webfonts-charset: 'latin1';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-off-original.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-off-original.scss
@@ -1,0 +1,6 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-kerning: 'off';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-on-ascii.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-on-ascii.scss
@@ -1,0 +1,6 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-charset: 'ascii';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-on-latin1.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-on-latin1.scss
@@ -1,0 +1,6 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+$guss-webfonts-charset: 'latin1';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-on-original.scss
+++ b/static/src/stylesheets/components/guss-webfonts/demo/hinting-on-kerning-on-original.scss
@@ -1,0 +1,5 @@
+$guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
+
+@import '../src/_webfonts';
+
+@include guss-webfonts();

--- a/static/src/stylesheets/components/guss-webfonts/demo/index.html
+++ b/static/src/stylesheets/components/guss-webfonts/demo/index.html
@@ -4,74 +4,153 @@
     <meta charset="utf-8" />
     <title>Guardian Web Fonts</title>
     <link rel="stylesheet" href="demo.css" />
+    <link id="font-css" rel="stylesheet" href="hinting-on-kerning-on-original.css" />
+    <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
 </head>
 <body>
     <h1>Guardian Web Fonts</h1>
-    <p class="family-GuardianAgateSans1Web">This is an overview of all Guardian font families for the web, hinted, in their largest available character sets.<br />Find a complete demo of each font, weight and style in the project sub-directories inside /webfonts/.</p>
-    <div class="family-GuardianAgateSans1Web">
-        <h2>Guardian Agate Sans 1 Web</h2>
-        <h3>Regular</h3>
-        <div class="weight-regular">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</div>
-        <h3>Bold</h3>
-        <div class="weight-bold">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</div>
+    <p>This is an overview of all Guardian font families for the web, hinted, in their largest available character sets.<br />Find a complete demo of each font, weight and style in the project sub-directories inside /webfonts/.</p>
+    <form id="font-type">
+        <label>
+            Hinting
+            <input name="hinting" type="checkbox" checked>
+        </label>
+        <label>
+            Kerning
+            <input name="kerning" type="checkbox" checked>
+        </label>
+        <label>
+            Charset
+            <select>
+                <option value="original" selected>Original</option>
+                <option value="latin1">Latin 1</option>
+                <option value="ascii">ASCII</option>
+            </select>
+        </label>
+    </form>
+    <script type="text/javascript">
+        var fontTypeStates = {
+                hinting: 'on',
+                kerning: 'on',
+                charset: 'original'
+            },
+            updateCss = function () {
+                $('#font-css').attr('href', 'hinting-' + fontTypeStates.hinting + '-kerning-' + fontTypeStates.kerning + '-' + fontTypeStates.charset + '.css')
+            };
+        $('#font-type').on('change', 'input', function (e) {
+            var input = e.target;
+            fontTypeStates[input.name] = input.checked ? 'on' : 'off';
+            updateCss();
+        });
+        $('#font-type').on('change', 'select', function (e) {
+            fontTypeStates.charset = $(e.target).val();
+            updateCss();
+        });
+    </script>
+    <div class="family-GuardianTextEgyptianWeb">
+        <h2>Guardian Text Egyptian Web</h2>
+        <div class="weight-regular">
+            <h3>Regular</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-medium">
+            <h3>Medium</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Saepe perspiciatis, ab qui beatae? <i>Asperiores,</i> praesentium veniam illum, sit laborum laboriosam. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-bold">
+            <h3>Bold</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-black">
+            <h3>Black</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Consectetur deleniti nesciunt alias, iusto et <i>reiciendis maxime</i> debitis maiores delectus corporis. Zażółć gęślą jaźń.</p>
+        </div>
     </div>
     <div class="family-GuardianEgyptianWeb">
         <h2>Guardian Egyptian Web</h2>
-        <h3>Light</h3>
-        <div class="weight-light">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum eos consequatur iste, pariatur mollitia culpa laudantium nobis error alias! Aperiam! Zażółć gęślą jaźń.</div>
-        <h3>Regular</h3>
-        <div class="weight-regular">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</div>
-        <h3>Medium</h3>
-        <div class="weight-medium">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Saepe perspiciatis, ab qui beatae? Asperiores, praesentium veniam illum, sit laborum laboriosam. Zażółć gęślą jaźń.</div>
-        <h3>Semibold</h3>
-        <div class="weight-semibold">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Tempora temporibus doloribus doloremque, nam possimus<i>! Itaque</i> eos possimus est ipsam! Asperiores. Zażółć gęślą jaźń.</div>
-        <h3>Bold</h3>
-        <div class="weight-bold">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</div>
-    </div>
-
-    <div class="family-GuardianSansWeb">
-        <h2>Guardian Sans Web</h2>
-        <h3>Light</h3>
-        <div class="weight-light">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Ipsum eos consequatur iste, pariatur mollitia <i>culpa laudantium</i> nobis error alias! Aperiam! Zażółć gęślą jaźń.</div>
-        <h3>Regular</h3>
-        <div class="weight-regular">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</div>
-    </div>
-    <div class="family-GuardianTextEgyptianWeb">
-        <h2>Guardian Text Egyptian Web</h2>
-        <h3>Regular</h3>
-        <div class="weight-regular">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</div>
-        <h3>Medium</h3>
-        <div class="weight-medium">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Saepe perspiciatis, ab qui beatae? <i>Asperiores,</i> praesentium veniam illum, sit laborum laboriosam. Zażółć gęślą jaźń.</div>
-        <h3>Bold</h3>
-        <div class="weight-bold">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</div>
-        <h3>Black</h3>
-        <div class="weight-black">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Consectetur deleniti nesciunt alias, iusto et <i>reiciendis maxime</i> debitis maiores delectus corporis. Zażółć gęślą jaźń.</div>
+        <div class="weight-light">
+            <h3>Light</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum eos consequatur iste, pariatur mollitia culpa laudantium nobis error alias! Aperiam! Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-regular">
+            <h3>Regular</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-medium">
+            <h3>Medium</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Saepe perspiciatis, ab qui beatae? Asperiores, praesentium veniam illum, sit laborum laboriosam. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-semibold">
+            <h3>Semibold</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Tempora temporibus doloribus doloremque, nam possimus<i>! Itaque</i> eos possimus est ipsam! Asperiores. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-bold">
+            <h3>Bold</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</p>
+        </div>
     </div>
     <div class="family-GuardianTextSansWeb">
         <h2>Guardian Text Sans Web</h2>
-        <h3>Regular</h3>
-        <div class="weight-regular">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</div>
-        <h3>Medium</h3>
-        <div class="weight-medium">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Saepe perspiciatis, ab qui beatae? <i>Asperiores,</i> praesentium veniam illum, sit laborum laboriosam. Zażółć gęślą jaźń.</div>
-        <h3>Bold</h3>
-        <div class="weight-bold">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</div>
-        <h3>Black</h3>
-        <div class="weight-black">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Consectetur deleniti nesciunt alias, iusto et <i>reiciendis maxime</i> debitis maiores delectus corporis. Zażółć gęślą jaźń.</div>
+        <div class="weight-regular">
+            <h3>Regular</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-medium">
+            <h3>Medium</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Saepe perspiciatis, ab qui beatae? <i>Asperiores,</i> praesentium veniam illum, sit laborum laboriosam. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-bold">
+            <h3>Bold</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-black">
+            <h3>Black</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Consectetur deleniti nesciunt alias, iusto et <i>reiciendis maxime</i> debitis maiores delectus corporis. Zażółć gęślą jaźń.</p>
+        </div>
+    </div>
+    <div class="family-GuardianSansWeb">
+        <h2>Guardian Sans Web</h2>
+        <div class="weight-light">
+            <h3>Light</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Ipsum eos consequatur iste, pariatur mollitia <i>culpa laudantium</i> nobis error alias! Aperiam! Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-regular">
+            <h3>Regular</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</p>
+        </div>
+    </div>
+    <div class="family-GuardianAgateSans1Web">
+        <h2>Guardian Agate Sans 1 Web</h2>
+        <div class="weight-regular">
+            <h3>Regular</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</p>
+        </div>
+        <div class="weight-bold">
+            <h3>Bold</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Suscipit, laborum, cum! Quibusdam <i>ducimus dolores</i>, mollitia totam asperiores illo at cum! Zażółć gęślą jaźń.</p>
+        </div>
     </div>
     <div class="family-GuardianCompactWeb">
         <h2>Guardian Compact Web</h2>
-        <h3>Black</h3>
-        <div class="weight-black">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Consectetur deleniti nesciunt alias, iusto et <i>reiciendis maxime</i> debitis maiores delectus corporis. Zażółć gęślą jaźń.</div>
+        <div class="weight-black">
+            <h3>Black</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Consectetur deleniti nesciunt alias, iusto et <i>reiciendis maxime</i> debitis maiores delectus corporis. Zażółć gęślą jaźń.</p>
+        </div>
     </div>
     <div class="family-GuardianTitlepieceWeb">
         <h2>Guardian Titlepiece Web</h2>
-        <h3>Regular</h3>
-        <div class="weight-regular">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</div>
+        <div class="weight-regular">
+            <h3>Regular</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.
+            </p>
+        </div>
      Zażółć gęślą jaźń.</div>
     <div class="family-GuardianWeekendCondWeb">
         <h2>Guardian Weekend Cond Web</h2>
-        <h3>Black</h3>
-        <div class="weight-black">Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</div>
+        <div class="weight-black">
+            <h3>Black</h3>
+            <p>Lorem ipsum dolor sit amet, <i>consectetur adipisicing elit</i>. Deleniti est repellendus, saepe voluptatum ducimus <i>ratione molestias</i> beatae cupiditate molestiae voluptates. Zażółć gęślą jaźń.</p>
+        </div>
     </div>
 </body>
 </html>

--- a/static/src/stylesheets/components/guss-webfonts/src/_webfonts.config.scss
+++ b/static/src/stylesheets/components/guss-webfonts/src/_webfonts.config.scss
@@ -57,15 +57,11 @@ $guss-webfonts-charset: 'original' !default;
 /**
  * Complete path
  *
- * @requires {variable} guss-webfonts-charset
- * @requires {variable} guss-webfonts-hinting
- * @requires {variable} guss-webfonts-kerning
- *
  * @type String
  *
  * @group webfonts
  */
-$guss-webfonts-path: '#{$guss-webfonts-version}/hinting-#{$guss-webfonts-hinting}/kerning-#{$guss-webfonts-kerning}/#{$guss-webfonts-charset}/' !default;
+$guss-webfonts-path: false !default;
 
 
 /**

--- a/static/src/stylesheets/components/guss-webfonts/src/_webfonts.helpers.scss
+++ b/static/src/stylesheets/components/guss-webfonts/src/_webfonts.helpers.scss
@@ -117,18 +117,18 @@
  * "Extra" fonts are stored in `$guss-extras-directory`.
  *
  * @param {String} $font-family - font name
+ * @param {String} $base-path ($guss-webfonts-path) - base path of where to look for this font
  *
  * @requires {variable} guss-extras-directory
- * @requires {variable} guss-webfonts-path
  * @requires {function} str-remove-white-space
  *
  * @return {String} - Path to the font
  *
  * @group webfonts
  */
-@function compose-webfont-path($font-family) {
+@function compose-webfont-path($font-family, $base-path: $guss-webfonts-path) {
     $directory: if(is-extra($font-family), $guss-extras-directory, str-remove-white-space($font-family));
-    $path: $guss-webfonts-path + $directory + '/';
+    $path: $base-path + $directory + '/';
 
     @return $path;
 }

--- a/static/src/stylesheets/components/guss-webfonts/src/_webfonts.mixins.scss
+++ b/static/src/stylesheets/components/guss-webfonts/src/_webfonts.mixins.scss
@@ -40,7 +40,7 @@
  * Output the @font-face declaration for a Guss webfont.
  *
  * @param {Number} $font-family - ID of the font in $guss-webfonts
- * @param {Map} $properties - weight (member of `$guss-font-weights`), style (`normal` | `italic`)
+ * @param {Map} $properties - weight (member of `$guss-font-weights`), style (`normal` | `italic`), version, hinting, kerning, charset
  * @param {Map} $overrides - weight (member of `$guss-font-weights`), style (`normal` | `italic`)
  *
  * @requires {variable} guss-webfonts
@@ -53,15 +53,28 @@
  */
 @mixin guss-webfonts-single-declaration(
     $font-family,
-    $properties: (weight: 'regular', style: 'normal'),
+    $properties: (
+        weight:  'regular',
+        style:   'normal',
+        version: false,
+        hinting: false,
+        kerning: false,
+        charset: false
+    ),
     $overrides: (weight: false, style: false)
 ) {
     $font: map-get($guss-webfonts, $font-family);
     $font-weight-override: map-get($overrides, weight);
     $font-style-override: map-get($overrides, style);
 
+    $version:   if(map-has-key($properties, version), map-get($properties, version), $guss-webfonts-version);
+    $hinting:   if(map-has-key($properties, hinting), map-get($properties, hinting), $guss-webfonts-hinting);
+    $kerning:   if(map-has-key($properties, kerning), map-get($properties, kerning), $guss-webfonts-kerning);
+    $charset:   if(map-has-key($properties, charset), map-get($properties, charset), $guss-webfonts-charset);
+    $base-path: if($guss-webfonts-path, $guss-webfonts-path, '#{$version}/hinting-#{$hinting}/kerning-#{$kerning}/#{$charset}/');
+
     $font-filename: compose-webfont-filename($font-family, map-get($properties, weight), map-get($properties, style));
-    $full-path: compose-webfont-path($font-family);
+    $full-path: compose-webfont-path($font-family, $base-path);
     $font-weight: guss-font-weight(if($font-weight-override, $font-weight-override, map-get($properties, weight)));
     $font-style: if($font-style-override, $font-style-override, map-get($properties, style));
 

--- a/static/src/stylesheets/webfonts-hinting-off-kerning-on.scss
+++ b/static/src/stylesheets/webfonts-hinting-off-kerning-on.scss
@@ -7,22 +7,22 @@ $guss-webfonts-hinting: 'off';
     (
         'Guardian Text Egyptian Web': (
             (weight: 'regular',  style: 'normal'),
-            (weight: 'regular',  style: 'italic'),
-            (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
+            (weight: 'regular',  style: 'italic', charset: 'latin1'),
+            (weight: 'medium',   style: 'normal', charset: 'latin1', use-as: (weight: 'bold', style: 'normal')),
         ),
         'Guardian Egyptian Web': (
-            (weight: 'light',    style: 'normal'),
-            (weight: 'regular',  style: 'normal'),
-            (weight: 'medium',   style: 'normal'),
-            (weight: 'semibold', style: 'normal', use-as: (weight: 'ultrablack', style: 'normal')),
+            (weight: 'light',    style: 'normal', charset: 'latin1'),
+            (weight: 'regular',  style: 'normal', charset: 'latin1'),
+            (weight: 'medium',   style: 'normal', charset: 'latin1'),
+            (weight: 'semibold', style: 'normal', charset: 'ascii', use-as: (weight: 'ultrablack', style: 'normal')),
         ),
         'Guardian Text Sans Web': (
             (weight: 'regular',  style: 'normal'),
-            (weight: 'regular',  style: 'italic'),
+            (weight: 'regular',  style: 'italic', charset: 'latin1'),
             (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
         ),
         'Guardian Sans Web': (
-            (weight: 'regular',  style: 'normal'),
+            (weight: 'regular',  style: 'normal', charset: 'latin1'),
         )
     )
 );

--- a/static/src/stylesheets/webfonts-hinting-on-kerning-on.scss
+++ b/static/src/stylesheets/webfonts-hinting-on-kerning-on.scss
@@ -6,22 +6,22 @@ $guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
     (
         'Guardian Text Egyptian Web': (
             (weight: 'regular',  style: 'normal'),
-            (weight: 'regular',  style: 'italic'),
-            (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
+            (weight: 'regular',  style: 'italic', charset: 'latin1'),
+            (weight: 'medium',   style: 'normal', charset: 'latin1', use-as: (weight: 'bold', style: 'normal')),
         ),
         'Guardian Egyptian Web': (
-            (weight: 'light',    style: 'normal'),
-            (weight: 'regular',  style: 'normal'),
-            (weight: 'medium',   style: 'normal'),
-            (weight: 'semibold', style: 'normal', use-as: (weight: 'ultrablack', style: 'normal')),
+            (weight: 'light',    style: 'normal', charset: 'latin1'),
+            (weight: 'regular',  style: 'normal', charset: 'latin1'),
+            (weight: 'medium',   style: 'normal', charset: 'latin1'),
+            (weight: 'semibold', style: 'normal', charset: 'ascii', use-as: (weight: 'ultrablack', style: 'normal')),
         ),
         'Guardian Text Sans Web': (
             (weight: 'regular',  style: 'normal'),
-            (weight: 'regular',  style: 'italic'),
+            (weight: 'regular',  style: 'italic', charset: 'latin1'),
             (weight: 'medium',   style: 'normal', use-as: (weight: 'bold', style: 'normal')),
         ),
         'Guardian Sans Web': (
-            (weight: 'regular',  style: 'normal'),
+            (weight: 'regular',  style: 'normal', charset: 'latin1'),
         )
     )
 );


### PR DESCRIPTION
Previously, for browsers that load in fonts asynchronously (i.e. IEx), we were serving the `original` charset for all fonts

Now it's brought inline with what browsers who supported storage are served, e.g. Guardian Text Egyptian Web regular is `latin1`, etc
