### PR TITLE
fix png resizer integer overflow

### DIFF
--- a/png-resizer/app/controllers/Resizer.scala
+++ b/png-resizer/app/controllers/Resizer.scala
@@ -70,10 +70,10 @@ object Resizer extends Controller with Logging with implicits.Requests {
   }
 
   // if we have too many pixels, it takes too long to resize.  This could be tweaked.
-  val MAX_PIXELS = 620 * 620
+  val MAX_PIXELS = 620 * 480
 
   def redirectTooBigAttempts(originalWidth: Int, originalHeight: Int, requestedWidth: Int, fallbackUri: String) = {
-    val requestedPixels = (originalHeight * requestedWidth * requestedWidth) / originalWidth
+    val requestedPixels = (originalHeight.toLong * requestedWidth * requestedWidth) / originalWidth
     if (requestedPixels > MAX_PIXELS) {
       PngResizerMetrics.tooHardCount.increment()
       log.info(s"won't resize if final image will be too big afterwards - total size $requestedPixels - redirecting to original")


### PR DESCRIPTION
The png resizer avoids attempting a resize if the resultant image will be too difficult to quantize because it just has too many pixels.

However, when you tried to resize something from 2060x1236 to 1920 width, the total number of pixels was greater than MAX_INT.  This meant it thought it was small enough (probably negative size) and then spent about 20 seconds chugging on it.

I've also tweaked the max size threshold down a bit because some images were just pushing over 5 seconds which causes fastly to be bored and give up.
