### PR TITLE
Remove unused context from Identity navigation Profile.js

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -139,7 +139,7 @@ define([
 
                 if (header) {
                     if (config.switches.idProfileNavigation) {
-                        profile = new Profile(header, {
+                        profile = new Profile({
                             url: config.page.idUrl
                         });
                         profile.init();

--- a/static/src/javascripts/projects/common/modules/identity/autosignin.js
+++ b/static/src/javascripts/projects/common/modules/identity/autosignin.js
@@ -64,12 +64,9 @@ function (
                 success: function (response) {
                     self.welcome(name);
                     if (response.status === 'ok') {
-                        var profile = new Profile(
-                            self.header,
-                            {
-                                url: config.page.idUrl
-                            }
-                        );
+                        var profile = new Profile({
+                            url: config.page.idUrl
+                        });
                         profile.init();
 
                         s.eVar36 = 'facebook auto';


### PR DESCRIPTION
[Context was removed a while ago](https://github.com/guardian/frontend/commit/dc3770071ffd66a1eba57afe09b544d9c3ef9b64), these two instances were missed.
