### PR TITLE
show quotes on printed articles

### DIFF
--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -13,7 +13,6 @@
 .l-footer,
 .element-video,
 .byline-img,
-.quoted,
 .element-embed,
 .gallery__most-popular,
 .block-share--gallery-mobile,

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -92,7 +92,7 @@ p {
 
 .l-side-margins:before,
 .l-side-margins:after {
-    background-color: #ffffff !important;
+    display: none;
 }
 
 .drop-cap {


### PR DESCRIPTION
someone tried to print http://www.theguardian.com/world/2015/feb/17/church-of-england-bishops-pastoral-letter-key-points and found all the quotes disappeared.  I'm guessing that was inadvertant.  I tried to make the styling a little more like on the normal article but all the margins are !important-ed to zero so it's not simple.

Perhaps we could have a smart strategy for making articles printable, but do people print articles much?  I've asked analytics for stats on how much people print articles which might inform matters more, but I suspect the answer is they don't really.

before and after pics:
![image](https://cloud.githubusercontent.com/assets/7304387/6507150/052d7afc-c348-11e4-9c5b-be82eb259d28.png)
.
.
.
![image](https://cloud.githubusercontent.com/assets/7304387/6507162/15a9d952-c348-11e4-8e40-72d60834ea8e.png)

Also at some widths it shows white bars at the side, e.g. landscape:
![image](https://cloud.githubusercontent.com/assets/7304387/6507235/726cf462-c348-11e4-94d1-1fcc488d4de7.png)
So I have removed those too.

@Jholder112233 you've done most work on this stylesheet so feel free to make suggestions!
