### PR TITLE
Add stop for JsonQueueWorker

### DIFF
--- a/facia-end-to-end/app/Global.scala
+++ b/facia-end-to-end/app/Global.scala
@@ -11,4 +11,8 @@ with ConfigAgentLifecycle {
     super.onStart(app)
     ToolPressQueueWorker.start()
   }
+
+  override def onStop(app: play.api.Application): Unit = {
+    ToolPressQueueWorker.stop()
+  }
 }

--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -111,7 +111,8 @@ abstract class JsonQueueWorker[A: Reads] extends Logging with ExecutionContexts 
 
   final private def next() {
     getAndProcess onComplete {
-      case _ => next()
+      case _ if started => next()
+      case _ => log.info("Stopping worker...")
     }
   }
 
@@ -126,6 +127,12 @@ abstract class JsonQueueWorker[A: Reads] extends Logging with ExecutionContexts 
         started = true
         next()
       }
+    }
+  }
+
+  final def stop(): Unit = {
+    synchronized {
+      started = false
     }
   }
 }


### PR DESCRIPTION
When developing with the project `facia-end-to-end`, when compilation changes happen weird things happen with classes.

```
There is no started application
java.lang.RuntimeException: There is no started application
```

I reckon it has something to do with this class running without ever stopping.

@robertberry 
