### PR TITLE
Removing un-needed padding for fluid 250 ads

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -341,8 +341,8 @@
     height: auto;
     width: 100%;
     margin-left: 0;
-	padding-left: 0;
-	padding-bottom: 0;
+    padding-left: 0;
+    padding-bottom: 0;
 
     .ad-slot__label {
         display: none;

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -341,6 +341,8 @@
     height: auto;
     width: 100%;
     margin-left: 0;
+	padding-left: 0;
+	padding-bottom: 0;
 
     .ad-slot__label {
         display: none;


### PR DESCRIPTION
This removes extra padding from responsive banner ads on the widest breakpoint.

Before;

![screen shot 2014-12-17 at 16 55 24](https://cloud.githubusercontent.com/assets/1303616/5475127/34c22e38-860e-11e4-8242-0d4687b630d0.png)

After;

![screen shot 2014-12-17 at 16 55 47](https://cloud.githubusercontent.com/assets/1303616/5475131/39b47342-860e-11e4-898c-7ab00d6058fc.png)
