### PR TITLE
Remove px from global.css…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,6 +71,7 @@ module.exports = function (grunt) {
             grunt.task.run(['replace:cssSourceMaps', 'copy:css']);
         }
 
+        grunt.task.run(['copy:pxCss']);
         grunt.task.run(['px_to_rem']);
 
         if (isOnlyTask(this) && !fullCompile) {

--- a/common/app/views/fragments/commonCssSetup.scala.html
+++ b/common/app/views/fragments/commonCssSetup.scala.html
@@ -70,6 +70,13 @@
     @fragments.stylesheetLink("stylesheets/global.css", "global")
 <!--<![endif]-->
 
+@* https://dev.opera.com/articles/opera-mini-and-javascript/#detectingmini *@
+<script>
+if (Object.prototype.toString.call(window.operamini) === "[object OperaMini]") {
+    document.querySelector('link[href$="global.css"]').href = '@Static("stylesheets/global.px.css")';
+}
+</script>
+
 @if(AsyncCss.isSwitchedOn) {
     <script>
         // The css is loaded by the `link`s above but with media of "only x".

--- a/grunt-configs/copy.js
+++ b/grunt-configs/copy.js
@@ -50,6 +50,10 @@ module.exports = function(grunt, options) {
                 dest: options.staticTargetDir + 'stylesheets'
             }]
         },
+        pxCss: {
+            src: [options.staticTargetDir + 'stylesheets/global.css'],
+            dest: options.staticTargetDir + 'stylesheets/global.px.css'
+        },
         images: {
             files: [{
                 expand: true,

--- a/grunt-configs/px_to_rem.js
+++ b/grunt-configs/px_to_rem.js
@@ -3,12 +3,12 @@ module.exports = function(grunt, options) {
         dist: {
             options: {
                 base: 16,
-                fallback: true // set to false when Opera Mini supports rem units
+                fallback: false // Opera Mini gets its own global.px.css
             },
             files: [{
                 expand: true,
                 cwd: options.staticTargetDir + 'stylesheets/',
-                src: ['*.css', '!old-ie*'],
+                src: ['*.css', '!old-ie*', '!*.px.css'],
                 dest: options.staticTargetDir + 'stylesheets/'
             }]
         }


### PR DESCRIPTION
…and create a separate `global.px.css` for opera mini.

Results in:
- 52 fewer kb
- 7 fewer kb (gzipped)
- but, **3048** fewer declarations

in `global.css`
