### PR TITLE
Css logging: canonicalise selectors

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -38,7 +38,7 @@ define([
     function canonicalise(selector) {
         var siblings = selector.match(/\.[^\s\.]+\.[^\s]+/g) || [];
 
-        siblings.forEach(function(s) {
+        siblings.forEach(function (s) {
             selector = selector.replace(s, canonicalOrder(s));
         });
         return selector;

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -41,7 +41,7 @@ define([
         siblings.forEach(function (s) {
             selector = selector.replace(s, canonicalOrder(s));
         });
-        return selector.replace(/^\s+|\s+$/g,'').replace(/\s+/g, ' ');
+        return selector.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
     }
 
     function canonicalOrder(s) {

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -41,7 +41,7 @@ define([
         siblings.forEach(function (s) {
             selector = selector.replace(s, canonicalOrder(s));
         });
-        return _.trim(selector).replace(/\s+/g, ' ');
+        return selector.replace(/^\s+|\s+$/g,'').replace(/\s+/g, ' ');
     }
 
     function canonicalOrder(s) {

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -41,7 +41,7 @@ define([
         siblings.forEach(function (s) {
             selector = selector.replace(s, canonicalOrder(s));
         });
-        return selector;
+        return _.trim(selector).replace(/\s+/g, ' ');
     }
 
     function canonicalOrder(s) {

--- a/static/src/javascripts/projects/common/modules/analytics/css-logging.js
+++ b/static/src/javascripts/projects/common/modules/analytics/css-logging.js
@@ -31,8 +31,8 @@ define([
         return rules ? _.values(rules) : s;
     }
 
-    function getSplitSelectors(classRule) {
-        return classRule && classRule.selectorText && classRule.selectorText.replace(rxPsuedoClass, '').split(rxSeparator);
+    function getSplitSelectors(ruleObj) {
+        return ruleObj && ruleObj.selectorText && ruleObj.selectorText.replace(rxPsuedoClass, '').split(rxSeparator);
     }
 
     function canonicalise(selector) {
@@ -62,8 +62,6 @@ define([
                 .uniq()
                 .map(canonicalise)
                 .value();
-
-        console.log('rules.length: ' + rules.length);
 
         if (all) {
             return rules;


### PR DESCRIPTION
It seems that some browsers change selectors like `.foo.bar` into `.bar.foo`, if they feel like it, in the `document.stylesheets` AST representation. So we need to canonicalise them alphabetically before reporting their usage.
