### PR TITLE
Weather – Only replace the appropriate data on refresh

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -245,6 +245,8 @@ define([
             this.addSearch();
 
             this.render = function (weatherData, city) {
+                $weather = $('.weather .js-weather-current');
+
                 var $weatherIcon = $('.js-weather-icon', $weather);
 
                 $('.js-weather-temp', $weather).text(this.getTemperature(weatherData));

--- a/static/src/javascripts/projects/facia/views/weather.html
+++ b/static/src/javascripts/projects/facia/views/weather.html
@@ -1,5 +1,5 @@
 <div class="weather">
-    <div class="u-unstyled weather__current">
+    <div class="u-unstyled weather__current js-weather-current">
         <p class="weather__desc">
             <span class="u-h">The temperature</span>
             <span class="weather__time">Now</span>


### PR DESCRIPTION
Nothing visual but I'll try to break it down a little.

Before:
- All weather icons (current and forecast icons) are replaced
- Forecast icons are replaced a second time with the correct icons

Now:
- The current forecast is replaced
- The forecast icons are replaced

Specificity!
