### PR TITLE
Fixing float problem on Soulmates mobile component

### DIFF
--- a/static/src/stylesheets/module/commercial/_soulmates.scss
+++ b/static/src/stylesheets/module/commercial/_soulmates.scss
@@ -209,6 +209,7 @@ $c-soulmates-high: colour(neutral-1);
 
         @include mq($until: tablet) {
             margin-top: $gs-baseline/2;
+            clear: both;
         }
 
         @include mq(tablet) {


### PR DESCRIPTION
Adding clear: both to the form element fixes it.

Before;
![screen shot 2014-12-18 at 15 54 39](https://cloud.githubusercontent.com/assets/1303616/5491083/440884d0-86ce-11e4-8880-ccbeaa0b2099.png)

After;
![screen shot 2014-12-18 at 15 54 51](https://cloud.githubusercontent.com/assets/1303616/5491086/48d8d532-86ce-11e4-9e78-03b8f62a74ed.png)
