### PR TITLE
Fixing padding and margin so widths of all commercial items are all equal

### DIFF
--- a/static/src/stylesheets/module/commercial/_lineitem.scss
+++ b/static/src/stylesheets/module/commercial/_lineitem.scss
@@ -4,7 +4,7 @@
 .commercial {
     .lineitems {
         padding: 0;
-        margin: 0;
+        margin: 0 $gs-gutter/-2;
     }
     .lineitem {
         @include box-sizing(border-box);
@@ -16,11 +16,6 @@
 
         &:first-child {
             border-left: 0;
-            padding-left: 0;
-        }
-
-        &:last-child {
-            padding-right: 0;
         }
     }
     .lineitem--v-high {


### PR DESCRIPTION
This fixes an issue where the items were different widths meaning that the images were larger in the first and last item in a commercial component list. It manifests itself because the first and last image are then larger.

Before;
![screen shot 2014-12-11 at 14 40 49](https://cloud.githubusercontent.com/assets/1303616/5395724/d5df9550-8143-11e4-9970-e9005e207dd6.png)

After;
![screen shot 2014-12-11 at 14 40 56](https://cloud.githubusercontent.com/assets/1303616/5395730/e0a470be-8143-11e4-8f97-ba2c782e7887.png)
