### PR TITLE
CSS logging: fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -64,8 +64,8 @@ define([
                             });
                             return isUsed;
                         }, {}),
-                        contentType: config.page.contentType,
-                        breakpoint: detect.getBreakpoint()
+                        contentType: config.page.contentType || 'unknown',
+                        breakpoint: detect.getBreakpoint() || 'unknown'
                     }), all);
                 }, all ? 0 : _.random(0, 3000));
             }


### PR DESCRIPTION
Sends valid report when metadata is missing.
