### PR TITLE
Social icons on select 

### DIFF
--- a/static/src/javascripts/projects/common/views/ui/selection-sharing.html
+++ b/static/src/javascripts/projects/common/views/ui/selection-sharing.html
@@ -1,25 +1,21 @@
 <div class="selection-sharing">
     <ul class="social u-unstyled u-cf" data-component="social-selection">
-        <li class="social__item social__item--twitter" data-link-name="twitter">
-            <a  class="social__action social-icon-wrapper"
+        <li class="social__item" data-link-name="twitter">
+            <a  class="rounded-icon social-icon social-icon--twitter"
                 data-link-name="social-selection"
                 target="_blank"
                 href="#">
                 <span class="u-h">Share on Twitter</span>
-                <span class="rounded-icon social-icon social-icon--twitter">
-                    <i class="i-share-twitter--white i"></i>
-                </span>
+                <i class="i-share-twitter--white i"></i>
             </a>
         </li>
-        <li class="social__item social__item--email" data-link-name="email">
-            <a  class="social__action social-icon-wrapper"
+        <li class="social__item" data-link-name="email">
+            <a  class="rounded-icon social-icon social-icon--email"
                 data-link-name="social-selection"
                 target="_blank"
                 href="#">
                 <span class="u-h">Share via Email</span>
-                <span class="rounded-icon social-icon social-icon--email">
-                    <i class="i-share-email--white i"></i>
-                </span>
+                <i class="i-share-email--white i"></i>
             </a>
         </li>
     </ul>


### PR DESCRIPTION
This is the part 3 of rounded icons refactoring and clean up.

There is some unnecessary html in select social sharing. This can be pushed further because those two icons don't need to be wrapped inside the list. Removing it will behave in exactly the same way. I am just not sure about all those link-name data attributes. Do we need them all?
![screen shot 2015-01-07 at 17 35 58](https://cloud.githubusercontent.com/assets/2579465/5650214/4da6799a-9694-11e4-8361-edf6eea713be.png)
