### PR TITLE
Hide show more button on article related containers at mobile breakpoint

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -774,3 +774,8 @@
         margin-top: $gs-baseline;
     }
 }
+
+.related .button--show-more {
+    display: none;
+}
+


### PR DESCRIPTION
Prevents these shenanigans:

![moremoremore](https://cloud.githubusercontent.com/assets/1001642/6038164/a7e23f06-ac52-11e4-94dd-7c9e5e82b0d6.png)
