### PR TITLE
Remove: dnt counting

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -569,11 +569,6 @@ object Switches {
     safeState = Off, sellByDate = new LocalDate(2015, 2, 28)
   )
 
-  val DoNotTrack = Switch("Analytics", "do-not-track",
-    "If this switch is on then we will count the number of people with do not track headers (yes, yes, I know)",
-    safeState = Off, sellByDate = new LocalDate(2015, 2, 28)
-  )
-
   val FaciaDynamoArchive = Switch("Facia", "facia-tool-dynamo-archive",
     "If this switch is on, facia-tool will directly archive to DynamoDB. When this is about to expire, please check the DB size.",
     safeState = Off, sellByDate = new LocalDate(2015, 8, 31)

--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -30,12 +30,6 @@ object DiagnosticsController extends Controller with Logging {
   }
 
   def analytics(prefix: String) = Action { implicit request =>
-
-    if (Switches.DoNotTrack.isSwitchedOn && prefix == "pv") {
-      // http://en.wikipedia.org/wiki/Do_Not_Track
-      request.headers.get("DNT").filter(_.nonEmpty).foreach( _ => Analytics.report("dnt"))
-    }
-
     Analytics.report(prefix)
     TinyResponse.gif
   }

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -28,8 +28,6 @@ object Metric extends Logging {
     ("video-tech-flash", CountMetric("video-tech-flash")),
     ("video-tech-html5", CountMetric("video-tech-html5")),
 
-    ("dnt", CountMetric("do-not-track")),
-
     ("sm-page-view", CountMetric("sm-page-view")),
     ("sm-interaction-on-same-page", CountMetric("sm-interaction-on-same-page")),
     ("sm-another-guardian-page", CountMetric("sm-another-guardian-page")),


### PR DESCRIPTION
This was to see just how many requests we get in a week that contain
the DNT header.

The data is currently available in Cloudwatch under the metric name "do-not-track".
