### PR TITLE
Liveblog caption fix

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -329,9 +329,6 @@ $block-padding-right: $gs-gutter;
             margin-left: 0;
             margin-right: 0;
         }
-        > .element-image + .element {
-            margin-top: $gs-baseline*-1;
-        }
 
         > .element-table {
             margin: 0;
@@ -390,6 +387,8 @@ $block-padding-right: $gs-gutter;
         > .element-video {
             clear: left;
             border-bottom: 2px solid colour(neutral-8);
+            margin-bottom: $gs-baseline;
+            padding-bottom: $gs-baseline/2;
 
             &:last-child {
                 border-bottom: 0;
@@ -400,6 +399,7 @@ $block-padding-right: $gs-gutter;
             background-color: #ffffff;
             margin-left: $gs-gutter/2;
             margin-right: $gs-gutter/2;
+            padding-bottom: $gs-baseline/2;
 
             @include mq(mobileLandscape) {
                 margin-left: $block-padding-left;


### PR DESCRIPTION
Adds back some padding to our liveblog image captions
Fix for issue https://github.com/guardian/frontend/issues/7540

Now on the left, before on the right:
![screen shot 2015-01-13 at 15 00 06](https://cloud.githubusercontent.com/assets/2236852/5722602/6994d30e-9b35-11e4-9355-bf7a4cf7f726.png)
