### PR TITLE
Use class selectors instead of tags

### DIFF
--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -3,7 +3,7 @@
 <div class="d-discussion @if(!page.isClosedForRecommendation){d-discussion--recommendations-open} u-cf"
     @page.switches.map{ switch => data-@switch.name="@switch.state" }>
 
-    <ul class="d-thread">
+    <ul class="d-thread d-thread--comments">
         @userMessageForLargeDiscussion
 
         @page.comments.map { comment =>

--- a/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
@@ -68,7 +68,7 @@ define([
         this.storeCommentPage(resp, 1);
 
         // Keep the container so it can be easily reduced.
-        this.discussionContainer = $('ul', bonzo.create(resp.commentsHtml)).empty();
+        this.discussionContainer = $('.d-thread--comments', bonzo.create(resp.commentsHtml)).empty();
         this.postedCommentHtml = resp.postedCommentHtml;
         this.lastPage = resp.lastPage;
 
@@ -83,8 +83,10 @@ define([
 
     // Caches a bonzo object/array of comments, so that they can be re-assembled when the load is complete.
     WholeDiscussion.prototype.storeCommentPage = function (response, page) {
-        var comments = $('li', bonzo.create(response.commentsHtml));
+        var container = $('.d-thread--comments', bonzo.create(response.commentsHtml));
+        var comments = $('.d-comment--top-level', container);
         if (this.params.orderBy === 'newest') {
+
             comments = comments.map(function (comment) {
                 return comment;
             }).reverse();

--- a/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
@@ -83,8 +83,8 @@ define([
 
     // Caches a bonzo object/array of comments, so that they can be re-assembled when the load is complete.
     WholeDiscussion.prototype.storeCommentPage = function (response, page) {
-        var container = $('.d-thread--comments', bonzo.create(response.commentsHtml));
-        var comments = $('.d-comment--top-level', container);
+        var container = $('.d-thread--comments', bonzo.create(response.commentsHtml)),
+            comments = $('.d-comment--top-level', container);
         if (this.params.orderBy === 'newest') {
 
             comments = comments.map(function (comment) {


### PR DESCRIPTION
The all page discussion feature was reversing comments to order things newest, but the selector was reordering responses (which never change order), aswell as top level comments.
