### PR TITLE
Fix bug with comment url

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -16,6 +16,7 @@
         data-discussion-id="@id"
         }
         data-discussion-closed="@item.discussionSettings.isClosedForComments"
+        data-discussion-url="@item.header.url.get(request)#comments"
     }
 data-link-name="@item.cardStyle.toneString | @{index + 1}"
     @item.id.map { id =>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -47,6 +47,7 @@ define([
                 var format,
                     $node = bonzo(node),
                     commentOrComments = (c.count === 1 ? 'comment' : 'comments'),
+                    url = $node.attr('data-discussion-url') || getContentUrl(node),
                     $container,
                     meta,
                     html;
@@ -61,7 +62,7 @@ define([
 
                 format = $node.data('commentcount-format');
                 html = template(templates[format] || defaultTemplate, {
-                    url: getContentUrl(node),
+                    url: url,
                     count: formatters.integerCommas(c.count),
                     label: commentOrComments
                 });


### PR DESCRIPTION
The comment code was just looking for the first `a` in the node and extracting the url from that. (Lol whut)
