### PR TITLE
Add an options endpoint for cors css

### DIFF
--- a/common/app/CorsErrorHandler.scala
+++ b/common/app/CorsErrorHandler.scala
@@ -19,7 +19,8 @@ trait CorsErrorHandler extends GlobalSettings with Results {
              "Vary" -> vary,
              "Access-Control-Allow-Origin" -> Configuration.ajax.corsOrigins.find( _ == requestOrigin ).getOrElse("*"),
              "Access-Control-Allow-Credentials" -> "true",
-             "Access-Control-Allow-Headers" -> "GET,POST,X-Requested-With"
+             "Access-Control-Allow-Headers" -> "X-Requested-With",
+             "Access-Control-Allow-Methods" -> "GET,POST"
           )
         )
     }

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -1,19 +1,26 @@
 package model
 
-import play.api.mvc.{RequestHeader, Result, Results}
+import play.api.mvc.{RequestHeader, Results}
 import play.api.mvc.Result
-import conf.Configuration.ajax._
-
+import conf.Configuration.ajax.corsOrigins
 
 object Cors extends Results {
-  def apply(result: Result)(implicit request: RequestHeader): Result = {
+  def apply(result: Result, allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
+
+    val controlHeaders = List(
+      allowedMethods.map("Access-Control-Allow-Methods" -> _),
+      request.headers.get("Access-Control-Request-Headers").map("Access-Control-Allow-Headers" -> _)
+    ).flatten
+
     request.headers.get("Origin") match {
       case None => result
-      case Some(requestOrigin) =>
-        result.withHeaders(
+      case Some(requestOrigin) => {
+        val headers = controlHeaders ++ List(
           "Access-Control-Allow-Origin" -> corsOrigins.find(_ == requestOrigin).getOrElse("*"),
-          "Access-Control-Allow-Credentials" -> "true"
-        )
+          "Access-Control-Allow-Credentials" -> "true",
+          "Access-Control-Allow-Headers" -> "accept, content-type")
+        result.withHeaders(headers: _*)
+      }
     }
   }
 }

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -17,8 +17,7 @@ object Cors extends Results {
       case Some(requestOrigin) => {
         val headers = controlHeaders ++ List(
           "Access-Control-Allow-Origin" -> corsOrigins.find(_ == requestOrigin).getOrElse("*"),
-          "Access-Control-Allow-Credentials" -> "true",
-          "Access-Control-Allow-Headers" -> "accept, content-type")
+          "Access-Control-Allow-Credentials" -> "true")
         result.withHeaders(headers: _*)
       }
     }

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -86,3 +86,6 @@ admin.oauth.callback=http://localhost:9000/oauth2callback
 #Preview Oauth
 preview.oauth.clientid=768784040766-1eq1drssgu65vrs4oi1hjh70d9b30fti.apps.googleusercontent.com
 preview.oauth.callback=http://localhost:9000/oauth2callback
+
+# Beacon diagnostics
+beacon.url=//localhost:9000

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -19,6 +19,7 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 
 ajax.url=http://localhost:9000
 ajax.secureUrl=http://localhost:9000
+ajax.cors.origin=http://m.random.com,http://127.0.0.1:9000,http://www.random.com,http://m.thegulocal.com,https://profile.thegulocal.com,http://localhost:9000
 
 # Admin switches
 admin.config.file=DEFINFRA/config/front.json

--- a/common/test/model/CorsTest.scala
+++ b/common/test/model/CorsTest.scala
@@ -1,0 +1,42 @@
+package model
+
+import org.scalatest.{Matchers, FlatSpec}
+import play.api.mvc.AnyContentAsEmpty
+import play.api.mvc.Results.NoContent
+import play.api.test.{FakeHeaders, FakeRequest}
+import play.api.test.Helpers._
+
+class CorsTest extends FlatSpec with Matchers {
+  "Cors Helper" should "provide the appropriate standard Cors response headers with any Origin" in {
+    // This test is here to show that we really do accept any origin outside of the whitelist. We should change this policy.
+    val fakeHeaders = FakeHeaders(List("Origin" -> List("unknown.origin.com")))
+    val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Origin" -> "*")
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Credentials" -> "true")
+  }
+
+  it should "provide the appropriate standard Cors response headers with an accepted Origin" in {
+    val fakeHeaders = FakeHeaders(List("Origin" -> List("http://www.random.com")))
+    val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Origin" -> "http://www.random.com")
+  }
+
+  it should "provide no Cors response headers if the request has no Origin" in {
+    val fakeHeaders = FakeHeaders(List("Origin" -> Nil))
+    val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
+    Cors(NoContent)(fakeRequest).header.headers should be ('empty)
+  }
+
+  it should "provide Cors response with allowed methods" in {
+    val fakeHeaders = FakeHeaders(List("Origin" -> List("http://www.random.com")))
+    val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
+    Cors(NoContent,Some("OPTIONS, POST, GET"))(fakeRequest).header.headers should contain("Access-Control-Allow-Methods" -> "OPTIONS, POST, GET")
+  }
+
+  it should "provide Cors response with allowed headers" in {
+    val fakeHeaders = FakeHeaders(List("Origin" -> List("http://www.random.com"),
+                                       "Access-Control-Request-Headers" -> List("X-GU-test")))
+    val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-GU-test")
+  }
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -16,6 +16,7 @@ GET         /js.gif                                                             
 GET         /count/$prefix<.+>.gif                                                                                   controllers.DiagnosticsController.analytics(prefix)
 GET         /counts.gif                                                                                              controllers.DiagnosticsController.analyticsCounts()
 POST        /css                                                                                                     controllers.DiagnosticsController.css
+OPTIONS     /css                                                                                                     controllers.DiagnosticsController.cssOptions
 
 # Crosswords
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.

--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import common._
-import model.NoCache
 import play.api.mvc.{ Content => _, _ }
 import model.diagnostics.javascript.JavaScript
 import model.diagnostics.abtests.AbTests
@@ -20,24 +19,27 @@ object DiagnosticsController extends Controller with Logging {
     TinyResponse()
   }
 
-  def analytics(prefix: String) = Action {
+  def analytics(prefix: String) = Action { implicit request =>
     Analytics.report(prefix)
     TinyResponse()
   }
 
   // e.g.  .../counts?c=pv&c=vv&c=ve
-  def analyticsCounts() = Action { request =>
+  def analyticsCounts() = Action { implicit request =>
     request.queryString.getOrElse("c", Nil).foreach(Analytics.report)
     TinyResponse()
   }
 
   private lazy val jsonParser = parse.tolerantJson(1024 *1024)
 
-  def css = Action(jsonParser) { request =>
+  def css = Action(jsonParser) { implicit request =>
     if (conf.Switches.CssLogging.isSwitchedOn) {
       Css.report(request.body)
     }
-    NoCache(Ok("OK"))
+    TinyResponse()
   }
 
+  def cssOptions = Action { implicit request =>
+    TinyResponse(Some("POST, OPTIONS"))
+  }
 }

--- a/diagnostics/app/controllers/TinyResponse.scala
+++ b/diagnostics/app/controllers/TinyResponse.scala
@@ -1,8 +1,10 @@
 package controllers
 
-import model.NoCache
-import play.api.mvc.{Result, Results}
+import model.{Cors, NoCache}
+import play.api.mvc.{RequestHeader, Result, Results}
 
 object TinyResponse extends Results {
-  def apply(): Result = NoCache(NoContent)
+  def apply(allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
+    Cors(NoCache(NoContent), allowedMethods)
+  }
 }

--- a/diagnostics/conf/routes
+++ b/diagnostics/conf/routes
@@ -14,3 +14,4 @@ GET        /counts.gif                      controllers.DiagnosticsController.an
 GET        /robots.txt                      controllers.Assets.at(path="/public", file="robots.txt")
 
 POST       /css                             controllers.DiagnosticsController.css
+OPTIONS    /css                             controllers.DiagnosticsController.cssOptions


### PR DESCRIPTION
It looks like browsers use the pre-flight cors system to handle POST, so the beacon api needs two endpoints to handle the beacon call; one for OPTIONS, one for POST. Additional response headers must also be sent.
