### PR TITLE
Revert "don't hide non-dreamsnap kickers"

### DIFF
--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
@@ -28,7 +28,7 @@ x x x x x x x x x x x x x x x x x x x x x x x x
         }
     }
 
-    .fc-item__kicker--dreamsnap {
+    .fc-item__kicker {
         display: none;
     }
 


### PR DESCRIPTION
Reverts guardian/frontend#7612
