### PR TITLE
Weather – Remove on blur

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -179,10 +179,6 @@ define([
                 e.preventDefault();
                 this.toggleControls(false);
             }.bind(this));
-            bean.on(qwery('.js-weather-input')[0], 'blur', function (e) {
-                e.preventDefault();
-                this.toggleControls(false);
-            }.bind(this));
             bean.on(qwery('.js-toggle-forecast')[0], 'click', function (e) {
                 e.preventDefault();
                 this.toggleForecast();


### PR DESCRIPTION
This is blocking the user from clicking on search results, so removing until we come up with a better fix.
