### PR TITLE
Measure the benefit of compressing CSS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,5 +150,8 @@ module.exports = function (grunt) {
      */
     grunt.registerTask('hookmeup', ['clean:hooks', 'shell:copyHooks']);
     grunt.registerTask('emitAbTestInfo', 'shell:abTestInfo');
+    grunt.registerTask('css-benchmark', function () {
+        grunt.task.run(['clean:cssBenchmark', 'compile:css', 'copy:cssBenchmark', 'shell:cssBenchmark']);
+    });
 
 };

--- a/grunt-configs/clean.js
+++ b/grunt-configs/clean.js
@@ -23,6 +23,7 @@ module.exports = function(grunt, options) {
         ],
         // Clean any pre-commit hooks in .git/hooks directory
         hooks: ['.git/hooks'],
-        assets: ['common/conf/assets']
+        assets: ['common/conf/assets'],
+        cssBenchmark: ['node_modules/css-minification-benchmark/data/*']
     };
 };

--- a/grunt-configs/copy.js
+++ b/grunt-configs/copy.js
@@ -103,6 +103,16 @@ module.exports = function(grunt, options) {
                 src: ['*'],
                 dest: '.git/hooks/'
             }]
+        },
+        cssBenchmark: {
+            files: [{
+                expand: true,
+                cwd: options.staticTargetDir + 'stylesheets',
+                src: ['**/*'],
+                dest: 'node_modules/css-minification-benchmark/data/',
+                flatten: true,
+                filter: 'isFile'
+            }]
         }
     };
 };

--- a/grunt-configs/copy.js
+++ b/grunt-configs/copy.js
@@ -108,7 +108,7 @@ module.exports = function(grunt, options) {
             files: [{
                 expand: true,
                 cwd: options.staticTargetDir + 'stylesheets',
-                src: ['**/*'],
+                src: ['**/*.css'],
                 dest: 'node_modules/css-minification-benchmark/data/',
                 flatten: true,
                 filter: 'isFile'

--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -22,6 +22,23 @@ module.exports = function(grunt, options) {
             command: 'node tools/ab-test-info/ab-test-info.js ' +
                      'static/src/javascripts/modules/experiments/tests ' +
                      'static/abtests.json'
+        },
+
+        cssBenchmark: {
+            command: [
+                'npm install',
+                'node bin/bench --html --only clean,csso,cssshrink,csswring,sqwish,ycssmin --verbose --gzip --total'
+                // basically exclude condense, more-css and ncss because they error out
+            ].join('&&'),
+            options: {
+                execOptions: {
+                    cwd: 'node_modules/css-minification-benchmark'
+                },
+                stdout: false,
+                callback: function (err, stdout, stderr, cb) {
+                    require('fs').writeFile('tmp/css-benchmark.html', stdout.substring(stdout.indexOf('<!DOCTYPE')), cb);
+                }
+            }
         }
     };
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "btoa": "1.1.2",
+    "css-minification-benchmark": "git+https://github.com/piuccio/css-minification-benchmark.git#percentages",
     "esprima": "1.2.2",
     "glob": "4.0.6",
     "grunt": "0.4.5",


### PR DESCRIPTION
-- **Warning** -- This pull request shouldn't be merged, it's just a conversation starter :smile: 

The current build lets SASS minify our CSS, however the algorithm used might not be the best.

I've added a grunt task, `css-benchmark`, that measures the compression ratio of our files using different algorithms.
The whole report is available in `tmp/css-benchmark.html`

What's interesting is that running `csso` on the already minified files we can go from `560305` to `525270` bytes (6% gain, `~34kB`) of the **gzip** size.

Even better results could be achieved by running different compression algorithms to different files (`~34.5kB`), but that would be slightly more complex.
For instance `csswring` performs better for `webfonts` while `clean-css` is the best algorithm for `old-ie` files.
