### PR TITLE
revert dream snap changes

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/kicker.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/kicker.scala.html
@@ -1,51 +1,51 @@
-@(header: layout.FaciaCardHeader, classes: String = "")(implicit request: RequestHeader)
+@(header: layout.FaciaCardHeader)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import views.support._
 
 @header.kicker.map {
     case BreakingNewsKicker => {
-        <span class="fc-item__breaking-indicator @classes">Breaking news</span>
+        <span class="fc-item__breaking-indicator">Breaking news</span>
     }
 
     case LiveKicker => {
-        <span class="fc-item__kicker fc-item__live-indicator @classes"><span class="live-pulse-icon"></span>Live</span>
+        <span class="fc-item__kicker fc-item__live-indicator"><span class="live-pulse-icon"></span>Live</span>
     }
 
     case CartoonKicker => {
-        <span class="fc-item__kicker @classes">Cartoon</span>
+        <span class="fc-item__kicker">Cartoon</span>
     }
 
     case AnalysisKicker => {
-        <span class="fc-item__kicker @classes">Analysis</span>
+        <span class="fc-item__kicker">Analysis</span>
     }
 
     case PodcastKicker(Some(series)) => {
-        <a href="@LinkTo(series.url)" data-link-name="kicker" class="fc-item__kicker @classes">@Html(series.name)</a>
+        <a href="@LinkTo(series.url)" data-link-name="kicker" class="fc-item__kicker">@Html(series.name)</a>
     }
 
     case PodcastKicker(None) => {
-        <span class="fc-item__kicker @classes">Podcast</span>
+        <span class="fc-item__kicker">Podcast</span>
     }
 
     case ReviewKicker => {
-        <span class="fc-item__kicker @classes">Review</span>
+        <span class="fc-item__kicker">Review</span>
     }
 
     case TagKicker(tagName, tagLink, _) => {
-        <a href="@LinkTo(tagLink)" data-link-name="kicker" class="fc-item__kicker @classes">@Html(tagName)</a>
+        <a href="@LinkTo(tagLink)" data-link-name="kicker" class="fc-item__kicker">@Html(tagName)</a>
     }
 
     case SectionKicker(sectionName, sectionLink) => {
-        <a href="@LinkTo(sectionLink)" data-link-name="kicker" class="fc-item__kicker @classes">@Html(sectionName)</a>
+        <a href="@LinkTo(sectionLink)" data-link-name="kicker" class="fc-item__kicker">@Html(sectionName)</a>
     }
 
     case FreeHtmlKickerWithLink(html, link) => {
-        <a href="@LinkTo(link)" data-link-name="kicker" class="fc-item__kicker @classes">@Html(html)</a>
+        <a href="@LinkTo(link)" data-link-name="kicker" class="fc-item__kicker">@Html(html)</a>
     }
 
     case FreeHtmlKicker(html) => {
-        <span class="fc-item__kicker @classes">@Html(html)</span>
+        <span class="fc-item__kicker">@Html(html)</span>
     }
 }
 

--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -6,9 +6,7 @@
 @import views.support._
 
 @itemHeader(containerIndex == 0 && itemIndex == 0, header.quoted) {
-    @if(snapType != Some(LatestSnap)) {
-        @kicker(header)
-    }
+    @kicker(header)
 } {
     <a href="@header.url.get(request)" class="fc-item__link" data-link-name="article"><span class="@labelCssClasses">@RemoveOuterParaHtml(header.headline)</span></a>
 }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -7,7 +7,6 @@
 @import views.html.fragments.items.facia_cards.meta
 @import views.html.fragments.items.elements.facia_cards._
 @import views.html.fragments.items.elements.starRating
-@import layout.LatestSnap
 
 <div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!isList){js-snappable}"
     @if(item.discussionSettings.isCommentable) {
@@ -26,10 +25,6 @@ data-test-id="facia-card"
     @item.snapStuff.dataAttributes>
 
     <div class="fc-item__container">
-        @if(item.snapStuff.snapType == LatestSnap) {
-            @kicker(item.header, "fc-item__kicker--dreamsnap fc-item__kicker--dreamsnap-list")
-        }
-
         @item.displayElement match {
             case Some(InlineVideo(videoElement, title, endSlatePath, fallback)) if item.cardTypes.showVideoPlayer => {
                 @defining(VideoPlayer(
@@ -79,9 +74,6 @@ data-test-id="facia-card"
         }
 
     <div class="fc-item__content">
-        @if(item.snapStuff.snapType == LatestSnap) {
-            @kicker(item.header, "fc-item__kicker--dreamsnap")
-        }
         <div class="@RenderClasses(Map(
             ("fc-item__header", true),
             ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -285,35 +285,6 @@ $fc-hover-transition: .25s ease;
     }
 }
 
-// dream snaps
-.fc-item__kicker--dreamsnap {
-    display: block;
-    @include fs-header(2);
-    background-color: fade-out(#000000, .9);
-    margin: 0 (0 - $gs-gutter * .25);
-    padding: ($gs-baseline * .25) ($gs-gutter * .25) ($gs-baseline * .5);
-
-    &:before {
-        content: 'Latest from\2026';
-        display: block;
-        @include fs-headline(1);
-        color: #ffffff;
-        line-height: 1; // IE bug
-    }
-
-    &:hover:before {
-        text-decoration: none;
-    }
-
-    &:after {
-        display: none;
-    }
-}
-
-.fc-item__kicker--dreamsnap-list {
-    display: none;
-}
-
 .fc-item__byline {
     margin-bottom: 0;
 }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
@@ -88,14 +88,6 @@ Media list item. Looks a bit like this:
         }
     }
 
-    .fc-item__kicker--dreamsnap-list {
-        margin-left: 0 - $image-width - $mobile-media-padding;
-
-        @include mq(tablet) {
-            margin-left: 0 - $image-width;
-        }
-    }
-
     &[class*="fc-item--has-sublinks"] .fc-item__media-wrapper {
         position: relative;
         float: left;

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
@@ -27,13 +27,4 @@ x x x x x x x x x x x x x x x x x x x x x x x x
             display: none;
         }
     }
-
-    .fc-item__kicker--dreamsnap {
-        display: none;
-    }
-
-    .fc-item__kicker--dreamsnap-list {
-        display: block;
-        margin: 0;
-    }
 }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
@@ -29,10 +29,6 @@
         color: colour(news-support-6);
     }
 
-    .fc-item__kicker--dreamsnap:before {
-        color: colour(neutral-1);
-    }
-
     .fc-item__meta {
         color: colour(neutral-2);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
@@ -26,10 +26,6 @@
         fill: colour(comment-default);
     }
 
-    .fc-item__kicker--dreamsnap:before {
-        color: colour(neutral-1);
-    }
-
     .fc-item__meta {
         background-color: fade-out(colour(comment-background), .5);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
@@ -6,10 +6,6 @@
         color: colour(external-main-1);
     }
 
-    .fc-item__kicker--dreamsnap:before {
-        color: colour(neutral-1);
-    }
-
     .u-faux-block-link--hover {
         background-color: darken(colour(neutral-6), 3%);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
@@ -18,10 +18,6 @@
     .flyer__arrow-icon {
         fill: colour(news-default);
     }
-
-    .fc-item__kicker--dreamsnap:before {
-        color: colour(neutral-1);
-    }
 }
 
 .tone-news--sublink {


### PR DESCRIPTION
this restores dreamsnaps to their previous state (github couldn't do a simple 'revert')

was

![screen shot 2014-12-19 at 16 05 20](https://cloud.githubusercontent.com/assets/867233/5507198/fcd4959c-8798-11e4-8356-c16ef3955745.png)

now

![screen shot 2014-12-19 at 16 05 32](https://cloud.githubusercontent.com/assets/867233/5507199/036cd8ba-8799-11e4-9cd0-3ba15e887bef.png)
