### PR TITLE
Add an experimental feature to provide a default origin control header

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -473,6 +473,11 @@ object Switches {
     safeState = On, sellByDate = new LocalDate(2015, 2, 16)
   )
 
+  val DiscussionOriginSwitch = Switch("Feature", "discussion-origin",
+    "If switched on, an experimental default header to allow origins will be added to discussion",
+    safeState = On, sellByDate = new LocalDate(2015, 1, 28)
+  )
+
   // Facia
 
   val ToolDisable = Switch("Facia", "facia-tool-disable",

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -55,13 +55,19 @@ object CommentsController extends DiscussionController {
         UnthreadedCommentPage(comments)
       }
       Cached(60) {
-        if (request.isJson)
-          JsonComponent(
+        if (request.isJson) {
+          val result = JsonComponent(
             "html" -> views.html.discussionComments.commentsList(page, BlankComment(), params.topComments).toString,
             "currentCommentCount" -> page.comments.length
           )
-        else
+          if (conf.Switches.DiscussionOriginSwitch.isSwitchedOn && request.headers.get("Origin").isEmpty) {
+            result.withHeaders("Access-Control-Allow-Origin" -> "*")
+          } else {
+            result
+          }
+        } else {
           Ok(views.html.discussionComments.discussionPage(page))
+        }
       }
     }
   }


### PR DESCRIPTION
...so next experiment is to try to provide an origin header on this endpoint, in all cases. 
