### PR TITLE
JS error when dragging from history

### DIFF
--- a/facia-tool/public/js/models/collections/new-items.js
+++ b/facia-tool/public/js/models/collections/new-items.js
@@ -131,7 +131,7 @@ define([
             });
         }
 
-        if (remove !== false && sourceGroup && !sourceGroup.keepCopy && sourceGroup !== targetGroup) {
+        if (remove !== false && sourceGroup && !sourceGroup.keepCopy && sourceGroup !== targetGroup && sourceGroup.items) {
             removeById(sourceGroup.items, id); // for immediate UI effect
         }
     }


### PR DESCRIPTION
Because the history collection doesn't have `.items`, and anyway elements should not be removed from the history
