### PR TITLE
Video error messgaing

### DIFF
--- a/static/src/images/video/error-exclamation.svg
+++ b/static/src/images/video/error-exclamation.svg
@@ -1,1 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44"><circle fill="#fff" cx="22" cy="22" r="22"/><path fill="#333" d="M18 7l2-2h4l2 2-2 19h-4l-2-19m8 27c0-2.2-1.8-4-4-4s-4 1.8-4 4 1.8 4 4 4 4-1.8 4-4"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+    <title>error-exclamation</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="error-exclamation" sketch:type="MSLayerGroup">
+            <circle id="Oval" fill="#FFFFFF" sketch:type="MSShapeGroup" cx="18" cy="18" r="18"></circle>
+            <path d="M14.7272727,5.72727273 L16.3636364,4.09090909 L19.6363636,4.09090909 L21.2727273,5.72727273 L19.6363636,21.2727273 L16.3636364,21.2727273 L14.7272727,5.72727273 M21.2727273,27.8181818 C21.2727273,26.0181818 19.8,24.5454545 18,24.5454545 C16.2,24.5454545 14.7272727,26.0181818 14.7272727,27.8181818 C14.7272727,29.6181818 16.2,31.0909091 18,31.0909091 C19.8,31.0909091 21.2727273,29.6181818 21.2727273,27.8181818" id="Shape" fill="#333333" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>

--- a/static/src/images/video/error-exclamation.svg
+++ b/static/src/images/video/error-exclamation.svg
@@ -1,13 +1,1 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
-    <title>error-exclamation</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
-        <g id="error-exclamation" sketch:type="MSLayerGroup">
-            <circle id="Oval" fill="#FFFFFF" sketch:type="MSShapeGroup" cx="18" cy="18" r="18"></circle>
-            <path d="M14.7272727,5.72727273 L16.3636364,4.09090909 L19.6363636,4.09090909 L21.2727273,5.72727273 L19.6363636,21.2727273 L16.3636364,21.2727273 L14.7272727,5.72727273 M21.2727273,27.8181818 C21.2727273,26.0181818 19.8,24.5454545 18,24.5454545 C16.2,24.5454545 14.7272727,26.0181818 14.7272727,27.8181818 C14.7272727,29.6181818 16.2,31.0909091 18,31.0909091 C19.8,31.0909091 21.2727273,29.6181818 21.2727273,27.8181818" id="Shape" fill="#333333" sketch:type="MSShapeGroup"></path>
-        </g>
-    </g>
-</svg>
+<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><circle fill="#fff" cx="18" cy="18" r="18"/><path d="m14.727 5.727l1.636-1.636h3.273l1.636 1.636-1.636 15.545h-3.273l-1.636-15.545m6.545 22.09c0-1.8-1.473-3.273-3.273-3.273-1.8 0-3.273 1.473-3.273 3.273 0 1.8 1.473 3.273 3.273 3.273 1.8 0 3.273-1.473 3.273-3.273" fill="#333"/></g></svg>

--- a/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
+++ b/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
@@ -1,8 +1,12 @@
 define([
+    'bean',
+    'common/utils/$',
     'common/utils/_',
     'common/utils/detect',
     'common/utils/config'
 ], function (
+    bean,
+    $,
     _,
     detect,
     config
@@ -15,8 +19,17 @@ define([
             'Opera': '14',
             'Safari': '7'
         },
+        closeCls = 'vjs-error-display__close',
         ua = detect.getUserAgent,
-        message = 'Please <a href="http://whatbrowser.org" target="_blank">update</a> your browser to watch this video.';
+        message = 'Please <a href="http://whatbrowser.org" target="_blank">update</a> your browser to watch this video. <button class="' + closeCls + '">close</button>';
+
+
+    function bindClose(player){
+        bean.on($('.' + closeCls)[0], 'click', function(){
+            console.log('clicked');
+            player.error(null);
+        });
+    }
 
     return function supportedBrowser(player) {
         var notSupported =  _.some(browsers, function (version, browser) {
@@ -25,6 +38,7 @@ define([
 
         if (notSupported && config.switches.mediaPlayerSupportedBrowsers) {
             player.error(message);
+            bindClose(player);
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
+++ b/static/src/javascripts/projects/common/modules/video/supportedBrowsers.js
@@ -23,10 +23,8 @@ define([
         ua = detect.getUserAgent,
         message = 'Please <a href="http://whatbrowser.org" target="_blank">update</a> your browser to watch this video. <button class="' + closeCls + '">close</button>';
 
-
-    function bindClose(player){
-        bean.on($('.' + closeCls)[0], 'click', function(){
-            console.log('clicked');
+    function bindClose(player) {
+        bean.on($('.' + closeCls)[0], 'click', function () {
             player.error(null);
         });
     }

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -461,9 +461,10 @@ $vjs-progress-inset-bottom: 4px;
 
 .vjs-error-display {
     position: absolute;
-    width: 100%;
-    top: 40%;
     display: none;
+    width: 100%;
+    top: 0;
+    z-index: 3; // Ensures that it is above fullscreen clickbox.
 
     .gu-media--video.vjs-error &,
     .gu-media__flash-fallback & {
@@ -473,29 +474,50 @@ $vjs-progress-inset-bottom: 4px;
         background-color: #000000;
     }
     > div {
-        color: #ffffff;
-        @include fs-headline(3);
-        text-align: left;
-        @include box-sizing(border-box);
-        padding: $gs-baseline $gs-gutter $gs-baseline (45 + $gs-gutter*2);
-        min-height: $gs-baseline*5;
-        background-color: $vjs-control-colour;
+        position: absolute;
+        display: table-cell;
         width: 100%;
         margin: auto;
+        padding: $gs-baseline*1.5 $gs-gutter*3 $gs-baseline*1.5 $gs-gutter*3;
+        @include box-sizing(border-box);
+        @include fs-headline(2);
+        line-height: 1em;
+        text-align: left;
+        color: #ffffff;
+        background-color: $vjs-control-colour;
+
         &:before {
             @include icon(error-exclamation);
             content: ' ';
             display: block;
             position: absolute;
             top: 50%;
-            left: $gs-gutter;
-            margin-top: -22px // half icon height for centering;
+            left: $gs-gutter/2;
+            margin-top: -18px // half icon height for centering;
         }
     }
 
     a {
         color: #ffffff;
         text-decoration: underline;
+    }
+}
+
+.vjs-error-display__close {
+    @include icon(close-icon-white-small);
+    content: ' ';
+    display: block;
+    position: absolute;
+    top: 50%;
+    margin-top: -16px; // half icon height for centering;
+    right: $gs-gutter/2;
+    text-indent: -9999px;
+    background: transparent;
+    border: 1px solid rgba(#ffffff, .3);
+    @include border-radius(50%);
+
+    &:hover {
+        border-color: #ffffff;
     }
 }
 

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -478,7 +478,7 @@ $vjs-progress-inset-bottom: 4px;
         display: table-cell;
         width: 100%;
         margin: auto;
-        padding: $gs-baseline*1.5 $gs-gutter*3 $gs-baseline*1.5 $gs-gutter*3;
+        padding: $gs-baseline*1.5 $gs-gutter*3;
         @include box-sizing(border-box);
         @include fs-headline(2);
         line-height: 1em;


### PR DESCRIPTION
This changes the styling of the video error messaging:
- Place at top of video player viewport
- Reduce size of icon
- Reduce size of text
- Add option close button

We also now allow the unsupported browser message to be dismissed clicking the close icon.
### Screenshot

![google chrome](https://cloud.githubusercontent.com/assets/80089/5776870/3a037f26-9d85-11e4-9496-0e3d7717a111.png)
