### PR TITLE
Fix for Pinterest block level sharing

### DIFF
--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -3,11 +3,11 @@ package model
 import common.`package`._
 
 case class ShareLink (
-  text: String,
-  css: String,
-  userMessage: String,
-  href: String
-)
+                       text: String,
+                       css: String,
+                       userMessage: String,
+                       href: String
+                       )
 
 trait ShareLinks { self: Content =>
 
@@ -24,6 +24,10 @@ trait ShareLinks { self: Content =>
     lazy val whatsapp = shareCampaignUrl("swa", elementId)
     lazy val webTitleAsciiEncoding = webTitle.encodeURIComponent
 
+    lazy val fullMediaPath: Option[String] = {
+      mediaPath.map { originalPath => if(originalPath.startsWith("//")) { "http:" + originalPath } else { originalPath } }
+    }
+
     shareType match {
       case "facebook" => Some(ShareLink("Facebook", "facebook", "Share on Facebook", s"https://www.facebook.com/sharer/sharer.php?u=$facebook&ref=responsive"))
       case "twitter"  => Some(ShareLink("Twitter", "twitter", "Share on Twitter", s"https://twitter.com/intent/tweet?text=${title.urlEncoded}&url=$twitter"))
@@ -32,7 +36,7 @@ trait ShareLinks { self: Content =>
       case "email"    => Some(ShareLink("Email", "email", "Share via Email", s"mailto:?subject=$webTitleAsciiEncoding&body=$link"))
       case "linkedin"  => Some(ShareLink("LinkedIn", "linkedin", "Share on LinkedIn", s"http://www.linkedin.com/shareArticle?mini=true&title=${title.urlEncoded}&url=${shortLinkUrl.urlEncoded}"))
       case "pinterestPage"  => Some(ShareLink("Pinterest", "pinterest", "Share on Pinterest", s"http://www.pinterest.com/pin/find/?url=${webLinkUrl.urlEncoded}"))
-      case "pinterestBlock"  => Some(ShareLink("Pinterest", "pinterest", "Share on Pinterest", s"http://www.pinterest.com/pin/create/button/?description=${title.urlEncoded}&url=${webLinkUrl.urlEncoded}&media=${mediaPath.getOrElse("").urlEncoded}"))
+      case "pinterestBlock"  => Some(ShareLink("Pinterest", "pinterest", "Share on Pinterest", s"http://www.pinterest.com/pin/create/button/?description=${title.urlEncoded}&url=${webLinkUrl.urlEncoded}&media=${fullMediaPath.getOrElse("").urlEncoded}"))
       case _ => None
     }
   }

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -3,11 +3,11 @@ package model
 import common.`package`._
 
 case class ShareLink (
-                       text: String,
-                       css: String,
-                       userMessage: String,
-                       href: String
-                       )
+  text: String,
+  css: String,
+  userMessage: String,
+  href: String
+)
 
 trait ShareLinks { self: Content =>
 

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -129,7 +129,13 @@ define([
 
     GalleryLightbox.prototype.generateImgHTML = function (img, i) {
         var blockShortUrl = config.page.shortUrl,
-            shareItems = [{
+            currentImage = GalleryLightbox.prototype.getImgSrc(img, '700', '700'),
+            urlPrefix,
+            shareItems;
+
+        if (/^\/\//.exec(currentImage) === '//') { urlPrefix = 'http:'; }
+
+        shareItems = [{
                 'text': 'Facebook',
                 'css': 'facebook',
                 'url': 'https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(blockShortUrl + '/sfb#img-' + i)
@@ -140,7 +146,7 @@ define([
             }, {
                 'text': 'Pinterest',
                 'css': 'pinterest',
-                'url': encodeURI('http://www.pinterest.com/pin/create/button/?description=' + config.page.webTitle + '&url=' + blockShortUrl + '&media=' + GalleryLightbox.prototype.getImgSrc(img, '700', '700'))
+                'url': encodeURI('http://www.pinterest.com/pin/create/button/?description=' + config.page.webTitle + '&url=' + blockShortUrl + '&media=' + urlPrefix + currentImage)
             }];
 
         return template(blockSharingTpl.replace(/^\s+|\s+$/gm, ''), {

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -130,12 +130,8 @@ define([
     GalleryLightbox.prototype.generateImgHTML = function (img, i) {
         var blockShortUrl = config.page.shortUrl,
             currentImage = GalleryLightbox.prototype.getImgSrc(img, '700', '700'),
-            urlPrefix,
-            shareItems;
-
-        if (/^\/\//.exec(currentImage) === '//') { urlPrefix = 'http:'; }
-
-        shareItems = [{
+            urlPrefix = currentImage.indexOf('//') === 0 ? 'http:' : '',
+            shareItems = [{
                 'text': 'Facebook',
                 'css': 'facebook',
                 'url': 'https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(blockShortUrl + '/sfb#img-' + i)


### PR DESCRIPTION
Pinterest changed the way it parsed the media paths we pass in and was erroring because they hadn't got a scheme.

This fixes that by prepending http: if it doesn't exist.
