### PR TITLE
Do not use Show More on tag pages

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -182,7 +182,8 @@ object FaciaContainer {
     None,
     hideToggle = false,
     showTimestamps = false,
-    None
+    None,
+    useShowMore = true
   )
 
   def forStoryPackage(dataId: String, items: Seq[Trail], title: String, href: Option[String] = None) = {
@@ -212,7 +213,8 @@ case class FaciaContainer(
   customClasses: Option[Seq[String]],
   hideToggle: Boolean,
   showTimestamps: Boolean,
-  dateLinkPath: Option[String]
+  dateLinkPath: Option[String],
+  useShowMore: Boolean
 ) {
   def transformCards(f: ContentCard => ContentCard) = copy(
     containerLayout = containerLayout.map(_.transformCards(f))

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -263,6 +263,8 @@ case class FaciaContainer(
     * can consume this data if they want to.
     */
   def showCPScottHeader = Switches.CPScottSwitch.isSwitchedOn && dataId == "uk/commentisfree/regular-stories"
+
+  def addShowMoreClasses = useShowMore && containerLayout.exists(_.hasShowMore)
 }
 
 object Front extends implicits.Collections {

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -128,6 +128,7 @@ object IndexPage {
         ).flatten),
         hideToggle = true,
         showTimestamps = true,
+        useShowMore = false,
         dateLinkPath = Some(s"/${indexPage.idWithoutEdition}")
       ).transformCards({ card =>
         card.copy(

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -10,8 +10,8 @@
     <div class="@RenderClasses(Map(
         ("fc-container__body", true),
         ("fc-container--rolled-up-hide", true),
-        ("fc-show-more--hidden", true),
-        ("js-container--fc-show-more", true),
+        ("fc-show-more--hidden", containerDefinition.useShowMore && containerDefinition.containerLayout.exists(_.hasShowMore)),
+        ("js-container--fc-show-more", containerDefinition.useShowMore && containerDefinition.containerLayout.exists(_.hasShowMore)),
         ("fc-show-more--mobile-only", containerDefinition.hasMobileOnlyShowMore)
     ))"
          data-title="@Html(Localisation(containerDefinition.displayName getOrElse ""))"
@@ -21,9 +21,17 @@
         }
 
         @if(containerDefinition.hasShowMore) {
-            <div class="js-show-more-placeholder"></div>
+            @if(containerDefinition.useShowMore) {
+                <div class="js-show-more-placeholder"></div>
 
-            @showMoreButton(containerDefinition.displayName getOrElse "")
+                @showMoreButton(containerDefinition.displayName getOrElse "")
+            } else {
+                @* Don't hide any items, for on tag pages, which are chronological *@
+                @showMore(
+                    containerDefinition.containerLayout.map(_.remainingCards).getOrElse(Nil),
+                    containerDefinition.index
+                )
+            }
         }
     </div>
 }

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -10,8 +10,8 @@
     <div class="@RenderClasses(Map(
         ("fc-container__body", true),
         ("fc-container--rolled-up-hide", true),
-        ("fc-show-more--hidden", containerDefinition.useShowMore && containerDefinition.containerLayout.exists(_.hasShowMore)),
-        ("js-container--fc-show-more", containerDefinition.useShowMore && containerDefinition.containerLayout.exists(_.hasShowMore)),
+        ("fc-show-more--hidden", containerDefinition.addShowMoreClasses),
+        ("js-container--fc-show-more", containerDefinition.addShowMoreClasses),
         ("fc-show-more--mobile-only", containerDefinition.hasMobileOnlyShowMore)
     ))"
          data-title="@Html(Localisation(containerDefinition.displayName getOrElse ""))"

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -9,7 +9,7 @@
 @* TODO Consolidate this with the master container template to get rid of repetition *@
 
 @defining(page.webTitle) { case (webTitle) =>
-    <section class="@GetClasses.forTagContainer(webTitle.nonEmpty, containerLayout.hasDesktopShowMore)"
+    <section class="@GetClasses.forTagContainer(webTitle.nonEmpty)"
         data-link-name="all index"
         @DfpAgent.sponsorshipTag(config).map { keyword =>
             data-keywords="@keyword"

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -59,12 +59,12 @@ object GetClasses {
     )
 
   /** TODO get rid of this when we consolidate 'all' logic with index logic */
-  def forTagContainer(hasTitle: Boolean, hasDesktopShowMore: Boolean) = forContainer(
+  def forTagContainer(hasTitle: Boolean) = forContainer(
     showLatestUpdate = false,
     isFirst = true,
     hasTitle,
     ContainerCommercialOptions.empty,
-    hasDesktopShowMore,
+    false,
     None,
     Nil,
     disableHide = true
@@ -81,7 +81,6 @@ object GetClasses {
     disableHide: Boolean = false
   ) = {
     RenderClasses((Seq(
-      ("js-container--fetch-updates", showLatestUpdate),
       ("fc-container", true),
       ("fc-container--first", isFirst),
       ("fc-container--has-show-more", hasDesktopShowMore),

--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -104,7 +104,8 @@ object FixturesAndResults extends Football {
           customClasses = Some(Seq("fc-container--tag")),
           hideToggle = true,
           showTimestamps = false,
-          dateLinkPath = None
+          dateLinkPath = None,
+          useShowMore = false
         )
       }
     }).flatten


### PR DESCRIPTION
It doesn't make sense to hide things behind show more on tag pages, as the stories are chronologically ordered, not by terms of importance. This leads sometimes to the most important story on a day not being displayed by default, which is silly.

We never show more than 35 stories per page on tag pages, so this never makes pages massive either in terms of DOM nodes or scroll length.

You do sometimes get ugly containers, due to the mix of four- & three-column items, so we should possibly (in a separate pull request) make a 4-column show more for these cases. CC @sammorrisdesign 

![screen shot 2015-02-12 at 11 30 28](https://cloud.githubusercontent.com/assets/1001642/6166750/f1d54294-b2aa-11e4-9556-63e36257a520.png)

I would like to get this out ASAP, though, as it fixes a current PROD bug where you can't see stories behind Show More.
