### PR TITLE
Fix Faulty Logic in isExpiredAdvertisementFeature()

### DIFF
--- a/common/app/dfp/PaidForTagAgent.scala
+++ b/common/app/dfp/PaidForTagAgent.scala
@@ -141,7 +141,7 @@ trait PaidForTagAgent {
                                     maybeSectionId: Option[String]): Boolean = {
     val lineItems = findWinningTagPair(capiTags,
       maybeSectionId) map (_.dfpTag.lineItems) getOrElse Nil
-    lineItems forall (_.endTime exists (_.isBeforeNow))
+    lineItems.nonEmpty && (lineItems forall (_.endTime exists (_.isBeforeNow)))
   }
 
   private def hasMultiplesOfAPaidForType(capiTags: Seq[Tag],

--- a/common/test/dfp/PaidForTagAgentTest.scala
+++ b/common/test/dfp/PaidForTagAgentTest.scala
@@ -497,4 +497,9 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
     val keyword = toKeyword("section/tagNameMatchingMoreMultipleLineItems")
     TestPaidForTagAgent.isExpiredAdvertisementFeature(Seq(keyword), None) should be(false)
   }
+
+  it should "be false for an un-paid-for page" in {
+    val keyword = toKeyword("anotherSection/someOtherUnrelatedTagName")
+    TestPaidForTagAgent.isExpiredAdvertisementFeature(Seq(keyword), None) should be(false)
+  }
 }


### PR DESCRIPTION
`forall` gives true for the empty list, which makes sense.
