### PR TITLE
force container body below header until leftcol

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -376,9 +376,11 @@ $header-image-size-desktop: 100px;
     @include mq(tablet) {
         padding-top: $gs-baseline / 4;
     }
+
     @include mq(leftCol) {
         margin-left: $left-column + $gs-gutter;
     }
+
     @include mq(wide) {
         margin-left: $left-column-wide + $gs-gutter;
         width: gs-span(12);
@@ -386,6 +388,10 @@ $header-image-size-desktop: 100px;
         .has-page-skin & {
             margin-left: 0;
         }
+    }
+
+    @include mq($until: leftCol) {
+        clear: left;
     }
 
     .fc-container--has-toggle & {


### PR DESCRIPTION
space created for the weather was causing the nav list items to squash up

before:

![screen shot 2015-01-16 at 17 29 12](https://cloud.githubusercontent.com/assets/867233/5780802/548f87f2-9da5-11e4-9109-a8d7f80fc269.png)

after:

![screen shot 2015-01-16 at 17 29 27](https://cloud.githubusercontent.com/assets/867233/5780804/59ea0574-9da5-11e4-8db5-0093463ac209.png)
