### PR TITLE
Make forecast times to be +3h sequence

### DIFF
--- a/weather/app/controllers/WeatherController.scala
+++ b/weather/app/controllers/WeatherController.scala
@@ -19,7 +19,7 @@ object WeatherController extends Controller with ExecutionContexts {
 
   def forecastForCityId(cityId: String) = Action.async { implicit request =>
     WeatherApi.getForecastForCityId(CityId(cityId)).map({ forecastDays =>
-      val response = forecastDays.map(models.ForecastResponse.fromAccuweather).filterByIndex(_ % 3 == 1).take(5)
+      val response = forecastDays.map(models.ForecastResponse.fromAccuweather).filterByIndex(_ % 3 == 0).take(5)
 
       Cached(10.minutes)(JsonComponent(views.html.cityForecast(response)))
     })


### PR DESCRIPTION
As we did some changes to time calculation on Friday I had to change how we are calculating the +3h sequence so it's accurate now.

Before:
![screen shot 2015-02-16 at 10 41 40](https://cloud.githubusercontent.com/assets/2579465/6210606/37c68cf6-b5c9-11e4-9918-af57b2bf994d.png)
The first time is +4h

After:
![screen shot 2015-02-16 at 10 41 55](https://cloud.githubusercontent.com/assets/2579465/6210616/44866790-b5c9-11e4-9b2d-0068a7dd0468.png)
The first time is +3h which is correct.
