### PR TITLE
Add more Content API metrics to Cloud Watch

### DIFF
--- a/applications/app/Global.scala
+++ b/applications/app/Global.scala
@@ -19,7 +19,10 @@ object Global extends WithFilters(Filters.common: _*)
   override lazy val applicationName = "frontend-applications"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
+    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.ElasticHttpTimingMetric,
     ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
-    ContentApiMetrics.ContentApiCircuitBreakerOnOpen
+    ContentApiMetrics.ContentApiCircuitBreakerOnOpen,
+    ContentApiMetrics.ContentApiErrorMetric
   )
 }

--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -18,6 +18,7 @@ object Global
     ContentApiMetrics.ElasticHttpTimingMetric,
     ContentApiMetrics.ElasticHttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
-    ContentApiMetrics.ContentApiCircuitBreakerOnOpen
+    ContentApiMetrics.ContentApiCircuitBreakerOnOpen,
+    ContentApiMetrics.ContentApiErrorMetric
   )
 }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -122,6 +122,11 @@ object ContentApiMetrics {
     "Elastic Content api calls that timeout"
   )
 
+  object ContentApiErrorMetric extends CountMetric(
+    "content-api-errors",
+    "Number of times the Content API returns errors (not counting when circuit breaker is on)"
+  )
+
   object ContentApi404Metric extends CountMetric(
     "content-api-404",
     "Number of times the Content API has responded with a 404"

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -34,6 +34,7 @@ object Global extends GlobalSettings
     ContentApiMetrics.ContentApiJsonMappingExceptionMetric,
     ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
     ContentApiMetrics.ContentApiCircuitBreakerOnOpen,
+    ContentApiMetrics.ContentApiErrorMetric,
     FaciaToolMetrics.InvalidContentExceptionMetric,
     S3Metrics.S3ClientExceptionsMetric,
     S3Metrics.S3AuthorizationError,

--- a/facia-tool/app/Global.scala
+++ b/facia-tool/app/Global.scala
@@ -14,6 +14,7 @@ object Global extends WithFilters(Gzipper)
   lazy val devConfig = Configuration.from(Map("session.secure" -> "false"))
 
   override lazy val applicationName = "frontend-facia-tool"
+
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
     FaciaToolMetrics.ApiUsageCount,
     FaciaToolMetrics.ProxyCount,
@@ -23,6 +24,7 @@ object Global extends WithFilters(Gzipper)
     FaciaToolMetrics.ExpiredRequestCount,
     ContentApiMetrics.ElasticHttpTimingMetric,
     ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.ContentApiErrorMetric,
     S3Metrics.S3ClientExceptionsMetric
   )
 

--- a/onward/app/Global.scala
+++ b/onward/app/Global.scala
@@ -1,8 +1,9 @@
-import common.CloudWatchApplicationMetrics
+import common.{ContentApiMetrics, CloudWatchApplicationMetrics}
 import conf.{Configuration, Filters}
 import dev.DevParametersLifecycle
 import dfp.DfpAgentLifecycle
 import feed.{MostReadLifecycle, OnwardJourneyLifecycle}
+import metrics.FrontendMetric
 import play.api.mvc.WithFilters
 
 object Global extends WithFilters(Filters.common: _*)
@@ -12,4 +13,11 @@ object Global extends WithFilters(Filters.common: _*)
   with DfpAgentLifecycle
   with MostReadLifecycle {
   override lazy val applicationName = "frontend-onward"
+
+  override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ Seq(
+    ContentApiMetrics.ContentApiCircuitBreakerOnOpen,
+    ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
+    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.ContentApiErrorMetric
+  )
 }

--- a/rss/app/Global.scala
+++ b/rss/app/Global.scala
@@ -18,7 +18,10 @@ with SectionsLookUpLifecycle {
   override lazy val applicationName = "frontend-rss"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
+    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.ElasticHttpTimingMetric,
     ContentApiMetrics.ContentApiCircuitBreakerRequestsMetric,
-    ContentApiMetrics.ContentApiCircuitBreakerOnOpen
+    ContentApiMetrics.ContentApiCircuitBreakerOnOpen,
+    ContentApiMetrics.ContentApiErrorMetric
   )
 }


### PR DESCRIPTION
Adds the timeout metric and timing metric to relevant servers.

I've also created a new metric which is just 'any error response' from Content API, to help us figure out which servers are experiencing a high number of errors (which I think will explain the issues we've seen with the circuit breaker).

Once we've got that info, we can do a bit of investigation to find out why, and see if it's either

a) Something we need to fix on those servers 

or 

b) An issue with the threshold we've set for the circuit breaker.
