### PR TITLE
Add image to unboosted 1st item on mobile

### DIFF
--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -469,7 +469,7 @@ case object QuarterThreeQuarter extends Slice {
       SingleItem(
         colSpan = 1,
         ItemClasses(
-          mobile = ListItem,
+          mobile = MediaList,
           tablet = Standard
         )
       ),


### PR DESCRIPTION
![before](https://cloud.githubusercontent.com/assets/1001642/5872581/13cc5278-a2e5-11e4-9f79-a0d84d1f31b8.png)

now shrinks down to

![after](https://cloud.githubusercontent.com/assets/1001642/5872610/4599551c-a2e5-11e4-8364-bcb298f39d9d.png)
