### PR TITLE
Rh column on the test page

### DIFF
--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -183,11 +183,9 @@
                 loadCommercial(function () {
                     require('core')
                         .next([
-                            'bean',
                             'common/utils/$'
                         ])
                         .then(function (
-                            bean,
                             $
                         ) {
                         $('.content__secondary-column').empty();
@@ -196,7 +194,7 @@
                             .then(function(
                                 BrandedComponent
                             ) {
-                                new BrandedComponent(document.querySelector('.branded-component-' + component), {
+                                new BrandedComponent($('.branded-component-' + component), {
                                     type: component,
                                     clickMacro: '%%CLICK_URL_ESC%%',
                                     omnitureId: 'omnitureId'

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -201,7 +201,7 @@
                                     clickMacro: '%%CLICK_URL_ESC%%',
                                     omnitureId: 'omnitureId'
                                 }, {
-                                    showEverywhere: false
+                                    showEverywhere: true
                                 }).create();
                             });
                         });

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -201,7 +201,7 @@
                                     clickMacro: '%%CLICK_URL_ESC%%',
                                     omnitureId: 'omnitureId'
                                 }, {
-                                    showEverywhere: true
+                                    force: false
                                 }).create();
                             });
                         });

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -79,6 +79,14 @@
                     <option value="gardening">Gardening</option>
                 </select>
             </dd>
+            <dt>Component in the RH column</dt>
+            <dd>
+                <select class="rh-column-component">
+                    <option value="soulmates">Soulmates</option>
+                    <option value="jobs">Jobs</option>
+                    <option value="membership">Membership</option>
+                </select>
+            </dd>
         </dl>
     </div>
 
@@ -93,18 +101,21 @@
                 $
             ) {
                 var $switchFronts   = $('#switchFronts'),
-                    $switchArticles = $('#switchArticles');
+                    $switchArticles = $('#switchArticles'),
+                    $rhColumn = $('.content__secondary-column');
 
                 bean.on($switchFronts[0], 'click', function () {
                     $('#head-css').attr('href', '@Static("stylesheets/head.facia.css")');
                     $switchArticles.removeClass('current');
                     $switchFronts.addClass('current');
+                    $rhColumn.hide();
                 });
 
                 bean.on($switchArticles[0], 'click', function () {
                     $('#head-css').attr('href', '@Static("stylesheets/head.content.css")');
                     $switchFronts.removeClass('current');
                     $switchArticles.addClass('current');
+                    $rhColumn.show();
                 });
 
                 bean.on($('#pageSkin')[0], 'click', function () {
@@ -132,6 +143,11 @@
                         .removeClass(toneClasses.join(' '))
                         .addClass('commercial--tone-' + $palette.val());
                 });
+
+                var $rhComponent = $('.rh-column-component');
+                bean.on($rhComponent[0], 'change', function () {
+                    showRHColumn($rhComponent.val());
+                });
             });
 
         var loadCommercial = function (callback) {
@@ -158,7 +174,43 @@
                     <p>Nemo becomes increasingly sinister despite Aronnax's romanticised eye: he drugs his captives, refuses to explain the violent death of a crew member and alternates between sorrowful melancholia and cold fury. Ultimately it is Aronnax's transition from admiration and envy to complete fear that makes Twenty Thousand Leagues so eerie and exciting. At the climax when Nemo finally attacks a ship with Aronnax on board, the reader, Aronnax and the "archangel of hate" Nemo reach a satisfyingly simultaneous understanding. The two men watch in silence as the drowning sailors sink into an ocean crevasse like "a human antheap caught out by the invasion of the sea", and everyone finally understands that Nemo will never let his captors live. Later, when Aronnax literally crawls across the salon floor in complete darkness, desperate to avoid the sobbing Nemo who is playing his organ in the same room, my heart was pounding thrillingly hard. I've read Twenty Thousand Leagues multiple times and Nemo's madness still scares me.</p>
                 </div>
             </div>
+            <div class="ad-slot ad-slot--merchandising ad-slot--commercial-component fc-container__inner js-secondary-column content__secondary-column">
+            </div>
         </div>
+
+        <script>
+            function showRHColumn(component) {
+                loadCommercial(function () {
+                    require('core')
+                        .next([
+                            'bean',
+                            'common/utils/$'
+                        ])
+                        .then(function (
+                            bean,
+                            $
+                        ) {
+                        $('.content__secondary-column').empty();
+
+                        require(['common/modules/commercial/creatives/branded-component'])
+                            .then(function(
+                                BrandedComponent
+                            ) {
+                                new BrandedComponent(document.querySelector('.branded-component-' + component), {
+                                    type: component,
+                                    clickMacro: '%%CLICK_URL_ESC%%',
+                                    omnitureId: 'omnitureId'
+                                }, {
+                                    showEverywhere: false
+                                }).create();
+                            });
+                        });
+                });
+            }
+
+            showRHColumn('soulmates');
+        </script>
+
         <script>
             loadCommercial(function () {
                 require(['common/modules/commercial/creatives/template'])
@@ -427,41 +479,6 @@
             });
         });
     </script>
-
-    <div class="fc-container__inner">
-        <h2 class="test-page-head">
-            <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10022487">RH components</a>
-        </h2>
-    </div>
-    <div class="ad-slot ad-slot--merchandising ad-slot--commercial-component fc-container__inner js-secondary-column fc-container-test-page">
-    </div>
-    @Seq(
-        Map(
-            ("type", "soulmates")
-        ),
-        Map(
-            ("type", "jobs")
-        ),
-        Map(
-            ("type", "membership")
-        )
-    ).map { component =>
-        <script>
-        loadCommercial(function () {
-            require(['common/modules/commercial/creatives/branded-component'])
-                .then(function(
-                    BrandedComponent
-                ) {
-                new BrandedComponent(document.querySelector('.branded-component-@component("type")'), {
-                    type: '@component("type")',
-                    clickMacro: '%%CLICK_URL_ESC%%',
-                    omnitureId: 'omnitureId',
-                    showEverywhere: 'true'
-                }).create();
-            });
-        });
-        </script>
-    }
 
     @Seq(
         Map(

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
@@ -40,7 +40,7 @@ define([
         BrandedComponent = function ($adSlot, params, options) {
             this.$adSlot = $adSlot;
             this.params  = params;
-            this.opts = defaults(options, {
+            this.opts = defaults(options || {}, {
                 force: false
             });
         };

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
@@ -5,7 +5,8 @@ define([
     'common/utils/template',
     'text!common/views/commercial/creatives/branded-component-jobs.html',
     'text!common/views/commercial/creatives/branded-component-membership.html',
-    'text!common/views/commercial/creatives/branded-component-soulmates.html'
+    'text!common/views/commercial/creatives/branded-component-soulmates.html',
+    'lodash/objects/defaults'
 ], function (
     qwery,
     $,
@@ -13,7 +14,8 @@ define([
     template,
     brandedComponentJobsTpl,
     brandedComponentMembershipTpl,
-    brandedComponentSoulmatesTpl
+    brandedComponentSoulmatesTpl,
+    defaults
 ) {
 
     var templates = {
@@ -35,10 +37,12 @@ define([
         /**
          * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10027767
          */
-        BrandedComponent = function ($adSlot, params, showEverywhere) {
+        BrandedComponent = function ($adSlot, params, options) {
             this.$adSlot = $adSlot;
             this.params  = params;
-            this.showEverywhere = showEverywhere || false;
+            this.opts = defaults(options, {
+                force: false
+            });
         };
 
     BrandedComponent.prototype.create = function () {
@@ -46,7 +50,7 @@ define([
             $rightHandCol  = $('.js-secondary-column');
 
         if (
-            !this.showEverywhere && (!templateConfig ||
+            !this.opts.force && (!templateConfig ||
             $rightHandCol.css('display') === 'none' ||
             $rightHandCol.dim().height < 1600 ||
             config.page.section === 'football')

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
@@ -35,9 +35,10 @@ define([
         /**
          * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10027767
          */
-        BrandedComponent = function ($adSlot, params) {
+        BrandedComponent = function ($adSlot, params, showEverywhere) {
             this.$adSlot = $adSlot;
             this.params  = params;
+            this.showEverywhere = showEverywhere || false;
         };
 
     BrandedComponent.prototype.create = function () {
@@ -45,7 +46,7 @@ define([
             $rightHandCol  = $('.js-secondary-column');
 
         if (
-            !this.params.showEverywhere && (!templateConfig ||
+            !this.showEverywhere && (!templateConfig ||
             $rightHandCol.css('display') === 'none' ||
             $rightHandCol.dim().height < 1600 ||
             config.page.section === 'football')

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -307,11 +307,7 @@ define([
                                 creativeConfig = JSON.parse(breakoutContent);
                                 require('bootstraps/creatives')
                                     .next(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
-                                        if (creativeConfig.name === 'branded-component') {
-                                            new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
-                                        } else {
-                                            new Creative($slot, creativeConfig.params).create();
-                                        }
+                                        new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
                                     });
                             } else {
                                 // evil, but we own the returning js snippet

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -308,7 +308,7 @@ define([
                                 require('bootstraps/creatives')
                                     .next(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
                                         if (creativeConfig.name === 'branded-component') {
-                                            new Creative($slot, creativeConfig.params, creativeConfig.showEverywhere).create();
+                                            new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
                                         } else {
                                             new Creative($slot, creativeConfig.params).create();
                                         }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -309,8 +309,7 @@ define([
                                     .next(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
                                         if (creativeConfig.name === 'branded-component') {
                                             new Creative($slot, creativeConfig.params, creativeConfig.showEverywhere).create();
-                                        }
-                                        else {
+                                        } else {
                                             new Creative($slot, creativeConfig.params).create();
                                         }
                                     });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -307,7 +307,12 @@ define([
                                 creativeConfig = JSON.parse(breakoutContent);
                                 require('bootstraps/creatives')
                                     .next(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
-                                        new Creative($slot, creativeConfig.params).create();
+                                        if (creativeConfig.name === 'branded-component') {
+                                            new Creative($slot, creativeConfig.params, creativeConfig.showEverywhere).create();
+                                        }
+                                        else {
+                                            new Creative($slot, creativeConfig.params).create();
+                                        }
                                     });
                             } else {
                                 // evil, but we own the returning js snippet

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -43,10 +43,6 @@
         @include fs-textSans(3);
         color: colour(neutral-2);
     }
-    .fc-container-test-page & {
-        position: static;
-        margin-bottom: 20px;
-    }
 }
 
 .creative--jobs {
@@ -164,12 +160,6 @@
 
         @include mq(wide) {
             right: auto;
-        }
-
-        .fc-container-test-page & {
-            top: 5px;
-            left: 30px;
-            height: 414px;
         }
     }
 }


### PR DESCRIPTION
I improved the way how the RH components are shown on the test page (http://m.code.dev-theguardian.com/commercial/test-page)

The rh component is now shown in the proper column on the right side of the article (only on the 
'Articles' layout):
![screen shot 2014-12-16 at 11 38 15](https://cloud.githubusercontent.com/assets/489567/5452873/1e3f8756-8518-11e4-9ad2-98386d2f27b7.png)

On the top of the page, there is an additional dropdown, where you can select specific component (soulmates, jobs or membership):
![screen shot 2014-12-16 at 11 41 39](https://cloud.githubusercontent.com/assets/489567/5452910/7bb53f52-8518-11e4-93a2-4e05159393da.png)

I also added the additional parameter 'showEverywhere' which indicates if you are willing to show rh component on every page. If the 'showEverywhere' is false then the rh component will be shown only on a page with certain rules.
