### PR TITLE
Fix template's inline svgs

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
@@ -1,6 +1,7 @@
 define([
     'common/utils/$',
     'common/utils/template',
+    'common/views/svgs',
 
     // require templates, so they're bundled up as part of the build
     'text!common/views/commercial/creatives/ad-feature-mpu.html',
@@ -12,7 +13,8 @@ define([
     'text!common/views/commercial/creatives/manual-single.html'
 ], function (
     $,
-    template
+    template,
+    svgs
 ) {
 
     /**
@@ -24,10 +26,10 @@ define([
     var Template = function ($adSlot, params) {
         this.$adSlot = $adSlot;
         this.params  = params;
-    };
 
-    // this.params.marque36icon = svgs('marque36icon');
-    // this.params.marque36iconCreativeMarque = svgs('marque36icon', ['creative__marque']);
+        this.params.marque36icon = svgs('marque36icon');
+        this.params.marque36iconCreativeMarque = svgs('marque36icon', ['creative__marque']);
+    };
 
     Template.prototype.create = function () {
         require(['text!common/views/commercial/creatives/' + this.params.creative + '.html'], function (creativeTpl) {


### PR DESCRIPTION
Should set `params` in correct context

cc: @phamann, @sndrs 
