### PR TITLE
Remove space in navigation hover

### DIFF
--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -36,8 +36,7 @@
                     </nav>
                 </div>
                 <a class="navigation__toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-header">
-                    <i class="burger-icon"></i>
-                    <span class="navigation__toggle-label navigation__toggle-label--open"
+                    <i class="burger-icon"></i><span class="navigation__toggle-label navigation__toggle-label--open"
                           aria-haspopup="true" aria-controls="all-sections-popup" aria-label="browse all sections"><span class="navigation__toggle-label__extra navigation__toggle-label__extra--browse">browse </span>all<span class="navigation__toggle-label__extra"> sections</span></span>
                     <span class="navigation__toggle-label navigation__toggle-label--close" aria-label="close all sections">close</span>
                 </a>


### PR DESCRIPTION
Stupid HTML. Fixes this: https://github.com/guardian/frontend/issues/8062

cc @kaelig

![screen recording 2015-02-04 at 04 33 pm](https://cloud.githubusercontent.com/assets/1607666/6044530/b7547de4-ac8b-11e4-93c7-4453930a98ab.gif)
