### PR TITLE
Helpers around the copied articles

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -81,13 +81,17 @@
             <div class="group-name" data-bind="text: name"></div>
         <!-- /ko -->
         <div class="droppable" data-bind="
-            makeDropabble: true,
+            makeDroppable: true,
             click: pasteItem,
             css: {
                 underDrag: underDrag() && !underControlDrag(),
                 underControlDrag: underDrag() && underControlDrag()
-            },
-            template: {name: 'template_article', foreach: items}"></div>
+            }">
+                <div data-bind="template: {name: 'template_article', foreach: items}"></div>
+                <div class="group-separator" data-bind="css: {'pasteOver': $root.isPasteActive}">
+                    <span class="helptext">Click to paste</span>
+                </div>
+        </div>
     </script>
 
     <script type="text/html" id="template_article">
@@ -122,13 +126,17 @@
                 <div data-bind="if: state.enableContentOverrides() && group.parentType !== 'Article'">
                     <div class="supporting" data-bind="with: meta.supporting">
                         <div class="droppable" data-bind="
-                            makeDropabble: true,
+                            makeDroppable: true,
                             click: pasteItem,
                             css: {
                                 underDrag: underDrag() && !underControlDrag(),
                                 underControlDrag: underDrag() && underControlDrag()
-                            },
-                            template: {name: 'template_article', foreach: items}"></div>
+                            }">
+                                <div data-bind="template: {name: 'template_article', foreach: items}"></div>
+                                <div class="group-separator" data-bind="css: {'pasteOver': $root.isPasteActive}">
+                                    <span class="helptext">Click to paste</span>
+                                </div>
+                        </div>
                     </div>
                     <span class="supporting-message">Drop content above, hold Ctrl key to replace item</span>
                 </div>
@@ -147,10 +155,12 @@
 
                 <div class="article__tools">
                     <a class="tool tool--small tool--small--paste" data-bind="
+                        visible: $root.isPasteActive,
                         clickBubble: false,
                         click: paste">paste</a>
 
                     <a class="tool tool--small tool--small--copy" data-bind="
+                        css: {'large': !$root.isPasteActive()},
                         clickBubble: false,
                         click: copy">copy</a>
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -496,6 +496,72 @@ h1 {
     margin-top: 5px;
 }
 
+.clipboard-indicator {
+    position: absolute;
+    display: inline-block;
+    margin-right: 22px;
+}
+.clipboard-indicator .headline {
+    font-weight: bold;
+}
+.clipboard-indicator.dropdown > ul {
+    position: relative;
+    top: 12px;
+    font-size: 12px;
+    padding: 0;
+    height: 0;
+}
+.clipboard-indicator.dropdown > ul > li {
+    padding: 16px;
+}
+.clipboard-indicator.dropdown-open > ul {
+    height: auto;
+}
+.clipboard-indicator.dropdown-open > ul > li:hover {
+    background-color: inherit;
+    cursor: default;
+}
+.clipboard-indicator.dropdown-open .buttons {
+    background-color: #fff;
+    text-align: right;
+    padding: 6px 0;
+    border-top: 1px solid #ddd;
+}
+
+
+.paper-button:before,.paper-button:after {
+    background: no-repeat 50% 50%;
+    border-radius: 50%;
+    box-shadow: 0 2px 10px 0 rgba(0,0,0,.16);
+    content: "";
+    height: 30px;
+    width: 30px;
+
+    left:0;
+    position:absolute;
+    right:0;
+    top:0;
+    transform: translate3d(0,0,0);
+    transition: all .28s cubic-bezier(.4,0,.2,1);
+}
+
+.paper-button:hover:after {
+    box-shadow: 0 8px 17px 0 rgba(0,0,0,.2);
+}
+
+.paper-button {
+    position: relative;
+    left: 0.5em;
+}
+
+.paper-button i {
+    font-size: 14px;
+    color: #333;
+    top: -1px;
+    position: relative;
+    left: 9px;
+}
+
 .count {
     font-weight: normal;
     margin-left: 0.4em;
@@ -512,12 +578,14 @@ h1 {
 .droppable {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
-    min-height: 20px;
-    padding: 0 0 20px;
     -webkit-transition: background-color 50ms;
     -moz-transition: background-color 50ms;
     transition: background-color 50ms;
     overflow: auto;
+}
+
+.group-separator {
+    height: 20px;
 }
 
 .supporting .droppable {
@@ -525,15 +593,15 @@ h1 {
     margin: 0 0 0 -4px;
 }
 
-.droppable.underDrag {
+.underDrag > .group-separator {
     background-color: #2ea3eb;
 }
 
-.open .droppable.underDrag {
+.open .underDrag > .group-separator {
     background-color: #999999;
 }
 
-.open .droppable.underControlDrag {
+.open .underControlDrag > .group-separator {
     background-color: #cdbbfb;
 }
 
@@ -1142,7 +1210,7 @@ button {
 
 .clipboard {
     width: 100%;
-    margin: 5px 0 15px 0;;
+    margin: 8px 0 15px 0;;
 }
 
 .article__spark {
@@ -1378,7 +1446,7 @@ button {
     color: #999999;
     background: transparent;
     width: 62px;
-    height: 24px;
+    height: 25px;
     padding: 1px;
     float: right;
 }
@@ -1403,7 +1471,8 @@ button {
     width: 120px;
 }
 
-.latest-articles .tool--small--copy {
+.latest-articles .tool--small--copy,
+.latest-articles .tool--small--copy.large {
     width: 83px;
 }
 
@@ -1412,7 +1481,8 @@ button {
     display: none;
 }
 
-.latest-articles .tool--small--href {
+.tool--small--copy.large {
+    width: 100%;
 }
 
 .article > .closed .tool--small:hover {
@@ -1816,6 +1886,32 @@ collection-widget > div {
     display: none;
 }
 
+.fadeElement {
+    opacity: 0;
+    transition: opacity 0.3s ease-out;
+    pointer-events: none;
+}
+.fadeElement.visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.group-separator .helptext {
+    display: none;
+    width: 100%;
+    text-align: center;
+    padding-top: 2px;
+    color: white;
+}
+.group-separator.pasteOver:hover .helptext {
+    display: inline-block;
+}
+.group-separator.pasteOver:hover {
+    background-color: #2ea3eb;
+}
+.open .group-separator.pasteOver:hover {
+    background-color: #999999;
+}
 
 .article-group {
     position: relative;

--- a/facia-tool/public/js/models/collections/main.js
+++ b/facia-tool/public/js/models/collections/main.js
@@ -48,7 +48,8 @@ define([
             modalDialog: modalDialog,
             switches: ko.observable(),
             fronts: ko.observableArray(),
-            loadedFronts: ko.observableArray()
+            loadedFronts: ko.observableArray(),
+            isPasteActive: ko.observable(false)
         };
 
         model.chooseLayout = function () {
@@ -86,6 +87,9 @@ define([
         });
         mediator.on('front:disposed', function (front) {
             model.loadedFronts.remove(front);
+        });
+        mediator.on('copied-article:change', function (hasArticle) {
+            model.isPasteActive(hasArticle);
         });
 
         this.init = function() {

--- a/facia-tool/public/js/modules/droppable.js
+++ b/facia-tool/public/js/modules/droppable.js
@@ -89,7 +89,7 @@ define([
             event.preventDefault();
         },false);
 
-        ko.bindingHandlers.makeDropabble = {
+        ko.bindingHandlers.makeDroppable = {
             init: function(element) {
                 for (var eventName in listeners) {
                     element.addEventListener(eventName, getListener(eventName, element), false);

--- a/facia-tool/public/js/widgets/clipboard.html
+++ b/facia-tool/public/js/widgets/clipboard.html
@@ -1,15 +1,40 @@
 <div class="col__inner clipboard-container">
-    <div class="title title--clipboard">clipboard</div>
+    <div class="title title--clipboard">
+        <span>clipboard</span>
+        <div class="clipboard-indicator dropdown fadeElement" data-bind="
+            css: {
+                'dropdown-open': dropdownOpen,
+                'visible': inCopiedArticle
+            }
+        ">
+            <a class="paper-button" data-bind="toggleClick: dropdownOpen">
+                <i class="fa fa-clipboard"></i>
+            </a>
+
+            <ul>
+                <li>
+                    <p>You have copied one article.</p>
+                    <p class="headline" data-bind="text: inCopiedArticle()"></p>
+                    <p>Click on <em>Paste</em> to add it to a collection.</p>
+                </li>
+                <li class="buttons">
+                    <button data-bind="click: flushCopiedArticles">Clear</button>
+                </li>
+            </ul>
+        </div>
+    </div>
     <div class="clipboard" data-bind="with: group">
         <div class="droppable" data-bind="
-            makeDropabble: true,
+            makeDroppable: true,
             click: pasteItem,
             css: {
                 underDrag: underDrag() && !underControlDrag(),
                 underControlDrag: underDrag() && underControlDrag()
             }">
             <div data-bind="template: {name: 'template_article', foreach: items}"></div>
-            <div class="group-separator"></div>
+            <div class="group-separator" data-bind="css: {'pasteOver': $root.isPasteActive}">
+                <span class="helptext">Click to paste</span>
+            </div>
         </div>
     </div>
 </div>

--- a/facia-tool/public/js/widgets/clipboard.js
+++ b/facia-tool/public/js/widgets/clipboard.js
@@ -2,11 +2,15 @@
 define([
     'knockout',
     'models/group',
+    'modules/cache',
+    'modules/copied-article',
     'utils/mediator',
     'utils/update-scrollables'
 ], function (
     ko,
     Group,
+    cache,
+    copiedArticle,
     mediator,
     updateScrollables
 ) {
@@ -39,7 +43,18 @@ define([
         this.listeners = listeners;
 
         listeners.on('ui:open', this.onUIOpen.bind(this));
+        listeners.on('copied-article:change', this.onCopiedChange.bind(this));
+
+        this.hasCopiedArticle = ko.observable(false).extend({ notify: 'always' });
+        this.inCopiedArticle = ko.pureComputed(this.getCopiedArticle, this);
+        this.dropdownOpen = ko.observable(false);
     }
+
+    Clipboard.prototype.getCopiedArticle = function () {
+        var inMemory = this.hasCopiedArticle() && copiedArticle.peek();
+
+        return inMemory ? inMemory.displayName : null;
+    };
 
     Clipboard.prototype.elementHasFocus = function (meta) {
         return meta === this.uiOpenElement();
@@ -52,6 +67,17 @@ define([
         updateClipboardScrollable(article ? {
             targetGroup: article.group
         } : null);
+    };
+
+    Clipboard.prototype.onCopiedChange = function (hasArticle) {
+        this.hasCopiedArticle(hasArticle);
+        if (!hasArticle) {
+            this.dropdownOpen(false);
+        }
+    };
+
+    Clipboard.prototype.flushCopiedArticles = function () {
+        copiedArticle.flush();
     };
 
     return Clipboard;


### PR DESCRIPTION
Display somewhere that the user has an article in the copied articles list.
Gives also a chance to remove it and makes dragging by copy/paste more intuitive on empty collections.

Closes #7862 ?

![screen shot 2015-01-27 at 15 14 26](https://cloud.githubusercontent.com/assets/680284/5920803/441bb0b8-a637-11e4-8351-5475943e6663.png)
![screen shot 2015-01-27 at 15 14 35](https://cloud.githubusercontent.com/assets/680284/5920806/4b3fa804-a637-11e4-8002-9a6cb4550d2b.png)
![screen shot 2015-01-27 at 15 14 46](https://cloud.githubusercontent.com/assets/680284/5920813/4f045bce-a637-11e4-95af-51a4e9418152.png)
