### PR TITLE
Left aligning text in traffic driver

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -533,6 +533,7 @@
     .creative__article__title {
         @include f-headlineSans;
         @include font-size(14, 18);
+        text-align: left;
     }
     .creative__logo-text,
     .creative__logo-info {


### PR DESCRIPTION
Text is central aligned and shouldn't be.

Before;
![screen shot 2015-03-06 at 16 44 44](https://cloud.githubusercontent.com/assets/1303616/6529373/2b8ea5a8-c420-11e4-89e6-24e00d4eb74f.png)

After;
![screen shot 2015-03-06 at 16 44 53](https://cloud.githubusercontent.com/assets/1303616/6529379/30edc8e4-c420-11e4-8a5b-35a06cf90810.png)
