### PR TITLE
Revert back to old version of videojs-contrib-ads

### DIFF
--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -14,7 +14,7 @@
     "reqwest": "guardian/reqwest#master",
     "enhancer": "0.1.1",
     "videojs": "guardian/video.js#158221b5d997a184972fbf038c9eebdb676d30c8",
-    "videojs-contrib-ads": "0.6.0",
+    "videojs-contrib-ads": "videojs/videojs-contrib-ads#f44387a4d2fd939f9a665762917e2fa6fc8838d7",
     "videojs-vast": "guardian/videojs-vast-plugin#f2b9fe764d90f364607ba2b7fca1694d9db8d31a",
     "vast-client-js": "guardian/vast-client-js#79a3102455eb8acc6b677424e6e556fb354131d4",
     "videojs-persistvolume": "~0.1.0",
@@ -27,7 +27,9 @@
     "videojs-embed": "~0.3.1"
   },
   "resolutions": {
-    "videojs-contrib-ads": "0.6.0"
+    "videojs": "158221b5d997a184972fbf038c9eebdb676d30c8",
+    "videojs-contrib-ads": "f44387a4d2fd939f9a665762917e2fa6fc8838d7",
+    "vast-client-js": "79a3102455eb8acc6b677424e6e556fb354131d4"
   },
   "install": {
     "path": "components",

--- a/static/src/javascripts/components/videojs-contrib-ads/videojs.ads.js
+++ b/static/src/javascripts/components/videojs-contrib-ads/videojs.ads.js
@@ -140,10 +140,6 @@ var
   getPlayerSnapshot = function(player) {
     var
       tech = player.el().querySelector('.vjs-tech'),
-      tracks = player.remoteTextTracks(),
-      track,
-      i,
-      suppressedTracks = [],
       snapshot = {
         src: player.currentSrc(),
         currentTime: player.currentTime(),
@@ -154,17 +150,6 @@ var
       snapshot.nativePoster = tech.poster;
       snapshot.style = tech.getAttribute('style');
     }
-
-    i = tracks.length;
-    while (i--) {
-      track = tracks[i];
-      suppressedTracks.push({
-        track: track,
-        mode: track.mode
-      });
-      track.mode = 'disabled';
-    }
-    snapshot.suppressedTracks = suppressedTracks;
 
     return snapshot;
   },
@@ -194,16 +179,6 @@ var
 
       // the number of remaining attempts to restore the snapshot
       attempts = 20,
-
-      suppressedTracks = snapshot.suppressedTracks,
-      trackSnapshot,
-      restoreTracks =  function() {
-        var i = suppressedTracks.length;
-        while (i--) {
-          trackSnapshot = suppressedTracks[i];
-          trackSnapshot.track.mode = trackSnapshot.mode;
-        }
-      },
 
       // finish restoring the playback state
       resume = function() {
@@ -266,9 +241,6 @@ var
     }
 
     if (srcChanged) {
-      // on ios7, fiddling with textTracks too early will cause it safari to crash
-      player.one('loadedmetadata', restoreTracks);
-
       // if the src changed for ad playback, reset it
       player.src({ src: snapshot.src, type: snapshot.type });
       // safari requires a call to `load` to pick up a changed source
@@ -276,9 +248,6 @@ var
       // and then resume from the snapshots time once the original src has loaded
       player.one('loadedmetadata', tryToResume);
     } else if (!player.ended()) {
-      // if we didn't change the src, just restore the tracks
-      restoreTracks();
-
       // the src didn't change and this wasn't a postroll
       // just resume playback at the current time.
       player.play();
@@ -528,13 +497,13 @@ var
       'adstart',  // startLinearAdMode()
       'adend'     // endLinearAdMode()
     ]), fsmHandler);
-
+    
     // keep track of the current content source
     // if you want to change the src of the video without triggering
     // the ad workflow to restart, you can update this variable before
     // modifying the player's source
     player.ads.contentSrc = player.currentSrc();
-
+    
     // implement 'contentupdate' event.
     (function(){
       var


### PR DESCRIPTION
Latest version it totally borked - requires a branch of a fork of videojs

cc: @rich-nguyen 
