### PR TITLE
Remove flex layout for facia slices/items at mobile breakpoints

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -74,7 +74,9 @@ $fc-item-gutter: $gs-gutter / 4;
     width: 100%;
 
     @include mq(tablet) {
-        @include flex(1);
+        .has-flex & {
+            @include flex(1);
+        }
 
         .has-flex-wrap & {
             @include flex-display;
@@ -92,7 +94,7 @@ $fc-item-gutter: $gs-gutter / 4;
     @include box-sizing(border-box);
 
     @include mq(tablet) {
-        .has-flex-wrap {
+        .has-flex-wrap & {
             @include flex-direction(column);
             @include flex-display;
             @include flex(1);
@@ -122,8 +124,18 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item,
 .item {
-    margin-left: $gs-gutter * .5;
-    margin-right: $gs-gutter * .5;
+    @include mq($until: tablet) {
+        padding-left: $gs-gutter * .5;
+        padding-right: $gs-gutter * .5;
+        @include box-sizing(border-box);
+    }
+
+    @include mq(tablet) {
+        padding-left: 0;
+        padding-right: 0;
+        margin-left: $gs-gutter * .5;
+        margin-right: $gs-gutter * .5;
+    }
 
     a {
         color: colour(neutral-1);

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -70,8 +70,9 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 .fc-item {
-    display: block;
-    width: 100%;
+    @include mq($until: tablet) {
+        width: 100%;
+    }
 
     @include mq(tablet) {
         .has-flex & {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -69,24 +69,33 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-.has-flex-wrap {
-    .fc-item {
-        @include flex-display;
-        @include flex(1);
-    }
+.fc-item {
+    display: block;
+    width: 100%;
 
-    .fc-item__container {
-        @include flex-direction(column);
-        @include flex-display;
-        @include flex(1);
-        width: 100%;
+    @include mq(tablet) {
+        .has-flex-wrap & {
+            @include flex-display;
+            @include flex(1);
+        }
+
+        .has-no-flex-wrap & {
+            @include clearfix;
+        }
     }
 }
 
-.has-no-flex-wrap {
-    .fc-item {
-        display: block;
-        @include clearfix;
+.fc-item__container {
+    display: block;
+    width: 100%;
+    @include box-sizing(border-box);
+
+    @include mq(tablet) {
+        .has-flex-wrap {
+            @include flex-direction(column);
+            @include flex-display;
+            @include flex(1);
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -21,6 +21,7 @@
 // overrides of current slices
 
 .fc-slice__item {
+    width: 100%;
     position: relative;
     padding-bottom: 0;
     margin-bottom: $gs-baseline;

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -25,15 +25,17 @@
     padding-bottom: 0;
     margin-bottom: $gs-baseline;
 
+    @include mq(tablet) {
+        .has-flex & {
+            @include flex-display;
+        }
+    }
+
     + .fc-slice__item {
         @include vertical-item-separator;
     }
     + .fc-slice__item--no-mpu:before {
         border-left: 0 !important;
-    }
-
-    .has-flex & {
-        @include flex-display;
     }
 
     &.l-list__item {

--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -1,9 +1,11 @@
 .l-list {
     width: 100%;
 
-    .has-flex-wrap & {
-        @include flex-display;
-        @include flex-wrap(wrap);
+    @include mq(mobile) {
+        .has-flex-wrap & {
+            @include flex-display;
+            @include flex-wrap(wrap);
+        }
     }
 }
 

--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -1,7 +1,7 @@
 .l-list {
     width: 100%;
 
-    @include mq(mobile) {
+    @include mq(tablet) {
         .has-flex-wrap & {
             @include flex-display;
             @include flex-wrap(wrap);


### PR DESCRIPTION
As our mobile breakpoint is a single column there is no need to layout with flexbox, which could be potentially affecting rendering of large DOMs for older devices (such as iPhone 4 iPad 1).

This wraps all flex layouts with media queries and ensures certain elements display full width. 

Thanks to @robertberry for the idea! @sndrs if you could have a review that would be great.
