### PR TITLE
Weather – Go to local storage to get previous city name

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -205,7 +205,7 @@ define([
             } else {
                 $location.removeClass('is-editing');
                 searchTool.clear();
-                searchTool.setInputValue(city);
+                searchTool.setInputValue(this.getUserLocation().city);
                 $close.addClass('u-h');
                 $edit.removeClass('u-h');
             }


### PR DESCRIPTION
When clicking x for the first time, the city wasn't stored as a variable because it hadn't been set. This uses the `getUserLocation()` function instead to retrieve the location from the start.
