### PR TITLE
use 302 not 307 redirect for png resizer

### DIFF
--- a/png-resizer/app/controllers/Resizer.scala
+++ b/png-resizer/app/controllers/Resizer.scala
@@ -62,7 +62,7 @@ object Resizer extends Controller with Logging with implicits.Requests {
   def redirectScaleUpAttempts(originalWidth: Int, width: Int, fallbackUri: String) = {
     if (originalWidth <= width) {
       log.info(s"won't resize image to be bigger - $originalWidth to $width - redirecting to original")
-      -\/(Cached(1.day)(TemporaryRedirect(fallbackUri)))
+      -\/(Cached(1.day)(Found(fallbackUri)))
     } else {
       \/-()
     }
@@ -106,7 +106,7 @@ object Resizer extends Controller with Logging with implicits.Requests {
     if (!request.isHealthcheck) {
       PngResizerMetrics.redirectCount.increment()
     }
-    future.point(-\/(Cached(60)(TemporaryRedirect(uri))))
+    future.point(-\/(Cached(60)(Found(uri))))
   }
 
   def resizePngBytes(width: Int, quality: Int, bytesPreResize: Array[Byte]): Future[Array[Byte]] = {


### PR DESCRIPTION
I was using 307 redirects for no good reason when the PNG resizer didn't want to resize the images.

Turns out fastly doesn't cache 307s, it just queues up the requests and sends them one after another.  So I have changed to 302 which is actually the same to our purposes (only makes a difference for POST or PUT requests)

[https://docs.fastly.com/guides/caching/which-http-status-codes-are-cached-by-default](https://docs.fastly.com/guides/caching/which-http-status-codes-are-cached-by-default)

Thanks @gklopper for the "Huge Hint" that saved me a lot of work

The resizer is turned off at the moment, once this is in I can turn on the png resizer again and monitor the stats.
