### PR TITLE
Improve Data Model of Sponsored Tags

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -33,6 +33,10 @@ object CommercialController extends Controller with Logging with AuthLogging wit
     NoCache(Ok(views.html.commercial.sponsorships(environment.stage, sponsoredTags, advertisementTags, foundationSupportedTags)))
   }
 
+  def renderPaidForTags = AuthActions.AuthActionTest { implicit request =>
+    NoCache(Ok(views.html.commercial.paidForTags(environment.stage, Store.getDfpPaidForTags())))
+  }
+
   def renderPageskins = AuthActions.AuthActionTest { implicit request =>
     val pageskinnedAdUnits = Store.getDfpPageSkinnedAdUnits()
 

--- a/admin/app/controllers/admin/commercial/DfpDataController.scala
+++ b/admin/app/controllers/admin/commercial/DfpDataController.scala
@@ -3,6 +3,7 @@ package controllers.admin.commercial
 import common.ExecutionContexts
 import conf.Configuration.environment
 import controllers.admin.AuthActions
+import dfp.DfpDataCacheJob
 import model.NoCache
 import play.api.mvc.{Action, AnyContent, Controller}
 
@@ -13,7 +14,7 @@ object DfpDataController extends Controller with ExecutionContexts {
   }
 
   def flushCache(): Action[AnyContent] = AuthActions.AuthActionTest { implicit request =>
-    dfp.refreshAllDfpData()
+    DfpDataCacheJob.refreshAllDfpData()
     NoCache(Redirect(routes.DfpDataController.renderCacheFlushPage()))
       .flashing("triggered" -> "true")
   }

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -11,49 +11,71 @@ import scala.concurrent.{Future, future}
 object DfpDataCacheJob extends ExecutionContexts with Logging {
 
   def run(): Future[Unit] = future {
-    if (DfpCachingSwitch.isSwitchedOn) cacheData()
+    if (DfpCachingSwitch.isSwitchedOn) {
+      log.info("Refreshing data cache")
+      val start = System.currentTimeMillis
+      val data = loadLineItems()
+      val duration = System.currentTimeMillis - start
+      log.info(s"Loading DFP data took $duration ms")
+
+      if (DfpMemoryLeakSwitch.isSwitchedOn) MemoryLeakPlug()
+
+      if (data.isValid) write(data)
+    }
     else log.info("DFP caching switched off")
   }
 
-  def cacheData(): Unit = {
-
-    def write(data: DfpDataExtractor): Unit = {
-      val now = printLondonTime(DateTime.now())
-
-      val sponsorships = data.sponsorships
-      Store.putDfpSponsoredTags(stringify(toJson(SponsorshipReport(now, sponsorships))))
-
-      val advertisementFeatureSponsorships = data.advertisementFeatureSponsorships
-      Store.putDfpAdvertisementFeatureTags(stringify(toJson(SponsorshipReport(now,
-        advertisementFeatureSponsorships))))
-
-      val inlineMerchandisingTargetedTags = data.inlineMerchandisingTargetedTags
-      Store.putInlineMerchandisingSponsorships(stringify(toJson(
-        InlineMerchandisingTargetedTagsReport(now, inlineMerchandisingTargetedTags))))
-
-      val foundationSupported = data.foundationSupported
-      Store.putDfpFoundationSupportedTags(stringify(toJson(SponsorshipReport(now,
-        foundationSupported))))
-
-      val pageSkinSponsorships = data.pageSkinSponsorships
-      Store.putDfpPageSkinAdUnits(stringify(toJson(PageSkinSponsorshipReport(now,
-        pageSkinSponsorships))))
-
-      Store.putDfpLineItemsReport(stringify(toJson(LineItemReport(now, data.lineItems))))
+  /*
+  for initialization and total refresh of data,
+  so would be used for first read and for emergency data update.
+  */
+  def refreshAllDfpData(): Unit = {
+    for {
+      _ <- AdUnitAgent.refresh()
+      _ <- CustomFieldAgent.refresh()
+      _ <- CustomTargetingKeyAgent.refresh()
+      _ <- CustomTargetingValueAgent.refresh()
+      _ <- PlacementAgent.refresh()
+    } {
+      val data = DfpDataCacheJob.loadLineItems()
+      val paidForTags = PaidForTag.fromLineItems(data.lineItems)
+      CapiLookupAgent.refresh(paidForTags) map {
+        _ => DfpDataCacheJob.write(data)
+      }
     }
+  }
 
-    log.info("Refreshing data cache")
-    val start = System.currentTimeMillis
-    val data = DfpDataExtractor(DfpDataHydrator().loadCurrentLineItems())
-    val duration = System.currentTimeMillis - start
-    log.info(s"Loading DFP data took $duration ms")
+  private def loadLineItems(): DfpDataExtractor = {
+    DfpDataExtractor(DfpDataHydrator().loadCurrentLineItems())
+  }
 
-    if (DfpMemoryLeakSwitch.isSwitchedOn) MemoryLeakPlug()
+  private def write(data: DfpDataExtractor): Unit = {
+    val now = printLondonTime(DateTime.now())
 
-    if (data.isValid) write(data)
+    val sponsorships = data.sponsorships
+    Store.putDfpSponsoredTags(stringify(toJson(SponsorshipReport(now, sponsorships))))
+
+    val paidForTags = PaidForTag.fromLineItems(data.lineItems)
+    CapiLookupAgent.refresh(paidForTags)
+    Store.putDfpPaidForTags(stringify(toJson(PaidForTagsReport(now, paidForTags))))
+
+    val advertisementFeatureSponsorships = data.advertisementFeatureSponsorships
+    Store.putDfpAdvertisementFeatureTags(stringify(toJson(SponsorshipReport(now,
+      advertisementFeatureSponsorships))))
+
+    val inlineMerchandisingTargetedTags = data.inlineMerchandisingTargetedTags
+    Store.putInlineMerchandisingSponsorships(stringify(toJson(
+      InlineMerchandisingTargetedTagsReport(now, inlineMerchandisingTargetedTags))))
+
+    val foundationSupported = data.foundationSupported
+    Store.putDfpFoundationSupportedTags(stringify(toJson(SponsorshipReport(now,
+      foundationSupported))))
+
+    val pageSkinSponsorships = data.pageSkinSponsorships
+    Store.putDfpPageSkinAdUnits(stringify(toJson(PageSkinSponsorshipReport(now,
+      pageSkinSponsorships))))
+
+    Store.putDfpLineItemsReport(stringify(toJson(LineItemReport(now, data.lineItems))))
   }
 
 }
-
-
-

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -64,7 +64,7 @@ trait DfpDataCacheLifecycle extends GlobalSettings with ExecutionContexts {
     }
 
     AkkaAsync {
-      refreshAllDfpData()
+      DfpDataCacheJob.refreshAllDfpData()
     }
   }
 

--- a/admin/app/dfp/package.scala
+++ b/admin/app/dfp/package.scala
@@ -6,15 +6,4 @@ package object dfp extends ExecutionContexts {
 
   def printLondonTime(timestamp: DateTime): String = DateTimeFormat.longDateTime().withZone(DateTimeZone.forID("Europe/London")).print(timestamp)
 
-  def refreshAllDfpData() {
-    for {
-      _ <- AdUnitAgent.refresh()
-      _ <- CustomFieldAgent.refresh()
-      _ <- CustomTargetingKeyAgent.refresh()
-      _ <- CustomTargetingValueAgent.refresh()
-      _ <- PlacementAgent.refresh()
-    } {
-      DfpDataCacheJob.run()
-    }
-  }
 }

--- a/admin/app/tools/DfpLink.scala
+++ b/admin/app/tools/DfpLink.scala
@@ -43,6 +43,8 @@ object SiteLink {
   }
 
   def contributorTagPage(contributor: String): String = s"${site.host}/profile/$contributor"
+
+  def page(pageId: String):String = s"${site.host}/$pageId"
 }
 
 object CapiLink {

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -6,6 +6,7 @@ import conf.Configuration.commercial._
 import dfp._
 import implicits.Dates
 import org.joda.time.DateTime
+import play.api.libs.json.Json
 import services.S3
 
 trait Store extends Logging with Dates {
@@ -28,6 +29,9 @@ trait Store extends Logging with Dates {
 
   def putDfpSponsoredTags(keywordsJson: String) {
     S3.putPublic(dfpSponsoredTagsDataKey, keywordsJson, defaultJsonEncoding)
+  }
+  def putDfpPaidForTags(content: String) {
+    S3.putPublic(dfpPaidForTagsDataKey, content, defaultJsonEncoding)
   }
   def putDfpAdvertisementFeatureTags(keywordsJson: String) {
     S3.putPublic(dfpAdvertisementFeatureTagsDataKey, keywordsJson, defaultJsonEncoding)
@@ -56,6 +60,11 @@ trait Store extends Logging with Dates {
     S3.get(dfpAdvertisementFeatureTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse SponsorshipReport(now, Nil)
   def getDfpFoundationSupportedTags() =
     S3.get(dfpFoundationSupportedTagsDataKey).flatMap(SponsorshipReportParser(_)) getOrElse SponsorshipReport(now, Nil)
+  def getDfpPaidForTags(): PaidForTagsReport =
+    S3.get(dfpPaidForTagsDataKey).map {
+    Json.parse(_).as[PaidForTagsReport]
+  }.getOrElse(PaidForTagsReport(now, Nil))
+
   def getDfpPageSkinnedAdUnits() =
     S3.get(dfpPageSkinnedAdUnitsKey).flatMap(PageSkinSponsorshipReportParser(_)) getOrElse PageSkinSponsorshipReport(now, Nil)
 

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -17,7 +17,7 @@
                             <ul>
                                 <li><a href="@controllers.admin.routes.ContentPerformanceController.renderGalleryDashboard()">Gallery</a></li>
                                 <li><a href="@controllers.admin.routes.ContentPerformanceController.renderLiveBlogDashboard()">Live Blog</a></li>
-                            <ul>
+                            </ul>
                         </li>
                     </ul>
                 </div>
@@ -100,7 +100,7 @@
                 <div class="panel-body">
                     <ul>
                         <li><a href="@controllers.admin.routes.CommercialController.renderSpecialAdUnits()">List Special Ad Units</a></li>
-                        <li><a href="@controllers.admin.routes.CommercialController.renderSponsorships()">Content Sponsorships</a></li>
+                        <li><a href="@controllers.admin.routes.CommercialController.renderPaidForTags()">Sponsored Tags</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderInlineMerchandisingTargetedTags()">Inline Merchandising Slot</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderPageskins()">Pageskins</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderSurgingContent()">Surging Content</a></li>

--- a/admin/app/views/commercial/commercial.scala.html
+++ b/admin/app/views/commercial/commercial.scala.html
@@ -34,7 +34,7 @@
 
     <h3>Other reports:</h3>
     <ul>
-        <li><a href="@controllers.admin.routes.CommercialController.renderSponsorships()">Content Sponsorships</a></li>
+        <li><a href="@controllers.admin.routes.CommercialController.renderPaidForTags()">Sponsored Tags</a></li>
         <li><a href="@controllers.admin.routes.CommercialController.renderPageskins()">Pageskins</a></li>
     </ul>
 }

--- a/admin/app/views/commercial/paidForTags.scala.html
+++ b/admin/app/views/commercial/paidForTags.scala.html
@@ -1,0 +1,104 @@
+@(env: String, report: dfp.PaidForTagsReport)
+@import dfp.{PaidForTag, PaidForType, TagType}
+@import tools.{DfpLink, SiteLink}
+
+@buildRef(s: String) = {@{s.toLowerCase.replaceAll("\\s+", "-")}}
+
+@summary(title: String, tags: Seq[PaidForTag]) = {
+    <p><a href="#@buildRef(title)">@title <span class="badge">@{tags.size}</span></a></p>
+}
+
+@tagLink(tagId: String) = {
+    <div><a href="@SiteLink.page(tagId)">@tagId</a></div>
+}
+
+@list(title: String, tags: Seq[PaidForTag]) = {
+    <a name="@buildRef(title)"></a>
+    <h2>@title</h2>
+    <ol>
+    @for(tag <- tags) {
+        <li class="line-item">
+            <h4>@{tag.targetedName} <small>[@{tag.tagType}] [@{tag.paidForType}]</small></h4>
+            @if(tag.matchingCapiTagIds.isEmpty) {
+                <div class="alert alert-danger"><span class="glyphicon glyphicon-exclamation-sign"></span> Targeted tag does not exist</div>
+            } else {
+                @if(tag.matchingCapiTagIds.size == 1) {
+                    @tagLink(tag.matchingCapiTagIds.head)
+                } else {
+                    <div>One of:</div>
+                    @for(tagId <- tag.matchingCapiTagIds) {
+                        @tagLink(tagId)
+                    }
+                }
+            }
+            <ul>
+            @for(lineItem <- tag.lineItems) {
+                <li>
+                    <div class="sub-line-item">
+                        <div class="large">@{lineItem.name}
+                            (<a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a> )</div>
+                        @if(lineItem.sponsor.isEmpty){
+                            <div class="alert alert-danger"><span class="glyphicon glyphicon-exclamation-sign"></span> No sponsor</div>
+                        } else {
+                            <div>Sponsor: <strong>@{lineItem.sponsor}</strong></div>
+                        }
+                        @if(lineItem.targeting.adUnits.nonEmpty) {
+                            @if(lineItem.targeting.adUnits.size == 1) {
+                                <div>
+                                    Ad Unit: @{lineItem.targeting.adUnits.map(_.path.mkString("/"))}</div>
+                            } else {
+                                <div>
+                                    Ad Units: @{lineItem.targeting.adUnits.map(_.path.mkString("/")).mkString(", ")}</div>
+                            }
+                        }
+                        @if(lineItem.targeting.geoTargetsIncluded.nonEmpty) {
+                            @if(lineItem.targeting.geoTargetsIncluded.size == 1){
+                                <div>
+                                    Geotarget: @{lineItem.targeting.geoTargetsIncluded.map(_.name)}</div>
+                            }else{
+                                <div>
+                                    Geotargets: @{lineItem.targeting.geoTargetsIncluded.map(_.name).mkString(", ")}</div>
+                            }
+                        }
+                        @if(lineItem.targeting.geoTargetsExcluded.nonEmpty) {
+                            @if(lineItem.targeting.geoTargetsExcluded.size == 1){
+                                <div>
+                                    Excluded geotarget: @{lineItem.targeting.geoTargetsExcluded.map(_.name)}</div>
+                            }else{
+                                <div>
+                                    Excluded geotargets: @{lineItem.targeting.geoTargetsExcluded.map(_.name).mkString(", ")}</div>
+                            }
+                        }
+                    </div>
+                </li>
+            }
+            </ul>
+        </li>
+    }
+    </ol>
+}
+
+@admin_main("Paid-for Tags", env, isAuthed = true) {
+
+    <link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/commercial.css")">
+
+    <h1>Paid-for Tags</h1>
+
+    <hr />
+    @summary("Sponsored Series", report.sponsoredSeries)
+    @summary("Sponsored Keywords", report.sponsoredKeywords)
+    @summary("Advertisement Feature Series", report.advertisementFeatureSeries)
+    @summary("Advertisement Feature Keywords", report.advertisementFeatureKeywords)
+    @summary("Foundation Funded Series", report.foundationFundedSeries)
+    @summary("Foundation Funded Keywords", report.foundationFundedKeywords)
+    <hr />
+
+    @list("Sponsored Series", report.sponsoredSeries)
+    @list("Sponsored Keywords", report.sponsoredKeywords)
+
+    @list("Advertisement Feature Series", report.advertisementFeatureSeries)
+    @list("Advertisement Feature Keywords", report.advertisementFeatureKeywords)
+
+    @list("Foundation Funded Series", report.foundationFundedSeries)
+    @list("Foundation Funded Keywords", report.foundationFundedKeywords)
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -50,7 +50,7 @@ GET         /analytics/omniture/*reportName                                     
 # Commercial
 GET         /analytics/commercial                                                              controllers.admin.CommercialController.renderCommercial()
 GET         /analytics/commercial/specialadunits                                               controllers.admin.CommercialController.renderSpecialAdUnits()
-GET         /analytics/commercial/sponsorships                                                 controllers.admin.CommercialController.renderSponsorships()
+GET         /analytics/commercial/sponsorships                                                 controllers.admin.CommercialController.renderPaidForTags()
 GET         /analytics/commercial/pageskins                                                    controllers.admin.CommercialController.renderPageskins()
 GET         /analytics/commercial/surging                                                      controllers.admin.CommercialController.renderSurgingContent()
 GET         /analytics/commercial/im-sponsorships                                              controllers.admin.CommercialController.renderInlineMerchandisingTargetedTags()

--- a/admin/public/css/commercial.css
+++ b/admin/public/css/commercial.css
@@ -33,6 +33,14 @@
     padding-bottom: 20px;
 }
 
+.line-item {
+    padding-bottom: 40px;
+}
+
+.sub-line-item {
+    padding-top: 10px;
+}
+
 th, td {
     padding: 10px 60px 20px 10px;
 }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -252,6 +252,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
     private lazy val dfpRoot = s"${environment.stage.toUpperCase}/commercial/dfp"
     lazy val dfpSponsoredTagsDataKey = s"$dfpRoot/sponsored-tags-v5.json"
+    lazy val dfpPaidForTagsDataKey = s"$dfpRoot/paid-for-tags-v1.json"
     lazy val dfpAdvertisementFeatureTagsDataKey = s"$dfpRoot/advertisement-feature-tags-v5.json"
     lazy val dfpFoundationSupportedTagsDataKey = s"$dfpRoot/foundation-supported-tags-v5.json"
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"

--- a/common/app/dfp/CapiLookupAgent.scala
+++ b/common/app/dfp/CapiLookupAgent.scala
@@ -1,0 +1,51 @@
+package dfp
+
+import common.{AkkaAgent, ExecutionContexts, Logging}
+import conf.LiveContentApi
+
+import scala.concurrent.Future
+
+object CapiLookupAgent extends ExecutionContexts with Logging {
+
+  private val agent = AkkaAgent[Map[(TagType, String), Seq[String]]](Map.empty)
+
+  def refresh(paidForTags: Seq[PaidForTag]): Future[Map[(TagType, String), Seq[String]]] = {
+    lookup(paidForTags) flatMap { freshData =>
+      agent alter { oldData =>
+        if (freshData.nonEmpty) freshData
+        else oldData
+      }
+    }
+  }
+
+  private def lookup(paidForTags: Seq[PaidForTag]): Future[Map[(TagType, String), Seq[String]]] = {
+
+    def lookup(tagType: TagType, tagName: String): Future[((TagType, String), Seq[String])] = {
+      val query = LiveContentApi.tags.q(tagName).tagType(tagType.name).pageSize(50)
+      val lookupResult = query.response map { response =>
+        val tags = response.results
+        log.info(s"Looking up $tagType '$tagName' gave ${tags.map(_.id)}")
+        tags
+      } recover {
+        case e: Exception =>
+          log.warn(s"Failed to look up $tagType '$tagName': ${e.getMessage}")
+          Nil
+      }
+      lookupResult map { tags =>
+        val matchingTagIds = tags.map(_.id).filter(_.endsWith(s"/$tagName")).sorted
+        (tagType, tagName) -> matchingTagIds
+      }
+    }
+
+    val lookupResults = paidForTags.groupBy(_.tagType).map { case (tagType, tags) =>
+      tags map { tag =>
+        lookup(tagType, tag.targetedName)
+      }
+    }.flatten
+
+    Future.sequence(lookupResults) map (_.toMap)
+  }
+
+  def getTagIds(tagType: TagType, targetedName: String): Seq[String] =
+    agent.get().getOrElse((tagType, targetedName), Nil)
+}

--- a/common/app/dfp/DfpData.scala
+++ b/common/app/dfp/DfpData.scala
@@ -196,6 +196,10 @@ case class GuLineItem(id: Long,
 
   val isCurrent = startTime.isBeforeNow && (endTime.isEmpty || endTime.exists(_.isAfterNow))
 
+  val paidForTags: Seq[String] = targeting.customTargetSets.flatMap { targetSet =>
+    targetSet.sponsoredTags ++ targetSet.advertisementFeatureTags ++ targetSet.foundationSupportedTags
+  }.distinct
+
   val sponsoredTags: Seq[String] = targeting.customTargetSets.flatMap(_.sponsoredTags).distinct
 
   val advertisementFeatureTags: Seq[String] = targeting.customTargetSets.flatMap(_.advertisementFeatureTags).distinct

--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -2,6 +2,8 @@ package dfp
 
 import common.Logging
 import model.Tag
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
 import play.api.libs.json._
 
 
@@ -122,4 +124,144 @@ object InlineMerchandisingTargetedTagsReportParser extends Logging {
       case e: JsError => log.error("Errors: " + JsError.toFlatJson(e).toString()); None
     }
   }
+}
+
+
+sealed trait TagType {
+  val name: String
+}
+
+case object Series extends TagType {
+  override val name: String = "series"
+}
+
+case object Keyword extends TagType {
+  override val name: String = "keyword"
+}
+
+
+sealed trait PaidForType {
+  val name: String
+}
+
+case object Sponsored extends PaidForType {
+  override val name: String = "sponsoredfeatures"
+}
+
+case object AdvertisementFeature extends PaidForType {
+  override val name: String = "advertisement-features"
+}
+
+case object FoundationFunded extends PaidForType {
+  override val name: String = "foundation-features"
+}
+
+
+case class PaidForTag(targetedName: String,
+                      tagType: TagType,
+                      paidForType: PaidForType,
+                      matchingCapiTagIds: Seq[String],
+                      lineItems: Seq[GuLineItem])
+
+object PaidForTag {
+
+  def fromLineItems(lineItems: Seq[GuLineItem]): Seq[PaidForTag] = {
+
+    val lineItemsGroupedByTag: Map[String, Seq[GuLineItem]] = {
+      val logoLineItems = lineItems filter { lineItem =>
+        lineItem.isCurrent && lineItem.paidForTags.nonEmpty
+      }
+      logoLineItems.foldLeft(Map.empty[String, Seq[GuLineItem]]) { case (soFar, lineItem) =>
+        val lineItemTags = lineItem.paidForTags map { tag =>
+          val tagLineItems = soFar.get(tag).map(_ :+ lineItem).getOrElse(Seq(lineItem))
+          tag -> tagLineItems
+        }
+        soFar ++ lineItemTags
+      }
+    }
+
+    lineItemsGroupedByTag.map { case (currTag, currLineItems) =>
+
+      val identifyingTargets = currLineItems.head.targeting.customTargetSets.find {
+        _.targets.exists(t => t.isSeriesTag || t.isKeywordTag)
+      }.head.targets
+
+      val tagType =
+        if (identifyingTargets exists (_.isSeriesTag)) Series
+        else Keyword
+
+      val paidForType =
+        if (identifyingTargets exists (_.isSponsoredSlot)) {
+          Sponsored
+        } else if (identifyingTargets exists (_.isAdvertisementFeatureSlot)) {
+          AdvertisementFeature
+        } else FoundationFunded
+
+      PaidForTag(targetedName = currTag,
+        tagType,
+        paidForType,
+        matchingCapiTagIds = CapiLookupAgent.getTagIds(tagType, currTag),
+        lineItems = currLineItems)
+    }.toList.sortBy(_.targetedName)
+  }
+
+  implicit val jsonWrites = new Writes[PaidForTag] {
+    override def writes(tag: PaidForTag): JsValue = {
+      Json.obj(
+        "targetedName" -> tag.targetedName,
+        "tagType" -> tag.tagType.name,
+        "paidForType" -> tag.paidForType.name,
+        "matchingCapiTagIds" -> tag.matchingCapiTagIds,
+        "lineItems" -> tag.lineItems
+      )
+    }
+  }
+
+  implicit val jsonReads: Reads[PaidForTag] = (
+    (JsPath \ "targetedName").read[String] and
+      (JsPath \ "tagType").read[String].map {
+        case Series.name => Series
+        case Keyword.name => Keyword
+      } and
+      (JsPath \ "paidForType").read[String].map {
+        case Sponsored.name => Sponsored
+        case AdvertisementFeature.name => AdvertisementFeature
+        case FoundationFunded.name => FoundationFunded
+      } and
+      (JsPath \ "matchingCapiTagIds").read[Seq[String]] and
+      (JsPath \ "lineItems").read[Seq[GuLineItem]]
+    )(PaidForTag.apply _)
+}
+
+
+case class PaidForTagsReport(updatedTimeStamp: String, paidForTags: Seq[PaidForTag]) {
+
+  private def subset(paidForType: PaidForType, tagType: TagType) = {
+    paidForTags filter { tag =>
+      tag.paidForType == paidForType && tag.tagType == tagType
+    }
+  }
+
+  val sponsoredSeries: Seq[PaidForTag] = subset(Sponsored, Series)
+  val sponsoredKeywords: Seq[PaidForTag] = subset(Sponsored, Keyword)
+
+  val advertisementFeatureSeries: Seq[PaidForTag] = subset(AdvertisementFeature, Series)
+  val advertisementFeatureKeywords: Seq[PaidForTag] = subset(AdvertisementFeature, Keyword)
+
+  val foundationFundedSeries: Seq[PaidForTag] = subset(FoundationFunded, Series)
+  val foundationFundedKeywords: Seq[PaidForTag] = subset(FoundationFunded, Keyword)
+}
+
+object PaidForTagsReport {
+
+  implicit val jsonWrites = new Writes[PaidForTagsReport] {
+    override def writes(report: PaidForTagsReport): JsValue = {
+      Json.obj(
+        "updatedTimeStamp" -> report.updatedTimeStamp,
+        "paidForTags" -> report.paidForTags
+      )
+    }
+  }
+
+  implicit val jsonReads = Json.reads[PaidForTagsReport]
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -35,7 +35,7 @@ GET         /analytics/omniture/segments/:rsid                                  
 GET         /analytics/omniture/*reportName                                                                          controllers.admin.OmnitureReportController.getReport(reportName)
 GET         /analytics/commercial                                                                                    controllers.admin.CommercialController.renderCommercial()
 GET         /analytics/commercial/specialadunits                                                                     controllers.admin.CommercialController.renderSpecialAdUnits()
-GET         /analytics/commercial/sponsorships                                                                       controllers.admin.CommercialController.renderSponsorships()
+GET         /analytics/commercial/sponsorships                                                                       controllers.admin.CommercialController.renderPaidForTags()
 GET         /analytics/commercial/pageskins                                                                          controllers.admin.CommercialController.renderPageskins()
 GET         /analytics/commercial/surging                                                                            controllers.admin.CommercialController.renderSurgingContent()
 GET         /analytics/commercial/im-sponsorships                                                                    controllers.admin.CommercialController.renderInlineMerchandisingTargetedTags()


### PR DESCRIPTION
Gives an admin view of sponsored tags ordered by tag rather than by line-item.
This also shows where tags are being targeted that don't actually exist on the site.

![image](https://cloud.githubusercontent.com/assets/1722550/5473926/1c6617ae-8605-11e4-84c4-b0a9b1475b97.png)

Next step is to totally replace `Sponsorship` data model with new `PaidForTag` model.
