### PR TITLE
reinstate foresee sampling

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/foresee-survey.js
+++ b/static/src/javascripts/projects/common/modules/analytics/foresee-survey.js
@@ -1,10 +1,12 @@
 define([
     'common/utils/config',
-    'common/utils/cookies'
+    'common/utils/cookies',
+    'common/utils/detect'
 ], function (
     config,
-    Cookie
-) {
+    Cookie,
+    detect
+    ) {
 
     function openForesee() {
         require(['js!foresee']);
@@ -13,10 +15,12 @@ define([
     function load() {
 
         var isNetworkFront = config.page.contentType === 'Network Front',
+            sampleRate = detect.isBreakpoint({max: 'mobile'}) ? 0.008 : 0.006, // 0.8% mobile and 0.6% rest
+            sample = Math.random() <= sampleRate,
             hasForcedOptIn = /forceForesee/.test(location.hash);
 
         // the Foresee code is large, we only want to load it in when necessary.
-        if (!Cookie.get('GU_TEST') && !isNetworkFront && (window.openForeseeWhenReady || hasForcedOptIn)) {
+        if (!Cookie.get('GU_TEST') && !isNetworkFront && (window.openForeseeWhenReady || sample || hasForcedOptIn)) {
             openForesee();
         }
 


### PR DESCRIPTION
reverting my change from yesterday. thought we were disabling our sampling completely and passing control to the ad server but apparently not. should have used the switch...
