### PR TITLE
Protect City, Region and Country headers from being Some empty string

### DIFF
--- a/weather/app/controllers/LocationsController.scala
+++ b/weather/app/controllers/LocationsController.scala
@@ -32,9 +32,9 @@ object LocationsController extends Controller with ExecutionContexts with Loggin
     def getEncodedHeader(key: String) =
       request.headers.get(key).map(java.net.URLDecoder.decode(_, "latin1"))
 
-    val maybeCity = getEncodedHeader(CityHeader)
-    val maybeRegion = getEncodedHeader(RegionHeader)
-    val maybeCountry = getEncodedHeader(CountryHeader)
+    val maybeCity = getEncodedHeader(CityHeader).filter(_.nonEmpty)
+    val maybeRegion = getEncodedHeader(RegionHeader).filter(_.nonEmpty)
+    val maybeCountry = getEncodedHeader(CountryHeader).filter(_.nonEmpty)
 
     log.info(s"What is my city request with headers $maybeCity $maybeRegion $maybeCountry")
 


### PR DESCRIPTION
Currently getting the exception in weather due to an empty city field:

`ERROR play - Cannot invoke the action, eventually got an error: com.fasterxml.jackson.databind.JsonMappingException: No content to map due to end-of-input`

This ensures that we don't get an Option[String] that is an empty string.

@uplne @robertberry 
