### PR TITLE
allow one PNG resize request in per CPU

### DIFF
--- a/png-resizer/app/load/LoadLimit.scala
+++ b/png-resizer/app/load/LoadLimit.scala
@@ -17,8 +17,7 @@ object LoadLimit extends ExecutionContexts with Logging {
   private lazy val currentNumberOfResizes = new AtomicInteger(0)
 
   private lazy val requestLimit = {
-    val limit = Runtime.getRuntime.availableProcessors() * 2
-    // one per cpu is too low as we have to wait for the content to download, so go for 2 per cpu
+    val limit = Runtime.getRuntime.availableProcessors()
     log.info(s"request limit set to $limit")
     limit
   }


### PR DESCRIPTION
since download time within AWS is so small, there's no need to queue up more than one request as they are just fighting each other for CPU time and then 500 erroring because some take over 5 seconds.

@gklopper 
