### PR TITLE
Visual changes for breaking news

### DIFF
--- a/facia-tool/app/views/priority.scala.html
+++ b/facia-tool/app/views/priority.scala.html
@@ -12,6 +12,9 @@
     <div class="front-priorities--priority">
         <a href="/training">Training Fronts</a>
     </div>
+    <div class="front-priorities--priority">
+        <a href="/editorial?layout=latest,front:breaking-news">Breaking News</a>
+    </div>
     <div class="front-priorities--extra">
         Bookmarklets:
         <a href="javascript:window.location.href='https://fronts.gutools.co.uk/editorial?layout=latest,front:'+window.location.pathname.replace(/^\/|\/$/g,'');">Edit PROD front</a> ·

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -625,6 +625,10 @@ h1 {
     background: #FFF8E1;
 }
 
+.front-container.attention {
+    background: #b51800;
+}
+
 .col__inner {
     padding: 10px 10px 15px 15px;
 }
@@ -1739,6 +1743,10 @@ collection-widget {
     padding: 5px 10px;
     border: 1px solid #ddd;
     background-color: #fff;
+}
+
+.attention collection-widget {
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.32), 0 1px 6px rgba(0, 0, 0, 0.32);
 }
 
 .article-group {

--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -317,6 +317,9 @@ define([
     };
 
     Collection.prototype.refreshVisibleStories = function (stale) {
+        if (this.front.requiresConfirmation()) {
+            return this.state.showIndicators(false);
+        }
         if (!stale || !this.visibleStories) {
             this.visibleStories = fetchVisibleStories(
                 this.configMeta.type(),

--- a/facia-tool/public/js/models/collections/main.js
+++ b/facia-tool/public/js/models/collections/main.js
@@ -103,6 +103,7 @@ define([
                     })
                     .without(undefined)
                     .without('testcard')
+                    .difference(vars.CONST.askForConfirmation)
                     .sortBy(function(path) { return path; })
                     .value();
 

--- a/facia-tool/public/js/modules/vars.js
+++ b/facia-tool/public/js/modules/vars.js
@@ -32,6 +32,10 @@ define([
             'breaking-news'
         ],
 
+        askForConfirmation: [
+            'breaking-news'
+        ],
+
         detectPressFailureMs: 10000,
 
         maxFronts: 500,

--- a/facia-tool/public/js/widgets/fronts.html
+++ b/facia-tool/public/js/widgets/fronts.html
@@ -1,6 +1,7 @@
 <div class="front-container" data-bind="css: {
     'live-mode': liveMode,
-    'draft-mode': !liveMode()
+    'draft-mode': !liveMode(),
+    'attention': requiresConfirmation()
 }">
     <div class="modes" data-bind="
         css: {
@@ -37,9 +38,11 @@
         </span>
     </div>
 
-    <div class="col__inner front-selector">
-        <select data-bind="options: $root.fronts, value: front, optionsCaption: 'choose a front...'"></select>
-    </div>
+    <!-- ko ifnot: requiresConfirmation() -->
+        <div class="col__inner front-selector">
+            <select data-bind="options: $root.fronts, value: front, optionsCaption: 'choose a front...'"></select>
+        </div>
+    <!-- /ko -->
 
     <div class="col__inner scrollable collection-container" data-bind="foreach: collections">
         <collection-widget params="context: $context" data-bind="ownerClass: $data"></collection-widget>

--- a/facia-tool/public/js/widgets/fronts.js
+++ b/facia-tool/public/js/widgets/fronts.js
@@ -232,6 +232,10 @@ define([
         return meta === this.uiOpenElement();
     };
 
+    Front.prototype.requiresConfirmation = function () {
+        return _.contains(vars.CONST.askForConfirmation, this.front());
+    };
+
     Front.prototype.dispose = function () {
         this.listeners.dispose();
         _.each(this.setIntervals, function (timeout) {


### PR DESCRIPTION
It's not possible anymore to select `breaking-news` front the front select, but a link is provided in the landing page.

The background changes to reflect the importance of breaking news.

This is how it looks like
![screen shot 2015-01-07 at 14 50 27](https://cloud.githubusercontent.com/assets/680284/5647306/b2e873c0-967c-11e4-9770-d822797b501b.png)
