### PR TITLE
Gallery share buttons fixes

### DIFF
--- a/common/app/views/fragments/share/blockLevelSharing.scala.html
+++ b/common/app/views/fragments/share/blockLevelSharing.scala.html
@@ -3,10 +3,8 @@
 <div class="block-share block-share--@contentType.toLowerCase hide-on-mobile" data-link-name="block share">
 
     @shareItems.map { item: model.ShareLink =>
-        <a class="block-share__link js-blockshare-link" href="@item.href" target="_blank" data-link-name="social @item.css">
-            <div class="rounded-icon block-share__item block-share__item--@item.css">
-                <i class="i"></i><span class="u-h">@item.text</span>
-            </div>
+        <a class="rounded-icon block-share__item block-share__item--@item.css js-blockshare-link" href="@item.href" target="_blank" data-link-name="social @item.css">
+            <i class="i"></i><span class="u-h">@item.text</span>
         </a>
     }
 

--- a/static/src/javascripts/projects/common/views/content/share-button.html
+++ b/static/src/javascripts/projects/common/views/content/share-button.html
@@ -1,6 +1,4 @@
-<a class="block-share__link js-blockshare-link" href="{{url}}" target="_blank" data-link-name="social {{css}}">
-    <div class="block-share__item block-share__item--{{css}}">
-        <i class="i"></i>
-        <span class="u-h">{{text}}</span>
-    </div>
+<a class="rounded-icon block-share__item block-share__item--{{css}} js-blockshare-link" href="{{url}}" target="_blank" data-link-name="social {{css}}">
+    <i class="i"></i>
+    <span class="u-h">{{text}}</span>
 </a>

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -1,12 +1,9 @@
 // Default
 
-.block-share__link {
+.block-share__item {
     display: block;
     float: left;
     cursor: pointer;
-}
-
-.block-share__item {
     border: 1px solid colour(neutral-3);
     margin-right: $gs-gutter / 4;
     width: $gs-baseline * 2;


### PR DESCRIPTION
Some fixing of missed things from https://github.com/guardian/frontend/pull/7637 and refactoring.

Before:
![screen shot 2015-01-07 at 16 41 45](https://cloud.githubusercontent.com/assets/2579465/5649282/8fa3e9de-968c-11e4-98c6-84e0625efd20.png)

After:
![screen shot 2015-01-07 at 16 41 22](https://cloud.githubusercontent.com/assets/2579465/5649284/98285f7c-968c-11e4-8551-a786c6bdbae2.png)
![screen shot 2015-01-07 at 16 41 27](https://cloud.githubusercontent.com/assets/2579465/5649285/982a4274-968c-11e4-9762-f011fccc4808.png)
