### PR TITLE
List-media items visually break less often

### DIFF
--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
@@ -25,6 +25,10 @@ Media list item. Looks a bit like this:
         min-height: $item-min-height + ($mobile-media-padding * 2);
     }
 
+    &.fc-item--has-metadata .fc-item__content {
+        padding-bottom: floor($gs-baseline * 1.2);
+    }
+
     @include mq(tablet) {
         .fc-item__content {
             min-height: $item-min-height;

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
@@ -18,7 +18,7 @@ Media list item. Looks a bit like this:
     $item-vertical-padding: $gs-baseline / 4;
     $estimate-item-min-height: (($item-vertical-padding * 2) + get-line-height(headline, $headline-size) * $text-lines-per-media-object);
     $image-width: normalize-width($estimate-item-min-height * $media-ratio);
-    $item-min-height: ($image-width / 5) * 3;
+    $item-min-height: $image-width / $media-ratio;
     $mobile-media-padding: ($gs-baseline / 3);
 
     .fc-item__content {

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-media.scss
@@ -16,11 +16,10 @@ Media list item. Looks a bit like this:
     // calculate image width
     $media-ratio: 5 / 3;
     $item-vertical-padding: $gs-baseline / 4;
-    $item-min-height: (($item-vertical-padding * 2) + get-line-height(headline, $headline-size) * $text-lines-per-media-object);
-    $image-width: normalize-width($item-min-height * $media-ratio);
+    $estimate-item-min-height: (($item-vertical-padding * 2) + get-line-height(headline, $headline-size) * $text-lines-per-media-object);
+    $image-width: normalize-width($estimate-item-min-height * $media-ratio);
+    $item-min-height: ($image-width / 5) * 3;
     $mobile-media-padding: ($gs-baseline / 3);
-
-    min-height: $item-min-height + ($mobile-media-padding * 2);
 
     .fc-item__content {
         min-height: $item-min-height + ($mobile-media-padding * 2);


### PR DESCRIPTION
A fix to `list-media` items to make sure they sit flush whenever possible.

Before:
![screen shot 2015-01-26 at 11 58 16](https://cloud.githubusercontent.com/assets/1607666/5899424/cd12ecb4-a552-11e4-8da2-b37af840c5e6.png)

After:
![screen shot 2015-01-26 at 11 56 52](https://cloud.githubusercontent.com/assets/1607666/5899425/cf9e9b68-a552-11e4-983b-b3a145fb420a.png)
