### PR TITLE
fixes label position when page is in page skin mode

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -71,7 +71,7 @@
         }
 
         .ad-slot__label {
-            width: 100%;
+            width: 970px;
         }
     }
 


### PR DESCRIPTION
This ensures that the "Advertisement" label is always in the right place when showing the 970px wide Apple ad under the navigation even if we are in page skin mode.
