### PR TITLE
Liveblog key events offset

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -188,8 +188,10 @@ $block-padding-right: $gs-gutter;
     position: relative;
 }
 
-.block.is-key-event {
-    border-top: 2px solid colour(live-accent);
+.block.is-key-event,
+.block.is-summary {
+    border-top: ($gs-baseline - 1) solid colour(neutral-8);
+    @include box-shadow(inset 0px 1px 0px 0px colour(live-accent));
 }
 
 .truncated-block {

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -570,7 +570,7 @@ $timeline-width: 15px;
         width: $right-column;
         top: $gs-baseline;
         padding-top: $gs-baseline;
-        border-top: 1px solid colour(live-default);
+        border-top: 1px solid colour(live-accent);
     }
 }
 

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -190,7 +190,7 @@ $block-padding-right: $gs-gutter;
 
 .block.is-key-event,
 .block.is-summary {
-    border-top: ($gs-baseline - 1) solid colour(neutral-8);
+    border-top: $gs-baseline solid colour(neutral-8);
     @include box-shadow(inset 0px 1px 0px 0px colour(live-accent));
 }
 

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -192,6 +192,7 @@ $block-padding-right: $gs-gutter;
 .block.is-summary {
     border-top: $gs-baseline solid colour(neutral-8);
     @include box-shadow(inset 0px 1px 0px 0px colour(live-accent));
+    margin-top: -$gs-baseline;
 }
 
 .truncated-block {


### PR DESCRIPTION
Chris noticed a problem after I added the new byline area to liveblogs:

![original](https://cloud.githubusercontent.com/assets/2236852/5773999/0441a26a-9d61-11e4-88a5-af86ed998dc1.gif)
The borders don't line up.

I didn't want to add any extra dom elements to the already-heavy liveblog pages, so I wanted to find a solution that worked using CSS. 

This solution works all the way back to IE9.
![new](https://cloud.githubusercontent.com/assets/2236852/5774066/c4df53f0-9d61-11e4-96d3-926fee587102.gif)

CSS gurus, are there any downsides to this? @phamann @sndrs @sammorrisdesign @paulrobertlloyd
