### PR TITLE
prevent PNG resizer attempting scale-ups

### DIFF
--- a/png-resizer/app/lib/Im4Java.scala
+++ b/png-resizer/app/lib/Im4Java.scala
@@ -2,7 +2,7 @@ package lib
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
-import org.im4java.core.{ConvertCmd, IMOperation}
+import org.im4java.core.{Info, ConvertCmd, IMOperation}
 import org.im4java.process.Pipe
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -36,4 +36,10 @@ object Im4Java {
 
     apply(operation)(imageBytes)
   }
+
+  def getWidth(imageBytes: Array[Byte]) = Future {
+    val imageInfo = new Info("png:-", new ByteArrayInputStream(imageBytes),true);
+    imageInfo.getImageWidth()
+  }
+
 }


### PR DESCRIPTION
the PNG resizer was getting requests to increase images up to sizes as large as 1920 pixels, which can take up to 25 seconds (this is pointless for many reasons).  In no situation could it be a benefit to scale an image up, so I've made it redirect to the original in that situation.

An alternative course could be to just refuse to scale images to any size bigger than (say) 500 pixels, which would save the download time of the image.

I'm also considering makeing a 4 second timeout on the resize, and serving a redirect cached for a day, so we don't spend a long time resizing something after fastly has given up, the user getting a 5xx, and then us get a retry the next time someone wants the same image, thus perpetuating the wasteful cycle.  But I might wait for stats on max response time after this one goes in before I do that.

Thoughts @robertberry @gklopper ?
