### PR TITLE
udpate 'guardian professional' in the nav

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -68,7 +68,7 @@ trait Navigation {
   val africa = SectionLink("world", "africa", "Africa", "/world/africa")
   val middleEast = SectionLink("world", "middle east", "Middle east", "/world/middleeast")
   val video = SectionLink("video", "video", "Video", "/video")
-  val guardianProfessional = SectionLink("guardian-professional", "guardian professional", "Guardian Professional", "/guardian-professional")
+  val guardianProfessional = SectionLink("guardian-professional", "professional networks", "Guardian Professional", "/guardian-professional")
   val observer = SectionLink("observer", "the observer", "The Observer", "/observer")
 
   val health = SectionLink("society", "health", "Health", "/society/health")


### PR DESCRIPTION
now says 'professional' (or 'professional networks' if there's room)

cc @mr-mr 
