### PR TITLE
check to see whether there is a right hand column

### DIFF
--- a/static/src/javascripts/bootstraps/football.js
+++ b/static/src/javascripts/bootstraps/football.js
@@ -227,7 +227,7 @@ define([
 
         page.isCompetition(function (competition) {
             var $rightHandCol = $('.js-secondary-column').dim().height;
-            if ($rightHandCol == 0 || $rightHandCol > 1800) {
+            if ($rightHandCol === 0 || $rightHandCol > 1800) {
                 renderTable(competition, extras, dropdownTemplate);
             }
         });

--- a/static/src/javascripts/bootstraps/football.js
+++ b/static/src/javascripts/bootstraps/football.js
@@ -226,8 +226,8 @@ define([
         });
 
         page.isCompetition(function (competition) {
-            var $rightHandCol = $('.js-secondary-column');
-            if ($rightHandCol.dim().height > 1800) {
+            var $rightHandCol = $('.js-secondary-column').dim().height;
+            if ($rightHandCol == 0 || $rightHandCol > 1800) {
                 renderTable(competition, extras, dropdownTemplate);
             }
         });


### PR DESCRIPTION
This change yesterday: https://github.com/guardian/frontend/pull/7664, meant that on live match reports, such as this one: http://www.theguardian.com/football/live/2014/dec/26/arsenal-v-qpr-live, thus breaking an integration test the league table was then being inadvertently ommitted from the left hand column. This fixes that: 

@jamesgorrie: Does this look OK to you? 

Before: 
![live-blog-before](https://cloud.githubusercontent.com/assets/986155/5662573/d149588c-9732-11e4-8932-4d88d292e966.png)

After: 
![live-blog-after](https://cloud.githubusercontent.com/assets/986155/5662595/1736e652-9733-11e4-9730-44ee95ac389e.png)
