### PR TITLE
Do not trigger layout when querying breakpoint (getBreakpoint)

### DIFF
--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -247,13 +247,12 @@ define([
         return (window.innerHeight > window.innerWidth) ? 'portrait' : 'landscape';
     }
 
-    function getDocumentWidth() {
-        var d = document.documentElement;
-        return Math.max(
-            d.clientWidth,
-            d.offsetWidth,
-            d.scrollWidth
-        );
+    function getViewportWidth() {
+        var w = window,
+            d = document,
+            e = d.documentElement,
+            g = d.getElementsByTagName('body')[0];
+        return w.innerWidth || e.clientWidth || g.clientWidth;
     }
 
     /** TEMPORARY: I'm going to update lodash in a separate pull request. */
@@ -274,10 +273,10 @@ define([
     }
 
     function getBreakpoint(includeTweakpoint) {
-        var documentWidth = getDocumentWidth(),
+        var viewportWidth = getViewportWidth(),
             index,
             breakpoint = _.last(takeWhile(breakpoints, function (bp) {
-                return bp.width <= documentWidth;
+                return bp.width <= viewportWidth;
             })).name;
         if (!includeTweakpoint) {
             index = _.findIndex(breakpoints, function (b) {

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -36,7 +36,8 @@ define([
             },
             {
                 name: 'phablet',
-                isTweakpoint: true
+                isTweakpoint: true,
+                width: 660
             },
             {
                 name: 'tablet',
@@ -246,14 +247,21 @@ define([
         return (window.innerHeight > window.innerWidth) ? 'portrait' : 'landscape';
     }
 
+    function getDocumentWidth() {
+        var d = document.documentElement;
+        return Math.max(
+            d.clientWidth,
+            d.offsetWidth,
+            d.scrollWidth
+        );
+    }
+
     function getBreakpoint(includeTweakpoint) {
-        // default to mobile
-        var breakpoint = (
-                window.getComputedStyle
-                    ? window.getComputedStyle(document.body, ':after').getPropertyValue('content')
-                    : document.getElementsByTagName('head')[0].currentStyle.fontFamily
-            ).replace(/['",]/g, '') || 'mobile',
-            index;
+        var documentWidth = getDocumentWidth();
+
+        var breakpoint = _.last(_.takeWhile(breakpoints, function (bp) {
+            return bp.width <= documentWidth;
+        })).name;
 
         if (!includeTweakpoint) {
             index = _.findIndex(breakpoints, function (b) {

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -277,9 +277,8 @@ define([
         var documentWidth = getDocumentWidth(),
             index,
             breakpoint = _.last(takeWhile(breakpoints, function (bp) {
-            return bp.width <= documentWidth;
-        })).name;
-        
+                return bp.width <= documentWidth;
+            })).name;
         if (!includeTweakpoint) {
             index = _.findIndex(breakpoints, function (b) {
                 return b.name === breakpoint;

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -256,13 +256,30 @@ define([
         );
     }
 
-    function getBreakpoint(includeTweakpoint) {
-        var documentWidth = getDocumentWidth();
+    /** TEMPORARY: I'm going to update lodash in a separate pull request. */
+    function takeWhile(xs, f) {
+        var acc = [],
+            i,
+            size = xs.length;
 
-        var breakpoint = _.last(_.takeWhile(breakpoints, function (bp) {
+        for (i = 0; i < size; i++) {
+            if (f(xs[i])) {
+                acc.push(xs[i]);
+            } else {
+                break;
+            }
+        }
+
+        return acc;
+    }
+
+    function getBreakpoint(includeTweakpoint) {
+        var documentWidth = getDocumentWidth(),
+            index,
+            breakpoint = _.last(takeWhile(breakpoints, function (bp) {
             return bp.width <= documentWidth;
         })).name;
-
+        
         if (!includeTweakpoint) {
             index = _.findIndex(breakpoints, function (b) {
                 return b.name === breakpoint;


### PR DESCRIPTION
`window.getComputedStyle` triggers layout. A whole lot of different things use `getBreakpoint`, so this should give us a performance boost.
