### PR TITLE
Do not automatically show cut out if more than one contributor

### DIFF
--- a/common/app/views/support/CutOut.scala
+++ b/common/app/views/support/CutOut.scala
@@ -11,10 +11,14 @@ object CutOut {
         /** We're assuming here that standard contributor images from CAPI are in landscape, as unfortunately they
           * do not come with dimensions attached.
           */
-        for {
-          contributor <- trail.contributors.find(_.contributorLargeImagePath.isDefined)
-          imagePath <- contributor.contributorLargeImagePath
-        } yield CutOut(contributor.name, ImgSrc(imagePath, Item360), Landscape)
+        if (trail.contributors.length == 1) {
+          for {
+            contributor <- trail.contributors.find(_.contributorLargeImagePath.isDefined)
+            imagePath <- contributor.contributorLargeImagePath
+          } yield CutOut(contributor.name, ImgSrc(imagePath, Item360), Landscape)
+        } else {
+          None
+        }
       }
     } else {
       None


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/1001642/5872405/194dbd9c-a2e3-11e4-8f03-c995f8680e7a.png)

After:

![after](https://cloud.githubusercontent.com/assets/1001642/5872408/1cfea3e8-a2e3-11e4-95cc-e6f92d1e1009.png)
