### PR TITLE
Hanging letters on labels v2

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -153,7 +153,6 @@
     }
 }
 
-
 .content__series-label {
     @include fs-headline(2);
     float: left;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -125,8 +125,6 @@
     border-bottom: 1px dotted colour(neutral-5);
     position: relative;
     z-index: 1; // bring-to-front fix to make it clickable
-    overflow: hidden;
-    word-wrap: break-word;
 
     @include mq(leftCol) {
         border: 0;
@@ -145,11 +143,13 @@
 .content__section-label {
     @include fs-header(1);
     float: left;
+    padding-right: $gs-gutter/3;
 
     @include mq(leftCol) {
         @include fs-header(4);
         line-height: get-line-height(header, 2);
         float: none;
+        padding-right: 0;
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -169,8 +169,10 @@
 }
 
 @include mq(leftCol, wide) {
-    .content__section-label__link {
-        @include font-size(20, 24);
+    .content__section-label__link,
+    .container__meta__title {
+        font-size: 20px !important;
+        line-height: 24px !important;
     }
 
     .content__series-label__link {

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -151,15 +151,8 @@
         line-height: get-line-height(header, 2);
         float: none;
     }
-
-    @include mq(leftCol, wide) {
-        .content__section-label__link {
-            @include font-size(20, 24);
-            display: block;
-            padding: $gs-baseline/6 0;
-        }
-    }
 }
+
 
 .content__series-label {
     @include fs-headline(2);
@@ -173,12 +166,16 @@
     .content__series-label__link {
         color: colour(neutral-2);
     }
+}
 
-    @include mq(leftCol, wide) {
-        .content__series-label__link {
-            @include font-size(18, 22);
-            display: block;
-        }
+@include mq(leftCol, wide) {
+    .content__section-label__link {
+        @include font-size(20, 24);
+    }
+
+    .content__series-label__link {
+        @include font-size(18, 22);
+        display: block;
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -145,12 +145,19 @@
 .content__section-label {
     @include fs-header(1);
     float: left;
-    padding-right: $gs-gutter/3;
 
     @include mq(leftCol) {
         @include fs-header(4);
         line-height: get-line-height(header, 2);
         float: none;
+    }
+
+    @include mq(leftCol, wide) {
+        .content__section-label__link {
+            @include font-size(20, 24);
+            display: block;
+            padding: $gs-baseline/6 0;
+        }
     }
 }
 
@@ -165,6 +172,13 @@
 
     .content__series-label__link {
         color: colour(neutral-2);
+    }
+
+    @include mq(leftCol, wide) {
+        .content__series-label__link {
+            @include font-size(18, 22);
+            display: block;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -559,6 +559,10 @@ $header-image-size-desktop: 100px;
             float: none;
         }
     }
+
+    @include mq(leftCol, wide) {
+        @include font-size(20px, 24px);
+    }
 }
 
 .index-page-header__description {

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -139,6 +139,10 @@ $header-image-size-desktop: 100px;
         width: gs-span(6) + $gs-gutter;
     }
 
+    @include mq(leftCol, wide) {
+        @include font-size(20px, 24px);
+    }
+
     .has-page-skin & {
         @include mq(wide) {
             float: left;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -132,7 +132,6 @@ $header-image-size-desktop: 100px;
     @include fs-header(4);
     line-height: get-line-height(header, 2);
     color: guss-colour(guardian-brand-dark, $pasteup-palette);
-    word-wrap: break-word;
 
     @include mq(tablet, leftCol) {
         float: left;


### PR DESCRIPTION
New, simpler way of solving our hanging letters on labels.

We're now reducing the font-size on all of the labels/headers at leftCol. 
![screen shot 2015-01-14 at 16 47 05](https://cloud.githubusercontent.com/assets/2236852/5742829/fca9845a-9c0c-11e4-80a9-0e574f2a667c.png)

Also removed word-wrap: break-word and overflow: hidden so that things like:
![screen shot 2015-01-14 at 16 46 12](https://cloud.githubusercontent.com/assets/2236852/5742820/e6c11b44-9c0c-11e4-92f1-e15ede5d53c0.png)

Become:
![screen shot 2015-01-14 at 16 46 05](https://cloud.githubusercontent.com/assets/2236852/5742821/ead1cbe8-9c0c-11e4-820f-733f0416c924.png)

cc @robertberry 
