### PR TITLE
breaking news design tweaks

### DIFF
--- a/static/src/stylesheets/module/onward/_breaking-news.scss
+++ b/static/src/stylesheets/module/onward/_breaking-news.scss
@@ -4,7 +4,7 @@ $breaking-news-icon-width: 36px;
     &:before {
         position: absolute;
         left: 0 - $breaking-news-icon-width - $gs-gutter / 2;
-        top: 0 - $gs-baseline / 2;
+        top: 0;
         width: $breaking-news-icon-width;
         height: $breaking-news-icon-width;
         @include icon(marque-36, false);
@@ -53,16 +53,12 @@ $breaking-news-icon-width: 36px;
 
 .breaking-news__item {
     display: block;
-    padding: 0;
+    padding: 0 0 $gs-baseline;
     background: fade-out(colour(live-default), 1 - .95);
     @include transition(background-color .25s ease);
 
     &:hover {
         background-color: darken(colour(live-default), 2%);
-    }
-
-    @include mq(tablet) {
-        padding: $gs-baseline 0;
     }
 
     & + & {
@@ -72,7 +68,7 @@ $breaking-news-icon-width: 36px;
 
 .breaking-news__item-content {
     @include box-sizing(border-box);
-    padding: $gs-baseline 0 $gs-baseline ($gs-gutter + $breaking-news-icon-width);
+    padding: $gs-baseline * .5 0 $gs-baseline ($gs-gutter + $breaking-news-icon-width);
     @include gs-container;
 
     @include mq(wide) {
@@ -91,6 +87,7 @@ $breaking-news-icon-width: 36px;
 .breaking-news__item-kicker,
 .breaking-news__item-headline {
     @include fs-headline(2);
+    line-height: 1.3;
 
     @include mq(tablet) {
         @include fs-headline(4);

--- a/static/src/stylesheets/module/onward/_breaking-news.scss
+++ b/static/src/stylesheets/module/onward/_breaking-news.scss
@@ -68,7 +68,7 @@ $breaking-news-icon-width: 36px;
 
 .breaking-news__item-content {
     @include box-sizing(border-box);
-    padding: $gs-baseline * .5 0 $gs-baseline ($gs-gutter + $breaking-news-icon-width);
+    padding: ($gs-baseline * .5) 0 $gs-baseline ($gs-gutter + $breaking-news-icon-width);
     @include gs-container;
 
     @include mq(wide) {


### PR DESCRIPTION
from 

![screen shot 2015-01-14 at 14 01 44](https://cloud.githubusercontent.com/assets/867233/5739885/1fce9eb4-9bf6-11e4-9e6b-8c76ad9026e8.png)
![screen shot 2015-01-14 at 14 01 31](https://cloud.githubusercontent.com/assets/867233/5739887/22727a1e-9bf6-11e4-8686-797c36b3d58c.png)

to

![screen shot 2015-01-14 at 13 59 04](https://cloud.githubusercontent.com/assets/867233/5739881/17dcdaa4-9bf6-11e4-8150-9843057b760a.png)
![screen shot 2015-01-14 at 13 59 19](https://cloud.githubusercontent.com/assets/867233/5739882/1ae2670a-9bf6-11e4-9edb-dedc7b29be9c.png)
