### PR TITLE
Improve the weather widget a whole bunch

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -159,7 +159,7 @@ define([
                 this.toggleControls(false);
             }.bind(this));
             bean.on($('.js-toggle-forecast')[0], 'click', function (e) {
-                this.toggleForecast(e);
+                this.toggleForecast();
             }.bind(this));
             mediator.on('autocomplete:fetch', this.fetchWeatherData.bind(this));
         },
@@ -184,10 +184,8 @@ define([
             }
         },
 
-        toggleForecast: function (e) {
-            $(e.currentTarget).toggleClass('is-visible');
-            $('.js-weather-forecast').toggleClass('hide-on-mobile');
-            $('.js-weather-location').toggleClass('hide-on-mobile');
+        toggleForecast: function () {
+            $('.weather').toggleClass('is-expanded');
         },
 
         getUnits: function () {

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -186,7 +186,8 @@ define([
 
         toggleForecast: function (e) {
             $(e.currentTarget).toggleClass('is-visible');
-            $('.' + e.currentTarget.dataset.toggleClass).toggleClass('u-h');
+            $('.js-weather-forecast').toggleClass('hide-on-mobile');
+            $('.js-weather-location').toggleClass('hide-on-mobile');
         },
 
         getUnits: function () {

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -159,6 +159,7 @@ define([
                 this.toggleControls(false);
             }.bind(this));
             bean.on($('.js-toggle-forecast')[0], 'click', function (e) {
+                e.preventDefault();
                 this.toggleForecast();
             }.bind(this));
             mediator.on('autocomplete:fetch', this.fetchWeatherData.bind(this));

--- a/static/src/javascripts/projects/facia/views/weather-forecast.html
+++ b/static/src/javascripts/projects/facia/views/weather-forecast.html
@@ -1,7 +1,9 @@
 <li class="forecast__item forecast__item--{{forecast-num}}">
-    <span class="u-h">The temperature at</span>
-    <span class="weather__time">{{forecast-time}}:00</span>
-    <span class="u-h">will be</span>
-    <span class="weather__temp">{{forecast-temp}}</span>
+    <p class="weather__desc">
+        <span class="u-h">The temperature at</span>
+        <span class="weather__time">{{forecast-time}}:00</span>
+        <span class="u-h">will be</span>
+        <span class="weather__temp">{{forecast-temp}}</span>
+    </p>
     <i class="i i-weather-{{forecast-icon}} weather__icon js-weather-icon" title="{{forecast-desc}}"><span class="u-h">{{forecast-desc}}</span></i>
 </li>

--- a/static/src/javascripts/projects/facia/views/weather.html
+++ b/static/src/javascripts/projects/facia/views/weather.html
@@ -8,11 +8,11 @@
         </p>
         <i class="i i-weather-{{icon}} weather__icon js-weather-icon" title="{{description}}"><span class="u-h">{{description}}</span></i>
     </div>
-    <button class="weather__toggle-forecast meta-button js-toggle-forecast" data-link-name="weather-toggle-forecast" data-toggle-class="js-weather-forecast-mobile"
+    <button class="weather__toggle-forecast meta-button js-toggle-forecast mobile-only" data-link-name="weather-toggle-forecast"
         href="#toggle-forecast"><span class="u-h">Toggle forecast</span><i class="i i-arrow-grey-large weather__toggle-icon"></i>
     </button>
-    <ul class="js-weather-forecast forecast hide-on-mobile"></ul>
-    <div class="weather__location js-weather-location hide-on-mobile">
+    <ul class="js-weather-forecast forecast"></ul>
+    <div class="weather__location js-weather-location">
         <div class="search-tool js-search-tool">
             <div class="search-tool__form u-cf">
                 <label class="u-h" for="editlocation">Edit your location</label>

--- a/static/src/javascripts/projects/facia/views/weather.html
+++ b/static/src/javascripts/projects/facia/views/weather.html
@@ -11,8 +11,8 @@
     <button class="weather__toggle-forecast meta-button js-toggle-forecast" data-link-name="weather-toggle-forecast" data-toggle-class="js-weather-forecast-mobile"
         href="#toggle-forecast"><span class="u-h">Toggle forecast</span><i class="i i-arrow-grey-large weather__toggle-icon"></i>
     </button>
-    <ul class="js-weather-forecast forecast"></ul>
-    <div class="weather__location">
+    <ul class="js-weather-forecast forecast hide-on-mobile"></ul>
+    <div class="weather__location js-weather-location hide-on-mobile">
         <div class="search-tool js-search-tool">
             <div class="search-tool__form u-cf">
                 <label class="u-h" for="editlocation">Edit your location</label>

--- a/static/src/javascripts/projects/facia/views/weather.html
+++ b/static/src/javascripts/projects/facia/views/weather.html
@@ -11,7 +11,7 @@
     <button class="weather__toggle-forecast meta-button js-toggle-forecast" data-link-name="weather-toggle-forecast" data-toggle-class="js-weather-forecast-mobile"
         href="#toggle-forecast"><span class="u-h">Toggle forecast</span><i class="i i-arrow-grey-large weather__toggle-icon"></i>
     </button>
-    <ul class="js-weather-forecast forecast forecast--desktop hide-until-leftcol"></ul>
+    <ul class="js-weather-forecast forecast"></ul>
     <div class="weather__location">
         <div class="search-tool js-search-tool">
             <div class="search-tool__form u-cf">
@@ -27,4 +27,3 @@
         </button>
     </div>
 </div>
-<ul class="js-weather-forecast js-weather-forecast-mobile forecast forecast--mobile u-h"></ul>

--- a/static/src/javascripts/projects/facia/views/weather.html
+++ b/static/src/javascripts/projects/facia/views/weather.html
@@ -2,7 +2,7 @@
     <div class="u-unstyled weather__current">
         <p class="weather__desc">
             <span class="u-h">The temperature</span>
-            <span class="weather__time">now</span>
+            <span class="weather__time">Now</span>
             <span class="u-h">is</span>
             <span class="weather__temp js-weather-temp">{{tempNow}}</span>
         </p>

--- a/static/src/javascripts/projects/facia/views/weather.html
+++ b/static/src/javascripts/projects/facia/views/weather.html
@@ -12,7 +12,7 @@
         href="#toggle-forecast"><span class="u-h">Toggle forecast</span><i class="i i-arrow-grey-large weather__toggle-icon"></i>
     </button>
     <ul class="js-weather-forecast forecast"></ul>
-    <div class="weather__location js-weather-location">
+    <div class="weather__location">
         <div class="search-tool js-search-tool">
             <div class="search-tool__form u-cf">
                 <label class="u-h" for="editlocation">Edit your location</label>

--- a/static/src/stylesheets/module/_search-tool.scss
+++ b/static/src/stylesheets/module/_search-tool.scss
@@ -50,12 +50,14 @@
     display: block;
     @include fs-headline(2);
 
-    @include mq($until: leftCol) {
+    @include mq(tablet, leftCol) {
         padding-left: $gs-gutter / 4;
     }
 
     .has-page-skin & {
-        padding-left: $gs-gutter / 4;
+        @include mq(wide) {
+            padding-left: $gs-gutter / 4;
+        }
     }
 
     &:hover,

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -56,24 +56,18 @@ $weather-large-size: 60px;
     @include mq($until: leftCol) {
         @include box-sizing(border-box);
         width: gs-span(1) + $gs-gutter;
-        padding-right: $weather-small-size + $gs-gutter / 4;
+        padding-right: $gs-gutter / 4;
         text-align: right;
 
         &:after {
             @include weather-rule();
-        }
-
-        .weather__icon {
-            position: absolute;
-            top: 0;
-            right: $gs-gutter / 4;
         }
     }
 
     .has-page-skin & {
         @include mq(wide) {
             @include box-sizing(border-box);
-            padding-right: $weather-small-size + $gs-gutter / 4;
+            padding-right: $gs-gutter / 4;
             width: gs-span(1) + $gs-gutter;
             text-align: right;
 
@@ -96,6 +90,7 @@ $weather-large-size: 60px;
 .weather__desc {
     @include fs-headline(2);
     margin-right: $gs-gutter / 4;
+    display: inline-block;
 
     @include mq(leftCol) {
         position: absolute;
@@ -130,6 +125,7 @@ $weather-large-size: 60px;
     height: $weather-small-size;
     margin: 0;
     margin-top: -($gs-baseline / 3);
+    vertical-align: middle;
 
     @include mq(leftCol) {
         width: $weather-large-size;
@@ -158,7 +154,7 @@ $weather-large-size: 60px;
         }
     }
 
-    @include mq(leftCol) {
+    @include mq(tablet) {
         display: none;
     }
 
@@ -283,6 +279,10 @@ $weather-large-size: 60px;
         width: 100%;
     }
 
+    @include mq(tablet, leftCol) {
+        padding-bottom: 0;
+    }
+
     @include mq(leftCol) {
         display: table;
         width: 100%;
@@ -298,6 +298,14 @@ $weather-large-size: 60px;
 
     @include mq(mobileLandscape) {
         min-width: gs-span(1) - ($gs-gutter / 4);
+    }
+
+    @include mq(tablet, leftCol) {
+        border-left: none;
+
+        &:after {
+            @include weather-rule();
+        }
     }
 
     @include mq(leftCol) {
@@ -316,7 +324,7 @@ $weather-large-size: 60px;
         }
     }
 
-    @include mq(leftCol, wide) {
+    @include mq(tablet, wide) {
         min-width: 33%;
 
         &.forecast__item--3 {
@@ -333,8 +341,9 @@ $weather-large-size: 60px;
     }
 
     .i.weather__icon {
-        display: block;
-        margin-top: $gs-baseline / 3;
+        @include mq(tablet, leftCol) {
+            display: inline-block;
+        }
 
         @include mq(leftCol) {
             width: $weather-small-size;

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -173,6 +173,10 @@ $weather-large-size: 60px;
         padding-top: $gs-baseline / 6;
     }
 
+    @include mq(wide) {
+        width: 90%;
+    }
+
     .has-page-skin & {
         @include mq(wide) {
             width: gs-span(2);
@@ -236,10 +240,10 @@ i.weather__close-icon {
     margin: 0;
     padding: ($gs-baseline / 3) 0 ($gs-baseline / 2);
     list-style: none;
+    width: 100%;
 
     @include mq($until: tablet) {
         display: none;
-        width: 100%;
 
         .is-expanded & {
             display: table;
@@ -248,11 +252,21 @@ i.weather__close-icon {
 
     @include mq(tablet, leftCol) {
         padding: 0;
+        width: auto;
     }
 
     @include mq(leftCol) {
         display: table;
-        width: 100%;
+    }
+
+    @include mq(wide) {
+        width: 90%;
+    }
+
+    .has-page-skin & {
+        @include mq(wide) {
+            width: auto;
+        }
     }
 }
 
@@ -262,16 +276,6 @@ i.weather__close-icon {
     border-left: 1px dotted colour(neutral-3);
     padding: 0 $gs-gutter / 4;
 
-    @include mq(mobileLandscape) {
-        min-width: gs-span(1) - ($gs-gutter / 4);
-    }
-
-    @include mq(tablet, desktop) {
-        &.forecast__item--3 {
-            display: none;
-        }
-    }
-
     @include mq(tablet, leftCol) {
         border-left: none;
         display: inline-block;
@@ -279,36 +283,33 @@ i.weather__close-icon {
         &:after {
             @include weather-rule;
         }
-
-        &.forecast__item--4 {
-            display: none;
-        }
     }
 
     @include mq(leftCol) {
         padding-right: 0;
     }
 
-    &:first-of-type {
-        padding-left: 0;
+    @include mq(leftCol, wide) {
+        width: 33%;
+    }
 
-        @include mq($until: tablet) {
-            border-left: 0;
+    &.forecast__item--1 {
+        border-left: 0;
+        padding-left: 0;
+    }
+
+    &.forecast__item--3 {
+        @include mq(tablet, desktop) {
+            display: none;
         }
 
-        @include mq(leftCol) {
-            border-left: 0;
+        @include mq(leftCol, wide) {
+            border-right: 0;
         }
     }
 
-    @include mq(leftCol, wide) {
-        min-width: 33%;
-
-        &.forecast__item--3 {
-            border-right: 0;
-        }
-
-        &.forecast__item--4 {
+    &.forecast__item--4 {
+        @include mq(tablet, wide) {
             display: none;
         }
     }

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -41,13 +41,10 @@ $weather-large-size: 60px;
     text-align: left;
 }
 
-
 .weather__current {
     @include transition(opacity .2s ease-in); // Needs Fixing
 
     @include mq($until: leftCol) {
-        @include box-sizing(border-box);
-        width: gs-span(1) + $gs-gutter;
         padding-right: $gs-gutter / 4;
         text-align: right;
 
@@ -57,15 +54,12 @@ $weather-large-size: 60px;
     }
 
     @include mq(tablet, leftCol) {
-        width: auto;
         text-align: left;
     }
 
     .has-page-skin & {
         @include mq(wide) {
-            @include box-sizing(border-box);
             padding-right: $gs-gutter / 4;
-            width: gs-span(1) + $gs-gutter;
             text-align: right;
 
             .weather__icon {
@@ -82,11 +76,11 @@ $weather-large-size: 60px;
             }
         }
     }
-    
+
     .weather__desc {
         @include mq(leftCol) {
             position: absolute;
-            bottom: 2px;
+            bottom: $gs-baseline;
         }
     }
 }
@@ -336,13 +330,13 @@ $weather-large-size: 60px;
     }
 
     &:first-of-type {
+        padding-left: 0;
+
         @include mq($until: tablet) {
-            padding-left: 0;
             border-left: 0;
         }
 
         @include mq(leftCol) {
-            padding-left: 0;
             border-left: 0;
         }
     }

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -304,6 +304,12 @@ $weather-large-size: 60px;
         min-width: gs-span(1) - ($gs-gutter / 4);
     }
 
+    @include mq(tablet, desktop) {
+        &.forecast__item--3 {
+            display: none;
+        }
+    }
+
     @include mq(tablet, leftCol) {
         border-left: none;
         display: inline-block;

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -12,7 +12,6 @@ $weather-large-size: 60px;
 
 .weather {
     color: colour(neutral-1);
-    float: right;
     text-align: right;
 
     @include mq($until: tablet) {
@@ -20,13 +19,13 @@ $weather-large-size: 60px;
     }
 
     @include mq(tablet) {
-        text-align: left;
-        margin-top: $gs-baseline * 2;
+        padding-top: $gs-baseline * 2;
     }
 
     @include mq(leftCol) {
         width: $left-column;
         margin-top: $gs-baseline;
+        text-align: left;
     }
 
     @include mq(wide) {
@@ -36,7 +35,6 @@ $weather-large-size: 60px;
     .has-page-skin & {
         @include mq(wide) {
             width: auto;
-            text-align: left;
             margin-top: $gs-baseline * 2;
         }
     }
@@ -44,14 +42,13 @@ $weather-large-size: 60px;
 
 .weather__current {
     position: relative;
+    display: inline-block;
     @include transition(opacity .2s ease-in); // Needs Fixing
 
     @include mq($until: leftCol) {
         @include box-sizing(border-box);
         width: gs-span(1) + $gs-gutter;
-        float: left;
         padding-right: $weather-small-size + $gs-gutter / 4;
-        margin-right: $gs-gutter / 4;
         text-align: right;
 
         &:after {
@@ -70,7 +67,6 @@ $weather-large-size: 60px;
             @include box-sizing(border-box);
             padding-right: $weather-small-size + $gs-gutter / 4;
             width: gs-span(1) + $gs-gutter;
-            float: left;
             text-align: right;
 
             .weather__icon {
@@ -147,11 +143,10 @@ $weather-large-size: 60px;
 
 .weather__toggle-forecast {
     position: relative;
-    float: left;
+    display: inline-block;
 
     @include mq(tablet) {
         padding-right: $gs-gutter / 4;
-        margin-right: $gs-gutter / 4;
 
         &:after {
             @include weather-rule();
@@ -178,16 +173,16 @@ $weather-large-size: 60px;
 }
 
 .weather__location {
-    display: none;
+    position: relative;
+    display: inline-block;
+    width: 100%;
 
     @include mq(tablet) {
         position: relative;
-        display: block;
     }
 
     @include mq(tablet, leftCol) {
         width: gs-span(2);
-        float: left;
     }
 
     @include mq(leftCol) {
@@ -205,7 +200,6 @@ $weather-large-size: 60px;
     }
 
     .search-tool__input {
-        display: none;
         width: 100%;
 
         @include fs-headline(2);

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -5,7 +5,7 @@ $weather-large-size: 60px;
     content: '';
     position: absolute;
     right: 0;
-    bottom: $gs-baseline;
+    bottom: ($gs-baseline / 3) * 2;
     height: $gs-baseline + 1px;
     border-right: 1px dotted colour(neutral-3);
 }
@@ -100,9 +100,10 @@ $weather-large-size: 60px;
 }
 
 .weather__desc {
-    @include fs-headline(2);
-    margin-right: $gs-gutter / 4;
     display: inline-block;
+    margin-right: $gs-gutter / 4;
+    margin-bottom: 0;
+    @include fs-headline(2);
 
     .has-page-skin & {
         @include mq(wide) {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -5,7 +5,7 @@ $weather-large-size: 60px;
     content: '';
     position: absolute;
     right: 0;
-    bottom: ($gs-baseline / 3) * 2;
+    bottom: $gs-baseline / 2;
     height: $gs-baseline + 1px;
     border-right: 1px dotted colour(neutral-3);
 }
@@ -135,7 +135,7 @@ $weather-large-size: 60px;
     .weather__toggle-icon {
         width: 18px;
         height: 8px;
-        margin-bottom: $gs-baseline / 4;
+        margin-bottom: $gs-baseline / 6;
 
         .is-expanded & {
             @include transform(rotate(180deg));

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -203,6 +203,12 @@ $weather-large-size: 60px;
         width: 100%;
         @include fs-headline(2);
 
+        @include mq($until: tablet) {
+            border-bottom: 1px dotted colour(neutral-3);
+            padding-bottom: $gs-baseline / 4;
+            margin-bottom: $gs-baseline;
+        }
+
         @include mq(tablet) {
             display: inherit;
         }
@@ -279,7 +285,7 @@ $weather-large-size: 60px;
     list-style: none;
     // line-height: 1.2;
 
-    @include mq($until: mobileLandscape) {
+    @include mq($until: tablet) {
         display: table;
         width: 100%;
     }
@@ -328,7 +334,7 @@ $weather-large-size: 60px;
     }
 
     &:first-of-type {
-        @include mq($until: mobileLandscape) {
+        @include mq($until: tablet) {
             padding-left: 0;
             border-left: 0;
         }
@@ -356,7 +362,9 @@ $weather-large-size: 60px;
     }
 
     .i.weather__icon {
-        @include mq(tablet, leftCol) {
+        display: block;
+
+        @include mq(mobileLandscape, leftCol) {
             display: inline-block;
         }
 

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -20,18 +20,12 @@ $weather-large-size: 60px;
     }
 
     @include mq(leftCol) {
-        width: $left-column;
         padding-top: $gs-baseline;
         text-align: left;
     }
 
-    @include mq(wide) {
-        width: $left-column-wide;
-    }
-
     .has-page-skin & {
         @include mq(wide) {
-            width: auto;
             padding-top: ($gs-baseline / 3) * 2;
             text-align: right;
         }

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -170,19 +170,27 @@ $weather-large-size: 60px;
         outline: 0;
     }
 
-    &.is-visible .weather__toggle-icon {
-        @include transform(rotate(180deg));
-    }
-
     .weather__toggle-icon {
         width: 18px;
         height: 8px;
         margin-bottom: $gs-baseline / 4;
+
+        .is-expanded & {
+            @include transform(rotate(180deg));
+        }
     }
 }
 
 .weather__location {
     width: 100%;
+
+    @include mq($until: tablet) {
+        display: none;
+
+        .is-expanded & {
+            display: inline-block;
+        }
+    }
 
     @include mq(tablet, leftCol) {
         width: gs-span(2);
@@ -210,10 +218,6 @@ $weather-large-size: 60px;
         @include mq($until: tablet) {
             border-bottom: 1px dotted colour(neutral-3);
             padding-bottom: $gs-baseline / 4;
-        }
-
-        @include mq(tablet) {
-            display: inherit;
         }
 
         @include mq(leftCol) {
@@ -286,11 +290,14 @@ $weather-large-size: 60px;
     margin: 0;
     padding: ($gs-baseline / 3) 0 ($gs-baseline / 2);
     list-style: none;
-    // line-height: 1.2;
 
     @include mq($until: tablet) {
-        display: table;
+        display: none;
         width: 100%;
+
+        .is-expanded & {
+            display: table;
+        }
     }
 
     @include mq(tablet, leftCol) {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -13,10 +13,7 @@ $weather-large-size: 60px;
 .weather {
     color: colour(neutral-1);
     text-align: right;
-
-    @include mq($until: tablet) {
-        padding-top: $gs-baseline / 4;
-    }
+    padding-top: $gs-baseline / 6;
 
     @include mq(tablet) {
         padding-top: ($gs-baseline / 3) * 2;
@@ -24,7 +21,7 @@ $weather-large-size: 60px;
 
     @include mq(leftCol) {
         width: $left-column;
-        margin-top: $gs-baseline;
+        padding-top: $gs-baseline;
         text-align: left;
     }
 
@@ -35,7 +32,8 @@ $weather-large-size: 60px;
     .has-page-skin & {
         @include mq(wide) {
             width: auto;
-            margin-top: $gs-baseline * 2;
+            padding-top: ($gs-baseline / 3) * 2;
+            text-align: right;
         }
     }
 }

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -205,11 +205,11 @@ $weather-large-size: 60px;
     .search-tool__input {
         width: 100%;
         @include fs-headline(2);
+        display: inline-block;
 
         @include mq($until: tablet) {
             border-bottom: 1px dotted colour(neutral-3);
             padding-bottom: $gs-baseline / 4;
-            margin-bottom: $gs-baseline;
         }
 
         @include mq(tablet) {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -4,8 +4,8 @@ $weather-large-size: 60px;
 @mixin weather-rule() {
     content: '';
     position: absolute;
-    top: 3px;
     right: 0;
+    bottom: $gs-baseline;
     height: $gs-baseline + 1px;
     border-right: 1px dotted colour(neutral-3);
 }
@@ -19,7 +19,7 @@ $weather-large-size: 60px;
     }
 
     @include mq(tablet) {
-        padding-top: $gs-baseline * 2;
+        padding-top: ($gs-baseline / 3) * 2;
     }
 
     @include mq(leftCol) {
@@ -62,6 +62,11 @@ $weather-large-size: 60px;
         &:after {
             @include weather-rule();
         }
+    }
+
+    @include mq(tablet, leftCol) {
+        width: auto;
+        text-align: left;
     }
 
     .has-page-skin & {
@@ -109,7 +114,7 @@ $weather-large-size: 60px;
     color: colour(neutral-2);
     @include fs-textSans(1);
 
-    @include mq(leftCol) {
+    @include mq(tablet) {
         display: block;
     }
 
@@ -272,7 +277,7 @@ $weather-large-size: 60px;
     margin: 0;
     padding: ($gs-baseline / 3) 0 ($gs-baseline / 2);
     list-style: none;
-    line-height: 1.2;
+    // line-height: 1.2;
 
     @include mq($until: mobileLandscape) {
         display: table;
@@ -280,7 +285,7 @@ $weather-large-size: 60px;
     }
 
     @include mq(tablet, leftCol) {
-        padding-bottom: 0;
+        padding: 0;
     }
 
     @include mq(leftCol) {
@@ -293,8 +298,7 @@ $weather-large-size: 60px;
     position: relative;
     display: table-cell;
     border-left: 1px dotted colour(neutral-3);
-    padding-left: $gs-gutter / 4;
-    padding-right: floor($gs-gutter / 1.333);
+    padding: 0 $gs-gutter / 4;
 
     @include mq(mobileLandscape) {
         min-width: gs-span(1) - ($gs-gutter / 4);
@@ -302,9 +306,14 @@ $weather-large-size: 60px;
 
     @include mq(tablet, leftCol) {
         border-left: none;
+        display: inline-block;
 
         &:after {
             @include weather-rule();
+        }
+
+        &.forecast__item--4 {
+            display: none;
         }
     }
 
@@ -324,7 +333,7 @@ $weather-large-size: 60px;
         }
     }
 
-    @include mq(tablet, wide) {
+    @include mq(leftCol, wide) {
         min-width: 33%;
 
         &.forecast__item--3 {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -42,8 +42,6 @@ $weather-large-size: 60px;
 }
 
 .weather__current {
-    @include transition(opacity .2s ease-in); // Needs Fixing
-
     @include mq($until: leftCol) {
         padding-right: $gs-gutter / 4;
         text-align: right;
@@ -205,10 +203,6 @@ $weather-large-size: 60px;
 
     &.is-editing {
         border-bottom: 1px solid colour(neutral-3);
-
-        & ~ .weather__forecasts {
-            opacity: .5; // This needs fixing
-        }
     }
 }
 
@@ -257,6 +251,7 @@ i.weather__close-icon {
 
     @include mq(leftCol) {
         display: table;
+        padding-top: 0;
     }
 
     @include mq(wide) {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -82,6 +82,12 @@ $weather-large-size: 60px;
             position: absolute;
             bottom: $gs-baseline;
         }
+
+        .has-page-skin & {
+            @include mq(wide) {
+                position: inherit;
+            }
+        }
     }
 }
 
@@ -90,12 +96,6 @@ $weather-large-size: 60px;
     margin-right: $gs-gutter / 4;
     margin-bottom: 0;
     @include fs-headline(2);
-
-    .has-page-skin & {
-        @include mq(wide) {
-            position: inherit;
-        }
-    }
 }
 
 .weather__time {
@@ -106,19 +106,12 @@ $weather-large-size: 60px;
     @include mq(tablet) {
         display: block;
     }
-
-    .has-page-skin & {
-        @include mq(wide) {
-            display: none;
-        }
-    }
 }
 
 .i.weather__icon {
     width: $weather-small-size;
     height: $weather-small-size;
-    margin: 0;
-    margin-top: -($gs-baseline / 3);
+    margin: -($gs-baseline / 3) 0 0;
     vertical-align: middle;
 
     @include mq(leftCol) {
@@ -132,22 +125,13 @@ $weather-large-size: 60px;
         @include mq(wide) {
             width: $weather-small-size;
             height: $weather-small-size;
-            margin: 0;
-            margin-top: -($gs-baseline / 3);
             display: inline-block;
+            margin: -($gs-baseline / 3) 0 0;
         }
     }
 }
 
 .weather__toggle-forecast {
-    @include mq(tablet) {
-        padding-right: $gs-gutter / 4;
-
-        &:after {
-            @include weather-rule;
-        }
-    }
-
     @include mq(tablet) {
         display: none;
     }
@@ -169,6 +153,7 @@ $weather-large-size: 60px;
 
 .weather__location {
     width: 100%;
+    border-top: 1px dotted colour(neutral-3);
 
     @include mq($until: tablet) {
         display: none;
@@ -180,39 +165,25 @@ $weather-large-size: 60px;
 
     @include mq(tablet, leftCol) {
         width: gs-span(2);
+        border-top-color: transparent;
     }
 
     @include mq(leftCol) {
-        border-top: 1px dotted colour(neutral-3);
-        padding-top: $gs-baseline / 3;
+        padding-top: $gs-baseline / 6;
     }
 
     .has-page-skin & {
         @include mq(wide) {
             width: gs-span(2);
-            float: left;
-            border-top: 0;
+            border-top-color: transparent;
             padding-top: 0;
         }
     }
 
     .search-tool__input {
         width: 100%;
-        @include fs-headline(2);
         display: inline-block;
-
-        @include mq($until: tablet) {
-            border-bottom: 1px dotted colour(neutral-3);
-            padding-bottom: $gs-baseline / 4;
-        }
-
-        @include mq(leftCol) {
-            padding-bottom: $gs-baseline / 4;
-        }
-
-        .has-page-skin & {
-            padding-bottom: 0;
-        }
+        @include fs-headline(2);
     }
 
     .search-tool__btn {
@@ -228,9 +199,7 @@ $weather-large-size: 60px;
     }
 
     &.is-editing {
-        .search-tool__input {
-            border-bottom: 1px solid colour(neutral-3);
-        }
+        border-bottom: 1px solid colour(neutral-3);
 
         & ~ .weather__forecasts {
             opacity: .5; // This needs fixing

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -267,7 +267,7 @@ i.weather__close-icon {
     padding: 0 ($gs-gutter / 2) 0 ($gs-gutter / 4);
 
     @include mq(tablet, leftCol) {
-        border-left: none;
+        border-left: 0;
         display: inline-block;
 
         &:after {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -157,6 +157,7 @@ $weather-large-size: 60px;
 
     @include mq($until: tablet) {
         display: none;
+        padding: ($gs-baseline / 6) 0;
 
         .is-expanded & {
             display: inline-block;
@@ -210,31 +211,21 @@ $weather-large-size: 60px;
 .weather__close-location,
 .weather__edit-location {
     position: absolute;
-    top: 1px;
+    top: $gs-baseline / 2.4;
     right: 0;
     display: block;
     z-index: 5;
     line-height: inherit;
 
-    @include mq(leftCol) {
-        top: $gs-baseline / 2.4;
-    }
-
     &:focus {
         outline: 0;
     }
+}
 
-    .has-page-skin & {
-        @include mq(wide) {
-            top: 1px;
-        }
-    }
-
-    .weather__search-icon,
-    .weather__close-icon {
-        width: 16px;
-        height: 16px;
-    }
+i.weather__search-icon,
+i.weather__close-icon {
+    width: 16px;
+    height: 16px;
 }
 
 .weather__edit-location {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -201,7 +201,6 @@ $weather-large-size: 60px;
 
     .search-tool__input {
         width: 100%;
-
         @include fs-headline(2);
 
         @include mq(tablet) {
@@ -219,6 +218,14 @@ $weather-large-size: 60px;
 
     .search-tool__btn {
         display: none;
+    }
+
+    .search-tool__list {
+        text-align: left;
+
+        @include mq($until: tablet) {
+            position: static;
+        }
     }
 
     &.is-editing {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -90,17 +90,19 @@ $weather-large-size: 60px;
             }
         }
     }
+    
+    .weather__desc {
+        @include mq(leftCol) {
+            position: absolute;
+            bottom: 2px;
+        }
+    }
 }
 
 .weather__desc {
     @include fs-headline(2);
     margin-right: $gs-gutter / 4;
     display: inline-block;
-
-    @include mq(leftCol) {
-        position: absolute;
-        bottom: 2px;
-    }
 
     .has-page-skin & {
         @include mq(wide) {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -286,10 +286,6 @@ $weather-large-size: 60px;
     @include mq(leftCol) {
         display: table;
         width: 100%;
-
-        &.forecast--mobile {
-            display: none;
-        }
     }
 }
 

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -40,9 +40,17 @@ $weather-large-size: 60px;
     }
 }
 
-.weather__current {
+.weather__current,
+.weather__toggle-forecast,
+.forecast,
+.weather__location {
     position: relative;
     display: inline-block;
+    text-align: left;
+}
+
+
+.weather__current {
     @include transition(opacity .2s ease-in); // Needs Fixing
 
     @include mq($until: leftCol) {
@@ -142,9 +150,6 @@ $weather-large-size: 60px;
 }
 
 .weather__toggle-forecast {
-    position: relative;
-    display: inline-block;
-
     @include mq(tablet) {
         padding-right: $gs-gutter / 4;
 
@@ -173,13 +178,7 @@ $weather-large-size: 60px;
 }
 
 .weather__location {
-    position: relative;
-    display: inline-block;
     width: 100%;
-
-    @include mq(tablet) {
-        position: relative;
-    }
 
     @include mq(tablet, leftCol) {
         width: gs-span(2);
@@ -274,20 +273,14 @@ $weather-large-size: 60px;
 }
 
 .forecast {
-    clear: both;
     margin: 0;
     padding: ($gs-baseline / 3) 0 ($gs-baseline / 2);
     list-style: none;
     line-height: 1.2;
-    display: inline-block;
 
     @include mq($until: mobileLandscape) {
         display: table;
         width: 100%;
-    }
-
-    @include mq(mobileLandscape, leftCol) {
-        float: right;
     }
 
     @include mq(leftCol) {

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -43,7 +43,7 @@ $weather-large-size: 60px;
 
 .weather__current {
     @include mq($until: leftCol) {
-        padding-right: $gs-gutter / 4;
+        padding-right: $gs-gutter / 2;
         text-align: right;
 
         &:after {
@@ -57,13 +57,8 @@ $weather-large-size: 60px;
 
     .has-page-skin & {
         @include mq(wide) {
-            padding-right: $gs-gutter / 4;
-            text-align: right;
-
-            .weather__icon {
-                position: absolute;
-                top: 0;
-            }
+            padding-right: $gs-gutter / 2;
+            text-align: left;
 
             &:after {
                 @include weather-rule;
@@ -83,7 +78,7 @@ $weather-large-size: 60px;
 
         .has-page-skin & {
             @include mq(wide) {
-                position: inherit;
+                position: static;
             }
         }
     }
@@ -91,8 +86,7 @@ $weather-large-size: 60px;
 
 .weather__desc {
     display: inline-block;
-    margin-right: $gs-gutter / 4;
-    margin-bottom: 0;
+    margin: 0;
     @include fs-headline(2);
 }
 
@@ -261,6 +255,7 @@ i.weather__close-icon {
     .has-page-skin & {
         @include mq(wide) {
             width: auto;
+            display: inline-block;
         }
     }
 }
@@ -269,7 +264,7 @@ i.weather__close-icon {
     position: relative;
     display: table-cell;
     border-left: 1px dotted colour(neutral-3);
-    padding: 0 $gs-gutter / 4;
+    padding: 0 ($gs-gutter / 2) 0 ($gs-gutter / 4);
 
     @include mq(tablet, leftCol) {
         border-left: none;
@@ -286,6 +281,18 @@ i.weather__close-icon {
 
     @include mq(leftCol, wide) {
         width: 33%;
+    }
+
+    .has-page-skin & {
+        @include mq(wide) {
+            display: inline-block;
+            border-left: 0;
+            padding-right: $gs-gutter / 2;
+
+            &:after {
+                @include weather-rule;
+            }
+        }
     }
 
     &.forecast__item--1 {
@@ -324,6 +331,12 @@ i.weather__close-icon {
             width: $weather-small-size;
             height: $weather-small-size;
             margin-left: 0;
+        }
+
+        .has-page-skin & {
+            @include mq(wide) {
+                display: inline-block;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -60,7 +60,7 @@ $weather-large-size: 60px;
         text-align: right;
 
         &:after {
-            @include weather-rule();
+            @include weather-rule;
         }
     }
 
@@ -82,7 +82,7 @@ $weather-large-size: 60px;
             }
 
             &:after {
-                @include weather-rule();
+                @include weather-rule;
             }
 
             .weather__icon {
@@ -158,7 +158,7 @@ $weather-large-size: 60px;
         padding-right: $gs-gutter / 4;
 
         &:after {
-            @include weather-rule();
+            @include weather-rule;
         }
     }
 
@@ -331,7 +331,7 @@ $weather-large-size: 60px;
         display: inline-block;
 
         &:after {
-            @include weather-rule();
+            @include weather-rule;
         }
 
         &.forecast__item--4 {

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -135,7 +135,7 @@ $header-image-size-desktop: 100px;
 
     @include mq(tablet, leftCol) {
         float: left;
-        width: gs-span(5) + $gs-gutter;
+        width: gs-span(4);
     }
 
     @include mq(leftCol, wide) {
@@ -145,7 +145,7 @@ $header-image-size-desktop: 100px;
     .has-page-skin & {
         @include mq(wide) {
             float: left;
-            width: gs-span(5) + $gs-gutter;
+            width: gs-span(4);
         }
     }
 


### PR DESCRIPTION
Ok so here goes...
- Adds search to mobile, behind the toggle
- Removes toggle from tablet and desktop. Forecast is shown by default
- Removed all the floats, uses inline-block instead. Much cleaner
- Seeing as toggle now does one thing on one breakpoint, js adds a class and css determines what is shown. I wanted to use helper classes but they're all with `!important` and messed up other breakpoints
- Forecast with `has-page-skin` no longer looks like garbage
- General clean up on CSS (This PR adds features but removes lines overall! :tada:)

Here are some screenshots...

**Page Skinz and what tablet looks like**
![screen shot 2015-01-23 at 15 35 22](https://cloud.githubusercontent.com/assets/1607666/5877165/9fc952f0-a315-11e4-91ed-d53f0ff7e6fc.png)

**Mobile with search**
![screen recording 2015-01-23 at 03 36 pm](https://cloud.githubusercontent.com/assets/1607666/5877162/9cedeba4-a315-11e4-8c46-fc9b2be673a5.gif)
