### PR TITLE
don't download app splash on mobiles

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -55,7 +55,7 @@ define([
     function showMessage() {
         var platform = (detect.isIOS()) ? 'ios' : 'android',
             msg = new Message(platform),
-            fullTemplate = tmp + (detect.isBreakpoint('mobile') ? "" : tablet);
+            fullTemplate = tmp + (detect.isBreakpoint('mobile') ? '' : tablet);
 
         msg.show(template(fullTemplate, DATA[platform.toUpperCase()]));
         cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -41,8 +41,8 @@ define([
         impressions = cookieVal && !isNaN(cookieVal) ? parseInt(cookieVal, 10) : 0,
         tmp = '<img src="{{LOGO}}" class="app__logo" alt="Guardian App logo" /><div class="app__cta"><h4 class="app__heading">The Guardian app</h4>' +
             '<p class="app__copy">Instant alerts. Offline reading.<br/>Tailored to you.</p>' +
-            '<p class="app__copy"><strong>FREE</strong> – {{STORE}}</p></div><a href="{{LINK}}" class="app__link">View</a>' +
-            '<img src="{{SCREENSHOTS}}" class="app__screenshots" alt="screenshots" />';
+            '<p class="app__copy"><strong>FREE</strong> – {{STORE}}</p></div><a href="{{LINK}}" class="app__link">View</a>',
+        tablet = '<img src="{{SCREENSHOTS}}" class="app__screenshots" alt="screenshots" />';
 
     function isDevice() {
         return ((detect.isIOS() || detect.isAndroid()) && !detect.isFireFoxOSApp());
@@ -54,9 +54,10 @@ define([
 
     function showMessage() {
         var platform = (detect.isIOS()) ? 'ios' : 'android',
-            msg = new Message(platform);
+            msg = new Message(platform),
+            fullTemplate = tmp + (detect.isBreakpoint('mobile') ? "" : tablet);
 
-        msg.show(template(tmp, DATA[platform.toUpperCase()]));
+        msg.show(template(fullTemplate, DATA[platform.toUpperCase()]));
         cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);
     }
 


### PR DESCRIPTION
The app splash http://assets.guim.co.uk/images/apps/ios-screenshots.jpg is displayed on tablets but not mobile.  However it's still downloaded either way.
tablet:
![image](https://cloud.githubusercontent.com/assets/7304387/6216811/4e6be8b6-b605-11e4-9246-d0a3bd70b4d4.png)
mobile:
![image](https://cloud.githubusercontent.com/assets/7304387/6216818/5e746bde-b605-11e4-939c-628e101acd59.png)

This changes it so it's only download if you are already at the tablet breakpoint thus saving 90kb for mobile users.
