### PR TITLE
Improve scrolling affordance for stocks widget

### DIFF
--- a/static/src/stylesheets/module/business/_stocks.scss
+++ b/static/src/stylesheets/module/business/_stocks.scss
@@ -58,11 +58,19 @@ $stocks-icon-height: 10px;
 @include stock('level', status-neutral, market-same);
 
 .stocks__stock-value {
-    display: table-cell;
+    display: inline-block;
     padding-left: 6px;
     padding-right: $gs-gutter;
-    min-width: gs-span(2) + $gs-gutter;
+    min-width: 60%;
     border-right: 1px dotted guss-colour(neutral-3, $pasteup-palette);
+
+    @include mq(mobileLandscape) {
+        min-width: 35%;
+    }
+
+    @include mq(tablet) {
+        min-width: gs-span(2) + $gs-gutter;
+    }
 
     @include mq(leftCol) {
         display: block;


### PR DESCRIPTION
Use percentages as `min-width` on the stocks widget to provide better affordance for scrolly-scroll.

![screen recording 2015-01-22 at 11 48 am](https://cloud.githubusercontent.com/assets/1607666/5855158/df476ce4-a22c-11e4-8087-469ff4477383.gif)
