### PR TITLE
Remove typo

### DIFF
--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -3,7 +3,6 @@ module.exports = function(grunt, options) {
         options: {
             baseUrl: 'static/src/javascripts',
             paths: {
-                bootsraps:            'bootstraps',
                 admin:                'projects/admin',
                 common:               'projects/common',
                 facia:                'projects/facia',


### PR DESCRIPTION
Note how the line I just removed says `bootsraps` instead of `boots_t_raps`.
The app was working perfectly fine right now, so I reckon that line is useless, better remove it than fix it.
