### PR TITLE
Cancel the video ad framework if vast doesn't provide an advert

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -129,8 +129,9 @@ define([
         };
         player.one('adsready', events.ready);
 
-        //If no preroll avaliable or preroll fails, still init content tracking
+        //If no preroll avaliable or preroll fails, cancel ad framework and init content tracking
         player.one('adtimeout', function () {
+            player.trigger('adscanceled');
             bindContentEvents(player);
         });
     }

--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -14,7 +14,7 @@
     "reqwest": "guardian/reqwest#master",
     "enhancer": "0.1.1",
     "videojs": "guardian/video.js#2f0dba8556e510a79d5e66dbbc7c45f1caffcb59",
-    "videojs-contrib-ads": "guardian/videojs-contrib-ads#af69a79e52b95a2c997e9c76a4a0e92db9a1b4a3",
+    "videojs-contrib-ads": "videojs/videojs-contrib-ads#f44387a4d2fd939f9a665762917e2fa6fc8838d7",
     "videojs-vast": "guardian/videojs-vast-plugin#f2b9fe764d90f364607ba2b7fca1694d9db8d31a",
     "vast-client-js": "guardian/vast-client-js#79a3102455eb8acc6b677424e6e556fb354131d4",
     "videojs-persistvolume": "~0.1.0",

--- a/static/src/javascripts/components/videojs-contrib-ads/videojs.ads.js
+++ b/static/src/javascripts/components/videojs-contrib-ads/videojs.ads.js
@@ -320,6 +320,9 @@ var
         fsm = {
           'content-set': {
             events: {
+              'adscanceled': function() {
+                this.state = 'content-playback';
+              },
               'adsready': function() {
                 this.state = 'ads-ready';
               },
@@ -390,6 +393,13 @@ var
             events: {
               'play': function() {
                 cancelContentPlay(player);
+              },
+              'adscanceled': function() {
+                this.state = 'content-playback';
+
+                clearImmediate(player.ads.cancelPlayTimeout);
+                player.ads.cancelPlayTimeout = null;
+                player.play();
               },
               'adsready': function() {
                 this.state = 'preroll?';
@@ -483,6 +493,7 @@ var
       'contentupdate',
       // events emitted by third party ad implementors
       'adsready',
+      'adscanceled',
       'adstart',  // startLinearAdMode()
       'adend'     // endLinearAdMode()
     ]), fsmHandler);


### PR DESCRIPTION
The lovely peeps at videojs-contrib-ads (thanks @dmlap) have merged our PR, so we can use their repo, which also has support for the much-needed 'adscanceled' event.

@mattosborn can you take a look please?
