### PR TITLE
Tweak the parallel test param to 4

### DIFF
--- a/onward/test/controllers/ChangeEditionControllerTest.scala
+++ b/onward/test/controllers/ChangeEditionControllerTest.scala
@@ -18,7 +18,7 @@ import test.{ConfiguredTestSuite, TestRequest}
     val result = controllers.ChangeEditionController.render("au")(TestRequest())
     val GU_EDITION = playCookies(result).apply("GU_EDITION")
 
-    GU_EDITION.maxAge should be (Some(5184000))  // 60 days, this is seconds
+    GU_EDITION.maxAge.getOrElse(0) should be (5184000 +- 1)  // 60 days, this is seconds
     GU_EDITION.value should be ("AU")
   }
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -13,16 +13,10 @@ trait Prototypes {
 
   val frontendCompilationSettings = Seq(
     organization := "com.gu",
-
     maxErrors := 20,
-    javacOptions := Seq(
-      "-g",
-      "-encoding", "utf8"
-    ),
+    javacOptions := Seq("-g","-encoding", "utf8"),
     scalacOptions := Seq("-unchecked", "-optimise", "-deprecation",
-      "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings",
-      "-Xfatal-warnings"
-    ),
+      "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
     doc in Compile <<= target.map(_ / "none"),
     incOptions := incOptions.value.withNameHashing(true),
     scalaVersion := "2.11.4"
@@ -69,7 +63,7 @@ trait Prototypes {
     // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
     testOptions in Test := Nil,
 
-    concurrentRestrictions in Global += Tags.limit(Tags.Test, 2),
+    concurrentRestrictions in Global += Tags.limit(Tags.Test, 3),
 
     // Copy unit test resources https://groups.google.com/d/topic/play-framework/XD3X6R-s5Mc/discussion
     unmanagedClasspath in Test <+= (baseDirectory) map { bd => Attributed.blank(bd / "test") },

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -75,7 +75,7 @@ trait Prototypes {
 
     // These settings are needed for forking, which in turn is needed for concurrent restrictions.
     javaOptions in Test += "-DAPP_SECRET=this_is_not_a_real_secret_just_for_tests",
-    javaOptions in Test += "-Xmx1024M",
+    javaOptions in Test += "-Xmx2048M",
     javaOptions in Test += "-XX:+UseConcMarkSweepGC",
     javaOptions in Test += "-XX:ReservedCodeCacheSize=128m",
     baseDirectory in Test := file(".")

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -63,7 +63,7 @@ trait Prototypes {
     // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
     testOptions in Test := Nil,
 
-    concurrentRestrictions in Global += Tags.limit(Tags.Test, 3),
+    concurrentRestrictions in Global += Tags.limit(Tags.Test, 4),
 
     // Copy unit test resources https://groups.google.com/d/topic/play-framework/XD3X6R-s5Mc/discussion
     unmanagedClasspath in Test <+= (baseDirectory) map { bd => Attributed.blank(bd / "test") },
@@ -75,7 +75,9 @@ trait Prototypes {
 
     // These settings are needed for forking, which in turn is needed for concurrent restrictions.
     javaOptions in Test += "-DAPP_SECRET=this_is_not_a_real_secret_just_for_tests",
-    javaOptions in Test += "-XX:MaxPermSize=680m",
+    javaOptions in Test += "-Xmx1024M",
+    javaOptions in Test += "-XX:+UseConcMarkSweepGC",
+    javaOptions in Test += "-XX:ReservedCodeCacheSize=128m",
     baseDirectory in Test := file(".")
   )
 


### PR DESCRIPTION
Just want to see if this is still causing memory issues, because it would still be much faster to run four concurrent tasks.
