### PR TITLE
Fix random test failures in facia-tool

### DIFF
--- a/facia-tool/public/js/widgets/clipboard.js
+++ b/facia-tool/public/js/widgets/clipboard.js
@@ -143,6 +143,7 @@ define([
     Clipboard.prototype.dispose = function () {
         globalListeners.off('paste', null, this);
         clearInterval(this.pollID);
+        this.listeners.dispose();
     };
 
     return Clipboard;


### PR DESCRIPTION
When the clipboard test runs before the config test (usually it runs after) some lost listeners cause an exception.

@johnduffell 
