### PR TITLE
Expect URL encoded headers from Fastly

### DIFF
--- a/weather/app/controllers/LocationsController.scala
+++ b/weather/app/controllers/LocationsController.scala
@@ -29,9 +29,12 @@ object LocationsController extends Controller with ExecutionContexts with Loggin
 
     def cityFromRequestEdition = CityResponse.fromEdition(Edition(request))
 
-    val maybeCity = request.headers.get(CityHeader)
-    val maybeRegion = request.headers.get(RegionHeader)
-    val maybeCountry = request.headers.get(CountryHeader)
+    def getEncodedHeader(key: String) =
+      request.headers.get(key).map(java.net.URLDecoder.decode(_, "latin1"))
+
+    val maybeCity = getEncodedHeader(CityHeader)
+    val maybeRegion = getEncodedHeader(RegionHeader)
+    val maybeCountry = getEncodedHeader(CountryHeader)
 
     log.info(s"What is my city request with headers $maybeCity $maybeRegion $maybeCountry")
 


### PR DESCRIPTION
At some point between the VCL and the LocationsController, the encodings of the GeoLocation headers that Fastly gives us get messed up. I've spent a long time debugging this and haven't been able to determine whether the fault lies with Fastly or Play (though I suspect the latter).

I'm changing Fastly so that it now URL encodes the headers, and then we decode them here.
