### PR TITLE
Use thumbnail profile in picture cleaner

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -228,7 +228,6 @@ import collection.JavaConversions._
         val inBodyImage = findFirst("figure[itemprop=associatedMedia]")
 
         ImageServerSwitch.switchOn()
-        inBodyImage.getAttribute("class") should include("img--extended")
         inBodyImage.findFirst("[itemprop=contentURL]").getAttribute("src") should
           endWith("sys-images/Travel/Late_offers/pictures/2012/10/11/1349951383662/Shops-in-Rainbow-Row-Char-001.jpg")
 

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -5,7 +5,7 @@
   url: Option[String] = None,
   isLightboxable: Boolean = false)
 
-@import views.support.{ImgSrc, Item620, Item940, Naked, Profile, SeoOptimisedContentImage, Showcase}
+@import views.support.{ImgSrc, Item620, Item940, Naked, Profile, SeoOptimisedContentImage, ContentShowcase}
 
 @img.map{ picture =>
 
@@ -21,7 +21,7 @@
             </div>
         } else {
             @if(isShowcase) {
-                @lightbox(picture, Showcase)
+                @lightbox(picture, ContentShowcase)
             } else {
                 @if(isImageContent) {
                     @lightbox(picture, Item940)

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -62,7 +62,6 @@ object GalleryUpgradedImage extends Profile(width = Some(800))
 object GalleryLargeImage extends Profile(width = Some(1024))
 object GalleryLargeTrail extends Profile(width = Some(480), height = Some(288))
 object GallerySmallTrail extends Profile(width = Some(280), height = Some(168))
-object Showcase extends Profile(width = Some(860))
 object Item120 extends Profile(width = Some(120))
 object Item140 extends Profile(width = Some(140))
 object Item160 extends Profile(width = Some(160))
@@ -78,6 +77,11 @@ object Item940 extends Profile(width = Some(940))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
 object Video460 extends VideoProfile(width = Some(460), height = Some(276)) // 5:3
 object SeoOptimisedContentImage extends Profile(width = Some(460))
+
+object ContentThumbnail extends Profile(width = Some(140))
+object ContentSupporting extends Profile(width = Some(380))
+object ContentStandard extends Profile(width = Some(620))
+object ContentShowcase extends Profile(width = Some(860))
 
 object Item115 extends Profile(width = Some(115))
 object Item130 extends Profile(width = Some(130))
@@ -98,7 +102,6 @@ object Profile {
     GalleryLargeImage,
     GalleryLargeTrail,
     GallerySmallTrail,
-    Showcase,
     Item120,
     Item140,
     Item220,

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -54,7 +54,7 @@ class TemplatesTest extends FlatSpec with Matchers {
     val figures = (body \\ "figure").toList
 
     val baseImg = figures(0)
-    (baseImg \ "@class").text should include("img--base img--inline")
+    (baseImg \ "@class").text should include("img--inline")
     (baseImg \ "img" \ "@class").text should be("gu-image")
     (baseImg \ "img" \ "@width").text should be("140")
 
@@ -64,7 +64,7 @@ class TemplatesTest extends FlatSpec with Matchers {
     (medianImg \ "img" \ "@width").text should be("250")
 
     val extendedImg = figures(2)
-    (extendedImg \ "@class").text should include("img--extended")
+    (extendedImg \ "@class").text should include("element-image")
     (extendedImg \ "img" \ "@class").text should be("gu-image")
     (extendedImg \ "img" \ "@width").text should be("600")
 

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -53,21 +53,11 @@ class TemplatesTest extends FlatSpec with Matchers {
 
     val figures = (body \\ "figure").toList
 
-    val baseImg = figures(0)
-    (baseImg \ "@class").text should include("img--inline")
-    (baseImg \ "img" \ "@class").text should be("gu-image")
-    (baseImg \ "img" \ "@width").text should be("140")
-
-    val medianImg = figures(1)
-    (medianImg \ "@class").text should include("img--median")
-    (medianImg \ "img" \ "@class").text should be("gu-image")
-    (medianImg \ "img" \ "@width").text should be("250")
-
-    val extendedImg = figures(2)
-    (extendedImg \ "@class").text should include("element-image")
-    (extendedImg \ "img" \ "@class").text should be("gu-image")
-    (extendedImg \ "img" \ "@width").text should be("600")
-
+    val inlineImg = figures(0)
+    (inlineImg \ "@class").text should include("img--inline")
+    (inlineImg \ "img" \ "@class").text should be("gu-image")
+    (inlineImg \ "img" \ "@width").text should be("140")
+    
     val landscapeImg = figures(3)
     (landscapeImg \ "@class").text should include("img--landscape")
     (landscapeImg \ "img" \ "@class").text should be("gu-image")

--- a/static/src/stylesheets/layout/_helpers.scss
+++ b/static/src/stylesheets/layout/_helpers.scss
@@ -76,8 +76,6 @@
     }
 }
 
-
-
 /* Inline images: included here for faster painting
    ========================================================================== */
 
@@ -95,12 +93,6 @@
         word-wrap: break-word;
     }
 }
-
-.img-tiny.img--inline {
-    width: auto;
-    max-width: $inArticleInlineImgWidth;
-}
-
 
 /* Ajax loading helpers
    ========================================================================== */

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -117,7 +117,6 @@ figure.element.element--showcase {
     }
 }
 
-figure.img--extended,
 figure.element-video {
     @include mq(leftCol) {
         &.element--thumbnail {

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -297,8 +297,7 @@
         margin-top: ($gs-baseline/3)*2;
     }
 
-    .element--thumbnail,
-    .img--base {
+    .element--thumbnail {
         .block-share--article {
             display: none !important;
         }

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -172,13 +172,12 @@ figure {
     img {
         display: block;
     }
-    &.img,
     &.element {
         margin-top: ($gs-baseline/3)*4;
         margin-bottom: $gs-baseline;
         position: relative;
     }
-    &.img {
+    &.element-image {
         position: relative;
         figcaption {
             padding-top: ($gs-baseline/6)*4;


### PR DESCRIPTION
This fixes #8398 . Unfortunately, supporting images vary in width so much that we cannot perform a similar fix, they need to stay at 620, unless our new picturefill solves everything.

I removed some classes which look really old, `img` and the like, only the `img-inline` and orientation stuff are doing something useful.
