### PR TITLE
Amend Discussion-is-off message for upcoming maintenance

### DIFF
--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -143,7 +143,7 @@
                             <h2 class="container__meta__title">Comments</h2>
                         </div>
                     </div>
-                    <div class="discussion__disabled-msg">Comments is currently undergoing scheduled maintenance but will be back again shortly.</div>
+                    <div class="discussion__disabled-msg">Comments are currently undergoing scheduled maintenance but will be back again shortly.</div>
                 </div>
             </div>
         </div>

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -143,7 +143,7 @@
                             <h2 class="container__meta__title">Comments</h2>
                         </div>
                     </div>
-                    <div class="discussion__disabled-msg">Discussion is currently unavailable.</div>
+                    <div class="discussion__disabled-msg">Comments is currently undergoing scheduled maintenance but will be back again shortly.</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This is the message displayed to users when the Discussion switch is turned off.

Suggestion is to revert this change once the maintenance has taken place, although happy to do something more thorough if people don't like this idea.
