### PR TITLE
Convert the search autocompleter to a dropdown

### DIFF
--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1215,7 +1215,9 @@ button {
 .autocompleter .suggestions {
     position: absolute;
     top: 27px;
-    z-index: 1;
+    z-index: 20;
+    right: 0;
+    left: 36%;
 }
 
 .autocompleter .suggestion {
@@ -1719,9 +1721,8 @@ button {
 .dropdown > ul {
     padding: 0;
     margin: 0;
-    min-width: 200px;
     transform: scale(0);
-    z-index: 10000;
+    z-index: 1000;
 }
 .dropdown-open > ul {
     transform: scale(1);
@@ -1732,7 +1733,7 @@ button {
     top: 1.5em;
     left: 0;
 }
-.dropdown > ul  > li {
+.dropdown > ul > li {
     list-style: none;
     padding: 10px 15px;
 }
@@ -1746,6 +1747,12 @@ button {
 }
 .dropdown > ul > li {
     cursor: pointer;
+}
+.dropdown > ul > li:nth-child(even) {
+    background-color: #FCFCFC;
+}
+.dropdown > ul > li:hover {
+    background-color: #F0F0F0;
 }
 
 .narrow .preview,

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1217,7 +1217,6 @@ button {
     top: 27px;
     z-index: 20;
     right: 0;
-    left: 36%;
 }
 
 .autocompleter .suggestion {
@@ -1717,6 +1716,11 @@ button {
     line-height: 24px;
     white-space: nowrap;
 }
+.autocompleter.dropdown > ul {
+    padding: 0;
+    max-height: 300px;
+    overflow: auto;
+}
 
 .dropdown > ul {
     padding: 0;
@@ -1735,7 +1739,7 @@ button {
 }
 .dropdown > ul > li {
     list-style: none;
-    padding: 10px 15px;
+    padding: 4px 10px;
 }
 
 .dropdown > ul {

--- a/facia-tool/public/js/models/collections/latest-articles.js
+++ b/facia-tool/public/js/models/collections/latest-articles.js
@@ -113,6 +113,11 @@ define([
 
             clearTimeout(deBounced);
             deBounced = setTimeout(function() {
+                if (self.suggestions().length) {
+                    // The auto complete is open, if we ask the API most likely we won't get any result
+                    // which will lead to displaying the alert
+                    return;
+                }
                 if (!opts.noFlushFirst) {
                     self.flush('searching...');
                 }

--- a/facia-tool/public/js/widgets/collection.html
+++ b/facia-tool/public/js/widgets/collection.html
@@ -53,7 +53,7 @@
                 'fa-chevron-up'  :  state.collapsed }"></i></a>
     </div>
 
-    <div class="dropdown"data-bind="
+    <div class="also dropdown"data-bind="
         if: alsoOn.length,
         css: {'dropdown-open': state.alsoOnVisible},
         slideVisible: state.alsoOnVisible() && !state.collapsed()

--- a/facia-tool/public/js/widgets/latest.html
+++ b/facia-tool/public/js/widgets/latest.html
@@ -45,7 +45,9 @@
                     valueUpdate: ["afterkeydown", "afterpaste"]'/>
             </div>
 
-            <div class="autocompleter">
+            <div class="autocompleter dropdown" data-bind="css: {
+                'dropdown-open': !!suggestions().length
+            }">
                 <select data-bind="
                     event: { change: clearFilter },
                     options: filterTypes,
@@ -58,14 +60,16 @@
                     value: filter,
                     valueUpdate: ["afterkeydown", "afterpaste"]'/>
 
-                <div class="suggestions" data-bind="foreach: suggestions">
-                    <!-- ko if: $data._alert -->
-                    <div class="suggestion" data-bind="text: _alert"></div>
-                    <!-- /ko -->
-                    <!-- ko if: $data.id -->
-                    <div class="suggestion linky"  data-bind="text: id, click: $parent.setFilter"></div>
-                    <!-- /ko -->
-                </div>
+                <ul class="suggestions" data-bind="foreach: suggestions">
+                    <li>
+                        <!-- ko if: $data._alert -->
+                        <span data-bind="text: _alert"></span>
+                        <!-- /ko -->
+                        <!-- ko if: $data.id -->
+                        <a data-bind="text: id, click: $parent.setFilter"></a>
+                        <!-- /ko -->
+                    </li>
+                </ul>
             </div>
         </div>
 


### PR DESCRIPTION
Because it looks prettier to me.
It also prevents calls to the API when the autocomplete is open. Most of the times this will cause the alert to show.

Looks like this
![screen shot 2015-01-16 at 15 08 35](https://cloud.githubusercontent.com/assets/680284/5778220/a44ebae2-9d91-11e4-857b-c911bc365cde.png)
