### PR TITLE
Show MPU on t-t-mpu slice

### DIFF
--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -319,15 +319,3 @@
         margin-right: 0;
     }
 }
-
-// Temporary hack, as MPU candidate is broken on tablet
-.fc-slice--t-t-mpu .fc-slice__item--mpu-candidate {
-    @include mq(tablet, desktop) {
-        display: none;
-
-        // have to do this here, too, or DFP still makes the call
-        .ad-slot {
-            display: none;
-        }
-    }
-}

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -153,6 +153,22 @@ Hence why a greater depth of selector specificity is needed.
     }
 }
 
+.fc-slice--t-t-mpu {
+    @include mq(tablet, desktop) {
+        .fc-slice__item {
+            width: 25%;
+
+            .fc-item__title {
+                @include fs-headline(2, true);
+            }
+        }
+
+        .fc-slice__item--mpu-candidate {
+            width: 50%;
+        }
+    }
+}
+
 .fc-slice--t-tl-mpu {
     @include mq(tablet, $until: desktop) {
         > .fc-slice__item {


### PR DESCRIPTION
Before the mpu in this slice was cropped, we hid it as a temporary measure on Friday but this is a more permanent fix (although isn't visually optimal in anyway). I've looked at this in multiple browsers but can't provide browserstack screenshot url as it doesn't let me resize the browser small enough in that mode.

Before:
![screen shot 2015-02-02 at 12 04 38](https://cloud.githubusercontent.com/assets/1607666/6000246/bb9f7bec-aad3-11e4-947e-5ee6828f51af.png)

Before (post-hiding):
![screen shot 2015-02-02 at 12 02 37](https://cloud.githubusercontent.com/assets/1607666/6000239/9be27174-aad3-11e4-82f2-8c2d7983c565.png)

After:
![screen shot 2015-02-02 at 12 01 40](https://cloud.githubusercontent.com/assets/1607666/6000240/9e8bbc0a-aad3-11e4-8862-a2ce1c01783f.png)
