### PR TITLE
Article lightbox refactor

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -19,6 +19,7 @@ case class ImageAsset(delegate: Asset, index: Int) {
 
   lazy val width: Int = fields.get("width").map(_.toInt).getOrElse(1)
   lazy val height: Int = fields.get("height").map(_.toInt).getOrElse(1)
+  lazy val ratio: Int = width/height
   lazy val role: Option[String] = fields.get("role")
 
   lazy val caption: Option[String] = fields.get("caption")

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -52,7 +52,7 @@ trait ImageContainer extends Element {
     }
   }
 
-  lazy val isLightboxable: Boolean = largestEditorialCrop.map(_.width).getOrElse(0) > 620
+  lazy val isLightboxable: Boolean = largestEditorialCrop.map(_.width).getOrElse(0) > 620 && (largestEditorialCrop.map(_.ratio).getOrElse(0) > 0.7)
 }
 
 object ImageContainer {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -492,17 +492,7 @@ class Article(content: ApiContentWithMeta) extends Content(content) with Lightbo
     leftColElements.isDefined
   }
 
-  override lazy val lightboxImages = mainPicture.toSeq ++ bodyImages
-
-  lazy val bodyLightboxImages = bodyImages.zip(bodyImages.map(_.largestEditorialCrop)).filter({
-    case (_, Some(crop)) => crop.width > 620
-    case _ => false
-  })
-
-  lazy val isMainImageLightboxable: Boolean = {
-    val isBigPicture = mainPicture.filter(_.largestEditorialCrop.nonEmpty).find(_.largestEditorialCrop.map(_.width).filter(_ > 620).size > 0)
-    isBigPicture.isDefined
-  }
+  lazy val zippedBodyImages = bodyFiltered.zip(bodyFiltered.map(_.largestEditorialCrop))
 
   lazy val linkCounts = LinkTo.countLinks(body) + standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
 
@@ -555,7 +545,7 @@ class LiveBlog(content: ApiContentWithMeta) extends Article(content) {
   }
 
   override def metaData: Map[String, JsValue] = super.metaData ++ cricketMetaData
-  override lazy val lightboxImages = mainPicture.toSeq
+  override lazy val lightboxImages = mainFiltered
 
   lazy val latestUpdateText = LiveBlogParser.parse(body) collectFirst {
     case Block(_, _, _, _, BlockToText(text), _) if !text.trim.nonEmpty => text
@@ -686,7 +676,6 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) with Lightbo
 
   lazy val galleryImages: Seq[ImageElement] = images.filter(_.isGallery)
   override lazy val lightboxImages = galleryImages
-  override lazy val minLightboxWidth = 0
   lazy val largestCrops: Seq[ImageAsset] = galleryImages.flatMap(_.largestImage)
 
   override def cards: List[(String, String)] = super.cards ++ Seq(
@@ -708,14 +697,14 @@ object Gallery {
 }
 
 trait Lightboxable extends Content {
+  lazy val mainFiltered = mainPicture.filter(_.largestEditorialCrop.map(_.ratio).getOrElse(0) > 0.7).filter(_.largestEditorialCrop.map(_.width).getOrElse(1) > 620).toSeq
+  lazy val bodyFiltered = bodyImages.filter(_.largestEditorialCrop.map(_.width).getOrElse(1) > 620).toSeq
+  lazy val lightboxImages: Seq[ImageContainer] = mainFiltered ++ bodyFiltered
 
-  lazy val lightboxImages: Seq[ImageContainer] = List()
-  lazy val minLightboxWidth = 620
   lazy val lightbox: JsObject = {
-    val allImages: Seq[ImageContainer] = lightboxImages
-    val imageContainers = allImages.filter(_.largestEditorialCrop.nonEmpty)
+    val imageContainers = lightboxImages.filter(_.largestEditorialCrop.nonEmpty)
     val imageJson = imageContainers.map { imgContainer =>
-      imgContainer.largestEditorialCrop.filter(_.width > minLightboxWidth).map { img =>
+      imgContainer.largestEditorialCrop.map { img =>
         JsObject(Seq(
           "caption" -> JsString(img.caption.getOrElse("")),
           "credit" -> JsString(img.credit.getOrElse("")),
@@ -762,7 +751,6 @@ class ImageContent(content: ApiContentWithMeta) extends Content(content) with Li
     "contentType" -> JsString(contentType),
     "lightboxImages" -> lightbox
   )
-  override lazy val lightboxImages = mainPicture.toSeq
 }
 
 case class ApiContentWithMeta(

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -189,14 +189,13 @@ case class PictureCleaner(article: Article) extends HtmlCleaner with implicits.N
 
   def addSharesAndFullscreen(body: Document): Document = {
     if(!article.isLiveBlog) {
-      article.bodyLightboxImages.zipWithIndex map {
+      article.zippedBodyImages.zipWithIndex map {
         case ((imageElement, Some(crop)), index) =>
           body.select("[data-media-id=" + imageElement.id + "]").map { fig =>
-            val linkIndex = (index + (if (article.isMainImageLightboxable) 2 else 1)).toString
+            val linkIndex = (index + (if (article.mainFiltered.size > 0) 2 else 1)).toString
             val hashSuffix = "img-" + linkIndex
             fig.attr("id", hashSuffix)
             fig.addClass("fig--narrow-caption")
-
             fig.getElementsByTag("img").foreach { img =>
               val html = views.html.fragments.share.blockLevelSharing(hashSuffix, article.elementShares(Some(hashSuffix), crop.url), article.contentType)
               img.after(html.toString())


### PR DESCRIPTION
This refactor cleans up a lot of duplicate code for launching the lightbox on different content types by moving more of the logic into the lightboxable trait.

Also now preventing long vertical cartoons from being lightboxable by checking the width/height ratio. This is important because long cartoons often get smaller in the lightbox view, thus making the feature redundant, for example:

![lightboxgif2](https://cloud.githubusercontent.com/assets/2236852/5613222/cb8b5456-94d8-11e4-9523-9eefa9aab601.gif)
