### PR TITLE
use correct breakpoint checking code for banner download

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -55,7 +55,7 @@ define([
     function showMessage() {
         var platform = (detect.isIOS()) ? 'ios' : 'android',
             msg = new Message(platform),
-            fullTemplate = tmp + (detect.isBreakpoint('mobile') ? '' : tablet);
+            fullTemplate = tmp + (detect.getBreakpoint() === 'mobile' ? '' : tablet);
 
         msg.show(template(fullTemplate, DATA[platform.toUpperCase()]));
         cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);


### PR DESCRIPTION
I accidentally used isBreakpoint('mobile') which always returns false, and seems to check a range, so I changed it to getBreakpoint() === 'mobile'.

This is fixing up https://github.com/guardian/frontend/pull/8354 as that PR didn't actually improve anything ;-(
