### PR TITLE
Omniture video id tracking

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -34,21 +34,7 @@
                 </figure>
             }
         } else {
-            @if(article.hasMainAudio) {
-                <figure itemprop="associatedMedia audio" itemscope itemtype="http://schema.org/AudioObject" data-component="main audio"
-                    class="media-primary media-content">
-                    @article.mainAudio.map { audioElement =>
-                        @fragments.media.audio(AudioPlayer(
-                            article,
-                            audioElement,
-                            article.headline,
-                            autoPlay = false
-                        ))
-                    }
-                </figure>
-            } else {
-                @fragments.img(article.mainPicture, article.hasShowcaseMainPicture, article.isFeature, Some(article.url))
-            }
+            @fragments.img(article.mainPicture, article.hasShowcaseMainPicture, article.isFeature, Some(article.url))
         }
     }
 }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -40,7 +40,7 @@ data-test-id="facia-card"
                     showControlsAtStart = false,
                     endSlatePath,
                     Some(false),
-                    None
+                    item.id
                 )) { player =>
                     <div class="fc-item__media-wrapper fc-item__media-wrapper--has-icon u-faux-block-link__promote">
                         <div class="fc-item__video-container">

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -35,8 +35,8 @@ GET        /gallery/most-viewed.json                  controllers.MostViewedGall
 GET        /video/end-slate/series/*seriesId.json     controllers.VideoEndSlateController.renderSeries(seriesId)
 GET        /video/end-slate/section/*sectionId.json   controllers.VideoEndSlateController.renderSection(sectionId)
 
-GET         /embed/card/*path.json                    controllers.FlyerController.render(path)
-GET         /embed/card/*path                         controllers.FlyerController.renderHtml(path)
+GET        /embed/card/*path.json                     controllers.FlyerController.render(path)
+GET        /embed/card/*path                          controllers.FlyerController.renderHtml(path)
 
 # For tests
 GET        /most-read/*path                           controllers.MostPopularController.renderHtml(path)

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -14,7 +14,7 @@ define([
         }
 
         var lastDurationEvent, durationEventTimer,
-            mediaName = getAttribute('data-title') || config.page.webTitle,
+            mediaId = getAttribute('data-embed-path') || config.page.pageId,
             // infer type (audio/video) from what element we have
             mediaType = qwery('audio', player.el()).length ? 'audio' : 'video',
             contentStarted = false,
@@ -59,6 +59,10 @@ define([
 
         this.sendEvent = function (event, eventName, ad) {
             s.eVar74 = ad ?  mediaType + ' ad' : mediaType + ' content';
+
+            // Set these each time because they are shared global variables, but OmnitureMedia is instanced.
+            s.eVar43 = s.prop43 = mediaType.charAt(0).toUpperCase() + mediaType.slice(1);
+            s.eVar44 = s.prop44 = mediaId;
             if (prerollPlayed) {
                 // Any event after 'video:preroll:play' should be tagged with this value.
                 s.prop41 = 'PrerollMilestone';
@@ -67,7 +71,7 @@ define([
             s.linkTrackEvents = values(events).join(',');
             s.events = event;
             s.tl(true, 'o', eventName || event);
-            s.prop41 = undefined;
+            s.prop41 = s.eVar44 = s.prop44 = s.eVar43 = s.prop43 = undefined;
         };
 
         this.sendNamedEvent = function (eventName, ad) {
@@ -84,11 +88,9 @@ define([
             s.Media.trackUsingContextData = false;
 
             s.eVar11 = s.prop11 = config.page.sectionName || '';
-            s.eVar43 = s.prop43 = mediaType.charAt(0).toUpperCase() + mediaType.slice(1);
-            s.eVar44 = s.prop44 = mediaName;
             s.eVar7 = s.pageName;
 
-            s.Media.open(mediaName, this.getDuration(), 'HTML5 Video');
+            s.Media.open(mediaId, this.getDuration(), 'HTML5 Video');
 
             if (mediaType === 'video') {
                 this.sendNamedEvent('video:request');


### PR DESCRIPTION
This tries to uniquely identify media when we perform omniture tracking.
- fixes an issue where the page title was being reported as the media name
- replaces the notion of media name with media id. Because a video can be embedded, main-media'ed, or seen on the video page, it may have different titles and this corrupts omniture reporting. The embed path, the video's canonical path, is consistent, so use this instead.
- adds the correct embed path for videos which appear in facia containers.

@mkopka
