### PR TITLE
Consider iPad 1 not modern

### DIFF
--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -107,7 +107,7 @@
                 We won't run all javascript on these
                 For usage stats see http://david-smith.org/iosversionstats/
             *@
-            return /.*iPhone OS ([56])_\d+/.test(navigator.userAgent);
+            return /.*(iPhone|iPad; CPU) OS ([3456])_\d+.*/.test(navigator.userAgent);
         }
         return false;
     })();


### PR DESCRIPTION
Part II of fixing iPad crashes.

Part III is disabling images for non-modern browsers .... 
