### PR TITLE
Extend Commercial Switches

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -290,11 +290,11 @@ object Switches {
 
   val AdFeatureExpirySwitch = Switch("Commercial", "enable-expire-ad-features",
     "If this switch is on, ad features with expired line items will return 410s.",
-    safeState = Off, sellByDate = new LocalDate(2015, 2, 4))
+    safeState = Off, sellByDate = new LocalDate(2015, 2, 11))
 
   val EditionAwareLogoSlots = Switch("Commercial", "edition-aware-logo-slots",
     "If this switch is on, logo slots will honour visitor's edition.",
-    safeState = Off, sellByDate = new LocalDate(2015, 2, 4))
+    safeState = Off, sellByDate = new LocalDate(2015, 2, 11))
 
   private def dateInFebruary(day: Int): Interval =
     new Interval(new DateTime(2015, 2, day, 0, 0, DateTimeZone.UTC), Days.ONE)


### PR DESCRIPTION
Deferring these two switches for a week.

They're waiting for business decisions about which ad features have expired and whether sponsorships should be edition-aware.  I'm assuming both decisions will have been made by two weeks' time.
