### PR TITLE
Flyers: Custom messages and larger byline image at wide breakpoint

### DIFF
--- a/onward/app/views/fragments/flyerBody.scala.html
+++ b/onward/app/views/fragments/flyerBody.scala.html
@@ -65,10 +65,14 @@
                 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path class="flyer__arrow-icon" d="m12 0c-6.627 0-12 5.373-12 12 0 6.627 5.373 12 12 12 6.627 0 12-5.373 12-12 0-6.627-5.373-12-12-12m.21 19l-.637-.668 4.888-6.326h-11.465v-1.01h11.465l-4.888-6.333.637-.668 6.79 7.158v.685l-6.79 7.157"/></g></svg>
             </div>
             <div class="flyer__read-more-text">
-                Read more
+                @{content.contentType match {
+                        case "Audio" => "Listen"
+                        case "Gallery" => "View gallery"
+                        case _ => "Read more"
+                    }
+                }
             </div>
         </div>
-
         <a class="flyer__link u-faux-block-link__overlay" href="@content.webUrl"></a>
     </div>
 </div>

--- a/static/src/stylesheets/module/_flyers.scss
+++ b/static/src/stylesheets/module/_flyers.scss
@@ -277,7 +277,7 @@
         &.element--supporting {
             width: gs-span(5);
             .flyer__byline-img {
-                height: $gs-baseline * 10;
+                height: $gs-baseline * 12;
             }
         }
     }


### PR DESCRIPTION
Flyers now have a custom 'Read more' message for galleries and podcasts.

![screen shot 2014-12-19 at 11 23 30](https://cloud.githubusercontent.com/assets/2236852/5503684/e0334f22-8771-11e4-9e04-cada5e7ac16d.png)
![screen shot 2014-12-19 at 11 21 43](https://cloud.githubusercontent.com/assets/2236852/5503688/ef04f96a-8771-11e4-8a92-425169ccea1c.png)

Also increased the size of the byline image:

Before:
![screen shot 2014-12-19 at 11 21 35](https://cloud.githubusercontent.com/assets/2236852/5503691/fe18af5a-8771-11e4-94c0-f2fbd9a82c91.png)

After:
![screen shot 2014-12-19 at 11 21 25](https://cloud.githubusercontent.com/assets/2236852/5503694/0c19fbf4-8772-11e4-8984-d337d5f6923a.png)
