### PR TITLE
Remove space from empty inline merchandising slot

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -333,10 +333,12 @@
 }
 .ad-slot--im {
     @include box-sizing(border-box);
-    padding-right: $gs-gutter;
-    width: 50%;
-    max-width: $left-column-wide + $gs-gutter;
+    max-width: 50%;
     float: left;
+
+    @include mq(mobileLandscape) {
+        max-width: $left-column-wide + $gs-gutter;
+    }
 }
 .ad-slot--fobadge.ad-slot--im {
     min-width: gs-span(2) + $gs-gutter;

--- a/static/src/stylesheets/module/commercial/_commercial--v-high.scss
+++ b/static/src/stylesheets/module/commercial/_commercial--v-high.scss
@@ -1,23 +1,8 @@
 /* ==========================================================================
    Super-high component styling
    ========================================================================== */
-.commercial.commercial--v-high {
-    .commercial--v-high__header {
-        padding: $gs-baseline/6 $gs-gutter/4;
-
-        .commercial__title {
-            .inline-icon {
-                display: block;
-            }
-            .i-commercial-brand {
-                height: $gs-baseline*1.3333;
-            }
-        }
-    }
-
-    .commercial--v-high__body {
-        padding: $gs-baseline/2 $gs-gutter/4 $gs-baseline;
-    }
+.commercial--v-high {
+    margin-right: $gs-gutter;
 
     .lineitem__image {
         float: none;
@@ -29,4 +14,21 @@
         width: 100%;
         width: calc(100% + #{$gs-gutter/2});
     }
+}
+
+.commercial--v-high__header {
+    padding: $gs-baseline/6 $gs-gutter/4;
+
+    .commercial__title {
+        .inline-icon {
+            display: block;
+        }
+        .i-commercial-brand {
+            height: $gs-baseline*1.3333;
+        }
+    }
+}
+
+.commercial--v-high__body {
+    padding: $gs-baseline/2 $gs-gutter/4 $gs-baseline;
 }


### PR DESCRIPTION
If no ad is served in an inline merchandising slot, you're left with an ugly space

![screen shot 2015-01-29 at 14 31 19](https://cloud.githubusercontent.com/assets/74132/5959163/a1e864ba-a7c3-11e4-966b-94b9c54e6feb.png)

Guess what? Fixed it
