### PR TITLE
hide comments label if there is a timestamp

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -485,20 +485,6 @@ $header-image-size-desktop: 100px;
     }
 }
 
-
-.content-footer {
-    /**
-     *  For the occasions where we want to show timestamp and there are comments.
-     *  In some cases this will force meta content to split to two lines for tablet view
-     *  so we need to increase the content div bottom space.
-     */
-    @include mq($until: desktop) {
-        .fc-item--has-metadata .fc-item__content {
-            padding-bottom: $gs-baseline * 3;
-        }
-    }
-}
-
 .fc-date-headline {
     color: colour(neutral-1);
     display: block;

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -334,6 +334,10 @@ $fc-item-gutter: $gs-gutter / 4;
     display: none;
 }
 
+.fc-item__timestamp + .fc-trail__count .fc-trail__count__label {
+    display: none;
+}
+
 .fc-item--has-cutout .fc-item__media-wrapper {
     // We never want to show the media and the cutout at the same time, hence the important
     display: none !important;


### PR DESCRIPTION
specifically to fix the following:

![screen shot 2015-01-09 at 16 13 33](https://cloud.githubusercontent.com/assets/867233/5682812/bc11333e-981a-11e4-9f00-949c2d833919.png)

results in 

![screen shot 2015-01-09 at 16 32 14](https://cloud.githubusercontent.com/assets/867233/5683096/1a698c2c-981d-11e4-8fcd-abd97153c650.png)

but it also cleans up examples like this:

![screen shot 2015-01-09 at 16 20 11](https://cloud.githubusercontent.com/assets/867233/5682897/6ee2e8c2-981b-11e4-8e95-efa06ee7c6cf.png)

becomes

![screen shot 2015-01-09 at 16 16 18](https://cloud.githubusercontent.com/assets/867233/5682839/03e0104a-981b-11e4-8ffb-468fe83f36a4.png)

or

![screen shot 2015-01-09 at 16 21 39](https://cloud.githubusercontent.com/assets/867233/5682930/a3a0112a-981b-11e4-91a6-c3fad8ea1aac.png)
