### PR TITLE
Remove unused old block level sharing CSS

### DIFF
--- a/common/app/views/fragments/share/blockLevelSharing.scala.html
+++ b/common/app/views/fragments/share/blockLevelSharing.scala.html
@@ -7,12 +7,6 @@
             <i class="i"></i><span class="u-h">@item.text</span>
         </a>
     }
-
-    <button class="meta-button block-share__item block-share__item--expand js-blockshare-expand u-h" data-link-name="expand">
-        <i class="i i-ellipsis-@if(contentType == model.GuardianContentTypes.Gallery){white-36} else {black}"></i>
-        <span class="u-h">expand</span>
-    </button>
-
 </div>
 
 @if(contentType != "Article") {

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -137,26 +137,6 @@
     cursor: pointer;
 }
 
-.block-share__item--expand {
-    overflow: visible;
-    position: relative;
-
-    .i {
-        @extend %absolute-center;
-        width: 18px !important;
-        height: 14px !important;
-        display: block;
-        opacity: .5;
-    }
-
-    &:hover {
-        border-color: colour(neutral-2);
-        .i {
-            opacity: .6;
-        }
-    }
-}
-
 .share-modal {
     width: 100%;
     height: 100%;
@@ -276,30 +256,6 @@
         }
     }
 
-    .block-share__item--gplus {
-        background-color: colour(social-gplus);
-
-        &:hover {
-            background-color: colour-hover(social-gplus);
-        }
-
-        .i {
-            @include icon(share-gplus--white);
-        }
-    }
-
-    .block-share__item--linkedin {
-        background-color: colour(social-linkedin);
-
-        &:hover {
-            background-color: colour-hover(social-linkedin);
-        }
-
-        .i {
-            @include icon(share-linkedin--white);
-        }
-    }
-
     .block-share__item--pinterest {
         background-color: colour(social-pinterest);
 
@@ -310,29 +266,6 @@
         .i {
             @include icon(share-pinterest--white);
         }
-    }
-
-    .block-share__item--expand {
-        border-color: colour(neutral-2);
-
-        &:hover {
-            border-color: #ffffff;
-        }
-    }
-
-    .block-share__item--link {
-        background-color: transparent;
-        color: #ffffff;
-        border-color: colour(neutral-2);
-
-        &:hover {
-            color: #ffffff;
-            border-color: #ffffff;
-        }
-    }
-
-    .block-share__item--expand .i {
-        opacity: 1;
     }
 }
 


### PR DESCRIPTION
None of this stuff is being used anymore. They're either old block level sharing options or relate to the time when we had the 'expand' ellipsis.
