### PR TITLE
cache resized PNGs

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -434,6 +434,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   object pngResizer {
     val cacheTimeInSeconds = configuration.getIntegerProperty("png_resizer.image_cache_time").getOrElse(86400)
     val ttlInSeconds = configuration.getIntegerProperty("png_resizer.image_ttl").getOrElse(86400)
+    lazy val bucket = configuration.getStringProperty("image.cache.bucket").getOrElse("aws-frontend-imagecache")
   }
 }
 

--- a/common/app/services/S3ByteStore.scala
+++ b/common/app/services/S3ByteStore.scala
@@ -1,0 +1,85 @@
+package services
+
+import java.io.ByteArrayInputStream
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.CannedAccessControlList.{Private, PublicRead}
+import com.amazonaws.services.s3.model._
+import common.Logging
+import common.S3Metrics.S3ClientExceptionsMetric
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Future, blocking}
+import scala.util.{Failure, Success, Try}
+
+class S3ByteStore(bucket: String, credentials: AWSCredentialsProvider) extends Logging {
+
+  lazy val client: AmazonS3Client = {
+    val client = new AmazonS3Client(credentials)
+    client.setEndpoint(AwsEndpoints.s3)
+    client
+  }
+
+  private def withS3Result[T](key: String)(action: S3Object => T): Future[Option[T]] = Future {
+    try {
+
+      val request = new GetObjectRequest(bucket, key)
+
+      val result = blocking {
+        client.getObject(request)
+      }
+
+      // http://stackoverflow.com/questions/17782937/connectionpooltimeoutexception-when-iterating-objects-in-s3
+      try {
+        Some(action(result))
+      } finally {
+        result.close()
+      }
+    } catch {
+      case e: AmazonS3Exception if e.getStatusCode == 404 => {
+        log.warn("not found at %s - %s" format(bucket, key))
+        None
+      }
+      case e: Exception => {
+        S3ClientExceptionsMetric.increment()
+        throw e
+      }
+    }
+  }
+
+  def get(key: String): Future[Option[Array[Byte]]] = try {
+    withS3Result[Array[Byte]](key)(response => org.apache.commons.io.IOUtils.toByteArray(response.getObjectContent))
+  }
+
+  def putPublic(key: String, value: Array[Byte], contentType: String) = {
+    put(key: String, value, contentType: String, PublicRead)
+  }
+
+  def putPrivate(key: String, value: Array[Byte], contentType: String) = {
+    put(key: String, value, contentType: String, Private)
+  }
+
+  private def put(key: String, value: Array[Byte], contentType: String, accessControlList: CannedAccessControlList) = Future {
+
+    val metadata = new ObjectMetadata()
+    metadata.setCacheControl("no-cache,no-store")
+    metadata.setContentType(contentType)
+    metadata.setContentLength(value.length)
+
+    val request = new PutObjectRequest(bucket, key, new ByteArrayInputStream(value), metadata).withCannedAcl(accessControlList)
+
+    Try {
+      blocking {
+        client.putObject(request)
+      }
+    }
+
+  }.flatMap {
+    case Success(s) => Future.successful(s)
+    case Failure(f) =>
+      S3ClientExceptionsMetric.increment()
+      Future.failed(f)
+  }
+
+}

--- a/png-resizer/app/controllers/Resizer.scala
+++ b/png-resizer/app/controllers/Resizer.scala
@@ -1,58 +1,104 @@
 package controllers
 
 import common.StopWatch
-import conf.{Configuration, PngResizerMetrics}
+import conf.Configuration
 import data.Backends
 import grizzled.slf4j.Logging
 import lib.Streams._
 import lib.WS._
-import lib.{Im4Java, IntString, PngQuant}
+import lib.{Im4Java, ImageCache, IntString, PngQuant}
 import model.Cached
 import play.api.Play.current
-import play.api.libs.ws.WS
-import play.api.mvc.{Action, Controller}
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.ws.{WS, WSResponseHeaders}
+import play.api.mvc.{Action, Controller, Result}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scalaz.EitherT._
+import scalaz._
 
 object Resizer extends Controller with Logging {
-  def resize(backend: String, path: String, widthString: String, qualityString: String) = Action.async {
+
+  implicit val futureMonad = new Monad[Future] {
+    def point[A](a: => A): Future[A] = Future.successful(a)
+    def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
+  }
+
+  def getPngBytes(uri: String, response: (WSResponseHeaders, Enumerator[Array[Byte]])): Future[\/[Result, Array[Byte]]] = {
+    val (responseHeaders, enumerator) = response
+      responseHeaders.status match {
+        case OK if responseHeaders.contentType != "image/png" =>
+          Future.successful(-\/(BadRequest(s"Original image $uri content type (${responseHeaders.contentType}) is not " +
+            "supported. Only PNG supported.")))
+
+        case OK =>
+
+          enumerator.toByteArray.map(\/-.apply)
+
+        case NOT_FOUND => Future.successful(-\/(NotFound(s"Unable to find source image at $uri")))
+
+        case otherErrorCode => Future.successful(-\/(BadGateway(s"Received $otherErrorCode for $uri")))
+      }
+  }
+
+  def getImage(path: String, meta: String): Future[Result \/ Unit] = {
+    ImageCache.getImage(path, meta).map { maybeCached =>
+      maybeCached match {
+        case Some(compressedImage) =>
+          // TODO should store metric about misses:hits ratio?
+          -\/(Cached(Configuration.pngResizer.ttlInSeconds)(Ok(compressedImage).as("image/png")))
+        case None =>
+          \/-(())
+      }
+    }
+  }
+
+  def putImage(path: String, meta: String, data: Array[Byte]): Future[Result \/ Unit] = {
+    ImageCache.putImage(path, meta, data).onFailure {
+      case t => logger.warn("couldn't store in image cache", t)
+        // TODO need to flag on some metric?
+    }
+    // if it fails, don't care (?)
+    Future.successful(\/-(()))
+  }
+
+  type FutureEither[T] = EitherT[Future, Result, T]
+
+  def eitherTRight[T](future: Future[T]): FutureEither[T] =
+    eitherT(future.map(\/-.apply))
+
+  def time[T](result: => FutureEither[T], action: String) = {
     val downloadStopWatch = new StopWatch
+    result.bimap({
+      contents =>
+        logger.info(s"took: $downloadStopWatch for: $action result: Left($contents)")
+        contents
+    },
+    {
+      contents =>
+        logger.info(s"took: $downloadStopWatch for: $action result: Right($contents)")
+        contents
+    })
+    result
+  }
+
+  def resize(backend: String, path: String, widthString: String, qualityString: String) = Action.async {
 
     (Backends.uri(backend, path), widthString, qualityString) match {
       case (Some(uri), IntString(width), IntString(quality)) =>
-        WS.url(uri).getStream() flatMap { case (responseHeaders, enumerator) =>
-          responseHeaders.status match {
-            case OK if responseHeaders.contentType != "image/png" =>
-              Future.successful(BadRequest(s"Original image $uri content type (${responseHeaders.contentType}) is not " +
-                "supported. Only PNG supported."))
 
-            case OK =>
-              logger.info(s"Resizing $uri to $width pixels wide at $quality compression")
-
-              enumerator.toByteArray flatMap { bytes =>
-                logger.info(s"Took $downloadStopWatch to download $uri")
-                PngResizerMetrics.downloadTime.recordDuration(downloadStopWatch.elapsed)
-
-                val resizeStopWatch = new StopWatch
-
-                val resized = Im4Java.resizeBufferedImage(width)(bytes)
-                logger.info(s"Took $resizeStopWatch to IM convert (resize) $uri")
-                val quantStopWatch = new StopWatch
-                PngQuant(resized, quality) map { compressedImage =>
-                  logger.info(s"Took $quantStopWatch to PngQuant $uri")
-                  PngResizerMetrics.resizeTime.recordDuration(resizeStopWatch.elapsed)
-
-                  Cached(Configuration.pngResizer.ttlInSeconds)(Ok(compressedImage).as("image/png"))
-                }
-
-              }
-
-            case NOT_FOUND => Future.successful(NotFound(s"Unable to find source image at $uri"))
-
-            case otherErrorCode => Future.successful(BadGateway(s"Received $otherErrorCode for $uri"))
-          }
-        }
+        // TODO everything probably shouldn't be a Array[Byte] as that prevents streaming
+        // Left here is the http result, right is the data that still needs computation
+        (for {
+          _ <- time(eitherT(getImage(path, s"$width/$quality")), "get cached image")
+          response <- eitherTRight(WS.url(uri).getStream())
+          bytesPreResize <- eitherT(getPngBytes(uri, response))
+          resized <- time(eitherTRight(Im4Java.resizeBufferedImage(width)(bytesPreResize)), "resize image")
+          quanted <- time(eitherTRight(PngQuant(resized, quality)), "quantize image")
+          _ <- time(eitherT(putImage(path, s"$width/$quality", quanted)), "store image in cache")
+          result = Cached(Configuration.pngResizer.ttlInSeconds)(Ok(quanted).as("image/png"))
+        } yield (result)).run.map(_.fold(identity,identity))
 
       case (None, _, _) => Future.successful(NotFound(s"$backend is not a backend we support"))
 

--- a/png-resizer/app/lib/Im4Java.scala
+++ b/png-resizer/app/lib/Im4Java.scala
@@ -1,11 +1,12 @@
 package lib
 
-import java.awt.image.BufferedImage
-import org.im4java.core.{Stream2BufferedImage, ConvertCmd, IMOperation}
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-import javax.imageio.ImageIO
 
+import org.im4java.core.{ConvertCmd, IMOperation}
 import org.im4java.process.Pipe
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object Im4Java {
   def apply(operation: IMOperation, format: String = "png")(imageBytes: Array[Byte]): Array[Byte] = {
@@ -24,15 +25,15 @@ object Im4Java {
     baos.toByteArray
   }
 
-  def resizeBufferedImage(width: Int) = {
+  def resizeBufferedImage(width: Int)(imageBytes: Array[Byte]) = Future {
     val operation = new IMOperation
 
     operation.addImage("-")
-    operation.sharpen(1.0)
     operation.resize(width)
-    operation.quality(100)
+    operation.sharpen(1.0)
+    operation.quality(0)
     operation.addImage("png:-")
 
-    apply(operation)_
+    apply(operation)(imageBytes)
   }
 }

--- a/png-resizer/app/lib/ImageCache.scala
+++ b/png-resizer/app/lib/ImageCache.scala
@@ -1,0 +1,32 @@
+package lib
+
+import common.Logging
+import conf.Configuration
+import services.S3ByteStore
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object ImageCache extends Logging {
+
+  lazy val version = {
+    val v = "v1"
+    log.info(s"Using imageresizer version path $v")
+    v
+  }
+
+  lazy val store = Configuration.aws.credentials.map { credentials =>
+    new S3ByteStore(Configuration.pngResizer.bucket, credentials)
+  }
+
+  def getImage(path: String, meta: String): Future[Option[Array[Byte]]] = {
+    store.map { _.get(s"$version/$meta/$path") }.getOrElse(Future.successful(None))
+  }
+  def putImage(path: String, meta: String, data: Array[Byte]): Future[Unit] = {
+    store.map { store =>
+      store.putPrivate(s"$version/$meta/$path", data, "image/png").map(_ => ())
+      // do we care if it fails?
+    }.getOrElse(Future.successful(()))
+  }
+
+}

--- a/png-resizer/conf/application-logger.xml
+++ b/png-resizer/conf/application-logger.xml
@@ -15,8 +15,17 @@
         </encoder>
     </appender>
 
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <file>logs/frontend-png-resizer.log</file>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+        </encoder>
+    </appender>
+
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="Console"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
The png resizer was using too much CPU, probably because it was resizing the same images to the same sizes repeatedly.

This stores the resized pngs in S3 and serves them from there in preference to resizing them.  The S3 bucket is set up to expire them after 7 days.

Not sure if I should also validate the resizes to only accept certain sizes - if we have a fixed set and the site has another size on then others will come through as the large original and be resized by the browser, if we cache any size, our S3 bucket could get very big.

There are also a few TODOs in there which I'd appreciate people's thoughts on whether it's sensible to do something with - mainly monitoring.

@robertberry any thoughts?
