### PR TITLE
Responsive banner bottom padding on mobile

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -362,6 +362,10 @@
             display: none;
         }
     }
+    
+    .top-banner-ad-container--mobile & {
+        padding-bottom: $gs-baseline*1.5;
+    }
 }
 
 .creative--fluid250 {

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -364,7 +364,10 @@
     }
     
     .top-banner-ad-container--mobile & {
+        height: auto;
+        padding: 0;
         padding-bottom: $gs-baseline*1.5;
+        
     }
 }
 

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -365,9 +365,8 @@
     
     .top-banner-ad-container--mobile & {
         height: auto;
-        padding: 0;
+        padding-top: 0;
         padding-bottom: $gs-baseline*1.5;
-        
     }
 }
 


### PR DESCRIPTION
This is a regression, putting in a bottom padding for fluid 250 on mobile only.

Before;

![screen shot 2014-12-18 at 11 59 08](https://cloud.githubusercontent.com/assets/1303616/5487832/287e891e-86ae-11e4-98c0-414f815e5809.png)

After;
![screen shot 2014-12-18 at 12 03 26](https://cloud.githubusercontent.com/assets/1303616/5487839/384c91d8-86ae-11e4-95b8-ff5a3a2f6a34.png)
