### PR TITLE
Adding js hooks to social icons on select

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -106,8 +106,8 @@ define([
         // and the UI is generally fiddly on touch.
         if (!detect.hasTouchScreen()) {
             $body.append($selectionSharing);
-            $twitterAction = $('.social__item--twitter .social__action');
-            $emailAction = $('.social__item--email .social__action');
+            $twitterAction = $('.js-selection-twitter');
+            $emailAction = $('.js-selection-email');
             // Set timeout ensures that any existing selection has been cleared.
             bean.on(document.body, 'keypress keydown keyup', _.debounce(updateSelection, 50));
             bean.on(document.body, 'mouseup', _.debounce(updateSelection, 200));

--- a/static/src/javascripts/projects/common/views/ui/selection-sharing.html
+++ b/static/src/javascripts/projects/common/views/ui/selection-sharing.html
@@ -1,7 +1,7 @@
 <div class="selection-sharing">
     <ul class="social u-unstyled u-cf" data-component="social-selection">
         <li class="social__item" data-link-name="twitter">
-            <a  class="rounded-icon social-icon social-icon--twitter"
+            <a  class="rounded-icon social-icon social-icon--twitter js-selection-twitter"
                 data-link-name="social-selection"
                 target="_blank"
                 href="#">
@@ -10,7 +10,7 @@
             </a>
         </li>
         <li class="social__item" data-link-name="email">
-            <a  class="rounded-icon social-icon social-icon--email"
+            <a  class="rounded-icon social-icon social-icon--email js-selection-email"
                 data-link-name="social-selection"
                 target="_blank"
                 href="#">


### PR DESCRIPTION
This is fixing bug that was introduced by https://github.com/guardian/frontend/pull/7685

Good example of why using js-hooks is important.
