### PR TITLE
Remove the ignored & obsolete MaxPermSize flag from the JVM args

### DIFF
--- a/sbt
+++ b/sbt
@@ -36,7 +36,7 @@ jvm_mem="-Xmx$((physical_mem / 2 / 1024))m"
 
 
 if [ -z $FRONTEND_JVM_ARGS ]; then
-    FRONTEND_JVM_ARGS="$jvm_mem -XX:MaxPermSize=256M -XX:ReservedCodeCacheSize=128m -XX:+UseConcMarkSweepGC -Djava.awt.headless=true -XX:NewRatio=4"
+    FRONTEND_JVM_ARGS="$jvm_mem -XX:ReservedCodeCacheSize=128m -XX:+UseConcMarkSweepGC -Djava.awt.headless=true -XX:NewRatio=4"
 fi
 
 echo ''


### PR DESCRIPTION
Frontend requires Java 8, where the `MaxPermSize` flag has no effect, so you get this noise in the sbt startup:

`warning: ignoring option MaxPermSize=256M;`

This flag was having no effect, and everyone seems to have been getting by ok. Be aware that there is a /new/ flag that kinda does the same as the old `MaxPermSize` - it's `MaxMetaspaceSize`, and that's what you'd want to set in future, if required.

See also https://github.com/sbt/sbt-launcher-package/pull/78 and http://java.dzone.com/articles/java-8-permgen-metaspace

```
********************************* JAVA VERSION *********************************
java version "1.8.0_31"
Java(TM) SE Runtime Environment (build 1.8.0_31-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.31-b07, mixed mode)
********************************************************************************

Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256M; support was removed in 8.0
[info] Loading project definition from /home/roberto/guardian/frontend/project/project
```
