### PR TITLE
Fix Snap Classes

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -27,7 +27,7 @@ case class ContainerLayoutContext(
   private def dedupCutOut(cardAndContext: CardAndContext): CardAndContext = {
     val (content, context) = cardAndContext
 
-    if (content.snapStuff.snapType == LatestSnap) {
+    if (content.snapStuff.map(_.snapType) == Some(LatestSnap)) {
       (content, context)
     } else {
       val newCard = if (content.cutOut.exists(cutOutsSeen.contains)) {

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -113,20 +113,19 @@ case object LinkSnap extends SnapType
 case object OtherSnap extends SnapType
 
 object SnapStuff {
-  def fromTrail(trail: Trail) = SnapStuff(
-    SnapData(trail),
-    trail match {
+  def fromTrail(trail: Trail): Option[SnapStuff] = {
+    lazy val snapCss = trail match {
       case c: Content => c.snapCss
-      case _ => None
-    },
-    if (trail.snapType.exists(_ == "latest")) {
-      LatestSnap
-    } else if (trail.snapType.exists(_ == "link")) {
-      LinkSnap
-    } else {
-      OtherSnap
+      case _ => None}
+    lazy val snapData = SnapData(trail)
+
+    trail.snapType match {
+      case Some("latest") => Option(SnapStuff(snapData, snapCss, LatestSnap))
+      case Some("link") => Option(SnapStuff(snapData, snapCss, LinkSnap))
+      case Some(s) => Option(SnapStuff(snapData, snapCss, OtherSnap))
+      case None => None
     }
-  )
+  }
 }
 
 case class SnapStuff(
@@ -250,7 +249,7 @@ case class ContentCard(
   starRating: Option[Int],
   url: EditionalisedLink,
   discussionSettings: DiscussionSettings,
-  snapStuff: SnapStuff,
+  snapStuff: Option[SnapStuff],
   webPublicationDate: Option[DateTime],
   trailText: Option[String],
   mediaType: Option[MediaType],
@@ -279,7 +278,7 @@ case class ContentCard(
   def showStandfirst = cardTypes.allTypes.exists(_.showStandfirst)
 
   def mediaWidthsByBreakpoint = WidthsByBreakpoint.fromItemClasses(cardTypes)
-  
+
   def showTimestamp = timeStampDisplay.isDefined && webPublicationDate.isDefined
 
   def showMeta = discussionSettings.isCommentable || showTimestamp

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -27,10 +27,10 @@ data-link-name="@item.cardStyle.toneString | @{index + 1}"
     }
 data-item-visibility="@visibilityDataAttribute"
 data-test-id="facia-card"
-    @item.snapStuff.dataAttributes>
+    @item.snapStuff.map(_.dataAttributes)>
 
     <div class="fc-item__container">
-        @if(item.snapStuff.snapType == LatestSnap) {
+        @if(item.snapStuff.map(_.snapType) == Some(LatestSnap)) {
             @kicker(item.header, List("fc-item__kicker--dreamsnap", "fc-item__kicker--dreamsnap-list"))
         }
 
@@ -93,14 +93,14 @@ data-test-id="facia-card"
         }
 
     <div class="fc-item__content">
-        @if(item.snapStuff.snapType == LatestSnap) {
+        @if(item.snapStuff.map(_.snapType) == Some(LatestSnap)) {
             @kicker(item.header, List("fc-item__kicker--dreamsnap"))
         }
         <div class="@RenderClasses(Map(
             ("fc-item__header", true),
             ("fc-item__header--inline-video", item.isVideo && item.displaySettings.isBoosted)
         ))">
-            @title(item.header, index, containerIndex, snapType = Some(item.snapStuff.snapType))
+            @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
 
             @item.byline.map { byline =>
                 <div class="fc-item__byline">@byline.htmlWithLinks(request)</div>

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -24,7 +24,7 @@ object GetClasses {
       ("fc-item--has-boosted-title", item.displaySettings.showBoostedHeadline),
       ("fc-item--live", item.isLive),
       ("fc-item--has-metadata", item.timeStampDisplay.isDefined || item.discussionSettings.isCommentable)
-    ) ++ item.snapStuff.cssClasses.map(_ -> true) ++ mediaTypeClass(item).map(_ -> true))
+    ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty) ++ mediaTypeClass(item).map(_ -> true))
   }
 
   def forSubLink(sublink: Sublink) = RenderClasses(Seq(


### PR DESCRIPTION
This stops the CSS classes `js-snap`, `facia-snap` and `facia-snap--default` getting output for every trail by making `SnapStuff` `Option`al.

@robertberry @stephanfowler 
