### PR TITLE
Add titles to share links

### DIFF
--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -6,7 +6,8 @@
             <a  class="social__action social-icon-wrapper"
                 data-link-name="social @position"
                 href="@item.href"
-                target="_blank">
+                target="_blank"
+                title="@item.text">
                 <span class="u-h">@item.userMessage</span>
                 <span class="rounded-icon social-icon social-icon--@item.css">
                     <i class="i-share-@item.css--white i"></i>


### PR DESCRIPTION
I saw a few people in comments asking about where the email link had gone on our "new trendy website". So figured we should add titles to those links. Tooltips!

![screen recording 2015-01-14 at 11 19 am](https://cloud.githubusercontent.com/assets/1607666/5738006/38242b6c-9bdf-11e4-98e4-bdccd54bd342.gif)
