### PR TITLE
Added UK jobs link to AU footer links

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -82,6 +82,8 @@
                     masterclasses</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : subscribe" target="_blank" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
                     subscribe</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
+                    UK jobs</a></li>
             }
         <li class="colophon__item"><a data-link-name="all topics" href="/index/subjects/a">all topics</a></li>
         <li class="colophon__item"><a data-link-name="all contributors" href="/index/contributors">all contributors</a></li>


### PR DESCRIPTION
Quickly adding 'UK jobs' link to AU footer links.
![screen shot 2015-01-06 at 17 50 23](https://cloud.githubusercontent.com/assets/2579465/5633152/5e8f4976-95cc-11e4-828a-cae5d30e18b4.png)
