### PR TITLE
exclude blockquotes from richlink spacefinder rules

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -51,7 +51,7 @@ define([
             minBelow: 250,
             selectors: {
                 ' > h2': {minAbove: detect.getBreakpoint() === 'mobile' ? 20 : 0, minBelow: 200},
-                ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 300},
+                ' > *:not(p):not(h2):not(blockquote)': {minAbove: 35, minBelow: 300},
                 ' .ad-slot': {minAbove: 150, minBelow: 200},
                 ' .element-rich-link': {minAbove: 500, minBelow: 500}
             }


### PR DESCRIPTION
allows for automated rich-links to place closer to blockquotes, e.g:

![image](https://cloud.githubusercontent.com/assets/960919/5977377/5c1a94e0-a88f-11e4-9e92-ff1602a17209.png)
