### PR TITLE
Reduce number of containers before lazy load to 5

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -266,7 +266,7 @@ case class FaciaContainer(
 
   def addShowMoreClasses = useShowMore && containerLayout.exists(_.hasShowMore)
 
-  def shouldLazyLoad = Switches.LazyLoadContainersSwitch.isSwitchedOn && index > 8
+  def shouldLazyLoad = Switches.LazyLoadContainersSwitch.isSwitchedOn && index > 4
 }
 
 object Front extends implicits.Collections {


### PR DESCRIPTION
As iPad crashes with more than this 

CC @gklopper 
