### PR TITLE
Moat tags in the iframe

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -354,6 +354,7 @@ define([
 
                         } else {
                             $iFrameParent.append(breakoutContent);
+                            $breakoutEl.remove();
 
                             $('.ad--responsive', $iFrameParent[0]).each(function (responsiveAd) {
                                 window.setTimeout(function () {
@@ -366,7 +367,7 @@ define([
                 });
             }
             if (shouldRemoveIFrame) {
-                $iFrame.remove();
+                $iFrame.hide();
             }
         },
         /**

--- a/static/test/javascripts/spec/common/commercial/dfp.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp.spec.js
@@ -252,7 +252,7 @@ define([
                         dfp.init();
                         window.googletag.cmd.forEach(function (func) { func(); });
                         window.googletag.pubads().listener(makeFakeEvent(slotId));
-                        expect($('#' + slotId).html()).toBe('<div class="dfp-iframe-content">Some content</div>');
+                        expect($('iframe', '#' + slotId).css('display')).toBe('none');
                     });
 
                     it('should run javascript', function () {


### PR DESCRIPTION
The moat script and noscript tags should stay in the ad iframe - even if the ad itself is taken out of it - and then iframe is only hidden not removed.

thx @robertberry 
