### PR TITLE
Fix font display on win/chrome

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -24,7 +24,8 @@
             ("has-localnav", Navigation.topLevelItem(edition.navigation, metaData).filter(_.links.nonEmpty).nonEmpty),
             ("childrens-books-site", metaData.section == "childrens-books-site")))"
         itemscope itemtype="http://schema.org/WebPage">
-        <div style="transform: translateZ(0)"></div>
+
+        <div style="-webkit-transform: translateZ(0)" class="desktop-only">@* hack to fix fonts in win/chrome with font-smoothing disabled *@</div>
 
         @fragments.message(metaData)
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -24,6 +24,7 @@
             ("has-localnav", Navigation.topLevelItem(edition.navigation, metaData).filter(_.links.nonEmpty).nonEmpty),
             ("childrens-books-site", metaData.section == "childrens-books-site")))"
         itemscope itemtype="http://schema.org/WebPage">
+        <div style="transform: translateZ(0)"></div>
 
         @fragments.message(metaData)
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -25,7 +25,7 @@
             ("childrens-books-site", metaData.section == "childrens-books-site")))"
         itemscope itemtype="http://schema.org/WebPage">
 
-        <div style="-webkit-transform: translateZ(0)" class="desktop-only">@* hack to fix fonts in win/chrome with font-smoothing disabled *@</div>
+        <div class="win-chrome-font-fix">@* hack to fix fonts in win/chrome with font-smoothing disabled *@</div>
 
         @fragments.message(metaData)
 

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -219,3 +219,11 @@
     margin: 0;
     padding: 0;
 }
+
+// smooth fonts in chrome/windows where font-smoothing is disabled
+// for all inline elements following this one (instead of just the larger ones)
+.win-chrome-font-fix {
+    @include mq(desktop) {
+        -webkit-transform: translateZ(0);
+    }
+}


### PR DESCRIPTION
fixes #7630

Egyptian text below 18px displays badly in chrome on windows where font-smoothing is disabled:

![screen shot 2015-01-05 at 16 54 23](https://cloud.githubusercontent.com/assets/867233/5616374/d3e9ce34-94fb-11e4-8637-1fe37f9fb833.png)

This curious hack renders all text that follows the new element smoothly:

![screen shot 2015-01-05 at 16 56 15](https://cloud.githubusercontent.com/assets/867233/5616407/097af1ea-94fc-11e4-877e-b8c073e4ed28.png)

It's in the DOM by default to avoid layout thrashing on initial load, given this happens mainly on old machines anyway. 

The overhead on more modern machines should be minimal; the vendor-prefix means it will be ignored by non-webkit browsers (and newer chromes that drop support for it, etc), and only on desktops too (both good ideas from @sammorrisdesign :star:).

cc @mattandrews @paperboyo @ironsidevsquincy
