### PR TITLE
Test disabling image upgrading on resize

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -51,9 +51,9 @@ function (
 
         listen: function () {
             mediator.addListeners({
-                'window:resize': debounce(function () {
-                    images.upgrade();
-                }, 200),
+                //'window:resize': debounce(function () {
+                //    images.upgrade();
+                //}, 200),
                 'window:orientationchange': debounce(function () {
                     images.upgrade();
                 }, 200),

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -4,6 +4,7 @@ define([
     'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/ajax',
+    'common/utils/detect',
     'common/utils/mediator',
     'common/utils/template',
     'common/utils/to-array',
@@ -15,6 +16,7 @@ define([
     debounce,
     $,
     ajax,
+    detect,
     mediator,
     template,
     toArray,
@@ -33,7 +35,7 @@ define([
 
         snaps.forEach(fetchSnap);
 
-        if (snaps.length) {
+        if (snaps.length && !detect.isIOS()) {
             mediator.on('window:resize', debounce(function () {
                 snaps.forEach(function (el) { addCss(el, true); });
             }, 200));


### PR DESCRIPTION
We've noticed that iOS is incorrectly firing resize events on scroll. This could potentially be causing devices to thrash the DOM. 

I'm going to ship this and leave over night to see its effect on the graphs. How we handle image upgrading on resize is completely changing with @samdesborough's PR #8296 which is coming in the next few days.

/cc @robertberry @gklopper @johnduffell 
