### PR TITLE
Most popular not displayed on commercial microsites

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
@@ -42,6 +42,10 @@ define([
             adType = 'right-small';
         }
 
+        if (config.page.contentType === 'Article' && config.page.sponsorshipType === 'advertisement-features') {
+            $('.js-components-container', '.js-secondary-column').addClass('u-h');
+        }
+
         return $(opts.adSlotContainerSelector)
             .append(createAdSlot(adType, 'mpu-banner-ad'));
     }


### PR DESCRIPTION
The most popular component shouldn't be displayed on the advertisement feature articles when there is an ad in the right hand column.
