### PR TITLE
Duplicate trails when article is open

### DIFF
--- a/facia-tool/public/js/models/collections/new-items.js
+++ b/facia-tool/public/js/models/collections/new-items.js
@@ -129,7 +129,7 @@ define([
             });
         }
 
-        if (remove && sourceGroup && !sourceGroup.keepCopy && sourceGroup !== targetGroup) {
+        if (sourceGroup && !sourceGroup.keepCopy && sourceGroup !== targetGroup) {
             removeById(sourceGroup.items, id); // for immediate UI effect
         }
     }


### PR DESCRIPTION
Avoid duplicates when dragging across groups (in the same collection) and an article is open.
