### PR TITLE
Discussion pagination and discussion tracking

### DIFF
--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -115,7 +115,7 @@
 
                         <div class="discussion__comment-box discussion__comment-box--bottom js-discussion-comment-box--bottom"></div>
 
-                        <button class="discussion__show-button button--show-more button button--large button--primary js-discussion-show-button">
+                        <button class="discussion__show-button button--show-more button button--large button--primary js-discussion-show-button" data-link-name="more-comments">
                             <i class="i i-plus-white"></i>
                             View more comments
                         </button>

--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -9,11 +9,9 @@
         }
     </ul>
 
-    @if(renderPagination) {
-        <div class="discussion__pagination discussion__pagination--bottom">
-            @fragments.commentPagination(page)
-        </div>
-    }
+    <div class="discussion__pagination discussion__pagination--bottom">
+        @fragments.commentPagination(page)
+    </div>
 
     @fragments.reportComment()
 </div>

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -185,6 +185,12 @@ $avatarPadding: $gs-gutter / 2;
     }
 }
 
+.discussion__pagination--bottom {
+    .pagination {
+        border-top: 1px solid colour(neutral-4);
+    }
+}
+
 .d-discussion__meta {
     @include fs-textSans(3);
     float: left;


### PR DESCRIPTION
We now have pagination at the bottom of comment threads and I have added tracking to the 'View more comments' button:

![screen shot 2015-01-26 at 16 36 21](https://cloud.githubusercontent.com/assets/2236852/5903419/7c505722-a579-11e4-953a-95a1176ee07b.png)
