### PR TITLE
Bottom margin below featured logos

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -468,6 +468,7 @@
             width: $left-column + $gs-gutter;
             content: '';
             border-bottom: 1px dotted colour(neutral-5);
+            margin-top: $gs-gutter/4;
 
             @include mq(leftCol) {
                 width: $left-column;


### PR DESCRIPTION
Added bottom margin (in fact margin-top on :after) below featured logos on fronts to show some space.
