### PR TITLE
Weather - On blur remove is-editing state

### DIFF
--- a/static/src/javascripts/projects/common/modules/weather.js
+++ b/static/src/javascripts/projects/common/modules/weather.js
@@ -131,7 +131,7 @@ define([
             bean.on($('.js-close-location')[0], 'click', function () {
                 self.toggleControls(false);
             });
-            bean.on($('.js-weather-input')[0], 'blur', function() {
+            bean.on($('.js-weather-input')[0], 'blur', function () {
                 self.toggleControls(false);
             });
             mediator.on('autocomplete:fetch', this.fetchData);

--- a/static/src/javascripts/projects/common/modules/weather.js
+++ b/static/src/javascripts/projects/common/modules/weather.js
@@ -131,6 +131,9 @@ define([
             bean.on($('.js-close-location')[0], 'click', function () {
                 self.toggleControls(false);
             });
+            bean.on($('.js-weather-input')[0], 'blur', function() {
+                self.toggleControls(false);
+            });
             mediator.on('autocomplete:fetch', this.fetchData);
         },
 


### PR DESCRIPTION
Catch the blur event and visually display it using the `is-editing` state. It means you can do this:

![screen recording 2015-01-15 at 02 38 pm](https://cloud.githubusercontent.com/assets/1607666/5759255/43b122f6-9cc4-11e4-99f0-df4d1759a320.gif)
