### PR TITLE
escape unicode chars that can't be used in JS

### DIFF
--- a/common/app/common/StringEncodings.scala
+++ b/common/app/common/StringEncodings.scala
@@ -5,4 +5,18 @@ import java.text.Normalizer
 object StringEncodings {
   def asAscii(s: String) =
     Normalizer.normalize(s, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
+
+  /**
+   * unicode CR and LF are valid in JSON but not in JS, so we need to run our JSON through
+   * this before embedding it into JS files.
+   * https://code.google.com/p/v8/issues/detail?id=1907
+   *
+   * @param json the original json source
+   * @return the JS
+   */
+  def jsonToJS(json: String) =
+    json
+      .replaceAll("""\u2028""", """\\u2028""")
+      .replaceAll("""\u2029""", """\\u2029""")
+
 }

--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -1,4 +1,5 @@
 @(item: model.MetaData)(implicit request: RequestHeader)
+@import common.StringEncodings
 
 @import common.Edition
 @import views.support.{JavaScriptPage, CamelCase}
@@ -6,7 +7,7 @@
 
 @defining(Edition(request)) { edition =>
     {
-        "page": @Html(Json.stringify(JavaScriptPage(item).get)),
+        "page": @Html(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage(item).get))),
         "switches" : { @{Html(conf.Switches.all.map{ switch =>
             s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}
         },

--- a/dev-build/conf/application-logger.xml
+++ b/dev-build/conf/application-logger.xml
@@ -19,8 +19,17 @@
     <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="OFF"/>
     <logger name="com.google.api.client.http.HttpTransport" level="OFF"/>
 
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <file>logs/frontend-png-resizer.log</file>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+        </encoder>
+    </appender>
+
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="Console"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
We had some issues with a page javascript not running reported:  #7711  on this page
http://www.theguardian.com/world/picture/2014/mar/13/eyewitness-12000-light-years-from-earth
which I traced down to this issue
http://timelessrepo.com/json-isnt-a-javascript-subset
Basically you can't have unicode u2028 and 2029 in JS but you can in JSON.

This PR just adds a function to convert JSON to JS safely and should fix the problem.

PS I also slipped in a change so the logger output with the full stack trace goes to the console.  On dev-build it does seema little verbose, so perhaps some further tweaking might help in future.
