### PR TITLE
Unhide endslate at smaller window sizes on embeds

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -911,14 +911,14 @@ $ima-controls-height: 70px;
             border-top: 1px solid colour(neutral-2);
         }
 
-        @include mq(mobileLandscape) {
-            .vjs-has-ended & {
-                display: block;
-            }
-        }
-
         @include mq(tablet, desktop) {
             top: 20%;
+        }
+    }
+
+    @include mq(mobileLandscape) {
+        .gu-video-embed .vjs-has-ended & {
+            display: block !important;
         }
     }
 }

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -918,7 +918,7 @@ $ima-controls-height: 70px;
 
     @include mq(mobileLandscape) {
         .gu-video-embed .vjs-has-ended & {
-            display: block !important;
+            display: block;
         }
     }
 }


### PR DESCRIPTION
Weird nesting meant that this wasn't working. 
