### PR TITLE
Fix for video embed hidden behind onward

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -761,7 +761,7 @@ $vjs-height-ratio: 7/3;
 .end-slate-container {
     display: none;
     position: absolute;
-    z-index: 3;
+    z-index: 2;
     width: 100%;
     left: 0;
     right: 0;


### PR DESCRIPTION
Before:
![screen shot 2015-01-13 at 11 33 27](https://cloud.githubusercontent.com/assets/2236852/5720158/53b1e68e-9b18-11e4-9085-8ef8343afd18.png)

After:
![screen shot 2015-01-13 at 11 33 37](https://cloud.githubusercontent.com/assets/2236852/5720159/569ede24-9b18-11e4-9a52-924348fa8015.png)
