### PR TITLE
Image content page style fixes and changes

### DIFF
--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -4,7 +4,7 @@
 
 @defining(page.image) { image =>
 
-<article class="content content--image tonal tonal--tone-media" itemprop="mainContentOfPage" itemscope itemtype="@image.schemaType" role="main">
+<article class="content content--media content--image tonal tonal--tone-media" itemprop="mainContentOfPage" itemscope itemtype="@image.schemaType" role="main">
 
     @fragments.headTonal(image)
 

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -13,7 +13,7 @@
             <div class="gs-container">
                 <div class="content__main-column content__main-column--image">
 
-                    @fragments.img(image.mainPicture)
+                    @fragments.img(image.mainPicture, isImageContent = true)
 
                     @fragments.contentMeta(image)
 

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -4,31 +4,27 @@
 
 @defining(page.image) { image =>
 
-<article class="content content--media content--image tonal tonal--tone-media" itemprop="mainContentOfPage" itemscope itemtype="@image.schemaType" role="main">
+<div class="l-side-margins l-side-margins--media">
+    <article class="content content--media content--image tonal tonal--tone-media" itemprop="mainContentOfPage" itemscope itemtype="@image.schemaType" role="main">
 
-    @fragments.headTonal(image)
+        @fragments.headTonal(image)
 
-    <div class="content__main tonal__main tonal__main--tone-media">
-        <div class="gs-container">
-            <div class="content__main-column content__main-column--image">
+        <div class="content__main tonal__main tonal__main--tone-media">
+            <div class="gs-container">
+                <div class="content__main-column content__main-column--image">
 
-                @fragments.img(image.mainPicture)
+                    @fragments.img(image.mainPicture)
 
-                @fragments.contentMeta(image)
+                    @fragments.contentMeta(image)
 
-                @fragments.submeta(image)
+                    @fragments.submeta(image)
 
+                    </div>
                 </div>
             </div>
-
-            <div class="content__secondary-column" aria-hidden="true">
-                <div class="mpu-container js-mpu-ad-slot"></div>
-                <div class="js-components-container"></div>
-            </div>
         </div>
-    </div>
-</article>
-
+    </article>
+</div>
 @fragments.contentFooter(image, page.related)
 
 }

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -4,11 +4,11 @@
 
 @defining(page.image) { image =>
 
-<article class="content content--image tonal tonal--@articleToneClass(image)" itemprop="mainContentOfPage" itemscope itemtype="@image.schemaType" role="main">
+<article class="content content--image tonal tonal--tone-media" itemprop="mainContentOfPage" itemscope itemtype="@image.schemaType" role="main">
 
     @fragments.headTonal(image)
 
-    <div class="content__main tonal__main tonal__main--@articleToneClass(image)">
+    <div class="content__main tonal__main tonal__main--tone-media">
         <div class="gs-container">
             <div class="content__main-column content__main-column--image">
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -59,10 +59,14 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
       case _ => false
     }
   }
-  lazy val hasTonalHeaderByline: Boolean = { visualTone == Tags.VisualTone.Comment && hasSingleContributor }
+  lazy val hasTonalHeaderByline: Boolean = {
+    visualTone == Tags.VisualTone.Comment && hasSingleContributor && contentType != GuardianContentTypes.ImageContent
+  }
   lazy val hasTonalHeaderIllustration: Boolean = isLetters
   lazy val showBylinePic: Boolean = {
-    visualTone != Tags.VisualTone.News && visualTone != Tags.VisualTone.Live && hasLargeContributorImage && contributors.length == 1 && !hasTonalHeaderByline
+    visualTone != Tags.VisualTone.News && visualTone != Tags.VisualTone.Live &&
+      contentType != GuardianContentTypes.ImageContent &&
+      hasLargeContributorImage && contributors.length == 1 && !hasTonalHeaderByline
   }
 
   private def largestImageUrl(i: ImageContainer) = i.largestImage.flatMap(_.url)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -705,8 +705,9 @@ object Gallery {
 }
 
 trait Lightboxable extends Content {
-  lazy val mainFiltered = mainPicture.filter(_.largestEditorialCrop.map(_.ratio).getOrElse(0) > 0.7).filter(_.largestEditorialCrop.map(_.width).getOrElse(1) > 620).toSeq
-  lazy val bodyFiltered = bodyImages.filter(_.largestEditorialCrop.map(_.width).getOrElse(1) > 620).toSeq
+  val lightboxableCutoffWidth = 620
+  lazy val mainFiltered = mainPicture.filter(_.largestEditorialCrop.map(_.ratio).getOrElse(0) > 0.7).filter(_.largestEditorialCrop.map(_.width).getOrElse(1) > lightboxableCutoffWidth).toSeq
+  lazy val bodyFiltered = bodyImages.filter(_.largestEditorialCrop.map(_.width).getOrElse(1) > lightboxableCutoffWidth).toSeq
   lazy val lightboxImages: Seq[ImageContainer] = mainFiltered ++ bodyFiltered
 
   lazy val lightbox: JsObject = {
@@ -747,9 +748,12 @@ object Interactive {
 }
 
 class ImageContent(content: ApiContentWithMeta) extends Content(content) with Lightboxable {
+  override val lightboxableCutoffWidth = 940
   override lazy val lightboxImages: Seq[ImageContainer] = mainFiltered
   override lazy val contentType = GuardianContentTypes.ImageContent
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
+
+
 
   override def cards: List[(String, String)] = super.cards ++ List(
     "twitter:card" -> "photo"

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -1,5 +1,10 @@
-@(img: Option[model.ImageContainer], isShowcase: Boolean = false, isFeature: Boolean = false, url: Option[String] = None)
-@import views.support.{ImgSrc, Item620, Naked, Profile, SeoOptimisedContentImage, Showcase}
+@(img: Option[model.ImageContainer],
+  isShowcase: Boolean = false,
+  isFeature: Boolean = false,
+  isImageContent: Boolean = false,
+  url: Option[String] = None)
+
+@import views.support.{ImgSrc, Item620, Item940, Naked, Profile, SeoOptimisedContentImage, Showcase}
 
 @img.map{ picture =>
 
@@ -17,7 +22,11 @@
             @if(isShowcase) {
                 @lightbox(picture, Showcase)
             } else {
-                @lightbox(picture, Item620)
+                @if(isImageContent) {
+                    @lightbox(picture, Item940)
+                } else {
+                    @lightbox(picture, Item620)
+                }
             }
             @caption(picture)
         }

--- a/common/app/views/support/ContentLayout.scala
+++ b/common/app/views/support/ContentLayout.scala
@@ -37,7 +37,7 @@ object ContentLayout {
         case l: LiveBlog => Some(l.visualTone)
         case m: Media => Some("media")
         case g: Gallery => Some("media")
-        case i: ImageContent if !i.isCartoon => Some("media")
+        case i: ImageContent => Some("media")
         case _ => None
       }
     }

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -37,31 +37,33 @@
     }
 }
 
-.submeta-container--break {
-    @include mq(leftCol) {
-        margin-top: 0;
-        position: absolute;
-        bottom: 0;
+@mixin submeta-break-common {
+    margin-top: 0;
+    position: absolute;
+    bottom: 0;
 
-        .content--media & {
-            border-top: 0;
-        }
-
-        .content__main-column--media & {
-            bottom: -($gs-baseline/4);
-        }
-
-        .submeta {
-            padding-top: 0;
-            border-top: 1px dotted colour(neutral-4);
-        }
-        .submeta__head {
-            display: block;
-        }
+    .content--media & {
+        border-top-width: 0;
     }
 
+    .content__main-column--media & {
+        bottom: -($gs-baseline/4);
+    }
+
+    .submeta {
+        padding-top: 0;
+        border-top-style: dotted;
+        border-top-width: 1px;
+    }
+    .submeta__head {
+        display: block;
+    }
+}
+
+.submeta-container--break {
     &.submeta-container--break-at-leftcol {
         @include mq(leftCol) {
+            @include submeta-break-common;
             width: $left-column;
             left: -1 * ($left-column + $gs-gutter);
         }
@@ -74,6 +76,7 @@
 
     &.submeta-container--break-at-wide {
         @include mq(wide) {
+            @include submeta-break-common;
             width: $left-column-wide;
             left: -$left-column-wide - $gs-gutter;
         }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -79,6 +79,14 @@
             margin-right: gs-span(1) + $gs-gutter;
         }
     }
+
+    .content--image & {
+        max-width: none;
+        margin-right: 0;
+        @include mq(wide) {
+            margin-right: gs-span(1) + $gs-gutter;
+        }
+    }
 }
 
 .content__hr {
@@ -99,6 +107,10 @@
     overflow: hidden;
 
     @include mq($until: desktop) {
+        display: none;
+    }
+
+    .content--image & {
         display: none;
     }
 }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -109,10 +109,6 @@
     @include mq($until: desktop) {
         display: none;
     }
-
-    .content--image & {
-        display: none;
-    }
 }
 
 .content__head__comment-count {

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -82,7 +82,8 @@
         width: 1.04em;
         @include icon(video-icon-white, $with-width: false);
     }
-    .content--gallery & {
+    .content--gallery &,
+    .content--image & {
         width: .9em;
         @include icon(camera-white-large, $with-width: false);
     }


### PR DESCRIPTION
## Changes
- remove byline pic
- remove tonal head/byline
- add camera icon to headline
- fix topic/keyword overlap bug
- add media tone margins
- fix meta rule and lozenge colours
- make all image pages use media tone
- serve a bigger image (now 940)
## Before

![image](https://cloud.githubusercontent.com/assets/960919/5917920/3f32129e-a61a-11e4-985d-ee150e1c5a92.png)
## After

![image](https://cloud.githubusercontent.com/assets/960919/5917908/22eeb6c8-a61a-11e4-8b2b-57d3a784ce11.png)
