### PR TITLE
Don't use strange characters in Facia container IDs

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -222,7 +222,7 @@ case class FaciaContainer(
 
   def faciaComponentName = componentId getOrElse {
     displayName map { title: String =>
-      title.toLowerCase.replace(" ", "-")
+      title.toLowerCase.replace(" ", "-").replaceAll("&", "and").replaceAll("""[^A-Za-z0-9_-]""", "")
     } getOrElse "no-name"
   }
 


### PR DESCRIPTION
It stops you from being able to select them using `document.querySelectorAll`, which I'm doing quite a bit at the moment, as I'm looking at the DOM.

I know basically any characters are valid in HTML5, but browsers don't implement it correctly.
