### PR TITLE
Never display lazy-loaded containers on non-modern browsers

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -614,4 +614,8 @@ $header-image-size-desktop: 100px;
     @include mq($until: desktop) {
         display: none;
     }
+
+    .is-not-modern & {
+        display: none;
+    }
 }


### PR DESCRIPTION
Stops iPad crashing if you change orientation ...
