### PR TITLE
turn on minification for video javascript

### DIFF
--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -188,7 +188,6 @@ module.exports = function(grunt, options) {
                     'text',
                     'inlineSvg'
                 ],
-                optimize: 'none',
                 generateSourceMaps: true,
                 preserveLicenseComments: false
             }
@@ -216,7 +215,6 @@ module.exports = function(grunt, options) {
                     'text',
                     'inlineSvg'
                 ],
-                optimize: 'none',
                 generateSourceMaps: true,
                 preserveLicenseComments: false
             }


### PR DESCRIPTION
The code wasn't minified before which was causing a lot of code in http://assets.guim.co.uk/javascripts/bootstraps/0a0726eb4dc5e864c842c99a0c1d0828/video-player.js

So I've turned it on, things still seem to work in general and the code is smaller.
