### PR TITLE
More cors headers

### DIFF
--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -62,13 +62,13 @@ object JsonComponent extends Results with implicits.Requests {
   // Note we are not setting Vary headers here as they get set in CorsVaryHeadersFilter
   // otherwise they get overwritten by the Gzip Filter
   private def resultFor(request: RequestHeader, json: String): Result = {
-    Cors(Ok(json).as(JSON).withHeaders("Access-Control-Allow-Headers" -> "X-Requested-With"))(request)
+    Cors(Ok(json).as(JSON))(request)
   }
 }
 
 object JsonNotFound {
 
   def apply()(implicit request: RequestHeader): Result = {
-    Cors(NotFound.as(JSON).withHeaders("Access-Control-Allow-Headers" -> "X-Requested-With"))(request)
+    Cors(NotFound.as(JSON))(request)
   }
 }

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -7,16 +7,15 @@ import conf.Configuration.ajax.corsOrigins
 object Cors extends Results {
   def apply(result: Result, allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
 
-    val controlHeaders = List(
-      allowedMethods.map("Access-Control-Allow-Methods" -> _),
-      request.headers.get("Access-Control-Request-Headers").map("Access-Control-Allow-Headers" -> _)
-    ).flatten
+    val responseHeaders = request.headers.get("Access-Control-Request-Headers").toList
+      .:+("X-Requested-With").mkString(",")
 
     request.headers.get("Origin") match {
       case None => result
       case Some(requestOrigin) => {
-        val headers = controlHeaders ++ List(
+        val headers = allowedMethods.map("Access-Control-Allow-Methods" -> _).toList ++ List(
           "Access-Control-Allow-Origin" -> corsOrigins.find(_ == requestOrigin).getOrElse("*"),
+          "Access-Control-Allow-Headers" -> responseHeaders,
           "Access-Control-Allow-Credentials" -> "true")
         result.withHeaders(headers: _*)
       }

--- a/common/test/model/CorsTest.scala
+++ b/common/test/model/CorsTest.scala
@@ -13,6 +13,7 @@ class CorsTest extends FlatSpec with Matchers {
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
     Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Origin" -> "*")
     Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Credentials" -> "true")
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-Requested-With")
   }
 
   it should "provide the appropriate standard Cors response headers with an accepted Origin" in {
@@ -37,6 +38,6 @@ class CorsTest extends FlatSpec with Matchers {
     val fakeHeaders = FakeHeaders(List("Origin" -> List("http://www.random.com"),
                                        "Access-Control-Request-Headers" -> List("X-GU-test")))
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
-    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-GU-test")
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-GU-test,X-Requested-With")
   }
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -137,6 +137,7 @@ GET         /football/:competition/table                                        
 GET         /football/:competition/table.json                                                                        football.controllers.LeagueTableController.renderCompetitionJson(competition)
 GET         /football/:competition/:group/table                                                                      football.controllers.LeagueTableController.renderCompetitionGroup(competition, group)
 GET         /football/:competition/:group/table.json                                                                 football.controllers.LeagueTableController.renderCompetitionGroupJson(competition, group)
+GET         /football/:team/fixtures-and-results-container                                                           football.controllers.FixturesAndResultsContainerController.renderContainer(team)
 
 GET         /football/:competitionTag/overview/embed                                                                 football.controllers.WallchartController.renderWallchartEmbed(competitionTag)
 GET         /football/:competitionTag/overview                                                                       football.controllers.WallchartController.renderWallchart(competitionTag)


### PR DESCRIPTION
A speculative effort to adhere to cors in special cases.

Whenever a request with Origin header is received, add the Cors response headers when the routing has failed, or when there is bad request.
