### PR TITLE
Rich link component name

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -499,7 +499,7 @@ object RichLinkCleaner extends HtmlCleaner {
     val richLinks = document.getElementsByClass("element-rich-link")
     richLinks
       .addClass("element-rich-link--not-upgraded")
-      .attr("data-component", s"rich-link")
+      .attr("data-component", "rich-link")
       .zipWithIndex.map{ case (el, index) => el.attr("data-link-name", s"rich-link-${richLinks.length} | ${index+1}") }
 
     document

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -499,7 +499,7 @@ object RichLinkCleaner extends HtmlCleaner {
     val richLinks = document.getElementsByClass("element-rich-link")
     richLinks
       .addClass("element-rich-link--not-upgraded")
-      .attr("data-component", s"rich-link-${richLinks.length}")
+      .attr("data-component", s"rich-link")
       .zipWithIndex.map{ case (el, index) => el.attr("data-link-name", s"rich-link-${richLinks.length} | ${index+1}") }
 
     document

--- a/static/src/javascripts/projects/common/views/content/richLinkTag.html
+++ b/static/src/javascripts/projects/common/views/content/richLinkTag.html
@@ -1,3 +1,3 @@
-<aside class="element element-rich-link element-rich-link--tag element--thumbnail element-rich-link--not-upgraded" data-component="rich-link-tag" data-link-name="rich-link-tag">
+<aside class="element element-rich-link element-rich-link--tag element--thumbnail element-rich-link--not-upgraded" data-component="rich-link" data-link-name="rich-link-tag">
     <p><a href="{{href}}">{{href}}</a></p>
 </aside>

--- a/static/src/javascripts/projects/common/views/content/richLinkTag.html
+++ b/static/src/javascripts/projects/common/views/content/richLinkTag.html
@@ -1,3 +1,3 @@
-<aside class="element element-rich-link element-rich-link--tag element--thumbnail element-rich-link--not-upgraded" data-component="rich-link" data-link-name="rich-link-tag">
+<aside class="element element-rich-link element-rich-link--tag element--thumbnail element-rich-link--not-upgraded" data-component="rich-link-tag" data-link-name="rich-link-tag">
     <p><a href="{{href}}">{{href}}</a></p>
 </aside>


### PR DESCRIPTION
Ophan should treat rich-links as a single component in the component breakdown graph. Varying the names is unnecessarily complicated and not all that useful
