### PR TITLE
Do not debounce lazy loading of containers

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
+++ b/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
@@ -18,7 +18,7 @@ define([
     return function () {
         var $frontBottom = bonzo(qwery('.js-front-bottom')),
             containers = qwery('.js-container--lazy-load'),
-            lazyLoad = _.throttle(function () {
+            lazyLoad = function () {
                 if (containers.length === 0) {
                     mediator.off('window:scroll', lazyLoad);
                 } else {
@@ -37,7 +37,7 @@ define([
                         }
                     });
                 }
-            }, 200);
+            };
 
         mediator.on('window:scroll', lazyLoad);
         lazyLoad();


### PR DESCRIPTION
As this is behind fastdom, it doesn't help, just makes the experience far jankier. I've tested it out on lower-powered phones, and it performs no worse.
