### PR TITLE
Minor IE8 content page cleanup

### DIFF
--- a/common/app/views/fragments/meta/contactAuthor.scala.html
+++ b/common/app/views/fragments/meta/contactAuthor.scala.html
@@ -3,21 +3,17 @@
 @tags.contributors.headOption.map { profile =>
     @profile.twitterHandle.map{ twitter =>
         <div class="meta__twitter">
-            <a href="http://twitter.com/@@@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle">
-                <button class="button button--small button--secondary button--tone-news tone-colour">
-                    @fragments.inlineSvg("twitter-bird", "icon", Seq("tone-fill"))
-                    <div class="contact">@@@twitter</div>
-                </button>
+            <a href="http://twitter.com/@@@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle" class="button button--small button--secondary tone-colour">
+                @fragments.inlineSvg("twitter-bird", "icon", Seq("tone-fill"))
+                <div class="contact">@@@twitter</div>
             </a>
       </div>
     }
     @profile.emailAddress.map { email =>
         <div class="meta__email">
-            <a href="mailto:@email" data-link-name="email-address" data-component="meta-email-address">
-                <button class="button button--small button--secondary button--tone-news tone-colour">
-                    @fragments.inlineSvg("mail", "icon", Seq("tone-fill"))
-                    <div class="contact">email</div>
-                </button>
+            <a href="mailto:@email" data-link-name="email-address" data-component="meta-email-address" class="button button--small button--secondary tone-colour">
+                @fragments.inlineSvg("mail", "icon", Seq("tone-fill"))
+                <div class="contact">email</div>
             </a>
         </div>
     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -666,7 +666,7 @@
         overflow: visible;
     }
 
-    button {
+    .button {
         padding-top: 1px;
         margin-right: $gs-gutter/5;
 

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -195,6 +195,10 @@
             }
         }
     }
+
+    @if $old-ie {
+        display: none;
+    }
 }
 
 .content__main-column--gallery {

--- a/static/src/stylesheets/module/nav/_control.scss
+++ b/static/src/stylesheets/module/nav/_control.scss
@@ -61,4 +61,8 @@ $control-size: 36px;
             display: none;
         }
     }
+
+    @if $old-ie {
+        display: none !important;
+    }
 }

--- a/static/src/stylesheets/module/nav/_control.scss
+++ b/static/src/stylesheets/module/nav/_control.scss
@@ -61,8 +61,4 @@ $control-size: 36px;
             display: none;
         }
     }
-
-    @if $old-ie {
-        display: none !important;
-    }
 }


### PR DESCRIPTION
Social icons also fixed but commits pushed as part of https://github.com/guardian/frontend/pull/7965

This PR hides the fullscreen icon on IE8 and simplifies the twitter/email button markup so they work on IE8. This now matches how the tag lozenges are done.

No more of this:
![screen shot 2015-01-21 at 12 45 49](https://cloud.githubusercontent.com/assets/2236852/5898548/6749d424-a548-11e4-91e1-7bc9e4e26c8f.png)
