### PR TITLE
CSS logging: bookmarklet

### DIFF
--- a/admin/app/views/cssReport.scala.html
+++ b/admin/app/views/cssReport.scala.html
@@ -12,19 +12,33 @@
             position: fixed;
             width: 100%;
             top: 0;
-            left: 0;
+            right: 0;
             padding-left: 15px;
             background: #fff;
             box-shadow: 0px 0px 5px #999;
         }
-        .css-reports-navbar .title {
+        .css-reports-navbar > * {
             float: right;
-            margin: 10px 0;
+            margin: 10px 20px 10px 0;
+            line-height: 30px;
+            font-size: 12px;
+            color: #999;
+        }
+        .css-reports-navbar .title {
             color: #666;
             font-size: 20px;
+            margin-top: 8px;
+        }
+        .css-reports-navbar__inner {
+            position: fixed;
+            top: 0;
+            left: 0;
+            background: #fff;
+            border-right: 1px solid #eee;
+            height: 49px;
+            overflow: hidden;
         }
         .days {
-            float: right;
             margin: 16px 20px 0 10px;
         }
         .selectors {
@@ -34,7 +48,7 @@
             padding: 65px 0 200px 0;
         }
         .alphas {
-            margin: 15px 0;
+            margin: 15px;
             float: left;
         }
         .alphas span {
@@ -83,6 +97,14 @@
     <script src="@routes.Assets.at("javascripts/components/react/react.js")"></script>
     <script src="@routes.Assets.at("javascripts/components/lodash/lodash.js")"></script>
 
+    <div class="css-reports-navbar">
+        <div>
+            bookmarklet:
+            <a href="javascript:(function()%7Bif(window.guardian)%7Bwindow.guardian.api.logCss(true)%7Delse%7Bconsole.log('Not a guardian page%3F')%7D%7D)()">Log CSS</a>
+        </div>
+    <div class="title">CSS selector usage</div>
+    </div>
+
     <div class="js-selectors">Loading...</div>
 
     <script>
@@ -114,10 +136,8 @@
                     starts = this.state.starts;
 
                 return React.DOM.div({onClick: this.handleClick}, [
-                    React.DOM.div({className: 'css-reports-navbar'}, [
+                    React.DOM.div({className: 'css-reports-navbar__inner'}, [
                         React.createElement(dayPicker, this.props),
-                        React.DOM.div({className: 'title'}, 'CSS selector usage :'),
-                        React.DOM.a({href: "javascript:(function()%7Bif(window.guardian)%7Bwindow.guardian.api.logCss(true)%7Delse%7Bconsole.log('Not a guardian page%3F')%7D%7D)()"}, 'Log CSS'),
                         React.DOM.div({className: 'alphas'},
                             _.reduce('abcdefghijklmnopqrstuvwxyz', function(acc, a, i) {
                                 acc['_' + i] = React.DOM.span({className: 'starts'}, a);

--- a/admin/app/views/cssReport.scala.html
+++ b/admin/app/views/cssReport.scala.html
@@ -117,6 +117,7 @@
                     React.DOM.div({className: 'css-reports-navbar'}, [
                         React.createElement(dayPicker, this.props),
                         React.DOM.div({className: 'title'}, 'CSS selector usage :'),
+                        React.DOM.a({href: "javascript:(function()%7Bif(window.guardian)%7Bwindow.guardian.api.logCss(true)%7Delse%7Bconsole.log('Not a guardian page%3F')%7D%7D)()"}, 'Log CSS'),
                         React.DOM.div({className: 'alphas'},
                             _.reduce('abcdefghijklmnopqrstuvwxyz', function(acc, a, i) {
                                 acc['_' + i] = React.DOM.span({className: 'starts'}, a);

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -76,7 +76,7 @@ define([
     Omniture,
     register,
     ScrollDepth,
-    cssLogging,
+    logCss,
     userAdTargeting,
     crosswordThumbnails,
     CommentCount,
@@ -406,7 +406,14 @@ define([
 
             runCssLogging: function () {
                 if (config.switches.cssLogging) {
-                    mediator.on('page:common:ready', cssLogging);
+                    mediator.on('page:common:ready', logCss);
+                }
+            },
+
+            initPublicApi: function () {
+                // BE CAREFUL what you expose here...
+                window.guardian.api = {
+                    logCss: logCss
                 }
             }
 
@@ -448,6 +455,8 @@ define([
             robust('c-onward',          function () { modules.transcludeOnwardContent(); });
             robust('c-overlay',         function () { modules.initOpenOverlayOnClick(); });
             robust('c-css-logging',     function () { modules.runCssLogging(); });
+            robust('c-public-api',      function () { modules.initPublicApi(); });
+
             robust('c-crosswords',      function () { crosswordThumbnails.init(); });
 
             robust('c-ready', function () { mediator.emit('page:common:ready'); });

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -414,7 +414,7 @@ define([
                 // BE CAREFUL what you expose here...
                 window.guardian.api = {
                     logCss: logCss
-                }
+                };
             }
 
         },

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -72,19 +72,19 @@ define([
     }
 
     function makeSender(sendAll) {
-        return _.debounce(function (clickSpec) {
+        return function (clickSpec) {
             if (!clickSpec || clickSpec.samePage) {
                 setTimeout(function () {
                     _.each(sendAll ? getStylesheets() : [getRandomStylesheet()], function (stylesheet) {
                         sendReport(stylesheet, sendAll);
                     });
-                }, _.random(0, 3000));
+                }, sendAll ? 0 : _.random(0, 3000));
             }
-        }, 300);
+        };
     }
 
-    return function () {
-        var sendAll = window.location.hash === '#csslogging',
+    return function (sendAll) {
+        var sendAll = sendAll || window.location.hash === '#csslogging',
             sender;
 
         if (sendAll || _.random(1, 5000) === 1) {
@@ -92,6 +92,7 @@ define([
             sender();
             mediator.on('module:clickstream:interaction', sender);
             mediator.on('module:clickstream:click', sender);
+            return true;
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -84,8 +84,9 @@ define([
     }
 
     return function (sendAll) {
-        var sendAll = sendAll || window.location.hash === '#csslogging',
-            sender;
+        var sender;
+
+        sendAll = sendAll || window.location.hash === '#csslogging';
 
         if (sendAll || _.random(1, 5000) === 1) {
             sender = makeSender(sendAll);


### PR DESCRIPTION
Adds a bookmarklet to manually log CSS usage from any Guardian page. Especially useful after an on-page interaction, to select against a modified DOM.

![screen shot 2015-01-30 at 16 18 34](https://cloud.githubusercontent.com/assets/1147913/5978949/6b9bd184-a89b-11e4-8322-db07a93a562b.png)

**Possibly controversial**: adds an `api` object to `window.guardian` to expose a specific inner method. Can be useful for debugging. Am I being naive?

@rich-nguyen @phamann @robertberry 
