### PR TITLE
Print stylesheet tweaks

### DIFF
--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -20,7 +20,12 @@
 .content__headline:before,
 .caption--img:before,
 #dfp-ad--top-above-nav,
-.ad-slot__label {
+.ad-slot__label,
+.gallery-lightbox,
+.element-rich-link,
+.element-pullquote,
+.site-message,
+.breaking-news {
     display: none !important;
 }
 
@@ -34,6 +39,10 @@
     height: auto !important;
     background-color: #ffffff !important;
     color: #000000 !important;
+}
+
+.content__meta-container {
+    position: static;
 }
 
 .responsive-img,

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -25,7 +25,15 @@
 .element-rich-link,
 .element-pullquote,
 .site-message,
-.breaking-news {
+.breaking-news,
+.meta__contact-header,
+.meta__twitter,
+.meta__email,
+.inline-icon,
+.element--thumbnail,
+.media-primary--showcase,
+.content__standfirst a,
+.content__standfirst br {
     display: none !important;
 }
 


### PR DESCRIPTION
Received a couple of emails from central prod and userhelp regarding bugs with the print stylesheet. 
This PR hides some of the newer content page elements (like rich links) and fixes some overlapping.
