### PR TITLE
Fix admin's A/B Tests page

### DIFF
--- a/static/src/javascripts/projects/admin/bootstraps/abtests.js
+++ b/static/src/javascripts/projects/admin/bootstraps/abtests.js
@@ -1,13 +1,13 @@
 define([
-    'common/modules/experiments/ab',
-    'qwery',
     'bean',
+    'qwery',
+    'common/modules/experiments/ab',
     'admin/modules/abtests/abtest-item',
     'admin/modules/abtests/audience'
 ], function(
-    abTests,
-    qwery,
     bean,
+    qwery,
+    abTests,
     Item,
     Audience
 ) {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -32,8 +32,7 @@ define([
     StickyContainerTitles
 ) {
 
-    var ab,
-        TESTS = [
+    var TESTS = [
             new HighCommercialComponent(),
             new HistoryContainers(),
             new StickyContainerTitles()
@@ -188,7 +187,7 @@ define([
         }
     }
 
-    ab = {
+    return {
 
         addTest: function (test) {
             TESTS.push(test);
@@ -302,7 +301,5 @@ define([
             TESTS = [];
         }
     };
-
-    return ab;
 
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/history-containers.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/history-containers.js
@@ -1,12 +1,15 @@
 define([
     'common/modules/onward/history-containers',
     'common/utils/config',
-    'common/utils/detect'
+    'common/utils/detect',
+    'common/utils/get-property'
 ], function (
     historyContainers,
     config,
-    detect
-    ) {
+    detect,
+    getProperty
+) {
+
     return function () {
         this.id = 'HistoryContainers';
         this.start = '2014-12-23';
@@ -20,7 +23,7 @@ define([
         this.dataLinkNames = 'history containers';
         this.idealOutcome = 'Users click through to more content as it is relevant to them';
 
-        var isNetworkFront = config.page.contentType === 'Network Front';
+        var isNetworkFront = getProperty(config, 'page.contentType') === 'Network Front';
 
         this.canRun = function () {
             return detect.isModernBrowser() && isNetworkFront && historyContainers.hasContainers();


### PR DESCRIPTION
Breaking, due to the `history-containers` ab test accessing the config object, which doesn't exists in the admin context
