### PR TITLE
Add ophan tracking to external video embeds

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -65,6 +65,7 @@
 
                 <script>
                     var guardian = {
+                        isEmbed: true,
                         isModernBrowser: (
                             'querySelector' in document
                             && 'addEventListener' in window
@@ -100,7 +101,7 @@
                             core: '@StaticSecure("javascripts/core.js")',
                             text: 'text', // noop
                             'bootstraps/video-embed': '@StaticSecure("javascripts/bootstraps/video-embed.js")',
-                            'ophan/ng':  '@{Configuration.javascript.config("ophanJsUrl")}'
+                            'ophan/embed':  '@{Configuration.javascript.config("ophanEmbedJsUrl")}'
                         }
                     };
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -125,6 +125,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
 
   object ophan {
     lazy val jsLocation = configuration.getStringProperty("ophan.js.location").getOrElse("//j.ophan.co.uk/ophan.ng")
+    lazy val embedJsLocation = configuration.getStringProperty("ophan.embed.js.location").getOrElse("//j.ophan.co.uk/ophan.embed")
   }
 
   object googletag {
@@ -298,6 +299,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       ("secureDiscussionApiRoot", discussion.secureApiRoot),
       "discussionApiClientHeader" -> discussion.apiClientHeader,
       ("ophanJsUrl", ophan.jsLocation),
+      ("ophanEmbedJsUrl", ophan.embedJsLocation),
       ("googletagJsUrl", googletag.jsLocation),
       ("membershipUrl", id.membershipUrl),
       ("stripePublicToken", id.stripePublicToken)

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -310,6 +310,11 @@ object Switches {
     safeState = Off, new LocalDate(2015, 2, 28)
   )
 
+  val ThirdPartyEmbedTracking = Switch("Monitoring", "third-party-embed-tracking",
+    "Enables tracking on our off-site third party embedded content. Such as: videos on embed.theguardian.com.",
+    safeState = Off, never
+  )
+
   // Features
   val FixturesAndResultsContainerSwitch = Switch(
     "Feature",

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -110,11 +110,11 @@ define([
                 player.fullscreener();
 
                 if (config.switches.thirdPartyEmbedTracking) {
-                        deferToAnalytics(function () {
-                            events.initOphanTracking(player, mediaId);
-                            events.initOmnitureTracking(player);
-                            events.bindContentEvents(player);
-                        });
+                    deferToAnalytics(function () {
+                        events.initOphanTracking(player, mediaId);
+                        events.initOmnitureTracking(player);
+                        events.bindContentEvents(player);
+                    });
 
                     new Omniture(window.s).go();
                 }

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -6,6 +6,7 @@ define([
     'videojs',
     'videojsembed',
     'common/utils/_',
+    'common/utils/config',
     'common/utils/defer-to-analytics',
     'common/modules/analytics/omniture',
     'common/modules/video/tech-order',
@@ -18,6 +19,7 @@ define([
     videojs,
     videojsembed,
     _,
+    config,
     deferToAnalytics,
     Omniture,
     techOrder,
@@ -97,7 +99,6 @@ define([
 
                 initLoadingSpinner(player);
                 events.bindGlobalEvents(player);
-                events.initOphanTracking(player, mediaId);
 
                 // unglitching the volume on first load
                 vol = player.volume();
@@ -108,12 +109,15 @@ define([
 
                 player.fullscreener();
 
-                deferToAnalytics(function () {
-                    events.initOmnitureTracking(player);
-                    events.bindContentEvents(player);
-                });
+                if (config.switches.thirdPartyEmbedTracking) {
+                        deferToAnalytics(function () {
+                            events.initOphanTracking(player, mediaId);
+                            events.initOmnitureTracking(player);
+                            events.bindContentEvents(player);
+                        });
 
-                new Omniture(window.s).go();
+                    new Omniture(window.s).go();
+                }
             });
 
             mouseMoveIdle = _.debounce(function () { player.removeClass('vjs-mousemoved'); }, 500);

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -10,6 +10,11 @@ define([
 ) {
 
     function OmnitureMedia(player) {
+
+        function getAttribute(attributeName) {
+            return player.el().getAttribute(attributeName);
+        }
+
         var lastDurationEvent, durationEventTimer,
             mediaId = getAttribute('data-embed-path') || config.page.pageId,
             // infer type (audio/video) from what element we have
@@ -34,10 +39,6 @@ define([
                 // extra events with no set ordering
                 duration: 'event57'
             };
-
-        function getAttribute(attributeName) {
-            return player.el().getAttribute(attributeName);
-        }
 
         this.getDuration = function () {
             return parseInt(getAttribute('data-duration'), 10) || undefined;

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -1,3 +1,4 @@
+/* global guardian */
 define([
     'lodash/objects/values',
     'common/utils/config',
@@ -9,16 +10,13 @@ define([
 ) {
 
     function OmnitureMedia(player) {
-        function getAttribute(attributeName) {
-            return player.el().getAttribute(attributeName);
-        }
-
         var lastDurationEvent, durationEventTimer,
             mediaId = getAttribute('data-embed-path') || config.page.pageId,
             // infer type (audio/video) from what element we have
             mediaType = qwery('audio', player.el()).length ? 'audio' : 'video',
             contentStarted = false,
             prerollPlayed = false,
+            isEmbed = !!guardian.isEmbed,
             events = {
                 // this is the expected ordering of events
                 'video:request': 'event98',
@@ -36,6 +34,10 @@ define([
                 // extra events with no set ordering
                 duration: 'event57'
             };
+
+        function getAttribute(attributeName) {
+            return player.el().getAttribute(attributeName);
+        }
 
         this.getDuration = function () {
             return parseInt(getAttribute('data-duration'), 10) || undefined;
@@ -87,7 +89,7 @@ define([
             s.Media.segmentByMilestones = false;
             s.Media.trackUsingContextData = false;
 
-            s.eVar11 = s.prop11 = (window.location.host === 'embed.theguardian.com') ? 'Embedded' : config.page.sectionName || '';
+            s.eVar11 = s.prop11 = isEmbed ? 'Embedded' : config.page.sectionName || '';
             s.eVar7 = s.pageName;
 
             s.Media.open(mediaId, this.getDuration(), 'HTML5 Video');

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -1,3 +1,271 @@
-/**
- * Created by phamann on 21/01/2015.
- */
+/* global guardian */
+define([
+    'raven',
+    'common/utils/_',
+    'common/utils/config',
+    'common/utils/detect',
+    'common/modules/analytics/omnitureMedia',
+    'text!common/views/ui/video-ads-overlay.html',
+    'text!common/views/ui/video-ads-skip-overlay.html'
+], function(
+    raven,
+    _,
+    config,
+    detect,
+    OmnitureMedia,
+    adsOverlayTmpl,
+    adsSkipOverlayTmpl
+){
+    var isDesktop = detect.isBreakpoint({ min: 'desktop' }),
+        isEmbed = !!guardian.isEmbed,
+        QUARTILES = [25, 50, 75],
+    // Advert and content events used by analytics. The expected order of bean events is:
+        EVENTS = [
+            'preroll:request',
+            'preroll:ready',
+            'preroll:play',
+            'preroll:end',
+            'content:ready',
+            'content:play',
+            'content:end'
+        ];
+
+    function getMediaType(player) {
+        return isEmbed ? 'video' : player.guMediaType;
+    }
+
+    function shouldAutoPlay(player) {
+        return isDesktop && !history.isRevisit(config.page.pageId) && player.guAutoplay;
+    }
+
+    function constructEventName(eventName, player) {
+        return getMediaType(player) + ':' + eventName;
+    }
+
+    function ophanRecord(id, event, player) {
+        var ophanPath = isEmbed ? 'ophan/embed' : 'ophan/ng';
+        if (id) {
+            require(ophanPath, function (ophan) {
+                var eventObject = {};
+                eventObject[getMediaType(player)] = {
+                    id: id,
+                    eventType: event.type
+                };
+                ophan.record(eventObject);
+            });
+        }
+    }
+
+    function initOphanTracking(player, mediaId) {
+        EVENTS.concat(QUARTILES.map(function (q) {
+            return 'play:' + q;
+        })).forEach(function (event) {
+            player.one(constructEventName(event, player), function (event) {
+                ophanRecord(mediaId, event, player);
+            });
+        });
+    }
+
+    function initOmnitureTracking(player) {
+        new OmnitureMedia(player).init();
+    }
+
+    function bindPrerollEvents(player) {
+        var events = {
+            end: function () {
+                player.trigger(constructEventName('preroll:end', player));
+                player.removeClass('vjs-ad-playing--vpaid');
+                bindContentEvents(player, true);
+            },
+            start: function () {
+                var duration = player.duration();
+                if (duration) {
+                    player.trigger(constructEventName('preroll:play', player));
+                } else {
+                    player.one('durationchange', events.start);
+                }
+            },
+            vpaidStarted: function () {
+                player.addClass('vjs-ad-playing--vpaid');
+            },
+            ready: function () {
+                player.trigger(constructEventName('preroll:ready', player));
+
+                player.one('adstart', events.start);
+                player.one('adend', events.end);
+
+                // Handle custom event to understand when vpaid is playing;
+                // there is a lag between 'adstart' and 'Vpaid::AdStarted'.
+                player.one('Vpaid::AdStarted', events.vpaidStarted);
+
+                if (shouldAutoPlay(player)) {
+                    player.play();
+                }
+            }
+        };
+        player.one('adsready', events.ready);
+
+        //If no preroll avaliable or preroll fails, cancel ad framework and init content tracking
+        player.one('adtimeout', function () {
+            player.trigger('adscanceled');
+            bindContentEvents(player);
+        });
+    }
+
+    function bindContentEvents(player) {
+        var events = {
+            end: function () {
+                player.trigger(constructEventName('content:end', player));
+            },
+            play: function () {
+                var duration = player.duration();
+                if (duration) {
+                    player.trigger(constructEventName('content:play', player));
+                } else {
+                    player.one('durationchange', events.play);
+                }
+            },
+            timeupdate: function () {
+                var progress = Math.round(parseInt(player.currentTime() / player.duration() * 100, 10));
+                QUARTILES.reverse().some(function (quart) {
+                    if (progress >= quart) {
+                        player.trigger(constructEventName('play:' + quart, player));
+                        return true;
+                    } else {
+                        return false;
+                    }
+                });
+            },
+            ready: function () {
+                player.trigger(constructEventName('content:ready', player));
+
+                player.one('play', events.play);
+                player.on('timeupdate', _.throttle(events.timeupdate, 1000));
+                player.one('ended', events.end);
+
+                if (shouldAutoPlay(player)) {
+                    player.play();
+                }
+            }
+        };
+        events.ready();
+    }
+
+    // The Flash player does not copy its events to the dom as the HTML5 player does. This makes some
+    // integrations difficult. These events are so that other libraries (e.g. Ophan) can hook into events without
+    // needing to know about videojs
+    function bindGlobalEvents(player) {
+        player.on('playing', function () {
+            bean.fire(document.body, 'videoPlaying');
+        });
+        player.on('pause', function () {
+            bean.fire(document.body, 'videoPause');
+        });
+        player.on('ended', function () {
+            bean.fire(document.body, 'videoEnded');
+        });
+    }
+
+    function adCountdown() {
+        var player = this,
+            events =  {
+                destroy: function () {
+                    $('.js-ads-overlay', this.el()).remove();
+                    this.off('timeupdate', events.update);
+                },
+                update: function () {
+                    if (this.currentTime() > 0.1) {
+                        $('.vjs-ads-overlay').removeClass('vjs-ads-overlay--not-started');
+                    }
+                    if (parseInt(this.currentTime().toFixed(), 10) === 5) {
+                        $('.vjs-ads-overlay-top').addClass('vjs-ads-overlay-top--animate-hide');
+                    }
+                },
+                init: function () {
+                    $(this.el()).append($.create(adsOverlayTmpl));
+                    this.on('timeupdate', events.update.bind(this));
+                    this.one(constructEventName('preroll:end', player), events.destroy.bind(player));
+                    this.one(constructEventName('content:play', player), events.destroy.bind(player));
+                    this.one('adtimeout', events.destroy.bind(player));
+                }
+            };
+        this.one(constructEventName('preroll:play', player), events.init.bind(player));
+    }
+
+    function adSkipCountdown(skipTimeout) {
+        var player = this,
+            events =  {
+                update: function () {
+                    var skipTime = parseInt((skipTimeout - this.currentTime()).toFixed(), 10);
+                    if (skipTime > 0) {
+                        $('.js-skip-remaining-time', this.el()).text(skipTime);
+                    } else if (!skipTime) {
+                        $('.vjs-ads-overlay-skip-countdown', this.el())
+                            .html('<button class="vjs-ads-overlay-skip-button" data-link-name="Skip video advert">' +
+                            '<i class="i i-play-icon-grey skip-icon"></i>' +
+                            '<i class="i i-play-icon-gold skip-icon"></i>Skip advert</button>');
+                        $('.vjs-ads-overlay-skip').addClass('vjs-ads-overlay-skip--enabled');
+                    }
+                },
+                skip: function () {
+                    if ($('.vjs-ads-overlay-skip').hasClass('vjs-ads-overlay-skip--enabled')) {
+                        events.hide.bind(player);
+                        player.trigger(constructEventName('preroll:skip', player));
+                        this.ads.endLinearAdMode();
+                    }
+                },
+                hide: function () {
+                    $('.js-ads-skip-overlay', this.el()).hide();
+                    this.off('timeupdate', events.update);
+                },
+                init: function () {
+                    $(this.el()).append($.create(adsSkipOverlayTmpl));
+                    bean.on($('.vjs-ads-overlay-skip')[0], 'click', events.skip.bind(player));
+                    this.on('timeupdate', events.update.bind(player));
+                    this.one(constructEventName('content:play', player), events.hide.bind(player));
+                    $('.js-skip-remaining-time', this.el()).text(parseInt(skipTimeout, 10).toFixed());
+                }
+            };
+        this.one(constructEventName('preroll:play', player), events.init.bind(player));
+    }
+
+    function beaconError(err) {
+        if (err && 'message' in err && 'code' in err) {
+            raven.captureException(new Error(err.message), {
+                tags: {
+                    feature: 'player',
+                    vjsCode: err.code
+                }
+            });
+        }
+    }
+
+    function handleInitialMediaError(player) {
+        var err = player.error();
+        if (err !== null) {
+            beaconError(err);
+            return err.code === 4;
+        }
+        return false;
+    }
+
+    function bindErrorHandler(player) {
+        player.on('error', function () {
+            beaconError(player.error());
+            $('.vjs-big-play-button').hide();
+        });
+    }
+
+    return {
+        constructEventName: constructEventName,
+        bindContentEvents: bindContentEvents,
+        bindPrerollEvents: bindPrerollEvents,
+        bindGlobalEvents: bindGlobalEvents,
+        initOphanTracking: initOphanTracking,
+        initOmnitureTracking: initOmnitureTracking,
+        adCountdown: adCountdown,
+        adSkipCountdown: adSkipCountdown,
+        handleInitialMediaError: handleInitialMediaError,
+        bindErrorHandler: bindErrorHandler
+    }
+});

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -1,5 +1,6 @@
 /* global guardian */
 define([
+    'bean',
     'raven',
     'common/utils/_',
     'common/utils/config',
@@ -7,7 +8,8 @@ define([
     'common/modules/analytics/omnitureMedia',
     'text!common/views/ui/video-ads-overlay.html',
     'text!common/views/ui/video-ads-skip-overlay.html'
-], function(
+], function (
+    bean,
     raven,
     _,
     config,
@@ -15,7 +17,7 @@ define([
     OmnitureMedia,
     adsOverlayTmpl,
     adsSkipOverlayTmpl
-){
+) {
     var isDesktop = detect.isBreakpoint({ min: 'desktop' }),
         isEmbed = !!guardian.isEmbed,
         QUARTILES = [25, 50, 75],
@@ -267,5 +269,5 @@ define([
         adSkipCountdown: adSkipCountdown,
         handleInitialMediaError: handleInitialMediaError,
         bindErrorHandler: bindErrorHandler
-    }
+    };
 });

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -1,0 +1,3 @@
+/**
+ * Created by phamann on 21/01/2015.
+ */


### PR DESCRIPTION
This PR does two tightly coupled things:
- Add Ophan tracking for our external video player embeds
- Add new configuration value to point to new tracker-js file `ophan/embed`
- Refactor and abstract the media player event system into a separate module so that it can be shared by both versions of the player, and in-turn making it more dry.

/cc @rich-nguyen @mattosborn 
