### PR TITLE
Update indicators as binding helpers

### DIFF
--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -357,16 +357,19 @@ define([
         update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
             var target = ko.unwrap(valueAccessor()),
                 numbers = bindingContext.$data.visibleCount(),
-                container = bindingContext.$data.dom;
+                container = bindingContext.$data.dom,
+                top, bottomElementPosition, bottomElement, bottom, height;
 
             if (!(target in numbers) || !container) {
                 return;
             }
-            var top = $(element).parents('.article-group')[0].getBoundingClientRect().top,
-                bottomElementPosition = numbers[target] - 1,
-                bottomElement = bottomElementPosition >= 0 ? container.querySelectorAll('.article')[bottomElementPosition] : null,
-                bottom = bottomElement ? bottomElement.getBoundingClientRect().bottom : NaN,
-                height = bottom - top - 15;
+
+            top = $(element).parents('.article-group')[0].getBoundingClientRect().top;
+            bottomElementPosition = numbers[target] - 1;
+            bottomElement = bottomElementPosition >= 0 ? container.querySelectorAll('.article')[bottomElementPosition] : null;
+            bottom = bottomElement ? bottomElement.getBoundingClientRect().bottom : NaN;
+            height = bottom - top - 15;
+
             element.style.height = (height || 0) + 'px';
         }
     };

--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -45,6 +45,7 @@ define([
         this.dom = undefined;
 
         this.visibleStories = null;
+        this.visibleCount = ko.observable({});
 
         this.listeners = mediator.scope();
 
@@ -345,21 +346,29 @@ define([
         }
 
         this.state.showIndicators(true);
-        var top = container.querySelector('.article-group').getBoundingClientRect().top;
-
-        _.each(['desktop', 'mobile'], function (target) {
-            var bottomElementPosition = numbers[target] - 1,
-                bottomElement = bottomElementPosition >= 0 ? container.querySelectorAll('.article')[bottomElementPosition] : null,
-                bottom = bottomElement ? bottomElement.getBoundingClientRect().bottom : NaN,
-                height = bottom - top - 15,
-                indicator = container.querySelector('.' + target + '-indicator .indicator');
-
-            indicator.style.height = (height || 0) + 'px';
-        });
+        this.visibleCount(numbers);
     };
 
     Collection.prototype.dispose = function () {
         this.listeners.dispose();
+    };
+
+    ko.bindingHandlers.indicatorHeight = {
+        update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
+            var target = ko.unwrap(valueAccessor()),
+                numbers = bindingContext.$data.visibleCount(),
+                container = bindingContext.$data.dom;
+
+            if (!(target in numbers) || !container) {
+                return;
+            }
+            var top = $(element).parents('.article-group')[0].getBoundingClientRect().top,
+                bottomElementPosition = numbers[target] - 1,
+                bottomElement = bottomElementPosition >= 0 ? container.querySelectorAll('.article')[bottomElementPosition] : null,
+                bottom = bottomElement ? bottomElement.getBoundingClientRect().bottom : NaN,
+                height = bottom - top - 15;
+            element.style.height = (height || 0) + 'px';
+        }
     };
 
     return Collection;

--- a/facia-tool/public/js/widgets/collection.html
+++ b/facia-tool/public/js/widgets/collection.html
@@ -69,11 +69,11 @@
             <!-- ko if: state.showIndicators -->
                 <div class="desktop-indicator">
                     <i class="fa fa-laptop" title="Visible on desktop"></i>
-                    <div class="indicator"></div>
+                    <div class="indicator" data-bind="indicatorHeight: 'desktop'"></div>
                 </div>
                 <div class="mobile-indicator">
                     <i class="fa fa-mobile" title="Visible on mobile"></i>
-                    <div class="indicator"></div>
+                    <div class="indicator" data-bind="indicatorHeight: 'mobile'"></div>
                 </div>
             <!-- /ko -->
             <div data-bind="


### PR DESCRIPTION
Move the logic that access the DOM to a binding helper. 

This should guarantee that the DOM is always ready and fix the errors that are randomly reported to sentry
