### PR TITLE
Correct response if no global popular items

### DIFF
--- a/onward/app/views/fragments/rightMostPopular.scala.html
+++ b/onward/app/views/fragments/rightMostPopular.scala.html
@@ -1,10 +1,10 @@
-@(popular: model.MostPopular)(implicit request: RequestHeader)
+@(popular: Option[model.MostPopular])(implicit request: RequestHeader)
 
-@if(popular.trails.nonEmpty) {
+@popular.map { pop =>
     <div class="right-most-popular right-most-popular--image component--rhc hide-on-childrens-books-site" data-component="right-most-popular" data-importance="-1">
         <h3 class="content__meta-heading">Most popular</h3>
         <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular">
-            @popular.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>
+            @pop.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>
                 <li class="right-most-popular-item" data-link-name="trail | @row.rowNum">
                     <a class="right-most-popular-item__url media u-cf" href="@LinkTo{@trail.url}">
                         @trail.trailPicture(5, 3).map{ image =>

--- a/onward/test/MostPopularFeatureTest.scala
+++ b/onward/test/MostPopularFeatureTest.scala
@@ -31,15 +31,5 @@ import scala.collection.JavaConversions._
 
       }
     }
-
-    scenario("Viewing site-wide most popular") {
-
-      Given("I am on a page in the 'World' section")
-      goTo("/most-read/world") { browser =>
-        import browser._
-        Then("I should see the site wide most read")
-        $("main h2")(1).getText should be("Most popular across the guardian")
-      }
-    }
   }
 }

--- a/onward/test/SeriesControllerTest.scala
+++ b/onward/test/SeriesControllerTest.scala
@@ -13,17 +13,4 @@ import play.api.test.Helpers._
     status(result) should be (200)
   }
 
-
-  it should "return JSON when " in {
-
-    val fakeRequest = FakeRequest(GET, s"/most-read/${series}.json")
-      .withHeaders("host" -> "localhost:9000")
-      .withHeaders("Origin" -> "http://www.theorigin.com")
-
-    val result = controllers.MostPopularController.render(series)(fakeRequest)
-    status(result) should be(200)
-    contentType(result).get should be("application/json")
-    contentAsString(result) should startWith("{\"html\"")
-  }
-
 }


### PR DESCRIPTION
Currently we are returning an (empty) popular container from the most-read endpoint even if there are no stories

This makes sure we return the correct(?) 404 if there are no stories
