### PR TITLE
make fronts videos placeholder clickable without JS

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -49,7 +49,7 @@ data-test-id="facia-card"
                         </div>
                         @fallback.map { fallbackImage =>
                             <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder">
-                                <div class="@RenderClasses("fc-item__video-play", "media__placeholder--active", "vjs-big-play-button", "js-video-play-button")"><span></span></div>
+                                <div class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span></span></div>
                                 @image(
                                     fallbackImage.imageContainer,
                                     inlineImage = containerIndex == 0 && index < 4

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -136,6 +136,8 @@ define([
         });
 
         $('.js-video-play-button').each(function (el) {
+            var $el = bonzo(el);
+            $el.removeClass('media__placeholder--hidden').addClass('media__placeholder--active');
             bean.on(el, 'click', function () {
                 var placeholder, player, container;
                 container = bonzo(el).parent().parent();
@@ -143,7 +145,7 @@ define([
                 placeholder.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
                 player = $('.js-video-player', container);
                 player.removeClass('media__container--hidden').addClass('media__container--active');
-                bonzo(el).removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
+                $el.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
                 enhanceVideo($('video', player).get(0), true);
             });
         });


### PR DESCRIPTION
At the moment the placeholder has the play overlay on top of it, with a click handler added by JS.  If JS is disabled, the play overlay steals the clicks but doesn't act on them.

This PR just makes the play overlay hidden by default.  The JS displays and makes it clickable.
