### PR TITLE
Css logging: recurse into media queries

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -26,22 +26,25 @@ define([
         classNameInlined = 'js-inlined',
         eventsInitialised = false;
 
-    function valsOrNull(obj) {
-        return !obj || _.isEmpty(obj) ? null : _.values(obj);
+    function getRules(s) {
+        var rules = s ? s.cssRules || s.rules : mull;
+        return rules && !_.isEmpty(rules) ? _.values(rules) : s;
     }
 
     function getSelectors(all) {
         var rand,
             len,
             rules = _.chain(getInlineStylesheets())
-                .map(function (s) { return valsOrNull(s.cssRules || s.rules); })
+                .map(getRules)
                 .flatten()
-                .map(function (s) { return valsOrNull(s.cssRules || s.rules) || s; }) // 2nd pass to fetch rule nested in media queries
+                .map(getRules) // 2nd pass for rules nested in media queries
                 .flatten()
-                .map(function (s) { return s.selectorText; })
+                .map(function (s) { return s && s.selectorText; })
                 .compact()
+                .uniq()
                 .value();
 
+        console.log("RULES: " + rules.length)
         if (all) {
             return rules;
         } else {

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -27,7 +27,7 @@ define([
         eventsInitialised = false;
 
     function getRules(s) {
-        var rules = s ? s.cssRules || s.rules : mull;
+        var rules = s ? s.cssRules || s.rules : null;
         return rules && !_.isEmpty(rules) ? _.values(rules) : s;
     }
 
@@ -44,7 +44,6 @@ define([
                 .uniq()
                 .value();
 
-        console.log("RULES: " + rules.length)
         if (all) {
             return rules;
         } else {

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -28,7 +28,7 @@ define([
 
     function getRules(s) {
         var rules = s ? s.cssRules || s.rules : null;
-        return rules && !_.isEmpty(rules) ? _.values(rules) : s;
+        return rules ? _.values(rules) : s;
     }
 
     function getSelectors(all) {

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -39,7 +39,7 @@ define([
                 .flatten()
                 .map(getRules) // 2nd pass for rules nested in media queries
                 .flatten()
-                .map(function (s) { return s && s.selectorText; })
+                .map(function (r) { return r && r.selectorText; })
                 .compact()
                 .uniq()
                 .value();

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -26,15 +26,19 @@ define([
         classNameInlined = 'js-inlined',
         eventsInitialised = false;
 
+    function valsOrNull(obj) {
+        return !obj || _.isEmpty(obj) ? null : _.values(obj);
+    }
+
     function getSelectors(all) {
         var rand,
             len,
             rules = _.chain(getInlineStylesheets())
-                .map(function (s) { return s.rules || s.cssRules; })
-                .compact()
-                .map(_.values)
+                .map(function (s) { return valsOrNull(s.cssRules || s.rules); })
                 .flatten()
-                .map(function (r) { return r && r.selectorText; })
+                .map(function (s) { return valsOrNull(s.cssRules || s.rules) || s; }) // 2nd pass to fetch rule nested in media queries
+                .flatten()
+                .map(function (s) { return s.selectorText; })
                 .compact()
                 .value();
 


### PR DESCRIPTION
Because we were ignoring rules within media queries. Doh.

@robertberry 
