### PR TITLE
Comment discussion limit size

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -56,10 +56,11 @@ object CommentsController extends DiscussionController {
       Cached(60) {
         if (request.isJson) {
           JsonComponent(
-            "commentsHtml" -> views.html.discussionComments.commentsList(page, false).toString,
+            "commentsHtml" -> views.html.discussionComments.commentsList(page, renderPagination = false).toString,
             "paginationHtml" -> views.html.fragments.commentPagination(page).toString,
             "postedCommentHtml" -> views.html.fragments.comment(BlankComment()).toString,
-            "lastPage" -> comments.pagination.lastPage
+            "lastPage" -> comments.pagination.lastPage,
+            "commentCount" -> comments.commentCount
           )
         } else {
           Ok(views.html.discussionComments.discussionPage(page))

--- a/discussion/app/discussion/CommentPage.scala
+++ b/discussion/app/discussion/CommentPage.scala
@@ -18,6 +18,7 @@ trait CommentPage extends Page {
   lazy val orderBy = discussionComments.orderBy
   lazy val isClosedForRecommendation = discussion.isClosedForRecommendation
   lazy val switches = discussionComments.switches
+  lazy val isLargeDiscussion = commentCount > 1000
 }
 
 case class ThreadedCommentPage(val discussionComments: DiscussionComments)

--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -3,10 +3,13 @@
 <div class="d-discussion @if(!page.isClosedForRecommendation){d-discussion--recommendations-open} u-cf"
     @page.switches.map{ switch => data-@switch.name="@switch.state" }>
 
-    <ul class="d-thread d-thread--top-level">
+    <ul class="d-thread">
+        @userMessageForLargeDiscussion
+
         @page.comments.map { comment =>
             @fragments.comment(comment, page.isClosedForRecommendation, false)
         }
+
     </ul>
 
     <div class="discussion__pagination discussion__pagination--bottom">
@@ -15,3 +18,11 @@
 
     @fragments.reportComment()
 </div>
+
+@userMessageForLargeDiscussion = {
+    @if(page.isLargeDiscussion){
+        <div class="d-discussion__size-message">
+            Due to the large number, comments are being shown 100 per page.
+        </div>
+    }
+}

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -1,3 +1,4 @@
+/*jshint -W024 */
 define([
     'bean',
     'bonzo',
@@ -7,6 +8,7 @@ define([
 
     'common/utils/$',
     'common/utils/ajax-promise',
+    'common/utils/config',
     'common/utils/mediator',
     'common/utils/scroller',
 
@@ -24,6 +26,7 @@ define([
 
     $,
     ajaxPromise,
+    config,
     mediator,
     scroller,
 
@@ -151,27 +154,32 @@ Comments.prototype.fetchComments = function(options) {
         queryParams.maxResponses = 3;
     }
 
-    // If the caller specified truncation, do not load all comments.
-    if (options.shouldTruncate && queryParams.pageSize === 'All') {
-        queryParams.pageSize = 10;
-    }
-
-    var promise;
-    if (queryParams.pageSize === 'All') {
-        promise = new WholeDiscussion({
-            discussionId: this.options.discussionId,
-            orderBy: queryParams.orderBy,
-            displayThreaded: queryParams.displayThreaded,
-            maxResponses: queryParams.maxResponses
-        }).loadAllComments();
-    } else {
-        promise = ajaxPromise({
+    var promise,
+        ajaxParams = {
             url: url,
             type: 'json',
             method: 'get',
             crossOrigin: true,
             data: queryParams
-        });
+        };
+    if (this.isAllPageSizeActive()) {
+        promise = new WholeDiscussion({
+            discussionId: this.options.discussionId,
+            orderBy: queryParams.orderBy,
+            displayThreaded: queryParams.displayThreaded,
+            maxResponses: queryParams.maxResponses
+        }).loadAllComments().catch(function() {
+            this.wholeDiscussionErrors = true;
+            queryParams.pageSize = 100;
+            return ajaxPromise(ajaxParams);
+            }.bind(this));
+    } else {
+        // It is possible that the user has chosen to view all comments,
+        // but the WholeDiscussion module has failed. Fall back to 100 comments.
+        if (queryParams.pageSize === 'All') {
+            queryParams.pageSize = 100;
+        }
+        promise = ajaxPromise(ajaxParams);
     }
     return promise.then(this.renderComments.bind(this)).then(this.goToPermalink.bind(this, options.comment));
 };
@@ -438,6 +446,19 @@ Comments.prototype.addUser = function(user) {
 
 Comments.prototype.relativeDates = function() {
     relativedates.init();
+};
+
+Comments.prototype.isAllPageSizeActive = function() {
+    return config.switches.discussionAllPageSize &&
+    this.options.pagesize === 'All' &&
+    !this.wholeDiscussionErrors;
+};
+
+Comments.prototype.shouldShowPageSizeMessage = function() {
+    // Similar to above, but tells the loader that the fallback size should be used.
+    return config.switches.discussionAllPageSize &&
+    this.options.pagesize === 'All' &&
+    this.wholeDiscussionErrors;
 };
 
 return Comments;

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -112,7 +112,7 @@ Loader.prototype.initMainComments = function() {
             container = $('.js-discussion-pagination', toolbarEl).empty();
 
         // When the pagesize is 'All', do not show any pagination.
-        if (this.comments.options.pagesize !== 'All') {
+        if (!this.comments.isAllPageSizeActive()) {
             container.html(newPagination);
         }
     }.bind(this));
@@ -394,6 +394,11 @@ Loader.prototype.loadComments = function(options) {
 
     this.setState('loading');
 
+    // If the caller specified truncation, do not load all comments.
+    if (options && options.shouldTruncate && this.comments.isAllPageSizeActive()) {
+        options.pageSize = 10;
+    }
+
     return this.comments.fetchComments(options)
     .then(function(){
         this.removeState('loading');
@@ -403,13 +408,18 @@ Loader.prototype.loadComments = function(options) {
             // do not call removeTruncation because it could invoke another fetch.
             this.removeState('truncated');
         }
+        if (this.comments.shouldShowPageSizeMessage()){
+            this.setState('pagesize-msg-show');
+        } else {
+            this.removeState('pagesize-msg-show');
+        }
     }.bind(this));
 };
 
 Loader.prototype.removeTruncation = function() {
 
     // When the pagesize is 'All', the full page is not yet loaded, so load the comments.
-    if (this.comments.options.pagesize === 'All') {
+    if (this.comments.isAllPageSizeActive()) {
         this.loadComments();
     } else {
         this.removeState('truncated');

--- a/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
@@ -17,7 +17,9 @@ define([
 ) {
     // This size effectively determines how many calls this module needs to make.
     // Number of ajax calls = number of comments / comments per page
-    var commentsPerPage = 50, concurrentLimit = 3;
+    var commentsPerPage = 50,
+        concurrentLimit = 3,
+        maximumCommentCount = 1000;
 
     // A basic Promise queue based on: http://talks.joneisen.me/presentation-javascript-concurrency-patterns/refactoru-9-23-2014.slide#25
     function runConcurrently(workFunction, items) {
@@ -69,6 +71,11 @@ define([
         this.discussionContainer = $('ul', bonzo.create(resp.commentsHtml)).empty();
         this.postedCommentHtml = resp.postedCommentHtml;
         this.lastPage = resp.lastPage;
+
+        // Decide if this discussion is too big to load the remaining pages for.
+        if (resp.commentCount > maximumCommentCount) {
+            throw new Error('Discussion comment count too large');
+        }
 
         // Return a collection of the indices of the remaining pages.
         return _.range(2, this.lastPage + 1);

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -103,6 +103,26 @@ $avatarPadding: $gs-gutter / 2;
     margin: 0;
 }
 
+.d-discussion__size-message {
+    display: none;
+}
+
+.discussion--pagesize-msg-show {
+
+    .d-discussion__size-message {
+        @include fs-textSans(2);
+        margin-bottom: $gs-baseline * 2 / 3;
+        border-top: 1px solid colour(neutral-4);
+        padding-top: $gs-baseline;
+        color: colour(neutral-2);
+        display: block;
+
+        & + .d-comment {
+            border-top: 0;
+        }
+    }
+}
+
 .discussion__heading {
     margin-bottom: 0;
     padding-top: 0;
@@ -142,8 +162,6 @@ $avatarPadding: $gs-gutter / 2;
         display: block;
     }
 }
-
-
 
 .discussion__show-button {
     display: none;


### PR DESCRIPTION
Adds functionality that limits the size of discussions that can work with the 'all' option.
![screen shot 2015-02-03 at 12 43 35](https://cloud.githubusercontent.com/assets/4549425/6020387/5c679aa8-aba3-11e4-8ae1-e4c539bc1354.png)
