### PR TITLE
use the correct beacon url for dns prefetching

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -24,7 +24,7 @@
 <link rel="dns-prefetch" href="//j.ophan.co.uk" />
 <link rel="dns-prefetch" href="//ophan.theguardian.com" />
 <link rel="dns-prefetch" href="//oas.theguardian.com" />
-<link rel="dns-prefetch" href="//beacon.www.theguardian.com" />
+<link rel="dns-prefetch" href="@Configuration.debug.beaconUrl" />
 
 
 @* Additional meta data that does not impact rendering speed (and can live at the end of the <head>) *@


### PR DESCRIPTION
no idea where the old url comes from but it's not what we're using in the page.

Also not sure what the oas host is, as it's not being used when I go to our page - //oas.theguardian.com
