### PR TITLE
History tags: simpler algorithm

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -127,11 +127,11 @@ define([
     }
 
     function getPopular() {
-        popularCache = popularCache || _getPopular({excludeRx: new RegExp(/^profile/)});
+        popularCache = popularCache || getPopularFiltered({excludeRx: new RegExp(/^profile/)});
         return popularCache;
     }
 
-    function _getPopular(opts) {
+    function getPopularFiltered(opts) {
         opts = opts || {};
 
         return _.chain(getSummary().tags)
@@ -163,7 +163,7 @@ define([
     function weeklyHabitFactor(freqs) {
         var days;
 
-        if(freqs.length < 2) {
+        if (freqs.length < 2) {
             return 1;
         } else {
             days = _.pluck(freqs, 0);

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -55,7 +55,6 @@ define([
         historyCache,
         summaryCache,
         popularCache,
-        popularProfilesCache,
         isEditionalisedRx = new RegExp('^(' + editions.join('|') + ')\/(' + editionalised.join('|') + ')$'),
         stripEditionRx = new RegExp('^(' + editions.join('|') + ')\/');
 
@@ -70,7 +69,8 @@ define([
     }
 
     function getHistory() {
-        return historyCache = historyCache || storage.local.get(storageKeyHistory) || [];
+        historyCache = historyCache || storage.local.get(storageKeyHistory) || [];
+        return historyCache;
     }
 
     function getSummary() {
@@ -127,11 +127,8 @@ define([
     }
 
     function getPopular() {
-        return popularCache = popularCache || _getPopular({excludeRx: new RegExp(/^profile/)});
-    }
-
-    function getPopularProfiles() {
-        return popularProfilesCache = popularProfilesCache || _getPopular({includeRx: new RegExp(/^profile/)});
+        popularCache = popularCache || _getPopular({excludeRx: new RegExp(/^profile/)});
+        return popularCache;
     }
 
     function _getPopular(opts) {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -127,24 +127,14 @@ define([
     }
 
     function getPopular() {
-        popularCache = popularCache || getPopularFiltered({excludeRx: new RegExp(/^profile/)});
-        return popularCache;
-    }
-
-    function getPopularFiltered(opts) {
-        opts = opts || {};
-
-        return _.chain(getSummary().tags)
+        popularCache = popularCache || _.chain(getSummary().tags)
             .map(function (nameAndFreqs, tid) {
                 var freqs = nameAndFreqs[1];
 
-                if ((!opts.includeRx ||  tid.match(opts.includeRx)) &&
-                    (!opts.excludeRx || !tid.match(opts.excludeRx))) {
-                    return {
-                        keep: [tid, nameAndFreqs[0]],
-                        rank: tally(freqs)
-                    };
-                }
+                return {
+                    keep: [tid, nameAndFreqs[0]],
+                    rank: tally(freqs)
+                };
             })
             .compact()
             .sortBy('rank')
@@ -152,6 +142,8 @@ define([
             .reverse()
             .pluck('keep')
             .value();
+
+        return popularCache;
     }
 
     function tally(freqs) {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -142,7 +142,7 @@ define([
                     (!opts.excludeRx || !tid.match(opts.excludeRx))) {
                     return {
                         keep: [tid, nameAndFreqs[0]],
-                        rank: tallyFreqs(freqs) * weeklyHabitFactor(freqs)
+                        rank: tally(freqs) * weeklies(freqs)
                     };
                 }
             })
@@ -154,27 +154,28 @@ define([
             .value();
     }
 
-    function tallyFreqs(freqs) {
+    function tally(freqs) {
         return _.reduce(freqs, function (tally, freq) {
             return tally + (9 + freq[1]) * (summaryPeriodDays - freq[0]);
         }, 0);
     }
 
-    function weeklyHabitFactor(freqs) {
-        var days;
+    function weeklies(freqs) {
+        var days,
+            weeks = 1;
 
-        if (freqs.length < 2) {
-            return 1;
-        } else {
+        if (freqs.length > 2) {
             days = _.pluck(freqs, 0);
-            return _.chain(days)
+            weeks = _.chain(days)
                 .zip(_.rest(days))
                 .initial()
                 .map(function (tup) { return tup[1] - tup[0]; })
                 .filter(function (gap) { return Math.abs(gap - 7) % 7 <= 2; })
                 .value()
-                .length + 1;
+                .length || 1;
         }
+
+        return weeks;
     }
 
     function firstCsv(str) {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -145,7 +145,7 @@ define([
                     (!opts.excludeRx || !tid.match(opts.excludeRx))) {
                     return {
                         keep: [tid, nameAndFreqs[0]],
-                        rank: tallyFreqs(freqs)
+                        rank: tallyFreqs(freqs) * weeklyHabitFactor(freqs)
                     };
                 }
             })
@@ -159,8 +159,25 @@ define([
 
     function tallyFreqs(freqs) {
         return _.reduce(freqs, function (tally, freq) {
-            return tally + (4 + freq[1]) * (summaryPeriodDays - freq[0]);
+            return tally + (9 + freq[1]) * (summaryPeriodDays - freq[0]);
         }, 0);
+    }
+
+    function weeklyHabitFactor(freqs) {
+        var days;
+
+        if(freqs.length < 2) {
+            return 1;
+        } else {
+            days = _.pluck(freqs, 0);
+            return _.chain(days)
+                .zip(_.rest(days))
+                .initial()
+                .map(function (tup) { return tup[1] - tup[0]; })
+                .filter(function (gap) { return Math.abs(gap - 7) % 7 <= 2; })
+                .value()
+                .length + 1;
+        }
     }
 
     function firstCsv(str) {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -142,7 +142,7 @@ define([
                     (!opts.excludeRx || !tid.match(opts.excludeRx))) {
                     return {
                         keep: [tid, nameAndFreqs[0]],
-                        rank: tally(freqs) * weeklies(freqs)
+                        rank: tally(freqs)
                     };
                 }
             })
@@ -158,24 +158,6 @@ define([
         return _.reduce(freqs, function (tally, freq) {
             return tally + (9 + freq[1]) * (summaryPeriodDays - freq[0]);
         }, 0);
-    }
-
-    function weeklies(freqs) {
-        var days,
-            weeks = 1;
-
-        if (freqs.length > 2) {
-            days = _.pluck(freqs, 0);
-            weeks = _.chain(days)
-                .zip(_.rest(days))
-                .initial()
-                .map(function (tup) { return tup[1] - tup[0]; })
-                .filter(function (gap) { return Math.abs(gap - 7) % 7 <= 2; })
-                .value()
-                .length || 1;
-        }
-
-        return weeks;
     }
 
     function firstCsv(str) {


### PR DESCRIPTION
For each tag, over 30 days:
- each day with a visit = 10 points
- each additional visit in a day = 1 point
- weight today's tally by 30, yesterday's by 29, the day before yesterday's by 28, etc.
- no longer computes a "habit factor"; the sample size is too small to make that stable.
- omit anything already in the top nav
- omit profile/.. tags.

@crifmulholland 
