### PR TITLE
Re-init Toggles for delayed Profile sign-in

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/autosignin.js
+++ b/static/src/javascripts/projects/common/modules/identity/autosignin.js
@@ -6,7 +6,8 @@ define([
     'common/modules/identity/api',
     'common/modules/identity/facebook-authorizer',
     'common/modules/navigation/profile',
-    'common/modules/ui/message'
+    'common/modules/ui/message',
+    'common/modules/ui/toggles'
 ],
 function (
     bonzo,
@@ -16,7 +17,8 @@ function (
     id,
     FacebookAuthorizer,
     Profile,
-    Message
+    Message,
+    Toggles
 ) {
 
     function AutoSignin() {
@@ -68,6 +70,7 @@ function (
                             url: config.page.idUrl
                         });
                         profile.init();
+                        new Toggles().init();
 
                         s.eVar36 = 'facebook auto';
                         s.linkTrackVars = 'eVar36';

--- a/static/src/javascripts/projects/common/modules/navigation/profile.js
+++ b/static/src/javascripts/projects/common/modules/navigation/profile.js
@@ -67,7 +67,7 @@ define([
             }
 
             $popup.html(
-                    '<ul class="popup popup__group popup--profile" data-link-name="Sub Sections" data-test-id="popup-profile">' +
+                    '<ul class="popup popup__group popup--profile is-off" data-link-name="Sub Sections" data-test-id="popup-profile">' +
                     this.menuListItem('Comment activity', this.opts.url + '/user/id/' + user.id) +
                     this.menuListItem('Edit profile', this.opts.url + '/public/edit') +
                     this.menuListItem('Email preferences', this.opts.url + '/email-prefs') +
@@ -75,11 +75,6 @@ define([
                     this.menuListItem('Sign out', this.opts.url + '/signout') +
                     '</ul>'
             );
-
-        } else {
-            fastdom.write(function () {
-                $popup.remove();
-            });
         }
 
         this.emitLoadedEvent(user);


### PR DESCRIPTION
Authentication may be delayed, e.g. with Facebook auto sign-in, in which case the user profile toggle menu doesn't exist to be bootstrapped on page load. We also shouldn't assume to remove it's container because of this.

`Toggles` no longer takes context but will [ignore existing instances](https://github.com/guardian/frontend/blob/identity-fix-delayed-profile/static/src/javascripts/projects/common/modules/ui/toggles.js#L18) elsewhere, so can be called again.

I thought about putting this into `Profile.js` ([probably here](https://github.com/guardian/frontend/blob/identity-fix-delayed-profile/static/src/javascripts/projects/common/modules/navigation/profile.js#L77)), but then it would instantiate all Toggles [earlier than the bootstrap intends](https://github.com/guardian/frontend/blob/identity-fix-delayed-profile/static/src/javascripts/bootstraps/common.js#L468) when it's run the first the [first time](https://github.com/guardian/frontend/blob/identity-fix-delayed-profile/static/src/javascripts/bootstraps/common.js#L466) (i.e. for already-authenticated users). Again, this wouldn't conflict because of the `readyClass` check, but it would be unexpected.
