### PR TITLE
User history - count fronts & articles seperately

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -416,7 +416,7 @@ object Switches {
 
   val HistoryTags = Switch("Feature", "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
-    safeState = Off, sellByDate = new LocalDate(2015, 3, 1)
+    safeState = On, sellByDate = new LocalDate(2015, 3, 1)
   )
 
   val ABHistoryContainers = Switch("A/B Tests", "ab-history-containers",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -416,7 +416,7 @@ object Switches {
 
   val HistoryTags = Switch("Feature", "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
-    safeState = On, sellByDate = new LocalDate(2015, 3, 1)
+    safeState = Off, sellByDate = new LocalDate(2015, 3, 1)
   )
 
   val ABHistoryContainers = Switch("A/B Tests", "ab-history-containers",


### PR DESCRIPTION
For each tag, count front hits and article hits separately. Allows different rankings to be tried out later. Uses a more compact format:

```
   "artanddesign": [
        "Art and design",
        "1...5...1...3.2....2",                  // fronts hits
        "..1..1.1.........2.....6..........1"    // article hits
    ]
```

Where `1...5...` means one hit today, five hits three days ago, etc.

// @crifmulholland 
