### PR TITLE
DNS prefetch assets.guim.co.uk for quicker JS/CSS retrieval

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -17,6 +17,7 @@
 <meta name="HandheldFriendly" content="True" />
 
 @* http://www.chromium.org/developers/design-documents/dns-prefetching *@
+<link rel="dns-prefetch" href="@Configuration.assets.path" />
 <link rel="dns-prefetch" href="@Configuration.images.path" />
 <link rel="dns-prefetch" href="@Configuration.ajax.url" />
 <link rel="dns-prefetch" href="@AnalyticsHost()" />


### PR DESCRIPTION
I noticed in the chrome timeline (when I use a laggy connection) it seems to only the the dns lookup for assets.guim.co.uk when it actually needs the resource, not as early as it could be.
So adding it here for a small benefit for laggy phone users.
Note that the overall limit for chrome at least is 6 concurrent DNS resolutions - chrome://net-internals/#dns so we should consider removing some?
