### PR TITLE
Add browser not supported message to video player.

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -389,6 +389,11 @@ object Switches {
     safeState = On, sellByDate = never
   )
 
+  val MediaPlayerSupportedBrowsers = Switch("Feature", "media-player-supported-browsers",
+    "If this is switched on then a message will be displayed to UAs not supported by our media player",
+    safeState = On, sellByDate = never
+  )
+
   val BreakingNewsSwitch = Switch("Feature", "breaking-news",
     "If this is switched on then the breaking news feed is requested and articles are displayed",
     safeState = Off, sellByDate = new LocalDate(2015, 2, 1)

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -18,6 +18,7 @@ define([
     'common/modules/onward/history',
     'common/modules/ui/images',
     'common/modules/video/tech-order',
+    'common/modules/video/supportedBrowsers',
     'common/modules/analytics/beacon',
     'text!common/views/ui/loading.html',
     'text!common/views/ui/video-ads-overlay.html'
@@ -40,6 +41,7 @@ define([
     history,
     images,
     techOrder,
+    checkBrowserSupport,
     beacon,
     loadingTmpl,
     adsOverlayTmpl
@@ -200,6 +202,7 @@ define([
     function bindErrorHandler(player) {
         player.on('error', function () {
             beaconError(player.error());
+            $('.vjs-big-play-button').hide();
         });
     }
 
@@ -371,6 +374,7 @@ define([
                 initLoadingSpinner(player);
                 bindGlobalEvents(player);
                 upgradeVideoPlayerAccessibility(player);
+                checkBrowserSupport(player);
 
                 player.one('playing', function (e) {
                     if (isFlash(e)) {

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -41,7 +41,7 @@ define([
     history,
     images,
     techOrder,
-    checkBrowserSupport,
+    supportedBrowsers,
     beacon,
     loadingTmpl,
     adsOverlayTmpl
@@ -374,7 +374,7 @@ define([
                 initLoadingSpinner(player);
                 bindGlobalEvents(player);
                 upgradeVideoPlayerAccessibility(player);
-                checkBrowserSupport(player);
+                supportedBrowsers(player);
 
                 player.one('playing', function (e) {
                     if (isFlash(e)) {

--- a/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
+++ b/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
@@ -1,0 +1,27 @@
+define([
+    'common/utils/_',
+    'common/utils/detect'
+], function (
+    _,
+    detect
+) {
+
+    var browsers = {
+        'Firefox': '25',
+        'Chrome': '30',
+        'IE': '9',
+        'Opera': '14'
+        },
+        ua = detect.getUserAgent,
+        message = 'Please <a href="http://whatbrowser.org" target="_blank">update</a> your browser to watch this video.'
+
+    return function supportedBrowser(player) {
+        var notSupported =  _.some(browsers, function(version, browser){
+            return (ua.browser === browser && ua.version < version);
+        });
+
+        if(notSupported) {
+            player.error(message);
+        }
+    }
+});

--- a/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
+++ b/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
@@ -10,7 +10,7 @@ define([
 
     var browsers = {
             'Firefox': '25',
-            'Chrome': '60',
+            'Chrome': '28',
             'IE': '9',
             'Opera': '14',
             'Safari': '7'

--- a/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
+++ b/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
@@ -1,16 +1,19 @@
 define([
     'common/utils/_',
-    'common/utils/detect'
+    'common/utils/detect',
+    'common/utils/config'
 ], function (
     _,
-    detect
+    detect,
+    config
 ) {
 
     var browsers = {
-        'Firefox': '25',
-        'Chrome': '30',
-        'IE': '9',
-        'Opera': '14'
+            'Firefox': '25',
+            'Chrome': '60',
+            'IE': '9',
+            'Opera': '14',
+            'Safari': '7'
         },
         ua = detect.getUserAgent,
         message = 'Please <a href="http://whatbrowser.org" target="_blank">update</a> your browser to watch this video.'
@@ -20,7 +23,7 @@ define([
             return (ua.browser === browser && ua.version < version);
         });
 
-        if(notSupported) {
+        if(notSupported && config.switches.mediaPlayerSupportedBrowsers) {
             player.error(message);
         }
     }

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -115,6 +115,25 @@ define([
         return navigator.mozApps && !window.locationbar.visible;
     }
 
+    var getUserAgent = (function(){
+        var ua= navigator.userAgent, tem,
+            M= ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+        if(/trident/i.test(M[1])){
+            tem=  /\brv[ :]+(\d+)/g.exec(ua) || [];
+            return 'IE '+(tem[1] || '');
+        }
+        if(M[1]=== 'Chrome'){
+            tem= ua.match(/\bOPR\/(\d+)/);
+            if(tem!= null) return 'Opera '+tem[1];
+        }
+        M= M[2]? [M[1], M[2]]: [navigator.appName, navigator.appVersion, '-?'];
+        if((tem= ua.match(/version\/(\d+)/i))!= null) M.splice(1, 1, tem[1]);
+        return {
+            browser: M[0],
+            version: M[1]
+        };
+    })();
+
     function getConnectionSpeed(performance, connection, reportUnknown) {
 
         connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
@@ -333,6 +352,7 @@ define([
         hasPushStateSupport: hasPushStateSupport,
         getOrientation: getOrientation,
         getBreakpoint: getBreakpoint,
+        getUserAgent: getUserAgent,
         isIOS: isIOS,
         isAndroid: isAndroid,
         isFireFoxOSApp: isFireFoxOSApp,


### PR DESCRIPTION
This add's a browser support table to the video player and displays an error message prompting the user to update their browser if it is not supported.

Unfortunately i've had to do some hacky UA detection to achieve this, please don't judge me :crying_cat_face: 

/cc @gklopper @rich-nguyen 
