### PR TITLE
Sticky MPU - redux

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
@@ -1,20 +1,26 @@
 define([
     'qwery',
+    'lodash/objects/defaults',
     'common/modules/ui/sticky'
 ], function (
     qwery,
+    defaults,
     Sticky
 ) {
 
-    var StickyMpu = function ($adSlot) {
-        this.$adSlot = $adSlot;
-    };
+    var mpuHeight = 275,
+        StickyMpu = function ($adSlot, options) {
+            this.$adSlot = $adSlot;
+            this.opts    = defaults(options || {}, {
+                top: 12
+            });
+        };
 
     StickyMpu.prototype.create = function () {
         var articleBodyOffset = qwery('.content__article-body')[0].offsetTop,
-            $mpuContainer     = this.$adSlot.parent().css('height', (articleBodyOffset + 275) + 'px');
+            $mpuContainer     = this.$adSlot.parent().css('height', (articleBodyOffset + mpuHeight) + 'px');
 
-        new Sticky(this.$adSlot[0], { top: 12 }).init();
+        new Sticky(this.$adSlot[0], { top: this.opts.top }).init();
     };
 
     return StickyMpu;

--- a/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
@@ -1,0 +1,22 @@
+define([
+    'qwery',
+    'common/modules/ui/sticky'
+], function (
+    qwery,
+    Sticky
+) {
+
+    var StickyMpu = function ($adSlot) {
+        this.$adSlot = $adSlot;
+    };
+
+    StickyMpu.prototype.create = function () {
+        var articleBodyOffset = qwery('.content__article-body')[0].offsetTop,
+            $mpuContainer     = this.$adSlot.parent().css('height', (articleBodyOffset + 275) + 'px');
+
+        new Sticky(this.$adSlot[0], { top: 12 }).init();
+    };
+
+    return StickyMpu;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
@@ -17,9 +17,9 @@ define([
         };
 
     StickyMpu.prototype.create = function () {
-        var articleBodyOffset = qwery('.content__article-body')[0].offsetTop,
-            $mpuContainer     = this.$adSlot.parent().css('height', (articleBodyOffset + mpuHeight) + 'px');
+        var articleBodyOffset = qwery('.content__article-body')[0].offsetTop;
 
+        this.$adSlot.parent().css('height', (articleBodyOffset + mpuHeight) + 'px');
         new Sticky(this.$adSlot[0], { top: this.opts.top }).init();
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
@@ -21,7 +21,7 @@ define([
             opts        = defaults(
                 options || {},
                 {
-                    columnSelector: '.content__secondary-column',
+                    columnSelector: '.js-secondary-column',
                     adSlotContainerSelector: '.js-mpu-ad-slot'
                 }
             ),
@@ -34,7 +34,13 @@ define([
         }
 
         $mainCol = config.page.contentType === 'Article' ? $('.js-content-main-column') : false;
-        adType   = !$mainCol.length || $mainCol.dim().height >= 600 ? 'right' : 'right-small';
+        if (!$mainCol.length || $mainCol.dim().height >= 1800) {
+            adType = 'right-sticky';
+        } else if ($mainCol.dim().height >= 600) {
+            adType = 'right';
+        } else {
+            adType = 'right-small';
+        }
 
         return $(opts.adSlotContainerSelector)
             .append(createAdSlot(adType, 'mpu-banner-ad'));

--- a/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
@@ -34,7 +34,11 @@ define([
         }
 
         $mainCol = config.page.contentType === 'Article' ? $('.js-content-main-column') : false;
-        if (!$mainCol.length || $mainCol.dim().height >= 1800) {
+        if (
+            !$mainCol.length ||
+            (config.page.section !== 'football' && $mainCol.dim().height >= 1300) ||
+            (config.page.section === 'football' && $mainCol.dim().height >= 2200)
+        ) {
             adType = 'right-sticky';
         } else if ($mainCol.dim().height >= 600) {
             adType = 'right';

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -19,8 +19,12 @@ define([
     var adSlotDefinitions = {
         right: {
             sizeMappings: {
-                mobile:  '1,1|300,250|300,251|300,600' +
-                    (config.page.edition === 'US' ? '|300,1050' : '')
+                mobile:  '1,1|300,250|300,600' + (config.page.edition === 'US' ? '|300,1050' : '')
+            }
+        },
+        'right-sticky': {
+            sizeMappings: {
+                mobile:  '1,1|300,250|300,251|300,600' + (config.page.edition === 'US' ? '|300,1050' : '')
             }
         },
         'right-small': {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -20,9 +20,9 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/utils/url',
+    'common/modules/commercial/ads/sticky-mpu',
     'common/modules/commercial/build-page-targeting',
-    'common/modules/onward/geo-most-popular',
-    'common/modules/ui/sticky'
+    'common/modules/onward/geo-most-popular'
 ], function (
     bean,
     bonzo,
@@ -44,9 +44,9 @@ define([
     detect,
     mediator,
     urlUtils,
+    StickyMpu,
     buildPageTargeting,
-    geoMostPopular,
-    Sticky
+    geoMostPopular
 ) {
 
     /**
@@ -86,10 +86,7 @@ define([
         ],
         callbacks = {
             '300,251': function (event, $adSlot) {
-                var $mpuContainer = $adSlot.parent();
-
-                $mpuContainer.next().remove();
-                new Sticky($mpuContainer[0], { top: 12 }).init();
+                new StickyMpu($adSlot).create();
             },
             '1,1': function (event, $adSlot) {
                 if (!event.slot.getOutOfPage()) {

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -14,30 +14,26 @@ define([
      * @todo: check if browser natively supports "position: sticky"
      */
     var Sticky = function (element, options) {
-        this.element  = element;
         this.$element = bonzo(element);
+        this.$parent  = this.$element.parent();
         this.opts     = defaults(options || {}, {
             top: 0
         });
     };
 
     Sticky.prototype.init = function () {
-        // position of element from document top
-        this.elementDocOffset = this.element.getBoundingClientRect().top + window.scrollY;
-
         mediator.on('window:scroll', throttle(this.updatePosition.bind(this), 10));
         // kick off an initial position update
         this.updatePosition();
     };
 
     Sticky.prototype.updatePosition = function () {
-        var parent, fixedTop, css;
+        var fixedTop, css;
 
         // have we scrolled past the element
-        if (window.scrollY >= this.elementDocOffset - this.opts.top) {
-            parent = this.$element.parent()[0];
+        if (window.scrollY >= this.$parent.offset().top - this.opts.top) {
             // make sure the element stays within its parent
-            fixedTop = Math.min(this.opts.top, parent.getBoundingClientRect().bottom - this.$element.dim().height);
+            fixedTop = Math.min(this.opts.top, this.$parent[0].getBoundingClientRect().bottom - this.$element.dim().height);
 
             css = {
                 position: 'fixed',

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -1,10 +1,12 @@
 define([
     'bonzo',
     'lodash/functions/throttle',
+    'lodash/objects/defaults',
     'common/utils/mediator'
 ], function (
     bonzo,
     throttle,
+    defaults,
     mediator
 ) {
 
@@ -12,8 +14,11 @@ define([
      * @todo: check if browser natively supports "position: sticky"
      */
     var Sticky = function (element, options) {
-        this.element = element;
-        this.top     = options.top || 0;
+        this.element  = element;
+        this.$element = bonzo(element);
+        this.opts     = defaults(options || {}, {
+            top: 0
+        });
     };
 
     Sticky.prototype.init = function () {
@@ -26,14 +31,13 @@ define([
     };
 
     Sticky.prototype.updatePosition = function () {
-        var parent, fixedTop, css,
-            $element = bonzo(this.element);
+        var parent, fixedTop, css;
 
         // have we scrolled past the element
-        if (window.scrollY >= this.elementDocOffset - this.top) {
-            parent = $element.parent()[0];
+        if (window.scrollY >= this.elementDocOffset - this.opts.top) {
+            parent = this.$element.parent()[0];
             // make sure the element stays within its parent
-            fixedTop = Math.min(this.top, parent.getBoundingClientRect().bottom - $element.dim().height);
+            fixedTop = Math.min(this.opts.top, parent.getBoundingClientRect().bottom - this.$element.dim().height);
 
             css = {
                 position: 'fixed',
@@ -46,7 +50,7 @@ define([
             };
         }
 
-        return $element.css(css);
+        return this.$element.css(css);
     };
 
     return Sticky;

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -7,11 +7,9 @@
 /*global DocumentTouch: true */
 
 define([
-    'lodash/collections/map',
     'common/utils/_',
     'common/utils/mediator'
 ], function (
-    map,
     _,
     mediator
 ) {
@@ -326,18 +324,6 @@ define([
         }
     }
 
-    function testCssSupport(property, value) {
-        var prefixes = ['', '-webkit-', '-moz-', '-o-', '-ms-'],
-            el       = document.createElement('div'),
-            style    = el.style;
-
-        style.cssText = map(prefixes, function (prefix) {
-            return property + ':' + prefix + value;
-        }).join(';');
-
-        return style[property].indexOf(value) !== -1;
-    }
-
     return {
         hasCrossedBreakpoint: hasCrossedBreakpoint,
         getConnectionSpeed: getConnectionSpeed,
@@ -356,8 +342,7 @@ define([
         hasWebSocket: hasWebSocket,
         getPageSpeed: getPageSpeed,
         breakpoints: breakpoints,
-        shouldUseHintedFonts: shouldUseHintedFonts(),
-        testCssSupport: testCssSupport
+        shouldUseHintedFonts: shouldUseHintedFonts()
     };
 
 });

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -7,9 +7,11 @@
 /*global DocumentTouch: true */
 
 define([
+    'lodash/collections/map',
     'common/utils/_',
     'common/utils/mediator'
 ], function (
+    map,
     _,
     mediator
 ) {
@@ -324,6 +326,18 @@ define([
         }
     }
 
+    function testCssSupport(property, value) {
+        var prefixes = ['', '-webkit-', '-moz-', '-o-', '-ms-'],
+            el       = document.createElement('div'),
+            style    = el.style;
+
+        style.cssText = map(prefixes, function (prefix) {
+            return property + ':' + prefix + value;
+        }).join(';');
+
+        return style[property].indexOf(value) !== -1;
+    }
+
     return {
         hasCrossedBreakpoint: hasCrossedBreakpoint,
         getConnectionSpeed: getConnectionSpeed,
@@ -342,7 +356,8 @@ define([
         hasWebSocket: hasWebSocket,
         getPageSpeed: getPageSpeed,
         breakpoints: breakpoints,
-        shouldUseHintedFonts: shouldUseHintedFonts()
+        shouldUseHintedFonts: shouldUseHintedFonts(),
+        testCssSupport: testCssSupport
     };
 
 });


### PR DESCRIPTION
Updates to the sticky MPU code
- don't remove most popular, etc components - start them half way down the column
- split into its own module (separate from the dfp.js code)
- only allow sticky mpus on articles which are long enough

![sticky-mpu](https://cloud.githubusercontent.com/assets/74132/5664191/5483a852-9746-11e4-9a5d-1f2b7b0edb24.gif)
