### PR TITLE
don't show the end slate for related videos at standard or third size

### DIFF
--- a/common/app/cards/CardType.scala
+++ b/common/app/cards/CardType.scala
@@ -3,9 +3,15 @@ package cards
 sealed trait CardType {
   val cssClassName: String
 
-  def showVideoPlayer = this match {
-    case Half | ThreeQuarters | ThreeQuartersRight | Third | Standard | FullMedia50 | FullMedia75 | FullMedia100 => true
-    case _ => false
+  case class VideoPlayerMode(show: Boolean, showEndSlate: Boolean)
+
+  def videoPlayer = this match {
+    case Half | ThreeQuarters | ThreeQuartersRight | FullMedia50 | FullMedia75 | FullMedia100 =>
+      VideoPlayerMode(show = true, showEndSlate = true)
+    case Third | Standard =>
+      VideoPlayerMode(show = true, showEndSlate = false)
+    case _ =>
+      VideoPlayerMode(show = false, showEndSlate = false)
   }
 
   def showCutOut = this match {

--- a/common/app/layout/Column.scala
+++ b/common/app/layout/Column.scala
@@ -21,7 +21,8 @@ case class ItemClasses(mobile: CardType, tablet: CardType, desktop: Option[CardT
 
   def allTypes = Set(mobile, tablet) ++ desktop.toSet
 
-  def showVideoPlayer = allTypes.exists(_.showVideoPlayer)
+  def showVideoPlayer = allTypes.exists(_.videoPlayer.show)
+  def showVideoEndSlate = allTypes.exists(_.videoPlayer.showEndSlate)
 
   def showCutOut = allTypes.exists(_.showCutOut)
 }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -45,7 +45,7 @@ data-test-id="facia-card"
                     )) { player =>
                         <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player">
                             <div class="fc-item__video-container">
-                                @video(player, false)
+                                @video(player, false, item.cardTypes.showVideoEndSlate)
                             </div>
                         </div>
                         @fallback.map { fallbackImage =>

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -1,4 +1,4 @@
-@(player: model.VideoPlayer, enhance: Boolean)
+@(player: model.VideoPlayer, enhance: Boolean, showEndSlate: Boolean = true)
 
 @import conf.Static
 @import views.support.RenderClasses
@@ -13,7 +13,7 @@
             ("gu-media--video", true),
             ("gu-media--show-controls-at-start", player.showControlsAtStart),
             ("js-gu-media--enhance", enhance)
-        ))" width="auto" height="auto" data-title="@player.title" data-auto-play="@player.autoPlay" data-show-end-slate="@player.showEndSlate"
+        ))" width="auto" height="auto" data-title="@player.title" data-auto-play="@player.autoPlay" data-show-end-slate="@(player.showEndSlate && showEndSlate)"
             poster="@player.poster" data-duration="@player.video.duration.toString()" data-media-id="@player.video.id"
             data-end-slate="@player.endSlatePath" data-block-video-ads="@player.blockVideoAds" data-embeddable="@player.video.embeddable"
             @player.embedPath.map{ p => data-embed-path="@p" }


### PR DESCRIPTION
At the moment when a video on a front gets to the end it shows an end slate with related videos on desktop only.  However these appear too small at third and standard size cards.
Third:
![image](https://cloud.githubusercontent.com/assets/7304387/6105934/b09e7384-b054-11e4-8799-6ad1ced2133b.png)
Standard (quarter):
![image](https://cloud.githubusercontent.com/assets/7304387/6105941/c14492c2-b054-11e4-8f5d-262645b972dc.png)

This PR just removes them at those two sizes.
![image](https://cloud.githubusercontent.com/assets/7304387/6105951/d7f4c91a-b054-11e4-9ab2-39d23bbb3eff.png)

If the breakpoint is smaller than desktop, they are never shown anyway.
