### PR TITLE
stop adblock plus breaking end slates

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -216,7 +216,6 @@ define([
 
                     player.fullscreener();
 
-                    // do ads last so if the ad blocker throws an exception it doesn't stop anything else
                     if (config.switches.videoAdverts && !blockVideoAds && !config.page.isPreview) {
                         raven.wrap(
                             { tags: { feature: 'media' } },
@@ -243,7 +242,6 @@ define([
                     if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
                         initEndSlate(player, endSlateUri);
                     }
-
                 } else {
                     player.playlist({
                         mediaType: 'audio',

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -214,8 +214,13 @@ define([
                 // preroll for videos only
                 if (mediaType === 'video') {
 
+                    if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
+                        initEndSlate(player, endSlateUri);
+                    }
+
                     player.fullscreener();
-                    // Init plugins
+
+                    // do ads last so if the ad blocker throws an exception it doesn't stop anything else
                     if (config.switches.videoAdverts && !blockVideoAds && !config.page.isPreview) {
                         events.bindPrerollEvents(player);
                         player.adSkipCountdown(15);
@@ -234,9 +239,6 @@ define([
                         events.bindContentEvents(player);
                     }
 
-                    if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
-                        initEndSlate(player, endSlateUri);
-                    }
                 } else {
                     player.playlist({
                         mediaType: 'audio',

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -214,29 +214,34 @@ define([
                 // preroll for videos only
                 if (mediaType === 'video') {
 
-                    if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
-                        initEndSlate(player, endSlateUri);
-                    }
-
                     player.fullscreener();
 
                     // do ads last so if the ad blocker throws an exception it doesn't stop anything else
                     if (config.switches.videoAdverts && !blockVideoAds && !config.page.isPreview) {
-                        events.bindPrerollEvents(player);
-                        player.adSkipCountdown(15);
+                        raven.wrap(
+                            { tags: { feature: 'media' } },
+                            function () {
+                                events.bindPrerollEvents(player);
+                                player.adSkipCountdown(15);
 
-                        require(['js!//imasdk.googleapis.com/js/sdkloader/ima3'])
-                            .then(function () {
-                                player.ima({
-                                    id: mediaId,
-                                    adTagUrl: getAdUrl()
-                                });
-                                // Video analytics event.
-                                player.trigger(events.constructEventName('preroll:request', player));
-                                player.ima.requestAds();
-                            });
+                                require(['js!//imasdk.googleapis.com/js/sdkloader/ima3'])
+                                    .then(function () {
+                                        player.ima({
+                                            id: mediaId,
+                                            adTagUrl: getAdUrl()
+                                        });
+                                        // Video analytics event.
+                                        player.trigger(events.constructEventName('preroll:request', player));
+                                        player.ima.requestAds();
+                                    });
+                            }
+                        );
                     } else {
                         events.bindContentEvents(player);
+                    }
+
+                    if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
+                        initEndSlate(player, endSlateUri);
                     }
 
                 } else {


### PR DESCRIPTION
The "ima3" google library is blocked by adblock plus which causes an exception to be thrown from the JS.  This breaks anything that happens after it, which was adding the end slate.

I have just tweaked the order so we don't have such a big problem - however this is probably not the best way in general.

Should we wrap the require call in a try-catch instead?  Or something else?

cc found in issue #8119
