### PR TITLE
monitor whether people print our stuff

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -341,6 +341,11 @@ object Switches {
     safeState = Off, new LocalDate(2015, 3, 24)
   )
 
+  val Print = Switch("Print analytics", "print",
+    "decide by now whether enough people are printing stuff to care whether they get a good experience",
+    safeState = Off, new LocalDate(2015, 3, 27)
+  )
+
   // Features
   val FixturesAndResultsContainerSwitch = Switch(
     "Feature",

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -39,10 +39,15 @@ object Metric extends Logging {
     ("ipad-old-start", CountMetric(s"ipad-old-start")),
     ("ipad-old-after-5", CountMetric(s"ipad-old-after-5")),
 
-    ("tech-feedback", CountMetric("tech-feedback"))
+    ("tech-feedback", CountMetric("tech-feedback")),
+
+    ("print", CountMetric("print"))
+
   ) ++ iPhoneMetrics
 
   lazy val techFeedback = Switches.FeedbackLink // remove tech-feedback metric when this switch is removed.
+
+  lazy val print = Switches.Print // remove print metric when this switch is removed.
 
 
   private val iPhoneMetrics: Seq[(String, CountMetric)] = Seq(4, 6).flatMap( model =>

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -20,6 +20,7 @@ define([
     'common/modules/analytics/clickstream',
     'common/modules/analytics/foresee-survey',
     'common/modules/analytics/livestats',
+    'common/modules/analytics/media-listener',
     'common/modules/analytics/omniture',
     'common/modules/analytics/register',
     'common/modules/analytics/scrollDepth',
@@ -75,6 +76,7 @@ define([
     Clickstream,
     Foresee,
     liveStats,
+    mediaListener,
     Omniture,
     register,
     ScrollDepth,
@@ -316,6 +318,10 @@ define([
                 }
             },
 
+            mediaEventListeners: function () {
+                mediaListener.init();
+            },
+
             checkIframe: function () {
                 if (window.self !== window.top) {
                     $('html').addClass('iframed');
@@ -497,6 +503,7 @@ define([
             robust('c-simple-metrics', modules.initSimpleMetrics);
             robust('c-crosswords', crosswordThumbnails.init);
             robust('c-tech-feedback', modules.initTechFeedback);
+            robust('c-media-listeners', modules.mediaEventListeners);
             robust('c-ready',           function () { mediator.emit('page:common:ready'); });
         };
 

--- a/static/src/javascripts/projects/common/modules/analytics/media-listener.js
+++ b/static/src/javascripts/projects/common/modules/analytics/media-listener.js
@@ -1,0 +1,23 @@
+define([
+    'bean',
+    'fastdom',
+    'common/modules/analytics/beacon'
+], function (
+    bean,
+    fastdom,
+    beacon
+) {
+
+    return {
+        init: function () {
+            if (window.matchMedia) {
+                var mql = window.matchMedia('print');
+                mql.addListener(function () {
+                    if (mql.matches) {
+                        beacon.fire('/count/print.gif');
+                    }
+                });
+            }
+        }
+    };
+});


### PR DESCRIPTION
Someone emailed userhelp to say an article didn't print correctly (missing sections). I investigated and also noticed if you print landscape the sides were cut off.  It's great that we have a print stylesheet, but it seems like it isn't the most loved part of our site.  But should we be caring more?

After some questions, it turns out no-one really knows whether users are printing much, and if that, what they are printing.  So I decided to get coding...

So I have put in a small beacon to detect if people change the stylesheet to the "print" one, which should be a reasonable approximation.  This isn't supported on ie9 but most other things can handle it.

If there are a lot, we can try to break it down by page type - I can imagine recipes and sudokus are more heavily printed than the network front.
