### PR TITLE
Lazy containers: fix back button UX

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -77,7 +77,7 @@ object Switches {
   // Performance
   val LazyLoadContainersSwitch = Switch("Performance", "lazy-load-containers",
     "If this switch is on, containers past the 8th will be lazily loaded on mobile and tablet",
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2015, 4, 1)
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -77,7 +77,7 @@ object Switches {
   // Performance
   val LazyLoadContainersSwitch = Switch("Performance", "lazy-load-containers",
     "If this switch is on, containers past the 8th will be lazily loaded on mobile and tablet",
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2015, 4, 1)
   )
 

--- a/common/app/views/fragments/stylesheetsLoad.scala.html
+++ b/common/app/views/fragments/stylesheetsLoad.scala.html
@@ -75,3 +75,23 @@ if (Object.prototype.toString.call(window.operamini) === "[object OperaMini]") {
 </script>
 
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />
+
+@if(LazyLoadContainersSwitch.isSwitchedOn) {
+    <script>
+        (function (session) {
+            var frontState, style ;
+
+            if (session) {
+                frontState = session.getItem('gu.front.lazystate');
+                frontState = frontState && JSON.parse (frontState);
+                frontState = frontState && frontState.value ;
+
+                if (frontState && frontState.pathname === window.location.pathname && frontState.openContainers > 0) {
+                    style = document.createElement('style') ;
+                    style.innerHTML = 'section:nth-child(-n+' + frontState.openContainers + ') {display: block !important;}';
+                    document.getElementsByTagName('head')[0].appendChild(style)
+                }
+            }
+        })(JSON && JSON.parse && window.sessionStorage)
+    </script>
+}

--- a/common/app/views/fragments/stylesheetsLoad.scala.html
+++ b/common/app/views/fragments/stylesheetsLoad.scala.html
@@ -88,7 +88,7 @@ if (Object.prototype.toString.call(window.operamini) === "[object OperaMini]") {
 
                 if (frontState && frontState.pathname === window.location.pathname && frontState.openContainers > 0) {
                     style = document.createElement('style') ;
-                    style.innerHTML = 'section:nth-child(-n+' + frontState.openContainers + ') {display: block !important;}';
+                    style.innerHTML = '.fc-container:nth-child(-n+' + frontState.openContainers + ') {display: block}';
                     document.getElementsByTagName('head')[0].appendChild(style)
                 }
             }

--- a/common/app/views/fragments/stylesheetsLoad.scala.html
+++ b/common/app/views/fragments/stylesheetsLoad.scala.html
@@ -83,7 +83,7 @@ if (Object.prototype.toString.call(window.operamini) === "[object OperaMini]") {
 
             if (session) {
                 frontState = session.getItem('gu.front.lazystate');
-                frontState = frontState && JSON.parse (frontState);
+                frontState = frontState && JSON.parse(frontState);
                 frontState = frontState && frontState.value ;
 
                 if (frontState && frontState.pathname === window.location.pathname && frontState.openContainers > 0) {

--- a/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
+++ b/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
@@ -59,7 +59,7 @@ define([
 
                             if (scrollBottom > bottomOffset - distanceBeforeLoad) {
                                 fastdom.write(function () {
-                                    revealContainer(lazies.shift())
+                                    revealContainer(lazies.shift());
                                     numOpen += 1;
                                     saveNumOpen(numOpen);
                                 });


### PR DESCRIPTION
If the current page is the last visited front within a session, before it's containers render, inject a style to un-hide lazy containers that were exposed via scrolling in the previous visit to the front. Means that an onward article click returns to the right scroll position, after back-buttoning.

(Possibly a bit controversial...)

@robertberry @sndrs 
