### PR TITLE
Desktop-only containers

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -75,6 +75,12 @@ object Switches {
   private lazy val never = new LocalDate(2100, 1, 1)
 
   // Performance
+  val DesktopOnlyContainersSwitch = Switch("Performance", "desktop-only-containers",
+    "If this switch is on, certain containers will only render on desktop breakpoints",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 4, 1)
+  )
+
   val TagPageSizeSwitch = Switch("Performance", "tag-page-size",
     "If this switch is on then we will request more items for larger tag pages",
     safeState = Off,

--- a/common/app/layout/DesktopOnlyContainers.scala
+++ b/common/app/layout/DesktopOnlyContainers.scala
@@ -9,11 +9,13 @@ object DesktopOnlyContainers {
   val WhatWereReading = "54d7dcce-93db-4d11-a0d0-0e6d69980918"
   val TakePart = "eaf2df82-f7b4-4d96-a681-db52be53c798"
   val People = "uk-alpha/people-in-the-news/feature-stories"
+  val RobTestContainer = "e5737dab-cc0f-4ea2-bb6a-6992cb21ac8e"
 
   val all = Set(
     InBrief,
     WhatWereReading,
     TakePart,
-    People
+    People,
+    RobTestContainer
   )
 }

--- a/common/app/layout/DesktopOnlyContainers.scala
+++ b/common/app/layout/DesktopOnlyContainers.scala
@@ -1,0 +1,19 @@
+package layout
+
+/** For now we are hardcoding the IDs of the containers here while we test if this helps performance on mobile devices.
+  *
+  * If it does, then we will introduce the idea of desktop-only containers to Facia Tool.
+  */
+object DesktopOnlyContainers {
+  val InBrief = "8852-9cf6-d938-01fb"
+  val WhatWereReading = "54d7dcce-93db-4d11-a0d0-0e6d69980918"
+  val TakePart = "eaf2df82-f7b4-4d96-a681-db52be53c798"
+  val People = "uk-alpha/people-in-the-news/feature-stories"
+
+  val all = Set(
+    InBrief,
+    WhatWereReading,
+    TakePart,
+    People
+  )
+}

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -266,7 +266,7 @@ case class FaciaContainer(
 
   def addShowMoreClasses = useShowMore && containerLayout.exists(_.hasShowMore)
 
-  def isDesktopOnly = DesktopOnlyContainers.all.contains(dataId)
+  def isDesktopOnly = Switches.DesktopOnlyContainersSwitch.isSwitchedOn && DesktopOnlyContainers.all.contains(dataId)
 }
 
 object Front extends implicits.Collections {

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -265,6 +265,8 @@ case class FaciaContainer(
   def showCPScottHeader = Switches.CPScottSwitch.isSwitchedOn && dataId == "uk/commentisfree/regular-stories"
 
   def addShowMoreClasses = useShowMore && containerLayout.exists(_.hasShowMore)
+
+  def isDesktopOnly = DesktopOnlyContainers.all.contains(dataId)
 }
 
 object Front extends implicits.Collections {

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -55,7 +55,8 @@ object GetClasses {
       Some(containerDefinition.container),
       extraClasses = containerDefinition.customClasses.getOrElse(Seq.empty) ++
         slices.Container.customClasses(containerDefinition.container),
-      disableHide = containerDefinition.hideToggle
+      disableHide = containerDefinition.hideToggle,
+      desktopOnly = containerDefinition.isDesktopOnly
     )
 
   /** TODO get rid of this when we consolidate 'all' logic with index logic */
@@ -67,7 +68,8 @@ object GetClasses {
     false,
     None,
     Nil,
-    disableHide = true
+    disableHide = true,
+    desktopOnly = false
   )
 
   def forContainer(
@@ -78,12 +80,14 @@ object GetClasses {
     hasDesktopShowMore: Boolean,
     container: Option[slices.Container] = None,
     extraClasses: Seq[String] = Nil,
-    disableHide: Boolean = false
+    disableHide: Boolean = false,
+    desktopOnly: Boolean
   ) = {
     RenderClasses((Seq(
       ("fc-container", true),
       ("fc-container--first", isFirst),
       ("fc-container--has-show-more", hasDesktopShowMore),
+      ("fc-container--desktop-only", desktopOnly),
       ("js-container--first", isFirst),
       ("fc-container--sponsored", commercialOptions.isSponsored),
       ("fc-container--advertisement-feature", commercialOptions.isAdvertisementFeature),

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -24,11 +24,7 @@
 
                 @defining(faciaPage.front.containers) { collections =>
                     @collections.map { containerDefinition =>
-                        @if(containerDefinition.isDesktopOnly) {
-                            <div class="js-desktop-container-placeholder" data-container-id="@containerDefinition.dataId"></div>
-                        } else {
-                            @fragments.containers.facia_cards.container(containerDefinition, faciaPage.frontProperties)
-                        }
+                        @fragments.containers.facia_cards.container(containerDefinition, faciaPage.frontProperties)
                     }
                 }
 

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -24,7 +24,11 @@
 
                 @defining(faciaPage.front.containers) { collections =>
                     @collections.map { containerDefinition =>
-                        @fragments.containers.facia_cards.container(containerDefinition, faciaPage.frontProperties)
+                        @if(containerDefinition.isDesktopOnly) {
+                            <div class="js-desktop-container-placeholder" data-container-id="@containerDefinition.dataId"></div>
+                        } else {
+                            @fragments.containers.facia_cards.container(containerDefinition, faciaPage.frontProperties)
+                        }
                     }
                 }
 

--- a/static/src/stylesheets/module/facia/_containers.scss
+++ b/static/src/stylesheets/module/facia/_containers.scss
@@ -97,3 +97,9 @@
         width: 100%;
     }
 }
+
+.fc-container--desktop-only {
+    @include mq($until: desktop) {
+        display: none;
+    }
+}


### PR DESCRIPTION
Initial test of desktop-only containers.

CC @gklopper 

Alex suggested we hide the containers at first by CSS, as he suspects that it's what it has to render that's the cause of the crashes, rather than stuff that's just in the DOM but hidden. It's also much simpler to do this. If it doesn't resolve the perf issues, we could then try removing them completely and AJAXing them in.
