### PR TITLE
Don't include meta element if no timestamp or comment count

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -277,6 +277,10 @@ case class ContentCard(
     cardTypes.allTypes.exists(_.canShowMedia) && !displaySettings.imageHide
 
   def showStandfirst = cardTypes.allTypes.exists(_.showStandfirst)
+
+  def showTimestamp = timeStampDisplay.isDefined && webPublicationDate.isDefined
+
+  def showMeta = discussionSettings.isCommentable || showTimestamp
 }
 
 case class HtmlBlob(html: Html, customCssClasses: Seq[String], cardTypes: ItemClasses) extends FaciaCard

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -107,7 +107,9 @@ data-test-id="facia-card"
             <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
         }
 
-        @meta(item)
+        @if(item.showMeta) {
+            @meta(item)
+        }
     </div>
 
         @item.cutOut.map { case cutOut @ CutOut(altText, imageUrl, _) =>


### PR DESCRIPTION
Probably won't save us much given most articles are commentable, but it's a start.
