### PR TITLE
Last modified interactive template tweaks 

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -381,7 +381,7 @@
     margin-bottom: $gs-baseline / 2;
 
     time {
-        display: block;
+        display: table;
     }
 
     i {

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -382,6 +382,13 @@
 
     time {
         display: table;
+
+        @include mq(desktop) {
+            .content--interactive & {
+                display: inline;
+                padding-right: $gs-gutter/4;
+            }
+        }
     }
 
     i {

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -381,7 +381,7 @@
     margin-bottom: $gs-baseline / 2;
 
     time {
-        display: table;
+        display: inline-block;
 
         @include mq(desktop) {
             .content--interactive & {

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -123,6 +123,10 @@
             }
         }
     }
+    .content__meta-container--twitter,
+    .content__meta-container--email {
+        padding-top: $gs-baseline/2;
+    }
     .byline {
         @include mq(desktop) {
             width: gs-span(7);
@@ -132,16 +136,22 @@
             border-top: 0;
             padding-bottom: 0;
             min-height: $gs-baseline * 2;
+            display: inline;
+            margin-right: $gs-gutter/2;
         }
+    }
+    .meta__email,
+    .meta__twitter {
+        display: inline !important;
     }
     .content__dateline {
         margin: 0;
         border-top: 0;
-        padding-top: $gs-baseline / 3;
         padding-bottom: $gs-baseline;
 
         @include mq(leftCol) {
             height: $gs-row-height + ($gs-baseline * 2/3);
+            padding-top: $gs-baseline / 3;
         }
     }
     // Ensure margins don't overlay full-page take over interactives


### PR DESCRIPTION
Fix for (spotted by @paperboyo):
<img src="https://cloud.githubusercontent.com/assets/6032869/6247015/4951e1a6-b767-11e4-8367-f712c65652c0.gif"/>

With:
![dateline](https://cloud.githubusercontent.com/assets/2236852/6248730/774171ea-b77a-11e4-81b2-79644df27fa8.gif)

---

And from:
![screen shot 2015-02-23 at 15 42 14](https://cloud.githubusercontent.com/assets/2236852/6330707/a3107a36-bb72-11e4-9c69-3f1a06098844.png)

To:
![screen shot 2015-02-23 at 15 42 31](https://cloud.githubusercontent.com/assets/2236852/6330711/a7c1c396-bb72-11e4-8cb3-e9b468e797e8.png)
