### PR TITLE
isNetworkFront should only be true for network fronts

### DIFF
--- a/common/app/model/FaciaPage.scala
+++ b/common/app/model/FaciaPage.scala
@@ -59,7 +59,7 @@ case class FaciaPage(id: String,
     "contentType" -> JsString(contentType)
   )
 
-  val isNetworkFront: Boolean = Edition.all.exists(edition => id.toLowerCase.endsWith(edition.id.toLowerCase))
+  val isNetworkFront: Boolean = Edition.all.exists(_.id.toLowerCase == id)
 
   override lazy val contentType: String = if (isNetworkFront) GuardianContentTypes.NetworkFront else GuardianContentTypes.Section
 


### PR DESCRIPTION
Was reporting true for any urls ending in an editions, e.g. /global-development/series/womens-rights-and-gender-equality-in-foc**us**
