### PR TITLE
Weather search icon now enters search box

### DIFF
--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -64,6 +64,8 @@ $weather-large-size: 60px;
     .search-tool__input {
         display: none;
         width: 100%;
+        position: relative;
+        z-index: 4;
         @include fs-headline(2);
 
         @include mq(tablet) {
@@ -108,7 +110,6 @@ $weather-large-size: 60px;
     top: 1px;
     right: 0;
     display: block;
-    z-index: 5;
     line-height: inherit;
 
     @include mq(leftCol) {
@@ -129,7 +130,12 @@ $weather-large-size: 60px;
 }
 
 .weather__close-location {
+    z-index: 5;
     display: none;
+}
+
+.weather__edit-location {
+    z-index: 3;
 }
 
 .weather__forecasts {


### PR DESCRIPTION
Push back the search icon in the z-index to allow the user to enter the search box by "clicking" on it. They're really just clicking on the input though.

Before:
![screen recording 2015-01-15 at 12 26 pm](https://cloud.githubusercontent.com/assets/1607666/5757279/dacd8c78-9cb1-11e4-9bb3-72601b3af047.gif)

After:
![screen recording 2015-01-15 at 12 26 pm-1](https://cloud.githubusercontent.com/assets/1607666/5757281/dc3d4b3e-9cb1-11e4-8c39-f5838d147227.gif)
