### PR TITLE
Fronts HTML optimisations

### DIFF
--- a/common/app/cards/CardType.scala
+++ b/common/app/cards/CardType.scala
@@ -24,7 +24,7 @@ sealed trait CardType {
   }
 
   def showStandfirst = this match {
-    case Fluid | FullMedia100 | FullMedia75 | FullMedia50 | Half | ThreeQuarters | ThreeQuartersRight => true
+    case Fluid | FullMedia100 | FullMedia75 | FullMedia50 | Half | ThreeQuarters | ThreeQuartersRight | Standard => true
     case _ => false
   }
 }

--- a/common/app/cards/CardType.scala
+++ b/common/app/cards/CardType.scala
@@ -22,6 +22,11 @@ sealed trait CardType {
     case ListItem => false
     case _ => true
   }
+
+  def showStandfirst = this match {
+    case Fluid | FullMedia100 | FullMedia75 | FullMedia50 | Half | ThreeQuarters | ThreeQuartersRight => true
+    case _ => false
+  }
 }
 
 /** This is called ListItem because List is already taken */

--- a/common/app/cards/CardType.scala
+++ b/common/app/cards/CardType.scala
@@ -12,6 +12,16 @@ sealed trait CardType {
     case ListItem => false
     case _ => true
   }
+
+  /** To actually find out if media is shown you would also need to check whether there is an image (or video) and
+    * whether image hide setting is on.
+    *
+    * But some card sizes can never show media, regardless of those options, and this is what this represents.
+    */
+  def canShowMedia = this match {
+    case ListItem => false
+    case _ => true
+  }
 }
 
 /** This is called ListItem because List is already taken */

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -272,6 +272,9 @@ case class ContentCard(
   }
 
   def withTimeStamp = copy(timeStampDisplay = Some(DateOrTimeAgo))
+
+  def showDisplayElement =
+    cardTypes.allTypes.exists(_.canShowMedia) && !displaySettings.imageHide
 }
 
 case class HtmlBlob(html: Html, customCssClasses: Seq[String], cardTypes: ItemClasses) extends FaciaCard

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -275,6 +275,8 @@ case class ContentCard(
 
   def showDisplayElement =
     cardTypes.allTypes.exists(_.canShowMedia) && !displaySettings.imageHide
+
+  def showStandfirst = cardTypes.allTypes.exists(_.showStandfirst)
 }
 
 case class HtmlBlob(html: Html, customCssClasses: Seq[String], cardTypes: ItemClasses) extends FaciaCard

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -98,7 +98,7 @@ data-test-id="facia-card"
             }
         </div>
 
-        @item.trailText.map { text =>
+        @item.trailText.filter(const(item.showStandfirst)).map { text =>
             <div class="fc-item__standfirst">@Html(text)</div>
         }
 

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -8,6 +8,7 @@
 @import views.html.fragments.items.elements.facia_cards._
 @import views.html.fragments.items.elements.starRating
 @import layout.LatestSnap
+@import Function.const
 
 <div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!isList){js-snappable}"
     @if(item.discussionSettings.isCommentable) {
@@ -30,7 +31,7 @@ data-test-id="facia-card"
             @kicker(item.header, List("fc-item__kicker--dreamsnap", "fc-item__kicker--dreamsnap-list"))
         }
 
-        @item.displayElement match {
+        @item.displayElement.filter(const(item.showDisplayElement)) match {
             case Some(InlineVideo(videoElement, title, endSlatePath, fallback)) if item.cardTypes.showVideoPlayer => {
                 @defining(VideoPlayer(
                     videoElement,

--- a/onward/test/RelatedFeatureTest.scala
+++ b/onward/test/RelatedFeatureTest.scala
@@ -42,7 +42,6 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
         val article = findFirst("li")
         article.findFirst("a").getAttribute("href").length should be > 0
         article.findFirst("h2").getText.length should be > 0
-        article.find(".fc-item__standfirst").size should be > 0
         article.findFirst("time").getAttribute("data-timestamp") should not be empty
 
         findFirst("ul").find(".fc-item__title").size should be > 0


### PR DESCRIPTION
There's a few elements that we always render for every item even if they're always hidden by CSS.

This gets rid of them.

On the current homepage it takes the HTML payload from 528kb -> 393kb.

CC @phamann @gklopper 
