### PR TITLE
crowdsource our UI testing

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -335,6 +335,11 @@ object Switches {
     safeState = Off, never
   )
 
+  val FeedbackLink = Switch("Monitoring", "tech-feedback",
+    "Enables a link in the footer soliciting clicks for technical problems",
+    safeState = Off, new LocalDate(2015, 3, 9)
+  )
+
   // Features
   val CPScottSwitch = Switch(
     "Feature",

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -94,6 +94,9 @@
                     contact us</a></li>
             }
 
+        <li class="colophon__item footer__feedback--hide js-tech-feedback"><a data-link-name="uk : footer : tech feedback">report technical issue</a></li>
+        <li class="colophon__message footer__feedback--hide js-feedback-thanks">Thanks for reporting!</li>
+
             @if(currentEdition == Us) {
                 <li class="colophon__item"><a data-link-name="us : footer : about us" href="http://www.theguardian.com/info/about-guardian-us">
                     about us</a></li>

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -3,6 +3,7 @@ package model.diagnostics.analytics
 import java.util.concurrent.atomic.AtomicLong
 
 import common.Logging
+import conf.Switches
 
 object Metric extends Logging {
 
@@ -38,8 +39,13 @@ object Metric extends Logging {
     ("sm-clicked-most-popular-component", CountMetric("sm-clicked-most-popular-component")),
 
     ("ipad-old-start", CountMetric(s"ipad-old-start")),
-    ("ipad-old-after-5", CountMetric(s"ipad-old-after-5"))
+    ("ipad-old-after-5", CountMetric(s"ipad-old-after-5")),
+
+    ("tech-feedback", CountMetric("tech-feedback"))
   ) ++ iPhoneMetrics
+
+  lazy val techFeedback = Switches.FeedbackLink // remove tech-feedback metric when this switch is removed.
+
 
   private val iPhoneMetrics: Seq[(String, CountMetric)] = Seq(4, 6).flatMap( model =>
     Seq(

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -25,6 +25,7 @@ define([
     'common/modules/analytics/scrollDepth',
     'common/modules/analytics/css-logging',
     'common/modules/analytics/simple-metrics',
+    'common/modules/analytics/tech-feedback',
     'common/modules/commercial/user-ad-targeting',
     'common/modules/crosswords/thumbnails',
     'common/modules/discussion/comment-count',
@@ -82,6 +83,7 @@ define([
     ScrollDepth,
     logCss,
     simpleMetrics,
+    techFeedback,
     userAdTargeting,
     crosswordThumbnails,
     CommentCount,
@@ -459,6 +461,12 @@ define([
                 });
             },
 
+            initTechFeedback: function () {
+                mediator.on('page:common:ready', function () {
+                    techFeedback.init();
+                });
+            },
+
             initPublicApi: function () {
                 // BE CAREFUL what you expose here...
                 window.guardian.api = {
@@ -509,6 +517,7 @@ define([
             robust('c-public-api', modules.initPublicApi);
             robust('c-simple-metrics', modules.initSimpleMetrics);
             robust('c-crosswords', crosswordThumbnails.init);
+            robust('c-tech-feedback', modules.initTechFeedback);
             robust('c-ready',           function () { mediator.emit('page:common:ready'); });
         };
 

--- a/static/src/javascripts/projects/common/modules/analytics/tech-feedback.js
+++ b/static/src/javascripts/projects/common/modules/analytics/tech-feedback.js
@@ -12,15 +12,15 @@ define([
 
     return {
         init: function () {
-                var link = $('.js-tech-feedback');
-                bean.on(link[0], 'click', function (e) {
-                    beacon.fire('/counts.gif?c=tech-feedback');
-                    fastdom.write(function () {
-                        $('.js-feedback-thanks').removeClass('footer__feedback--hide');
-                        link.addClass('footer__feedback--hide');
-                    });
+            var link = $('.js-tech-feedback');
+            bean.on(link[0], 'click', function () {
+                beacon.fire('/counts.gif?c=tech-feedback');
+                fastdom.write(function () {
+                    $('.js-feedback-thanks').removeClass('footer__feedback--hide');
+                    link.addClass('footer__feedback--hide');
                 });
-                link.removeClass('footer__feedback--hide');
+            });
+            link.removeClass('footer__feedback--hide');
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/analytics/tech-feedback.js
+++ b/static/src/javascripts/projects/common/modules/analytics/tech-feedback.js
@@ -1,0 +1,26 @@
+define([
+    'bean',
+    'fastdom',
+    'common/utils/$',
+    'common/modules/analytics/beacon'
+], function (
+    bean,
+    fastdom,
+    $,
+    beacon
+) {
+
+    return {
+        init: function () {
+                var link = $('.js-tech-feedback');
+                bean.on(link[0], 'click', function (e) {
+                    beacon.fire('/counts.gif?c=tech-feedback');
+                    fastdom.write(function () {
+                        $('.js-feedback-thanks').removeClass('footer__feedback--hide');
+                        link.addClass('footer__feedback--hide');
+                    });
+                });
+                link.removeClass('footer__feedback--hide');
+        }
+    };
+});

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -106,6 +106,15 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
     @include box-sizing(border-box);
 }
 
+.colophon__message {
+    @include box-sizing(border-box);
+    padding-bottom: $gs-baseline;
+}
+
+.footer__feedback--hide {
+    display: none;
+}
+
 .l-footer__misc {
     padding-top: $gs-baseline * .5;
     padding-bottom: $gs-baseline * 1.5;


### PR DESCRIPTION
So we have way too many browsers to test everything ourselves, and many users.  At the moment we have 2 ways to find out if we broke something:
1a. rely on them contacting userhelp and the messages getting through to us in an unstructured trickle
1b. rely on them tweeting us and someone noticing etc
2. capture actual browser errors with raven sentry
3. metrics about behaviour
4. forsee surveys? not sure 
We don't have any way to capture large amounts structured data about what doesn't work but causes problems for users.

So.. I had an idea to put a button on every page to see if people would report issues in a way we can automatically analyse their input.  We could go as far as capturing browser info, page url, and screenshots, as well as giving them a multi choice questionnaire.  And probably other stuff.

However this first attempt is just to check if people even click the link.  If they don't, it needs making bigger, checking if there are bugs in the link(!), or we try something else.
![report-issue](https://cloud.githubusercontent.com/assets/7304387/6370868/23203e48-bced-11e4-862f-00c126aab13a.gif)

Comments very much appreciated.
