### PR TITLE
videos on quarter cards, desktop size

### DIFF
--- a/common/app/cards/CardType.scala
+++ b/common/app/cards/CardType.scala
@@ -4,7 +4,7 @@ sealed trait CardType {
   val cssClassName: String
 
   def showVideoPlayer = this match {
-    case Half | ThreeQuarters | ThreeQuartersRight | Third | FullMedia50 | FullMedia75 | FullMedia100 => true
+    case Half | ThreeQuarters | ThreeQuartersRight | Third | Standard | FullMedia50 | FullMedia75 | FullMedia100 => true
     case _ => false
   }
 

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -176,6 +176,20 @@
         }
     }
 
+    &.fc-item--video {
+        @include mq($until: desktop) {
+
+            //.fc-item__video-container,
+            .fc-item__video-play {
+                display: none;
+            }
+            .fc-item__video-fallback {
+                display: block;
+            }
+
+        }
+    }
+
     @include mq(desktop) {
         &.fc-item--has-cutout .fc-item__container {
             padding-bottom: gs-height(3) + $gs-baseline  * 2;

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -179,7 +179,6 @@
     &.fc-item--video {
         @include mq($until: desktop) {
 
-            //.fc-item__video-container,
             .fc-item__video-play {
                 display: none;
             }


### PR DESCRIPTION
Added playable videos to quarter size cards but only at desktop breakpoint and above.

As you can see below, the play button disappears if you move from desktop to tablet - however, if you started it playing and reduce to tablet, it carries on playing.

That was partly because I can use entirely CSS to do it that way, but I think it also makes sense.

![quarter-playable](https://cloud.githubusercontent.com/assets/7304387/5921533/8816ac6e-a63c-11e4-9b84-1f1c91ea7658.gif)
