### PR TITLE
Encode URI parameters

### DIFF
--- a/facia-tool/public/js/models/layout.js
+++ b/facia-tool/public/js/models/layout.js
@@ -5,7 +5,6 @@ define([
     'modules/copied-article',
     'modules/vars',
     'utils/layout-from-url',
-    'utils/parse-query-params',
     'utils/update-scrollables'
 ],function (
     ko,
@@ -13,7 +12,6 @@ define([
     copiedArticle,
     vars,
     layoutFromURL,
-    parseQueryParams,
     updateScrollables
 ) {
     function Layout () {

--- a/facia-tool/public/js/utils/draggable-element.js
+++ b/facia-tool/public/js/utils/draggable-element.js
@@ -56,7 +56,7 @@ define([
         } else {
             sourceItem = {
                 id: id.split('?')[0] + (_.isEmpty(unknownQueryParams) ? '' : '?' + _.map(unknownQueryParams, function(val, key) {
-                    return key + (val ? '=' + val : '');
+                    return key + (val ? '=' + encodeURIComponent(val) : '');
                 }).join('&')),
                 meta: knownQueryParams
             };


### PR DESCRIPTION
When draging snap link with spaces (or other URI components) we decode URI componend but we don't encode it back before talking to the server.

Re-encode params after they've been handled.

@stephanfowler I'm not sure how to test that the server handles this correctly, but the request seems correct, look at all those `%20` instead of white spaces.

![screen shot 2015-01-26 at 13 34 49](https://cloud.githubusercontent.com/assets/680284/5900376/37ec18a0-a560-11e4-80a1-36c42b3bd811.png)
