### PR TITLE
Commercial  Soulmates sub feeds

### DIFF
--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -434,6 +434,62 @@
     <div class="fc-container__inner">
         <h2 class="test-page-head">
             <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10030887">
+                Merchandising: commercial component (soulmates) + feed
+            </a>
+        </h2>
+        <form class="js-soulmates-feed">
+            <label>Feed selection:
+                <select>
+                    <option value="brighton" selected>Brighton</option>
+                    <option value="northwest">Northwest</option>
+                    <option value="scotland">Scotland</option>
+                    <option value="young">Young</option>
+                    <option value="mature">Mature</option>
+                </select>
+            </label>
+        </form>
+    </div>
+    <div class="fc-container fc-container--commercial">
+        <div class="js-merchandising-soulmates-feed ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component"></div>
+    </div>
+    <script>
+    loadCommercial(function () {
+        require([
+            'bean',
+            'qwery',
+            'common/utils/$',    
+            'common/modules/commercial/creatives/commercial-component'
+        ])
+            .then(function(
+                bean,
+                qwery,
+                $,
+                CommercialComponent
+            ) {
+                var $soulmatesFeed = $('.js-merchandising-soulmates-feed');
+                
+                bean.on(qwery('.js-soulmates-feed select')[0], 'change', function (event) {
+                    console.log(event, $soulmatesFeed);
+                    var commercialComponent = new CommercialComponent($soulmatesFeed[0], {
+                        type: 'soulmatesGroup',
+                        omnitureId: '[%OmnitureID%]',
+                        clickMacro: '%%CLICK_URL_ESC%%',
+                        soulmatesFeedName: $(event.srcElement).val()
+                    });
+                    commercialComponent.postLoadEvents.soulmatesFeed = function () {
+                        $soulmatesFeed.removeClass('lazyloaded');
+                    };
+
+                    commercialComponent.create();
+                });
+                bean.fire(qwery('.js-soulmates-feed select')[0], 'change');
+            });
+        });
+    </script>
+
+    <div class="fc-container__inner">
+        <h2 class="test-page-head">
+            <a href="https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10030887">
                 Merchandising: commercial component (soulmates)
             </a>
         </h2>

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -469,14 +469,13 @@
                 var $soulmatesFeed = $('.js-merchandising-soulmates-feed');
                 
                 bean.on(qwery('.js-soulmates-feed select')[0], 'change', function (event) {
-                    console.log(event, $soulmatesFeed);
                     var commercialComponent = new CommercialComponent($soulmatesFeed[0], {
                         type: 'soulmatesGroup',
                         omnitureId: '[%OmnitureID%]',
                         clickMacro: '%%CLICK_URL_ESC%%',
                         soulmatesFeedName: $(event.srcElement).val()
                     });
-                    commercialComponent.postLoadEvents.soulmatesFeed = function () {
+                    commercialComponent.postLoadEvents.soulmatesGroup = function () {
                         $soulmatesFeed.removeClass('lazyloaded');
                     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -87,7 +87,7 @@ define([
                 jobs:           buildComponentUrl('jobs', merge({}, this.params, { t: this.params.jobIds ? this.params.jobIds.split(',') : [] })),
                 masterclasses:  buildComponentUrl('masterclasses', merge({}, this.params, { t: this.params.ids ? this.params.ids.split(',') : [] })),
                 soulmates:      buildComponentUrl('soulmates/mixed', this.params),
-                soulmatesGroup: buildComponentUrl('soulmates/' + this.params.soulmatesFeedName + '.json', this.params),
+                soulmatesGroup: buildComponentUrl('soulmates/' + this.params.soulmatesFeedName, this.params),
                 travel:         buildComponentUrl('travel/offers', this.params),
                 multi:          buildComponentUrl('multi', this.params),
                 capiSingle:     buildComponentUrl('capi-single', this.params),


### PR DESCRIPTION
This adds the ability for merchandising to specify some sub-feeds to be used in the Soulmates commercial component.

To use this a new DFP template has been created - https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10034727

Options (so far) are Brighton, Northwest, Scotland, Young & Mature.

No visual change to the component.
