### PR TITLE
Wrap comment count endpoint in a memcached action

### DIFF
--- a/discussion/app/controllers/CommentCountController.scala
+++ b/discussion/app/controllers/CommentCountController.scala
@@ -3,13 +3,13 @@ package controllers
 import model.Cached
 import common.JsonComponent
 import play.api.libs.json.{JsArray, JsObject}
-import play.api.mvc.Action
+import performance.MemcachedAction
 
 object CommentCountController extends DiscussionController {
 
   def commentCountJson(shortUrls: String) = commentCount(shortUrls)
 
-  def commentCount(shortUrls: String) = Action.async {
+  def commentCount(shortUrls: String) = MemcachedAction {
     implicit request =>
       val counts = discussionApi.commentCounts(shortUrls)
       counts map {

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -31,9 +31,11 @@ define([
         defaultTemplate = commentCountTemplate;
 
     function getContentIds() {
-        return _.uniq(_.map(qwery('[' + attributeName + ']'), function (el) {
-            return bonzo(el).attr(attributeName);
-        })).join(',');
+        return _.chain(qwery('[' + attributeName + ']'))
+                    .map(function (el) { return bonzo(el).attr(attributeName); })
+                    .uniq()
+                    .sortBy()
+                    .join(',');
     }
 
     function getContentUrl(node) {


### PR DESCRIPTION
This endpoint currently has a median response time in the 1000s of milliseconds (I regularly see it being returned after 4s) hopefully this will smooth that out a bit.
- Order the ids to ensure we always generate same request
- Wrap action in MemcachedAction

/cc @gklopper @robertberry @janua 
