### PR TITLE
only resize pngs if they'll end up small

### DIFF
--- a/png-resizer/app/conf/PngResizerMetrics.scala
+++ b/png-resizer/app/conf/PngResizerMetrics.scala
@@ -26,7 +26,17 @@ object PngResizerMetrics {
 
   val redirectCount = CountMetric(
     "png-resizer-redirect-count",
-    "Number of 307 responses sent because we were at capacity"
+    "Number of 302 responses sent because we were at capacity"
+  )
+
+  val wontMakeBiggerCount = CountMetric(
+    "png-resizer-wont-make-bigger-count",
+    "Number of 302 responses sent because there's no point scaling an image to be bigger"
+  )
+
+  val tooHardCount = CountMetric(
+    "png-resizer-too-hard-count",
+    "Number of 302 responses sent because we thought it would be too slow to resize the image"
   )
 
 }

--- a/png-resizer/app/controllers/Resizer.scala
+++ b/png-resizer/app/controllers/Resizer.scala
@@ -61,7 +61,22 @@ object Resizer extends Controller with Logging with implicits.Requests {
 
   def redirectScaleUpAttempts(originalWidth: Int, width: Int, fallbackUri: String) = {
     if (originalWidth <= width) {
+      PngResizerMetrics.wontMakeBiggerCount.increment()
       log.info(s"won't resize image to be bigger - $originalWidth to $width - redirecting to original")
+      -\/(Cached(1.day)(Found(fallbackUri)))
+    } else {
+      \/-(())
+    }
+  }
+
+  // if we have too many pixels, it takes too long to resize.  This could be tweaked.
+  val MAX_PIXELS = 620 * 620
+
+  def redirectTooBigAttempts(originalWidth: Int, originalHeight: Int, requestedWidth: Int, fallbackUri: String) = {
+    val requestedPixels = (originalHeight * requestedWidth * requestedWidth) / originalWidth
+    if (requestedPixels > MAX_PIXELS) {
+      PngResizerMetrics.tooHardCount.increment()
+      log.info(s"won't resize if final image will be too big afterwards - total size $requestedPixels - redirecting to original")
       -\/(Cached(1.day)(Found(fallbackUri)))
     } else {
       \/-(())
@@ -79,8 +94,10 @@ object Resizer extends Controller with Logging with implicits.Requests {
             response <- EitherT.right(Time(getUpstreamResponse(uri, request.headers), "download image", PngResizerMetrics.downloadTime))
             cacheableContent <- EitherT(getPngBytesToResize(uri, response))
             CacheableContent(cacheHeaders, bytesPreResize) = cacheableContent
-            originalWidth <- EitherT.right(Im4Java.getWidth(bytesPreResize))
+            originalSize <- EitherT.right(Im4Java.getWidth(bytesPreResize))
+            (originalWidth, originalHeight) = originalSize
             _ <- EitherT(future.point(redirectScaleUpAttempts(originalWidth, width, uri)))
+            _ <- EitherT(future.point(redirectTooBigAttempts(originalWidth, originalHeight, width, uri)))
             processed <- EitherT(resizeWithLoadLimit(request, uri, width, quality, bytesPreResize))
             result = Ok(processed).as("image/png").withHeaders(cacheHeaders: _*)
           } yield result

--- a/png-resizer/app/lib/Im4Java.scala
+++ b/png-resizer/app/lib/Im4Java.scala
@@ -38,8 +38,8 @@ object Im4Java {
   }
 
   def getWidth(imageBytes: Array[Byte]) = Future {
-    val imageInfo = new Info("png:-", new ByteArrayInputStream(imageBytes),true);
-    imageInfo.getImageWidth()
+    val imageInfo = new Info("png:-", new ByteArrayInputStream(imageBytes),true)
+    (imageInfo.getImageWidth, imageInfo.getImageHeight)
   }
 
 }

--- a/png-resizer/app/lib/Im4Java.scala
+++ b/png-resizer/app/lib/Im4Java.scala
@@ -7,6 +7,7 @@ import org.im4java.process.Pipe
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.blocking
 
 object Im4Java {
   def apply(operation: IMOperation, format: String = "png")(imageBytes: Array[Byte]): Array[Byte] = {
@@ -19,7 +20,9 @@ object Im4Java {
     val s2b = new Pipe(null, baos)
     cmd.setOutputConsumer(s2b)
 
-    cmd.run(operation)
+    blocking {
+      cmd.run(operation)
+    }
 
     baos.flush()
     baos.toByteArray


### PR DESCRIPTION
we are spending too much time resizing PNGs which will end up big anyway (galleries etc.)

Doing so takes over 5 seconds so fastly won't get the result, and it's blocking up the execution context capacity on our resizer boxes meaning other requests are getting queued up behind them.

Most of the benefit is got for the "garnish" images like the cutouts and whatnot, and we're just ruining the quality of the big images by trying to resize them (that is, if the users could even see them in time....)

So, from this, if the image is bigger than 620x620, we will just redirect to the original.  I chose that number semi-arbitrarily to let the garnish through but not the galleries, if we're still seeing bad perf we can tweak it.
