### PR TITLE
Rendering fix for FF

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -51,7 +51,7 @@ $header-image-size-desktop: 100px;
 }
 
 .fc-slice-wrapper {
-    padding-top: 0;
+    padding-top: .01px; // Pure magic: makes it to jump below the header for FF
     margin: 0 $gs-gutter/2 * -1;
 
     .show-more--hidden & {


### PR DESCRIPTION
In FF before:
![screen shot 2014-12-30 at 15 38 12](https://cloud.githubusercontent.com/assets/2579465/5587453/cdf4526e-90e2-11e4-968c-de6e70366fea.png)
![screen shot 2014-12-31 at 10 53 17](https://cloud.githubusercontent.com/assets/2579465/5587452/cdf41f74-90e2-11e4-9be3-7461ef9ccf8d.png)

This is solving bug [7147](https://github.com/guardian/frontend/issues/7147)

It seems that in FF the slice wrapper is inline with the header. Both clear: both or display: inline-block were solving the issue but were causing unwanted behaviour in different cases (creating big gap on the right side or pushing content very low if header has more content - usually first-child).

I've found out that the issue can be solved by setting padding-top to .01px. I have no logical explanation to this just that it must be some weird rendering calculations in FF. This solution is an obvious hack but as mentioned before, unfortunately, clean solutions are not working in this case for various reasons.
