### PR TITLE
Navigation toggle now reads "Browse all sections" at widest point

### DIFF
--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -36,7 +36,7 @@
                 <a class="navigation__toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
                     <i class="burger-icon"></i>
                     <span class="navigation__toggle-label navigation__toggle-label--open"
-                          aria-haspopup="true" aria-controls="all-sections-popup" aria-label="view all sections"><span class="navigation__toggle-label__extra navigation__toggle-label__extra--browse">browse </span>all<span class="navigation__toggle-label__extra"> sections</span></span>
+                          aria-haspopup="true" aria-controls="all-sections-popup" aria-label="browse all sections"><span class="navigation__toggle-label__extra navigation__toggle-label__extra--browse">browse </span>all<span class="navigation__toggle-label__extra"> sections</span></span>
                     <span class="navigation__toggle-label navigation__toggle-label--close" aria-label="close all sections">close</span>
                 </a>
             </div>

--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -36,7 +36,7 @@
                 <a class="navigation__toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
                     <i class="burger-icon"></i>
                     <span class="navigation__toggle-label navigation__toggle-label--open"
-                          aria-haspopup="true" aria-controls="all-sections-popup" aria-label="view all sections">all<span class="navigation__toggle-label__extra"> sections</span></span>
+                          aria-haspopup="true" aria-controls="all-sections-popup" aria-label="view all sections"><span class="navigation__toggle-label__extra navigation__toggle-label__extra--browse">browse </span>all<span class="navigation__toggle-label__extra"> sections</span></span>
                     <span class="navigation__toggle-label navigation__toggle-label--close" aria-label="close all sections">close</span>
                 </a>
             </div>

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -642,6 +642,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     @include fs-header(1);
     line-height: $navigation-height;
     padding: 0 $gs-gutter / 2;
+    min-width: $navigation-toggler-width;
     background: $c-navigation-toggle-background;
     -moz-background-clip: padding-box;
     -webkit-background-clip: padding-box;
@@ -649,7 +650,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     text-align: left;
     border-left: 2px solid $c-navigation-toggle-shadow;
     outline: none;
-    min-width: $navigation-toggler-width;
+
 
     &,
     &:hover,
@@ -692,6 +693,10 @@ $c-navigation-expandable-background: colour(neutral-1);
 
     &.navigation__toggle-label__extra--browse {
         @include mq($until: wide) {
+            display: none;
+        }
+
+        .has-page-skin & {
             display: none;
         }
     }

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -9,8 +9,9 @@ $c-navigation-base: colour(neutral-5);
 
 $navigation-height: $gs-row-height;
 
-$navigation-toggler-width: 48px;
-$navigation-toggler-width-full: 128px;
+$navigation-toggler-width: 44px;
+$navigation-toggler-width-halffull: 132px;
+$navigation-toggler-width-full: 186px;
 
 $c-navigation-background: mix($c-navigation-base, #ffffff, 80%);
 $c-navigation-background-side-bar: #005182;
@@ -632,15 +633,6 @@ $c-navigation-expandable-background: colour(neutral-1);
 /* Toggle button
    ========================================================================== */
 
-@mixin navigation__toggle--width($width: small) {
-    @if $width == small {
-        min-width: $navigation-toggler-width;
-    }
-    @if $width == wide {
-        min-width: $navigation-toggler-width-full;
-    }
-}
-
 .navigation__toggle {
     z-index: 2;
     position: absolute;
@@ -650,7 +642,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     @include fs-header(1);
     line-height: $navigation-height;
     padding: 0 $gs-gutter / 2;
-    @include navigation__toggle--width(small);
     background: $c-navigation-toggle-background;
     -moz-background-clip: padding-box;
     -webkit-background-clip: padding-box;
@@ -658,6 +649,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     text-align: left;
     border-left: 2px solid $c-navigation-toggle-shadow;
     outline: none;
+    min-width: $navigation-toggler-width;
 
     &,
     &:hover,
@@ -673,34 +665,33 @@ $c-navigation-expandable-background: colour(neutral-1);
         border-left-color: transparent;
     }
 
-    @include mq(tablet) {
-        @include navigation__toggle--width(wide);
-        text-align: left;
-    }
     @include mq(navigationBreakOnTwoLevels) {
         border-left: 0;
     }
-    @include mq(navigationBreakOnTwoLevels, navigationBreakOnTwoLevelsWithWideToggle) {
-        @include navigation__toggle--width(small);
+
+    @include mq(leftCol) {
+        min-width: $navigation-toggler-width-halffull;
     }
+
     @include mq(wide) {
-        .has-page-skin & {
-            @include navigation__toggle--width(small);
+        min-width: $navigation-toggler-width-full;
+    }
+
+    .has-page-skin & {
+        @include mq(leftCol) {
+            min-width: $navigation-toggler-width;
         }
     }
 }
-.navigation__toggle-label {}
 .navigation__toggle-label__extra {
     display: none;
 
-    @include mq(tablet) {
+    @include mq(leftCol) {
         display: inline;
     }
-    @include mq(navigationBreakOnTwoLevels, navigationBreakOnTwoLevelsWithWideToggle) {
-        display: none;
-    }
-    @include mq(wide) {
-        .has-page-skin & {
+
+    &.navigation__toggle-label__extra--browse {
+        @include mq($until: wide) {
             display: none;
         }
     }


### PR DESCRIPTION
A slight modification to the `navigation__toggle` or all sections button. It's been simplified and expands out across the breakpoints rather than jumping back and forth. It also expands to read 'browse all sections' when we have the room for it at the widest breakpoint.

Until Desktop
![screen shot 2015-01-09 at 18 46 06](https://cloud.githubusercontent.com/assets/1607666/5685270/9cefdc74-9830-11e4-84ce-12c40ace8471.png)

LeftCol
![screen shot 2015-01-09 at 18 45 59](https://cloud.githubusercontent.com/assets/1607666/5685271/9fe2e570-9830-11e4-9428-127730e69e70.png)

Wide
![screen shot 2015-01-09 at 18 45 47](https://cloud.githubusercontent.com/assets/1607666/5685273/a5659d08-9830-11e4-8093-293660cb1c2e.png)
