### PR TITLE
Weather search fix

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -47,6 +47,7 @@ define([
             handleClick: function (e) {
                 e.preventDefault();
 
+                $('.active').removeClass('active');
                 $(e.currentTarget).addClass('active');
                 this.pushData();
             },

--- a/static/test/javascripts/spec/facia/search-tool.spec.js
+++ b/static/test/javascripts/spec/facia/search-tool.spec.js
@@ -90,11 +90,11 @@ define([
                 spyOn(sut, "track");
                 spyOn(mocks.store['common/utils/mediator'], "emit");
 
-                $(".js-search-tool-list").html("<li><a data-weather-id='292177' data-weather-city='Ufa'></a></li>");
+                $(".js-search-tool-list").html("<li><a class='active'></a><a data-weather-id='292177' data-weather-city='Ufa'></a></li>");
 
                 sut.init();
 
-                bean.fire($(".js-search-tool-list a")[0], "click");
+                bean.fire($(".js-search-tool-list a")[1], "click");
 
                 expect(sut.pushData).toHaveBeenCalled();
                 expect(mocks.store['common/utils/mediator'].emit).toHaveBeenCalledWith('autocomplete:fetch',
@@ -105,6 +105,7 @@ define([
                     }
                 );
                 expect(sut.track).toHaveBeenCalledWith('Ufa');
+                expect($(".active").length).toEqual(1);
             });
 
             it("should not push data after enter without selecting from the list", function() {


### PR DESCRIPTION
We are setting first item in the search to be active as default. So we need to make sure that after making other element active we clear the first one.

Fixing https://github.com/guardian/frontend/issues/8082

![screen shot 2015-01-29 at 16 33 24](https://cloud.githubusercontent.com/assets/2579465/5961496/f0e49f32-a7d4-11e4-828a-2f7b63d76c93.png)
