### PR TITLE
Fetch All DFP Line Items That Are Ready or Delivering

### DIFF
--- a/common/app/dfp/TagSponsorship.scala
+++ b/common/app/dfp/TagSponsorship.scala
@@ -109,9 +109,7 @@ object PaidForTag {
   def fromLineItems(lineItems: Seq[GuLineItem]): Seq[PaidForTag] = {
 
     val lineItemsGroupedByTag: Map[String, Seq[GuLineItem]] = {
-      val logoLineItems = lineItems filter { lineItem =>
-        lineItem.isCurrent && lineItem.paidForTags.nonEmpty
-      }
+      val logoLineItems = lineItems filter (_.paidForTags.nonEmpty)
       logoLineItems.foldLeft(Map.empty[String, Seq[GuLineItem]]) { case (soFar, lineItem) =>
         val lineItemTags = lineItem.paidForTags map { tag =>
           val tagLineItems = soFar.get(tag).map(_ :+ lineItem).getOrElse(Seq(lineItem))


### PR DESCRIPTION
Previously we were excluding DFP line items that had expired, but we need to know about these.
