### PR TITLE
Couple of style fixes for the special report

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -72,6 +72,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
           val html = views.html.fragments.share.blockLevelSharing(blockId, article.elementShares(shortLinkUrl = shortUrl, webLinkUrl = webUrl,  mediaPath = Some(mediaPath), title = mediaTitle), article.contentType)
           element.child(0).after(html.toString())
           element.addClass("fig--has-shares")
+          element.addClass("fig--narrow-caption")
           // add extra margin if there is no caption to fit the share buttons
           val figcaption = element.getElementsByTag("figcaption")
           if(figcaption.length < 1) {

--- a/static/src/stylesheets/base/_inline-svgs.scss
+++ b/static/src/stylesheets/base/_inline-svgs.scss
@@ -41,6 +41,10 @@
     .tonal--tone-media & {
         fill: colour(media-default);
     }
+
+    .tonal--tone-special-report & {
+        fill: colour(news-support-6);
+    }
 }
 
 .no-svg {

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -20,7 +20,7 @@
 
 .tonal--tone-media .tonal__main--tone-media,
 .tonal--tone-podcast .tonal__main--tone-podcast,
-.tonal--tone-special-report .tonal__main--tone-special-report {
+.tonal--tone-special-report .content__main-column--media {
     .sharecount__heading .i {
         @include icon(share-android--white);
         opacity: .6;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -37,7 +37,6 @@
         .content__article-body {
             padding-right: gs-span(1) + $gs-gutter;
 
-            .img--landscape,
             .ad-slot {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
             }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -699,7 +699,6 @@
 
         @include mq(leftCol, wide) {
             max-width: $left-column;
-            word-wrap
         }
     }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -674,7 +674,7 @@
 
     .button {
         padding-top: 1px;
-        margin-right: $gs-gutter/5;
+        margin-right: 0;
 
         .tonal--tone-media & {
             border: 0;
@@ -695,6 +695,11 @@
             .inline-mail svg {
                 margin-top: $gs-baseline/4;
             }
+        }
+
+        @include mq(leftCol, wide) {
+            max-width: $left-column;
+            word-wrap
         }
     }
 

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -711,6 +711,10 @@ $ima-controls-height: 70px;
         display: block;
     }
 
+    .element--supporting & {
+        display: none;
+    }
+
     &:hover {
         .vjs-control-content::before {
             @include icon(embed--tone-media);


### PR DESCRIPTION
- Adds a fill colour for the Twitter bird on the special project tone
- Prevents the video caption from clashing with the social share buttons on supporting videos
- Hides the embed button on the video player when it's supporting
- Sneaks in a fix for: https://github.com/guardian/frontend/issues/8231
- Rescope the colour of the share icon so it's not white on article pages

Fixes:
![screen shot 2015-02-09 at 13 56 53](https://cloud.githubusercontent.com/assets/2236852/6107526/90a2a7e4-b063-11e4-8e2c-8cbae9fb6e76.png)
![screen shot 2015-02-09 at 13 56 45](https://cloud.githubusercontent.com/assets/2236852/6107533/98d51334-b063-11e4-8988-39521fe5b6f3.png)
![screen shot 2015-02-09 at 14 07 22](https://cloud.githubusercontent.com/assets/2236852/6107707/082a9d84-b065-11e4-8340-4d6220a98689.png)
![screen shot 2015-02-09 at 14 53 52](https://cloud.githubusercontent.com/assets/2236852/6108532/db79e3f6-b06b-11e4-83d4-08b63fdb7e0f.png)
