### PR TITLE
Upgrade sbt to 13.7

### DIFF
--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -40,15 +40,17 @@ trait Prototypes {
       "Akka" at "http://repo.akka.io/releases",
       "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
       "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",
-      "JBoss Releases" at "https://repository.jboss.org/nexus/content/repositories/releases"
+      "JBoss Releases" at "https://repository.jboss.org/nexus/content/repositories/releases",
+      "BionicSpirit Releases" at "http://maven.bionicspirit.com/releases/",
+      "Spy" at "https://files.couchbase.com/maven2/"
     ),
 
-    resolvers ++= Seq(
-      // where Shade lives
-      "BionicSpirit Releases" at "http://maven.bionicspirit.com/releases/",
-      // for SpyMemcached
-      "Spy" at "https://files.couchbase.com/maven2/"
-    )
+    updateOptions := updateOptions.value.withCachedResolution(true),
+
+    evictionWarningOptions in update := EvictionWarningOptions.default
+      .withWarnTransitiveEvictions(false)
+      .withWarnDirectEvictions(false)
+      .withWarnScalaVersionEviction(false)
   )
 
   val frontendClientSideSettings = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7


### PR DESCRIPTION
I've hidden the ivy warnings, but I don't mind because 1. the ivy resolution is already happening, and 2. we can't fix a lot of them.

Info about minigraph caching: http://www.scala-sbt.org/0.13/docs/Cached-Resolution.html
