### PR TITLE
Alt history ranking 

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -446,7 +446,7 @@ object Switches {
 
   val HistoryTags = Switch("Feature", "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
-    safeState = On, sellByDate = never
+    safeState = Off, sellByDate = never
   )
 
   val IdentityBlockSpamEmails = Switch("Feature", "id-block-spam-emails",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -446,7 +446,7 @@ object Switches {
 
   val HistoryTags = Switch("Feature", "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
-    safeState = Off, sellByDate = never
+    safeState = On, sellByDate = never
   )
 
   val IdentityBlockSpamEmails = Switch("Feature", "id-block-spam-emails",

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -133,14 +133,12 @@ define([
         ],
         buckets = [
             {
-                desc: 'Tags from articles',
-                indexInRecord: 1,
-                weight: 1
+                type: 'content',
+                indexInRecord: 1
             },
             {
-                desc: 'Tags from fronts',
-                indexInRecord: 2,
-                weight: 1 // increase this, to favour direct visits to fronts/tag pages
+                type: 'front',
+                indexInRecord: 2
             }
         ],
         summaryPeriodDays = 30,
@@ -155,6 +153,7 @@ define([
         summaryCache,
         popularFilteredCache,
         topNavItemsCache,
+        blacklistCache,
 
         inMegaNav = false,
 
@@ -237,22 +236,22 @@ define([
         return summary;
     }
 
-    function getPopular(number, filtered) {
+    function getPopular(opts) {
         var tags = getSummary().tags,
             tids = _.keys(tags),
-            blacklist;
+            op = _.extend({
+                number: 100,
+                weights: {}
+            }, opts);
 
-        if (filtered) {
-            blacklist = getTopNavItems();
-            tids = tids.filter(function (tid) { return whitelist.indexOf(tid) > -1; });
-            tids = tids.filter(function (tid) { return blacklist.indexOf(tid) === -1; });
-        }
+        tids = op.whitelist ? tids.filter(function (tid) { return op.whitelist.indexOf(tid) > -1; }) : tids;
+        tids = op.blacklist ? tids.filter(function (tid) { return op.blacklist.indexOf(tid) === -1; }) : tids;
 
         return _.chain(tids)
             .map(function (tid) {
                 var record = tags[tid],
                     rank = _.reduce(buckets, function (rank, bucket) {
-                        return rank + tally(record[bucket.indexInRecord], bucket.weight);
+                        return rank + tally(record[bucket.indexInRecord], op.weights[bucket.type] || 1);
                     }, 0);
 
                 return {
@@ -262,19 +261,27 @@ define([
             })
             .compact()
             .sortBy('rank')
-            .last(number || 100)
+            .last(op.number)
             .reverse()
             .pluck('idAndName')
             .value();
     }
 
     function getPopularFiltered(opts) {
-        if (opts && opts.flush) {
-            popularFilteredCache = getPopular(10, true);
-        } else {
-            popularFilteredCache = popularFilteredCache || getPopular(10, true);
+        var flush = opts && opts.flush,
+            filterOpts = {
+                blacklist: blacklistCache || getTopNavItems(),
+                whitelist: whitelist,
+                number: 10
+            };
+
+        // Temporary...
+        if (window.location.hash === '#alt-history') {
+            delete filterOpts.whitelist;
+            filterOpts.weights = {'content': 1, 'front': 10};
         }
 
+        popularFilteredCache = (!flush && popularFilteredCache) || getPopular(filterOpts);
         return popularFilteredCache;
     }
 


### PR DESCRIPTION
Allow internal assessment, to see if we can make the history tags more maintainable by getting rid of the unwieldy whitelist. Adding `#alt-history` to a url produces a different ranking of your history tags.

Notably:
- doesn't apply a whitelist (exposes a more personalised set of tags)
- favours front tags over article tags by a factor of 10 (ie downplays obscure tags picked up from news articles)
