### PR TITLE
Revert "Sort latest articles by first publication date"

### DIFF
--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -259,7 +259,7 @@ function (
             url += 'search?' + vars.CONST.apiSearchParams;
             url += options.isDraft ?
                 '&content-set=-web-live&order-by=oldest&use-date=scheduled-publication&from-date=' + dateYyyymmdd() :
-                '&content-set=web-live&order-by=newest&use-date=first-publication';
+                '&content-set=web-live&order-by=newest';
             url += '&page-size=' + options.pageSize;
             url += '&page=' + options.page;
             url += term ? '&q=' + term : '';


### PR DESCRIPTION
Reverts guardian/frontend#7504

Because video are missing from the feed
