### PR TITLE
Hide elements overlaid on video player when using flash tech

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -323,7 +323,7 @@ define([
 
         $('.js-gu-media').each(function (el) {
             var mediaType = el.tagName.toLowerCase(),
-                $el = bonzo(el).addClass('vjs'),
+                $el = bonzo(el).addClass('vjs vjs-tech-' + videojs.options.techOrder[0]),
                 mediaId = $el.attr('data-media-id'),
                 blockVideoAds = $el.attr('data-block-video-ads') === 'true',
                 showEndSlate = $el.attr('data-show-end-slate') === 'true',

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -801,3 +801,14 @@ $vjs-progress-inset-bottom: 4px;
     color: colour(neutral-7);
     @include fs-textSans(1);
 }
+
+/* Tech overrides
+   ========================================================================== */
+.vjs-tech-flash {
+    .vjs-poster,
+    .vjs-big-play-button,
+    .vjs-fullscreen-clickbox,
+    .vast-blocker {
+        display: none !important;
+    }
+}

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -804,7 +804,8 @@ $vjs-progress-inset-bottom: 4px;
 
 /* Tech overrides
    ========================================================================== */
-.vjs-tech-flash {
+.vjs-tech-flash,
+.vjs-tech-vpaid {
     .vjs-poster,
     .vjs-big-play-button,
     .vjs-fullscreen-clickbox,


### PR DESCRIPTION
It turns out Safari 7 & 8 have a _"power saver"_ feature enabled by default which disables flash plugins in certain instances. This is preventing our video content from playing properly. 

In order for a user to see the banner which is displayed by flash prompting the user to disable the feature, we are hiding any overlaid elements which may obstruct. Such as big play button, poster image etc.

![Banner](http://www.imore.com/sites/imore.com/files/styles/large/public/field/image/2013/07/safari_power_saver_hero%20copy.jpg?itok=0K3X55Zq)

(p.s. come and talk to @rich-nguyen or myself if you want to hear more about our conspiracy theory that this is a prime example of Apple trying to banish flash into the dark ages :wink:) 
