### PR TITLE
Fix 404 errors in footer on sign-in page

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -75,9 +75,9 @@
             }
 
             @if(currentEdition == Au) {
-                <li class="colophon__item"><a data-link-name="au : footer : advertising" href="www.theguardian.com/advertising/guardian-australia-advertising">
+                <li class="colophon__item"><a data-link-name="au : footer : advertising" href="http://www.theguardian.com/advertising/guardian-australia-advertising">
                     advertising</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="www.theguardian.com/guardian-masterclasses/guardian-masterclasses-australia">
+                <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="http://www.theguardian.com/guardian-masterclasses/guardian-masterclasses-australia">
                     masterclasses</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
                     subscribe</a></li>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -113,12 +113,12 @@
                     email sign-up</a></li>
             }
             @if(currentEdition != Au) {
-                <li class="colophon__item"><a data-link-name="complaints" href="/info/complaints-and-corrections">
+                <li class="colophon__item"><a data-link-name="complaints" href="http://www.theguardian.com/info/complaints-and-corrections">
                     complaints &amp; corrections</a></li>
             }
-            <li class="colophon__item"><a data-link-name="terms" href="/help/terms-of-service">terms &amp; conditions</a></li>
-            <li class="colophon__item"><a data-link-name="privacy" href="/help/privacy-policy">privacy policy</a></li>
-            <li class="colophon__item"><a data-link-name="cookie" href="/info/cookies">cookie policy</a></li>
+            <li class="colophon__item"><a data-link-name="terms" href="http://www.theguardian.com/help/terms-of-service">terms &amp; conditions</a></li>
+            <li class="colophon__item"><a data-link-name="privacy" href="http://www.theguardian.com/help/privacy-policy">privacy policy</a></li>
+            <li class="colophon__item"><a data-link-name="cookie" href="http://www.theguardian.com/info/cookies">cookie policy</a></li>
             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">securedrop</a></li>
         }
         </ul>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -61,7 +61,7 @@
                     jobs</a></li>
                 <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
                     dating</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES">
+                <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="http://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES">
                     masterclasses</a></li>
                 <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
                     subscribe</a></li>
@@ -75,41 +75,41 @@
             }
 
             @if(currentEdition == Au) {
-                <li class="colophon__item"><a data-link-name="au : footer : advertising" href="/advertising/guardian-australia-advertising">
+                <li class="colophon__item"><a data-link-name="au : footer : advertising" href="www.theguardian.com/advertising/guardian-australia-advertising">
                     advertising</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="/guardian-masterclasses/guardian-masterclasses-australia">
+                <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="www.theguardian.com/guardian-masterclasses/guardian-masterclasses-australia">
                     masterclasses</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
                     subscribe</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
                     UK jobs</a></li>
             }
-        <li class="colophon__item"><a data-link-name="all topics" href="/index/subjects/a">all topics</a></li>
-        <li class="colophon__item"><a data-link-name="all contributors" href="/index/contributors">all contributors</a></li>
+        <li class="colophon__item"><a data-link-name="all topics" href="http://www.theguardian.com/index/subjects/a">all topics</a></li>
+        <li class="colophon__item"><a data-link-name="all contributors" href="http://www.theguardian.com/index/contributors">all contributors</a></li>
 
             @if(currentEdition == Uk) {
-                <li class="colophon__item"><a data-link-name="uk : footer : about us" href="/info">
+                <li class="colophon__item"><a data-link-name="uk : footer : about us" href="http://www.theguardian.com/info">
                     about us</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="/help/contact-us">
+                <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="http://www.theguardian.com/help/contact-us">
                     contact us</a></li>
             }
 
             @if(currentEdition == Us) {
-                <li class="colophon__item"><a data-link-name="us : footer : about us" href="/info/about-guardian-us">
+                <li class="colophon__item"><a data-link-name="us : footer : about us" href="http://www.theguardian.com/info/about-guardian-us">
                     about us</a></li>
-                <li class="colophon__item"><a data-link-name="us : footer : contact us" href="/info/about-guardian-us/contact">
+                <li class="colophon__item"><a data-link-name="us : footer : contact us" href="http://www.theguardian.com/info/about-guardian-us/contact">
                     contact us</a></li>
             }
             @if(currentEdition == Au) {
-                <li class="colophon__item"><a data-link-name="au : footer : about us" href="/info/about-guardian-australia">
+                <li class="colophon__item"><a data-link-name="au : footer : about us" href="http://www.theguardian.com/info/about-guardian-australia">
                     about us</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="/info/2014/aug/11/guardian-australia-vacancies">
+                <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="http://www.theguardian.com/info/2014/aug/11/guardian-australia-vacancies">
                     vacancies</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : information" href="/info">
+                <li class="colophon__item"><a data-link-name="au : footer : information" href="http://www.theguardian.com/info">
                     information</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : contact us" href="/info/2013/may/26/contact-guardian-australia">
+                <li class="colophon__item"><a data-link-name="au : footer : contact us" href="http://www.theguardian.com/info/2013/may/26/contact-guardian-australia">
                     contact us</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : email sign-up" href="/info/2015/jan/30/guardian-australia-emails-delivered-to-your-inbox-subscribe-now">
+                <li class="colophon__item"><a data-link-name="au : footer : email sign-up" href="http://www.theguardian.com/info/2015/jan/30/guardian-australia-emails-delivered-to-your-inbox-subscribe-now">
                     email sign-up</a></li>
             }
             @if(currentEdition != Au) {


### PR DESCRIPTION
This is a fix to https://github.com/guardian/frontend/issues/8336
On sign-in page links in the footer were returning 404 errors.
Reason for this was that the links in question were relative links and the base url of the sign-in page is https://profile.theguardian.com/signin not http://www.theguardian.com .

Change is to hardcode http://www.theguardian.com as the base url in all relative links in the footer.
