### PR TITLE
Fix Masterclass Cache Failure

### DIFF
--- a/commercial/app/model/commercial/Lookup.scala
+++ b/commercial/app/model/commercial/Lookup.scala
@@ -11,8 +11,17 @@ import scala.concurrent.Future
 object Lookup extends ExecutionContexts with Logging {
 
   def content(contentId: String): Future[Option[Content]] = {
-    LiveContentApi.item(contentId, defaultEdition).response map {
+    val response = try {
+      LiveContentApi.item(contentId, defaultEdition).response
+    } catch {
+      case e: Exception => Future.failed(e)
+    }
+    response map {
       _.content map (Content(_))
+    } recover {
+      case e: Exception =>
+        log.info(s"CAPI search for item '$contentId' failed: ${e.getMessage}")
+        None
     }
   }
 

--- a/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
@@ -27,7 +27,9 @@ object MasterClassAgent extends MerchandiseAgent[MasterClass] with ExecutionCont
   def wrapEventbriteWithContentApi(eventbriteEvents: Seq[EventbriteMasterClass]): Future[Seq[MasterClass]] = {
 
     val futureMasterclasses = eventbriteEvents map { event =>
-      val contentId = event.guardianUrl.replace("http://www.theguardian.com/", "")
+      val contentId = event.guardianUrl
+        .replace("http://www.theguardian.com/", "")
+        .replaceFirst("\\?.*", "")
       Lookup.mainPicture(contentId) map { imageContainer =>
         MasterClass(event, imageContainer)
       } recover {


### PR DESCRIPTION
Caching masterclasses was failing because some of the URLs in the data feed have query strings attached.  Looking these up in Capi was throwing an uncaught exception.
