### PR TITLE
Fix editorial dreamsnap header colour

### DIFF
--- a/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
@@ -34,7 +34,7 @@
     }
 
     .fc-item__kicker--dreamsnap {
-        background-color: mix(#000000, colour(editorial-accent), 10%);
+        background-color: mix(#000000, colour(editorial-default), 10%);
     }
 
     .flyer__arrow-icon {


### PR DESCRIPTION
![screen shot 2015-03-04 at 10 44 55](https://cloud.githubusercontent.com/assets/867233/6482193/89349dc8-c25b-11e4-8dbd-5fe766d29906.png)

should have been

![screen shot 2015-03-04 at 10 44 37](https://cloud.githubusercontent.com/assets/867233/6482200/8e94123a-c25b-11e4-9e0d-010a724c349f.png)
