### PR TITLE
Remove two unnecessary spans in comment counts

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -17,6 +17,9 @@
         }
         data-discussion-closed="@item.discussionSettings.isClosedForComments"
         data-discussion-url="@item.header.url.get(request)#comments"
+        @if(item.cutOut.isDefined || item.showTimestamp) {
+            data-discussion-hide-label="true"
+        }
     }
 data-link-name="@item.cardStyle.toneString | @{index + 1}"
     @item.id.map { id =>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -62,6 +62,7 @@ define([
                         $node = bonzo(node),
                         commentOrComments = (c.count === 1 ? 'comment' : 'comments'),
                         url = $node.attr('data-discussion-url') || getContentUrl(node),
+                        hideLabel = $node.attr('data-discussion-hide-label') === 'true',
                         $container,
                         meta,
                         html;
@@ -75,7 +76,7 @@ define([
                     html = template(templates[format] || defaultTemplate, {
                         url: url,
                         count: formatters.integerCommas(c.count),
-                        label: commentOrComments
+                        label: hideLabel ? '' : commentOrComments
                     });
 
                     meta = qwery('.js-item__meta', node);

--- a/static/src/javascripts/projects/common/views/discussion/comment-count.html
+++ b/static/src/javascripts/projects/common/views/discussion/comment-count.html
@@ -1,3 +1,1 @@
-<a class="fc-trail__count fc-trail__count--commentcount" href="{{url}}" data-link-name="Comment count">
-    <span class="js-item__comment-count">{{count}}</span> <span class="fc-trail__count__label js-item__comment-or-comments">{{label}}</span>
-</a>
+<a class="fc-trail__count fc-trail__count--commentcount" href="{{url}}" data-link-name="Comment count">{{count}} {{label}}</a>

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -356,10 +356,6 @@ $fc-item-gutter: $gs-gutter / 4;
     display: none;
 }
 
-.fc-item__timestamp + .fc-trail__count .fc-trail__count__label {
-    display: none;
-}
-
 .fc-item--has-cutout .fc-item__media-wrapper {
     // We never want to show the media and the cutout at the same time, hence the important
     display: none !important;

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -164,10 +164,6 @@
             .fc-item__container {
                 padding-bottom: gs-height(3) + $gs-baseline * 3;
             }
-
-            .fc-trail__count__label {
-                display: none;
-            }
         }
 
         .fc-item__avatar {


### PR DESCRIPTION
Should save us a bunch of elements as most stories get these appended
