### PR TITLE
Rich links (flyers): dedupe tag-targeted rich links

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -60,7 +60,7 @@ define([
 
     function insertTagFlyer() {
         var richLinkHrefs = $('.element-rich-link a')
-            .map(function (el) { return $(el).attr('href'); }),
+                .map(function (el) { return $(el).attr('href'); }),
             testIfDuplicate = function (richLinkHref) {
                 // Tag-targeted rich links can be absolute
                 return _.contains(config.page.richLink, richLinkHref);

--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -59,8 +59,16 @@ define([
     }
 
     function insertTagFlyer() {
-        if (config.page.richLink && !config.page.shouldHideAdverts && config.page.showRelatedContent
-            && config.page.richLink.indexOf(config.page.pageId) === -1) {
+        var richLinkHrefs = $('.element-rich-link a')
+            .map(function (el) { return $(el).attr('href'); });
+        var testIfDuplicate = function (richLinkHref) {
+            // Tag-targeted rich links can be absolute
+            return _.contains(config.page.richLink, richLinkHref);
+        };
+        var isNotDuplicate = ! richLinkHrefs.some(testIfDuplicate);
+
+        if (config.page.richLink && config.page.richLink.indexOf(config.page.pageId) === -1
+            && !config.page.shouldHideAdverts && config.page.showRelatedContent && isNotDuplicate) {
             var space = spacefinder.getParaWithSpace(getSpacefinderRules());
             if (space) {
                 $.create(template(richLinkTagTmpl, {href: config.page.richLink}))

--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -65,12 +65,12 @@ define([
                 // Tag-targeted rich links can be absolute
                 return _.contains(config.page.richLink, richLinkHref);
             },
-            isNotDuplicate = !richLinkHrefs.some(testIfDuplicate),
-            isNotSensitive = !config.page.shouldHideAdverts && config.page.showRelatedContent,
+            isDuplicate = richLinkHrefs.some(testIfDuplicate),
+            isSensitive = config.page.shouldHideAdverts || !config.page.showRelatedContent,
             space;
 
         if (config.page.richLink && config.page.richLink.indexOf(config.page.pageId) === -1
-            && isNotSensitive && isNotDuplicate) {
+            && !isSensitive && !isDuplicate) {
             space = spacefinder.getParaWithSpace(getSpacefinderRules());
             if (space) {
                 $.create(template(richLinkTagTmpl, {href: config.page.richLink}))

--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -66,10 +66,11 @@ define([
                 return _.contains(config.page.richLink, richLinkHref);
             },
             isNotDuplicate = !richLinkHrefs.some(testIfDuplicate),
+            isNotSensitive = !config.page.shouldHideAdverts && config.page.showRelatedContent,
             space;
 
         if (config.page.richLink && config.page.richLink.indexOf(config.page.pageId) === -1
-            && !config.page.shouldHideAdverts && config.page.showRelatedContent && isNotDuplicate) {
+            && isNotSensitive && isNotDuplicate) {
             space = spacefinder.getParaWithSpace(getSpacefinderRules());
             if (space) {
                 $.create(template(richLinkTagTmpl, {href: config.page.richLink}))

--- a/static/src/javascripts/projects/common/modules/article/flyers.js
+++ b/static/src/javascripts/projects/common/modules/article/flyers.js
@@ -60,16 +60,17 @@ define([
 
     function insertTagFlyer() {
         var richLinkHrefs = $('.element-rich-link a')
-            .map(function (el) { return $(el).attr('href'); });
-        var testIfDuplicate = function (richLinkHref) {
-            // Tag-targeted rich links can be absolute
-            return _.contains(config.page.richLink, richLinkHref);
-        };
-        var isNotDuplicate = ! richLinkHrefs.some(testIfDuplicate);
+            .map(function (el) { return $(el).attr('href'); }),
+            testIfDuplicate = function (richLinkHref) {
+                // Tag-targeted rich links can be absolute
+                return _.contains(config.page.richLink, richLinkHref);
+            },
+            isNotDuplicate = !richLinkHrefs.some(testIfDuplicate),
+            space;
 
         if (config.page.richLink && config.page.richLink.indexOf(config.page.pageId) === -1
             && !config.page.shouldHideAdverts && config.page.showRelatedContent && isNotDuplicate) {
-            var space = spacefinder.getParaWithSpace(getSpacefinderRules());
+            space = spacefinder.getParaWithSpace(getSpacefinderRules());
             if (space) {
                 $.create(template(richLinkTagTmpl, {href: config.page.richLink}))
                     .insertBefore(space)

--- a/static/test/javascripts/spec/common/article/flyers.spec.js
+++ b/static/test/javascripts/spec/common/article/flyers.spec.js
@@ -38,7 +38,7 @@ define([
 
                 var articleBodyFixtureElement;
                 beforeEach(function() {
-                    fixtures.render(articleBodyConf);
+                    articleBodyFixtureElement = fixtures.render(articleBodyConf);
                 });
 
                 afterEach(function() {
@@ -110,6 +110,22 @@ define([
 
                                 var richLinkElements = getRichLinkElements();
                                 expect(richLinkElements.length).toBe(0);
+                            });
+                        });
+
+                        describe('given an existing rich link with the same URL', function () {
+                            // No need to clean because the parent element is reset after each
+                            beforeEach(function() {
+                                var existingRichLinkElement = $.create(template(richLinkTagTmpl, { href: config.page.richLink }));
+
+                                articleBodyFixtureElement.append(existingRichLinkElement);
+                            });
+
+                            it('should not insert the provided tag rich link', function () {
+                                flyers.insertTagFlyer();
+
+                                var richLinkElements = getRichLinkElements();
+                                expect(richLinkElements.length).toBe(1);
                             });
                         });
                     });

--- a/static/test/javascripts/spec/common/article/flyers.spec.js
+++ b/static/test/javascripts/spec/common/article/flyers.spec.js
@@ -28,7 +28,7 @@ define([
             };
 
             describe('Flyers', function () {
-                var conf = {
+                var articleBodyConf = {
                         id: 'article-body',
                         fixtures: [
                             // Minimal article body fixture
@@ -36,12 +36,13 @@ define([
                         ]
                 };
 
+                var articleBodyFixtureElement;
                 beforeEach(function() {
-                    fixtures.render(conf);
+                    fixtures.render(articleBodyConf);
                 });
 
                 afterEach(function() {
-                    fixtures.clean(conf.id);
+                    fixtures.clean(articleBodyConf.id);
                 });
 
                 describe('#insertTagFlyer', function () {


### PR DESCRIPTION
Don't insert a rich link into an article that already has that rich link (provided by a tag).

/cc @cantlin
