### PR TITLE
Remove Duplicate Tones in Ad Calls

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -1,5 +1,6 @@
 define([
     'lodash/arrays/compact',
+    'lodash/arrays/uniq',
     'lodash/collections/map',
     'lodash/objects/isArray',
     'lodash/objects/merge',
@@ -14,6 +15,7 @@ define([
     'common/modules/experiments/ab'
 ], function (
     compact,
+    uniq,
     map,
     isArray,
     merge,
@@ -91,7 +93,7 @@ define([
                 co:      parseIds(page.authorIds),
                 bl:      parseIds(page.blogIds),
                 ms:      formatTarget(page.source),
-                tn:      compact([page.sponsorshipType].concat(parseIds(page.tones))),
+                tn:      uniq(compact([page.sponsorshipType].concat(parseIds(page.tones)))),
                 // round video duration up to nearest 30 multiple
                 vl:      page.contentType === 'Video' ? (Math.ceil(page.videoDuration / 30.0) * 30).toString() : undefined
             }, audienceScienceGateway.getSegments(), criteo.getSegments());


### PR DESCRIPTION
Previously we were passing this in ad calls, for example:
`tn=advertisement-features,advertisement-features`

But with this change we are passing:
`tn=advertisement-features`

:tada: 
