### PR TITLE
Refactor JS templating for speed and to allow cleaner inline SVGs

### DIFF
--- a/docs/inline-svgs.md
+++ b/docs/inline-svgs.md
@@ -1,6 +1,6 @@
 # Inline SVGs
 
-The use of inline SVGs is encouraged over BASE-64-encoded URLs in CSS. It means: 
+The use of inline SVGs is encouraged over BASE-64-encoded URLs in CSS. It means:
 
 - the browser only has to parse what it needs, rather than all the images for the entire site on every page load
 - the weight of the CSS is massively reduced (about 50kb gzipped in theory)
@@ -15,7 +15,7 @@ Any image which you want to insert needs to be added to `/static/src/inline-svgs
 
 All images in `inline-svgs` are run through SVGO before being inserted, so you can afford to leave useful comments etc. in a file if you want.
 
-In order to stop IE8 from freaking out (even though it cannot even render SVGs), you *must* remove any `xmlns` attributes from the `svg` element. 
+In order to stop IE8 from freaking out (even though it cannot even render SVGs), you *must* remove any `xmlns` attributes from the `svg` element.
 
 IE also needs dimensions being set (all versions).
 
@@ -40,7 +40,7 @@ A scala helper method will insert the image for you:
 
 ### JavaScript templates
 
-These are a bit more complex. To ensures they only appear in the source once, all SVGs that will be used in a JavaScript template need to be added to `common/views/svgs.js`:
+These are slightly more complex. To ensures they only appear in the source once, any SVG that will be used in a JavaScript template needs to be added to `common/views/svgs.js`:
 
 ```javascript
 // common/views/svgs.js
@@ -62,45 +62,30 @@ define([
 - `Filename` **String** The name of the file, excluding the extention
 - `Subdirectory` **String** (optional) The folder the image lives in within `inline-svgs/`, prefixed by a `!`
 
-Then in the file that will use the template, require `svgs.js`:
+This provides a look-up method to pull icons out from the `svgs` object in `svgs.js`, which can be used in templates. The method takes an optional array of classes and an optional title string, like the Scala helper:
 
-```javascript
-// myfile.js
-define([
-    'common/views/svgs',
-], function (
-    svgs
-) { ... })
+```html
+// mytemplate.html
+        <div class="breaking-news__item-header">
+            {{inlineSvg("myImage"[, Classes[, Title]])}}
+            <em class="breaking-news__item-kicker">Breaking news</em>
 ```
-This returns a look-up method to pull icons out of the `svgs` object in `svgs.js`, which can then be passed into templates. The method takes an optional array of classes, like the Scala helper:
 
-```javascript
-// myfile.js
-define([
-    'common/utils/template',
-    'common/views/svgs'
-], function (
-    template,
-    svgs
-) {
-	var htmlWithInlineSVG = template("Here is my inline image: {{myImage}}", {
-		myImage: svgs('myImage'[, Classes[, Title]])
-	})
-})
-```
 - `Classes` **Array** (optional) An array of bespoke classes for this image
 - `Title` **String** (optional) A title that gets added to the wrapping `span`
 
+Unlike the Scala helper, you need to use the `key` from the `svgs` object of `common/views/svgs.js` and not the filename/subdirectory.
+
 ## Output
 
-The result of inserting an SVG with either method is the compressed source wrapped inside a `span`, with some default classes for free, plus any extra you've specified. 
+The result of inserting an SVG with either method is the compressed source wrapped inside a `span`, with some default classes for free, plus any extra you've specified.
 
 So both this Scala:
 
 ```scala
 @fragments.inlineSvg("profile-36", "icon", List("rounded-icon", "control__icon-wrapper"), Some("Profile icon"))
 ```
-and this JavaScript:
+and this JavaScript/HTML:
 
 ```javascript
 // common/views/svgs.js
@@ -114,15 +99,9 @@ define([
     };
 });
 ```
-```javascript
-// myfile.js
-define([
-    'common/views/svgs'
-], function (
-    svgs
-) {
-	svgs('profile36icon', ["rounded-icon", "control__icon-wrapper"], "Profile icon");
-});
+```html
+// mytemplate.html
+{{inlineSvg("profile36icon", ["rounded-icon", "control__icon-wrapper"], "Profile icon")}}
 ```
 
 will give you this HTML:

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -1,15 +1,12 @@
 define([
-    'lodash/collections/reduce',
     'lodash/objects/keys'
 ], function (
-    reduce,
     keys
 ) {
-
-    return function template(tmpl, params) {
-        return reduce(keys(params), function (tmpl, token) {
-            return tmpl.replace(new RegExp('{{' + token + '}}', 'g'), params[token]);
-        }, tmpl);
+    return function template(template, params) {
+        var regEx = new RegExp("({{)(" + keys(params).join("|") + ")(}})", "g");
+        return template.replace(regEx, function(match, openingDelimiter, key, closingDelimiter) {
+            return params[key];
+        });
     };
-
 });

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -1,3 +1,6 @@
+// jshint evil:true
+// jshint unused:false
+
 define([
     'lodash/objects/keys',
     'common/views/svgs'
@@ -5,10 +8,9 @@ define([
     keys,
     inlineSvg
 ) {
-    var svgRegEx = /({{)(inlineSvg\([^)]*\))(}})/g, // e.g. {{inlineSvg('marque36icon')}}
-        svgParamCleanerRegEx = /["'\s]/g;
+    var svgRegEx = /({{)(inlineSvg\([^)]*\))(}})/g; // e.g. {{inlineSvg('marque36icon')}}
 
-    function svgReplacer (match, openingDelimiter, inlineSvgCall) {
+    function svgReplacer(match, openingDelimiter, inlineSvgCall) {
         return eval(inlineSvgCall);
     }
 

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -3,17 +3,20 @@ define([
     'common/views/svgs'
 ], function (
     keys,
-    svgs
+    inlineSvg
 ) {
-    var svgRegEx = /({{inlineSvg\()([^)]*)(\)}})/g, // e.g. {{inlineSvg('marque36icon')}}
+    var svgRegEx = /({{)(inlineSvg\([^)]*\))(}})/g, // e.g. {{inlineSvg('marque36icon')}}
         svgParamCleanerRegEx = /["'\s]/g;
+
+    function svgReplacer (match, openingDelimiter, inlineSvgCall) {
+        return eval(inlineSvgCall);
+    }
 
     return function (template, params) {
         var keyRegEx = new RegExp('({{)(' + keys(params).join('|') + ')(}})', 'g');
+
         return template
-            .replace(svgRegEx, function (match, openingDelimiter, svg) {
-                return svgs.apply(this, svg.replace(svgParamCleanerRegEx, '').split(','));
-            })
+            .replace(svgRegEx, svgReplacer)
             .replace(keyRegEx, function (match, openingDelimiter, key) {
                 return params[key];
             });

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -1,12 +1,21 @@
 define([
-    'lodash/objects/keys'
+    'lodash/objects/keys',
+    'common/views/svgs'
 ], function (
-    keys
+    keys,
+    svgs
 ) {
-    return function template(template, params) {
-        var regEx = new RegExp("({{)(" + keys(params).join("|") + ")(}})", "g");
-        return template.replace(regEx, function(match, openingDelimiter, key, closingDelimiter) {
-            return params[key];
-        });
+    var svgRegEx = /({{inlineSvg\()([^)]*)(\)}})/g, // e.g. {{inlineSvg('marque36icon')}}
+        svgParamCleanerRegEx = /["'\s]/g;
+
+    return function (template, params) {
+        var keyRegEx = new RegExp('({{)(' + keys(params).join('|') + ')(}})', 'g');
+        return template
+            .replace(svgRegEx, function (match, openingDelimiter, svg) {
+                return svgs.apply(this, svg.replace(svgParamCleanerRegEx, '').split(','));
+            })
+            .replace(keyRegEx, function (match, openingDelimiter, key) {
+                return params[key];
+            });
     };
 });

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -8,15 +8,15 @@ define([
     keys,
     inlineSvg
 ) {
-    var svgRegEx = /({{)(inlineSvg\([^)]*\))(}})/g; // e.g. {{inlineSvg('marque36icon')}}
+    var svgRegEx = /{{(inlineSvg.*)?}}/g,
+        keyRegEx = /{{(.*?)}}/g;
 
-    function svgReplacer(match, openingDelimiter, inlineSvgCall) {
+    // see docs/inline-svgs.md for info on how to insert an inline SVG in template
+    function svgReplacer(match, inlineSvgCall) {
         return eval(inlineSvgCall);
     }
 
     return function (template, params) {
-        var keyRegEx = new RegExp('{{(' + keys(params).join('|') + ')}}', 'g');
-
         return template
             .replace(svgRegEx, svgReplacer)
             .replace(keyRegEx, function (match, key) {

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -15,11 +15,11 @@ define([
     }
 
     return function (template, params) {
-        var keyRegEx = new RegExp('({{)(' + keys(params).join('|') + ')(}})', 'g');
+        var keyRegEx = new RegExp('{{(' + keys(params).join('|') + ')}}', 'g');
 
         return template
             .replace(svgRegEx, svgReplacer)
-            .replace(keyRegEx, function (match, openingDelimiter, key) {
+            .replace(keyRegEx, function (match, key) {
                 return params[key];
             });
     };

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -2,10 +2,8 @@
 // jshint unused:false
 
 define([
-    'lodash/objects/keys',
     'common/views/svgs'
 ], function (
-    keys,
     inlineSvg
 ) {
     var svgRegEx = /{{(inlineSvg.*)?}}/g,


### PR DESCRIPTION
Moves management of loading svg strings in javascript to the template module itself, so there's no longer the need to get the string and pass it in to the template from wherever you use it. 

Means they can almost be used like the scala helper, e.g.

``` html
<div>{{inlineSvg("marque36icon", ["class-1", "class-2"], "This is a title")}}</div>
```

Also updates the `template` function to use `String.replace` as it's cleaner to read and faster on lower powered/older devices and browsers (though slower in modern chrome):

![screen shot 2015-03-05 at 12 33 49](https://cloud.githubusercontent.com/assets/867233/6504880/dfcb1e72-c333-11e4-89ff-27a662bb8d4a.png)
http://jsperf.com/reduce-vs-replace/4

While this doesn't break existing instances of inline svgs in JS, I'll update them to use this in separate PRs if this is merged.
