### PR TITLE
Add an options route for fetch comments end points

### DIFF
--- a/common/app/model/TinyResponse.scala
+++ b/common/app/model/TinyResponse.scala
@@ -1,6 +1,5 @@
-package controllers
+package model
 
-import model.{Cors, NoCache}
 import play.api.mvc.{RequestHeader, Result, Results}
 import org.apache.commons.codec.binary.Base64
 
@@ -13,6 +12,4 @@ object TinyResponse extends Results {
   def noContent(allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
     Cors(NoCache(NoContent), allowedMethods)
   }
-
-
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -54,7 +54,9 @@ GET         /discussion/comment-counts.json                                     
 GET         /discussion/comment/*id.json                                                                             controllers.CommentsController.commentJson(id: Int)
 GET         /discussion/comment/*id                                                                                  controllers.CommentsController.comment(id: Int)
 GET         /discussion/comment-context/*commentId.json                                                              controllers.CommentsController.commentContextJson(commentId: Int)
+OPTIONS     /discussion/comment-context/*commentId.json                                                              controllers.CommentsController.commentContextJsonOptions(commentId: Int)
 GET         /discussion/$discussionKey</?p/\w+>.json                                                                 controllers.CommentsController.commentsJson(discussionKey: discussion.model.DiscussionKey)
+OPTIONS     /discussion/$discussionKey</?p/\w+>.json                                                                 controllers.CommentsController.commentsJsonOptions(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/$discussionKey</?p/\w+>                                                                      controllers.CommentsController.comments(discussionKey: discussion.model.DiscussionKey)
 
 GET         /discussion/profile/:id/search/:q.json                                                                   controllers.ProfileActivityController.profileSearch(id: String, q: String)

--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -7,6 +7,7 @@ import model.diagnostics.javascript.JavaScript
 import model.diagnostics.abtests.AbTests
 import model.diagnostics.analytics.Analytics
 import model.diagnostics.css.Css
+import model.TinyResponse
 
 object DiagnosticsController extends Controller with Logging {
 

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import model.Cached
+import model.{Cached, TinyResponse}
 import scala.concurrent.Future
 import common.JsonComponent
 import play.api.mvc.{ Action, RequestHeader, Result }
@@ -14,6 +14,10 @@ object CommentsController extends DiscussionController {
     discussionApi.commentContext(id, params) flatMap { context =>
       getComments(context._1, Some(params.copy(page = context._2)))
     }
+  }
+
+  def commentContextJsonOptions(id: Int) = Action { implicit request =>
+    TinyResponse.noContent(Some("GET, OPTIONS"))
   }
 
   def commentJson(id: Int) = comment(id)
@@ -34,6 +38,10 @@ object CommentsController extends DiscussionController {
   }
 
   def commentsJson(key: DiscussionKey) = comments(key)
+  def commentsJsonOptions(key: DiscussionKey) = Action { implicit request =>
+    TinyResponse.noContent(Some("GET, OPTIONS"))
+  }
+
   def comments(key: DiscussionKey) = Action.async { implicit request =>
     getComments(key)
   }

--- a/discussion/conf/routes
+++ b/discussion/conf/routes
@@ -13,7 +13,9 @@ GET         /discussion/comment-counts.json                                     
 GET         /discussion/comment/*id.json                                        controllers.CommentsController.commentJson(id: Int)
 GET         /discussion/comment/*id                                             controllers.CommentsController.comment(id: Int)
 GET         /discussion/comment-context/*commentId.json                         controllers.CommentsController.commentContextJson(commentId: Int)
+OPTIONS     /discussion/comment-context/*commentId.json                         controllers.CommentsController.commentContextJsonOptions(commentId: Int)
 GET         /discussion/$discussionKey</?p/\w+>.json                            controllers.CommentsController.commentsJson(discussionKey: discussion.model.DiscussionKey)
+OPTIONS     /discussion/$discussionKey</?p/\w+>.json                            controllers.CommentsController.commentsJsonOptions(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/$discussionKey</?p/\w+>                                 controllers.CommentsController.comments(discussionKey: discussion.model.DiscussionKey)
 
 GET         /discussion/profile/:id/search/:q.json                              controllers.ProfileActivityController.profileSearch(id: String, q: String)


### PR DESCRIPTION
Just investigating the XHR mystery, and wondered if some browsers are opting to pre-flight the CORs request.

I don't advocate adding OPTIONS everywhere (despite adding three routes recently), this is a test to confirm if this really is the issue. We can do something clever to handle options later if needed.
