### PR TITLE
Restore iOS smooth-scrolling nav via JS

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -3,12 +3,14 @@ define([
     'qwery',
     'fastdom',
     'common/utils/mediator',
+    'common/utils/detect',
     'common/utils/$'
 ], function (
     bean,
     qwery,
     fastdom,
     mediator,
+    detect,
     $
 ) {
     var Navigation = {
@@ -16,6 +18,10 @@ define([
             this.addMegaNavMenu();
             this.enableMegaNavToggle();
             this.replaceAllSectionsLink();
+
+            if (navigator.userAgent.match(/(iPad|iPhone|iPod)/g) && detect.getUserAgent.version > 5) {
+                $('.navigation__scroll').css({'-webkit-overflow-scrolling': 'touch'});
+            }
         },
 
         addMegaNavMenu: function () {

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -20,7 +20,7 @@ define([
             this.replaceAllSectionsLink();
 
             if (detect.isIOS() && detect.getUserAgent.version > 5) {
-                // crashed mobile safari < 6, so we add it here after detection
+                // crashes mobile safari < 6, so we add it here after detection
                 $('.navigation__scroll').css({'-webkit-overflow-scrolling': 'touch'});
             }
         },

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -21,7 +21,9 @@ define([
 
             if (detect.isIOS() && detect.getUserAgent.version > 5) {
                 // crashes mobile safari < 6, so we add it here after detection
-                $('.navigation__scroll').css({'-webkit-overflow-scrolling': 'touch'});
+                fastdom.write(function () {
+                    $('.navigation__scroll').css({'-webkit-overflow-scrolling': 'touch'});
+                });
             }
         },
 

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -19,7 +19,7 @@ define([
             this.enableMegaNavToggle();
             this.replaceAllSectionsLink();
 
-            if (navigator.userAgent.match(/(iPad|iPhone|iPod)/g) && detect.getUserAgent.version > 5) {
+            if (detect.isIOS() && detect.getUserAgent.version > 5) {
                 $('.navigation__scroll').css({'-webkit-overflow-scrolling': 'touch'});
             }
         },

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -20,6 +20,7 @@ define([
             this.replaceAllSectionsLink();
 
             if (detect.isIOS() && detect.getUserAgent.version > 5) {
+                // crashed mobile safari < 6, so we add it here after detection
                 $('.navigation__scroll').css({'-webkit-overflow-scrolling': 'touch'});
             }
         },


### PR DESCRIPTION
smooth-scrolling in the overflow nav was disabled for all mobile safari versions in #8357 to stop versions < 6 (~0.4% of users) crashing, as detailed in #5693.

This restores it from JS. It's not pretty but it's a significant improvement in experience and seems worth it...
