### PR TITLE
Test: Disable resize handlers on iOS (take 2)

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -61,7 +61,7 @@ function (
                 }
             });
 
-            if(!detect.isIOS) {
+            if (!detect.isIOS) {
                 mediator.on('window:resize', debounce(function () {
                     images.upgrade();
                 }, 200));

--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -5,6 +5,7 @@ define([
     'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/$css',
+    'common/utils/detect',
     'common/utils/mediator'
 ],
 function (
@@ -14,6 +15,7 @@ function (
     debounce,
     $,
     $css,
+    detect,
     mediator
 ) {
 
@@ -51,9 +53,6 @@ function (
 
         listen: function () {
             mediator.addListeners({
-                //'window:resize': debounce(function () {
-                //    images.upgrade();
-                //}, 200),
                 'window:orientationchange': debounce(function () {
                     images.upgrade();
                 }, 200),
@@ -61,6 +60,12 @@ function (
                     images.upgrade(context);
                 }
             });
+
+            if(!detect.isIOS) {
+                mediator.on('window:resize', debounce(function () {
+                    images.upgrade();
+                }, 200));
+            }
         }
 
     };

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -4,6 +4,7 @@ define([
     'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/ajax',
+    'common/utils/detect',
     'common/utils/mediator',
     'common/utils/template',
     'common/utils/to-array',
@@ -15,6 +16,7 @@ define([
     debounce,
     $,
     ajax,
+    detect,
     mediator,
     template,
     toArray,
@@ -33,7 +35,7 @@ define([
 
         snaps.forEach(fetchSnap);
 
-        if (snaps.length) {
+        if (snaps.length && !detect.isIOS) {
             mediator.on('window:resize', debounce(function () {
                 snaps.forEach(function (el) { addCss(el, true); });
             }, 200));

--- a/static/test/javascripts/spec/common/ui/images.spec.js
+++ b/static/test/javascripts/spec/common/ui/images.spec.js
@@ -67,7 +67,6 @@ define([
             ['orientationchange'].forEach(function (event) {
                 it('should listen to "' + event + '"', function (done) {
                     var upgradeSpy = sinon.spy(images, 'upgrade');
-                    navigator.userAgent = 'test';
                     images.listen();
                     mediator.emit('window:' + event);
                     waitsForAndRuns(

--- a/static/test/javascripts/spec/common/ui/images.spec.js
+++ b/static/test/javascripts/spec/common/ui/images.spec.js
@@ -64,9 +64,10 @@ define([
 
         describe('window events', function () {
 
-            ['resize', 'orientationchange'].forEach(function (event) {
+            ['orientationchange'].forEach(function (event) {
                 it('should listen to "' + event + '"', function (done) {
                     var upgradeSpy = sinon.spy(images, 'upgrade');
+                    navigator.userAgent = 'test';
                     images.listen();
                     mediator.emit('window:' + event);
                     waitsForAndRuns(


### PR DESCRIPTION
To see if this is causing some of our iOS problems.

We've noticed that iOS is incorrectly firing resize events on scroll. This could potentially be causing devices to thrash the DOM.

I'm going to ship this and see its effect on the graphs. How we handle image upgrading on resize is completely changing with @samdesborough's PR #8296 which is coming in the next few days.

/cc @robertberry @gklopper @johnduffell
