### PR TITLE
Cors tidy up

### DIFF
--- a/admin/test/football/PlayerControllerTest.scala
+++ b/admin/test/football/PlayerControllerTest.scala
@@ -46,15 +46,4 @@ import test.ConfiguredTestSuite
     contentType(result).get should be("application/json")
     contentAsString(result) should startWith("{\"html\"")
   }
-
-  "test can return jsonp when callback supplied" in {
-    val callbackName = "theCallbackName"
-    val fakeRequest = FakeRequest(GET, s"/admin/football/player/card/date/attack/237670/19/20140101?callback=${callbackName}")
-      .withHeaders("host" -> "localhost:9000")
-      .withHeaders("Origin" -> "www.theguorigin.com")
-    val Some(result) = route(fakeRequest)
-    status(result) should equal(OK)
-    contentType(result).get should be ("application/javascript")
-    contentAsString(result) should startWith(s"""${callbackName}({\"html\"""") // the callback
-  }
 }

--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -6,18 +6,10 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 @DoNotDiscover class GalleryControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   val galleryUrl = "news/gallery/2012/may/02/picture-desk-live-kabul-burma"
-  val callbackName = "aFunction"
 
   "Gallery Controller" should "200 when content type is gallery" in {
     val result = controllers.GalleryController.render(galleryUrl)(TestRequest(s"/$galleryUrl"))
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied" in {
-    val result = controllers.GalleryController.render(galleryUrl)(TestRequest(s"/${galleryUrl}?callback=$callbackName"))
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
   it should "return JSON when .json format is supplied" in {

--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -9,7 +9,6 @@ import conf.Switches.MemcachedSwitch
 @DoNotDiscover class IndexControllerTest extends FlatSpec with Matchers with BeforeAndAfterAll with ConfiguredTestSuite{
 
   val section = "books"
-  val callbackName = "aFunction"
 
   override def beforeAll(): Unit = {
     MemcachedSwitch.switchOff()
@@ -23,16 +22,6 @@ import conf.Switches.MemcachedSwitch
   "Index Controller" should "200 when content type is front" in {
     val result = controllers.IndexController.render(section)(TestRequest(s"/$section"))
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied to front" in {
-    val fakeRequest = TestRequest(s"/$section?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-
-    val result = controllers.IndexController.render(section)(fakeRequest)
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""$callbackName({\"html\"""")
   }
 
   it should "return JSON when .json format is supplied to front" in {
@@ -71,16 +60,6 @@ import conf.Switches.MemcachedSwitch
 
     status(result) should be (302)
     header("Location", result).get should be ("/music/2013/oct/11/david-byrne-internet-content-world")
-  }
-
-  it should "return JSONP when callback is supplied to front trails" in {
-    val fakeRequest = FakeRequest(GET, s"$section/trails?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-
-    val result = controllers.IndexController.renderTrails(section)(fakeRequest)
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""$callbackName({\"html\"""")
   }
 
   it should "return JSON when .json format is supplied to front trails" in {

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -6,21 +6,10 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 @DoNotDiscover class MediaControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   val videoUrl = "uk/video/2012/jun/26/queen-enniskillen-northern-ireland-video"
-  val callbackName = "aFunction"
 
   "Media Controller" should "200 when content type is video" in {
     val result = controllers.MediaController.render(videoUrl)(TestRequest(videoUrl))
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied" in {
-    val fakeRequest = TestRequest(s"${videoUrl}?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-
-    val result = controllers.MediaController.render(videoUrl)(fakeRequest)
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
   it should "return JSON when .json format is supplied" in {

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -10,7 +10,6 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
   val liveBlogUrl = "global/middle-east-live/2013/sep/09/syria-crisis-russia-kerry-us-live"
   val sudokuUrl = "lifeandstyle/2013/sep/09/sudoku-2599-easy"
-  val callbackName = "aFunction"
 
   "Article Controller" should "200 when content type is article" in {
     val result = controllers.ArticleController.renderArticle(articleUrl)(TestRequest(articleUrl))
@@ -44,15 +43,6 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
     val result = controllers.ArticleController.renderArticle("p/39heg")(TestRequest("/p/39heg"))
     status(result) should be (302)
     header("Location", result).head should be ("/uk/2012/aug/07/woman-torture-burglary-waterboard-surrey")
-  }
-
-  it should "return JSONP when callback is supplied" in {
-    val fakeRequest = FakeRequest(GET, s"${articleUrl}?callback=$callbackName")
-
-    val result = controllers.ArticleController.renderArticle(articleUrl)(fakeRequest)
-    status(result) should be(200)
-    contentType(result).get should be("application/javascript")
-    contentAsString(result) should startWith(s"""$callbackName({\"config\"""")
   }
 
   it should "return JSON when .json format is supplied" in {

--- a/common/app/performance/MemcachedAction.scala
+++ b/common/app/performance/MemcachedAction.scala
@@ -97,13 +97,14 @@ private object CacheKey extends implicits.Requests {
 
   // if you have incompatible changes you can invalidate the cache
   // simply by changing the version
-  private val version = "1"
+  private val version = "2"
 
   def apply(r: RequestHeader): String = {
     val build = if (IncludeBuildNumberInMemcachedKey.isSwitchedOn) ManifestData.build else ""
     val upstreamCacheKey = r.headers.get("X-Gu-Cache-Key").getOrElse("")
+    val originKey = r.headers.get("Origin").getOrElse("")
     val edition = Edition(r).id
-    sha256Hex(s"${r.host}${r.uri} $edition $upstreamCacheKey $build $version")
+    sha256Hex(s"${r.host}${r.uri} $edition $upstreamCacheKey $build $version $originKey")
   }
 }
 

--- a/common/test/common/JsonComponentTest.scala
+++ b/common/test/common/JsonComponentTest.scala
@@ -11,71 +11,66 @@ import scala.concurrent.Future
 
 class JsonComponentTest extends FlatSpec with Matchers with ExecutionContexts {
 
-  "JsonComponent" should "not allow script injection" in {
-    val request = FakeRequest("GET", "http://foo.bar.com?callback=some<script>")
-    JsonComponent(Html("<html></html>"))(request).header.status should be(403)
-  }
-
-  it should "build json output with standard name" in {
+  "JsonComponent" should "build json output with standard name" in {
     AutoRefreshSwitch.switchOn()
 
     val result = Future {
-      val request = FakeRequest("GET", "http://foo.bar.com?callback=success_0")
+      val request = FakeRequest("GET", "http://foo.bar.com/data.json")
       JsonComponent(Html("hello world"))(request)
     }
 
-    contentType(result) should be(Some("application/javascript"))
+    contentType(result) should be(Some("application/json"))
     status(result) should be(200)
-    contentAsString(result) should be("""success_0({"html":"hello world","refreshStatus":true});""")
+    contentAsString(result) should be("""{"html":"hello world","refreshStatus":true}""")
   }
 
   it should "build json from multiple items" in {
     AutoRefreshSwitch.switchOn()
 
     val result = Future {
-      val request = FakeRequest("GET", "http://foo.bar.com?callback=callbackName3")
+      val request = FakeRequest("GET", "http://foo.bar.com/data.json")
       JsonComponent("text" -> Html("hello world"), "url" -> Html("http://foo.bar.com"))(request)
     }
 
-    contentType(result) should be(Some("application/javascript"))
+    contentType(result) should be(Some("application/json"))
     status(result) should be(200)
-    contentAsString(result) should be("""callbackName3({"text":"hello world","url":"http://foo.bar.com","refreshStatus":true});""")
+    contentAsString(result) should be("""{"text":"hello world","url":"http://foo.bar.com","refreshStatus":true}""")
   }
 
   it should "render booleans properly" in {
     AutoRefreshSwitch.switchOn()
 
     val result = Future {
-      val request = FakeRequest("GET", "http://foo.bar.com?callback=callbackName3")
+      val request = FakeRequest("GET", "http://foo.bar.com/data.json")
       JsonComponent("text" -> Html("hello world"), "url" -> Html("http://foo.bar.com"), "refresh" -> false)(request)
     }
 
-    contentType(result) should be(Some("application/javascript"))
+    contentType(result) should be(Some("application/json"))
     status(result) should be(200)
-    contentAsString(result) should be("""callbackName3({"text":"hello world","url":"http://foo.bar.com","refresh":false,"refreshStatus":true});""")
+    contentAsString(result) should be("""{"text":"hello world","url":"http://foo.bar.com","refresh":false,"refreshStatus":true}""")
   }
 
   it should "render a json object properly" in {
     AutoRefreshSwitch.switchOn()
 
     val result = Future {
-      val request = FakeRequest("GET", "http://foo.bar.com?callback=callbackName3")
+      val request = FakeRequest("GET", "http://foo.bar.com/data.json")
       JsonComponent(obj("name" -> "foo"))(request)
     }
 
-    contentType(result) should be(Some("application/javascript"))
+    contentType(result) should be(Some("application/json"))
     status(result) should be(200)
-    contentAsString(result) should be( """callbackName3({"name":"foo","refreshStatus":true});""")
+    contentAsString(result) should be( """{"name":"foo","refreshStatus":true}""")
   }
 
   it should "disable refreshing if auto refresh switch is off" in {
     AutoRefreshSwitch.switchOff()
 
     val result = Future {
-      val request = FakeRequest("GET", "http://foo.bar.com?callback=success")
+      val request = FakeRequest("GET", "http://foo.bar.com/data.json")
       JsonComponent(Html("hello world"))(request)
     }
 
-    contentAsString(result) should be("""success({"html":"hello world","refreshStatus":false});""")
+    contentAsString(result) should be("""{"html":"hello world","refreshStatus":false}""")
   }
 }

--- a/discussion/test/CommentCountControllerTest.scala
+++ b/discussion/test/CommentCountControllerTest.scala
@@ -7,20 +7,8 @@ import controllers.CommentCountController
 
 @DoNotDiscover class CommentCountControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
-  val callbackName = "foo"
-
   "Discussion" should "return 200" in {
     val result = CommentCountController.commentCount("p/37v3a")(TestRequest())
     status(result) should be(200)
   }
-
-  it should "return JSONP when callback is supplied" in {
-    val fakeRequest = FakeRequest(GET, "/discussion/comment-counts.json?shortUrls=/p/37v3a&callback=" + callbackName).withHeaders("host" -> "localhost:9000")
-    val result = CommentCountController.commentCount("p/37v3a")(fakeRequest)
-
-    status(result) should be(200)
-    contentType(result).get should be("application/javascript")
-    contentAsString(result) should startWith(callbackName + "({\"counts\"") // the callback
-  }
-
 }

--- a/discussion/test/CommentPageControllerTest.scala
+++ b/discussion/test/CommentPageControllerTest.scala
@@ -8,20 +8,8 @@ import discussion.model.DiscussionKey
 
 @DoNotDiscover class CommentPageControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
-  val callbackName = "foo"
-
   "Discussion" should "return 200" in {
     val result = CommentsController.comments(DiscussionKey("p/37v3a"))(TestRequest())
     status(result) should be(200)
   }
-
-  it should "return JSONP when callback is supplied" in {
-    val fakeRequest = FakeRequest(GET, "/discussion/p/37v3a.json?callback=" + callbackName).withHeaders("host" -> "localhost:9000")
-    val result = CommentsController.commentsJson(DiscussionKey("p/37v3a"))(fakeRequest)
-
-    status(result) should be(200)
-    contentType(result).get should be("application/javascript")
-    contentAsString(result).substring(0, 200) should startWith(callbackName + "({") // the callback
-  }
-
 }

--- a/onward/test/ContentCardControllerTest.scala
+++ b/onward/test/ContentCardControllerTest.scala
@@ -7,21 +7,10 @@ import play.api.test.Helpers._
 @DoNotDiscover class FlyerControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite  {
 
   val article = "/world/2014/nov/18/hereford-hospital-patient-tested-for-ebola"
-  val callbackName = "aCallback"
 
   "Content Card Controller" should "200 when the content is found" in {
       val result = controllers.FlyerController.render(article)(TestRequest())
       status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied" in {
-      val fakeRequest = FakeRequest(GET, s"/embed/card/${article}?callback=${callbackName}")
-          .withHeaders("host" -> "localhost:9000")
-
-    val result = controllers.FlyerController.render(article)(fakeRequest)
-    status(result) should be(200)
-    contentType(result).get should be ("application/javascript")
-    contentAsString(result) should startWith(s"""${callbackName}({\"html\"""") // the callback
   }
 
   it should "return JSON when .json format is supplied" in {

--- a/onward/test/MostPopularControllerTest.scala
+++ b/onward/test/MostPopularControllerTest.scala
@@ -5,23 +5,12 @@ import play.api.test._
 import play.api.test.Helpers._
 
 @DoNotDiscover class MostPopularControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
-  
+
   val tag = "technology"
-  val callbackName = "aFunction"
 
   "Most Popular Controller" should "200 when content type is tag" in {
     val result = controllers.MostPopularController.render(tag)(TestRequest())
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied" in {
-    val fakeRequest = FakeRequest(GET, s"/most-read/${tag}?callback=${callbackName}")
-      .withHeaders("host" -> "localhost:9000")
-
-    val result = controllers.MostPopularController.render(tag)(fakeRequest)
-    status(result) should be(200)
-    contentType(result).get should be("application/javascript")
-    contentAsString(result) should startWith(s"""${callbackName}({\"html\"""") // the callback
   }
 
   it should "return JSON when .json format is supplied" in {

--- a/onward/test/RelatedControllerTest.scala
+++ b/onward/test/RelatedControllerTest.scala
@@ -5,27 +5,16 @@ import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 
 @DoNotDiscover class RelatedControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
-  
+
   val article = "uk/2012/aug/07/woman-torture-burglary-waterboard-surrey"
   val badArticle = "i/am/not/here"
   val articleWithoutRelated = "uk/2012/aug/29/eva-rausing-information-murder-olaf-palme"
-  val callback = "aFunction"
-
-  it should "serve the correct headers when given a callback parameter" in {
-    val fakeRequest = FakeRequest(GET, s"/related/${article}.json?callback=$callback")
-      .withHeaders("host" -> "http://localhost:9000")
-        
-    val Some(result) = route(fakeRequest)
-    status(result) should be(200)
-    contentType(result).get should be("application/javascript")
-    contentAsString(result) should startWith(s"""${callback}({\"html\"""") // the callback
-  }
 
   it should "serve JSON when .json format is supplied" in {
     val fakeRequest = FakeRequest(GET, s"/related/${article}.json")
       .withHeaders("host" -> "http://localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-        
+
     val Some(result) = route(fakeRequest)
     status(result) should be(200)
     contentType(result).get should be("application/json")

--- a/onward/test/TopStoriesControllerTest.scala
+++ b/onward/test/TopStoriesControllerTest.scala
@@ -5,22 +5,10 @@ import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 
 @DoNotDiscover class TopStoriesControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
-  
-  val callbackName = "aFunction"
 
   "Top Stories" should "should return 200" in {
     val result = controllers.TopStoriesController.renderTopStories()(TestRequest())
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied" in {
-    val fakeRequest = FakeRequest(GET, s"/top-stories?callback=${callbackName}")
-      .withHeaders("host" -> "localhost:9000")
-
-    val result = controllers.TopStoriesController.renderTopStories()(fakeRequest)
-    status(result) should be(200)
-    contentType(result).get should be("application/javascript")
-    contentAsString(result) should startWith(s"""${callbackName}({\"html\"""") // the callback
   }
 
   it should "return JSON when .json format is supplied" in {
@@ -37,15 +25,5 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
   it should "should return 200 for trails" in {
     val result = controllers.TopStoriesController.renderTrails()(TestRequest())
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied to trails" in {
-    val fakeRequest = FakeRequest(GET, s"/top-stories/trails?callback=${callbackName}")
-      .withHeaders("host" -> "localhost:9000")
-
-    val result = controllers.TopStoriesController.renderTrails()(fakeRequest)
-    status(result) should be(200)
-    contentType(result).get should be("application/javascript")
-    contentAsString(result) should startWith(s"""${callbackName}({\"html\"""") // the callback
   }
 }

--- a/sport/test/controllers/CompetitionListControllerTest.scala
+++ b/sport/test/controllers/CompetitionListControllerTest.scala
@@ -5,35 +5,23 @@ import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 
 @DoNotDiscover class CompetitionListControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
-  
+
   val url = "/football/competitions"
-  val callbackName = "aFunction"
-  
+
   "Competition List Controller" should "200 when content type is competition list" in {
     val result = football.controllers.CompetitionListController.renderCompetitionList()(TestRequest())
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied" in {
-    val fakeRequest = FakeRequest(GET, s"${url}?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-      .withHeaders("Accept" -> "application/javascript")
-      
-    val result = football.controllers.CompetitionListController.renderCompetitionList()(fakeRequest)
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""${callbackName}({\"config\"""")
   }
 
   it should "return JSON when .json format is supplied" in {
     val fakeRequest = FakeRequest(GET, "${url}.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-      
+
     val result = football.controllers.CompetitionListController.renderCompetitionListJson()(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
-  
+
 }

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -5,26 +5,14 @@ import play.api.test.Helpers._
 import org.scalatest._
 
 @DoNotDiscover class FixturesControllerTest extends FreeSpec with ShouldMatchers with ConfiguredTestSuite {
-  
+
   val fixturesUrl = "/football/fixtures"
   val fixtureForUrl = "/football/fixtures/2012/oct/20"
   val tag = "premierleague"
-  val callbackName = "aFunction"
 
   "can load the all fixtures page" in {
     val result = football.controllers.FixturesController.allFixtures()(TestRequest())
     status(result) should be(200)
-  }
-
-  "should return JSONP for all fixtures with JSONP callback parameter provided" in {
-    val fakeRequest = FakeRequest(GET, s"$fixturesUrl.json?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-    val result = football.controllers.FixturesController.allFixtures()(fakeRequest)
-
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""$callbackName({"""")
-
   }
 
   "should return basic JSON without callback parameter" in {
@@ -43,16 +31,6 @@ import org.scalatest._
     status(result) should be(200)
   }
 
-  "can return JSONP fixtures for a given date" in {
-    val fakeRequest = FakeRequest(GET, s"$fixtureForUrl.json?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-    val result = football.controllers.FixturesController.allFixturesFor("2012", "oct", "20")(fakeRequest)
-
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""$callbackName({""")
-  }
-
   "returns normal JSON for .json request without callback" in {
     val fakeRequest = FakeRequest(GET, s"$fixtureForUrl.json")
       .withHeaders("host" -> "localhost:9000")
@@ -69,16 +47,6 @@ import org.scalatest._
     status(result) should be(200)
   }
 
-  "tag fixtures page returns JSONP with callback parameter" in {
-    val fakeRequest = FakeRequest(GET, s"/football/$tag/fixtures.json?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-    val result = football.controllers.FixturesController.tagFixtures(tag)(fakeRequest)
-
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""$callbackName({""")
-  }
-
   "should return normal JSON for .json request without callback param" in {
     val fakeRequest = FakeRequest(GET, s"/football/$tag/fixtures.json")
       .withHeaders("host" -> "localhost:9000")
@@ -93,16 +61,6 @@ import org.scalatest._
   "can load tag fixtures for a given date" in {
     val result = football.controllers.FixturesController.tagFixturesFor("2012", "oct", "20", tag)(TestRequest())
     status(result) should be(200)
-  }
-
-  "can return tag JSONP fixtures for a given date" in {
-    val fakeRequest = FakeRequest(GET, s"/football/$tag/fixtures.json?callback=$callbackName")
-      .withHeaders("host" -> "localhost:9000")
-    val result = football.controllers.FixturesController.tagFixturesFor("2012", "oct", "20", tag)(fakeRequest)
-
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
-    contentAsString(result) should startWith(s"""$callbackName({"""")
   }
 
   "returns normal tag JSON for .json request without callback" in {

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -5,82 +5,55 @@ import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 
 @DoNotDiscover class LeagueTableControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
-  
+
   "League Table Controller" should "200 when content type is table" in {
     val result = football.controllers.LeagueTableController.renderLeagueTable()(TestRequest())
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied to table" in {
-    val fakeRequest = FakeRequest(GET, "/football/tables?callback=foo")
-      .withHeaders("host" -> "localhost:9000")
-      .withHeaders("Accept" -> "application/javascript")
-    val result = football.controllers.LeagueTableController.renderLeagueTable()(fakeRequest)
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to table" in {
     val fakeRequest = FakeRequest(GET, "/football/tables.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-      
+
     val result = football.controllers.LeagueTableController.renderLeagueTableJson()(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
-  
+
   it should "200 when content type is teams" in {
     val result = football.controllers.LeagueTableController.renderTeamlist()(TestRequest().withHeaders("Accept" -> "application/javascript"))
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied to teams" in {
-    val fakeRequest = FakeRequest(GET, "/football/teams?callback=foo")
-      .withHeaders("host" -> "localhost:9000")
-      .withHeaders("Accept" -> "application/javascript")
-    val result = football.controllers.LeagueTableController.renderTeamlist()(fakeRequest)
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to teams" in {
     val fakeRequest = FakeRequest(GET, "/football/teams.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-      
+
     val result = football.controllers.LeagueTableController.renderTeamlist()(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
-  
+
   val competitionId = "premierleague"
-  
+
   it should "200 when content type is competition table" in {
     val result = football.controllers.LeagueTableController.renderCompetition(competitionId)(TestRequest())
     status(result) should be(200)
-  }
-
-  it should "return JSONP when callback is supplied to competition table" in {
-    val fakeRequest = FakeRequest(GET, "/football/" + competitionId + "/table?callback=foo")
-      .withHeaders("host" -> "localhost:9000")
-      .withHeaders("Accept" -> "application/javascript")
-    val result = football.controllers.LeagueTableController.renderCompetition(competitionId)(fakeRequest)
-    status(result) should be(200)
-    header("Content-Type", result).get should be("application/javascript; charset=utf-8")
   }
 
   it should "return JSON when .json format is supplied to competition table" in {
     val fakeRequest = FakeRequest(GET, "/football/" + competitionId + "/table.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-      
+
     val result = football.controllers.LeagueTableController.renderCompetition(competitionId)(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"html\"")
   }
-  
+
 }

--- a/sport/test/controllers/MoreOnMatchFeatureTest.scala
+++ b/sport/test/controllers/MoreOnMatchFeatureTest.scala
@@ -7,8 +7,6 @@ import play.api.test.FakeRequest
 
 @DoNotDiscover class MoreOnMatchFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
 
-  val theMatch =
-
   feature("Match Nav") {
 
     scenario("View content related to a match") {
@@ -32,7 +30,7 @@ import play.api.test.FakeRequest
       }
     }
 
-    scenario("Non-existant match pages return jsonp with status property 404") {
+    scenario("Non-existant match pages return status 404") {
 
       Given("I visit a non-existant match page")
 
@@ -41,12 +39,7 @@ import play.api.test.FakeRequest
 
         val result = MoreOnMatchController.matchNav("2010", "01", "01", "1", "2")(request)
 
-        status(result) should be(200)
-
-        val body = contentAsString(result)
-
-        Then("I should see the status in the object with value 404")
-        body should include("\"status\":404")
+        status(result) should be(404)
       }
     }
   }
@@ -74,7 +67,7 @@ import play.api.test.FakeRequest
       }
     }
 
-    scenario("Non-existant match pages return jsonp with status property 404") {
+    scenario("Non-existant match pages return status 404") {
 
       Given("I visit a non-existant match page")
 
@@ -83,14 +76,9 @@ import play.api.test.FakeRequest
 
         val result = MoreOnMatchController.moreOn("bad-id")(request)
 
-        status(result) should be(200)
-
-        val body = contentAsString(result)
-
-        Then("I should see the status in the object with value 404")
-        body should include("\"status\":404")
+        status(result) should be(404)
       }
     }
-    
+
   }
 }


### PR DESCRIPTION
Removes JSONP, and adds origin headers to the memcache key so that we avoid returning an incorrect cached Cors response (one which has the wrong/no access control headers).
