### PR TITLE
Reinstate old default cors allow headers and Origin too

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -473,8 +473,8 @@ object Switches {
     safeState = On, sellByDate = new LocalDate(2015, 2, 16)
   )
 
-  val DiscussionOriginSwitch = Switch("Feature", "discussion-origin",
-    "If switched on, an experimental default header to allow origins will be added to discussion",
+  val DefaultOriginSwitch = Switch("Feature", "default-origin",
+    "If switched on, an experimental default header to allow origins will be added to Json endpoints",
     safeState = On, sellByDate = new LocalDate(2015, 1, 28)
   )
 

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -5,12 +5,21 @@ import play.api.mvc.Result
 import conf.Configuration.ajax.corsOrigins
 
 object Cors extends Results {
+
+  private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
+
   def apply(result: Result, allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
 
-    val responseHeaders = request.headers.get("Access-Control-Request-Headers").toList
-      .:+("X-Requested-With").mkString(",")
+    val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
 
-    request.headers.get("Origin") match {
+    val origin = if (conf.Switches.DefaultOriginSwitch.isSwitchedOn && request.headers.get("Origin").isEmpty) {
+      // Not nice, but this is temporary code to investigate Cors behaviour.
+      Some("")
+    } else {
+      request.headers.get("Origin")
+    }
+
+    origin match {
       case None => result
       case Some(requestOrigin) => {
         val headers = allowedMethods.map("Access-Control-Allow-Methods" -> _).toList ++ List(

--- a/common/test/model/CorsTest.scala
+++ b/common/test/model/CorsTest.scala
@@ -13,7 +13,7 @@ class CorsTest extends FlatSpec with Matchers {
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
     Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Origin" -> "*")
     Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Credentials" -> "true")
-    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-Requested-With")
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-Requested-With,Origin,Accept,Content-Type")
   }
 
   it should "provide the appropriate standard Cors response headers with an accepted Origin" in {
@@ -22,10 +22,12 @@ class CorsTest extends FlatSpec with Matchers {
     Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Origin" -> "http://www.random.com")
   }
 
-  it should "provide no Cors response headers if the request has no Origin" in {
+  it should "provide Cors response headers if the request has no Origin" in {
     val fakeHeaders = FakeHeaders(List("Origin" -> Nil))
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
-    Cors(NoContent)(fakeRequest).header.headers should be ('empty)
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Origin" -> "*")
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Credentials" -> "true")
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-Requested-With,Origin,Accept,Content-Type")
   }
 
   it should "provide Cors response with allowed methods" in {
@@ -38,6 +40,6 @@ class CorsTest extends FlatSpec with Matchers {
     val fakeHeaders = FakeHeaders(List("Origin" -> List("http://www.random.com"),
                                        "Access-Control-Request-Headers" -> List("X-GU-test")))
     val fakeRequest = FakeRequest(POST, "/css", fakeHeaders, AnyContentAsEmpty)
-    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-GU-test,X-Requested-With")
+    Cors(NoContent)(fakeRequest).header.headers should contain ("Access-Control-Allow-Headers" -> "X-Requested-With,Origin,Accept,Content-Type,X-GU-test")
   }
 }

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -56,15 +56,10 @@ object CommentsController extends DiscussionController {
       }
       Cached(60) {
         if (request.isJson) {
-          val result = JsonComponent(
+          JsonComponent(
             "html" -> views.html.discussionComments.commentsList(page, BlankComment(), params.topComments).toString,
             "currentCommentCount" -> page.comments.length
           )
-          if (conf.Switches.DiscussionOriginSwitch.isSwitchedOn && request.headers.get("Origin").isEmpty) {
-            result.withHeaders("Access-Control-Allow-Origin" -> "*")
-          } else {
-            result
-          }
         } else {
           Ok(views.html.discussionComments.discussionPage(page))
         }


### PR DESCRIPTION
I'm reinstating Accept and Content Type as default headers, these are often needed during Cors negotiation. 
And the feature switch has been extended so that it provides more cors headers.
