### PR TITLE
stop sublinks underlining when hovering on an item link

### DIFF
--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -68,7 +68,7 @@
     &:active,
     &:focus {
         .headline-list__body,
-        .fc-item__link {
+        .fc-item__headline {
             text-decoration: underline;
         }
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -155,13 +155,6 @@ $fc-hover-transition: .25s ease;
         }
     }
 
-    .fc-item__link,
-    .fc-sublink__link {
-        &:visited {
-            color: mix(colour(neutral-1), #ffffff, 80%);
-        }
-    }
-
     // This is a temp fix until we completely remove tone-colour from fc-item
     .tone-colour,
     .tone-colour:hover,
@@ -376,6 +369,26 @@ $fc-hover-transition: .25s ease;
             height: auto;
             width: 100%;
             bottom: auto;
+        }
+    }
+}
+
+.fc-item__link,
+.fc-sublink__link {
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
+    &:visited {
+        color: mix(colour(neutral-1), #ffffff, 80%);
+    }
+}
+
+.fc-item__link {
+    &:hover,
+    &:focus {
+        .fc-item__headline {
+            text-decoration: underline;
         }
     }
 }


### PR DESCRIPTION
before

![screen shot 2015-01-07 at 15 05 29](https://cloud.githubusercontent.com/assets/867233/5647518/9e3200ca-967e-11e4-814e-da648dd7a9bf.png)

after

![screen shot 2015-01-07 at 15 05 45](https://cloud.githubusercontent.com/assets/867233/5647523/a449008a-967e-11e4-9312-d2fc3248a990.png)
