### PR TITLE
Revert "Test disabling fastclick on some old devices"

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -1,6 +1,4 @@
 /* jshint nonew: false */
-/* jshint undef: true */
-/* global guardian */
 /* TODO - fix module constructors so we can remove the above jshint override */
 define([
     'bean',
@@ -131,9 +129,6 @@ define([
             },
 
             initFastClick: function () {
-                if (config.switches.iphoneConfidence && guardian.isIphone4 && guardian.inTestBucket) {
-                    return;
-                }
                 FastClick.attach(document.body);
             },
 


### PR DESCRIPTION
Reverts guardian/frontend#8253

had no effect:

![screen shot 2015-02-10 at 10 03 53](https://cloud.githubusercontent.com/assets/867233/6125247/092c78d6-b10c-11e4-8c53-409a117e964c.png)
