### PR TITLE
Minor style fixes for captions and section labels

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -152,6 +152,10 @@
         float: none;
         padding-right: 0;
     }
+
+    .content--interactive & {
+        padding-right: $gs-gutter/3 !important;
+    }
 }
 
 .content__series-label {
@@ -178,6 +182,11 @@
     .content__series-label__link {
         @include font-size(18, 22);
         display: block;
+
+        .content--interactive & {
+            font-size: 20px !important;
+            line-height: 24px !important;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -191,6 +191,13 @@ figure {
             }
         }
     }
+    &.element--showcase {
+        figcaption {
+            @include mq(tablet) {
+                max-width: gs-span(9);
+            }
+        }
+    }
     &.img--inline {
         margin: 5px $gs-gutter 6px 0;
     }


### PR DESCRIPTION
Fixes for:

Narrow figcaption on showcase videos:
![screen shot 2015-01-20 at 17 41 27](https://cloud.githubusercontent.com/assets/2236852/5822392/a4dceba4-a0cb-11e4-97e7-8305fdb22a02.png)

No padding on interactive labels:
![unnamed](https://cloud.githubusercontent.com/assets/2236852/5822412/c427905e-a0cb-11e4-869a-2953389dbf8d.png)
