### PR TITLE
Fix for hanging letters on series/blog labels

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -267,6 +267,12 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     }
   }
 
+  lazy val isSectionLabelLong: Boolean = {
+    val labelList: Seq[String] = sectionLabelName.split(" ").toSeq
+    val filteredList: Seq[String] = labelList.filter(_.length > 10)
+    if(filteredList.length > 0) { true } else { false }
+  }
+
   lazy val blogOrSeriesTag: Option[Tag] = {
     tags.find( tag => tag.showSeriesInMeta && (tag.isBlog || tag.isSeries )).headOption
   }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -267,9 +267,11 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     }
   }
 
-  lazy val isSectionLabelLong: Boolean = {
-    val labelList: Seq[String] = sectionLabelName.split(" ").toSeq
-    val filteredList: Seq[String] = labelList.filter(_.length > 10)
+// This is a fix for the hanging letters on long section/series labels on the leftCol breakpoint.
+  lazy val areLabelsLong: Boolean = {
+    val sectionLabelList: Seq[String] = sectionLabelName.split(" ").toSeq
+    val blogLabelList: Seq[String] = blogOrSeriesTag.map(_.name.split(" ").toSeq).getOrElse(Nil)
+    val filteredList: Seq[String] = sectionLabelList.filter(_.length > 10) ++ blogLabelList.filter(_.length > 12)
     if(filteredList.length > 0) { true } else { false }
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -267,12 +267,12 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
     }
   }
 
-// This is a fix for the hanging letters on long section/series labels on the leftCol breakpoint.
+// This is a fix for the hanging letters on long section/series labels on the leftCol breakpoint. Use case explained in PR https://github.com/guardian/frontend/pull/7766
   lazy val areLabelsLong: Boolean = {
     val sectionLabelList: Seq[String] = sectionLabelName.split(" ").toSeq
     val blogLabelList: Seq[String] = blogOrSeriesTag.map(_.name.split(" ").toSeq).getOrElse(Nil)
     val filteredList: Seq[String] = sectionLabelList.filter(_.length > 10) ++ blogLabelList.filter(_.length > 12)
-    if(filteredList.length > 0) { true } else { false }
+    filteredList.length > 0
   }
 
   lazy val blogOrSeriesTag: Option[Tag] = {

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -2,7 +2,7 @@
 
 @import common.{LinkTo, Localisation}
 
-<div class="content__labels @if(content.isSectionLabelLong) { content__labels--long}">
+<div class="content__labels @if(content.areLabelsLong) { content__labels--long}">
     <div class="content__section-label">
         <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@content.sectionLabelLink}">@Html(Localisation(content.sectionLabelName))</a>
     </div>

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -2,7 +2,7 @@
 
 @import common.{LinkTo, Localisation}
 
-<div class="content__labels">
+<div class="content__labels @if(content.isSectionLabelLong) { content__labels--long}">
     <div class="content__section-label">
         <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@content.sectionLabelLink}">@Html(Localisation(content.sectionLabelName))</a>
     </div>

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -158,13 +158,12 @@
 .content__labels--long {
     @include mq(leftCol, wide) {
         .content__section-label__link {
-            @include fs-header(2);
-            line-height: 22px;
+            @include font-size(18, 22);
             display: block;
             padding: $gs-baseline/6 0;
         }
         .content__series-label__link {
-            @include fs-headline(2);
+            @include font-size(16, 20);
             display: block;
         }
     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -154,6 +154,12 @@
     }
 }
 
+.content__labels--long {
+    .content__section-label__link {
+        @include fs-header(2);
+    }
+}
+
 .content__series-label {
     @include fs-headline(2);
     float: left;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -154,9 +154,19 @@
     }
 }
 
+// Styling for long section/series labels at the leftCol breakpoint
 .content__labels--long {
-    .content__section-label__link {
-        @include fs-header(2);
+    @include mq(leftCol, wide) {
+        .content__section-label__link {
+            @include fs-header(2);
+            line-height: 22px;
+            display: block;
+            padding: $gs-baseline/6 0;
+        }
+        .content__series-label__link {
+            @include fs-headline(2);
+            display: block;
+        }
     }
 }
 


### PR DESCRIPTION
This is a first attempt at fixing the hanging letters on labels at the leftCol breakpoint.

I went for character counting in Scala as opposed to measuring the width in JavaScript as switching classes after load would have caused flickering.

This fixes all of the cases emailed over from central prod.

After:
![screen shot 2015-01-13 at 17 27 27](https://cloud.githubusercontent.com/assets/2236852/5725355/09788e88-9b4a-11e4-8d82-ca3bda092222.png)
![screen shot 2015-01-13 at 17 33 19](https://cloud.githubusercontent.com/assets/2236852/5725381/4dbeceb8-9b4a-11e4-86cb-dcec6f4b56a1.png)

Before:
![screen shot 2015-01-13 at 17 26 57](https://cloud.githubusercontent.com/assets/2236852/5725358/0db39894-9b4a-11e4-82bc-ee077230ec02.png)
![screen shot 2015-01-13 at 17 33 23](https://cloud.githubusercontent.com/assets/2236852/5725385/55072c10-9b4a-11e4-903b-73c1f5715620.png)

@robertberry @sndrs would be good to hear your thoughts.
