### PR TITLE
Move comment count template to JavaScript

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -15,7 +15,6 @@
         data-discussion-id="@id"
         }
         data-discussion-closed="@item.discussionSettings.isClosedForComments"
-        data-discussion-inline-upgrade="true"
     }
 data-link-name="@item.cardStyle.toneString | @{index + 1}"
     @item.id.map { id =>

--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -3,7 +3,7 @@
 @import common.LinkTo
 @import views.support.Format
 
-<aside class="fc-item__meta">
+<aside class="fc-item__meta js-item__meta">
     @for(publishedAt <- item.webPublicationDate; timeStampDisplay <- item.timeStampDisplay) {
         <time class="fc-item__timestamp@if(timeStampDisplay.javaScriptUpdate){ js-item__timestamp}"
               datetime="@publishedAt.toString("yyyy-MM-dd'T'HH:mm:ssZ")"

--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -1,6 +1,5 @@
 @(item: layout.ContentCard)(implicit request: RequestHeader)
 
-@import common.LinkTo
 @import views.support.Format
 
 <aside class="fc-item__meta js-item__meta">
@@ -14,8 +13,4 @@
             </span>
         </time>
     }
-
-    <a class="fc-trail__count fc-trail__count--commentcount fc-trail__count--inline-template js-item__inline-comment-template" href="@LinkTo(item)#comments" data-link-name="Comment count">
-        <span class="js-item__comment-count"></span> <span class="fc-trail__count__label js-item__comment-or-comments"></span>
-    </a>
 </aside>

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -80,7 +80,6 @@ object GetClasses {
     RenderClasses((Seq(
       ("js-container--fetch-updates", showLatestUpdate),
       ("fc-container", true),
-      ("fc-container", true),
       ("fc-container--first", isFirst),
       ("fc-container--sponsored", commercialOptions.isSponsored),
       ("fc-container--advertisement-feature", commercialOptions.isAdvertisementFeature),

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -61,24 +61,18 @@ define([
                 }
                 $node.removeClass('u-h');
 
-                if ($node.attr('data-discussion-inline-upgrade') === 'true') {
-                    $('.js-item__comment-count', node).html(formatters.integerCommas(c.count));
-                    $('.js-item__comment-or-comments', node).html(commentOrComments);
-                    $('.js-item__inline-comment-template', node).show('inline');
-                } else {
-                    // put in trail__meta, if exists
-                    meta = qwery('.item__meta, .card__meta, .js-append-commentcount', node);
-                    $container = meta.length ? bonzo(meta) : $node;
-                    format = $node.data('commentcount-format');
+                // put in trail__meta, if exists
+                meta = qwery('.js-item__meta', node);
+                $container = meta.length ? bonzo(meta) : $node;
+                format = $node.data('commentcount-format');
 
-                    $container.append(template(templates[format] || defaultTemplate, {
-                        url: getContentUrl(node),
-                        count: formatters.integerCommas(c.count),
-                        label: commentOrComments
-                    }));
+                $container.append(template(templates[format] || defaultTemplate, {
+                    url: getContentUrl(node),
+                    count: formatters.integerCommas(c.count),
+                    label: commentOrComments
+                }));
 
-                    $node.removeAttr(attributeName);
-                }
+                $node.removeAttr(attributeName);
             });
         });
     }

--- a/static/src/javascripts/projects/common/views/discussion/comment-count.html
+++ b/static/src/javascripts/projects/common/views/discussion/comment-count.html
@@ -1,3 +1,3 @@
-<a class="fc-trail__count fc-trail__count--commentcount fc-trail__count--inline-template js-item__inline-comment-template" href="{{url}}" data-link-name="Comment count">
+<a class="fc-trail__count fc-trail__count--commentcount" href="{{url}}" data-link-name="Comment count">
     <span class="js-item__comment-count">{{count}}</span> <span class="fc-trail__count__label js-item__comment-or-comments">{{label}}</span>
 </a>

--- a/static/src/javascripts/projects/common/views/discussion/comment-count.html
+++ b/static/src/javascripts/projects/common/views/discussion/comment-count.html
@@ -1,3 +1,3 @@
-<span class="trail__count trail__count--commentcount tone-colour">
-    <a href="{{url}}" data-link-name="Comment count"><i class="i i-comment-light-grey"></i>{{count}}
-<span class="u-h"> {{label}}</span></a></span>
+<a class="fc-trail__count fc-trail__count--commentcount fc-trail__count--inline-template js-item__inline-comment-template" href="{{url}}" data-link-name="Comment count">
+    <span class="js-item__comment-count">{{count}}</span> <span class="fc-trail__count__label js-item__comment-or-comments">{{label}}</span>
+</a>


### PR DESCRIPTION
Rather than outputting it for every article on a front (including articles that don't get comment counts in the end).
