### PR TITLE
Reschedule Caching of DFP Data

### DIFF
--- a/admin/app/controllers/admin/commercial/DfpDataController.scala
+++ b/admin/app/controllers/admin/commercial/DfpDataController.scala
@@ -3,7 +3,6 @@ package controllers.admin.commercial
 import common.ExecutionContexts
 import conf.Configuration.environment
 import controllers.admin.AuthActions
-import dfp.DfpDataCacheJob
 import model.NoCache
 import play.api.mvc.{Action, AnyContent, Controller}
 
@@ -14,7 +13,7 @@ object DfpDataController extends Controller with ExecutionContexts {
   }
 
   def flushCache(): Action[AnyContent] = AuthActions.AuthActionTest { implicit request =>
-    DfpDataCacheJob.run()
+    dfp.refreshAllDfpData()
     NoCache(Redirect(routes.DfpDataController.renderCacheFlushPage()))
       .flashing("triggered" -> "true")
   }

--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -4,9 +4,12 @@ import com.google.api.ads.dfp.axis.utils.v201411.StatementBuilder
 import com.google.api.ads.dfp.axis.v201411.InventoryStatus
 import conf.Configuration
 
+import scala.util.Try
+import scala.util.control.Exception._
+
 object AdUnitAgent extends DataAgent[String, GuAdUnit] {
 
-  override def loadFreshData() = {
+  override def loadFreshData() = Try {
     DfpServiceRegistry().fold(Map[String, GuAdUnit]()) { serviceRegistry =>
 
       val statementBuilder = new StatementBuilder()
@@ -31,4 +34,5 @@ object AdUnitAgent extends DataAgent[String, GuAdUnit] {
       }.toMap
     }
   }
+
 }

--- a/admin/app/dfp/CustomFieldAgent.scala
+++ b/admin/app/dfp/CustomFieldAgent.scala
@@ -2,12 +2,15 @@ package dfp
 
 import com.google.api.ads.dfp.axis.utils.v201411.StatementBuilder
 
+import scala.util.Try
+
 object CustomFieldAgent extends DataAgent[String, Long] {
 
-  override def loadFreshData() = {
+  override def loadFreshData() = Try {
     DfpServiceRegistry() map { serviceRegistry =>
       val fields = DfpApiWrapper.fetchCustomFields(serviceRegistry, new StatementBuilder())
       fields.map(f => f.getName -> f.getId.toLong).toMap
     } getOrElse Map.empty
   }
+
 }

--- a/admin/app/dfp/CustomTargetingKeyAgent.scala
+++ b/admin/app/dfp/CustomTargetingKeyAgent.scala
@@ -2,9 +2,11 @@ package dfp
 
 import com.google.api.ads.dfp.axis.utils.v201411.StatementBuilder
 
+import scala.util.Try
+
 object CustomTargetingKeyAgent extends DataAgent[Long, String] {
 
-  override def loadFreshData() = {
+  override def loadFreshData() = Try {
     DfpServiceRegistry().fold(Map[Long, String]()) { serviceRegistry =>
       val keys = DfpApiWrapper.fetchCustomTargetingKeys(serviceRegistry, new StatementBuilder())
       keys.map { k => k.getId.longValue() -> k.getName}.toMap

--- a/admin/app/dfp/CustomTargetingValueAgent.scala
+++ b/admin/app/dfp/CustomTargetingValueAgent.scala
@@ -2,9 +2,11 @@ package dfp
 
 import com.google.api.ads.dfp.axis.utils.v201411.StatementBuilder
 
+import scala.util.Try
+
 object CustomTargetingValueAgent extends DataAgent[Long, String] {
 
-  override def loadFreshData() = {
+  override def loadFreshData() = Try {
     DfpServiceRegistry().fold(Map[Long, String]()) { serviceRegistry =>
       val values = DfpApiWrapper.fetchCustomTargetingValues(serviceRegistry, new StatementBuilder())
       values.map { v => v.getId.longValue() -> v.getName}.toMap

--- a/admin/app/dfp/DataAgent.scala
+++ b/admin/app/dfp/DataAgent.scala
@@ -33,6 +33,7 @@ trait DataAgent[K, V] extends ExecutionContexts with Logging {
             oldCache
         }
       } else {
+        log.info("DFP caching switched off so no fresh data loaded")
         oldCache
       }
     }

--- a/admin/app/dfp/DataAgent.scala
+++ b/admin/app/dfp/DataAgent.scala
@@ -3,24 +3,30 @@ package dfp
 import common.{AkkaAgent, ExecutionContexts, Logging}
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 trait DataAgent[K, V] extends ExecutionContexts with Logging {
 
   private val initialCache: DataCache[K, V] = DataCache(Map.empty[K, V])
   private lazy val cache = AkkaAgent(initialCache)
 
-  def loadFreshData(): Map[K, V]
+  def loadFreshData(): Try[Map[K, V]]
 
   def refresh(): Future[DataCache[K, V]] = {
     log.info("Refreshing data cache")
     cache alterOff { oldCache =>
-      val freshData = loadFreshData()
-      if (freshData.nonEmpty) {
-        log.info("Fresh data loaded")
-        DataCache(freshData)
-      } else {
-        log.error("No fresh data loaded so keeping old data")
-        oldCache
+      loadFreshData() match {
+        case Success(freshData) =>
+          if (freshData.nonEmpty) {
+            log.info("Fresh data loaded")
+            DataCache(freshData)
+          } else {
+            log.error("No fresh data loaded so keeping old data")
+            oldCache
+          }
+        case Failure(e) =>
+          log.error(e.getStackTraceString)
+          oldCache
       }
     }
   }

--- a/admin/app/dfp/DataAgent.scala
+++ b/admin/app/dfp/DataAgent.scala
@@ -22,7 +22,7 @@ trait DataAgent[K, V] extends ExecutionContexts with Logging {
           case Success(freshData) =>
             if (freshData.nonEmpty) {
               val duration = System.currentTimeMillis - start
-              log.info(s"Loading data took $duration ms")
+              log.info(s"Loading DFP data took $duration ms")
               DataCache(freshData)
             } else {
               log.error("No fresh data loaded so keeping old data")

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -1,10 +1,9 @@
 package dfp
 
-import common.{AkkaAsync, ExecutionContexts, Jobs, Logging}
+import common.{ExecutionContexts, Logging}
 import conf.Switches.{DfpCachingSwitch, DfpMemoryLeakSwitch}
 import org.joda.time.DateTime
 import play.api.libs.json.Json.{toJson, _}
-import play.api.{Application, GlobalSettings}
 import tools.Store
 
 import scala.concurrent.{Future, future}
@@ -42,10 +41,11 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
       Store.putDfpLineItemsReport(stringify(toJson(LineItemReport(now, data.lineItems))))
     }
 
+    log.info("Refreshing data cache")
     val start = System.currentTimeMillis
     val data = DfpDataExtractor(DfpDataHydrator().loadCurrentLineItems())
     val duration = System.currentTimeMillis - start
-    log.info(s"Reading DFP data took $duration ms")
+    log.info(s"Loading DFP data took $duration ms")
 
     if (DfpMemoryLeakSwitch.isSwitchedOn) MemoryLeakPlug()
 
@@ -55,81 +55,4 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
 }
 
 
-trait DfpDataCacheLifecycle extends GlobalSettings with ExecutionContexts {
 
-  trait Job[T] {
-    val name: String
-    val interval: Int
-    def run(): Future[T]
-  }
-
-  val jobs = Set(
-
-    new Job[DataCache[String, GuAdUnit]] {
-      val name = "DFP-AdUnits-Update"
-      val interval = 30
-      def run() = AdUnitAgent.refresh()
-    },
-
-    new Job[DataCache[String, Long]] {
-      val name = "DFP-CustomFields-Update"
-      val interval = 30
-      def run() = CustomFieldAgent.refresh()
-    },
-
-    new Job[DataCache[Long, String]] {
-      val name = "DFP-TargetingKeys-Update"
-      val interval = 30
-      def run() = CustomTargetingKeyAgent.refresh()
-    },
-
-    new Job[DataCache[Long, String]] {
-      val name = "DFP-TargetingValues-Update"
-      val interval = 30
-      def run() = CustomTargetingValueAgent.refresh()
-    },
-
-    new Job[DataCache[Long, Seq[String]]] {
-      val name = "DFP-Placements-Update"
-      val interval = 30
-      def run() = PlacementAgent.refresh()
-    },
-
-    new Job[Unit] {
-      val name: String = "DFP-Cache"
-      val interval: Int = 5
-      def run(): Future[Unit] = DfpDataCacheJob.run()
-    }
-
-  )
-
-  override def onStart(app: Application) {
-    super.onStart(app)
-
-    jobs foreach { job =>
-      Jobs.deschedule(job.name)
-      Jobs.scheduleEveryNMinutes(job.name, job.interval) {
-        job.run()
-      }
-    }
-
-    AkkaAsync {
-      for {
-        _ <- AdUnitAgent.refresh()
-        _ <- CustomFieldAgent.refresh()
-        _ <- CustomTargetingKeyAgent.refresh()
-        _ <- CustomTargetingValueAgent.refresh()
-        _ <- PlacementAgent.refresh()
-      } {
-        DfpDataCacheJob.run()
-      }
-    }
-  }
-
-  override def onStop(app: Application) {
-    jobs foreach { job =>
-      Jobs.deschedule(job.name)
-    }
-    super.onStop(app)
-  }
-}

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -12,6 +12,7 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
 
   def run(): Future[Unit] = future {
     if (DfpCachingSwitch.isSwitchedOn) cacheData()
+    else log.info("DFP caching switched off")
   }
 
   def cacheData(): Unit = {

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -48,6 +48,7 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
           _ <- CustomFieldAgent.refresh()
           _ <- CustomTargetingKeyAgent.refresh()
           _ <- CustomTargetingValueAgent.refresh()
+          _ <- PlacementAgent.refresh()
         } {
           cacheData()
         }

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -1,0 +1,77 @@
+package dfp
+
+import common.{AkkaAsync, ExecutionContexts, Jobs}
+import play.api.{Application, GlobalSettings}
+
+import scala.concurrent.Future
+
+trait DfpDataCacheLifecycle extends GlobalSettings with ExecutionContexts {
+
+  trait Job[T] {
+    val name: String
+    val interval: Int
+    def run(): Future[T]
+  }
+
+  val jobs = Set(
+
+    new Job[DataCache[String, GuAdUnit]] {
+      val name = "DFP-AdUnits-Update"
+      val interval = 30
+      def run() = AdUnitAgent.refresh()
+    },
+
+    new Job[DataCache[String, Long]] {
+      val name = "DFP-CustomFields-Update"
+      val interval = 30
+      def run() = CustomFieldAgent.refresh()
+    },
+
+    new Job[DataCache[Long, String]] {
+      val name = "DFP-TargetingKeys-Update"
+      val interval = 30
+      def run() = CustomTargetingKeyAgent.refresh()
+    },
+
+    new Job[DataCache[Long, String]] {
+      val name = "DFP-TargetingValues-Update"
+      val interval = 30
+      def run() = CustomTargetingValueAgent.refresh()
+    },
+
+    new Job[DataCache[Long, Seq[String]]] {
+      val name = "DFP-Placements-Update"
+      val interval = 30
+      def run() = PlacementAgent.refresh()
+    },
+
+    new Job[Unit] {
+      val name: String = "DFP-Cache"
+      val interval: Int = 5
+      def run(): Future[Unit] = DfpDataCacheJob.run()
+    }
+
+  )
+
+  override def onStart(app: Application) {
+    super.onStart(app)
+
+    jobs foreach { job =>
+      Jobs.deschedule(job.name)
+      Jobs.scheduleEveryNMinutes(job.name, job.interval) {
+        job.run()
+      }
+    }
+
+    AkkaAsync {
+      refreshAllDfpData()
+    }
+  }
+
+  override def onStop(app: Application) {
+    jobs foreach { job =>
+      Jobs.deschedule(job.name)
+    }
+    super.onStop(app)
+  }
+}

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -33,7 +33,7 @@ class DfpDataHydrator extends Logging {
       val optSponsorFieldId = CustomFieldAgent.get.data.get("Sponsor")
 
       val allAdUnits = AdUnitAgent.get.data
-      val placementAdUnits = loadAdUnitIdsByPlacement()
+      val placementAdUnits = PlacementAgent.get.data
 
       val allCustomTargetingKeys = CustomTargetingKeyAgent.get.data
       val allCustomTargetingValues = CustomTargetingValueAgent.get.data
@@ -160,13 +160,6 @@ class DfpDataHydrator extends Logging {
       DfpApiWrapper.approveTheseAdUnits(serviceRegistry, statementBuilder)
   }.getOrElse(Failure(new DfpSessionException()))
 
-
-  def loadAdUnitIdsByPlacement(): Map[Long, Seq[String]] =
-    dfpServiceRegistry.fold(Map[Long, Seq[String]]()) { serviceRegistry =>
-      DfpApiWrapper.fetchPlacements(serviceRegistry, new StatementBuilder()).map { placement =>
-      placement.getId.toLong -> placement.getTargetedAdUnitIds.toSeq
-    }.toMap
-  }
 
   def loadActiveUserDefinedCreativeTemplates(): Seq[GuCreativeTemplate] =
     dfpServiceRegistry.fold(Seq.empty[GuCreativeTemplate]) { serviceRegistry =>

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -1,0 +1,16 @@
+package dfp
+
+import com.google.api.ads.dfp.axis.utils.v201411.StatementBuilder
+
+object PlacementAgent extends DataAgent[Long, Seq[String]] {
+
+  override def loadFreshData(): Map[Long, Seq[String]] = {
+    DfpServiceRegistry().fold(Map[Long, Seq[String]]()) { serviceRegistry =>
+      val placements = DfpApiWrapper.fetchPlacements(serviceRegistry, new StatementBuilder())
+      placements.map { placement =>
+        placement.getId.toLong -> placement.getTargetedAdUnitIds.toSeq
+      }.toMap
+    }
+  }
+
+}

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -2,9 +2,11 @@ package dfp
 
 import com.google.api.ads.dfp.axis.utils.v201411.StatementBuilder
 
+import scala.util.Try
+
 object PlacementAgent extends DataAgent[Long, Seq[String]] {
 
-  override def loadFreshData(): Map[Long, Seq[String]] = {
+  override def loadFreshData() = Try {
     DfpServiceRegistry().fold(Map[Long, Seq[String]]()) { serviceRegistry =>
       val placements = DfpApiWrapper.fetchPlacements(serviceRegistry, new StatementBuilder())
       placements.map { placement =>

--- a/admin/app/dfp/package.scala
+++ b/admin/app/dfp/package.scala
@@ -1,7 +1,20 @@
-import org.joda.time.{DateTimeZone, DateTime}
+import common.ExecutionContexts
 import org.joda.time.format.DateTimeFormat
+import org.joda.time.{DateTime, DateTimeZone}
 
-package object dfp {
+package object dfp extends ExecutionContexts {
 
   def printLondonTime(timestamp: DateTime): String = DateTimeFormat.longDateTime().withZone(DateTimeZone.forID("Europe/London")).print(timestamp)
+
+  def refreshAllDfpData() {
+    for {
+      _ <- AdUnitAgent.refresh()
+      _ <- CustomFieldAgent.refresh()
+      _ <- CustomTargetingKeyAgent.refresh()
+      _ <- CustomTargetingValueAgent.refresh()
+      _ <- PlacementAgent.refresh()
+    } {
+      DfpDataCacheJob.run()
+    }
+  }
 }

--- a/common/app/dfp/PageSkinSponsorship.scala
+++ b/common/app/dfp/PageSkinSponsorship.scala
@@ -44,6 +44,7 @@ object PageSkin {
   def isValidForNextGenPageSkin(adUnit: String): Boolean = adUnit.endsWith("/front") || adUnit.endsWith("/front/ng")
 }
 
+
 case class PageSkinSponsorshipReport(updatedTimeStamp: String, sponsorships: Seq[PageSkinSponsorship]) {
 
   val (deliverableAndTestSponsorships, legacySponsorships) = sponsorships partition { sponsorship =>
@@ -51,6 +52,20 @@ case class PageSkinSponsorshipReport(updatedTimeStamp: String, sponsorships: Seq
   }
   val (testSponsorships, deliverableSponsorships) = deliverableAndTestSponsorships partition (_.targetsAdTest)
 }
+
+object PageSkinSponsorshipReport {
+
+  implicit val pageSkinSponsorshipReportWrites = new Writes[PageSkinSponsorshipReport] {
+    def writes(report: PageSkinSponsorshipReport): JsValue = {
+      Json.obj(
+        "updatedTimeStamp" -> report.updatedTimeStamp,
+        "sponsorships" -> report.sponsorships
+      )
+    }
+  }
+
+}
+
 
 object PageSkinSponsorshipReportParser extends Logging {
 

--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -37,6 +37,17 @@ case class Sponsorship(tags: Seq[String],
 
 object InlineMerchandisingTagSet {
   implicit val jsonReads = Json.reads[InlineMerchandisingTagSet]
+
+  implicit val inlineMerchandisingTagSetWrites = new Writes[InlineMerchandisingTagSet] {
+    def writes(tagSet: InlineMerchandisingTagSet): JsValue = {
+      Json.obj(
+        "keywords" -> tagSet.keywords,
+        "series" -> tagSet.series,
+        "contributors" -> tagSet.contributors
+      )
+    }
+  }
+
 }
 
 case class InlineMerchandisingTagSet(keywords: Set[String] = Set.empty, series: Set[String] = Set.empty, contributors: Set[String] = Set.empty) {
@@ -88,6 +99,16 @@ object SponsorshipReportParser extends Logging {
 
 object InlineMerchandisingTargetedTagsReport {
   implicit val jsonReads = Json.reads[InlineMerchandisingTargetedTagsReport]
+
+  implicit val inlineMerchandisingTargetedTagsReportWrites =
+    new Writes[InlineMerchandisingTargetedTagsReport] {
+      def writes(report: InlineMerchandisingTargetedTagsReport): JsValue = {
+        Json.obj(
+          "updatedTimeStamp" -> report.updatedTimeStamp,
+          "targetedTags" -> report.targetedTags
+        )
+      }
+    }
 }
 
 case class InlineMerchandisingTargetedTagsReport(updatedTimeStamp: String, targetedTags: InlineMerchandisingTagSet)


### PR DESCRIPTION
This reads different types of DFP data at different intervals.  Line items are read every 5 minutes but all other data is read every 30 minutes.  If all looks well, will increase rate of line-item reads to every 2 minutes.
