### PR TITLE
Quotemark + non-linked kicker fix

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.items.elements.facia_cards.itemHeader
 @import views.support._
 
-@headline() = {<span class="@labelCssClasses">@RemoveOuterParaHtml(header.headline)</span>}
+@headline() = {<span class="@labelCssClasses fc-item__headline">@RemoveOuterParaHtml(header.headline)</span>}
 
 @articleLink(html: Html) = {<a href="@header.url.get(request)" class="fc-item__link" data-link-name="article">@html</a>}
 

--- a/static/src/stylesheets/module/facia/_icons.scss
+++ b/static/src/stylesheets/module/facia/_icons.scss
@@ -45,7 +45,7 @@
 }
 
 .fc-item__title--quoted {
-    .fc-item__link {
+    .u-faux-block-link__cta {
         @include icon(quote-grey, false);
         display: inline !important;
         background-size: 1.2em .75em !important;
@@ -53,27 +53,27 @@
         padding-left: 1.4em;
     }
 
-    .tone-podcast--item & .fc-item__link {
+    .tone-podcast--item & .u-faux-block-link__cta {
         @include icon(quote-white, false);
     }
 
-    .tone-feature--item & .fc-item__link {
+    .tone-feature--item & .u-faux-block-link__cta {
         @include icon(quote-light-pink, false);
     }
 
-    .tone-live--item & .fc-item__link {
+    .tone-live--item & .u-faux-block-link__cta {
         @include icon(quote-white, false);
     }
 
-    .tone-media--item & .fc-item__link {
+    .tone-media--item & .u-faux-block-link__cta {
         @include icon(quote-white, false);
     }
 
-    .tone-editorial--item & .fc-item__link {
+    .tone-editorial--item & .u-faux-block-link__cta {
         @include icon(quote-white, false);
     }
 
-    .tone-review--item & .fc-item__link {
+    .tone-review--item & .u-faux-block-link__cta {
         @include icon(quote-white, false);
     }
 }

--- a/static/src/stylesheets/module/facia/_icons.scss
+++ b/static/src/stylesheets/module/facia/_icons.scss
@@ -45,7 +45,7 @@
 }
 
 .fc-item__title--quoted {
-    .u-faux-block-link__cta {
+    .fc-item__headline {
         @include icon(quote-grey, false);
         display: inline !important;
         background-size: 1.2em .75em !important;
@@ -53,27 +53,27 @@
         padding-left: 1.4em;
     }
 
-    .tone-podcast--item & .u-faux-block-link__cta {
+    .tone-podcast--item & .fc-item__headline {
         @include icon(quote-white, false);
     }
 
-    .tone-feature--item & .u-faux-block-link__cta {
+    .tone-feature--item & .fc-item__headline {
         @include icon(quote-light-pink, false);
     }
 
-    .tone-live--item & .u-faux-block-link__cta {
+    .tone-live--item & .fc-item__headline {
         @include icon(quote-white, false);
     }
 
-    .tone-media--item & .u-faux-block-link__cta {
+    .tone-media--item & .fc-item__headline {
         @include icon(quote-white, false);
     }
 
-    .tone-editorial--item & .u-faux-block-link__cta {
+    .tone-editorial--item & .fc-item__headline {
         @include icon(quote-white, false);
     }
 
-    .tone-review--item & .u-faux-block-link__cta {
+    .tone-review--item & .fc-item__headline {
         @include icon(quote-white, false);
     }
 }


### PR DESCRIPTION
This problem started happening after  @robertberry's changes to include the kicker as part of the headline, if the kicker isn't a link. Examples below; first item has a linked kicker, second item doesn't showing the issue.

Before:
![screen shot 2015-01-06 at 17 11 04](https://cloud.githubusercontent.com/assets/1607666/5632480/039b7594-95c7-11e4-9ab1-087e819da903.png)

After:
![screen shot 2015-01-06 at 17 09 33](https://cloud.githubusercontent.com/assets/1607666/5632471/f49ef0fc-95c6-11e4-8236-210e53579ce2.png)
