### PR TITLE
limit concurrent png resizes per box

### DIFF
--- a/png-resizer/app/controllers/Resizer.scala
+++ b/png-resizer/app/controllers/Resizer.scala
@@ -7,6 +7,7 @@ import grizzled.slf4j.Logging
 import lib.Streams._
 import lib.WS._
 import lib.{Im4Java, IntString, PngQuant}
+import load.LoadLimit
 import model.Cached
 import play.api.Play.current
 import play.api.libs.ws.WS
@@ -16,47 +17,50 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object Resizer extends Controller with Logging {
-  def resize(backend: String, path: String, widthString: String, qualityString: String) = Action.async {
-    val downloadStopWatch = new StopWatch
+  def resize(backend: String, path: String, widthString: String, qualityString: String) =
+    Action.async {
+      val downloadStopWatch = new StopWatch
 
-    (Backends.uri(backend, path), widthString, qualityString) match {
-      case (Some(uri), IntString(width), IntString(quality)) =>
-        WS.url(uri).getStream() flatMap { case (responseHeaders, enumerator) =>
-          responseHeaders.status match {
-            case OK if responseHeaders.contentType != "image/png" =>
-              Future.successful(BadRequest(s"Original image $uri content type (${responseHeaders.contentType}) is not " +
-                "supported. Only PNG supported."))
+      (Backends.uri(backend, path), widthString, qualityString) match {
+        case (Some(uri), IntString(width), IntString(quality)) =>
+          LoadLimit(uri) {
+            WS.url(uri).getStream() flatMap { case (responseHeaders, enumerator) =>
+              responseHeaders.status match {
+                case OK if responseHeaders.contentType != "image/png" =>
+                  Future.successful(BadRequest(s"Original image $uri content type (${responseHeaders.contentType}) is not " +
+                    "supported. Only PNG supported."))
 
-            case OK =>
-              logger.info(s"Resizing $uri to $width pixels wide at $quality compression")
+                case OK =>
+                  logger.info(s"Resizing $uri to $width pixels wide at $quality compression")
 
-              enumerator.toByteArray flatMap { bytes =>
-                logger.info(s"Took $downloadStopWatch to download $uri")
-                PngResizerMetrics.downloadTime.recordDuration(downloadStopWatch.elapsed)
+                  enumerator.toByteArray flatMap { bytes =>
+                    logger.info(s"Took $downloadStopWatch to download $uri")
+                    PngResizerMetrics.downloadTime.recordDuration(downloadStopWatch.elapsed)
 
-                val resizeStopWatch = new StopWatch
+                    val resizeStopWatch = new StopWatch
 
-                val resized = Im4Java.resizeBufferedImage(width)(bytes)
-                logger.info(s"Took $resizeStopWatch to IM convert (resize) $uri")
-                val quantStopWatch = new StopWatch
-                PngQuant(resized, quality) map { compressedImage =>
-                  logger.info(s"Took $quantStopWatch to PngQuant $uri")
-                  PngResizerMetrics.resizeTime.recordDuration(resizeStopWatch.elapsed)
+                    val resized = Im4Java.resizeBufferedImage(width)(bytes)
+                    logger.info(s"Took $resizeStopWatch to IM convert (resize) $uri")
+                    val quantStopWatch = new StopWatch
+                    PngQuant(resized, quality) map { compressedImage =>
+                      logger.info(s"Took $quantStopWatch to PngQuant $uri")
+                      PngResizerMetrics.resizeTime.recordDuration(resizeStopWatch.elapsed)
 
-                  Cached(Configuration.pngResizer.ttlInSeconds)(Ok(compressedImage).as("image/png"))
-                }
+                      Cached(Configuration.pngResizer.ttlInSeconds)(Ok(compressedImage).as("image/png"))
+                    }
 
+                  }
+
+                case NOT_FOUND => Future.successful(NotFound(s"Unable to find source image at $uri"))
+
+                case otherErrorCode => Future.successful(BadGateway(s"Received $otherErrorCode for $uri"))
               }
-
-            case NOT_FOUND => Future.successful(NotFound(s"Unable to find source image at $uri"))
-
-            case otherErrorCode => Future.successful(BadGateway(s"Received $otherErrorCode for $uri"))
+            }
           }
-        }
 
-      case (None, _, _) => Future.successful(NotFound(s"$backend is not a backend we support"))
+        case (None, _, _) => Future.successful(NotFound(s"$backend is not a backend we support"))
 
-      case _ => Future.successful(BadRequest(s"width and quality must be integers"))
+        case _ => Future.successful(BadRequest(s"width and quality must be integers"))
+      }
     }
-  }
 }

--- a/png-resizer/app/load/LoadLimit.scala
+++ b/png-resizer/app/load/LoadLimit.scala
@@ -22,7 +22,7 @@ object LoadLimit extends Logging {
 
     val requestsIncludingUs = inProgress.incrementAndGet
 
-    val result = try {
+    try {
       if (requestsIncludingUs > requestLimit) {
         log.info(s"limit exceeded - redirecting to: $fallbackUri")
         Future.successful(TemporaryRedirect(fallbackUri))
@@ -33,8 +33,6 @@ object LoadLimit extends Logging {
     } finally {
       inProgress.decrementAndGet
     }
-
-    result
   }
 
 }

--- a/png-resizer/app/load/LoadLimit.scala
+++ b/png-resizer/app/load/LoadLimit.scala
@@ -1,0 +1,40 @@
+package load
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import common.Logging
+import play.api.mvc.Results._
+import play.api.mvc._
+
+import scala.concurrent.Future
+
+object LoadLimit extends Logging {
+
+  val inProgress = new AtomicInteger(0)
+  lazy val requestLimit = {
+    val limit = Runtime.getRuntime.availableProcessors() * 2
+    // one per cpu is too low as we have to wait for the content to download, so go for 2 per cpu
+    log.info(s"request limit set to $limit")
+    limit
+  }
+
+  def apply(fallbackUri: String)(available: =>  Future[Result]): Future[Result] = {
+
+    val requestsIncludingUs = inProgress.incrementAndGet
+
+    val result = try {
+      if (requestsIncludingUs > requestLimit) {
+        log.info(s"limit exceeded - redirecting to: $fallbackUri")
+        Future.successful(TemporaryRedirect(fallbackUri))
+      } else {
+        log.info(s"capacity available - now at $requestsIncludingUs")
+        available
+      }
+    } finally {
+      inProgress.decrementAndGet
+    }
+
+    result
+  }
+
+}

--- a/png-resizer/conf/application-logger.xml
+++ b/png-resizer/conf/application-logger.xml
@@ -15,8 +15,17 @@
         </encoder>
     </appender>
 
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <file>logs/frontend-png-resizer.log</file>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+        </encoder>
+    </appender>
+
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="Console"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
We serve full sized PNGs at the moment.  We want to serve resized PNGs but although they are very cacheable once resized, we don't have the cpu time to resize them at the rate needed to fill the cache.

So this PR is to limit the number of concurrent resizes to 2*cores, after that it will 307 redirect them to the original static image.  This means we will be resizing the images as quickly as we can according to demand, but if we can't cope we can offload the resize onto the browser.

Latency will always be good, so we will never autoscale with the current rules, so we may need to modify the health check so we scale up/down if there are too many/too few 307s in a given time period.

We can also potentially save ourself a lot time resizing images that haven't changed since last time by adding an ETag/last-modied from the original image and returning 304 if it's not changed.  This would remove the trade-off of long cache times.

@gklopper @robertberry any thoughts?
