### PR TITLE
Video errors

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -182,7 +182,7 @@ define([
             raven.captureException(new Error(err.message), {
                 tags: {
                     feature: 'player',
-                    code: err.code
+                    vjsCode: err.code
                 }
             });
         }

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -178,7 +178,7 @@ define([
     }
 
     function beaconError(err) {
-        if (err && 'message' in err) {
+        if (err && 'message' in err && 'code' in err) {
             raven.captureException(new Error(err.message), {
                 tags: {
                     feature: 'player',
@@ -198,8 +198,8 @@ define([
     }
 
     function bindErrorHandler(player) {
-        player.on('error', function (e) {
-            beaconError(e);
+        player.on('error', function () {
+            beaconError(player.error());
         });
     }
 
@@ -360,15 +360,14 @@ define([
                 }
             });
 
-            player.guMediaType = mediaType;
+            // Location of this is important.
+            bindErrorHandler(player);
 
-            //Location of this is important
-            handleInitialMediaError(player);
+            player.guMediaType = mediaType;
 
             player.ready(function () {
                 var vol;
 
-                bindErrorHandler(player);
                 initLoadingSpinner(player);
                 bindGlobalEvents(player);
                 upgradeVideoPlayerAccessibility(player);


### PR DESCRIPTION
It turns out we were passing the error `Event` passed to the bound callback, and not the correct vjs error `Object`, which the `beaconError` function was expecting. This was preventing us from beaconing the actual message and error code.

I've also done some slight refactoring:
- positions in which we invoke the error handling functions
- renamed key passed to Sentry to something more descriptive

/cc @rich-nguyen @gklopper 
