### PR TITLE
Add Endpoint to Flush DFP Data Cache

### DIFF
--- a/admin/app/controllers/admin/commercial/DfpDataController.scala
+++ b/admin/app/controllers/admin/commercial/DfpDataController.scala
@@ -1,0 +1,16 @@
+package controllers.admin.commercial
+
+import common.ExecutionContexts
+import controllers.admin.AuthActions
+import dfp.DfpDataCacheJob
+import model.NoCache
+import play.api.mvc.{Action, AnyContent, Controller}
+
+object DfpDataController extends Controller with ExecutionContexts {
+
+  def flushCache(): Action[AnyContent] = AuthActions.AuthActionTest { implicit request =>
+    DfpDataCacheJob.run()
+    NoCache(Ok("All cached DFP data is being refreshed."))
+  }
+
+}

--- a/admin/app/controllers/admin/commercial/DfpDataController.scala
+++ b/admin/app/controllers/admin/commercial/DfpDataController.scala
@@ -1,6 +1,7 @@
 package controllers.admin.commercial
 
 import common.ExecutionContexts
+import conf.Configuration.environment
 import controllers.admin.AuthActions
 import dfp.DfpDataCacheJob
 import model.NoCache
@@ -8,9 +9,14 @@ import play.api.mvc.{Action, AnyContent, Controller}
 
 object DfpDataController extends Controller with ExecutionContexts {
 
+  def renderCacheFlushPage(): Action[AnyContent] = AuthActions.AuthActionTest { implicit request =>
+    NoCache(Ok(views.html.commercial.dfpFlush(environment.stage)))
+  }
+
   def flushCache(): Action[AnyContent] = AuthActions.AuthActionTest { implicit request =>
     DfpDataCacheJob.run()
-    NoCache(Ok("All cached DFP data is being refreshed."))
+    NoCache(Redirect(routes.DfpDataController.renderCacheFlushPage()))
+      .flashing("triggered" -> "true")
   }
 
 }

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -99,10 +99,6 @@
                 <div class="panel-heading">Tools for the commercial team</div>
                 <div class="panel-body">
                     <ul>
-                        <li>
-                            <a class="btn btn-danger" href="@controllers.admin.commercial.routes.DfpDataController.flushCache()" role="button">Flush!</a>
-                            Refresh all cached DFP data
-                        </li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderSpecialAdUnits()">List Special Ad Units</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderSponsorships()">Content Sponsorships</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderInlineMerchandisingTargetedTags()">Inline Merchandising Slot</a></li>
@@ -115,6 +111,7 @@
                         <li><a href="@controllers.admin.routes.CommercialController.renderFluidAds()">Fluid 250 Ads</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.sponsoredContainers()">Sponsored Containers Debug</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderAdTests()">Ad Tests</a></li>
+                        <li><a href="@controllers.admin.commercial.routes.DfpDataController.renderCacheFlushPage()">Refresh all cached DFP data</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -99,6 +99,10 @@
                 <div class="panel-heading">Tools for the commercial team</div>
                 <div class="panel-body">
                     <ul>
+                        <li>
+                            <a class="btn btn-danger" href="@controllers.admin.commercial.routes.DfpDataController.flushCache()" role="button">Flush!</a>
+                            Refresh all cached DFP data
+                        </li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderSpecialAdUnits()">List Special Ad Units</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderSponsorships()">Content Sponsorships</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderInlineMerchandisingTargetedTags()">Inline Merchandising Slot</a></li>

--- a/admin/app/views/commercial/dfpFlush.scala.html
+++ b/admin/app/views/commercial/dfpFlush.scala.html
@@ -1,0 +1,21 @@
+@(env: String)(implicit flash: Flash)
+
+@link(cssClass: String) = {
+    <a class="@cssClass" href="@controllers.admin.commercial.routes.DfpDataController.flushCache()" role="button">
+        Flush!</a>
+}
+
+@admin_main("DFP Data Cache Flush", env, isAuthed = true) {
+
+    <h1>DFP Data Cache Flush</h1>
+
+    <p>Click this button to refresh all cached DFP data</p>
+
+    @if(flash.get("triggered") == Some("true")) {
+        @link("btn btn-danger disabled")
+        <p>Data is being refreshed now.</p>
+    } else {
+        @link("btn btn-danger")
+    }
+
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -60,6 +60,7 @@ GET         /commercialtools/adunits/toapprove                                  
 POST        /commercialtools/adunits/toapprove                                                 controllers.admin.CommercialAdUnitController.approve()
 GET         /admin/commercial/fluid250                                                         controllers.admin.CommercialController.renderFluidAds()
 GET         /analytics/commercial/adtests                                                      controllers.admin.CommercialController.renderAdTests()
+GET         /admin/commercial/dfp/flush/view                                                   controllers.admin.commercial.DfpDataController.renderCacheFlushPage()
 GET         /admin/commercial/dfp/flush                                                        controllers.admin.commercial.DfpDataController.flushCache()
 
 # Metrics

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -60,6 +60,7 @@ GET         /commercialtools/adunits/toapprove                                  
 POST        /commercialtools/adunits/toapprove                                                 controllers.admin.CommercialAdUnitController.approve()
 GET         /admin/commercial/fluid250                                                         controllers.admin.CommercialController.renderFluidAds()
 GET         /analytics/commercial/adtests                                                      controllers.admin.CommercialController.renderAdTests()
+GET         /admin/commercial/dfp/flush                                                        controllers.admin.commercial.DfpDataController.flushCache()
 
 # Metrics
 GET         /metrics/loadbalancers                                                             controllers.admin.MetricsController.renderLoadBalancers()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -266,6 +266,7 @@ GET         /commercialtools/adunits/toapprove                                  
 POST        /commercialtools/adunits/toapprove                                                                       controllers.admin.CommercialAdUnitController.approve()
 GET         /admin/commercial/fluid250                                                                               controllers.admin.CommercialController.renderFluidAds()
 GET         /commercial/multi.json                                                                                   controllers.commercial.Multi.renderMulti
+GET         /admin/commercial/dfp/flush                                                                              controllers.admin.commercial.DfpDataController.flushCache()
 
 # dev-build only
 GET         /commercial/magento/token                                                                                controllers.commercial.magento.AccessTokenGenerator.generate

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -266,6 +266,7 @@ GET         /commercialtools/adunits/toapprove                                  
 POST        /commercialtools/adunits/toapprove                                                                       controllers.admin.CommercialAdUnitController.approve()
 GET         /admin/commercial/fluid250                                                                               controllers.admin.CommercialController.renderFluidAds()
 GET         /commercial/multi.json                                                                                   controllers.commercial.Multi.renderMulti
+GET         /admin/commercial/dfp/flush/view                                                                         controllers.admin.commercial.DfpDataController.renderCacheFlushPage()
 GET         /admin/commercial/dfp/flush                                                                              controllers.admin.commercial.DfpDataController.flushCache()
 
 # dev-build only


### PR DESCRIPTION
This is for emergency cases.  It might become more useful as we refresh data at different rates.  But if we're using it more than once a week something has gone terribly wrong.
