### PR TITLE
Fix breaking news staying pinned to bottom of the page

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -117,7 +117,7 @@ define([
 
                         bean.on($('.js-breaking-news__item__close', el)[0], 'click', function () {
                             fastdom.write(function () {
-                                $(el).hide();
+                                $('[data-breaking-article-id]').hide();
                             });
                             hiddenIds[article.id] = true;
                             storage.local.set(storageKeyHidden, cleanIDs(articleIds, hiddenIds));

--- a/static/src/javascripts/projects/common/views/breaking-news.html
+++ b/static/src/javascripts/projects/common/views/breaking-news.html
@@ -1,4 +1,4 @@
-<div class="js-breaking-news__item breaking-news__item">
+<div class="js-breaking-news__item breaking-news__item" data-breaking-article-id="{{id}}">
     <div class="breaking-news__item-content">
         <div class="breaking-news__item-header">
             {{marque36icon}}


### PR DESCRIPTION
When a breaking news alert is shown, 2 copies are actually added to the dom - one fixed to the bottom of the viewport, and one inline at the bottom of the page (`.breaking-news--spectre`). 

The inline one creates space on the page the size of the fixed one, so that the page can scroll 'past' the fixed one and footer content is not hidden behind it. 

Currently, dismissing the alert only removed the fixed alert, not the inline one, so the alert appears to have been moved to the bottom of the page after closing it. 

This PR updates the dismiss code to make sure both of copies of the alert are removed.
