### PR TITLE
Update postgres dependency URL

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val paClient = "com.gu" %% "pa-client" % "5.0.1-NG"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"
   val playJsonVariants = "org.julienrf" %% "play-json-variants" % "0.2"
-  val postgres = "postgresql" % "postgresql" % "8.4-703.jdbc4" from "http://jdbc.postgresql.org/download/postgresql-8.4-703.jdbc4.jar"
+  val postgres = "postgresql" % "postgresql" % "8.4-703.jdbc4" from "https://jdbc.postgresql.org/download/postgresql-8.4-703.jdbc4.jar"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.2.0"
   val rome = "rome" % "rome" % "1.0"
   val romeModules = "org.rometools" % "rome-modules" % "1.0"


### PR DESCRIPTION
The original http url responds with a 301 to the https one, which broke my build:

````[warn] 	[FAILED     ] postgresql#postgresql;8.4-703.jdbc4!postgresql.jar: The HTTP response code for http://jdbc.postgresql.org/download/postgresql-8.4-703.jdbc4.jar did not indicate a success.````

@kenlim 