### PR TITLE
Fix login bug in facia-tool

### DIFF
--- a/facia-tool/app/auth/ExpiringActions.scala
+++ b/facia-tool/app/auth/ExpiringActions.scala
@@ -17,7 +17,7 @@ object ExpiringActions extends implicits.Dates with implicits.Requests with Exec
 
     val loginTarget: Call = routes.OAuthLoginController.login()
 
-    override def sendForAuth[A](request:RequestHeader) =
+    override def sendForAuth[A](request:RequestHeader): Result =
       if (request.isXmlHttpRequest)
         Forbidden.withNewSession
       else

--- a/facia-tool/app/auth/ExpiringActions.scala
+++ b/facia-tool/app/auth/ExpiringActions.scala
@@ -36,7 +36,7 @@ object ExpiringActions extends implicits.Dates with implicits.Requests with Exec
         if (request.isXmlHttpRequest)
           Future.successful(Forbidden.withNewSession)
         else {
-          Future.successful(Redirect(AuthActions.loginTarget).withNewSession)
+          Future.successful(AuthActions.sendForAuth(request))
         }
       }
     }


### PR DESCRIPTION
#### What

Sometimes users are not being correctly directed to the link they are trying to get to. If a user has bookmarked a deeplink into the application, it should carry through google, but sometimes doesn't.
#### Why

There are two expiries for a session:
- The `session` `expiry` itself
- `lastSeen`

`session` expiry is handled by `play-googleauth`. When this expires, the `URL` that the user was trying to get to is carried through google, and the user gets properly redirected when they come back.

`lastSeen` expiry is handled by `facia-tool`, explicitly `ExpiringAuthActions`. When this expires, it clears the `session`, and does not carry the `URL` the user was trying to get to.

If the user gets into the state where their `session` is still valid, but their `lastSeen` is invalid, they go through the reauth workflow with their `session` cleared. 
#### Fix

This uses the `sendForAuth` provided by `play-googleauth` to redirect the user through the google and carrying the `URL` the original request was trying to get to.

@stephanfowler @piuccio 
