### PR TITLE
Return 410 for fronts with expired ad features

### DIFF
--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -1,5 +1,6 @@
 package services
 
+import conf.Switches._
 import model._
 import conf.LiveContentApi
 import model.Section
@@ -127,7 +128,11 @@ trait Index extends ConciergeRepository with QueryDefaults {
       val page = maybeSection.map(s => section(s, response)) orElse
         response.tag.flatMap(t => tag(response, pageNum)) orElse
         response.section.map(s => section(s, response))
-      ModelOrResult(page, response, maybeSection)
+      if (AdFeatureExpirySwitch.isSwitchedOn && page.exists (_.page.isExpiredAdvertisementFeature)) {
+        Right(Gone)
+      } else {
+        ModelOrResult(page, response)
+      }
     }
 
     promiseOfResponse.recover({


### PR DESCRIPTION
In line with #7673, this is the equivalent behaviour for fronts.