### PR TITLE
make the playable videos trigger even when related content is ajaxed in

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -114,20 +114,9 @@ define([
             event.target.firstChild.id.indexOf('flash_api') > 0;
     }
 
-    function initPlayer() {
+    function initPlayButtons(root) {
 
-        // When possible, use our CDN instead of a third party (zencoder).
-        if (config.page.videoJsFlashSwf) {
-            videojs.options.flash.swf = config.page.videoJsFlashSwf;
-        }
-        videojs.plugin('adSkipCountdown', events.adSkipCountdown);
-        videojs.plugin('fullscreener', fullscreener);
-
-        $('.js-gu-media--enhance').each(function (el) {
-            enhanceVideo(el, false);
-        });
-
-        $('.js-video-play-button').each(function (el) {
+        $('.js-video-play-button', root).each(function (el) {
             var $el = bonzo(el);
             $el.removeClass('media__placeholder--hidden').addClass('media__placeholder--active');
             bean.on(el, 'click', function () {
@@ -141,6 +130,24 @@ define([
                 enhanceVideo($('video', player).get(0), true);
             });
         });
+    }
+
+    function initPlayer() {
+
+        // When possible, use our CDN instead of a third party (zencoder).
+        if (config.page.videoJsFlashSwf) {
+            videojs.options.flash.swf = config.page.videoJsFlashSwf;
+        }
+        videojs.plugin('adSkipCountdown', events.adSkipCountdown);
+        videojs.plugin('fullscreener', fullscreener);
+
+        $('.js-gu-media--enhance').each(function (el) {
+            enhanceVideo(el, false);
+        });
+
+        initPlayButtons(document.body);
+
+        mediator.on('modules:related:loaded', initPlayButtons);
     }
 
     function enhanceVideo(el, autoplay) {
@@ -330,8 +337,6 @@ define([
         }
         initMoreInSection();
         initMostViewedMedia();
-
-        mediator.emit('page:media:ready');
     }
 
     return {

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -2,6 +2,7 @@
 define([
     'bean',
     'bonzo',
+    'fastdom',
     'raven',
     'common/utils/$',
     'common/utils/_',
@@ -22,6 +23,7 @@ define([
 ], function (
     bean,
     bonzo,
+    fastdom,
     raven,
     $,
     _,
@@ -116,18 +118,24 @@ define([
 
     function initPlayButtons(root) {
 
-        $('.js-video-play-button', root).each(function (el) {
-            var $el = bonzo(el);
-            $el.removeClass('media__placeholder--hidden').addClass('media__placeholder--active');
-            bean.on(el, 'click', function () {
-                var placeholder, player, container;
-                container = bonzo(el).parent().parent();
-                placeholder = $('.js-video-placeholder', container);
-                placeholder.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
-                player = $('.js-video-player', container);
-                player.removeClass('media__container--hidden').addClass('media__container--active');
-                $el.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
-                enhanceVideo($('video', player).get(0), true);
+        fastdom.read(function () {
+            $('.js-video-play-button', root).each(function (el) {
+                var $el = bonzo(el);
+                bean.on(el, 'click', function () {
+                    var placeholder, player, container;
+                    container = bonzo(el).parent().parent();
+                    placeholder = $('.js-video-placeholder', container);
+                    player = $('.js-video-player', container);
+                    fastdom.write(function () {
+                        placeholder.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
+                        player.removeClass('media__container--hidden').addClass('media__container--active');
+                        $el.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
+                    });
+                    enhanceVideo($('video', player).get(0), true);
+                });
+                fastdom.write(function () {
+                    $el.removeClass('media__placeholder--hidden').addClass('media__placeholder--active');
+                });
             });
         });
     }
@@ -141,8 +149,10 @@ define([
         videojs.plugin('adSkipCountdown', events.adSkipCountdown);
         videojs.plugin('fullscreener', fullscreener);
 
-        $('.js-gu-media--enhance').each(function (el) {
-            enhanceVideo(el, false);
+        fastdom.read(function () {
+            $('.js-gu-media--enhance').each(function (el) {
+                enhanceVideo(el, false);
+            });
         });
 
         initPlayButtons(document.body);

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -120,7 +120,7 @@ define([
         }
 
         //Load new counts when more trails are loaded
-        mediator.on('modules:related:loaded', getCommentCounts.bind(null, qwery('.js-related')[0]));
+        mediator.on('modules:related:loaded', getCommentCounts);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -72,7 +72,6 @@ define([
                 expanded: false,
                 showCount: false
             }).init();
-            mediator.emit('modules:related:loaded');
 
         } else if (fetchRelated) {
 
@@ -106,7 +105,7 @@ define([
                         new Expandable({dom: relatedTrails, expanded: false, showCount: false}).init();
                         // upgrade images
                         images.upgrade(relatedTrails);
-                        mediator.emit('modules:related:loaded');
+                        mediator.emit('modules:related:loaded', container);
                         register.end(componentName);
                     },
                     error: function () {


### PR DESCRIPTION
Since we started ajaxing in related content, the playable buttons didn't appear on the videos, as the cards weren't there in time.

I have updated it so the videos are playable and tidied up some unneeded code for bonus points.

I couldn't easily test that the comment counts still work as comments don't seem to work on code - this is a bit of a problem.  ISTR someone was looking at this problem, but I can't remember what the issue was?

@mattosborn if you have a min it would be great for a sanity check please!
