### PR TITLE
stop omniture forcing a relayout

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -185,7 +185,6 @@ define([
             s.eVar21    = (window.innerWidth || document.documentElement.clientWidth)
                         + 'x'
                         + (window.innerHeight || document.documentElement.clientHeight);
-            console.log("size IS: ",s.eVar21);
             s.eVar32    = detect.getOrientation();
 
             /* Set Time Parting Day and Hour Combination - 0 = GMT */

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -181,7 +181,11 @@ define([
 
             // see http://blogs.adobe.com/digitalmarketing/mobile/responsive-web-design-and-web-analytics/
             s.eVar18    = detect.getBreakpoint();
-            s.eVar21    = document.documentElement.clientWidth + 'x' + document.documentElement.clientHeight;
+            // getting clientWidth causes a reflow, so avoid using if possible
+            s.eVar21    = (window.innerWidth || document.documentElement.clientWidth)
+                        + 'x'
+                        + (window.innerHeight || document.documentElement.clientHeight);
+            console.log("size IS: ",s.eVar21);
             s.eVar32    = detect.getOrientation();
 
             /* Set Time Parting Day and Hour Combination - 0 = GMT */


### PR DESCRIPTION
I found that the omniture clientWidth was forcing a relayout which is expensive and unnecessary.  This is because it takes into account the CSS border and margin before it can return a value.
![image](https://cloud.githubusercontent.com/assets/7304387/6186571/110f401a-b373-11e4-8c90-7f26c4819f22.png)

On my laptop it only takes a millisecond or two to do the relayout, but it may be significant on slower machines or phones.

The innerWidth works on most browsers and gives the viewport dimensions which will include the scrollbar (and any border and margin, which there is none on documentElement)  This isn't really a significant different, but if we are on IE8 or earlier it will fall back to the clientWidth as this isn't supported.

For more exciting info see:
http://www.phpied.com/rendering-repaint-reflowrelayout-restyle/
