### PR TITLE
Recompute narrow width after animation

### DIFF
--- a/facia-tool/public/js/models/layout.js
+++ b/facia-tool/public/js/models/layout.js
@@ -115,7 +115,7 @@ define([
                 $element.hide();
             }
         },
-        update: function (element, valueAccessor) {
+        update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
             var value = ko.unwrap(valueAccessor()),
                 $element = $(element);
             if (value) {
@@ -129,6 +129,7 @@ define([
                         $element.hide();
                     }
                     updateScrollables();
+                    bindingContext.$data.layout.onConfigVisibilityChange();
                 }
             });
         }


### PR DESCRIPTION
When click on workspace->cancel, the width computation must be done after the slide animation ends.

Fixes #7864
