### PR TITLE
Remove guss rem

### DIFF
--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -3,7 +3,6 @@
 // Guss - https://github.com/guardian/guss
 // =============================================================================
 
-@import 'components/guss-rem/_rem';
 @import 'components/guss-typography/_typography';
 @import 'components/guss-css3/_css3';
 @import 'components/guss-layout/_columns';

--- a/static/src/stylesheets/bower.json
+++ b/static/src/stylesheets/bower.json
@@ -8,7 +8,6 @@
     "guss-css3": "~2.2.1",
     "guss-grid-system": "~1.2.1",
     "guss-layout": "~1.3.3",
-    "guss-rem": "~1.2.0",
     "guss-typography": "~3.1.0",
     "guss-webfonts": "~4.0.0",
     "sass-mq": "~3.0.0"


### PR DESCRIPTION
Removing this dependency as we are not using it in our codebase.

We are using [this](https://github.com/guardian/frontend/pull/8248)

CC @sndrs 
