### PR TITLE
Cif Left hand meta

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -46,7 +46,7 @@ case class Tag(private val delegate: ApiTag, override val pagination: Option[Pag
     SectionTagLookUp.sectionId(id).exists(_ == section)
   }
 
-  lazy val showSeriesInMeta = id != "commentisfree/commentisfree"  &&  id != "childrens-books-site/childrens-books-site"
+  lazy val showSeriesInMeta = id != "childrens-books-site/childrens-books-site"
 
   lazy val isKeyword = tagType == "keyword"
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -255,7 +255,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
 
   override lazy val adUnitSuffix: String = super.adUnitSuffix + "/" + contentType.toLowerCase
 
-  lazy val showSectionNotTag: Boolean = tags.exists{ tag => (tag.id == "commentisfree/commentisfree" || tag.id == "childrens-books-site/childrens-books-site") && tag.tagType == "blog" }
+  lazy val showSectionNotTag: Boolean = tags.exists{ tag => tag.id == "childrens-books-site/childrens-books-site" && tag.tagType == "blog" }
 
   lazy val sectionLabelLink : String = {
     if (showSectionNotTag || DfpAgent.isAdvertisementFeature(tags, Some(section))) {


### PR DESCRIPTION
At the request of @cantlin - for before launch, drop the special logic we use of CIF articles in the left hand meta, and have them treated as per everything else ( ie, section link and first series or blog tag link, if there is one )

So: 

Before: 
![cif-meta-before](https://cloud.githubusercontent.com/assets/986155/5922003/030f7e3e-a640-11e4-8981-8f813d49e84e.png)

After:
![cif-meta-after](https://cloud.githubusercontent.com/assets/986155/5922084/bc574552-a640-11e4-8316-4dc2e2336999.png)
