### PR TITLE
Give a permanent bg colour to facia and index pages

### DIFF
--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -8,7 +8,8 @@
         <div class="@RenderClasses(Map(
                 "fc-container--sponsored" -> faciaPage.isSponsored,
                 "fc-container--advertisement-feature" -> faciaPage.isAdvertisementFeature,
-                "js-sponsored-front" -> (faciaPage.isSponsored || faciaPage.isAdvertisementFeature || faciaPage.isFoundationSupported)))"
+                "js-sponsored-front" -> (faciaPage.isSponsored || faciaPage.isAdvertisementFeature || faciaPage.isFoundationSupported)
+            ), "facia-page")"
             data-link-name="Front | @request.path"
             @faciaPage.sponsor.map { sponsor =>
                 data-sponsor="@sponsor"

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -14,7 +14,6 @@ $header-image-size-desktop: 100px;
             margin-left: auto;
             margin-right: auto;
             width: gs-span(12) + ($gs-gutter*2);
-            background-color: #ffffff;
         }
     }
 }
@@ -33,7 +32,6 @@ $header-image-size-desktop: 100px;
     @include mq(wide) {
         .has-page-skin & {
             width: gs-span(12);
-            background-color: #ffffff;
         }
     }
 
@@ -459,6 +457,10 @@ $header-image-size-desktop: 100px;
     border-top: 0 !important;
 }
 
+.facia-page,
+.index-page {
+    background-color: #ffffff;
+}
 .index-page-header {
     border-top: 1px solid colour(news-accent);
     padding-top: $gs-baseline / 2;


### PR DESCRIPTION
To stop text bleeding into page skin background if page hasn't switched to page skin mode
### Before

![screen shot 2014-12-17 at 10 27 03](https://cloud.githubusercontent.com/assets/74132/5469754/480822d6-85d7-11e4-892a-0e7287ad352d.png)
### After

![screen shot 2014-12-17 at 10 26 44](https://cloud.githubusercontent.com/assets/74132/5469755/4b5b79ec-85d7-11e4-8e1b-063836d8511b.png)
