### PR TITLE
Update Sentry public key and host for new service

### DIFF
--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -62,8 +62,8 @@ guardian.page.idApiJsClientToken=frontend-code-js-client-token
 guardian.page.onwardWebSocket=ws://code.api.nextgen.guardianapps.co.uk/recently-published
 guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
-guardian.page.sentryApiKey=33fa498f015d4d66b90d5ee27fa45b54
-guardian.page.sentryHost=frontend-sentrylo-35h427x3sdhb-2122817448.eu-west-1.elb.amazonaws.com/2
+guardian.page.sentryPublicApiKey=344003a8d11c41d8800fbad8383fdc50
+guardian.page.sentryHost=app.getsentry.com/35463
 guardian.page.externalEmbedHost=https://embed.theguardian.com/embed/video/
 
 # Beacon

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -54,8 +54,8 @@ guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.onwardWebSocket=wss://frontend-OnwardLo-G3SS42I4G3PN-384008737.eu-west-1.elb.amazonaws.com/recently-published
 guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
-guardian.page.sentryPublicApiKey=49094b9a8f3d48889e30b9f2f36b7d19
-guardian.page.sentryHost=frontend.errors.guim.co.uk/2
+guardian.page.sentryPublicApiKey=344003a8d11c41d8800fbad8383fdc50
+guardian.page.sentryHost=app.getsentry.com/35463
 guardian.page.externalEmbedHost=https://embed.theguardian.com/embed/video/
 
 memcached.host=127.0.0.1:11211

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -57,8 +57,8 @@ guardian.page.idApiJsClientToken=ARwXnPbUzJ9T2qcUJRv15DuT_LkxAKnUqtdrHdx7XXtQrKp
 guardian.page.onwardWebSocket=ws://api.nextgen.guardianapps.co.uk/recently-published
 guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
-guardian.page.sentryPublicApiKey=49094b9a8f3d48889e30b9f2f36b7d19
-guardian.page.sentryHost=frontend.errors.guim.co.uk/2
+guardian.page.sentryPublicApiKey=344003a8d11c41d8800fbad8383fdc50
+guardian.page.sentryHost=app.getsentry.com/35463
 guardian.page.externalEmbedHost=https://embed.theguardian.com/embed/video/
 
 # Beacon


### PR DESCRIPTION
We are moving our Sentry service from a self hosted instance to their managed SaaS version at: https://getsentry.com/welcome/

This simply updates the keys and host the raven client uses to post the data.

/cc @ironsidevsquincy @rich-nguyen @gklopper 
