### PR TITLE
Rich links (flyers): don't show tag-targeted rich links on "sensitive content"

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -59,7 +59,8 @@ define([
     }
 
     function insertTagFlyer() {
-        if (config.page.richLink && config.page.richLink.indexOf(config.page.pageId) === -1) {
+        if (config.page.richLink && !config.page.shouldHideAdverts && !config.page.showRelatedContent
+            && config.page.richLink.indexOf(config.page.pageId) === -1) {
             var space = spacefinder.getParaWithSpace(getSpacefinderRules());
             if (space) {
                 $.create(template(richLinkTagTmpl, {href: config.page.richLink}))

--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -59,7 +59,7 @@ define([
     }
 
     function insertTagFlyer() {
-        if (config.page.richLink && !config.page.shouldHideAdverts && !config.page.showRelatedContent
+        if (config.page.richLink && !config.page.shouldHideAdverts && config.page.showRelatedContent
             && config.page.richLink.indexOf(config.page.pageId) === -1) {
             var space = spacefinder.getParaWithSpace(getSpacefinderRules());
             if (space) {

--- a/static/test/javascripts/spec/common/article/flyers.spec.js
+++ b/static/test/javascripts/spec/common/article/flyers.spec.js
@@ -1,0 +1,118 @@
+define([
+    'helpers/injector',
+    'helpers/fixtures',
+
+    'common/utils/$',
+    'common/utils/template',
+
+    'text!common/views/content/richLinkTag.html'
+], function(
+    Injector,
+    fixtures,
+
+    $,
+    template,
+
+    richLinkTagTmpl
+) {
+
+    return new Injector()
+        .store(['common/utils/config', 'common/modules/article/spacefinder'])
+        .require(['common/modules/article/flyers', 'mocks'], function (flyers, mocks) {
+            var config = mocks.store['common/utils/config'];
+            var spacefinder = mocks.store['common/modules/article/spacefinder'];
+            var getRichLinkElements = function () { return $('#article-body .element-rich-link'); };
+
+            spacefinder.getParaWithSpace = function () {
+                return $('#article-body p').first();
+            };
+
+            describe('Flyers', function () {
+                var conf = {
+                        id: 'article-body',
+                        fixtures: [
+                            // Minimal article body fixture
+                            '<div class="js-article__body"><p>foo</p></div>'
+                        ]
+                };
+
+                beforeEach(function() {
+                    fixtures.render(conf);
+                });
+
+                afterEach(function() {
+                    fixtures.clean(conf.id);
+                });
+
+                describe('#insertTagFlyer', function () {
+                    describe('given no tag rich link', function () {
+                        it('should not insert a tag rich link', function () {
+                            flyers.insertTagFlyer();
+
+                            var richLinkElements = getRichLinkElements();
+                            expect(richLinkElements.length).toBe(0);
+                        });
+                    });
+
+                    describe('given a tag rich link', function () {
+                        // Mock a tag rich link
+                        beforeEach(function () {
+                            config.page = {
+                                richLink: 'foo',
+                                // Content API defaults
+                                shouldHideAdverts: false,
+                                showRelatedContent: true
+                            };
+                        });
+
+                        afterEach(function () {
+                            delete config.page.richLink;
+                        });
+
+                        it('should insert the provided tag rich link', function () {
+                            flyers.insertTagFlyer();
+
+                            var richLinkElements = getRichLinkElements();
+                            expect(richLinkElements.length).toBe(1);
+                            expect(richLinkElements[0].outerHTML)
+                                .toBe(template(richLinkTagTmpl, { href: config.page.richLink }).trim());
+                        });
+
+                        describe('given `config.page.shouldHideAdverts` is set to `true`', function () {
+                            beforeEach(function () {
+                                config.page.shouldHideAdverts = true;
+                            });
+
+                            afterEach(function () {
+                                delete config.page.shouldHideAdverts;
+                            });
+
+                            it('should not insert the provided tag rich link', function () {
+                                flyers.insertTagFlyer();
+
+                                var richLinkElements = getRichLinkElements();
+                                expect(richLinkElements.length).toBe(0);
+                            });
+                        });
+
+                        describe('given `config.page.showRelatedContent` is set to `false`', function () {
+                            beforeEach(function () {
+                                config.page.showRelatedContent = false;
+                            });
+
+                            afterEach(function () {
+                                delete config.page.showRelatedContent;
+                            });
+
+                            it('should not insert the provided tag rich link', function () {
+                                flyers.insertTagFlyer();
+
+                                var richLinkElements = getRichLinkElements();
+                                expect(richLinkElements.length).toBe(0);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+});


### PR DESCRIPTION
"sensitive content" = `shouldHideAdverts || !showRelatedContent`

/cc @cantlin
