### PR TITLE
Foundation supported logos move out of inline article

### DIFF
--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -43,7 +43,7 @@
                           @if(content.isAdvertisementFeature) {
                             Brought to you by:
                           } else {
-                            Supported by:
+                            Guardian @content.sectionLabelName.split(" ").map(_.capitalize).mkString(" ") is supported by:
                           }
                         }
                     </h3>

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -34,11 +34,7 @@
     @if(!content.hasMainPicture && !content.hasMainVideo && !content.hasMainAudio && !content.hasMainEmbed){ content__meta-container--float}">
 
     @if(showBadge) {
-        @* on articles, foundation supported badges go inline *@
-        @content match {
-            case a: Article if a.isFoundationSupported => { }
-            case c => { @fragments.commercial.badge(c) }
-        }
+        @fragments.commercial.badge(content)
     }
 
     @if(content.showBylinePic) {

--- a/static/src/javascripts/bootstraps/creatives.js
+++ b/static/src/javascripts/bootstraps/creatives.js
@@ -4,6 +4,7 @@ define([
     'common/modules/commercial/creatives/expandable',
     'common/modules/commercial/creatives/fluid250',
     'common/modules/commercial/creatives/fluid250GoogleAndroid',
+    'common/modules/commercial/creatives/foundation-funded-logo',
     'common/modules/commercial/creatives/scrollable-mpu',
     'common/modules/commercial/creatives/template'
 ], function () {});

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -61,13 +61,6 @@ define([
             rules = getRules();
             lenientRules = getLenientRules();
 
-            if (
-                config.page.sponsorshipType === 'foundation-features' &&
-                    config.page.isInappropriateForSponsorship === false
-            ) {
-                adNames.unshift(['fobadge', ['im', 'paid-for-badge']]);
-                insertAdAtP(spacefinder.getParaWithSpace(lenientRules));
-            }
             if (config.page.hasInlineMerchandise) {
                 adNames.unshift(['im', 'im']);
                 insertAdAtP(spacefinder.getParaWithSpace(lenientRules));

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/foundation-funded-logo.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/foundation-funded-logo.js
@@ -1,0 +1,44 @@
+define([
+    'common/utils/$',
+    'common/utils/config',
+    'common/utils/template',
+
+    // require templates, so they're bundled up as part of the build
+    'text!common/views/commercial/creatives/logo-foundation-funded.html',
+    'text!common/views/commercial/creatives/logo-foundation-funded-partners.html'
+], function (
+    $,
+    config,
+    template
+) {
+
+    /**
+     * Create the foundation logo
+     *
+     * * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10022127
+     * * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10026327
+     */
+    var Template = function ($adSlot, params) {
+        this.$adSlot       = $adSlot;
+        this.params        = params;
+        this.params.header = config.page.isFront ?
+            'Supported by:' :
+            'Guardian ' + config.page.sectionName.replace(/(^|\s)[a-z]/g, function (m) {
+                return m.toUpperCase();
+            }) + ' is supported by:';
+    };
+
+    Template.prototype.create = function () {
+        var templateName = 'logo-foundation-funded' + (this.params.hasPartners ? '-partners' : '');
+
+        require(['text!common/views/commercial/creatives/' + templateName + '.html'], function (creativeTpl) {
+            var creativeHtml = template(creativeTpl, this.params);
+
+            $.create(creativeHtml)
+                .appendTo(this.$adSlot);
+        }.bind(this));
+    };
+
+    return Template;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
@@ -6,8 +6,6 @@ define([
     'text!common/views/commercial/creatives/ad-feature-mpu.html',
     'text!common/views/commercial/creatives/ad-feature-mpu-large.html',
     'text!common/views/commercial/creatives/logo-ad-feature.html',
-    'text!common/views/commercial/creatives/logo-foundation-funded.html',
-    'text!common/views/commercial/creatives/logo-foundation-funded-partners.html',
     'text!common/views/commercial/creatives/logo-sponsored.html',
     'text!common/views/commercial/creatives/manual-inline.html',
     'text!common/views/commercial/creatives/manual-multiple.html',
@@ -24,9 +22,9 @@ define([
      * * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10028127
      */
     var Template = function ($adSlot, params) {
-            this.$adSlot = $adSlot;
-            this.params  = params;
-        };
+        this.$adSlot = $adSlot;
+        this.params  = params;
+    };
 
     Template.prototype.create = function () {
         require(['text!common/views/commercial/creatives/' + this.params.creative + '.html'], function (creativeTpl) {

--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded-partners.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded-partners.html
@@ -1,5 +1,5 @@
 <div class="ad-slot--paid-for-badge__inner">
-    <h3 class="ad-slot--paid-for-badge__header">Supported by:</h3>
+    <h3 class="ad-slot--paid-for-badge__header">{{header}}</h3>
     <a href="{{clickMacro}}{{logoUrl}}" class="ad-slot--paid-for-badge__link">
         <img class="ad-slot--paid-for-badge__logo" src="{{logoImage}}" />
     </a>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-foundation-funded.html
@@ -1,5 +1,5 @@
 <div class="ad-slot--paid-for-badge__inner">
-    <h3 class="ad-slot--paid-for-badge__header">Supported by:</h3>
+    <h3 class="ad-slot--paid-for-badge__header">{{header}}</h3>
     <a href="{{clickMacro}}{{logoUrl}}" class="ad-slot--paid-for-badge__link">
         <img class="ad-slot--paid-for-badge__logo" src="{{logoImage}}" />
     </a>


### PR DESCRIPTION
Back to the left-hand col

Also, text changes, so it's of the format `Guardian [section title] is supported by:`
