### PR TITLE
Catch and log general exceptions from capi library

### DIFF
--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -25,6 +25,12 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     case timeout: TimeoutException =>
       log.info(s"Got a timeout while calling content api: ${timeout.getMessage}")
       Right(NoCache(GatewayTimeout(timeout.getMessage)))
+    case error =>
+      log.info(s"Content api exception: ${error.getMessage}")
+      Option(error.getCause).map { cause =>
+        log.info(s"Content api exception cause: ", cause)
+      }
+      Right(NoCache(InternalServerError))
   }
 
   /*


### PR DESCRIPTION
I was encountering the "MappingException" quite a lot recently. This turned out to be a thrown Exception by json4s, within the CAPI client library. So I've added a general catch-all for these throwables, which are logged.
