### PR TITLE
use 304 not modified to avoid resizing PNGs repeatedly

### DIFF
--- a/png-resizer/app/conf/PngResizerMetrics.scala
+++ b/png-resizer/app/conf/PngResizerMetrics.scala
@@ -1,8 +1,9 @@
 package conf
 
-import metrics.{FrontendTimingMetric, DurationMetric}
+import metrics.{CountMetric, FrontendTimingMetric}
 
 object PngResizerMetrics {
+
   val downloadTime = FrontendTimingMetric(
     "png-resizer-download-time",
     "Time to download PNG from static"
@@ -12,4 +13,20 @@ object PngResizerMetrics {
     "png-resizer-resize-time",
     "Time to resize a PNG after it's been downloaded"
   )
+
+  val quantizeTime = FrontendTimingMetric(
+    "png-resizer-quantize-time",
+    "Time to quantize a PNG after it's been resized"
+  )
+
+  val notModifiedCount = CountMetric(
+    "png-resizer-not-modified-count",
+    "Number of 304 responses sent because the PNG wasn't modified"
+  )
+
+  val redirectCount = CountMetric(
+    "png-resizer-redirect-count",
+    "Number of 307 responses sent because we were at capacity"
+  )
+
 }

--- a/png-resizer/app/controllers/Resizer.scala
+++ b/png-resizer/app/controllers/Resizer.scala
@@ -1,61 +1,80 @@
 package controllers
 
-import common.StopWatch
-import conf.{Configuration, PngResizerMetrics}
+import conf.PngResizerMetrics
 import data.Backends
 import grizzled.slf4j.Logging
+import lib.FutureEither._
+import lib.HeadersImplicits._
 import lib.Streams._
 import lib.WS._
-import lib.{Im4Java, IntString, PngQuant}
+import lib.{Im4Java, IntString, PngQuant, Time}
 import load.LoadLimit
-import model.Cached
 import play.api.Play.current
+import play.api.libs.iteratee.Enumerator
 import play.api.libs.ws.WS
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{Action, Controller, Headers}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scalaz.EitherT._
+import scalaz._
 
 object Resizer extends Controller with Logging {
+
+  case class CacheableContent(cacheHeaders: CacheHeaderList, content: Array[Byte])
+
+  def getPngBytesToResize(uri: String, response: PngResponse): FutureEither[CacheableContent] = eitherT {
+    val PngResponse(status, contentType, cacheHeaders, enumerator) = response
+    status match {
+
+      case OK if contentType == "image/png" && cacheHeaders.toMap.contains("Last-Modified") =>
+        enumerator.toByteArray.map(bytes => \/-(CacheableContent(cacheHeaders, bytes)))
+
+      case NOT_MODIFIED =>
+        PngResizerMetrics.notModifiedCount.increment
+        Future.successful(-\/(NotModified.withHeaders(cacheHeaders: _*)))
+
+      case OK if contentType == "image/png" =>
+        Future.successful(-\/(BadRequest(s"Original image $uri did not send exactly one last-modified header (${cacheHeaders.toMap.get("Last-Modified")}}). This prevents caching.")))
+
+      case OK =>
+        Future.successful(-\/(BadRequest(s"Original image $uri content type (${contentType}) is not " +
+          "supported. Only PNG supported.")))
+
+      case NOT_FOUND => Future.successful(-\/(NotFound(s"Unable to find source image at $uri")))
+
+      case otherErrorCode => Future.successful(-\/(BadGateway(s"Received $otherErrorCode for $uri")))
+    }
+  }
+
+  case class PngResponse(status: Int, contentType: String, cacheHeaders: CacheHeaderList, body: Enumerator[Array[Byte]])
+  type CacheHeaderList = Seq[(String, String)]
+
+  def getUpstreamResponse(uri: String, headers: Headers): FutureEither[PngResponse] = eitherTRight {
+    val unrolledHeaders = headers.getHeaders(Seq("Cache-Control", "If-Modified-Since", "If-None-Match"))
+    WS.url(uri).withHeaders(unrolledHeaders: _*).getStream().map {
+      case (headers, enumerator) =>
+        PngResponse(headers.status, headers.contentType, headers.getHeaders(Seq("Cache-Control", "Expires", "Last-Modified", "Etag")), enumerator)
+    }
+  }
+
   def resize(backend: String, path: String, widthString: String, qualityString: String) =
-    Action.async {
-      val downloadStopWatch = new StopWatch
+    Action.async { request =>
 
       (Backends.uri(backend, path), widthString, qualityString) match {
         case (Some(uri), IntString(width), IntString(quality)) =>
           LoadLimit(uri) {
-            WS.url(uri).getStream() flatMap { case (responseHeaders, enumerator) =>
-              responseHeaders.status match {
-                case OK if responseHeaders.contentType != "image/png" =>
-                  Future.successful(BadRequest(s"Original image $uri content type (${responseHeaders.contentType}) is not " +
-                    "supported. Only PNG supported."))
 
-                case OK =>
-                  logger.info(s"Resizing $uri to $width pixels wide at $quality compression")
+            // Left here is the http result, right is the data that still needs computation
+            (for {
+              response <- Time(getUpstreamResponse(uri, request.headers), "download image", PngResizerMetrics.downloadTime)
+              cacheableContent <- getPngBytesToResize(uri, response)
+              CacheableContent(cacheHeaders, bytesPreResize) = cacheableContent
+              resized <- Time(eitherTRight(Im4Java.resizeBufferedImage(width)(bytesPreResize)), "resize image", PngResizerMetrics.resizeTime)
+              quanted <- Time(eitherTRight(PngQuant(resized, quality)), "quantize image", PngResizerMetrics.quantizeTime)
+              result = Ok(quanted).as("image/png").withHeaders(cacheHeaders: _*)
+            } yield (result)).run.map(_.fold(identity,identity))
 
-                  enumerator.toByteArray flatMap { bytes =>
-                    logger.info(s"Took $downloadStopWatch to download $uri")
-                    PngResizerMetrics.downloadTime.recordDuration(downloadStopWatch.elapsed)
-
-                    val resizeStopWatch = new StopWatch
-
-                    val resized = Im4Java.resizeBufferedImage(width)(bytes)
-                    logger.info(s"Took $resizeStopWatch to IM convert (resize) $uri")
-                    val quantStopWatch = new StopWatch
-                    PngQuant(resized, quality) map { compressedImage =>
-                      logger.info(s"Took $quantStopWatch to PngQuant $uri")
-                      PngResizerMetrics.resizeTime.recordDuration(resizeStopWatch.elapsed)
-
-                      Cached(Configuration.pngResizer.ttlInSeconds)(Ok(compressedImage).as("image/png"))
-                    }
-
-                  }
-
-                case NOT_FOUND => Future.successful(NotFound(s"Unable to find source image at $uri"))
-
-                case otherErrorCode => Future.successful(BadGateway(s"Received $otherErrorCode for $uri"))
-              }
-            }
           }
 
         case (None, _, _) => Future.successful(NotFound(s"$backend is not a backend we support"))
@@ -63,4 +82,5 @@ object Resizer extends Controller with Logging {
         case _ => Future.successful(BadRequest(s"width and quality must be integers"))
       }
     }
+
 }

--- a/png-resizer/app/lib/FutureEither.scala
+++ b/png-resizer/app/lib/FutureEither.scala
@@ -1,0 +1,47 @@
+package lib
+
+import common.StopWatch
+import grizzled.slf4j.Logging
+import lib.FutureEither._
+import metrics.FrontendTimingMetric
+import play.api.mvc.Result
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scalaz.EitherT._
+import scalaz.{EitherT, Monad, \/-}
+
+object FutureEither {
+
+  implicit val futureMonad = new Monad[Future] {
+    def point[A](a: => A): Future[A] = Future.successful(a)
+
+    def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
+  }
+
+  type FutureEither[T] = EitherT[Future, Result, T]
+
+  def eitherTRight[T](future: Future[T]): FutureEither[T] =
+    eitherT(future.map(\/-.apply))
+
+}
+
+object Time extends Logging {
+
+  def apply[T](result: => FutureEither[T], action: String, metric: FrontendTimingMetric) = {
+    val stopWatch = new StopWatch
+    result.bimap({
+      contents =>
+        logger.info(s"took: $stopWatch for: $action result: Left($contents)")
+        contents
+    },
+    {
+      contents =>
+        logger.info(s"took: $stopWatch for: $action result: Right($contents)")
+        contents
+    })
+    metric.recordDuration(stopWatch.elapsed)
+    result
+  }
+
+}

--- a/png-resizer/app/lib/Headers.scala
+++ b/png-resizer/app/lib/Headers.scala
@@ -1,0 +1,15 @@
+package lib
+
+import play.api.mvc.Headers
+
+import scala.language.reflectiveCalls
+
+object HeadersImplicits {
+  implicit class RichHeaders(headers: Headers) {
+    def getHeaders(allowedHeaders: Seq[String]): Seq[(String, String)] = {
+      val copiedHeaders = headers.toMap.filterKeys(allowedHeaders.contains)
+      copiedHeaders.flatMap { case (headerName, values) => values.map(value => (headerName, value))}.toSeq
+    }
+
+  }
+}

--- a/png-resizer/app/lib/Im4Java.scala
+++ b/png-resizer/app/lib/Im4Java.scala
@@ -1,11 +1,12 @@
 package lib
 
-import java.awt.image.BufferedImage
-import org.im4java.core.{Stream2BufferedImage, ConvertCmd, IMOperation}
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-import javax.imageio.ImageIO
 
+import org.im4java.core.{ConvertCmd, IMOperation}
 import org.im4java.process.Pipe
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object Im4Java {
   def apply(operation: IMOperation, format: String = "png")(imageBytes: Array[Byte]): Array[Byte] = {
@@ -24,15 +25,15 @@ object Im4Java {
     baos.toByteArray
   }
 
-  def resizeBufferedImage(width: Int) = {
+  def resizeBufferedImage(width: Int)(imageBytes: Array[Byte]) = Future {
     val operation = new IMOperation
 
     operation.addImage("-")
-    operation.sharpen(1.0)
     operation.resize(width)
-    operation.quality(100)
+    operation.sharpen(1.0)
+    operation.quality(0)
     operation.addImage("png:-")
 
-    apply(operation)_
+    apply(operation)(imageBytes)
   }
 }

--- a/png-resizer/app/lib/WS.scala
+++ b/png-resizer/app/lib/WS.scala
@@ -1,10 +1,16 @@
 package lib
 
 import play.api.libs.ws
-import language.reflectiveCalls
+
+import scala.language.reflectiveCalls
 
 object WS {
   implicit class RichResponse(response: ws.WSResponseHeaders) {
     lazy val contentType: String = response.headers.get("Content-Type").map(_ mkString " ").getOrElse("")
+    def getHeaders(allowedHeaders: Seq[String]): Seq[(String, String)] = {
+      val copiedHeaders = response.headers.filterKeys(allowedHeaders.contains)
+      copiedHeaders.flatMap { case (headerName, values) => values.map(value => (headerName, value))}.toSeq
+    }
+
   }
 }

--- a/png-resizer/app/load/LoadLimit.scala
+++ b/png-resizer/app/load/LoadLimit.scala
@@ -3,6 +3,7 @@ package load
 import java.util.concurrent.atomic.AtomicInteger
 
 import common.{ExecutionContexts, Logging}
+import conf.PngResizerMetrics
 import model.Cached
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -37,6 +38,7 @@ object LoadLimit extends ExecutionContexts with Logging {
         currentNumberOfRequests.decrementAndGet()
         throw t
     } else {
+      PngResizerMetrics.redirectCount.increment
       currentNumberOfRequests.decrementAndGet()
       Future.successful(Cached(60)(TemporaryRedirect(fallbackUri)))
     }


### PR DESCRIPTION
Once the cache time expires, browsers/proxies which still have the content send an If-Modified-Since header if there was a Last-Modified in the original response.  If the content is still the same, the server can return a 304 to say the content has not changed.

Since the default cache time for the PNGs is about a day, we have having to re-resize all our PNGs every day (to every size) resulting in a lot of redirects due to lack of capacity.

This PR updates the code so if an If-Modified-Since is sent it will forward to the server and skip the resize and return a 304.  This should result in mostly 304s and not much cpu time needed once everything is cached.

@robertberry @adamnfish please quickly give me a thumbs up before @gklopper notices ;)
