### PR TITLE
Dealt with a couple of expiring switches.

### DIFF
--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -1,6 +1,5 @@
 package test
 
-import conf.Switches.ForceHttpResponseCodeSwitch
 import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
@@ -90,48 +89,9 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 
   }
 
-  "ForceHttpResponseFilter" should "not error if switched off" in {
-    ForceHttpResponseCodeSwitch.switchOff()
-
-    val request = TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")
-      .withHeaders("X-Gu-Force-Status" -> "503")
-    val Some(result) = route(request)
-    status(result) should be (200)
-  }
-
-  it should "not error if there is no header" in {
-    ForceHttpResponseCodeSwitch.switchOn()
-
-    val request = TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")
-
-    val Some(result) = route(request)
-    status(result) should be (200)
-  }
-
   it should "know which backend served the request" in {
     val result = route(app, TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")).head
     status(result) should be (200)
     header("X-Gu-Backend-App", result).head should be ("test-project")
   }
-
-  it should "error if there is an appropriate header and it is switched on" in {
-    ForceHttpResponseCodeSwitch.switchOn()
-
-    val request = TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")
-      .withHeaders("X-Gu-Force-Status" -> "503")
-
-    val Some(result) = route(request)
-    status(result) should be (503)
-  }
-
-  it should "404 with an appropriate header" in {
-    ForceHttpResponseCodeSwitch.switchOn()
-
-    val request = TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")
-      .withHeaders("X-Gu-Force-Status" -> "404")
-
-    val Some(result) = route(request)
-    status(result) should be (404)
-  }
-
 }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -71,13 +71,6 @@ object Switches {
     sellByDate = never
   )
 
-  val ForceHttpResponseCodeSwitch = Switch("Performance", "force-response-codes",
-    "If this switch is switched on and you specify the correct header, then you can force a specific http response code",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 2, 1)
-  )
-
-
   val MemcachedSwitch = Switch("Performance", "memcached-action",
     "If this switch is switched on then the MemcacheAction will be operational",
     safeState = On,
@@ -99,7 +92,7 @@ object Switches {
   val EnableOauthOnPreview = Switch("Performance", "enable-oauth-on-preview",
     "If this switch is switched on then the preview server requires login",
     safeState = On,
-    sellByDate = new LocalDate(2015, 1, 31)
+    sellByDate = new LocalDate(2015, 2, 26)
   )
 
   val AutoRefreshSwitch = Switch("Performance", "auto-refresh",
@@ -424,12 +417,6 @@ object Switches {
   val HistoryTags = Switch("Feature", "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
     safeState = Off, sellByDate = new LocalDate(2015, 3, 1)
-  )
-
-  // actually just here to make us remove this in the future
-  val GuShiftCookieSwitch = Switch("Feature", "gu-shift-cookie",
-    "If switched on, the GU_SHIFT cookie will be updated when users opt into or out of Next Gen",
-    safeState = On, sellByDate = new LocalDate(2015, 1, 31)
   )
 
   val IdentityBlockSpamEmails = Switch("Feature", "id-block-spam-emails",


### PR DESCRIPTION
`ForceHttpResponseFilter` can go. As far as I can see nobody except me has ever used it.

Someone deleted all the `GuShiftCookieSwitch` functionality but left the switch behind. I'm not mentioning names @phamann 

`EnableOauthOnPreview` gets an extension till I can find out about project Panda
