### PR TITLE
De-rgba facia cards

### DIFF
--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -109,7 +109,7 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
 .l-footer__misc {
     padding-top: $gs-baseline * .5;
     padding-bottom: $gs-baseline * 1.5;
-    border-top: 1px solid fade-out(colour(neutral-4), .8);
+    border-top: 1px solid mix(colour(neutral-4), $c-footer-background, 20%);
 }
 
 .really-serious-copyright {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -218,10 +218,6 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 .fc-item__image-container {
-    background-color: rgba(0, 0, 0, .1);
-}
-
-.fc-item__image-container {
     display: none;
 }
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -269,7 +269,7 @@ $fc-item-gutter: $gs-gutter / 4;
         content: '/';
         display: inline-block;
         margin-left: .2em;
-        color: fade-out(colour(neutral-1), .8);
+        color: mix(colour(neutral-1), #ffffff, 20%);
     }
 
     &:hover:after {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -282,7 +282,7 @@ $fc-item-gutter: $gs-gutter / 4;
     display: block;
     @include fs-header(2);
     line-height: get-line-height(bodyHeading, 1);
-    background-color: fade-out(#000000, .9);
+    background-color: mix(#000000, #ffffff, 10%);
     margin: 0 (0 - $gs-gutter * .25);
     padding: ($gs-baseline * .25) ($gs-gutter * .25);
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
@@ -29,6 +29,10 @@
         color: colour(news-support-6);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(analysis-background), 10%);
+    }
+
     .fc-item__meta {
         color: colour(neutral-2);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
@@ -26,10 +26,6 @@
         fill: colour(comment-default);
     }
 
-    .fc-item__meta {
-        background-color: fade-out(colour(comment-background), .5);
-    }
-
     .fc-item__standfirst,
     .flyer__standfirst {
         ul > li:before {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
@@ -22,6 +22,10 @@
         color: colour(comment-default);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(comment-background), 10%);
+    }
+
     .flyer__arrow-icon {
         fill: colour(comment-default);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
@@ -18,6 +18,10 @@
         color: colour(live-accent);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(neutral-7), 10%);
+    }
+
     .flyer__read-more-text {
         color: colour(neutral-2);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
@@ -33,6 +33,10 @@
         color: colour(editorial-accent);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(editorial-accent), 10%);
+    }
+
     .flyer__arrow-icon {
         fill: colour(editorial-accent);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
@@ -46,7 +46,7 @@
     }
 
     .fc-sublink__title:before {
-        border-color: fade-out($c-headline, .8);
+        border-color: mix($c-headline, colour(editorial-default), 20%);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
@@ -6,6 +6,10 @@
         color: colour(external-main-1);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(neutral-6), 10%);
+    }
+
     .u-faux-block-link--hover {
         background-color: darken(colour(neutral-6), 3%);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -50,7 +50,7 @@
     .flyer__standfirst {
         color: mix($c-headline, colour(feature-default), 80%);
         ul > li:before {
-            background: rgba($c-headline, .4);
+            background: mix($c-headline, colour(feature-default), 40%);
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -33,6 +33,10 @@
         color: colour(feature-mute);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(feature-default), 10%);
+    }
+
     .flyer__arrow-icon {
         fill: colour(feature-mute);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -43,7 +43,7 @@
 
     .fc-item__kicker:after,
     .fc-sublink__kicker:after {
-        color: fade-out($c-headline, .8);
+        color: mix($c-headline, colour(feature-default), 20%);
     }
 
     .fc-item__standfirst,
@@ -62,7 +62,7 @@
     }
 
     .fc-sublink__title:before {
-        border-color: fade-out($c-headline, .6);
+        border-color: mix($c-headline, colour(feature-default), 40%);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -41,6 +41,10 @@
         color: fade-out($c-headline, .8);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(live-default), 10%);
+    }
+
     .fc-item__standfirst {
         color: mix($c-headline, colour(live-default), 80%);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -38,7 +38,7 @@
     .fc-item__kicker:after,
     .flyer__kicker:after,
     .fc-sublink__kicker:after {
-        color: fade-out($c-headline, .8);
+        color: mix($c-headline, colour(live-default), 20%);
     }
 
     .fc-item__kicker--dreamsnap {
@@ -56,7 +56,7 @@
     }
 
     .fc-sublink__title:before {
-        border-color: fade-out($c-headline, .8);
+        border-color: mix($c-headline, colour(live-default), 20%);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
@@ -42,6 +42,10 @@
         color: fade-out($c-headline, .6);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(media-background), 10%);
+    }
+
     .fc-item__standfirst,
     .flyer__standfirst,
     .fc-item__meta {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
@@ -39,7 +39,7 @@
     .fc-item__kicker:after,
     .flyer__kicker:after,
     .fc-sublink__kicker:after {
-        color: fade-out($c-headline, .6);
+        color: mix($c-headline, colour(media-background), 40%);
     }
 
     .fc-item__kicker--dreamsnap {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
@@ -15,6 +15,10 @@
         color: colour(news-default);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(neutral-8), 10%);
+    }
+
     .fc-item__kicker--breaking-news {
         color: colour(live-default);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-podcast.scss
@@ -42,7 +42,7 @@
     .fc-item__kicker:after,
     .flyer__kicker:after,
     .fc-sublink__kicker:after {
-        color: fade-out($c-headline, .8);
+        color: mix($c-headline, colour(podcast-background), 20%);
     }
 
     .fc-item__standfirst,

--- a/static/src/stylesheets/module/facia/item-tones/_tone-podcast.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-podcast.scss
@@ -31,6 +31,10 @@
         color: colour(podcast-default);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(podcast-background), 10%);
+    }
+
     .flyer__arrow-icon {
         fill: colour(podcast-default);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
@@ -30,6 +30,10 @@
         color: colour(review-accent);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(review-background), 10%);
+    }
+
     .flyer__arrow-icon {
         fill: colour(review-accent);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
@@ -40,11 +40,11 @@
 
     .fc-item__kicker:after,
     .fc-sublink__kicker:after {
-        color: fade-out($c-headline, .8);
+        color: mix($c-headline, colour(review-background), 20%);
     }
 
     .fc-item__standfirst {
-        color: fade-out($c-headline, .4);
+        color: mix($c-headline, colour(review-background), 60%);
     }
 
     .fc-item__meta {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
@@ -50,7 +50,7 @@
     .fc-item__kicker:after,
     .flyer__kicker:after,
     .fc-sublink__kicker:after {
-        color: mix(#ffffff, colour(news-support-6), 80%);
+        color: mix(#ffffff, colour(news-support-6), 20%);
     }
 
     .fc-sublink__title:before {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
@@ -31,6 +31,10 @@
         color: colour(news-support-1);
     }
 
+    .fc-item__kicker--dreamsnap {
+        background-color: mix(#000000, colour(news-support-6), 10%);
+    }
+
     .fc-item__kicker--breaking-news {
         color: #ffffff;
     }

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -750,7 +750,7 @@ $burger-width: 16px;
 %burger-icon__line {
     width: 100%;
     height: $burger-line-h;
-    background-color: rgba(#ffffff, .9);
+    background-color: mix(#ffffff, $c-navigation-toggle-background, 90%);
 }
 
 .burger-icon {


### PR DESCRIPTION
uses solid colours instead of fading in sass (excpt for breaking news alert, which makes good use of them)
