### PR TITLE
Refactor videojs tech priority assumption

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -323,9 +323,9 @@ object Switches {
     "If switched on then the preview server will poll until the latest content is indexed.",
     safeState = On, sellByDate = new LocalDate(2015, 1, 15))
 
-  val PrioritiseFlashVideoPlayer = Switch("Feature", "prioritise-flash-video-player",
-    "If switched on then the Flash player will be preferred over the html5 player.",
-    safeState = Off, sellByDate = new LocalDate(2015, 1, 31))
+  val InferVideoTechFromCodec = Switch("Feature", "infer-video-tech-from-codec",
+    "If switched on then will will infer the video player tech priority based on the video source codec",
+    safeState = On, sellByDate = new LocalDate(2015, 1, 31))
 
   val OutbrainSwitch = Switch("Feature", "outbrain",
     "Enable the Outbrain content recommendation widget.",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -323,7 +323,7 @@ object Switches {
     "If switched on then the preview server will poll until the latest content is indexed.",
     safeState = On, sellByDate = new LocalDate(2015, 1, 15))
 
-  val InferVideoTechFromCodec = Switch("Feature", "infer-video-tech-from-codec",
+  val Hmtl5MediaCompatibilityCheck = Switch("Feature", "html-5-media-compatibility-check",
     "If switched on then will will infer the video player tech priority based on the video source codec",
     safeState = On, sellByDate = new LocalDate(2015, 1, 31))
 

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -39,7 +39,7 @@ define([
     Component,
     history,
     images,
-    playerPriority,
+    techOrder,
     beacon,
     loadingTmpl,
     adsOverlayTmpl
@@ -318,20 +318,21 @@ define([
                 showEndSlate = $el.attr('data-show-end-slate') === 'true',
                 endSlateUri = $el.attr('data-end-slate'),
                 embedPath = $el.attr('data-embed-path'),
+                techPriority = techOrder(el),
                 player,
                 mouseMoveIdle;
 
-            videojs.options.techOrder = playerPriority(el);
 
             if (config.page.videoJsVpaidSwf && config.switches.vpaidAdverts) {
 
                 // clone the video options and add 'vpaid' to them.
-                videojs.options.techOrder = ['vpaid'].concat(videojs.options.techOrder);
+                techPriority = ['vpaid'].concat(techPriority);
 
                 videojs.options.vpaid = {swf: config.page.videoJsVpaidSwf};
             }
 
             player = createVideoPlayer(el, {
+                techOrder: techPriority,
                 controls: true,
                 autoplay: false,
                 preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -303,21 +303,10 @@ define([
 
     function initPlayer() {
 
-        videojs.options.techOrder = playerPriority;
-
         // When possible, use our CDN instead of a third party (zencoder).
         if (config.page.videoJsFlashSwf) {
             videojs.options.flash.swf = config.page.videoJsFlashSwf;
         }
-        if (config.page.videoJsVpaidSwf && config.switches.vpaidAdverts) {
-
-            // clone the video options and add 'vpaid' to them.
-            videojs.options.techOrder = videojs.options.techOrder.slice(0);
-            videojs.options.techOrder.unshift('vpaid');
-
-            videojs.options.vpaid = {swf: config.page.videoJsVpaidSwf};
-        }
-
         videojs.plugin('adCountdown', adCountdown);
         videojs.plugin('fullscreener', fullscreener);
 
@@ -329,18 +318,30 @@ define([
                 showEndSlate = $el.attr('data-show-end-slate') === 'true',
                 endSlateUri = $el.attr('data-end-slate'),
                 embedPath = $el.attr('data-embed-path'),
-                player = createVideoPlayer(el, {
-                    controls: true,
-                    autoplay: false,
-                    preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35
-                    plugins: {
-                        embed: {
-                            embeddable: !config.page.isFront && config.switches.externalVideoEmbeds && $el.attr('data-embeddable') === 'true',
-                            location: config.page.externalEmbedHost + (embedPath ? embedPath : config.page.pageId)
-                        }
-                    }
-                }),
+                player,
                 mouseMoveIdle;
+
+            videojs.options.techOrder = playerPriority(el);
+
+            if (config.page.videoJsVpaidSwf && config.switches.vpaidAdverts) {
+
+                // clone the video options and add 'vpaid' to them.
+                videojs.options.techOrder = ['vpaid'].concat(videojs.options.techOrder);
+
+                videojs.options.vpaid = {swf: config.page.videoJsVpaidSwf};
+            }
+
+            player = createVideoPlayer(el, {
+                controls: true,
+                autoplay: false,
+                preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35
+                plugins: {
+                    embed: {
+                        embeddable: !config.page.isFront && config.switches.externalVideoEmbeds && $el.attr('data-embeddable') === 'true',
+                        location: config.page.externalEmbedHost + (embedPath ? embedPath : config.page.pageId)
+                    }
+                }
+            });
 
             player.guMediaType = mediaType;
 

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -286,7 +286,7 @@ define([
 
         if (handleInitialMediaError(player)) {
             player.dispose();
-            options.techOrder = playerPriority.reverse();
+            options.techOrder = techOrder(el).reverse();
             player = videojs(el, options);
         }
 
@@ -321,7 +321,6 @@ define([
                 techPriority = techOrder(el),
                 player,
                 mouseMoveIdle;
-
 
             if (config.page.videoJsVpaidSwf && config.switches.vpaidAdverts) {
 

--- a/static/src/javascripts/projects/common/modules/video/tech-order.js
+++ b/static/src/javascripts/projects/common/modules/video/tech-order.js
@@ -34,11 +34,11 @@ define([
     }
 
     return function priority(el) {
-        var defaultPriority = ['html5', 'flash'];
-        if (config.switches.inferVideoTechFromCodec) {
-            return ('canPlayType' in el && hasProbableHtml5Source(el)) ? defaultPriority : defaultPriority.reverse();
+        var defaultPriority = ['flash', 'html5'];
+        if (config.switches.html5MediaCompatibilityCheck) {
+            return ('canPlayType' in el && hasProbableHtml5Source(el)) ? defaultPriority.reverse() : defaultPriority;
         } else {
-            return defaultPriority.reverse();
+            return defaultPriority;
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/video/tech-order.js
+++ b/static/src/javascripts/projects/common/modules/video/tech-order.js
@@ -1,13 +1,44 @@
 define([
+    'common/utils/$',
+    'common/utils/_',
     'common/utils/config'
 ], function (
+    $,
+    _,
     config
 ) {
-    var playerPriority = ['html5', 'flash'];
 
-    if (config.switches.prioritiseFlashVideoPlayer) {
-        playerPriority = ['flash', 'html5'];
+    var codecs = {
+        'video/m3u8': 'video/m3u8; codecs="avc1.42C01e, mp4a.40.2"',
+        'video/mp4': 'video/mp4; codecs="avc1.42C01e, mp4a.40.2"',
+        'video/3gp:large': 'video/3gp:large; codecs="avc1.42C01e, mp4a.40.2"',
+        'video/3gp:small': 'video/3gp:small; codecs="avc1.42C01e, mp4a.40.2"',
+        'video/webm' : 'video/webm; codecs="vp8, vorbis"'
+    };
+
+    function getMediaSources(el) {
+        return $('source', el).map(function(source){
+            var type = source.getAttribute('type');
+            return codecs[type] ? codecs[type] : type;
+        });
     }
 
-    return playerPriority;
+    function hasProbableHtml5Source(el) {
+        return _.chain(getMediaSources(el))
+            .map(function(type){
+                return el.canPlayType(type);
+            })
+            .compact()
+            .contains('probably')
+            .value();
+    }
+
+    return function priority(el) {
+        var defaultPriority = ['html5', 'flash'];
+        if(config.switches.prioritiseFlashVideoPlayer) {
+            return defaultPriority.reverse();
+        } else {
+            return ('canPlayType' in el && hasProbableHtml5Source(el)) ? defaultPriority : defaultPriority.reverse();
+        }
+    };
 });

--- a/static/src/javascripts/projects/common/modules/video/tech-order.js
+++ b/static/src/javascripts/projects/common/modules/video/tech-order.js
@@ -13,11 +13,11 @@ define([
         'video/mp4': 'video/mp4; codecs="avc1.42C01e, mp4a.40.2"',
         'video/3gp:large': 'video/3gp:large; codecs="avc1.42C01e, mp4a.40.2"',
         'video/3gp:small': 'video/3gp:small; codecs="avc1.42C01e, mp4a.40.2"',
-        'video/webm' : 'video/webm; codecs="vp8, vorbis"'
+        'video/webm': 'video/webm; codecs="vp8, vorbis"'
     };
 
     function getMediaSources(el) {
-        return $('source', el).map(function(source){
+        return $('source', el).map(function (source) {
             var type = source.getAttribute('type');
             return codecs[type] ? codecs[type] : type;
         });
@@ -25,7 +25,7 @@ define([
 
     function hasProbableHtml5Source(el) {
         return _.chain(getMediaSources(el))
-            .map(function(type){
+            .map(function (type) {
                 return el.canPlayType(type);
             })
             .compact()
@@ -35,7 +35,7 @@ define([
 
     return function priority(el) {
         var defaultPriority = ['html5', 'flash'];
-        if(config.switches.inferVideoTechFromCodec) {
+        if (config.switches.inferVideoTechFromCodec) {
             return ('canPlayType' in el && hasProbableHtml5Source(el)) ? defaultPriority : defaultPriority.reverse();
         } else {
             return defaultPriority.reverse();

--- a/static/src/javascripts/projects/common/modules/video/tech-order.js
+++ b/static/src/javascripts/projects/common/modules/video/tech-order.js
@@ -35,10 +35,10 @@ define([
 
     return function priority(el) {
         var defaultPriority = ['html5', 'flash'];
-        if(config.switches.prioritiseFlashVideoPlayer) {
-            return defaultPriority.reverse();
-        } else {
+        if(config.switches.inferVideoTechFromCodec) {
             return ('canPlayType' in el && hasProbableHtml5Source(el)) ? defaultPriority : defaultPriority.reverse();
+        } else {
+            return defaultPriority.reverse();
         }
     };
 });


### PR DESCRIPTION
This refactors how we choose the default videojs tech ordering based on a more robust assumption if the current UA can actually play the video sources in an HTML5 video element. If not we default back to flash first.

/cc @rich-nguyen @gklopper 

(p.s Needs testing in older Firefox's before I attempt to merge)
