### PR TITLE
simplify regex for matching emails on domain check and log ip

### DIFF
--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -67,7 +67,9 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
       logger.info("Invalid registration request")
       formWithErrors.error("user.primaryEmailAddress") match {
         case Some(FormError("user.primaryEmailAddress", Seq("This domain is blacklisted"), _)) => {
-          logger.info("Blocking registration from blacklisted domain here: %s".format(formWithErrors.data.getOrElse(emailKey," should be an email address")))
+          val emailAddressOrError = formWithErrors.data.getOrElse(emailKey," should be an email address")
+          val clientIp = idRequest.clientIp.getOrElse("Could not get remote ip address")
+          logger.info(s"Blocking registration from blacklisted domain here: Email: $emailAddressOrError Remote ip <$clientIp>")
           Future.successful(redirectToRegistrationPageWithoutErrors(formWithErrors, verifiedReturnUrlAsOpt, skipConfirmation))
         }
         case _ =>

--- a/identity/app/form/Mappings.scala
+++ b/identity/app/form/Mappings.scala
@@ -22,7 +22,8 @@ trait Mappings {
     { value => value.isEmpty || UrlPattern.findFirstIn(value).isDefined }
   )
 
-  private val EmailPattern = """(\w+)@([\w\.]+)""".r
+  private val EmailPattern = """(.*)@(.*)""".r
+
   val idRegEmail = text.verifying (
     Messages("error.emailDomainInvalid"),
     { value =>


### PR DESCRIPTION
This follows on from this change: https://github.com/guardian/frontend/pull/6730 and logs the remote ip for any attempted registration from a blocked domain;.

It also fixes the email address parsing in the form validation. Note: we're not validating emails here ( that's done by the identity api ) we just want to capture the domain
