### PR TITLE
Removed link from most popular

### DIFF
--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -9,9 +9,7 @@
     data-component="most-popular">
         <div class="fc-container__inner">
             <div class="fc-container__header js-container__header">
-                <h2 class="fc-container__header__title">
-                    <a href="@LinkTo(url)" data-link-name="Most viewed @section">popular</a>
-                </h2>
+                <h2 class="fc-container__header__title">popular</h2>
             </div>
             <div class="fc-container__body fc-container--rolled-up-hide js-popular-trails">
 


### PR DESCRIPTION
This is removing link from the most popular as per issue [6728](https://github.com/guardian/frontend/issues/6728)

Before:
![screen shot 2015-01-02 at 14 42 42](https://cloud.githubusercontent.com/assets/2579465/5596752/f1946928-928d-11e4-9e50-c81e35e44bd0.png)

After:
![screen shot 2015-01-02 at 14 43 13](https://cloud.githubusercontent.com/assets/2579465/5596756/f92fe91e-928d-11e4-879e-8bd3cea8bfda.png)

CC @crifmulholland - Test is suggesting that this was done for the 'no-JavaScript' scenario. 
