### PR TITLE
Separate Ad Feature Expiry Switches

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -283,7 +283,11 @@ object Switches {
     safeState = Off, sellByDate = never)
 
   val AdFeatureExpirySwitch = Switch("Commercial", "enable-expire-ad-features",
-    "If this switch is on, ad features with expired line items will return 410s.",
+    "If this switch is on, expired ad features will be redirected.",
+    safeState = Off, sellByDate = new LocalDate(2015, 2, 11))
+
+  val LegacyAdFeatureExpirySwitch = Switch("Commercial", "enable-expire-legacy-ad-features",
+    "If this switch is on, expired legacy ad features will be redirected.",
     safeState = Off, sellByDate = new LocalDate(2015, 2, 11))
 
   val EditionAwareLogoSlots = Switch("Commercial", "edition-aware-logo-slots",

--- a/common/test/dfp/PaidForTagAgentTest.scala
+++ b/common/test/dfp/PaidForTagAgentTest.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.{Tag => ApiTag}
 import com.gu.facia.client.models.CollectionConfigJson
 import common.Edition.defaultEdition
 import common.editions.Us
-import conf.Switches.EditionAwareLogoSlots
+import conf.Switches.{EditionAwareLogoSlots, LegacyAdFeatureExpirySwitch}
 import model.Tag
 import org.joda.time.DateTime
 import org.scalatest.Inspectors._
@@ -559,6 +559,7 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
   }
 
   it should "be true for a page with ad-feature tone and no logo" in {
+    LegacyAdFeatureExpirySwitch.switchOn()
     val tags = Seq(adFeatureTone)
     TestPaidForTagAgent.isExpiredAdvertisementFeature("pageId", tags, None) should be(true)
   }


### PR DESCRIPTION
So that we can switch on redirect of ad features we know have expired, and continue to consider the legacy ad features that we're not sure about.
