### PR TITLE
flex items out for all flex

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -69,10 +69,15 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
+.has-flex {
+    .fc-item {
+        @include flex(1);
+    }
+}
+
 .has-flex-wrap {
     .fc-item {
         @include flex-display;
-        @include flex(1);
     }
 
     .fc-item__container {


### PR DESCRIPTION
`.has-flex` but `.has-no-flex-wrap` items were not filling their parents if the content wasn't large enough, resulting in this:

![screen shot 2015-02-11 at 14 12 39](https://cloud.githubusercontent.com/assets/867233/6148255/f164fe70-b1f7-11e4-84dc-7ab4a7c57222.png)

this makes sure they expand to their container, regardless of content.

http://www.browserstack.com/screenshots/6f0076494e86c7fb600bf0e4f9a4a4ffa3fda13f
