### PR TITLE
Limit number of video players on tag pages

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -45,7 +45,7 @@ case class ContainerLayoutContext(
     val (content, context) = cardAndContext
 
     content.displayElement match {
-      case Some(vp: InlineVideo) =>
+      case Some(vp: InlineVideo) if content.cardTypes.showVideoPlayer =>
         if (videoPlayersRemaining > 0) {
           (content, context.copy(videoPlayersRemaining = videoPlayersRemaining - 1))
         } else {

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -12,6 +12,7 @@ import slices.MostPopular
 
 /** For de-duplicating cutouts */
 object ContainerLayoutContext {
+  val MaximumVideoPlayersPerTagPage = 1
   val MaximumVideoPlayersPerFront = 4
 
   val empty = ContainerLayoutContext(Set.empty, false, MaximumVideoPlayersPerFront)

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -52,7 +52,7 @@ case class ContainerLayoutContext(
           (content.copy(displayElement = vp.fallBack), context)
         }
 
-      case None => (content, context)
+      case _ => (content, context)
     }
   }
 

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -91,7 +91,11 @@ object IndexPage {
 
     val front = Front.fromConfigsAndContainers(
       containerDefinitions,
-      ContainerLayoutContext(Set.empty, hideCutOuts = indexPage.page.isContributorPage)
+      ContainerLayoutContext(
+        Set.empty,
+        hideCutOuts = indexPage.page.isContributorPage,
+        ContainerLayoutContext.MaximumVideoPlayersPerFront
+      )
     )
 
     val headers = grouped.map(_.dateHeadline).zipWithIndex map { case (headline, index) =>

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -94,7 +94,7 @@ object IndexPage {
       ContainerLayoutContext(
         Set.empty,
         hideCutOuts = indexPage.page.isContributorPage,
-        ContainerLayoutContext.MaximumVideoPlayersPerFront
+        ContainerLayoutContext.MaximumVideoPlayersPerTagPage
       )
     )
 


### PR DESCRIPTION
CC @gklopper 

To stop terrible performance on pages like Telly Addict:

![screen shot 2015-01-07 at 17 40 42](https://cloud.githubusercontent.com/assets/1001642/5650257/b1135264-9694-11e4-9d35-02999c742121.png)
