### PR TITLE
Beacon discussion timeouts

### DIFF
--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -12,7 +12,7 @@
     "curl": "~0.8.9",
     "qwery": "3.4.2",
     "react": "0.11.2",
-    "reqwest": "guardian/reqwest#master",
+    "reqwest": "1.1.5",
     "enhancer": "0.1.1",
     "videojs": "guardian/video.js#158221b5d997a184972fbf038c9eebdb676d30c8",
     "videojs-contrib-ads": "videojs/videojs-contrib-ads#f44387a4d2fd939f9a665762917e2fa6fc8838d7",

--- a/static/src/javascripts/components/reqwest/reqwest.js
+++ b/static/src/javascripts/components/reqwest/reqwest.js
@@ -13,7 +13,8 @@
   var win = window
     , doc = document
     , httpsRe = /^http/
-    , twoHundo = /^(20\d|1223)$/
+    , protocolRe = /(^\w+):\/\//
+    , twoHundo = /^(20\d|1223)$/ //http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
     , byTag = 'getElementsByTagName'
     , readyState = 'readyState'
     , contentType = 'Content-Type'
@@ -68,8 +69,10 @@
         }
       }
 
-  function succeed(request) {
-    return httpsRe.test(window.location.protocol) ? twoHundo.test(request.status) : !!request.response;
+  function succeed(r) {
+    var protocol = protocolRe.exec(r.url);
+    protocol = (protocol && protocol[1]) || window.location.protocol;
+    return httpsRe.test(protocol) ? twoHundo.test(r.request.status) : !!r.request.response;
   }
 
   function handleReadyState(r, success, error) {
@@ -77,9 +80,10 @@
       // use _aborted to mitigate against IE err c00c023f
       // (can't read props on aborted request objects)
       if (r._aborted) return error(r.request)
+      if (r._timedOut) return error(r.request, 'Request is aborted: timeout')
       if (r.request && r.request[readyState] == 4) {
         r.request.onreadystatechange = noop
-        if (succeed(r.request)) success(r.request)
+        if (succeed(r)) success(r.request)
         else
           error(r.request)
       }
@@ -94,7 +98,7 @@
       || defaultHeaders['accept'][o['type']]
       || defaultHeaders['accept']['*']
 
-    var isAFormData = typeof FormData === "function" && (o['data'] instanceof FormData);
+    var isAFormData = typeof FormData === 'function' && (o['data'] instanceof FormData);
     // breaks cross-origin requests with legacy browsers
     if (!o['crossOrigin'] && !headers[requestedWith]) headers[requestedWith] = defaultHeaders['requestedWith']
     if (!headers[contentType] && !isAFormData) headers[contentType] = o['contentType'] || defaultHeaders['contentType']
@@ -263,7 +267,7 @@
 
     if (o['timeout']) {
       this.timeout = setTimeout(function () {
-        self.abort()
+        timedOut()
       }, o['timeout'])
     }
 
@@ -294,7 +298,7 @@
     }
 
     function success (resp) {
-      var type = o['type'] || setType(resp.getResponseHeader('Content-Type'))
+      var type = o['type'] || resp && setType(resp.getResponseHeader('Content-Type')) // resp can be undefined in IE
       resp = (type !== 'jsonp') ? self.request : resp
       // use global data filter on response text
       var filteredResponse = globalSetupOptions.dataFilter(resp.responseText, type)
@@ -339,6 +343,11 @@
       }
 
       complete(resp)
+    }
+
+    function timedOut() {
+      self._timedOut = true
+      self.request.abort()      
     }
 
     function error(resp, msg, t) {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -154,16 +154,24 @@ Loader.prototype.initMainComments = function() {
         this.loadComments({
             comment: commentId,
             shouldTruncate: shouldTruncate})
-            .catch(function(err) {
-                var reportMsg = 'Comments failed to load: ' + ('status' in err ? err.status : '');
+            .catch(function(error) {
+                var reportMsg = 'Comments failed to load: ',
+                    request = error.request;
+                if (error.message === 'Request is aborted: timeout') {
+                    reportMsg += 'XHR timeout';
+                } else if (error.message) {
+                    reportMsg += error.message;
+                } else {
+                    reportMsg += 'status' in request ? request.status : '';
+                }
                 raven.captureMessage(reportMsg, {
                     tags: {
                         contentType: 'comments',
                         discussionId: this.getDiscussionId(),
-                        status: 'status' in err ? err.status : '',
-                        readyState: 'readyState' in err ? err.readyState : '',
-                        response: 'response' in err ? err.response : '',
-                        statusText: 'status' in err ? err.statusText : ''
+                        status: 'status' in request ? request.status : '',
+                        readyState: 'readyState' in request ? request.readyState : '',
+                        response: 'response' in request ? request.response : '',
+                        statusText: 'status' in request ? request.statusText : ''
                     }
                 });
             }.bind(this));

--- a/static/src/javascripts/projects/common/utils/ajax-promise.js
+++ b/static/src/javascripts/projects/common/utils/ajax-promise.js
@@ -11,8 +11,10 @@ define([
             .then(function (value) {
                 resolve(value);
             })
-            .fail(function (err) {
-                reject(err);
+            .fail(function (request, text, err) {
+                var error = err ? err : new Error(text);
+                error.request = request;
+                reject(error);
             });
         });
         return promise;


### PR DESCRIPTION
Modifies the error handler for discussion load errors, so that we can distinguish between timeouts from the backend (sometimes appear as 499 status codes via nginx) and other general errors
