### PR TITLE
Tweaks on breaking news

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -50,6 +50,7 @@
                         <a class="editor__revert" data-bind="
                             visible: meta() && field(),
                             click: revert"><i class="fa fa-fast-backward"></i></a>
+                        <span class="editor__alert__message">Text is too long.</span>
                     <!-- /ko -->
                 </div>
             <!-- /ko -->

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1005,8 +1005,18 @@ select {
     color: #DD4B39;
 }
 
-.length--alert textarea.active {
+.attention .length--alert textarea.active {
     background-color: #FFCDD2;
+}
+
+.editor__alert__message {
+    margin-left: 4px;
+    color: #DD4B39;
+    display: none;
+}
+
+.attention .length--alert .editor__alert__message {
+    display: inline;
 }
 
 .editor__length {
@@ -1740,7 +1750,9 @@ collection-widget > div {
 }
 .attention .performances,
 .attention .modes .live-mode,
-.attention .preview {
+.attention .preview,
+.attention .tool--small--ophan,
+.attention .time__publication {
     display: none;
 }
 


### PR DESCRIPTION
Show a text message when the headline is too long.
Remove the ophan link from breaking news
Show only the front publication time
