### PR TITLE
Content media overrides for the new special report tone

### DIFF
--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -19,7 +19,8 @@
 }
 
 .tonal--tone-media .tonal__main--tone-media,
-.tonal--tone-podcast .tonal__main--tone-podcast {
+.tonal--tone-podcast .tonal__main--tone-podcast,
+.tonal--tone-special-report .tonal__main--tone-special-report {
     .sharecount__heading .i {
         @include icon(share-android--white);
         opacity: .6;

--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -62,14 +62,20 @@
         .byline,
         .content__dateline,
         .meta__numbers .sharecount__heading,
-        .meta__numbers .sharecount__value {
+        .meta__numbers .sharecount__value,
+        .submeta__head {
             color: #ffffff;
         }
 
-        .meta__social,
+        .byline,
         .content__meta-container,
+        .content__secondary-column--media,
+        .content__dateline,
+        .fc-item:before,
+        .meta__social,
+        .meta__numbers,
         .most-viewed-container--media,
-        .content__secondary-column--media {
+        .submeta {
             border-color: mix(colour(news-support-6), #ffffff, 70%);
         }
 

--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -42,4 +42,40 @@
             }
         }
     }
+
+    &.content--media {
+        .content__main,
+        .tonal__standfirst,
+        .content__standfirst {
+            background-color: colour(news-support-6);
+            color: #ffffff;
+        }
+
+        a.tone-colour {
+            color: colour(news-support-1);
+
+            &:hover {
+                color: mix(colour(news-support-1), #ffffff, 70%);
+            }
+        }
+
+        .byline,
+        .content__dateline,
+        .meta__numbers .sharecount__heading,
+        .meta__numbers .sharecount__value {
+            color: #ffffff;
+        }
+
+        .meta__social,
+        .content__meta-container,
+        .most-viewed-container--media,
+        .content__secondary-column--media {
+            border-color: mix(colour(news-support-6), #ffffff, 70%);
+        }
+
+        .button--tag {
+            background-color: mix(colour(news-support-6), colour(neutral-1), 70%);
+            border-color: mix(colour(news-support-6), colour(neutral-1), 70%);
+        }
+    }
 }


### PR DESCRIPTION
This probably needs a better look going forward. `content--media` shouldn't really expect a dark background (the one it gets with `tone--media`) and set everything in white. But this fixes the issue with the new page.

Example: http://www.theguardian.com/business/video/2015/feb/08/hsbc-files-secret-swiss-account-data-misconduct-video

Before:
![screen shot 2015-02-09 at 09 26 42](https://cloud.githubusercontent.com/assets/1607666/6103609/12468476-b03e-11e4-8944-a78314c7a59f.png)

After:
![screen shot 2015-02-09 at 09 26 25](https://cloud.githubusercontent.com/assets/1607666/6103610/1256a5ea-b03e-11e4-86b3-641b2c0fb555.png)
