### PR TITLE
move rounded icon to inline css

### DIFF
--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -61,6 +61,7 @@
 @import 'module/_headers';
 @import 'module/nav/_has-localnav-overrides';
 @import 'module/nav/_navigation';
+@import 'module/_rounded-icon';
 
 
 /* ==========================================================================

--- a/static/src/stylesheets/global.scss
+++ b/static/src/stylesheets/global.scss
@@ -41,7 +41,6 @@
 @import 'module/content/_media.global';
 @import 'module/_loader';
 
-@import 'module/_rounded-icon';
 @import 'module/content/_live-blog';
 @import 'module/content/_live-filter';
 

--- a/static/src/stylesheets/head.facia.scss
+++ b/static/src/stylesheets/head.facia.scss
@@ -7,7 +7,6 @@
    Facia
    ========================================================================== */
 
-@import 'module/_rounded-icon';
 @import 'module/facia/_l-list';
 @import 'module/facia/_container';
 @import 'module/facia/_slices';

--- a/static/src/stylesheets/head.flyers.scss
+++ b/static/src/stylesheets/head.flyers.scss
@@ -13,7 +13,6 @@
 @import 'base/_faux-block-link';
 @import 'base/_lists';
 
-@import 'module/_rounded-icon';
 @import 'module/_icons';
 @import 'icons/_content-icons-sprite';
 @import 'icons/_content-icons-svg';

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -90,8 +90,9 @@ $block-padding-right: $gs-gutter;
 }
 
 .live-pulse-icon:before {
-    @extend %rounded-icon;
-
+    display: inline-block;
+    position: relative;
+    @include border-radius(50%);
     $size: 12px;
     background-color: #ffffff;
     width: $size;


### PR DESCRIPTION
stops this happening:

![screen shot 2015-01-23 at 12 11 02](https://cloud.githubusercontent.com/assets/867233/5874413/02636fe4-a2f9-11e4-93a1-499f934feef2.png)

while the page is loading (especially on mobile)
