### PR TITLE
Fix text.js loading bug in svg.js

### DIFF
--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -57,21 +57,24 @@ module.exports = function(grunt, options) {
                     {
                         name: 'core',
                         exclude: [
-                            'text'
+                            'text',
+                            'inlineSvg'
                         ]
                     },
                     {
                         name: 'bootstraps/app',
                         exclude: [
                             'core',
-                            'text'
+                            'text',
+                            'inlineSvg'
                         ]
                     },
                     {
                         name: 'bootstraps/commercial',
                         exclude: [
                             'core',
-                            'text'
+                            'text',
+                            'inlineSvg'
                         ]
                     }
                 ]
@@ -84,7 +87,8 @@ module.exports = function(grunt, options) {
                 exclude: [
                     'core',
                     'bootstraps/app',
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ]
             }
         },
@@ -95,7 +99,8 @@ module.exports = function(grunt, options) {
                 exclude: [
                     'core',
                     'bootstraps/app',
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ]
             }
         },
@@ -106,7 +111,8 @@ module.exports = function(grunt, options) {
                 exclude: [
                     'core',
                     'bootstraps/app',
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ]
             }
         },
@@ -117,7 +123,8 @@ module.exports = function(grunt, options) {
                 exclude: [
                     'core',
                     'bootstraps/app',
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ]
             }
         },
@@ -129,7 +136,8 @@ module.exports = function(grunt, options) {
                     'core',
                     'bootstraps/app',
                     '../../public/javascripts/vendor/stripe/stripe.min',
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ]
             }
         },
@@ -201,7 +209,8 @@ module.exports = function(grunt, options) {
                     }
                 },
                 exclude: [
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ],
                 optimize: 'none',
                 generateSourceMaps: true,
@@ -215,7 +224,8 @@ module.exports = function(grunt, options) {
                 exclude: [
                     'core',
                     'bootstraps/app',
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ]
             }
         },
@@ -227,7 +237,8 @@ module.exports = function(grunt, options) {
                     'core',
                     'bootstraps/app',
                     'bootstraps/commercial',
-                    'text'
+                    'text',
+                    'inlineSvg'
                 ]
             }
         }

--- a/static/src/javascripts/projects/common/views/svgs.js
+++ b/static/src/javascripts/projects/common/views/svgs.js
@@ -1,9 +1,13 @@
 // Include any images needed in templates here.
 // This file is only required by core, and so has a long cache time.
 
-define(function (require) {
+define([
+    'inlineSvg!svgs/marque-36!icon'
+],function (
+    marque36icon
+) {
     var svgs = {
-        marque36icon: require('inlineSvg!svgs/marque-36!icon')
+        marque36icon: marque36icon
     };
 
     return function (name, classes) {

--- a/static/src/javascripts/projects/common/views/svgs.js
+++ b/static/src/javascripts/projects/common/views/svgs.js
@@ -3,7 +3,7 @@
 
 define([
     'inlineSvg!svgs/marque-36!icon'
-],function (
+], function (
     marque36icon
 ) {
     var svgs = {


### PR DESCRIPTION
the `require` method that was being called in `svgs.js` seems to actually runs modules through any plugins that are specified. `inlineSvg!` was not being excluded, so that didn't error, but `text!` was not, so require was trying to load it, hence the 404 error on `text.js`.

this PR:
- excludes `inlineSvg!` from all builds (like `text!`)
- changes `svgs.js` to use standard AMD syntax, which doesn't error if the plugin is missing from the build.

one thing I don't understand is why despite lacking the text plugin (and failing to load it), `svgs.js` could still return the image as needed i.e. why did `require()` need the plugins at all? 

cc @ironsidevsquincy @phamann 
