### PR TITLE
various richlink/openmodule stylefixes

### DIFF
--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -1,7 +1,7 @@
 @(content: model.Content)(implicit request: RequestHeader)
 @import views.support.ContentLayout.ContentLayout
 
-<div class="submeta-container @content.submetaBreakpoint.map{ bp => submeta-container--break-at-@bp }">
+<div class="submeta-container @content.submetaBreakpoint.map{ bp => submeta-container--break submeta-container--break-at-@bp }">
     @if(content.keywords.filterNot(_.isSectionTag).nonEmpty) {
         <div class="submeta" data-link-name="keywords">
             <h2 class="submeta__head">Topics</h2>

--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -39,6 +39,7 @@ define([
                         .removeClass('element-rich-link--not-upgraded')
                         .addClass('element-rich-link--upgraded');
                     imagesModule.upgrade(el);
+                    $('.submeta-container--break').removeClass('submeta-container--break')
                 }
             });
         }

--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -39,7 +39,7 @@ define([
                         .removeClass('element-rich-link--not-upgraded')
                         .addClass('element-rich-link--upgraded');
                     imagesModule.upgrade(el);
-                    $('.submeta-container--break').removeClass('submeta-container--break')
+                    $('.submeta-container--break').removeClass('submeta-container--break');
                 }
             });
         }

--- a/static/src/javascripts/projects/common/modules/article/open-module.js
+++ b/static/src/javascripts/projects/common/modules/article/open-module.js
@@ -39,6 +39,7 @@ define([
                             $.create(resp.html)
                                 .addClass('element--supporting')
                                 .insertBefore(space);
+                            $('.submeta-container--break').removeClass('submeta-container--break')
                         }
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/article/open-module.js
+++ b/static/src/javascripts/projects/common/modules/article/open-module.js
@@ -39,7 +39,7 @@ define([
                             $.create(resp.html)
                                 .addClass('element--supporting')
                                 .insertBefore(space);
-                            $('.submeta-container--break').removeClass('submeta-container--break')
+                            $('.submeta-container--break').removeClass('submeta-container--break');
                         }
                     });
                 }

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -37,13 +37,11 @@
     }
 }
 
-.submeta-container--break-at-leftcol {
+.submeta-container--break {
     @include mq(leftCol) {
         margin-top: 0;
-        width: $left-column;
         position: absolute;
         bottom: 0;
-        left: -1 * ($left-column + $gs-gutter);
 
         .content--media & {
             border-top: 0;
@@ -62,35 +60,22 @@
         }
     }
 
-    @include mq(wide) {
-        width: $left-column-wide;
-        left: -$left-column-wide - $gs-gutter;
+    &.submeta-container--break-at-leftcol {
+        @include mq(leftCol) {
+            width: $left-column;
+            left: -1 * ($left-column + $gs-gutter);
+        }
+
+        @include mq(wide) {
+            width: $left-column-wide;
+            left: -$left-column-wide - $gs-gutter;
+        }
     }
-}
 
-.submeta-container--break-at-wide {
-    @include mq(wide) {
-        margin-top: 0;
-        width: $left-column-wide;
-        position: absolute;
-        bottom: 0;
-        left: -$left-column-wide - $gs-gutter;
-
-        .content--media & {
-            border-top: 0;
-        }
-
-        .submeta {
-            padding-top: 0;
-            border-top: 1px dotted colour(neutral-4);
-        }
-
-        .submeta__head {
-            display: block;
-        }
-
-        .content__main-column--media & {
-            bottom: -($gs-baseline/4);
+    &.submeta-container--break-at-wide {
+        @include mq(wide) {
+            width: $left-column-wide;
+            left: -$left-column-wide - $gs-gutter;
         }
     }
 }

--- a/static/src/stylesheets/module/content/_tones-mixins.scss
+++ b/static/src/stylesheets/module/content/_tones-mixins.scss
@@ -129,6 +129,10 @@
                 }
             }
 
+            .tone-accent-border {
+                border-color: $tonal__headline-accent;
+            }
+
             .drop-cap,
             .element-pullquote cite {
                 color: $tonal__article-link;

--- a/static/src/stylesheets/module/content/tones/_tone-news.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-news.scss
@@ -10,6 +10,14 @@
         }
     }
 
+    .tone-colour {
+        color: colour(news-default);
+    }
+
+    .tone-accent-border {
+        border-color: colour(news-accent);
+    }
+
     // Interactives need help because their headers are not tonal
     &.content--interactive {
         .commentcount i {

--- a/static/src/stylesheets/module/external/_open-module.scss
+++ b/static/src/stylesheets/module/external/_open-module.scss
@@ -1,6 +1,6 @@
 .open {
     margin-bottom: $gs-baseline;
-    border-top: 1px solid;
+    border-top: 2px solid;
     border-bottom: 1px solid colour(neutral-4) !important;
 }
 


### PR DESCRIPTION
- open module border top colour -> accent tone
- open module border top size -> 2px
- adding tone-news style for tone-colour class
- clear left-floated tags when inserting tag targeted content
