### PR TITLE
Hide standfirst for HL4-H

### DIFF
--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -24,6 +24,12 @@ Hence why a greater depth of selector specificity is needed.
 
         .fc-item--half-tablet {
             @include vertical-item-separator;
+
+            .fc-item__standfirst {
+                @include mq(desktop) {
+                    display: none;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The standfirst on desktop was always causing strange gaps no matter how well the editors trimmed down the text. This hides it from `desktop`.

cc @Pearson82 

Before:
![screen shot 2015-02-02 at 12 21 58](https://cloud.githubusercontent.com/assets/1607666/6000493/5da0db32-aad6-11e4-9074-26d364e02b98.png)

After:
![screen shot 2015-02-02 at 12 21 31](https://cloud.githubusercontent.com/assets/1607666/6000491/5cb1c24a-aad6-11e4-9fac-7e7f6234d33b.png)
