### PR TITLE
Pinterest icon fix

### DIFF
--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -103,8 +103,8 @@ category: Common
             width: 100%;
             height: 100%;
             vertical-align: middle;
-            background-size: 88% !important;
-            background-position: center !important;
+            background-size: 88%;
+            background-position: center;
         }
     }
 


### PR DESCRIPTION
Fix for 
![screen shot 2015-01-28 at 09 41 18](https://cloud.githubusercontent.com/assets/2236852/5935342/d7c34868-a6d1-11e4-9e08-ab4425dfd1d3.png)

Caused by over-specific class change yesterday so the important is no longer needed.

https://github.com/guardian/frontend/issues/8034
