### PR TITLE
User history: record Front visits separately

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -448,7 +448,7 @@ object Switches {
 
   val HistoryTags = Switch("Feature", "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
-    safeState = Off, sellByDate = new LocalDate(2015, 3, 1)
+    safeState = On, sellByDate = new LocalDate(2015, 3, 1)
   )
 
   val IdentityBlockSpamEmails = Switch("Feature", "id-block-spam-emails",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -448,7 +448,7 @@ object Switches {
 
   val HistoryTags = Switch("Feature", "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
-    safeState = On, sellByDate = new LocalDate(2015, 3, 1)
+    safeState = Off, sellByDate = never
   )
 
   val IdentityBlockSpamEmails = Switch("Feature", "id-block-spam-emails",

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -402,9 +402,9 @@ define([
     }
 
     function removeFromMegaNav() {
-        getMegaNav().each(function () {
+        getMegaNav().each(function (megaNav) {
             fastdom.write(function () {
-                $('.js-global-navigation__section--history', this).remove();
+                $('.js-global-navigation__section--history', megaNav).remove();
             });
         });
         inMegaNav = false;


### PR DESCRIPTION
New format in for history storage: 

```
"film":[
   "Film",          // display name
   [[2,1],[7,3]],   // Content visits (one visit two days ago, three visits seven days ago 
   [[0,1]]          // Front visits (one visit today)
],
```

IMPORTANT: history logging on R2 must be killed off before merging this.
