### PR TITLE
Mark premium content

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -200,6 +200,10 @@
                                 <span class="time__front" data-bind="text: frontPublicationTime"></span>
                             </span>
 
+                            <!-- ko if: state.premium -->
+                                <span class="label label--premium">premium</span>
+                            <!-- /ko -->
+
                             <!-- ko if: fields.isLive() === 'false' -->
                                 <span class="label" data-bind="
                                     css: {

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -914,6 +914,10 @@ collection-widget:first-child .collection {
     color: #CCCCCC;
 }
 
+.article__ammends .label--premium {
+    color: #b71c1c;
+}
+
 .article__ammends .label--draft {
     color: #ffc107;
 }

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -797,6 +797,7 @@ define([
 
         function isPremium(contentApiArticle) {
             return contentApiArticle.fields.membershipAccess === 'members-only' ||
+                contentApiArticle.fields.membershipAccess === 'paid-members-only' ||
                 !!_.find(contentApiArticle.tags, {id: 'news/series/looking-back'});
         }
 

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -297,7 +297,8 @@ define([
                 'hasMainVideo',
                 'imageCutoutSrcFromCapi',
                 'ophanUrl',
-                'sparkUrl']);
+                'sparkUrl',
+                'premium']);
 
             this.state.enableContentOverrides(this.meta.snapType() !== 'latest');
             this.state.inDynamicCollection(deepGet(opts, '.group.parent.isDynamic'));
@@ -557,6 +558,7 @@ define([
                 this.state.hasMainVideo(getMainMediaType(opts) === 'video');
                 this.state.tone(opts.frontsMeta && opts.frontsMeta.tone);
                 this.state.ophanUrl(vars.CONST.ophanBase + '?path=/' + urlAbsPath(opts.webUrl));
+                this.state.premium(isPremium(opts));
 
                 this.metaDefaults = _.extend(deepGet(opts, '.frontsMeta.defaults') || {}, this.collectionMetaDefaults);
 
@@ -791,6 +793,11 @@ define([
 
         function getContributorImage(contentApiArticle) {
             return _.chain(contentApiArticle.tags).where({type: 'contributor'}).pluck('bylineLargeImageUrl').first().value();
+        }
+
+        function isPremium(contentApiArticle) {
+            return contentApiArticle.fields.membershipAccess === 'members-only' ||
+                !!_.find(contentApiArticle.tags, {id: 'news/series/looking-back'});
         }
 
         function validateImage (imageSrc, imageSrcWidth, imageSrcHeight, opts) {

--- a/facia-tool/public/js/modules/vars.js
+++ b/facia-tool/public/js/modules/vars.js
@@ -74,7 +74,7 @@ define([
 
         apiBase:               '',
         apiSearchBase:         '/api/proxy',
-        apiSearchParams:       'show-elements=video&show-tags=all&show-fields=internalContentCode,isLive,firstPublicationDate,scheduledPublicationDate,headline,trailText,byline,thumbnail,liveBloggingNow',
+        apiSearchParams:       'show-elements=video&show-tags=all&show-fields=internalContentCode,isLive,firstPublicationDate,scheduledPublicationDate,headline,trailText,byline,thumbnail,liveBloggingNow,membershipAccess',
 
         imageCdnDomain:        'guim.co.uk',
         previewBase:           'http://preview.gutools.co.uk',


### PR DESCRIPTION
Content from looking-back and membership should be tagged in the front tool.

Looks like this
![screen shot 2015-03-04 at 17 23 10](https://cloud.githubusercontent.com/assets/680284/6489605/7a7206ae-c297-11e4-9015-67b97af90575.png)

@rtyley 

Discussion still ongoing for what content should be tagged as premium.
