### PR TITLE
Separate top-comments from comments list, split json response into fragments

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -51,23 +51,21 @@ GET         /analytics/commercial/adtests                                       
 # Discussion
 GET         /discussion/comment-counts                                                                               controllers.CommentCountController.commentCount(shortUrls: String)
 GET         /discussion/comment-counts.json                                                                          controllers.CommentCountController.commentCountJson(shortUrls: String)
-
 GET         /discussion/comment/*id.json                                                                             controllers.CommentsController.commentJson(id: Int)
 GET         /discussion/comment/*id                                                                                  controllers.CommentsController.comment(id: Int)
 GET         /discussion/comment-context/*commentId.json                                                              controllers.CommentsController.commentContextJson(commentId: Int)
 OPTIONS     /discussion/comment-context/*commentId.json                                                              controllers.CommentsController.commentContextJsonOptions(commentId: Int)
+GET         /discussion/top-comments/$discussionKey</?p/\w+>.json                                                    controllers.CommentsController.topCommentsJson(discussionKey: discussion.model.DiscussionKey)
+OPTIONS     /discussion/top-comments/$discussionKey</?p/\w+>.json                                                    controllers.CommentsController.topCommentsJsonOptions(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/$discussionKey</?p/\w+>.json                                                                 controllers.CommentsController.commentsJson(discussionKey: discussion.model.DiscussionKey)
 OPTIONS     /discussion/$discussionKey</?p/\w+>.json                                                                 controllers.CommentsController.commentsJsonOptions(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/$discussionKey</?p/\w+>                                                                      controllers.CommentsController.comments(discussionKey: discussion.model.DiscussionKey)
-
 GET         /discussion/profile/:id/search/:q.json                                                                   controllers.ProfileActivityController.profileSearch(id: String, q: String)
 GET         /discussion/profile/:id/discussions.json                                                                 controllers.ProfileActivityController.profileDiscussions(id: String)
 GET         /discussion/profile/:id/replies.json                                                                     controllers.ProfileActivityController.profileReplies(id: String)
 GET         /discussion/profile/:id/picks.json                                                                       controllers.ProfileActivityController.profilePicks(id: String)
 GET         /discussion/profile/:id/witness.json                                                                     controllers.WitnessActivityController.witnessActivity(id: String)
-
 GET         /open/cta/article/*discussionKey.json                                                                    controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
-
 
 # Onward
 GET         /most-read.json                                                                                          controllers.MostPopularController.render(path = "")

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -9,22 +9,21 @@ import discussion.model.{BlankComment, DiscussionKey}
 
 object CommentsController extends DiscussionController {
 
+  // Used for jump to comment, comment hash location.
   def commentContextJson(id: Int) = Action.async { implicit request =>
     val params = DiscussionParams(request)
     discussionApi.commentContext(id, params) flatMap { context =>
       getComments(context._1, Some(params.copy(page = context._2)))
     }
   }
-
   def commentContextJsonOptions(id: Int) = Action { implicit request =>
     TinyResponse.noContent(Some("GET, OPTIONS"))
   }
 
+  // Used for getting more replies for a specific comment.
   def commentJson(id: Int) = comment(id)
   def comment(id: Int) = Action.async { implicit request =>
-    val comment = discussionApi.commentFor(id, request.getQueryString("displayThreaded"))
-
-    comment map {
+    discussionApi.commentFor(id, request.getQueryString("displayThreaded")) map {
       comment =>
         Cached(60) {
           if (request.isJson)
@@ -37,16 +36,16 @@ object CommentsController extends DiscussionController {
     }
   }
 
-  def commentsJson(key: DiscussionKey) = comments(key)
-  def commentsJsonOptions(key: DiscussionKey) = Action { implicit request =>
-    TinyResponse.noContent(Some("GET, OPTIONS"))
-  }
+  // Get a list of comments for a discussion.
+  def comments(key: DiscussionKey) = Action.async { implicit request => getComments(key) }
+  def commentsJson(key: DiscussionKey) = Action.async { implicit request => getComments(key) }
+  def commentsJsonOptions(key: DiscussionKey) = Action { implicit request => TinyResponse.noContent(Some("GET, OPTIONS")) }
 
-  def comments(key: DiscussionKey) = Action.async { implicit request =>
-    getComments(key)
-  }
+  // Get the top comments for a discussion.
+  def topCommentsJson(key: DiscussionKey) = Action.async { implicit request => getTopComments(key) }
+  def topCommentsJsonOptions(key: DiscussionKey) = Action { implicit request => TinyResponse.noContent(Some("GET, OPTIONS")) }
 
-  def getComments(key: DiscussionKey, optParams: Option[DiscussionParams] = None)(implicit request: RequestHeader): Future[Result] = {
+  private def getComments(key: DiscussionKey, optParams: Option[DiscussionParams] = None)(implicit request: RequestHeader): Future[Result] = {
     val params = optParams.getOrElse(DiscussionParams(request))
     discussionApi.commentsFor(key, params).map { comments =>
       val page = if (params.displayThreaded) {
@@ -57,11 +56,30 @@ object CommentsController extends DiscussionController {
       Cached(60) {
         if (request.isJson) {
           JsonComponent(
-            "html" -> views.html.discussionComments.commentsList(page, BlankComment(), params.topComments).toString,
+            "commentsHtml" -> views.html.discussionComments.commentsList(page, false).toString,
+            "paginationHtml" -> views.html.fragments.commentPagination(page).toString,
+            "postedCommentHtml" -> views.html.fragments.comment(BlankComment()).toString,
             "currentCommentCount" -> page.comments.length
           )
         } else {
           Ok(views.html.discussionComments.discussionPage(page))
+        }
+      }
+    }
+  }
+
+  private def getTopComments(key: DiscussionKey)(implicit request: RequestHeader): Future[Result] = {
+
+    discussionApi.commentsFor(key, DiscussionParams(topComments = true)).map { comments =>
+      val page = UnthreadedCommentPage(comments)
+
+      Cached(60) {
+        if (request.isJson) {
+          JsonComponent(
+            "html" -> views.html.discussionComments.topCommentsList(page).toString
+          )
+        } else {
+          Ok(views.html.discussionComments.topCommentsList(page))
         }
       }
     }

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -165,12 +165,12 @@ object AuthHeaders {
 }
 
 case class DiscussionParams(
-  orderBy: String,
-  page: String,
-  pageSize: String,
-  topComments: Boolean,
-  maxResponses: Option[String],
-  displayThreaded: Boolean)
+  orderBy: String = "newest",
+  page: String = "1",
+  pageSize: String = "50",
+  topComments: Boolean = false,
+  maxResponses: Option[String] = None,
+  displayThreaded: Boolean = false)
 
 object DiscussionParams extends {
   def apply(request: RequestHeader): DiscussionParams = {
@@ -179,7 +179,6 @@ object DiscussionParams extends {
       page = request.getQueryString("page").getOrElse("1"),
       pageSize = request.getQueryString("pageSize").getOrElse("50"),
       maxResponses = request.getQueryString("maxResponses"),
-      topComments = request.getQueryString("topComments").exists(_ == "true"),
       displayThreaded = request.getQueryString("displayThreaded").exists(_ == "true")
     )
   }

--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -1,41 +1,15 @@
-@(page: discussion.CommentPage, blankComment: discussion.model.Comment = null, isTopComments: Boolean = false)(implicit request: RequestHeader)
+@(page: discussion.CommentPage, renderPagination: Boolean)(implicit request: RequestHeader)
 
-@** TODO: WTF? NULL? SERIOUSLY? ARGH! *@
+<div class="d-discussion @if(!page.isClosedForRecommendation){d-discussion--recommendations-open} u-cf"
+    @page.switches.map{ switch => data-@switch.name="@switch.state" }>
 
-@import common.SimplePagePaths
+    <ul class="d-thread d-thread--top-level">
+        @page.comments.map { comment =>
+            @fragments.comment(comment, page.isClosedForRecommendation, false)
+        }
+    </ul>
 
-<div
-    class="d-discussion @if(isTopComments){d-discussion--top-comments} @if(!page.isClosedForRecommendation){d-discussion--recommendations-open} u-cf"
-    @page.switches.map{ switch =>
-        data-@switch.name="@switch.state"
-    }>
+    @if(renderPagination) {fragments.commentPagination(page)}
 
-    @if(isTopComments) {
-        <ul class="d-top-comment-container d-top-comment-container--left">
-            @page.comments.zipWithIndex.filter(_._2 % 2 == 0).map { case (comment, i) =>
-                @fragments.topComment(comment, page.isClosedForRecommendation, false)
-            }
-        </ul>
-        <ul class="d-top-comment-container d-top-comment-container--right">
-            @page.comments.zipWithIndex.filter(_._2 % 2 == 1).map { case (comment, i) =>
-                @fragments.topComment(comment, page.isClosedForRecommendation, false)
-            }
-        </ul>
-        } else {
-        <ul class="d-thread d-thread--top-level">
-            @page.comments.map { comment =>
-                @fragments.comment(comment, page.isClosedForRecommendation, false)
-            }
-        </ul>
-    }
-
-    @if(blankComment != null){<script type="text/template" id="tmpl-comment">@fragments.comment(blankComment)</script>}
-
-    @if(!isTopComments) {
-    <div class="discussion__pagination discussion__pagination--bottom js-discussion-pagination">
-        @page.pagination.map{ paginate => @fragments.pagination(page.webTitle, paginate, SimplePagePaths(page.url), Some("js-discussion-change-page"), false, Some("Comments")) }
-    </div>
     @fragments.reportComment()
-    }
-
 </div>

--- a/discussion/app/views/discussionComments/discussionPage.scala.html
+++ b/discussion/app/views/discussionComments/discussionPage.scala.html
@@ -14,7 +14,7 @@
     <div class="gs-container">
         <div class="content__main-column">
             <h2 class="page-sub-header tone-colour">Comments</h2>
-            @commentsList(page)
+            @commentsList(page, true)
         </div>
     </div>
 </div>

--- a/discussion/app/views/discussionComments/topCommentsList.scala.html
+++ b/discussion/app/views/discussionComments/topCommentsList.scala.html
@@ -1,0 +1,16 @@
+@(page: discussion.CommentPage)(implicit request: RequestHeader)
+
+<div class="d-discussion d-discussion--top-comments @if(!page.isClosedForRecommendation){d-discussion--recommendations-open} u-cf"
+    @page.switches.map{ switch => data-@switch.name="@switch.state" }>
+
+    <ul class="d-top-comment-container d-top-comment-container--left">
+        @page.comments.zipWithIndex.filter(_._2 % 2 == 0).map { case (comment, i) =>
+            @fragments.topComment(comment, page.isClosedForRecommendation, false)
+        }
+    </ul>
+    <ul class="d-top-comment-container d-top-comment-container--right">
+        @page.comments.zipWithIndex.filter(_._2 % 2 == 1).map { case (comment, i) =>
+            @fragments.topComment(comment, page.isClosedForRecommendation, false)
+        }
+    </ul>
+</div>

--- a/discussion/app/views/fragments/commentPagination.scala.html
+++ b/discussion/app/views/fragments/commentPagination.scala.html
@@ -1,0 +1,7 @@
+@(page: discussion.CommentPage)(implicit request: RequestHeader)
+
+@import common.SimplePagePaths
+
+<div class="discussion__pagination discussion__pagination--bottom">
+    @page.pagination.map{ paginate => @fragments.pagination(page.webTitle, paginate, SimplePagePaths(page.url), Some("js-discussion-change-page"), false, Some("Comments")) }
+</div>

--- a/discussion/conf/routes
+++ b/discussion/conf/routes
@@ -12,8 +12,13 @@ GET         /discussion/comment-counts.json                                     
 
 GET         /discussion/comment/*id.json                                        controllers.CommentsController.commentJson(id: Int)
 GET         /discussion/comment/*id                                             controllers.CommentsController.comment(id: Int)
+
 GET         /discussion/comment-context/*commentId.json                         controllers.CommentsController.commentContextJson(commentId: Int)
 OPTIONS     /discussion/comment-context/*commentId.json                         controllers.CommentsController.commentContextJsonOptions(commentId: Int)
+
+GET         /discussion/top-comments/$discussionKey</?p/\w+>.json               controllers.CommentsController.topCommentsJson(discussionKey: discussion.model.DiscussionKey)
+OPTIONS     /discussion/top-comments/$discussionKey</?p/\w+>.json               controllers.CommentsController.topCommentsJsonOptions(discussionKey: discussion.model.DiscussionKey)
+
 GET         /discussion/$discussionKey</?p/\w+>.json                            controllers.CommentsController.commentsJson(discussionKey: discussion.model.DiscussionKey)
 OPTIONS     /discussion/$discussionKey</?p/\w+>.json                            controllers.CommentsController.commentsJsonOptions(discussionKey: discussion.model.DiscussionKey)
 GET         /discussion/$discussionKey</?p/\w+>                                 controllers.CommentsController.comments(discussionKey: discussion.model.DiscussionKey)

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -191,14 +191,21 @@ Comments.prototype.goToPermalink = function(commentId) {
 
 Comments.prototype.renderComments = function(resp) {
 
-    var contentEl = bonzo.create(resp.html),
+    // The resp object received has a collection of rendered html fragments, ready for DOM insertion.
+    // - commentsHtml - the main comments content.
+    // - paginationHtml - the discussion's pagination based on user page size and number of comments.
+    // - postedCommentHtml - an empty comment for when the user successfully posts a comment.
+
+    var contentEl = bonzo.create(resp.commentsHtml),
         comments = qwery(this.getClass('comment'), contentEl);
 
     bonzo(this.elem).empty().append(contentEl);
     this.addMoreRepliesButtons(comments);
 
+    this.postedCommentEl = bonzo.create(resp.postedCommentHtml);
+
     this.relativeDates();
-    this.emit('rendered');
+    this.emit('rendered', resp.paginationHtml);
 };
 
 Comments.prototype.showHiddenComments = function(e) {
@@ -291,7 +298,7 @@ Comments.prototype.addComment = function(comment, focus, parent) {
                 src: this.user.avatar
             }
         },
-        commentElem = bonzo.create(document.getElementById('tmpl-comment').innerHTML)[0],
+        commentElem = bonzo.create(this.postedCommentEl)[0],
         $commentElem = bonzo(commentElem);
 
     $commentElem.addClass('d-comment--new');

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -65,11 +65,10 @@ Loader.prototype.initTopComments = function() {
     });
 
     return ajax({
-        url: '/discussion/' + this.getDiscussionId() + '.json',
+        url: '/discussion/top-comments/' + this.getDiscussionId() + '.json',
         type: 'json',
         method: 'get',
-        crossOrigin: true,
-        data: { topComments: true }
+        crossOrigin: true
     }).then(
         function render(resp) {
             this.$topCommentsContainer.html(resp.html);
@@ -107,9 +106,10 @@ Loader.prototype.initMainComments = function() {
         this.removeState('truncated');
     }.bind(this));
 
-    this.comments.on('rendered', function() {
-        var newPagination = $('.js-discussion-pagination', this.comments.elem).html();
-        $('.js-discussion-pagination', this.toolbarEl).empty().html(newPagination);
+    this.comments.on('rendered', function(paginationHtml) {
+        var newPagination = bonzo.create(paginationHtml),
+            toolbarEl = qwery('.js-discussion-toolbar', this.el)[0];
+        $('.js-discussion-pagination', toolbarEl).empty().html(newPagination);
     }.bind(this));
 
     this.setState('loading');
@@ -229,7 +229,6 @@ Loader.prototype.initRecommend = function() {
 Loader.prototype.ready = function() {
 
     this.$topCommentsContainer = $('.js-discussion-top-comments');
-    this.toolbarEl = qwery('.js-discussion-toolbar', this.el)[0];
 
     this.on('click', '.js-discussion-show-button, .d-show-more-replies__button', function() {
         this.removeState('truncated');


### PR DESCRIPTION
A refactor before adding the 'all' feature.

The main discussion json endpoint was using query params like 'topComments' to vary a single html template, so the logic was quite convoluted. Also the final html in the json component was identical to the json page, so lots of bonzo and qwery work was needed in the comments js.

Should make things easier to understand in the future. Platform request coming soon.
