### PR TITLE
update privacy policy URL

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -102,7 +102,7 @@
                     complaints &amp; corrections</a></li>
             }
             <li class="colophon__item"><a data-link-name="terms" href="http://www.theguardian.com/help/terms-of-service">terms &amp; conditions</a></li>
-            <li class="colophon__item"><a data-link-name="privacy" href="http://www.theguardian.com/help/privacy-policy">privacy policy</a></li>
+            <li class="colophon__item"><a data-link-name="privacy" href="http://www.theguardian.com/info/privacy">privacy policy</a></li>
             <li class="colophon__item"><a data-link-name="cookie" href="http://www.theguardian.com/info/cookies">cookie policy</a></li>
             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">securedrop</a></li>
         }


### PR DESCRIPTION
as requested:
"The team behind the privacy front would like the link at the bottom of the website "privacy policy" to redirect to the Guardian's privacy homepage so users can see the full list of privacy information.

The link is currently directing to: http://www.theguardian.com/help/privacy-policy

The privacy team would like it to direct to: http://www.theguardian.com/info/privacy
"
