### PR TITLE
Css logging: split selectors

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -307,7 +307,7 @@ object Switches {
 
   val CssLogging = Switch("Monitoring", "css-logging",
     "If this is on, then a subset of clients will post css selector information for diagnostics.",
-    safeState = Off, new LocalDate(2015, 2, 28)
+    safeState = On, new LocalDate(2015, 2, 28)
   )
 
   val ThirdPartyEmbedTracking = Switch("Monitoring", "third-party-embed-tracking",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -307,7 +307,7 @@ object Switches {
 
   val CssLogging = Switch("Monitoring", "css-logging",
     "If this is on, then a subset of clients will post css selector information for diagnostics.",
-    safeState = On, new LocalDate(2015, 2, 28)
+    safeState = Off, new LocalDate(2015, 2, 28)
   )
 
   val ThirdPartyEmbedTracking = Switch("Monitoring", "third-party-embed-tracking",

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -78,7 +78,7 @@ define([
                     _.each(sendAll ? getStylesheets() : [getRandomStylesheet()], function (stylesheet) {
                         sendReport(stylesheet, sendAll);
                     });
-                }, _.random(0, 1000));
+                }, _.random(0, 3000));
             }
         }, 300);
     }

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -15,7 +15,8 @@ define([
     mediator,
     beacon
 ) {
-    var stripRx = new RegExp(/\:(active|hover|visited)/g);
+    var rxPsuedoClass = new RegExp(/:+[^\s\,]+/g),
+        rxSeperator = new RegExp(/\s*,\s*/g);
 
     function getStylesheets() {
         return _.chain(document.styleSheets)
@@ -56,7 +57,11 @@ define([
 
         beacon.postJson('/css', JSON.stringify({
             selectors: rules.reduce(function (isUsed, rule) {
-                isUsed[rule] = !!document.querySelector(rule.replace(stripRx, ''));
+                _.each(rule.replace(rxPsuedoClass, '').split(rxSeperator), function (s) {
+                    if (_.isUndefined(isUsed[s])) {
+                        isUsed[s] = !!document.querySelector(s);
+                    }
+                });
                 return isUsed;
             }, {}),
             contentType: config.page.contentType,
@@ -73,7 +78,7 @@ define([
                     _.each(sendAll ? getStylesheets() : [getRandomStylesheet()], function (stylesheet) {
                         sendReport(stylesheet, sendAll);
                     });
-                }, _.random(0, 3000));
+                }, _.random(0, 1000));
             }
         }, 300);
     }

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -16,7 +16,7 @@ define([
     beacon
 ) {
     var rxPsuedoClass = new RegExp(/:+[^\s\,]+/g),
-        rxSeperator = new RegExp(/\s*,\s*/g);
+        rxSeparator = new RegExp(/\s*,\s*/g);
 
     function getStylesheets() {
         return _.chain(document.styleSheets)
@@ -57,7 +57,7 @@ define([
 
         beacon.postJson('/css', JSON.stringify({
             selectors: rules.reduce(function (isUsed, rule) {
-                _.each(rule.replace(rxPsuedoClass, '').split(rxSeperator), function (s) {
+                _.each(rule.replace(rxPsuedoClass, '').split(rxSeparator), function (s) {
                     if (_.isUndefined(isUsed[s])) {
                         isUsed[s] = !!document.querySelector(s);
                     }


### PR DESCRIPTION
Split selectors and remove psuedo clasess. 

So this:

```
.foo, .foo:nth-child(2) .bar:hover
```

becomes this:

```
.foo
.foo .bar
```

@rich-nguyen @robertberry @phamann 
