### PR TITLE
removing jumping when below nav ad is present

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -37,9 +37,6 @@
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
         @if(showAdverts) {
-            @if(adBelowNav) {
-                <style type="text/css">.top-banner-ad-container--desktop #dfp-ad--top-above-nav {padding-bottom:0; min-height:0; height: 0;} .top-banner-ad-container--below-nav #dfp-ad--top-below-nav {min-height: 42px;}</style>
-            }
             @fragments.commercial.topBanner()
         }
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -292,7 +292,7 @@ define([
                 callbacks[size] && callbacks[size](event, $slot);
 
                 if (!($slot.hasClass('ad-slot--top-above-nav') && size === '1,1')) {
-                    $slot.parent().css('display','block');
+                    $slot.parent().css('display', 'block');
                 }
             }
         },

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -290,6 +290,10 @@ define([
                 size = event.size.join(',');
                 // is there a callback for this size
                 callbacks[size] && callbacks[size](event, $slot);
+
+                if (!($slot.hasClass('ad-slot--top-above-nav') && size === '1,1')) {
+                    $slot.parent().css('display','block');
+                }
             }
         },
         allAdsRendered = function (slotId) {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -59,8 +59,12 @@
 }
 .top-banner-ad-container--desktop {
     background-color: colour(neutral-8);
-    border-bottom: 1px solid colour(neutral-4);
+    border-bottom: 2px solid colour(neutral-4);
     display: none;
+
+    &.top-banner-ad-container--below-nav {
+        border-bottom: 0;
+    }
 
     .ad-slot__label {
         /* this is the minimum width of possible ads sizes */

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -46,12 +46,20 @@
 /**
  * Banner ads
  */
+
+.js-on {
+    .top-banner-ad-container--desktop.top-banner-ad-container--above-nav,
+    .ad-below-nav .ad-slot--top-below-nav {
+        display: none;
+    }
+}
+
 .top-banner-ad-container--mobile {
     background-color: #f0f0f0;
 }
 .top-banner-ad-container--desktop {
     background-color: colour(neutral-8);
-    border-bottom: 2px solid colour(neutral-4);
+    border-bottom: 1px solid colour(neutral-4);
     display: none;
 
     .ad-slot__label {


### PR DESCRIPTION
This removes the white space above the nav when we have an ad below the nav, this space then collapses when the below nav ad comes in and isn't a good experience.

The down side is that when we are running with ads above the navigation they have to start with a height of 0 and then open up. (Presently this slot starts at 90px high and sometimes goes to 250 if there is a large ad.)

Functionality will be reverted once Apple campaign is over.
