### PR TITLE
set top to 0

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
@@ -12,7 +12,7 @@ define([
         StickyMpu = function ($adSlot, options) {
             this.$adSlot = $adSlot;
             this.opts    = defaults(options || {}, {
-                top: 12
+                top: 0
             });
         };
 


### PR DESCRIPTION
The 'sticky ad' top position is set to 0. Chrome has some weird issues with painting/refreshing elements with position: fixed style.
