### PR TITLE
Don't show bottom comment box on short discussion threads

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -356,6 +356,10 @@ Loader.prototype.renderCommentCount = function() {
                     $('.js-comment-count').html(html);
 
                     $('.js-discussion-comment-count').text('(' + commentCount + ')');
+
+                    if (commentCount < 4) {
+                        $('.js-discussion-comment-box--bottom').remove();
+                    }
                 } else {
                     this.setState('empty');
                 }


### PR DESCRIPTION
Having two comment boxes feels redundant when there are only a couple of comments. This PR hides the bottom comment box when there are 3 or less comments.
This:
![screen shot 2015-02-18 at 15 30 29](https://cloud.githubusercontent.com/assets/2236852/6250035/1e1fa6dc-b783-11e4-96fb-c48ca4df29f6.png)
Becomes:
![screen shot 2015-02-18 at 15 26 41](https://cloud.githubusercontent.com/assets/2236852/6250022/0a16dbe2-b783-11e4-8b53-4fbdc34c9d9a.png)
