### PR TITLE
s/Noriwch/Norwich

### DIFF
--- a/facia/public/humans.txt
+++ b/facia/public/humans.txt
@@ -58,7 +58,7 @@ Developer: Justin Pinner
 Twitter: @_JustinPinner
 
 Client-side Developer: Alex Sanders
-Location: London/Noriwch
+Location: London/Norwich
 Twitter: @asanders
 
 Director of Digital Strategy: Wolfgang Blau


### PR DESCRIPTION
Fixes a typo - s/Noriwch/Norwich. I'm sure there's an Alan Partridge joke in here somewhere... disappointed in myself that I can't find one. In more serious news, great work on the [contributor guidelines](https://github.com/guardian/frontend/blob/master/CONTRIBUTING.md), and having so much open on GitHub.com.
