### PR TITLE
Treats empty collection

### DIFF
--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -276,7 +276,8 @@ trait UpdateActions extends Logging with ExecutionContexts {
         .map(archiveUpdateBlock(collectionId, _, updateJson, identity))
         .map(FaciaApi.updateIdentity(_, identity))
         .map(putBlock(collectionId, _))
-        .orElse(Option(createCollectionForTreat(collectionId, identity, update)))}}
+        .orElse(Option(createCollectionForTreat(collectionId, identity, update)))
+        .map(putBlock(collectionId, _))}}
 
   def removeTreats(collectionId: String, update: UpdateList, identity: UserIdentity): Future[Option[CollectionJson]] = {
     lazy val updateJson = Json.toJson(update)


### PR DESCRIPTION
When we currently drag a treat into a collection that has been been created but does not exist yet as a file, it does not get created. This it out of line with the behaviour that happens when normally curating a collection.

This fixes that with slight refactoring.

@robertberry 
