### PR TITLE
Remove blog tags from seriesId

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -93,8 +93,14 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     .map(_.id).map(Reference(_)).map(_._2)
 
   lazy val seriesMeta = {
-    blogsAndSeries.filterNot{ tag => tag.id == "commentisfree/commentisfree"}.headOption.map( series =>
+    series.filterNot{ tag => tag.id == "commentisfree/commentisfree"}.headOption.map( series =>
       Seq(("series", JsString(series.name)), ("seriesId", JsString(series.id)))
+    ) getOrElse Nil
+  }
+
+  lazy val blogMeta = {
+    blogs.headOption.map( blog =>
+      Seq(("blog", JsString(blog.name)), ("blogId", JsString(blog.id)))
     ) getOrElse Nil
   }
 
@@ -156,6 +162,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     super.metaData ++ Map(
       ("keywords", JsString(keywords.map { _.name }.mkString(","))),
       ("keywordIds", JsString(keywords.map { _.id }.mkString(","))),
+      ("nonKeywordTagIds", JsString(nonKeywordTags.map { _.id }.mkString(","))),
       ("publication", JsString(publication)),
       ("headline", JsString(headline)),
       ("webPublicationDate", Json.toJson(webPublicationDate)),
@@ -177,7 +184,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
       ("sectionName", JsString(sectionName)),
       ("showRelatedContent", JsBoolean(showInRelated)),
       ("productionOffice", JsString(productionOffice.getOrElse("")))
-    ) ++ Map(seriesMeta: _*)
+    ) ++ Map(seriesMeta: _*) ++ Map(blogMeta: _*)
   }
 
   override lazy val cacheSeconds = {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -98,12 +98,6 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     ) getOrElse Nil
   }
 
-  lazy val blogMeta = {
-    blogs.headOption.map( blog =>
-      Seq(("blog", JsString(blog.name)), ("blogId", JsString(blog.id)))
-    ) getOrElse Nil
-  }
-
   private lazy val fields: Map[String, String] = delegate.safeFields
 
   // Inherited from Trail
@@ -171,7 +165,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
       ("tones", JsString(tones.map(_.name).mkString(","))),
       ("toneIds", JsString(tones.map(_.id).mkString(","))),
       ("blogs", JsString(blogs.map { _.name }.mkString(","))),
-      ("blogIds", JsString(blogs.map { _.id.split("/").last }.mkString(","))),
+      ("blogIds", JsString(blogs.map { _.id.last }.mkString(","))),
       ("commentable", JsBoolean(isCommentable)),
       ("hasStoryPackage", JsBoolean(fields.get("hasStoryPackage").exists(_.toBoolean))),
       ("pageCode", JsString(fields("internalPageCode"))),
@@ -184,7 +178,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
       ("sectionName", JsString(sectionName)),
       ("showRelatedContent", JsBoolean(showInRelated)),
       ("productionOffice", JsString(productionOffice.getOrElse("")))
-    ) ++ Map(seriesMeta: _*) ++ Map(blogMeta: _*)
+    ) ++ Map(seriesMeta: _*)
   }
 
   override lazy val cacheSeconds = {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -237,13 +237,13 @@ trait Tags {
   private def tagsOfType(tagType: String): Seq[Tag] = tags.filter(_.tagType == tagType)
 
   lazy val keywords: Seq[Tag] = tagsOfType("keyword")
+  lazy val nonKeywordTags: Seq[Tag] = tags.filterNot(_.tagType == "keyword")
   lazy val contributors: Seq[Tag] = tagsOfType("contributor")
   lazy val isContributorPage: Boolean = contributors.nonEmpty
   lazy val series: Seq[Tag] = tagsOfType("series")
   lazy val blogs: Seq[Tag] = tagsOfType("blog")
   lazy val tones: Seq[Tag] = tagsOfType("tone")
   lazy val types: Seq[Tag] = tagsOfType("type")
-  lazy val blogsAndSeries: Seq[Tag] = tags.filter{ tag => tag.tagType == "series" || tag.tagType == "blog"}
 
   def isSponsored: Boolean
   def hasMultipleSponsors: Boolean = DfpAgent.hasMultipleSponsors(tags)

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -178,7 +178,7 @@ define([
             },
 
             transcludeOnwardContent: function () {
-                if ('seriesId' in config.page && 'showRelatedContent' in config.page && config.page.showRelatedContent) {
+                if ((config.page.seriesId || config.page.blogId) && config.page.showRelatedContent) {
                     new Onward(qwery('.js-onward'));
                 } else if (config.page.tones !== '') {
                     $('.js-onward').each(function (c) {

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -178,7 +178,7 @@ define([
             },
 
             transcludeOnwardContent: function () {
-                if ((config.page.seriesId || config.page.blogId) && config.page.showRelatedContent) {
+                if ((config.page.seriesId || config.page.blogIds) && config.page.showRelatedContent) {
                     new Onward(qwery('.js-onward'));
                 } else if (config.page.tones !== '') {
                     $('.js-onward').each(function (c) {

--- a/static/src/javascripts/projects/common/modules/onward/onward-content.js
+++ b/static/src/javascripts/projects/common/modules/onward/onward-content.js
@@ -34,7 +34,7 @@ define([
         badges.add(container);
         images.upgrade(this.context);
         register.end('series-content');
-        mediator.emit('modules:onward:loaded')
+        mediator.emit('modules:onward:loaded');
     };
 
     OnwardContent.prototype.error = function () {

--- a/static/src/javascripts/projects/common/modules/onward/onward-content.js
+++ b/static/src/javascripts/projects/common/modules/onward/onward-content.js
@@ -1,6 +1,7 @@
 define([
     'lodash/arrays/union',
     'common/utils/config',
+    'common/utils/mediator',
     'common/modules/analytics/register',
     'common/modules/commercial/badges',
     'common/modules/component',
@@ -8,6 +9,7 @@ define([
 ], function (
     union,
     config,
+    mediator,
     register,
     badges,
     Component,
@@ -15,7 +17,8 @@ define([
 ) {
 
     var getTag = function () {
-        return union(config.page.nonKeywordTagIds.split(','), [config.page.seriesId, config.page.blogId]).shift();
+        var seriesAndBlogTags = config.page.blogIds.split(',').concat([config.page.seriesId]);
+        return union(config.page.nonKeywordTagIds.split(','), seriesAndBlogTags).shift();
     };
 
     function OnwardContent(context) {
@@ -31,6 +34,7 @@ define([
         badges.add(container);
         images.upgrade(this.context);
         register.end('series-content');
+        mediator.emit('modules:onward:loaded')
     };
 
     OnwardContent.prototype.error = function () {

--- a/static/src/javascripts/projects/common/modules/onward/onward-content.js
+++ b/static/src/javascripts/projects/common/modules/onward/onward-content.js
@@ -1,20 +1,27 @@
 define([
+    'lodash/arrays/union',
     'common/utils/config',
     'common/modules/analytics/register',
     'common/modules/commercial/badges',
     'common/modules/component',
     'common/modules/ui/images'
 ], function (
+    union,
     config,
     register,
     badges,
     Component,
     images
 ) {
+
+    var getTag = function () {
+        return union(config.page.nonKeywordTagIds.split(','), [config.page.seriesId, config.page.blogId]).shift();
+    };
+
     function OnwardContent(context) {
         register.begin('series-content');
         this.context = context;
-        this.endpoint = '/series/' + config.page.seriesId + '.json?shortUrl=' + encodeURIComponent(config.page.shortUrl);
+        this.endpoint = '/series/' + getTag() + '.json?shortUrl=' + encodeURIComponent(config.page.shortUrl);
         this.fetch(this.context, 'html');
     }
 
@@ -31,4 +38,5 @@ define([
     };
 
     return OnwardContent;
+
 });

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -32,7 +32,7 @@ define([
                         seriesId: 'film/series/filmweekly',
                         pageId: 'football/series/footballweekly',
                         keywordIds: 'uk-news/prince-charles-letters,uk/uk,uk/prince-charles',
-                        blogIds: 'blog',
+                        blogIds: 'a/blog',
                         videoDuration: 63
                     };
                     mocks.store['common/utils/config'].switches = {

--- a/static/test/javascripts/spec/common/onward/onward-content.spec.js
+++ b/static/test/javascripts/spec/common/onward/onward-content.spec.js
@@ -1,0 +1,62 @@
+define([
+    'helpers/injector'
+], function (
+    Injector
+) {
+
+    return new Injector()
+        .store(['common/utils/config', 'common/utils/mediator'])
+        .require(['common/modules/onward/onward-content', 'mocks'], function (OnwardContent, mocks) {
+
+            describe('Onward Content', function () {
+
+                var server;
+
+                beforeEach(function () {
+                    mocks.store['common/utils/config'].page = {
+                        shortUrl: 'http://gu.com/p/42zeg',
+                        blogIds: 'global-development/poverty-matters',
+                        seriesId: 'global-development/series/modern-day-slavery-in-focus'
+                    };
+
+                    // set up fake server
+                    server = sinon.fakeServer.create();
+                    server.autoRespond = true;
+                    server.autoRespondAfter = 20;
+                });
+
+                afterEach(function () {
+                    server.restore();
+                });
+
+                it('should exist', function () {
+                    expect(OnwardContent).toBeDefined();
+                });
+
+                it('should use blog tag if first', function (done) {
+                    mocks.store['common/utils/config'].page.nonKeywordTagIds =
+                        'global-development/poverty-matters,global-development/series/modern-day-slavery-in-focus';
+                    server.respondWith('/series/global-development/poverty-matters.json?shortUrl=http%3A%2F%2Fgu.com%2Fp%2F42zeg', [200, {}, '']);
+                    new OnwardContent();
+
+                    mocks.store['common/utils/mediator'].once('modules:onward:loaded', function () {
+                        done();
+                    });
+                });
+
+                it('should use series tag if first', function (done) {
+                    mocks.store['common/utils/config'].page.nonKeywordTagIds =
+                        'global-development/series/modern-day-slavery-in-focus,global-development/poverty-matters';
+                    server.respondWith('/series/global-development/series/modern-day-slavery-in-focus.json?shortUrl=http%3A%2F%2Fgu.com%2Fp%2F42zeg', [200, {}, '']);
+                    new OnwardContent();
+
+                    mocks.store['common/utils/mediator'].once('modules:onward:loaded', function () {
+                        done();
+                    });
+                });
+
+            });
+
+        });
+
+});


### PR DESCRIPTION
Previously, `seriesId` on the page object was returning both series and blog tags (whichever one was first in the tag list). This breaks some sponsored pages

Reason for this is the series container can be populated with either the page's blog or series tag.

Now `seriesId` will only ever return a series tag, and `OnwardContent` module uses the blog information if it's available

cc: @NathanielBennett 
