### PR TITLE
Make PNG resizer use more CPU time

### DIFF
--- a/png-resizer/app/controllers/Resizer.scala
+++ b/png-resizer/app/controllers/Resizer.scala
@@ -13,7 +13,7 @@ import model.Cached
 import play.api.Play.current
 import play.api.libs.iteratee.Enumerator
 import play.api.libs.ws.WS
-import play.api.mvc.{Action, Controller, Headers}
+import play.api.mvc._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -25,7 +25,7 @@ object Resizer extends Controller with Logging with implicits.Requests {
 
   case class CacheableContent(cacheHeaders: CacheHeaderList, content: Array[Byte])
 
-  def getPngBytesToResize(uri: String, response: PngResponse): FutureEither[CacheableContent] = eitherT {
+  def getPngBytesToResize(uri: String, response: PngResponse) = {
     val PngResponse(status, contentType, cacheHeaders, enumerator) = response
     status match {
 
@@ -34,25 +34,25 @@ object Resizer extends Controller with Logging with implicits.Requests {
 
       case NOT_MODIFIED =>
         PngResizerMetrics.notModifiedCount.increment()
-        Future.successful(-\/(NotModified.withHeaders(cacheHeaders: _*)))
+        future.point(-\/(NotModified.withHeaders(cacheHeaders: _*)))
 
       case OK if contentType == "image/png" =>
-        Future.successful(-\/(BadRequest(s"Original image $uri did not send exactly one last-modified header (${cacheHeaders.toMap.get("Last-Modified")}}). This prevents caching.")))
+        future.point(-\/(BadRequest(s"Original image $uri did not send exactly one last-modified header (${cacheHeaders.toMap.get("Last-Modified")}}). This prevents caching.")))
 
       case OK =>
-        Future.successful(-\/(BadRequest(s"Original image $uri content type ($contentType) is not " +
+        future.point(-\/(BadRequest(s"Original image $uri content type ($contentType) is not " +
           "supported. Only PNG supported.")))
 
-      case NOT_FOUND => Future.successful(-\/(NotFound(s"Unable to find source image at $uri")))
+      case NOT_FOUND => future.point(-\/(NotFound(s"Unable to find source image at $uri")))
 
-      case otherErrorCode => Future.successful(-\/(BadGateway(s"Received $otherErrorCode for $uri")))
+      case otherErrorCode => future.point(-\/(BadGateway(s"Received $otherErrorCode for $uri")))
     }
   }
 
   case class PngResponse(status: Int, contentType: String, cacheHeaders: CacheHeaderList, body: Enumerator[Array[Byte]])
   type CacheHeaderList = Seq[(String, String)]
 
-  def getUpstreamResponse(uri: String, requestHeaders: Headers): FutureEither[PngResponse] = eitherTRight {
+  def getUpstreamResponse(uri: String, requestHeaders: Headers): Future[PngResponse] = {
     val unrolledHeaders = requestHeaders.getHeaders(Seq("Cache-Control", "If-Modified-Since", "If-None-Match"))
     WS.url(uri).withHeaders(unrolledHeaders: _*).getStream().map {
       case (headers, enumerator) =>
@@ -60,46 +60,60 @@ object Resizer extends Controller with Logging with implicits.Requests {
     }
   }
 
-  def redirectScaleUpAttempts(originalWidth: Int, width: Int, fallbackUri: String) = eitherT (Future.successful {
+  def redirectScaleUpAttempts(originalWidth: Int, width: Int, fallbackUri: String) = {
     if (originalWidth <= width) {
       log.info(s"won't resize image to be bigger - $originalWidth to $width - redirecting to original")
       -\/(Cached(1.day)(TemporaryRedirect(fallbackUri)))
     } else {
       \/-()
     }
-  })
+  }
 
   def resize(backend: String, path: String, widthString: String, qualityString: String) =
     Action.async { request =>
 
       (Backends.uri(backend, path), widthString, qualityString) match {
         case (Some(uri), IntString(width), IntString(quality)) =>
-          LoadLimit {
-            log.info(s"too many requests - redirecting to $uri")
-            if (!request.isHealthcheck) {
-              PngResizerMetrics.redirectCount.increment()
-            }
-            Future.successful(Cached(60)(TemporaryRedirect(uri)))
-          } {
 
-            // Left here is the http result, right is the data that still needs computation
-            (for {
-              response <- Time(getUpstreamResponse(uri, request.headers), "download image", PngResizerMetrics.downloadTime)
-              cacheableContent <- getPngBytesToResize(uri, response)
-              CacheableContent(cacheHeaders, bytesPreResize) = cacheableContent
-              originalWidth <- eitherTRight(Im4Java.getWidth(bytesPreResize))
-              _ <- redirectScaleUpAttempts(originalWidth, width, uri)
-              resized <- Time(eitherTRight(Im4Java.resizeBufferedImage(width)(bytesPreResize)), "resize image", PngResizerMetrics.resizeTime)
-              quanted <- Time(eitherTRight(PngQuant(resized, quality)), "quantize image", PngResizerMetrics.quantizeTime)
-              result = Ok(quanted).as("image/png").withHeaders(cacheHeaders: _*)
-            } yield result).run.map(_.fold(identity,identity))
+          // Left here is the http result, right is the data that still needs computation
+          val resultEitherT = for {
+            response <- EitherT.right(Time(getUpstreamResponse(uri, request.headers), "download image", PngResizerMetrics.downloadTime))
+            cacheableContent <- eitherT(getPngBytesToResize(uri, response))
+            CacheableContent(cacheHeaders, bytesPreResize) = cacheableContent
+            originalWidth <- EitherT.right(Im4Java.getWidth(bytesPreResize))
+            _ <- eitherT(future.point(redirectScaleUpAttempts(originalWidth, width, uri)))
+            processed <- eitherT(resizeWithLoadLimit(request, uri, width, quality, bytesPreResize))
+            result = Ok(processed).as("image/png").withHeaders(cacheHeaders: _*)
+          } yield result
 
-          }
+          resultEitherT.fold(identity, identity)
 
-        case (None, _, _) => Future.successful(NotFound(s"$backend is not a backend we support"))
+        case (None, _, _) => future.point(NotFound(s"$backend is not a backend we support"))
 
-        case _ => Future.successful(BadRequest(s"width and quality must be integers"))
+        case _ => future.point(BadRequest(s"width and quality must be integers"))
       }
     }
 
+  def resizeWithLoadLimit(request: Request[AnyContent], uri: String, width: Int, quality: Int, bytesPreResize: Array[Byte]): Future[Result \/ Array[Byte]] = {
+    LoadLimit.tryOperation[Result \/ Array[Byte]] {
+      resizePngBytes(width, quality, bytesPreResize).map(\/-.apply)
+    } {
+      noCapacity(request, uri)
+    }
+  }
+
+  def noCapacity(request: Request[AnyContent], uri: String) = {
+    log.info(s"too many requests - redirecting to $uri")
+    if (!request.isHealthcheck) {
+      PngResizerMetrics.redirectCount.increment()
+    }
+    future.point(-\/(Cached(60)(TemporaryRedirect(uri))))
+  }
+
+  def resizePngBytes(width: Int, quality: Int, bytesPreResize: Array[Byte]): Future[Array[Byte]] = {
+    for {
+      resized <- Time(Im4Java.resizeBufferedImage(width)(bytesPreResize), "resize image", PngResizerMetrics.resizeTime)
+      quanted <- Time(PngQuant(resized, quality), "quantize image", PngResizerMetrics.quantizeTime)
+    } yield quanted
+  }
 }


### PR DESCRIPTION
Now the PNG resizer refuses to increase the size of images, instead pushing a 307, a lot of clock time is spent getting to the point of sending the 307.  This is blocking out threads from getting to the CPU intensive section of actually doing the resize.

This PR is putting the exclusion section only around the intensive part, so we can have many threads checking if it's a resize up, 304 not modified, etc, but only two threads in the CPU intensive section - if a resize is not required, we will always serve them the correct code, and only if a resize is required, it might still get a 307 due to capacity.

@janua have fun with the Transformers ;) @robertberry if you have time too please take a look

BTW This is built on yesterday's unmerged PR and it seems to have included both commits in the tab
