### PR TITLE
Removing float on container title when in page-skin mode

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -144,7 +144,6 @@ $header-image-size-desktop: 100px;
 
     .has-page-skin & {
         @include mq(wide) {
-            float: left;
             width: gs-span(6) + $gs-gutter;
         }
     }


### PR DESCRIPTION
This just removes the float on the title when the we have a page-skin.

Before;
![screen shot 2015-01-21 at 13 56 33](https://cloud.githubusercontent.com/assets/1303616/5837246/61e66d7a-a175-11e4-8e72-1b3e20fb6fed.png)

After;
![screen shot 2015-01-21 at 13 56 44](https://cloud.githubusercontent.com/assets/1303616/5837250/67394c20-a175-11e4-86dc-e91afb183bfe.png)
