### PR TITLE
fix user login issue when using single letter subdomain

### DIFF
--- a/identity/app/form/Mappings.scala
+++ b/identity/app/form/Mappings.scala
@@ -35,8 +35,7 @@ trait Mappings {
     }
   )
 
-  val emailRegex = """^(?!\.)("([^"\r\\]|\\["\r\\])*"|([-a-zA-Z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)@[a-zA-Z0-9](?:[\w\.-]*[a-zA-Z0-9])*\.[a-zA-Z][a-zA-Z\.]*[a-zA-Z]$""".r
-  val idEmail: Mapping[String] = text.verifying(Messages("error.email"),{ value => value.isEmpty || emailRegex.findFirstIn(value).isDefined })
+  val idEmail: Mapping[String] = text.verifying(Messages("error.email"), value => value.isEmpty || EmailPattern.findFirstIn(value).isDefined)
 
   val idFirstName: Mapping[String] = nonEmptyText(maxLength = 50)
 

--- a/identity/app/form/Mappings.scala
+++ b/identity/app/form/Mappings.scala
@@ -35,7 +35,8 @@ trait Mappings {
     }
   )
 
-  val idEmail: Mapping[String] = email
+  val emailRegex = """^(?!\.)("([^"\r\\]|\\["\r\\])*"|([-a-zA-Z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)@[a-zA-Z0-9](?:[\w\.-]*[a-zA-Z0-9])*\.[a-zA-Z][a-zA-Z\.]*[a-zA-Z]$""".r
+  val idEmail: Mapping[String] = text.verifying(Messages("error.email"),{ value => value.isEmpty || emailRegex.findFirstIn(value).isDefined })
 
   val idFirstName: Mapping[String] = nonEmptyText(maxLength = 50)
 

--- a/identity/test/controllers/SigninControllerTest.scala
+++ b/identity/test/controllers/SigninControllerTest.scala
@@ -132,5 +132,13 @@ class SigninControllerTest extends path.FreeSpec with ShouldMatchers with Mockit
         body should not include "good-password"
       }
     }
+
+    "should authenticate single letter subdomain" in Fake {
+      when(api.authBrowser(any[Auth], same(trackingData), any[Option[Boolean]])).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("testCookie", "testVal"), CookieResponse("SC_testCookie", "secureVal"))))))
+      val goodRequest = FakeRequest(POST, "/signin").withFormUrlEncodedBody("email" -> "username@q.com", "password" -> "good-password")
+      val badRequest = FakeRequest(POST, "/signin").withFormUrlEncodedBody("email" -> "usernameq$.com", "password" -> "good-password")
+
+      header("Location", signinController.processForm()(goodRequest)) should not be (Some("/signin"))
+    }
   }
 }


### PR DESCRIPTION
It's a known issue that the builtin email validation of Play does not properly validate the email address with a single letter subdomain (ie. `username@q.com`).

We've been receiving user complaints for some time now.

https://github.com/playframework/playframework/blob/02e05755753407bc238da6f57f551fa455d820cb/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala#L76
