### PR TITLE
Add  Omniture tracking to the fullscreen button on videos

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -15,6 +15,7 @@ define([
     'common/modules/component',
     'common/modules/ui/images',
     'common/modules/video/events',
+    'common/modules/video/fullscreener',
     'common/modules/video/supportedBrowsers',
     'common/modules/video/tech-order',
     'text!common/views/ui/loading.html'
@@ -34,6 +35,7 @@ define([
     Component,
     images,
     events,
+    fullscreener,
     supportedBrowsers,
     techOrder,
     loadingTmpl
@@ -56,27 +58,6 @@ define([
         };
 
         return 'http://' + config.page.dfpHost + '/gampad/ads?' + urlUtils.constructQuery(queryParams);
-    }
-
-    function fullscreener() {
-        var player = this,
-            clickbox = bonzo.create('<div class="vjs-fullscreen-clickbox"></div>')[0],
-            events = {
-                click: function (e) {
-                    this.paused() ? this.play() : this.pause();
-                    e.stop();
-                },
-                dblclick: function (e) {
-                    e.stop();
-                    this.isFullScreen() ? this.exitFullscreen() : this.requestFullscreen();
-                }
-            };
-
-        bonzo(clickbox)
-            .appendTo(player.contentEl());
-
-        bean.on(clickbox, 'click', events.click.bind(player));
-        bean.on(clickbox, 'dblclick', events.dblclick.bind(player));
     }
 
     function initLoadingSpinner(player) {
@@ -252,6 +233,8 @@ define([
                     } else {
                         events.bindContentEvents(player);
                     }
+
+                    bindFullscreenEvent(player);
 
                     if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
                         initEndSlate(player, endSlateUri);

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -234,8 +234,6 @@ define([
                         events.bindContentEvents(player);
                     }
 
-                    bindFullscreenEvent(player);
-
                     if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
                         initEndSlate(player, endSlateUri);
                     }

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -14,6 +14,7 @@ define([
     'common/modules/component',
     'common/modules/video/tech-order',
     'common/modules/video/events',
+    'common/modules/video/fullscreener',
     'common/views/svgs',
     'text!common/views/ui/loading.html',
     'text!common/views/media/titlebar.html'
@@ -32,6 +33,7 @@ define([
     Component,
     techOrder,
     events,
+    fullscreener,
     svgs,
     loadingTmpl,
     titlebarTmpl
@@ -57,35 +59,6 @@ define([
 
         return player;
     }
-
-    function fullscreener() {
-        var player = this,
-            clickbox = bonzo.create('<div class="vjs-fullscreen-clickbox"></div>')[0],
-            events = {
-                click: function (e) {
-                    this.paused() ? this.play() : this.pause();
-                    e.stop();
-                },
-                dblclick: function (e) {
-                    e.stop();
-                    this.isFullScreen() ? this.exitFullscreen() : this.requestFullscreen();
-                }
-            };
-
-        bonzo(clickbox)
-            .appendTo(player.contentEl());
-
-        bean.on(clickbox, 'click', events.click.bind(player));
-        bean.on(clickbox, 'dblclick', events.dblclick.bind(player));
-    }
-
-
-    function bindFullscreenEvent() {
-        player.on('fullscreenchange', function(){
-            if(this.isFullScreen()) { player.trigger('video:fullscreen'); }
-        })
-    }
-
 
     function addTitleBar() {
         var data = {

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -79,6 +79,14 @@ define([
         bean.on(clickbox, 'dblclick', events.dblclick.bind(player));
     }
 
+
+    function bindFullscreenEvent() {
+        player.on('fullscreenchange', function(){
+            if(this.isFullScreen()) { player.trigger('video:fullscreen'); }
+        })
+    }
+
+
     function addTitleBar() {
         var data = {
             webTitle: config.page.webTitle,

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -87,7 +87,7 @@ define([
             s.Media.autoTrack = false;
             s.Media.trackWhilePlaying = false;
             s.Media.trackVars = 'events,eVar7,eVar43,eVar44,prop44,eVar47,eVar61';
-            s.Media.trackEvents = 'event17,event18,event19,event20,event21,event22,event23,event57,event59,event64,event97,event98';
+            s.Media.trackEvents = 'event17,event18,event19,event20,event21,event22,event23,event57,event59,event64,event96,event97,event98';
             s.Media.segmentByMilestones = false;
             s.Media.trackUsingContextData = false;
 

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -36,6 +36,7 @@ define([
                 'video:75': 'event23',
                 'video:end': 'event18',
                 'audio:end': 'event20',
+                'video:fullscreen': 'eventfoo',
                 // extra events with no set ordering
                 duration: 'event57'
             };
@@ -176,6 +177,7 @@ define([
             player.one('video:play:75', this.sendNamedEvent.bind(this, 'video:75'));
             player.one('video:content:end', this.sendNamedEvent.bind(this, 'video:end'));
             player.one('audio:content:end', this.sendNamedEvent.bind(this, 'audio:end'));
+            player.on('player:fullscreen', this.sendNamedEvent.bind(this, 'video:fullscreen'));
         };
     }
     return OmnitureMedia;

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -36,7 +36,7 @@ define([
                 'video:75': 'event23',
                 'video:end': 'event18',
                 'audio:end': 'event20',
-                'video:fullscreen': 'eventfoo',
+                'video:fullscreen': 'event96',
                 // extra events with no set ordering
                 duration: 'event57'
             };

--- a/static/src/javascripts/projects/common/modules/video/fullscreener.js
+++ b/static/src/javascripts/projects/common/modules/video/fullscreener.js
@@ -25,9 +25,9 @@ define([
         bean.on(clickbox, 'click', events.click.bind(player));
         bean.on(clickbox, 'dblclick', events.dblclick.bind(player));
 
+        //initialise omniture tracking for fullscreen event
         player.on('fullscreenchange', function(){
-            alert("fullscreenchange");
-            if(this.isFullScreen()) { player.trigger('video:fullscreen'); }
+            if(this.isFullScreen()) { player.trigger('player:fullscreen'); }
         });
     }
 

--- a/static/src/javascripts/projects/common/modules/video/fullscreener.js
+++ b/static/src/javascripts/projects/common/modules/video/fullscreener.js
@@ -1,0 +1,35 @@
+define([
+    'bean',
+    'bonzo'
+], function (
+    bean,
+    bonzo
+) {
+    function fullscreener() {
+        var player = this,
+            clickbox = bonzo.create('<div class="vjs-fullscreen-clickbox"></div>')[0],
+            events = {
+                click: function (e) {
+                    this.paused() ? this.play() : this.pause();
+                    e.stop();
+                },
+                dblclick: function (e) {
+                    e.stop();
+                    this.isFullScreen() ? this.exitFullscreen() : this.requestFullscreen();
+                }
+            };
+
+        bonzo(clickbox)
+            .appendTo(player.contentEl());
+
+        bean.on(clickbox, 'click', events.click.bind(player));
+        bean.on(clickbox, 'dblclick', events.dblclick.bind(player));
+
+        player.on('fullscreenchange', function(){
+            alert("fullscreenchange");
+            if(this.isFullScreen()) { player.trigger('video:fullscreen'); }
+        });
+    }
+
+    return fullscreener;
+});

--- a/static/src/javascripts/projects/common/modules/video/fullscreener.js
+++ b/static/src/javascripts/projects/common/modules/video/fullscreener.js
@@ -26,8 +26,8 @@ define([
         bean.on(clickbox, 'dblclick', events.dblclick.bind(player));
 
         //initialise omniture tracking for fullscreen event
-        player.on('fullscreenchange', function(){
-            if(this.isFullScreen()) { player.trigger('player:fullscreen'); }
+        player.on('fullscreenchange', function () {
+            if (this.isFullScreen()) { player.trigger('player:fullscreen'); }
         });
     }
 


### PR DESCRIPTION
We now fire an event96 when you enter fullscreen either by clicking the button or double clicking, both on embeds and on theguardian.com.
