### PR TITLE
Use Single-Thread Execution Context for Book Lookups

### DIFF
--- a/commercial/app/model/commercial/books/BookFinder.scala
+++ b/commercial/app/model/commercial/books/BookFinder.scala
@@ -20,7 +20,7 @@ object BookFinder extends ExecutionContexts with Logging {
   private final val circuitBreaker = new CircuitBreaker(
     scheduler = Akka.system.scheduler,
     maxFailures = 10,
-    callTimeout = 4.seconds,
+    callTimeout = 2.seconds,
     resetTimeout = 1.minute
   )
 
@@ -82,7 +82,7 @@ object MagentoService extends Logging {
       val request = FeedRequest(
         feedName = "Book Lookup",
         url = Some(s"${props.urlPrefix}/$isbn"),
-        timeout = 5.seconds,
+        timeout = 3.seconds,
         switch = GuBookshopFeedsSwitch)
 
       FeedReader.read(request,

--- a/commercial/app/model/commercial/books/BookFinder.scala
+++ b/commercial/app/model/commercial/books/BookFinder.scala
@@ -72,8 +72,8 @@ object MagentoService extends Logging {
     )
   }
 
-  private implicit val singleThreadExecutionContext: ExecutionContext =
-    Akka.system.dispatchers.lookup("play.akka.actor.single-thread")
+  private implicit val bookLookupExecutionContext: ExecutionContext =
+    Akka.system.dispatchers.lookup("play.akka.actor.book-lookup")
 
   def findByIsbn(isbn: String): Future[Option[Book]] = {
 

--- a/commercial/app/model/commercial/books/BookFinder.scala
+++ b/commercial/app/model/commercial/books/BookFinder.scala
@@ -10,8 +10,8 @@ import play.api.libs.concurrent.Akka
 import play.api.libs.json._
 import play.api.libs.oauth.{ConsumerKey, OAuthCalculator, RequestToken}
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 object BookFinder extends ExecutionContexts with Logging {
 
@@ -51,7 +51,7 @@ object BookFinder extends ExecutionContexts with Logging {
 }
 
 
-object MagentoService extends ExecutionContexts with Logging {
+object MagentoService extends Logging {
 
   private case class MagentoProperties(oauth: OAuthCalculator, urlPrefix: String)
 
@@ -71,6 +71,9 @@ object MagentoService extends ExecutionContexts with Logging {
       urlPrefix = s"http://$domain/$path"
     )
   }
+
+  private implicit val singleThreadExecutionContext: ExecutionContext =
+    Akka.system.dispatchers.lookup("play.akka.actor.single-thread")
 
   def findByIsbn(isbn: String): Future[Option[Book]] = {
 

--- a/commercial/app/model/commercial/masterclasses/EventbriteApi.scala
+++ b/commercial/app/model/commercial/masterclasses/EventbriteApi.scala
@@ -1,5 +1,6 @@
 package model.commercial.masterclasses
 
+import common.ExecutionContexts
 import conf.Switches.MasterclassFeedSwitch
 import conf.{CommercialConfiguration, Configuration}
 import model.commercial.{FeedReader, FeedRequest}
@@ -8,7 +9,7 @@ import play.api.libs.json.JsValue
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-object EventbriteApi {
+object EventbriteApi extends ExecutionContexts {
 
   lazy val organiserId = "684756979"
   lazy val apiKeyOption = CommercialConfiguration.getProperty("masterclasses.api.key")

--- a/commercial/app/model/commercial/money/package.scala
+++ b/commercial/app/model/commercial/money/package.scala
@@ -10,7 +10,7 @@ import scala.xml.Elem
 
 package object money {
 
-  trait MoneySupermarketApi[T] extends Logging {
+  trait MoneySupermarketApi[T] extends ExecutionContexts with Logging {
 
     protected val adTypeName: String
 

--- a/commercial/app/model/commercial/soulmates/SoulmatesApi.scala
+++ b/commercial/app/model/commercial/soulmates/SoulmatesApi.scala
@@ -1,5 +1,6 @@
 package model.commercial.soulmates
 
+import common.ExecutionContexts
 import conf.CommercialConfiguration
 import conf.Switches.SoulmatesFeedSwitch
 import model.commercial.{FeedReader, FeedRequest}
@@ -8,7 +9,7 @@ import play.api.libs.json.{JsArray, JsValue}
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-trait SoulmatesApi {
+trait SoulmatesApi extends ExecutionContexts {
 
   protected val adTypeName: String
 

--- a/commercial/conf/application.conf
+++ b/commercial/conf/application.conf
@@ -47,6 +47,12 @@ play {
           parallelism-max = 24
         }
       }
+      single-thread = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 1
+        }
+      }
     }
   }
 }

--- a/commercial/conf/application.conf
+++ b/commercial/conf/application.conf
@@ -47,7 +47,7 @@ play {
           parallelism-max = 24
         }
       }
-      single-thread = {
+      book-lookup = {
         fork-join-executor {
           parallelism-factor = 1.0
           parallelism-max = 1


### PR DESCRIPTION
To improve performance of Commercial servers.

Next step is to store book lookup results in distributed cache instead of agent.

@gklopper 
