### PR TITLE
make the png resizer not do all timed tasks twice

### DIFF
--- a/png-resizer/app/lib/FutureEither.scala
+++ b/png-resizer/app/lib/FutureEither.scala
@@ -26,7 +26,8 @@ object Time extends Logging {
 
   def apply[T](result: => Future[T], action: String, metric: FrontendTimingMetric): Future[T] = {
     val stopWatch = new StopWatch
-    result.onComplete({ result =>
+    val resultEvaluated = result
+    resultEvaluated.onComplete({ result =>
       metric.recordDuration(stopWatch.elapsed)
       result match {
         case Success(contents) =>
@@ -35,7 +36,7 @@ object Time extends Logging {
           logger.info(s"took: $stopWatch for: $action failure: $exception")
       }
     })
-    result
+    resultEvaluated
   }
 
 }


### PR DESCRIPTION
forgot that putting => on a function parameter makes it like a def, not a lazy val.  Therefore the png resizer was timing the resize and reporting the time, then actually doing it (again)
