### PR TITLE
Show merchandising high ad on pageskin

### DIFF
--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -31,6 +31,9 @@
                 @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
                 @if(!isAdFeature) {
+                    <div class="fc-container fc-container--commercial-high">
+                    @fragments.commercial.commercialComponentHigh()
+                    </div>
                     <div class="fc-container fc-container--commercial">
                     @fragments.commercial.commercialComponent()
                     </div>

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -31,9 +31,6 @@
                 @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
                 @if(!isAdFeature) {
-                    <div class="fc-container fc-container--commercial-high">
-                    @fragments.commercial.commercialComponentHigh()
-                    </div>
                     <div class="fc-container fc-container--commercial">
                     @fragments.commercial.commercialComponent()
                     </div>

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -94,25 +94,33 @@ define([
 
     return function (name, types, series, keywords, slotTarget) {
         var attrName,
-            definition = adSlotDefinitions[slotTarget ? slotTarget : name],
-            dataAttrs  = {
-                label:   definition.label !== undefined ? definition.label : true,
-                refresh: definition.refresh !== undefined ? definition.refresh : true
-            },
-            $adSlot = $.create(template(
-                adSlotTpl,
-                {
-                    name: definition.name || name,
-                    // badges now append their index to the name
-                    normalisedName: (definition.name || name).replace(/((?:ad|fo|sp)badge).*/, '$1'),
-                    types: types ? map((isArray(types) ? types : [types]), function (type) {
-                        return ' ad-slot--' + type;
-                    }).join('') : '',
-                    sizeMappings: map(pairs(definition.sizeMappings), function (size) {
-                        return ' data-' + size[0] + '="' + size[1] + '"';
-                    }).join('')
-                })
-            );
+            slotName = slotTarget ? slotTarget : name,
+            definition,
+            dataAttrs,
+            $adSlot;
+
+        definition = adSlotDefinitions[slotName];
+        if (config.page.hasPageSkin && slotName === 'merchandising-high') {
+            definition.sizeMappings.wide = '1,1';
+        }
+        dataAttrs  = {
+            label:   definition.label !== undefined ? definition.label : true,
+            refresh: definition.refresh !== undefined ? definition.refresh : true
+        },
+        $adSlot = $.create(template(
+            adSlotTpl,
+            {
+                name: definition.name || name,
+                // badges now append their index to the name
+                normalisedName: (definition.name || name).replace(/((?:ad|fo|sp)badge).*/, '$1'),
+                types: types ? map((isArray(types) ? types : [types]), function (type) {
+                    return ' ad-slot--' + type;
+                }).join('') : '',
+                sizeMappings: map(pairs(definition.sizeMappings), function (size) {
+                    return ' data-' + size[0] + '="' + size[1] + '"';
+                }).join('')
+            })
+        );
         for (attrName in dataAttrs) {
             if (dataAttrs[attrName] === false) {
                 $adSlot.attr('data-' + attrName, 'false');

--- a/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
+++ b/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
@@ -11,7 +11,7 @@ define([
 ) {
 
     function init() {
-        if (!config.switches.commercialComponents || !config.page.isFront || config.page.hasPageSkin) {
+        if (!config.switches.commercialComponents || !config.page.isFront) {
             return false;
         }
 

--- a/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
+++ b/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
@@ -48,18 +48,18 @@ define([
                 });
 
                 it('should place ad between 3rd and 4th containers if there are 4 or more containers', function () {
-                    '1234'.split('').forEach(function () {
+                    for (var i = 0; i<4; i++) {
                         appendContainer($fixturesContainer);
-                    });
+                    }
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
                 });
 
                 it('should place ad between 1st and 2nd containers if there are less than 4 containers', function () {
-                    '12'.split('').forEach(function () {
+                    for (var i = 0; i<2; i++) {
                         appendContainer($fixturesContainer);
-                    });
+                    }
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
@@ -70,9 +70,9 @@ define([
                 it('should place ad between between the 4th and 5th container if a network front', function () {
                     mocks.store['common/utils/config'].page.contentType = 'Network Front';
 
-                    '12345'.split('').forEach(function () {
+                    for (var i = 0; i<5; i++) {
                         appendContainer($fixturesContainer);
-                    });
+                    }
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
@@ -82,10 +82,10 @@ define([
                 });
 
                 it('should have 1,1 slot for wide breakpoint if there is a page skin', function () {
-                    mocks.store['common/utils/config'].page.hasPageSkin = true;
-                    '12'.split('').forEach(function () {
+                    for (var i = 0; i<2; i++) {
                         appendContainer($fixturesContainer);
-                    });
+                    }
+                    mocks.store['common/utils/config'].page.hasPageSkin = true;
                     frontCommercialComponents.init();
 
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);

--- a/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
+++ b/static/test/javascripts/spec/common/commercial/front-commercial-components.spec.js
@@ -81,6 +81,17 @@ define([
                     expect(bonzo(adSlot).hasClass('ad-slot')).toBe(true);
                 });
 
+                it('should have 1,1 slot for wide breakpoint if there is a page skin', function () {
+                    mocks.store['common/utils/config'].page.hasPageSkin = true;
+                    '12'.split('').forEach(function () {
+                        appendContainer($fixturesContainer);
+                    });
+                    frontCommercialComponents.init();
+
+                    expect(qwery('.ad-slot', $fixturesContainer).length).toBe(1);
+                    expect($('.ad-slot', $fixturesContainer).attr('data-wide')).toBe('1,1');
+                });
+
                 it('should not display ad slot if commercial-components switch is off', function () {
                     mocks.store['common/utils/config'].switches.commercialComponents = false;
 
@@ -90,13 +101,6 @@ define([
 
                 it('should not display ad slot if not a front', function () {
                     mocks.store['common/utils/config'].page.isFront = false;
-
-                    expect(frontCommercialComponents.init()).toBe(false);
-                    expect(qwery('.ad-slot', $fixturesContainer).length).toBe(0);
-                });
-
-                it('should not display ad slot if there is a page skin', function () {
-                    mocks.store['common/utils/config'].page.hasPageSkin = true;
 
                     expect(frontCommercialComponents.init()).toBe(false);
                     expect(qwery('.ad-slot', $fixturesContainer).length).toBe(0);


### PR DESCRIPTION
Show merchandising-high creative on pageskin but only on breakpoints up to wide. On wide, we want to target 1x1, so no ad will be visible. 
