### PR TITLE
don't float all row__items

### DIFF
--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -16,10 +16,6 @@
     }
 }
 
-.l-row__item {
-    float: left;
-}
-
 // We only need this functionality for 2 & 4 column rows.
 @for $column from 2 through 4 {
     @for $span from 1 through 5 {
@@ -27,6 +23,7 @@
             .l-row__item--span-#{$span} {
                 @include mq(tablet) {
                     width: (100% / $column) * $span;
+                    float: left;
 
                     .has-flex & {
                         @include flex($span);


### PR DESCRIPTION
causes this to happen on mobile:

![screen shot 2015-02-12 at 12 14 36](https://cloud.githubusercontent.com/assets/867233/6167217/ca5fb4d2-b2b0-11e4-85e0-72c5f21a0e30.png)

putting it back returns it to:

![screen shot 2015-02-12 at 12 14 43](https://cloud.githubusercontent.com/assets/867233/6167220/d3723266-b2b0-11e4-9a52-2ada4e2dc150.png)
