### PR TITLE
Removing unused JS code

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -174,18 +174,6 @@ define([
             $('.weather').toggleClass('is-expanded');
         },
 
-        getUnits: function () {
-            if (config.page.edition === 'US') {
-                return 'imperial';
-            }
-
-            return 'metric';
-        },
-
-        getTemperature: function (weatherData) {
-            return weatherData.temperature[this.getUnits()];
-        },
-
         addSearch: function () {
             searchTool = new SearchTool({
                 container: $('.js-search-tool'),


### PR DESCRIPTION
We are not using this methods anymore as the temp unit type is taken care of on the server side now.
