### PR TITLE
Weather push to top

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -20,6 +20,7 @@ define([
     'common/utils/$',
     'common/utils/ajax',
     'common/utils/config',
+    'common/utils/detect',
     'common/utils/mediator',
     'common/utils/template',
     'common/modules/user-prefs',
@@ -32,6 +33,7 @@ define([
     $,
     ajax,
     config,
+    detect,
     mediator,
     template,
     userPrefs,
@@ -191,6 +193,12 @@ define([
             this.render = function (weatherData, city) {
                 this.attachToDOM(weatherData.html, city);
                 searchTool.bindElements($('.js-search-tool'));
+
+                console.log('Detect: ', detect.isBreakpoint({max: 'mobile'}));
+                if (detect.isBreakpoint({max: 'phablet'})) {
+                    console.log('move');
+                    window.scrollTo(0,0);
+                }
             };
         },
 

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -195,7 +195,7 @@ define([
                 searchTool.bindElements($('.js-search-tool'));
 
                 if (detect.isBreakpoint({max: 'phablet'})) {
-                    window.scrollTo(0,0);
+                    window.scrollTo(0, 0);
                 }
             };
         },

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -194,9 +194,7 @@ define([
                 this.attachToDOM(weatherData.html, city);
                 searchTool.bindElements($('.js-search-tool'));
 
-                console.log('Detect: ', detect.isBreakpoint({max: 'mobile'}));
                 if (detect.isBreakpoint({max: 'phablet'})) {
-                    console.log('move');
                     window.scrollTo(0,0);
                 }
             };


### PR DESCRIPTION
On mobile, search is pushing view down (focusing on input field). After selecting new city the weather widget is outside the screen. This is solving it:
![tzludezott](https://cloud.githubusercontent.com/assets/2579465/6130732/0e0957ba-b13f-11e4-9189-4ed54627834f.gif)
