### PR TITLE
Twitter handle mobile tweaks

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -24,10 +24,6 @@
         @fragments.meta.dateline(content.webPublicationDate, secondary = true)
     }
 
-    @if(content.contributors.length == 1) {
-        @fragments.meta.twitterHandle(content, mobile = true)
-    }
-
     <div class="meta__extras">
         <div class="meta__social" data-component="share">
             @fragments.social(content, "top")

--- a/common/app/views/fragments/meta/twitterHandle.scala.html
+++ b/common/app/views/fragments/meta/twitterHandle.scala.html
@@ -1,17 +1,12 @@
-@(tags: Tags, mobile: Boolean = false)
+@(tags: Tags)
 
 @tags.contributors.headOption.map { profile =>
     @profile.twitterHandle.map{ twitter =>
-        <div class="meta__twitter @if(mobile) { hide-from-leftcol } else { hide-until-leftcol }">
+        <div class="meta__twitter">
             <a href="http://twitter.com/@@@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle">
                 <button class="button button--small button--secondary button--tone-news tone-colour">
                     <svg class="icon" width="13" height="11" viewBox="0 -1 13 11" xmlns="http://www.w3.org/2000/svg"><path class="svg-tone-fill" d="m13 1.3c-.5.2-1 .4-1.5.4.6-.3 1-.9 1.2-1.5-.5.3-1.1.5-1.7.7-.5-.5-1.2-.9-1.9-.9-1.5 0-2.7 1.2-2.7 2.8 0 .2 0 .4.1.6-2.2-.1-4.2-1.2-5.5-2.9-.2.4-.4.9-.4 1.4 0 1 .5 1.8 1.2 2.3-.4 0-.8-.1-1.2-.3 0 1.4.9 2.5 2.1 2.8-.2.1-.5.1-.7.1-.2 0-.3 0-.5 0 .3 1.1 1.3 1.9 2.5 1.9-.9.7-2.1 1.2-3.3 1.2-.2 0-.4 0-.6 0 1.2.8 2.6 1.2 4.1 1.2 4.9 0 7.6-4.2 7.6-7.9 0-.1 0-.2 0-.4.5-.4 1-.9 1.3-1.4" fill="#fff"/></svg>
-
-                    @if(mobile == true) {
-                        <div class="twitter-handle">follow</div>
-                    } else {
-                        <div class="twitter-handle">@@@twitter</div>
-                    }
+                    <div class="twitter-handle">@@@twitter</div>
                 </button>
             </a>
       </div>

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -676,7 +676,14 @@
 }
 
 .meta__twitter {
-    margin-top: -($gs-baseline/2);
+    margin-top: -($gs-baseline*2/3);
+    margin-bottom: -($gs-baseline/6);
+
+    .content__meta-container--tonal-header & {
+        @include mq($until: leftCol) {
+            margin-top: -($gs-baseline/3);
+        }
+    }
 
     .icon {
         margin-top: $gs-baseline/3;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -703,7 +703,7 @@
 
         @include mq($until: leftCol) {
             padding: 0;
-            margin: $gs-baseline/2 0 0 0;
+            margin: $gs-baseline/2 0 0;
             border: 0;
             background-color: transparent !important;
         }
@@ -713,7 +713,7 @@
         height: 21px;
         display: inline-block;
         vertical-align: top;
-        
+
         @include mq(leftCol) {
             margin-top: -1px;
         }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -681,7 +681,6 @@
     .icon {
         margin-top: $gs-baseline/3;
         overflow: visible;
-        padding-right: $gs-gutter/10;
     }
 
     button {
@@ -699,6 +698,7 @@
         @include mq($until: leftCol) {
             padding: 0;
             margin: 0;
+            margin-top: $gs-baseline/2;
             border: 0;
             border-radius: 0;
             background-color: transparent !important;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -676,8 +676,7 @@
 }
 
 .meta__twitter {
-    margin-top: -($gs-baseline*2/3);
-    margin-bottom: -($gs-baseline/6);
+    margin: -($gs-baseline*2/3) 0 -($gs-baseline/6) 0;
 
     .content__meta-container--tonal-header & {
         @include mq($until: leftCol) {
@@ -704,15 +703,9 @@
 
         @include mq($until: leftCol) {
             padding: 0;
-            margin: 0;
-            margin-top: $gs-baseline/2;
+            margin: $gs-baseline/2 0 0 0;
             border: 0;
-            border-radius: 0;
             background-color: transparent !important;
-
-            &:hover {
-                text-decoration: underline;
-            }
         }
     }
 
@@ -720,7 +713,7 @@
         height: 21px;
         display: inline-block;
         vertical-align: top;
-
+        
         @include mq(leftCol) {
             margin-top: -1px;
         }


### PR DESCRIPTION
We've moved the twitter handles above the dateline on mobile, which means we no longer need to have two elements that we hide/unhide (hoorah!). 

Before:
![screen shot 2015-01-15 at 15 56 13](https://cloud.githubusercontent.com/assets/2236852/5760811/10a07352-9ccf-11e4-960c-0ab5986559c1.png)

After:
![screen shot 2015-01-15 at 15 56 01](https://cloud.githubusercontent.com/assets/2236852/5760812/1312ef7a-9ccf-11e4-96dc-4e5fd59fd6a4.png)
