### PR TITLE
Release the Behemoth (make a test container and use it)

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -354,6 +354,8 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
         oauthCallback <- configuration.getStringProperty("faciatool.oauth.callback")
       } yield OAuthCredentials(oauthClientId, oauthSecret, oauthCallback)
 
+    val showTestContainers = configuration.getStringProperty("faciatool.show_test_containers").exists(_ == "true")
+
     lazy val adminPressJobStandardPushRateInMinutes: Int =
       Try(configuration.getStringProperty("admin.pressjob.standard.push.rate.inminutes").get.toInt)
         .getOrElse(5)

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -68,8 +68,6 @@ object FixedContainers {
 
   val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher"))
 
-  val testContainer = slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, Hl4Half, TTTL4)
-
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),
     ("fixed/small/slow-II", slices(HalfHalf)),

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -1,6 +1,7 @@
 package slices
 
 import model.Content
+import conf.Configuration
 
 object TagContainers {
   import ContainerDefinition.{ofSlices => slices}
@@ -67,6 +68,8 @@ object FixedContainers {
 
   val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher"))
 
+  val testContainer = slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, Hl4Half, TTTL4)
+
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),
     ("fixed/small/slow-II", slices(HalfHalf)),
@@ -87,7 +90,9 @@ object FixedContainers {
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/large/fast-XV", slices(HalfQQ, Ql3Ql3Ql3Ql3)),
     ("fixed/thrasher", thrasher)
-  )
+  ) ++ (if (Configuration.faciatool.showTestContainers) Map(
+    ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, Hl4Half, TTTL4))
+  ) else Map.empty)
 
   def unapply(collectionType: Option[String]): Option[ContainerDefinition] =
     collectionType.flatMap(all.lift)

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -89,7 +89,7 @@ object FixedContainers {
     ("fixed/large/fast-XV", slices(HalfQQ, Ql3Ql3Ql3Ql3)),
     ("fixed/thrasher", thrasher)
   ) ++ (if (Configuration.faciatool.showTestContainers) Map(
-    ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, Hl4Half, TTTL4))
+    ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, ThreeQuarterQuarter, Hl4Half, HalfQuarterQl2Ql4, TTTL4, Ql3Ql3Ql3Ql3))
   ) else Map.empty)
 
   def unapply(collectionType: Option[String]): Option[ContainerDefinition] =

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -95,6 +95,8 @@ admin.pressjob.low.push.rate.inminutes=60
 faciatool.oauth.clientid=283258724824-0bgu6mhprebo5k3288h1fc1ogakmvgb8.apps.googleusercontent.com
 faciatool.oauth.callback=https://fronts.code.dev-gutools.co.uk/oauth2callback
 
+faciatool.show_test_containers=true
+
 #Admin Oauth
 admin.oauth.clientid=265127054270-oh215l6pe6csgtucra1ugjruuqptgsjh.apps.googleusercontent.com
 admin.oauth.callback=https://frontend.code.dev-gutools.co.uk/oauth2callback

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -81,6 +81,8 @@ dfp.guMerchandising.advertiserId=24113847
 faciatool.oauth.clientid=283258724824-gv88hsfbl2os5n9qlt2ocs8bu94cao5r.apps.googleusercontent.com
 faciatool.oauth.callback=http://localhost:9000/oauth2callback
 
+faciatool.show_test_containers=true
+
 #Admin Oauth
 admin.oauth.clientid=265127054270-97f63kb58ns533alnhlb1vj4jds79q2f.apps.googleusercontent.com
 admin.oauth.callback=http://localhost:9000/oauth2callback


### PR DESCRIPTION
@phamann asked if we had a test page for facia fronts. We didn't. Now we do.

So I've added this monstrosity to the containers... (limited to DEV and CODE only)
![screen recording 2015-03-03 at 03 47 pm](https://cloud.githubusercontent.com/assets/1607666/6466022/c0e9c508-c1bc-11e4-81ab-9b581d643e72.gif)

The result gives you something like this...
![itsalive](https://cloud.githubusercontent.com/assets/1607666/6466081/1b8036aa-c1bd-11e4-8e3f-a7ad7d1fa70e.jpg)

I've also setup a shared test page made up of these containers and tonally focused api queries at http://m.code.dev-theguardian.com/behemoth (won't work until we've deployed (or you could run this branch locally))

Release the Behemoth...
![tumblr_njtfofxo101s2yegdo1_r1_500 1](https://cloud.githubusercontent.com/assets/1607666/6466125/60c1ed12-c1bd-11e4-95a5-8f0b423f745f.gif)
