### PR TITLE
Specify that Java 8 is required for this project

### DIFF
--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -15,11 +15,16 @@ trait Prototypes {
     organization := "com.gu",
     maxErrors := 20,
     javacOptions := Seq("-g","-encoding", "utf8"),
-    scalacOptions := Seq("-unchecked", "-optimise", "-deprecation",
+    scalacOptions := Seq("-unchecked", "-optimise", "-deprecation", "-target:jvm-1.8",
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
     doc in Compile <<= target.map(_ / "none"),
     incOptions := incOptions.value.withNameHashing(true),
-    scalaVersion := "2.11.4"
+    scalaVersion := "2.11.4",
+    initialize := {
+      val _ = initialize.value
+      assert(sys.props("java.specification.version") == "1.8",
+        "Java 8 is required for this project.")
+    }
   )
 
   val frontendIntegrationTestsSettings = Seq (


### PR DESCRIPTION
This is to help guide the unwitting Java-7-using-developer (like me and @mchv) to upgrade their Java version to Java 8. Output looks like this:

```
********************************* JAVA VERSION *********************************
java version "1.7.0_76"
Java(TM) SE Runtime Environment (build 1.7.0_76-b13)
Java HotSpot(TM) 64-Bit Server VM (build 24.76-b04, mixed mode)
********************************************************************************

[info] Loading project definition from /home/roberto/guardian/frontend/project/project
...
java.lang.AssertionError: assertion failed: Java 8 is required for this project.
    at scala.Predef$.assert(Predef.scala:179)
    at com.gu.Prototypes$$anonfun$8.apply(Prototypes.scala:25)
    at com.gu.Prototypes$$anonfun$8.apply(Prototypes.scala:23)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.EvaluateSettings$MixedNode.evaluate0(INode.scala:175)
    at sbt.EvaluateSettings$INode.evaluate(INode.scala:135)
    at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$submitEvaluate$1.apply$mcV$sp(INode.scala:69)
    at sbt.EvaluateSettings.sbt$EvaluateSettings$$run0(INode.scala:78)
    at sbt.EvaluateSettings$$anon$3.run(INode.scala:74)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
[error] java.lang.AssertionError: assertion failed: Java 8 is required for this project.
[error] Use 'last' for the full log.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```
