### PR TITLE
Refactor the tags trait and added Sudoku specific print CSS (v2)

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -20,7 +20,7 @@
 
         <div class="content__main tonal__main tonal__main--@articleToneClass(article)">
             <div class="gs-container">
-                <div class="content__main-column content__main-column--article js-content-main-column">
+                <div class="content__main-column content__main-column--article js-content-main-column @if(article.isSudoku) {sudoku}">
 
                     <div class="js-football-tabs football-tabs content__mobile-full-width"></div>
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -294,13 +294,13 @@ trait Tags {
   lazy val isLetters = tones.exists(_.id == Tags.Letters)
   lazy val isCrossword = types.exists(_.id == Tags.Crossword)
 
-  lazy val isArticle: Boolean = tags.exists { _.id == "type/article" }
-  lazy val isSudoku: Boolean = tags.exists { _.id == "type/sudoku" } || tags.exists(t => t.id == "lifeandstyle/series/sudoku")
-  lazy val isGallery: Boolean = tags.exists { _.id == "type/gallery" }
-  lazy val isVideo: Boolean = tags.exists { _.id == "type/video" }
-  lazy val isPoll: Boolean = tags.exists { _.id == "type/poll" }
+  lazy val isArticle: Boolean = tags.exists { _.id == Tags.Article }
+  lazy val isSudoku: Boolean = tags.exists { _.id == Tags.Sudoku } || tags.exists(t => t.id == "lifeandstyle/series/sudoku")
+  lazy val isGallery: Boolean = tags.exists { _.id == Tags.Gallery }
+  lazy val isVideo: Boolean = tags.exists { _.id == Tags.Video }
+  lazy val isPoll: Boolean = tags.exists { _.id == Tags.Poll }
   lazy val isImageContent: Boolean = tags.exists { tag => List("type/cartoon", "type/picture", "type/graphic").contains(tag.id) }
-  lazy val isInteractive: Boolean = tags.exists { _.id == "type/interactive" }
+  lazy val isInteractive: Boolean = tags.exists { _.id == Tags.Interactive }
 
   lazy val hasLargeContributorImage: Boolean = tagsOfType("contributor").filter(_.contributorLargeImagePath.nonEmpty).nonEmpty
 
@@ -318,12 +318,24 @@ object Tags {
   val Letters = "tone/letters"
   val Podcast = "type/podcast"
 
+  val Article = "type/article"
+  val Gallery = "type/gallery"
+  val Video = "type/video"
+  val Poll = "type/poll"
+  val Interactive = "type/interactive"
+  val Sudoku = "type/sudoku"
+
   object VisualTone {
     val Live = "live"
     val Comment = "comment"
     val Feature = "feature"
     val News = "news"
   }
+
+  val sudokuTags = Seq(
+    "type/sudoku",
+    "lifeandstyle/series/sudoku"
+  )
 
   val liveMappings = Seq(
     "tone/minutebyminute"

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -332,11 +332,6 @@ object Tags {
     val News = "news"
   }
 
-  val sudokuTags = Seq(
-    "type/sudoku",
-    "lifeandstyle/series/sudoku"
-  )
-
   val liveMappings = Seq(
     "tone/minutebyminute"
   )

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -294,6 +294,14 @@ trait Tags {
   lazy val isLetters = tones.exists(_.id == Tags.Letters)
   lazy val isCrossword = types.exists(_.id == Tags.Crossword)
 
+  lazy val isArticle: Boolean = tags.exists { _.id == "type/article" }
+  lazy val isSudoku: Boolean = tags.exists { _.id == "type/sudoku" } || tags.exists(t => t.id == "lifeandstyle/series/sudoku")
+  lazy val isGallery: Boolean = tags.exists { _.id == "type/gallery" }
+  lazy val isVideo: Boolean = tags.exists { _.id == "type/video" }
+  lazy val isPoll: Boolean = tags.exists { _.id == "type/poll" }
+  lazy val isImageContent: Boolean = tags.exists { tag => List("type/cartoon", "type/picture", "type/graphic").contains(tag.id) }
+  lazy val isInteractive: Boolean = tags.exists { _.id == "type/interactive" }
+
   lazy val hasLargeContributorImage: Boolean = tagsOfType("contributor").filter(_.contributorLargeImagePath.nonEmpty).nonEmpty
 
   lazy val isCricketLiveBlog = isLiveBlog &&

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -21,18 +21,6 @@ object `package` {
     lazy val isReview = content.tags.exists(t => Tags.reviewMappings.contains(t.id))
   }
 
-  implicit class Content2Is(content: Content) {
-    lazy val isArticle: Boolean = content.tags exists { _.id == "type/article" }
-    lazy val isSudoku: Boolean = content.tags exists { _.id == "type/sudoku" }
-    lazy val isGallery: Boolean = content.tags exists { _.id == "type/gallery" }
-    lazy val isVideo: Boolean = content.tags exists { _.id == "type/video" }
-    lazy val isAudio: Boolean = content.tags exists { _.id == "type/audio" }
-    lazy val isMedia: Boolean = isGallery || isVideo || isAudio
-    lazy val isPoll: Boolean = content.tags exists { _.id == "type/poll" }
-    lazy val isImageContent: Boolean = content.tags exists { tag => List("type/cartoon", "type/picture", "type/graphic").contains(tag.id) }
-    lazy val isInteractive: Boolean = content.tags exists { _.id == "type/interactive" }
-  }
-
   implicit class Any2In[A](a: A) {
     def in(as: Set[A]): Boolean = as contains a
   }

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -33,8 +33,13 @@
 .element--thumbnail,
 .media-primary--showcase,
 .content__standfirst a,
-.content__standfirst br {
+.content__standfirst br,
+figure {
     display: none !important;
+}
+
+.sudoku figure {
+    display: block !important;
 }
 
 * {


### PR DESCRIPTION
Had numerous user requests for an image-free print stylesheet, so this PR hides all figures.

This would have hidden our sudoku images though, so I've scoped the CSS to a sudoku class. Also some refactoring to move some more implicit classes into the tags trait.

@gklopper this move shouldn't cause any problems with legacy content should it?
