### PR TITLE
playable video on More In.... area

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -158,6 +158,7 @@ define([
         initPlayButtons(document.body);
 
         mediator.on('modules:related:loaded', initPlayButtons);
+        mediator.on('page:media:moreinloaded', initPlayButtons);
     }
 
     function enhanceVideo(el, autoplay) {
@@ -322,6 +323,7 @@ define([
 
         section.fetch(attachTo).then(function () {
             images.upgrade(attachTo);
+            mediator.emit('page:media:moreinloaded', attachTo);
         });
     }
 


### PR DESCRIPTION
http://www.theguardian.com/stage/video/2015/feb/06/the-departure-gillian-anderson-streetcar-named-desire-video
has a load of More in stuff that isn't the related content section.  This wasn't getting the play buttons so you could play it without clicking through.

Now it does.  Joy!

Before:
![image](https://cloud.githubusercontent.com/assets/7304387/6152416/cb1e7b7a-b214-11e4-9034-6e699b3f3785.png)
After:
![image](https://cloud.githubusercontent.com/assets/7304387/6152419/d68f55e2-b214-11e4-8b00-33c92deda992.png)
