### PR TITLE
Buttons mixins update and football matches button fix

### DIFF
--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -59,10 +59,7 @@
                                    data-new-url="next"
                                    data-link-name="next"
                                    title="Next page">
-                                    <span class="collection__show-more__icon">
-                                        <i class="i i-plus-white"></i>More
-                                    </span>
-                                    <span class="u-h">Next</span>
+                                   <i class="i i-plus-white"></i>More
                                 </a>
                             }
                         </div>

--- a/static/src/stylesheets/components/pasteup-buttons/.bower.json
+++ b/static/src/stylesheets/components/pasteup-buttons/.bower.json
@@ -1,7 +1,7 @@
 {
   "name": "pasteup-buttons",
   "description": "Button component in the Pasteup collection",
-  "version": "0.4.12",
+  "version": "0.4.16",
   "main": [
     "build/buttons.min.css",
     "src/_buttons.scss"
@@ -14,19 +14,19 @@
   "dependencies": {
     "guss-colours": "~3.0.0",
     "guss-grid-system": "~1.2.1",
-    "guss-typography": "~3.0.0",
+    "guss-typography": "~3.1.0",
     "guss-webfonts": "~3.0.0",
-    "pasteup-palette": "~3.1.0",
-    "sass-mq": "~2.1.1"
+    "pasteup-palette": "~3.3.0",
+    "sass-mq": "~3.0.0"
   },
   "devDependencies": {
     "Cortana": "~1.2.7"
   },
-  "_release": "0.4.12",
+  "_release": "0.4.16",
   "_resolution": {
     "type": "version",
-    "tag": "0.4.12",
-    "commit": "035e684170b12daf617a2630af7e8485ab9cd2ed"
+    "tag": "0.4.16",
+    "commit": "82f39df66bff7081aa996f4cb0739f152de772eb"
   },
   "_source": "git://github.com/guardian/pasteup-buttons.git",
   "_target": "~0.4.0",

--- a/static/src/stylesheets/components/pasteup-buttons/bower.json
+++ b/static/src/stylesheets/components/pasteup-buttons/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "pasteup-buttons",
   "description": "Button component in the Pasteup collection",
-  "version": "0.4.12",
+  "version": "0.4.16",
   "main": [
     "build/buttons.min.css",
     "src/_buttons.scss"
@@ -14,10 +14,10 @@
   "dependencies": {
     "guss-colours": "~3.0.0",
     "guss-grid-system": "~1.2.1",
-    "guss-typography": "~3.0.0",
+    "guss-typography": "~3.1.0",
     "guss-webfonts": "~3.0.0",
-    "pasteup-palette": "~3.1.0",
-    "sass-mq": "~2.1.1"
+    "pasteup-palette": "~3.3.0",
+    "sass-mq": "~3.0.0"
   },
   "devDependencies": {
     "Cortana": "~1.2.7"

--- a/static/src/stylesheets/components/pasteup-buttons/src/_buttons.scss
+++ b/static/src/stylesheets/components/pasteup-buttons/src/_buttons.scss
@@ -63,15 +63,10 @@ $base-size: $gs-baseline / 2;
  *    we have to change line-height depending on resolution.
  */
 @mixin button-height($button-size) {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     height: $button-size;
     padding: 0 ($button-size / 3);
     margin-right: $button-size / 3;
     line-height: $button-size - 2px; /* [1] */
-    border-width: 1px;
-    border-style: solid;
 
     .i {
         width: $button-size;
@@ -80,13 +75,9 @@ $base-size: $gs-baseline / 2;
     }
     .i-left {
         margin-left: -($button-size / 3);
-        margin-right: 0;
-        float: left;
     }
     .i-right {
         margin-right: -($button-size / 3);
-        margin-left: 0;
-        float: right;
     }
 }
 @mixin button-colour(
@@ -107,18 +98,26 @@ $border-color: $fill-colour
         border-color: $hover-border;
     }
 }
+
+/*
+    If we want to draw a circle, output a pixel value instead,
+    as older versions of WebKit do not support % in border-radius
+*/
 .button {
     display: inline-block;
     vertical-align: top;
     width: auto;
-    @include fs-textSans(2);
     font-weight: bold;
     text-decoration: none;
+    -webkit-border-radius: 1000px; /* [1] */
+    border-radius: 1000px;         /* [1] */
+    border-width: 1px;
+    border-style: solid;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    @include fs-textSans(2);
     @include button-height($base-size * 5);
-    // If we want to draw a circle, output a pixel value instead,
-    // as older versions of WebKit do not support % in border-radius
-    -webkit-border-radius: 1000px;
-    border-radius: 1000px;
     @include button-colour(
         guss-colour(news-main-2, $pasteup-palette),
         #ffffff,
@@ -129,6 +128,15 @@ $border-color: $fill-colour
     &:focus,
     &:active {
         text-decoration: none;
+    }
+
+    .i-left {
+        margin-right: 0;
+        float: left;
+    }
+    .i-right {
+        margin-left: 0;
+        float: right;
     }
 }
 .button--primary {
@@ -154,7 +162,6 @@ $border-color: $fill-colour
         guss-colour(neutral-4, $pasteup-palette)
     );
 }
-
 .button--tone-media {
     @include button-colour(
         guss-colour(multimedia-support-4, $pasteup-palette),
@@ -235,7 +242,6 @@ $border-color: $fill-colour
         guss-colour(neutral-3, $pasteup-palette)
     );
 }
-
 .button--xlarge {
     @include button-height(44px);
 }


### PR DESCRIPTION
Just improving the buttons mixin efficiency and removing some unnecessary HTML around `more` button on results page. Button looks still the same.

![screen shot 2014-12-15 at 15 45 08](https://cloud.githubusercontent.com/assets/2579465/5438596/66234956-8471-11e4-9125-452696f68292.png)
