### PR TITLE
remove console logger from dev-build

### DIFF
--- a/dev-build/conf/application-logger.xml
+++ b/dev-build/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
         </encoder>
     </appender>
 
@@ -19,17 +19,8 @@
     <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="OFF"/>
     <logger name="com.google.api.client.http.HttpTransport" level="OFF"/>
 
-    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
-        <file>logs/frontend-png-resizer.log</file>
-
-        <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
-        </encoder>
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="Console"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
The dev build spits out a lot of stuff at info level so putting the console logger on is a bit too crazy.

This PR turns it off again, but also makes sure the full stack traces are put into the logs/ file.

I think in reality there are other issues with logging, I think we're spitting too much out by default when more should probably be at a finer level (and presumably run prod at that finer level), then we can switch the logger on only for what we want locally.  It'd probably be nice to at least have requests/responses basic info and exceptions in the console log?  Because even when I was running locally it was very hard to find what I was interested in which was the exception causing the 5xx error.

@kelvin-chappell @phamann this should turn off the console again!
