### PR TITLE
dreamsnaps - IE rendering bug

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -298,6 +298,7 @@ $fc-hover-transition: .25s ease;
         display: block;
         @include fs-headline(1);
         color: #ffffff;
+        line-height: 1; // IE bug
     }
 
     &:hover:before {


### PR DESCRIPTION
IE was showing this intermittently before and seemed to have been fixed, but it wasn't - this fixes it:

before:

![screen shot 2014-12-19 at 14 25 43](https://cloud.githubusercontent.com/assets/867233/5505764/b6878eb2-878b-11e4-8c79-d043a2cc61ff.png)

after:

![screen shot 2014-12-19 at 14 25 21](https://cloud.githubusercontent.com/assets/867233/5505765/bc2a7514-878b-11e4-9309-2b1436c79e23.png)
