### PR TITLE
fix png resizer load limiting to work

### DIFF
--- a/png-resizer/app/load/LoadLimit.scala
+++ b/png-resizer/app/load/LoadLimit.scala
@@ -25,15 +25,15 @@ object LoadLimit extends ExecutionContexts with Logging {
       log.info(s"AltPool: $alternativePool: Resize $concurrentRequests/$requestLimit")
       val result = operation
       result.onComplete{_ =>
-        currentNumberOfRequests.decrementAndGet()
+        reqCounter.decrementAndGet()
       }
       result
     } catch {
       case t: Throwable =>
-        currentNumberOfRequests.decrementAndGet()
+        reqCounter.decrementAndGet()
         throw t
     } else {
-      currentNumberOfRequests.decrementAndGet()
+      reqCounter.decrementAndGet()
       outOfCapacity
     }
   }


### PR DESCRIPTION
The load limiting only allows one resize per CPU concurrently as it's cpu intensive and latency would be a big problem.

However when I changed the healthcheck to be ignored from the main load limit (as it's really quick) I forgot to code or test it properly, so all healthchecks were being 302'ed and all the real requests were being accepted even if we were too busy!

This fixes it... and it's tested locally (honest!)
