### PR TITLE
Iphone confidence metrics

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -524,6 +524,11 @@ object Switches {
     safeState = Off, sellByDate = never
   )
 
+  val IphoneConfidence = Switch("Performance", "iphone-confidence",
+    "If this switch is on then some beacons will be dropped to gauge iPhone confidence",
+    safeState = Off, sellByDate = new LocalDate(2015, 2, 28)
+  )
+
   def all: Seq[Switch] = Switch.allSwitches
 
   def grouped: List[(String, Seq[Switch])] = {

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -179,3 +179,24 @@
     document.documentElement.className = document.documentElement.className.replace(/\bjs-off\b/g, 'js-on');
 
 </script>
+
+@* Not the usual type of thing we do, but I want this separate to our "normal" javascript. *@
+@* also delete iPhoneConfidenceCheck inside of facia.js *@
+@if(IphoneConfidence.isSwitchedOn && Seq("uk", "us", "au").contains(item.id)) {
+    @* see http://www.paintcodeapp.com/news/ultimate-guide-to-iphone-resolutions *@
+    <script>
+        if (navigator.platform === 'iPhone' || navigator.platform === 'MacIntel') {
+
+            guardian.isIphone6 = (screen.width === 375 && screen.height === 667) || (screen.width === 375 && screen.height === 667);
+            guardian.isIphone4 = screen.width === 320 && screen.height === 480 && window.devicePixelRatio > 1;
+
+            if (guardian.isIphone6) {
+                (new Image()).src = guardian.config.page.beaconUrl + '/count/iphone-6-start.gif';
+            }
+
+            if (guardian.isIphone4) {
+                (new Image()).src = guardian.config.page.beaconUrl + '/count/iphone-4-start.gif';
+            }
+        }
+    </script>
+}

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -187,7 +187,7 @@
     <script>
         if (navigator.platform === 'iPhone') {
 
-            guardian.isIphone6 = (screen.width === 375 && screen.height === 667) || (screen.width === 375 && screen.height === 667);
+            guardian.isIphone6 = (screen.width === 375 && screen.height === 667) || (screen.width === 414 && screen.height === 736);
             guardian.isIphone4 = screen.width === 320 && screen.height === 480 && window.devicePixelRatio > 1;
 
             if (guardian.isIphone6) {

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -185,7 +185,7 @@
 @if(IphoneConfidence.isSwitchedOn && Seq("uk", "us", "au").contains(item.id)) {
     @* see http://www.paintcodeapp.com/news/ultimate-guide-to-iphone-resolutions *@
     <script>
-        if (navigator.platform === 'iPhone' || navigator.platform === 'MacIntel') {
+        if (navigator.platform === 'iPhone') {
 
             guardian.isIphone6 = (screen.width === 375 && screen.height === 667) || (screen.width === 375 && screen.height === 667);
             guardian.isIphone4 = screen.width === 320 && screen.height === 480 && window.devicePixelRatio > 1;

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -31,8 +31,10 @@ object Metric extends Logging {
 
     ("iphone-6-start", CountMetric("iphone-6-start")),
     ("iphone-6-end", CountMetric("iphone-6-end")),
+    ("iphone-6-timeout", CountMetric("iphone-6-timeout")),
     ("iphone-4-start", CountMetric("iphone-4-start")),
-    ("iphone-4-end", CountMetric("iphone-4-end"))
+    ("iphone-4-end", CountMetric("iphone-4-end")),
+    ("iphone-4-timeout", CountMetric("iphone-4-timeout"))
   )
 
   //just here so that when you delete this you see this comment and delete the 'iphone' metrics above

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -26,6 +26,15 @@ object Metric extends Logging {
 
     // video
     ("video-tech-flash", CountMetric("video-tech-flash")),
-    ("video-tech-html5", CountMetric("video-tech-html5"))
+    ("video-tech-html5", CountMetric("video-tech-html5")),
+
+
+    ("iphone-6-start", CountMetric("iphone-6-start")),
+    ("iphone-6-end", CountMetric("iphone-6-end")),
+    ("iphone-4-start", CountMetric("iphone-4-start")),
+    ("iphone-4-end", CountMetric("iphone-4-end"))
   )
+
+  //just here so that when you delete this you see this comment and delete the 'iphone' metrics above
+  private lazy val deleteIphoneMetrics = conf.Switches.IphoneConfidence.isSwitchedOn
 }

--- a/static/src/javascripts/bootstraps/facia.js
+++ b/static/src/javascripts/bootstraps/facia.js
@@ -14,7 +14,7 @@ define([
     'facia/modules/onwards/geo-most-popular-front',
     'facia/modules/ui/container-toggle',
     'facia/modules/ui/container-show-more',
-    'facia/modules/ui/snaps',
+    'facia/modules/ui/snaps'
 ], function (
     bonzo,
     qwery,
@@ -81,6 +81,8 @@ define([
             // temporary to check an 'older' iphone perf problem
             iPhoneConfidenceCheck: function () {
                 if (config.switches.iphoneConfidence) {
+                    /* jshint undef: true */
+                    /* global guardian */
                     mediator.on('page:front:ready', function () {
                         if (guardian.isIphone6) {
                             beacon.counts('iphone-6-end');

--- a/static/src/javascripts/bootstraps/facia.js
+++ b/static/src/javascripts/bootstraps/facia.js
@@ -8,12 +8,13 @@ define([
     'common/utils/mediator',
     'common/utils/storage',
     'common/utils/to-array',
+    'common/modules/analytics/beacon',
     // Modules
     'common/modules/business/stocks',
     'facia/modules/onwards/geo-most-popular-front',
     'facia/modules/ui/container-toggle',
     'facia/modules/ui/container-show-more',
-    'facia/modules/ui/snaps'
+    'facia/modules/ui/snaps',
 ], function (
     bonzo,
     qwery,
@@ -23,6 +24,7 @@ define([
     mediator,
     storage,
     toArray,
+    beacon,
     stocks,
     GeoMostPopularFront,
     ContainerToggle,
@@ -74,6 +76,20 @@ define([
                 if (config.switches.geoMostPopular) {
                     new GeoMostPopularFront().go();
                 }
+            },
+
+            // temporary to check an 'older' iphone perf problem
+            iPhoneConfidenceCheck: function () {
+                if (config.switches.iphoneConfidence) {
+                    mediator.on('page:front:ready', function () {
+                        if (guardian.isIphone6) {
+                            beacon.counts('iphone-6-end');
+                        }
+                        if (guardian.isIphone4) {
+                            beacon.counts('iphone-4-end');
+                        }
+                    });
+                }
             }
         },
 
@@ -85,6 +101,7 @@ define([
                 modules.showContainerToggle();
                 modules.upgradeMostPopularToGeo();
                 stocks();
+                modules.iPhoneConfidenceCheck();
             }
             mediator.emit('page:front:ready');
         };

--- a/static/src/javascripts/bootstraps/facia.js
+++ b/static/src/javascripts/bootstraps/facia.js
@@ -86,9 +86,15 @@ define([
                     mediator.on('page:front:ready', function () {
                         if (guardian.isIphone6) {
                             beacon.counts('iphone-6-end');
+                            setTimeout(function () {
+                                beacon.counts('iphone-6-timeout');
+                            }, 5000);
                         }
                         if (guardian.isIphone4) {
                             beacon.counts('iphone-4-end');
+                            setTimeout(function () {
+                                beacon.counts('iphone-4-timeout');
+                            }, 5000);
                         }
                     });
                 }


### PR DESCRIPTION
We get reports of (and experience) performance problems on "older" smartphones (an iPhone 4s ain't that old).

This code will hopefully be able to highlight the extent of the problem by telling us what percentage of phones start the page and what percentage of phones finish our javascript.

"New" phones are represented by iPhone 6 & 6 Plus and "old" phones are represented by iPhone 4 & 4s.

Only running it on the 3 main front pages.

If this actually works we can harden it up and alert against it in the longer term.
