### PR TITLE
Weather forecast toggle fix

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -162,7 +162,7 @@ define([
         },
 
         bindEvents: function () {
-            bean.on(qwery('body')[0], 'click', '.js-toggle-forecast', function (e) {
+            bean.on(document.body, 'click', '.js-toggle-forecast', function (e) {
                 e.preventDefault();
                 this.toggleForecast();
             }.bind(this));

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -162,7 +162,7 @@ define([
         },
 
         bindEvents: function () {
-            bean.on(qwery('.js-toggle-forecast')[0], 'click', function (e) {
+            bean.on(qwery('body')[0], 'click', '.js-toggle-forecast', function (e) {
                 e.preventDefault();
                 this.toggleForecast();
             }.bind(this));


### PR DESCRIPTION
Before: on mobile the forecast toggle event wasn't triggering after template reload. This PR is using event delegation so the click event is added to the body instead of weather component.

After:
![dhcsgmek7c](https://cloud.githubusercontent.com/assets/2579465/6105621/277a76e6-b051-11e4-8aa6-d2af563f3370.gif)
