### PR TITLE
Video most popular & endslate quick fix

### DIFF
--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -105,6 +105,7 @@
         background-color: transparent;
         margin-left: 0;
         margin-right: 0;
+        padding: 0 $gs-gutter/2;
     }
 
     + .fc-item {
@@ -195,6 +196,7 @@
     .fc-item--media {
         float: left;
         width: 50%;
+        padding: 0 $gs-gutter/2;
 
         @include mq($until: tablet) {
             &:nth-child(odd):before {


### PR DESCRIPTION
Fix for:
![screen shot 2015-02-16 at 15 26 14](https://cloud.githubusercontent.com/assets/2236852/6214430/641b4766-b5f0-11e4-8dc3-418222c1fbe2.png)

To:
![screen shot 2015-02-16 at 15 26 58](https://cloud.githubusercontent.com/assets/2236852/6214435/6832a2e0-b5f0-11e4-81eb-5550e2c6f2d1.png)

@mattosborn this does fix everything rather simply. I looked at refactoring and would mean branching mediaItem and the associated flex CSS, which I'm not sure is worth it but happy to investigate further. For now, this quick fix will solve our issues.
