### PR TITLE
Improve layout of social links on fronts

### DIFF
--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -60,13 +60,6 @@ category: Common
 
 .social__action {
     display: inline-block;
-
-    &,
-    &:hover,
-    &:focus,
-    &:active {
-        text-decoration: none;
-    }
 }
 
 
@@ -94,6 +87,17 @@ category: Common
     width: auto;
     height: 32px;
     display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &,
+    &:hover,
+    &:active,
+    &:focus {
+        color: #ffffff;
+        text-decoration: none;
+    }
 
     i {
         display: inline-block;
@@ -126,7 +130,6 @@ category: Common
 }
 
 .social-icon__label {
-    color: #ffffff;
     white-space: nowrap;
     font-weight: bold;
 }

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -90,8 +90,10 @@ category: Common
     @extend %icon-holder-circle;
     border: 0;
     min-width: 32px;
+    max-width: 100%;
     width: auto;
     height: 32px;
+    display: inline-block;
 
     i {
         display: inline-block;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -206,7 +206,7 @@ $header-image-size-desktop: 100px;
         width: 100%;
 
         & + & {
-            border-top: none;
+            border-top: 0;
             margin-top: 0;
             padding-top: 0;
         }

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -193,6 +193,12 @@ $header-image-size-desktop: 100px;
         position: absolute;
         right: 0;
         top: 0;
+
+        & + & {
+            display: none;
+        }
+    }
+
     @include mq(leftCol) {
         border-top: 1px dotted colour(neutral-5);
         padding-top: $gs-baseline / 2;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -193,6 +193,17 @@ $header-image-size-desktop: 100px;
         position: absolute;
         right: 0;
         top: 0;
+    @include mq(leftCol) {
+        border-top: 1px dotted colour(neutral-5);
+        padding-top: $gs-baseline / 2;
+        margin-top: $gs-baseline;
+        width: 100%;
+
+        & + & {
+            border-top: none;
+            margin-top: 0;
+            padding-top: 0;
+        }
     }
 }
 


### PR DESCRIPTION
- only show first link on mobile
- give some space on desktop
- prevent labels wrapping if there's too little space

![screen shot 2014-12-11 at 13 21 19](https://cloud.githubusercontent.com/assets/867233/5394787/704660b6-8139-11e4-83b7-43fb6dd63cb4.png)

![screen shot 2014-12-11 at 13 21 37](https://cloud.githubusercontent.com/assets/867233/5394790/744e5790-8139-11e4-8f63-fd4b12e55b30.png)

![screen shot 2014-12-11 at 13 22 08](https://cloud.githubusercontent.com/assets/867233/5394793/77a580c6-8139-11e4-9c11-afbe1d2251e3.png)

http://www.browserstack.com/screenshots/f6c6bb5c3f712328cbc346dc98ecc5ad99036e41
