### PR TITLE
Robust module in commercial.js

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -1,6 +1,7 @@
 define([
     'common/utils/config',
     'common/utils/mediator',
+    'common/utils/robust',
     'common/modules/commercial/article-aside-adverts',
     'common/modules/commercial/article-body-adverts',
     'common/modules/commercial/badges',
@@ -12,6 +13,7 @@ define([
 ], function (
     config,
     mediator,
+    robust,
     articleAsideAdverts,
     articleBodyAdverts,
     badges,
@@ -31,16 +33,16 @@ define([
                 !window.location.hash.match(/[#&]noads(&.*)?$/)
             ) {
                 // load tags
-                thirdPartyTags.init();
-                articleAsideAdverts.init();
-                articleBodyAdverts.init();
-                sliceAdverts.init();
-                frontCommercialComponents.init();
-                badges.init();
-                dfp.init();
+                robust('cm-thirdPartyTags',                function () { thirdPartyTags.init(); });
+                robust('cm-articleAsideAdverts',           function () { articleAsideAdverts.init(); });
+                robust('cm-articleBodyAdverts',            function () { articleBodyAdverts.init(); });
+                robust('cm-sliceAdverts',                  function () { sliceAdverts.init(); });
+                robust('cm-frontCommercialComponents',     function () { frontCommercialComponents.init(); });
+                robust('cm-badges',                        function () { badges.init(); });
+                robust('cm-dfp',                           function () { dfp.init(); });
             }
 
-            mediator.emit('page:commercial:ready');
+            robust('cm-ready',      function () { mediator.emit('page:commercial:ready'); });
         }
     };
 

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -33,16 +33,16 @@ define([
                 !window.location.hash.match(/[#&]noads(&.*)?$/)
             ) {
                 // load tags
-                robust('cm-thirdPartyTags',                function () { thirdPartyTags.init(); });
-                robust('cm-articleAsideAdverts',           function () { articleAsideAdverts.init(); });
-                robust('cm-articleBodyAdverts',            function () { articleBodyAdverts.init(); });
-                robust('cm-sliceAdverts',                  function () { sliceAdverts.init(); });
-                robust('cm-frontCommercialComponents',     function () { frontCommercialComponents.init(); });
-                robust('cm-badges',                        function () { badges.init(); });
-                robust('cm-dfp',                           function () { dfp.init(); });
+                robust('cm-thirdPartyTags',            function () { thirdPartyTags.init(); });
+                robust('cm-articleAsideAdverts',       function () { articleAsideAdverts.init(); });
+                robust('cm-articleBodyAdverts',        function () { articleBodyAdverts.init(); });
+                robust('cm-sliceAdverts',              function () { sliceAdverts.init(); });
+                robust('cm-frontCommercialComponents', function () { frontCommercialComponents.init(); });
+                robust('cm-badges',                    function () { badges.init(); });
+                robust('cm-dfp',                       function () { dfp.init(); });
             }
 
-            robust('cm-ready',      function () { mediator.emit('page:commercial:ready'); });
+            robust('cm-ready', function () { mediator.emit('page:commercial:ready'); });
         }
     };
 

--- a/static/src/javascripts/core.js
+++ b/static/src/javascripts/core.js
@@ -14,6 +14,7 @@ require([
     'common/utils/storage',
     'common/utils/template',
     'common/utils/url',
+    'common/utils/robust',
 
     // shared modules
     'common/modules/analytics/beacon',

--- a/static/src/javascripts/core.js
+++ b/static/src/javascripts/core.js
@@ -11,10 +11,10 @@ require([
     'common/utils/cookies',
     'common/utils/detect',
     'common/utils/mediator',
+    'common/utils/robust',
     'common/utils/storage',
     'common/utils/template',
     'common/utils/url',
-    'common/utils/robust',
 
     // shared modules
     'common/modules/analytics/beacon',


### PR DESCRIPTION
The robust module was added to the commercial.js. Now for example, third party tags throwing an exception should not stop displaying ads.
