### PR TITLE
Don't remove user Profile container (for delayed authentications)

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -13,7 +13,7 @@ to apply any necessary changes to non-shared code there too.
         <div class="brand-bar">
             @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
                 <div class="brand-bar__item brand-bar__item--profile popup-container has-popup brand-bar__item--has-control js-profile-nav" data-component="identity-profile">
-                    <a href="@Configuration.id.url/signin" data-link-name="User profile" data-toggle="popup--profile"
+                    <a href="@Configuration.id.url/signin" data-link-name="User profile" data-toggle="js-profile-popup"
                        class="brand-bar__item--action popup__toggle" data-test-id="sign-in-link"
                        aria-haspopup="true">
                         @fragments.inlineSvg("profile-36", "icon", List("rounded-icon", "control__icon-wrapper"))

--- a/identity/app/views/fragments/identityHeader.scala.html
+++ b/identity/app/views/fragments/identityHeader.scala.html
@@ -6,7 +6,7 @@
         <div class="brand-bar">
             @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
                 <div class="brand-bar__item brand-bar__item--profile popup-container has-popup brand-bar__item--has-control js-profile-nav">
-                    <a href="@Configuration.id.url/signin" data-link-name="User profile" data-toggle="popup--profile"
+                    <a href="@Configuration.id.url/signin" data-link-name="User profile" data-toggle="js-profile-popup"
                        class="brand-bar__item--action popup__toggle">
                         @fragments.inlineSvg("profile-36", "icon", List("rounded-icon", "control__icon-wrapper"))
                         <span class="js-profile-info control__info" data-test-id="sign-in-name">Sign in</span>

--- a/static/src/javascripts/projects/common/modules/navigation/profile.js
+++ b/static/src/javascripts/projects/common/modules/navigation/profile.js
@@ -75,11 +75,6 @@ define([
                     this.menuListItem('Sign out', this.opts.url + '/signout') +
                     '</ul>'
             );
-
-        } else {
-            fastdom.write(function () {
-                $popup.remove();
-            });
         }
 
         this.emitLoadedEvent(user);


### PR DESCRIPTION
Authentication may occur after page load (i.e. after bootstrap), e.g. Facebook auto sign-in. So:
- Keep the container
- Toggle on the container rather than inner list ([which is created on auth](https://github.com/guardian/frontend/blob/identity-fix-delayed-profile/static/src/javascripts/projects/common/modules/navigation/profile.js#L70)) so binding can occur at bootstrap [as normal](https://github.com/guardian/frontend/blob/identity-fix-delayed-profile/static/src/javascripts/bootstraps/common.js#L230).
