### PR TITLE
Fix bug with show more not working on mobile when no more desktop stories

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -115,9 +115,17 @@ define([
         });
 
         loadShowMore(config.page.pageId, button.id).then(function (response) {
-            var dedupedShowMore = dedupShowMore(button.$container, response.html);
+            var dedupedShowMore,
+                html = response.html.trim();
+
+            if (html) {
+                dedupedShowMore = dedupShowMore(button.$container, html);
+            }
+
             fastdom.write(function () {
-                button.$placeholder.replaceWith(dedupedShowMore);
+                if (dedupedShowMore) {
+                    button.$placeholder.replaceWith(dedupedShowMore);
+                }
                 setButtonState(button, STATE_DISPLAYED);
                 updatePref(button.id, button.state);
             });


### PR DESCRIPTION
![penguins](https://cloud.githubusercontent.com/assets/1001642/6150013/9829a880-b204-11e4-817b-f32dc6390327.gif)
