### PR TITLE
Fix IE8 layout of facia containers on fronts

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -57,6 +57,10 @@ $header-image-size-desktop: 100px;
     .show-more--hidden & {
         display: none;
     }
+
+    @if($old-ie) {
+        clear: left;
+    }
 }
 
 .fc-container__header,

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -48,6 +48,9 @@
         ul > li:before {
             background: rgba($c-headline, .4);
         }
+        @if($old-ie) {
+            color: #ffffff;
+        }
     }
 
     .fc-item__title .i {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -44,12 +44,9 @@
 
     .fc-item__standfirst,
     .flyer__standfirst {
-        color: fade-out($c-headline, .2);
+        color: mix($c-headline, colour(feature-default), 80%);
         ul > li:before {
             background: rgba($c-headline, .4);
-        }
-        @if($old-ie) {
-            color: #ffffff;
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -42,10 +42,7 @@
     }
 
     .fc-item__standfirst {
-        color: fade-out($c-headline, .2);
-        @if($old-ie) {
-            color: #ffffff;
-        }
+        color: mix($c-headline, colour(live-default), 80%);
     }
 
     .fc-item__live-indicator,

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -43,6 +43,9 @@
 
     .fc-item__standfirst {
         color: fade-out($c-headline, .2);
+        @if($old-ie) {
+            color: #ffffff;
+        }
     }
 
     .fc-item__live-indicator,


### PR DESCRIPTION
Fixes the layout issues we are seeing on fronts in IE8
- Ensure all .fc-slices clear each other to avoid weird float situations
- Make standfirst text solid colour rather than an un-parseable rgba() value

/cc @sndrs @sammorrisdesign 
