### PR TITLE
Force a refresh of the page for ads during test

### DIFF
--- a/integrated-tests/src/test/scala/commercial/AdsTest.scala
+++ b/integrated-tests/src/test/scala/commercial/AdsTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
   "Ads" should "display on the network front" in {
 
     webDriver.get(theguardianWithAds("/uk"))
+    webDriver.navigate().refresh()
 
     // This is an essential sleep, because the implicitlyWait isn't sufficient to ensure that
     // the js application has completed, since the dfp-ad classes exist on page load.

--- a/integrated-tests/src/test/scala/package.scala
+++ b/integrated-tests/src/test/scala/package.scala
@@ -58,6 +58,7 @@ trait SharedWebDriver extends SuiteMixin { this: Suite =>
 
   protected def get(path: String) = {
     webDriver.get(s"${Config.baseUrl}$path?test=test#gu.prefs.switchOff=adverts&countmein&noads")
+    webDriver.navigate().refresh()
   }
 
   protected def implicitlyWait(seconds: Int) = {


### PR DESCRIPTION
Trying a force refresh, because it seems like the browser doesn't refresh the page when the url matches the previous test's url. The tests don't have a defined order. @johnduffell 
