### PR TITLE
Fix Edition-Targeting Bug

### DIFF
--- a/common/app/dfp/PaidForTagAgent.scala
+++ b/common/app/dfp/PaidForTagAgent.scala
@@ -41,7 +41,7 @@ trait PaidForTagAgent {
               _.isEditionTag
             } flatMap (_.values.map(_.toLowerCase))
           }.distinct
-          editionIds contains edition.id.toLowerCase
+          editionIds.isEmpty || editionIds.contains(edition.id.toLowerCase)
         }
       }
     }


### PR DESCRIPTION
Logic was previously that a page wasn't sponsored in the visitor's edition if none of the relevant line items were targeting a particular edition.
