### PR TITLE
Align MPUs to the grid on fronts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -297,7 +297,7 @@ define([
                 // is there a callback for this size
                 callbacks[size] && callbacks[size](event, $slot);
 
-                if ($slot.hasClass('ad-slot--container-inline')) {
+                if ($slot.hasClass('ad-slot--container-inline') && $slot.hasClass('ad-slot--not-mobile')) {
                     $slot.parent().css('display', 'flex');
                 } else if (!($slot.hasClass('ad-slot--top-above-nav') && size === '1,1')) {
                     $slot.parent().css('display', 'block');

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -293,7 +293,6 @@ define([
                 checkForBreakout($slot);
                 addLabel($slot);
                 size = event.size.join(',');
-
                 // is there a callback for this size
                 callbacks[size] && callbacks[size](event, $slot);
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -295,7 +295,9 @@ define([
                 // is there a callback for this size
                 callbacks[size] && callbacks[size](event, $slot);
 
-                if (!($slot.hasClass('ad-slot--top-above-nav') && size === '1,1')) {
+                if ($slot.hasClass('ad-slot--container-inline')) {
+                    $slot.parent().css('display', 'flex');
+                } else if (!($slot.hasClass('ad-slot--top-above-nav') && size === '1,1')) {
                     $slot.parent().css('display', 'block');
                 }
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -289,7 +289,7 @@ define([
             } else {
                 // remove any placeholder ad content
                 $('.ad-slot__content--placeholder', $slot).remove();
-                $('#' + slotId + ' div').addClass("ad-slot__content");
+                $('#' + slotId + ' div').addClass('ad-slot__content');
                 checkForBreakout($slot);
                 addLabel($slot);
                 size = event.size.join(',');

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -289,9 +289,11 @@ define([
             } else {
                 // remove any placeholder ad content
                 $('.ad-slot__content--placeholder', $slot).remove();
+                $('#' + slotId + ' div').addClass("ad-slot__content");
                 checkForBreakout($slot);
                 addLabel($slot);
                 size = event.size.join(',');
+
                 // is there a callback for this size
                 callbacks[size] && callbacks[size](event, $slot);
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -213,8 +213,20 @@
     }
 
     @include mq(tablet, desktop) {
+        position: relative;
+
         .ad-slot__label {
             padding: 0 $gs-gutter;
+        }
+
+        .ad-slot__content {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            height: 250px;
+            margin: auto;
         }
     }
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -202,8 +202,8 @@
 .ad-slot--container-inline {
     @include mq(tablet) {
         height: auto;
-        width: 100%;
         margin: 0 $gs-gutter/2;
+        width: 300px;
 
         .linkslist-container & {
             position: absolute;
@@ -223,6 +223,7 @@
 
     @include mq(tablet, desktop) {
         position: relative;
+        width: gs-span(4.5);
 
         .ad-slot__label {
             padding: 0 $gs-gutter;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -190,13 +190,10 @@
 .ad-slot--inline,
 .ad-slot--container-inline {
     background-color: colour(neutral-8);
-
-    @include mq(tablet) {
-        width: 300px;
-    }
 }
 .ad-slot--inline {
     @include mq(tablet) {
+        width: 300px;
         float: right;
         margin-top: $gs-baseline/3;
         margin-left: $gs-gutter;
@@ -204,12 +201,20 @@
 }
 .ad-slot--container-inline {
     @include mq(tablet) {
-        margin: 0 $gs-gutter/2 0 auto;
+        height: auto;
+        width: 100%;
+        margin: 0 $gs-gutter/2;
 
         .linkslist-container & {
             position: absolute;
             top: 0;
             right: 0;
+        }
+    }
+
+    @include mq(tablet, desktop) {
+        .ad-slot__label {
+            padding: 0 $gs-gutter;
         }
     }
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -190,10 +190,13 @@
 .ad-slot--inline,
 .ad-slot--container-inline {
     background-color: colour(neutral-8);
+
+    @include mq(tablet) {
+        width: 300px;
+    }
 }
 .ad-slot--inline {
     @include mq(tablet) {
-        width: 300px;
         float: right;
         margin-top: $gs-baseline/3;
         margin-left: $gs-gutter;
@@ -203,7 +206,6 @@
     @include mq(tablet) {
         height: auto;
         margin: 0 $gs-gutter/2;
-        width: 300px;
 
         .linkslist-container & {
             position: absolute;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -232,7 +232,7 @@
         }
 
         .ad-slot__content {
-            top: 0;
+            top: $mpu-ad-label-height;
         }
     }
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -210,6 +210,15 @@
             top: 0;
             right: 0;
         }
+
+        .ad-slot__content {
+            position: absolute;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            height: 250px;
+            margin: auto;
+        }
     }
 
     @include mq(tablet, desktop) {
@@ -220,13 +229,7 @@
         }
 
         .ad-slot__content {
-            position: absolute;
             top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            height: 250px;
-            margin: auto;
         }
     }
 }

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -214,10 +214,6 @@ Hence why a greater depth of selector specificity is needed.
                 margin: 0;
                 height: 286px;
             }
-
-            .ad-slot__content {
-                top: $gs-baseline;
-            }
         }
     }
 

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -200,7 +200,7 @@ Hence why a greater depth of selector specificity is needed.
     @include mq(tablet) {
         .fc-slice__popular-mpu {
             position: absolute;
-            max-width: 320px;
+            width: 320px;
         }
     }
 
@@ -208,6 +208,16 @@ Hence why a greater depth of selector specificity is needed.
         .fc-slice__popular-mpu {
             bottom: 0;
             right: 0;
+            width: gs-span(4.5);
+
+            .ad-slot--container-inline {
+                margin: 0;
+                height: 286px;
+            }
+
+            .ad-slot__content {
+                top: $gs-baseline;
+            }
         }
     }
 


### PR DESCRIPTION
Finally getting rid of those horrible gaps. Purposely picked an extreme example to show off the solution.

Before (tablet followed by desktop)
![screen shot 2015-03-02 at 17 03 54](https://cloud.githubusercontent.com/assets/1607666/6445774/3c917b02-c0fe-11e4-974a-ac2bc9f97ee4.png)
![screen shot 2015-03-02 at 17 03 44](https://cloud.githubusercontent.com/assets/1607666/6445773/3c909778-c0fe-11e4-9473-75908e2cc3c2.png)

After (tablet followed by desktop)
![screen shot 2015-03-02 at 17 03 34](https://cloud.githubusercontent.com/assets/1607666/6445775/3c934356-c0fe-11e4-96c6-7dbf8c7b2d75.png)
![screen shot 2015-03-02 at 17 03 25](https://cloud.githubusercontent.com/assets/1607666/6445776/3c943b30-c0fe-11e4-960b-bd5c0c0738ed.png)

BrowserStack Screenshots (Some haven't loaded Ads yet, but still work on BS-Live inspection): http://www.browserstack.com/screenshots/8c7b95b5baf53a26e952ee84ed2723140eac9f39
