### PR TITLE
Removing requirejs raven wrap

### DIFF
--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -138,9 +138,6 @@
             raven
         ) {
 
-            define  = raven.wrap({ deep: false }, define);
-            require = raven.wrap({ deep: false }, require);
-
             raven.config(
                 'http://' + guardian.config.page.sentryPublicApiKey + '@@' + guardian.config.page.sentryHost,
                 {


### PR DESCRIPTION
Breaks interactives that use http://interactive.guim.co.uk/next-gen/world/ng-interactive/2013/nov/walls/boot.js
