### PR TITLE
Stop using window.console

### DIFF
--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -3,45 +3,47 @@ define([
     'modules/vars',
     'knockout',
     'utils/alert',
-    'utils/mediator',
-    'utils/url-abs-path',
     'utils/as-observable-props',
-    'utils/populate-observables',
-    'utils/full-trim',
-    'utils/sanitize-html',
     'utils/deep-get',
-    'utils/snap',
+    'utils/full-trim',
     'utils/human-time',
-    'utils/validate-image-src',
     'utils/identity',
     'utils/is-guardian-url',
+    'utils/logger',
+    'utils/mediator',
+    'utils/populate-observables',
+    'utils/sanitize-html',
+    'utils/snap',
+    'utils/url-abs-path',
+    'utils/url-host',
+    'utils/validate-image-src',
     'modules/copied-article',
     'modules/authed-ajax',
     'modules/content-api',
-    'models/group',
-    'utils/url-host'
+    'models/group'
 ],
     function (
         vars,
         ko,
         alert,
-        mediator,
-        urlAbsPath,
         asObservableProps,
-        populateObservables,
-        fullTrim,
-        sanitizeHtml,
         deepGet,
-        snap,
+        fullTrim,
         humanTime,
-        validateImageSrc,
         identity,
         isGuardianUrl,
+        logger,
+        mediator,
+        populateObservables,
+        sanitizeHtml,
+        snap,
+        urlAbsPath,
+        urlHost,
+        validateImageSrc,
         copiedArticle,
         authedAjax,
         contentApi,
-        Group,
-        urlHost
+        Group
     ) {
         var capiProps = [
                 'webUrl',
@@ -543,7 +545,7 @@ define([
 
             if (missingProps.length) {
                 vars.model.alert('ContentApi is returning invalid data. Fronts may not update.');
-                window.console.error('ContentApi missing: "' + missingProps.join('", "') + '" for ' + this.id());
+                logger.error('ContentApi missing: "' + missingProps.join('", "') + '" for ' + this.id());
             } else {
                 this.state.isLoaded(true);
                 this.state.sectionName(this.props.sectionName());

--- a/facia-tool/public/js/models/config/main.js
+++ b/facia-tool/public/js/models/config/main.js
@@ -11,6 +11,7 @@ define([
     'utils/clean-clone',
     'utils/clone-with-key',
     'utils/find-first-by-id',
+    'utils/logger',
     'utils/terminate',
     'models/group',
     'models/config/front',
@@ -29,6 +30,7 @@ define([
     cleanClone,
     cloneWithKey,
     findFirstById,
+    logger,
     terminate,
     Group,
     Front,
@@ -133,9 +135,9 @@ define([
                        .value()
                     );
 
-                    window.console.log('CONTAINER USAGE\n');
+                    logger.log('CONTAINER USAGE\n');
                     _.each(containerUsage(), function(fronts, type) {
-                        window.console.log(type + ': ' + fronts.join(',') + '\n');
+                        logger.log(type + ': ' + fronts.join(',') + '\n');
                     });
                 }
             }, opts.pollingMs, opts.terminateOnFail);

--- a/facia-tool/public/js/utils/logger.js
+++ b/facia-tool/public/js/utils/logger.js
@@ -1,0 +1,20 @@
+/* globals Raven */
+define(function () {
+    function call (what) {
+        return function () {
+            window.console[what].apply(window.console, arguments);
+            if (what === 'error') {
+                try {
+                    throw new Error([].slice.call(arguments, 0).join(' '));
+                } catch (ex) {
+                    Raven.captureException(ex);
+                }
+            }
+        };
+    }
+
+    return {
+        log: call('log'),
+        error: call('error')
+    };
+});

--- a/facia-tool/test/public/mocks/logger.js
+++ b/facia-tool/test/public/mocks/logger.js
@@ -1,0 +1,6 @@
+define('utils/logger', function () {
+    return {
+        log: function () {},
+        error: function () {}
+    };
+});


### PR DESCRIPTION
Move all window.console calls to a logger module. When logging an error, it's also sent to Sentry.
Sort dependencies in articles.js, it's getting wild
