### PR TITLE
User timings event

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -291,12 +291,7 @@ define([
             }
         },
         allAdsRendered = function (slotId) {
-            forEach(slots, function (value, key) {
-                if (key === slotId) {
-                    slots[slotId].isRendered = true;
-                    return;
-                }
-            });
+            slots[slotId].isRendered = true;
 
             if (_.every(slots, 'isRendered')) {
                 userTiming.mark('All ads are rendered');

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -201,7 +201,6 @@ define([
                     refreshSlot($adSlot);
                 };
 
-            console.log('addSlot: ',slots);
             if (displayed && !slots[slotId]) { // dynamically add ad slot
                 // this is horrible, but if we do this before the initial ads have loaded things go awry
                 if (rendered) {
@@ -275,7 +274,6 @@ define([
 
             allAdsRendered(slot);
 
-            //console.log(event, slots, 'parseAd');
             if (event.isEmpty) {
                 removeLabel($slot);
             } else {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -169,6 +169,7 @@ define([
          * Public functions
          */
         init = function (options) {
+
             var opts = defaults(options || {}, {
                 resizeTimeout: 2000
             });
@@ -192,6 +193,7 @@ define([
             window.googletag.cmd.push(postDisplay);
 
             return dfp;
+
         },
         addSlot = function ($adSlot) {
             var slotId = $adSlot.attr('id'),
@@ -200,7 +202,6 @@ define([
                     googletag.display(slotId);
                     refreshSlot($adSlot);
                 };
-
             if (displayed && !slots[slotId]) { // dynamically add ad slot
                 // this is horrible, but if we do this before the initial ads have loaded things go awry
                 if (rendered) {
@@ -211,7 +212,6 @@ define([
                     });
                 }
             }
-
         },
         refreshSlot = function ($adSlot) {
             var slot = slots[$adSlot.attr('id')];

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -287,7 +287,7 @@ define([
                 // is there a callback for this size
                 callbacks[size] && callbacks[size](event, $slot);
             }
-        }
+        },
         allAdsRendered = function (slot) {
             forEach(slots, function (value, key) {
                 if (key === slot) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -141,10 +141,14 @@ define([
                     }
                 })
                 .map(function ($adSlot) {
-                    return [$adSlot.attr('id'), defineSlot($adSlot)];
+                    return [$adSlot.attr('id'), {
+                        isRendered: false,
+                        slot: defineSlot($adSlot)
+                    }];
                 })
                 .zipObject()
                 .valueOf();
+            console.log(slots);
         },
         displayAds = function () {
             googletag.pubads().enableSingleRequest();
@@ -198,7 +202,8 @@ define([
         addSlot = function ($adSlot) {
             var slotId = $adSlot.attr('id'),
                 displayAd = function ($adSlot) {
-                    slots[slotId] = defineSlot($adSlot);
+                    slots[slotId].isRendered = false;
+                    slots[slotId].slot = defineSlot($adSlot);
                     googletag.display(slotId);
                     refreshSlot($adSlot);
                 };
@@ -214,7 +219,7 @@ define([
             }
         },
         refreshSlot = function ($adSlot) {
-            var slot = slots[$adSlot.attr('id')];
+            var slot = slots[$adSlot.attr('id')].slot;
             if (slot) {
                 googletag.pubads().refresh([slot]);
             }
@@ -269,10 +274,10 @@ define([
         },
         parseAd = function (event) {
             var size,
-                slot = event.slot.getSlotId().getDomId(),
-                $slot = $('#' + slot);
+                slotId = event.slot.getSlotId().getDomId(),
+                $slot = $('#' + slotId);
 
-            allAdsRendered(slot);
+            allAdsRendered(slotId);
 
             if (event.isEmpty) {
                 removeLabel($slot);
@@ -286,16 +291,16 @@ define([
                 callbacks[size] && callbacks[size](event, $slot);
             }
         },
-        allAdsRendered = function (slot) {
+        allAdsRendered = function (slotId) {
             forEach(slots, function (value, key) {
-                if (key === slot) {
-                    slots[key].rendered = true;
+                if (key === slotId) {
+                    slots[slotId].isRendered = true;
                     return;
                 }
             });
 
-            if (_.every(slots, 'rendered')) {
-                userTiming.mark('Ads rendered');
+            if (_.every(slots, 'isRendered')) {
+                userTiming.mark('All ads are rendered');
             }
         },
         addLabel = function ($slot) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -148,7 +148,6 @@ define([
                 })
                 .zipObject()
                 .valueOf();
-            console.log(slots);
         },
         displayAds = function () {
             googletag.pubads().enableSingleRequest();

--- a/static/src/javascripts/projects/common/modules/commercial/tags/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/tags/krux.js
@@ -5,7 +5,6 @@ define([
 ) {
     function load() {
         if (config.switches.krux) {
-            userTiming.mark('Krux Begin');
             return require(['js!' + '//cdn.krxd.net/controltag?confid=JVZiE3vn']);
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/tags/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/tags/krux.js
@@ -5,6 +5,7 @@ define([
 ) {
     function load() {
         if (config.switches.krux) {
+            userTiming.mark('Krux Begin');
             return require(['js!' + '//cdn.krxd.net/controltag?confid=JVZiE3vn']);
         }
     }


### PR DESCRIPTION
The 'user timings' event (http://www.html5rocks.com/en/tutorials/webperformance/usertiming/) is now fired when all of the dfp ads are fully rendered. That event should be visible now on the webpagetest (http://www.webpagetest.org/result/150112_BP_XFK/1/details/).
