### PR TITLE
R2 video cleaner

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -16,6 +16,7 @@ object BodyCleaner {
         WitnessCleaner,
         new TagLinker(article),
         TableEmbedComplimentaryToP,
+        R2VideoCleaner(article),
         VideoEmbedCleaner(article),
         PictureCleaner(article),
         LiveBlogDateFormatter(article.isLiveBlog),

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -36,6 +36,21 @@ object BlockNumberCleaner extends HtmlCleaner {
   }
 }
 
+case class R2VideoCleaner(article: Article) extends HtmlCleaner {
+
+override def clean(document: Document): Document = {
+
+    val legacyVideos = document.getElementsByTag("video").filter(_.hasClass("gu-video")).filter(_.parent().tagName() != "figure")
+
+    legacyVideos.foreach( videoElement => {
+      videoElement.wrap("<figure class=\"test element element-video\"></figure>")
+    })
+
+    document
+  }
+
+}
+
 case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
   override def clean(document: Document): Document = {
@@ -109,9 +124,11 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
         findVideoApiElement(mediaId).foreach{ videoElement =>
           element.attr("data-block-video-ads", videoElement.blockVideoAds.toString)
-          element.attr("data-embeddable", videoElement.embeddable.toString)
-          if(!canonicalUrl.isEmpty) {
+          if(!canonicalUrl.isEmpty && videoElement.embeddable) {
+            element.attr("data-embeddable", "true")
             element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))
+          } else {
+            element.attr("data-embeddable", "false")
           }
         }
       }

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -189,7 +189,7 @@ define([
             preload: 'auto', // preload='none' & autoplay breaks ad loading on chrome35, preload="metadata" breaks older Safari's
             plugins: {
                 embed: {
-                    embeddable: !config.page.isFront && config.switches.externalVideoEmbeds && $el.attr('data-embeddable') === 'true',
+                    embeddable: !config.page.isFront && config.switches.externalVideoEmbeds && (config.page.contentType === "Video" || $el.attr('data-embeddable') === 'true'),
                     location: config.page.externalEmbedHost + '/embed/video/' + (embedPath ? embedPath : config.page.pageId)
                 }
             }

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -189,7 +189,7 @@ define([
             preload: 'auto', // preload='none' & autoplay breaks ad loading on chrome35, preload="metadata" breaks older Safari's
             plugins: {
                 embed: {
-                    embeddable: !config.page.isFront && config.switches.externalVideoEmbeds && (config.page.contentType === "Video" || $el.attr('data-embeddable') === 'true'),
+                    embeddable: !config.page.isFront && config.switches.externalVideoEmbeds && (config.page.contentType === 'Video' || $el.attr('data-embeddable') === 'true'),
                     location: config.page.externalEmbedHost + '/embed/video/' + (embedPath ? embedPath : config.page.pageId)
                 }
             }


### PR DESCRIPTION
There are some old video embeds that do not get treated as video upgrades, mainly due to the lack of a figure wrapper.

Modified the embeddable logic to ensure that the existence of a an embed path is considered, and that video pages are always embeddable.
