### PR TITLE
Updating urls for responsive ad examples.

### DIFF
--- a/admin/app/views/commercial/fluidAds.scala.html
+++ b/admin/app/views/commercial/fluidAds.scala.html
@@ -13,32 +13,32 @@
     
     <ul class="list-group">
         <li class="list-group-item">
-            <h4><a href="http://www.theguardian.com/technology?adtest=ng101&view=mobile">Live Better</a></h4>
+            <h4><a href="http://www.theguardian.com/uk/technology?adtest=ng101&view=mobile">Live Better</a></h4>
             <small>Fluid250</small>
             <p><a href="https://www.google.com/dfp/59666047#delivery/PreviewCreative/orderId=191567367&lineItemId=71342607&creativeId=44634448407">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://www.theguardian.com/technology?adtest=ng102&view=mobile">Nissan</a></h4>
+            <h4><a href="http://www.theguardian.com/uk/technology?adtest=ng102&view=mobile">Nissan</a></h4>
             <small>Fluid250 with basic animation</small>
             <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=191567367&lineItemId=73829127">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://www.theguardian.com/technology?adtest=ng103&view=mobile">Own the Weekend</a></h4>
+            <h4><a href="http://www.theguardian.com/uk/technology?adtest=ng103&view=mobile">Own the Weekend</a></h4>
             <small>Fluid250 with animation</small>
             <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=191567367&lineItemId=74480367">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://www.theguardian.com/technology?adtest=ng104&view=mobile">ITV - Grantchester</a></h4>
+            <h4><a href="http://www.theguardian.com/uk/technology?adtest=ng104&view=mobile">ITV - Grantchester</a></h4>
             <small>Fluid250, Expandable, scrollable MPU</small>
             <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=206037807&lineItemId=76437927">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://www.theguardian.com/technology?adtest=ng105&view=mobile">Google Android</a></h4>
+            <h4><a href="http://www.theguardian.com/uk/technology?adtest=ng105&view=mobile">Google Android</a></h4>
             <small>Fluid250, Expandable, scrollable MPU + all on mobile</small>
             <p><a href="https://www.google.com/dfp/59666047#delivery/LineItemDetail/orderId=208612407&lineItemId=77324247">DFP Line item</a></p>
         </li>
         <li class="list-group-item">
-            <h4><a href="http://www.theguardian.com/technology?adtest=ng107&view=mobile">Hyundai</a></h4>
+            <h4><a href="http://www.theguardian.com/uk/technology?adtest=ng107&view=mobile">Hyundai</a></h4>
             <small>Fluid250, Expandable, scrollable MPU + all on mobile</small>
             <p><a href="https://www.google.com/dfp/59666047#delivery/OrderDetail/orderId=210091887">DFP Line item</a></p>
         </li>


### PR DESCRIPTION
Updates the test urls on https://frontend.gutools.co.uk/admin/commercial/fluid250 page to use editionalised urls.

The old ones were re-directing but stripping off the query strings.
