### PR TITLE
dont' make items so dark on hover

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -139,7 +139,7 @@ $fc-hover-transition: .25s ease;
     }
 
     .u-faux-block-link--hover {
-        background-color: colour(neutral-6);
+        background-color: colour(neutral-7);
 
         .fc-item__image-container {
             background-color: #000000;

--- a/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
@@ -4,6 +4,10 @@
         background-color: colour(neutral-7);
     }
 
+    .u-faux-block-link--hover {
+        background-color: colour(neutral-6);
+    }
+
     .fc-item__container:before,
     .flyer__container:before {
         background-color: colour(live-default);


### PR DESCRIPTION
cc @sammorrisdesign - the difference between default and hover state on standard items feels much greater than others, this lightens the hover state a notch

before

![screen shot 2015-01-07 at 18 06 30](https://cloud.githubusercontent.com/assets/867233/5650607/d5dcf76e-9697-11e4-8269-d281ba5351c1.png)

after

![screen shot 2015-01-07 at 18 06 13](https://cloud.githubusercontent.com/assets/867233/5650616/ddc3d448-9697-11e4-8bd4-37d44e882fc7.png)
