### PR TITLE
Change media players default preload attribute to "auto"

### DIFF
--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -17,6 +17,7 @@
             poster="@player.poster" data-duration="@player.video.duration.toString()" data-media-id="@player.video.id"
             data-end-slate="@player.endSlatePath" data-block-video-ads="@player.blockVideoAds" data-embeddable="@player.video.embeddable"
             @player.embedPath.map{ p => data-embed-path="@p" }
+            preload="auto"
         >
 
             @player.video.encodings.map { encoding =>

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -334,7 +334,7 @@ define([
                 techOrder: techPriority,
                 controls: true,
                 autoplay: false,
-                preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35
+                preload: 'auto', // preload='none' & autoplay breaks ad loading on chrome35, preload="metadata" breaks older Safari's
                 plugins: {
                     embed: {
                         embeddable: !config.page.isFront && config.switches.externalVideoEmbeds && $el.attr('data-embeddable') === 'true',


### PR DESCRIPTION
After lots of investigation it turns out `preload="metadata"` breaks the player implementation in older versions of Safari. This changes the preload attribute to 'auto'

> hints that the user needs have priority; in others terms this hint indicated that, if needed, the whole video could be downloaded, even if the user is not expected to use it.
> https://developer.mozilla.org/en/docs/Web/HTML/Element/video#attr-preload

This does now mean that certain UA's may download the entire file without even being used, but we know that all common mobile browsers ignore this for data plan reasons, so its a happy compromise.

/cc @rich-nguyen @gklopper @cantlin 
