### PR TITLE
AU about us link changed to information

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -105,8 +105,8 @@
                     about us</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="/info/2014/aug/11/guardian-australia-vacancies">
                     vacancies</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : about us" target="_blank" href="/info">
-                    about us</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : information" target="_blank" href="/info">
+                    information</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : contact us" target="_blank" href="/info/2013/may/26/contact-guardian-australia">
                     contact us</a></li>
             }


### PR DESCRIPTION
As we have two 'about us' links in the footer in AU edition.

Before:
![screen shot 2015-02-11 at 16 52 10](https://cloud.githubusercontent.com/assets/2579465/6151497/20349ee8-b20e-11e4-94e9-8326897c4f6c.png)

After:
![screen shot 2015-02-11 at 16 51 58](https://cloud.githubusercontent.com/assets/2579465/6151503/2cd86224-b20e-11e4-86df-f33cbf25054e.png)
