### PR TITLE
Correcting duplicate html tags in expandable template

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v2.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v2.html
@@ -35,12 +35,10 @@
                     <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide1Layer1BGImage}}') {{slide1Layer1BGImageRepeat}} {{slide1Layer1BGImagePosition}};"></div>
                     <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide1Layer2BGImage}}') {{slide1Layer2BGImageRepeat}} {{slide1Layer2BGImagePosition}};"></div>
                     <div class="ad-exp__layer ad-exp__layer3" style="background : url('{{slide1Layer3BGImage}}') {{slide1Layer3BGImageRepeat}} {{slide1Layer3BGImagePosition}};"></div>
-                </div>
-                <div class="ad-exp-collapse__slide slide-2" style="background: {{slide2BGColor}} url('{{slide2BGImage}}') {{slide2BGImagePosition}} {{slide2BGImageRepeat}};">
-                    {{video}}
                 </a>
             </div>
             <div class="ad-exp-collapse__slide slide-2" style="background: {{slide2BGColor}} url('{{slide2BGImage}}') {{slide2BGImagePosition}} {{slide2BGImageRepeat}};">
+                {{video}}
                 <a href="{{clickMacro}}{{link}}" target="_new">
                     <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide2Layer1BGImage}}') {{slide2Layer1BGImageRepeat}} {{slide2Layer1BGImagePosition}};"></div>
                     <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide2Layer2BGImage}}') {{slide2Layer2BGImageRepeat}} {{slide2Layer2BGImagePosition}};"></div>


### PR DESCRIPTION
Removing extra div tags in the expandable template, this was causing the template html to layout incorrectly.
