### PR TITLE
Add Series to Container Logo Targeting

### DIFF
--- a/common/app/dfp/PaidForTagAgent.scala
+++ b/common/app/dfp/PaidForTagAgent.scala
@@ -164,8 +164,10 @@ trait PaidForTagAgent {
     findWinningTagPair(currentPaidForTags, capiTags, maybeSectionId, None) map (_.capiTag)
   }
 
-  def sponsorshipTag(config: CollectionConfig): Option[String] = {
-    findContainerCapiTagIdAndDfpTag(config) map (_.capiTagId)
+  def sponsorshipTag(config: CollectionConfig): Option[SponsorshipTag] = {
+    findContainerCapiTagIdAndDfpTag(config) map { tagPair =>
+      SponsorshipTag(tagPair.dfpTag.tagType, tagPair.capiTagId)
+    }
   }
 
   private def isExpiredAdvertisementFeature(pageId: String,
@@ -243,3 +245,5 @@ trait PaidForTagAgent {
 sealed case class CapiTagAndDfpTag(capiTag: Tag, dfpTag: PaidForTag)
 
 sealed case class CapiTagIdAndDfpTag(capiTagId: String, dfpTag: PaidForTag)
+
+case class SponsorshipTag(tagType: TagType, tagId: String)

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -2,7 +2,7 @@ package layout
 
 import com.gu.facia.client.models.{CollectionConfigJson => CollectionConfig}
 import conf.Switches
-import dfp.DfpAgent
+import dfp.{DfpAgent, SponsorshipTag}
 import model._
 import org.joda.time.DateTime
 import services.CollectionConfigWithId
@@ -13,7 +13,7 @@ import scala.Function._
 
 /** For de-duplicating cutouts */
 object ContainerLayoutContext {
-  val empty = ContainerLayoutContext(Set.empty, false)
+  val empty = ContainerLayoutContext(Set.empty, hideCutOuts = false)
 }
 
 case class ContainerLayoutContext(
@@ -99,20 +99,12 @@ object ContainerCommercialOptions {
     DfpAgent.sponsorshipType(config)
   )
 
-  def fromMetaData(metaData: MetaData) = ContainerCommercialOptions(
-    metaData.isSponsored(),
-    metaData.isAdvertisementFeature,
-    metaData.isFoundationSupported,
-    metaData.sponsor,
-    metaData.sponsorshipType
-  )
-
   val empty = ContainerCommercialOptions(
-    false,
-    false,
-    false,
-    None,
-    None
+    isSponsored = false,
+    isAdvertisementFeature = false,
+    isFoundationSupported = false,
+    sponsorshipTag = None,
+    sponsorshipType = None
   )
 }
 
@@ -120,7 +112,7 @@ case class ContainerCommercialOptions(
   isSponsored: Boolean,
   isAdvertisementFeature: Boolean,
   isFoundationSupported: Boolean,
-  sponsorshipTag: Option[String],
+  sponsorshipTag: Option[SponsorshipTag],
   sponsorshipType: Option[String]
 ) {
   val isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
@@ -188,8 +180,8 @@ object FaciaContainer {
     },
     None,
     None,
-    false,
-    false,
+    hideToggle = false,
+    showTimestamps = false,
     None
   )
 
@@ -233,7 +225,7 @@ case class FaciaContainer(
   }
 
   def latestUpdate = (collectionEssentials.items.map(_.webPublicationDate) ++
-    collectionEssentials.lastUpdated.map(DateTime.parse(_))).sortBy(-_.getMillis).headOption
+    collectionEssentials.lastUpdated.map(DateTime.parse)).sortBy(-_.getMillis).headOption
 
   def items = collectionEssentials.items
 

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,10 +1,10 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties = model.FrontProperties.empty)(implicit request: RequestHeader)
 
-@import views.support.GetClasses
-@import views.html.fragments.containers.facia_cards.{standardContainer, navListContainer, navMediaListContainer, mostPopularContainer}
-@import slices.{Dynamic, Fixed, NavList, NavMediaList, MostPopular}
-@import fragments.containers.facia_cards.containerMetaData
+@import dfp.{Keyword, Series}
 @import layout.MetaDataHeader
+@import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList}
+@import views.html.fragments.containers.facia_cards.{containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
+@import views.support.GetClasses
 
 @defining(containerDefinition.displayName, containerDefinition.faciaComponentName) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
@@ -17,8 +17,11 @@
              class="@GetClasses.forContainerDefinition(containerDefinition)"
              data-link-name="@{containerDefinition.index + 1} | @componentName"
              data-id="@containerDefinition.dataId"
-             @containerDefinition.commercialOptions.sponsorshipTag.map { keyword =>
-                 data-keywords="@keyword"
+             @for(tag <- containerDefinition.commercialOptions.sponsorshipTag) {
+                 @tag.tagType match {
+                     case Series => { data-series="@{tag.tagId}" }
+                     case Keyword => { data-keywords="@{tag.tagId}" }
+                 }
              }
              @containerDefinition.commercialOptions.sponsorshipType.map { sponsorshipType =>
                  data-sponsorship="@sponsorshipType"

--- a/static/src/javascripts/projects/common/modules/commercial/badges.js
+++ b/static/src/javascripts/projects/common/modules/commercial/badges.js
@@ -51,8 +51,12 @@ define([
                 slotTarget  = badgeConfig.namePrefix + 'badge',
                 name        = slotTarget + (++badgeConfig.count),
                 $adSlot     = bonzo(createAdSlot(
-                    name, ['paid-for-badge', 'paid-for-badge--front'], opts.keywords, slotTarget
-                ));
+                                name,
+                                ['paid-for-badge', 'paid-for-badge--front'],
+                                opts.series,
+                                opts.keywords,
+                                slotTarget
+                              ));
 
             addPreBadge($adSlot, badgeConfig.header, opts.sponsor);
             $('.js-container__header', container)
@@ -87,6 +91,7 @@ define([
                         $container.data('sponsorship'),
                         {
                             sponsor:  $container.data('sponsor'),
+                            series:   $container.data('series'),
                             keywords: $container.data('keywords')
                         }
                     );
@@ -111,6 +116,7 @@ define([
                         $container.data('sponsorship'),
                         {
                             sponsor:  $container.data('sponsor'),
+                            series:   $container.data('series'),
                             keywords: $container.data('keywords')
                         }
                     );

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -92,7 +92,7 @@ define([
         }
     };
 
-    return function (name, types, keywords, slotTarget) {
+    return function (name, types, series, keywords, slotTarget) {
         var attrName,
             definition = adSlotDefinitions[slotTarget ? slotTarget : name],
             dataAttrs  = {
@@ -120,6 +120,9 @@ define([
         }
         if (slotTarget) {
             $adSlot.attr('data-slot-target', slotTarget);
+        }
+        if (series) {
+            $adSlot.attr('data-series', series);
         }
         if (keywords) {
             $adSlot.attr('data-keywords', keywords);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -258,6 +258,10 @@ define([
                     .defineSizeMapping(sizeMapping)
                     .setTargeting('slot', slotTarget);
 
+            if ($adSlot.data('series')) {
+                slot.setTargeting('se', parseKeywords($adSlot.data('series')));
+            }
+
             if ($adSlot.data('keywords')) {
                 slot.setTargeting('k', parseKeywords($adSlot.data('keywords')));
             }


### PR DESCRIPTION
This change modifies our ad calls so that containers are able to target series as well as keywords.

For example, on [this page](http://www.theguardian.com/media-network/series/agencies), the slot targeting part of the ad call changes 

from this:
`slot=top-above-nav|slot=spbadge|slot=spbadge&k=agencies|slot=inline1|slot=merchandising-high|slot=adbadge&k=marketing-agencies-association-partner-zone|slot=adbadge&k=best-awards|slot=inline2|slot=merchandising|slot=pageskin-inread`

to this:
`slot=top-above-nav|slot=spbadge|slot=spbadge&se=agencies|slot=inline1|slot=merchandising-high|slot=adbadge&k=marketing-agencies-association-partner-zone|slot=adbadge&k=best-awards|slot=inline2|slot=merchandising|slot=pageskin-inread`
