### PR TITLE
Reduce standfirst spacing on fronts

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -300,7 +300,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__standfirst {
     @include fs-headline(1);
-    padding-bottom: get-line-height(bodyCopy, 1);
+    padding-bottom: .5em;
     color: colour(neutral-2);
     display: none;
 


### PR DESCRIPTION
A quick fix to reduce the spacing below a standfirst on fronts. 

Before:
![screen shot 2015-02-10 at 14 40 03](https://cloud.githubusercontent.com/assets/1607666/6128998/bfea7462-b132-11e4-87ba-7b26708c8edc.png)

After
![screen shot 2015-02-10 at 14 39 54](https://cloud.githubusercontent.com/assets/1607666/6128999/bffd010e-b132-11e4-9145-5a200c30442e.png)
