### PR TITLE
make the ads in the responsive viewer togglable

### DIFF
--- a/preview/app/views/responsive_viewer.scala.html
+++ b/preview/app/views/responsive_viewer.scala.html
@@ -65,6 +65,11 @@
                 top: 2px;
             }
 
+            #ads-toggler {
+                text-align: center;
+                cursor: pointer;
+            }
+
             #edition-switcher a {
                 font-weight: bold;
             }
@@ -97,19 +102,34 @@
                     html += '<div style="left:' + leftAcc + 'px">' +
                             '<h2>' + bp.name + '</h2>' +
                             '<iframe frameBorder="0" sandbox="allow-same-origin allow-forms allow-scripts" seamless ' +
-                            'src="' + src + '#noads" ' +
+                            'src="' + src + (window.location.hash ? window.location.hash : '') + '" ' +
                             'width="' + ( bp.width + sbWidth ) + '"></iframe>' +
                             '</div>' ;
                     leftAcc += bp.width + sbWidth + 15 ;
                 });
 
                 document.querySelector ( '.frames' ).innerHTML = html ;
+
+                document.getElementById('toggle-ads' ).innerHTML = 'Turn ads ' +
+                    (window.location.hash === '#noads' ? 'on' : 'off');
+            }
+
+            function toggleAds() {
+                if (window.location.hash === '#noads') {
+                    window.location.hash = '';
+                } else {
+                    window.location.hash = '#noads';
+                }
+                window.location.reload();
             }
         </script>
     </head>
     <body>
         <div id="edition-switcher">
             <a href="./uk">UK</a> <a href="./us">US</a> <a href="./au">AU</a>
+        </div>
+        <div id="ads-toggler">
+            <a id='toggle-ads' onclick='toggleAds()'>Toggle ads</a>
         </div>
         <div id="chrome-instructions" style="display: none;">
             <a id="chrome-instructions__toggle" onclick="toggle('chrome-instructions__text')">Looks wrong in Chrome?</a>


### PR DESCRIPTION
Recently we turned off ads in the repsonsive viewer because some were breaking in the iframes.  However recently we had a comment that the layout is different without ads enabled.

So to keep everyone happy but still allow turning off it something breaks, I have changed it so they are on by default and there's a quick bit of JS in there to toggle them.

![responsive-ad-toggle](https://cloud.githubusercontent.com/assets/7304387/5613255/38936fde-94d9-11e4-9dfb-7a6f8175c12e.gif)

@stephanfowler how does it look?
