### PR TITLE
Avoid regenerating the same list over and over again

### DIFF
--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -268,6 +268,7 @@ define([
             this.front = opts.group ? opts.group.front : null;
 
             this.props = asObservableProps(capiProps);
+            this.props.webPublicationDate.extend({ notify: 'always' });
 
             this.fields = asObservableProps(capiFields);
 

--- a/facia-tool/public/js/models/collections/latest-articles.js
+++ b/facia-tool/public/js/models/collections/latest-articles.js
@@ -160,6 +160,9 @@ define([
 
                                 opts.uneditable = true;
                                 return new Article(opts, true);
+                            }, function (oldArticle, newArticle) {
+                                oldArticle.props.webPublicationDate(newArticle.webPublicationDate);
+                                return oldArticle;
                             });
                             self.articles(newArticles);
                             self.message(null);

--- a/facia-tool/public/js/models/collections/latest-articles.js
+++ b/facia-tool/public/js/models/collections/latest-articles.js
@@ -240,26 +240,6 @@ define([
             this.startPoller = function() {}; // make idempotent
         };
 
-        this.afterAdd = function (element) {
-            element = $(element);
-            var lastSearch = self.lastSearch();
-            if (lastSearch && lastSearch.isPoll && element.is('.article')) {
-                $(element).animate({
-                    backgroundColor: '#fffde7'
-                }, 800, null, function () {
-                    $(element).animate({
-                        backgroundColor: '#fff'
-                    }, 800);
-                });
-            }
-        };
-        // Remove this block of code when the switch is gone
-        var isHighlightEnabled = parseQueryParams(window.location.search).flash === 'please';
-        if (!isHighlightEnabled) {
-            this.afterAdd = function () {};
-        }
-        // ^ until here
-
         this.dispose = function () {
             clearTimeout(deBounced);
             clearInterval(poller);

--- a/facia-tool/public/js/utils/array.js
+++ b/facia-tool/public/js/utils/array.js
@@ -1,0 +1,30 @@
+define([
+    'underscore'
+], function (
+    _
+) {
+    function combine (destination, previous, comparator, generator) {
+        previous = previous.slice();
+
+        return _.map(destination, function (item) {
+            var previousItem = _.find(previous, function (old, index) {
+                var areTheSame = comparator(old, item);
+                if (areTheSame) {
+                    previous.splice(index, 1);
+                    return true;
+                }
+                return false;
+            });
+
+            if (previousItem) {
+                return previousItem;
+            } else {
+                return generator(item);
+            }
+        });
+    }
+
+    return {
+        combine: combine
+    };
+});

--- a/facia-tool/public/js/utils/array.js
+++ b/facia-tool/public/js/utils/array.js
@@ -3,7 +3,7 @@ define([
 ], function (
     _
 ) {
-    function combine (destination, previous, comparator, generator) {
+    function combine (destination, previous, comparator, generator, update) {
         previous = previous.slice();
 
         return _.map(destination, function (item) {
@@ -17,7 +17,7 @@ define([
             });
 
             if (previousItem) {
-                return previousItem;
+                return update(previousItem, item);
             } else {
                 return generator(item);
             }

--- a/facia-tool/public/js/widgets/latest.html
+++ b/facia-tool/public/js/widgets/latest.html
@@ -1,15 +1,15 @@
 <div data-bind="
     css: {
-        'live-mode': !latestArticles.showingDrafts(),
-        'draft-mode': latestArticles.showingDrafts
+        'live-mode': !showingDrafts(),
+        'draft-mode': showingDrafts
     }">
     <div class="modes">
     <!-- ko if: $root.switches()['facia-tool-draft-content'] --><a class="draft-mode" data-bind="
-        click: latestArticles.showDrafts,
-        css: {active: latestArticles.showingDrafts}">Draft content</a
+        click: showDrafts,
+        css: {active: showingDrafts}">Draft content</a
    ><!-- /ko --><a class="live-mode" data-bind="
-        click: latestArticles.showLive,
-        css: {active: !latestArticles.showingDrafts()}">Live content</a>
+        click: showLive,
+        css: {active: !showingDrafts()}">Live content</a>
     </div>
 </div>
 
@@ -63,7 +63,17 @@
 
         <search-controls params="context: $context"></search-controls>
 
-        <div class="latest-articles" data-bind="template: {name: 'template_article', foreach: articles}"></div>
+        <div class="latest-articles">
+            <div data-bind="template: {
+                name: 'template_article',
+                foreach: articles,
+                afterAdd: afterAdd
+            }"></div>
+
+            <!-- ko if: message -->
+                <div class="search-message" data-bind="text: message"></div>
+            <!-- /ko -->
+        </div>
 
         <search-controls params="context: $context"></search-controls>
     </div>

--- a/facia-tool/public/js/widgets/latest.html
+++ b/facia-tool/public/js/widgets/latest.html
@@ -66,8 +66,7 @@
         <div class="latest-articles">
             <div data-bind="template: {
                 name: 'template_article',
-                foreach: articles,
-                afterAdd: afterAdd
+                foreach: articles
             }"></div>
 
             <!-- ko if: message -->

--- a/facia-tool/public/js/widgets/latest.js
+++ b/facia-tool/public/js/widgets/latest.js
@@ -13,16 +13,33 @@ define([
 ) {
 
     function Latest (params, element) {
+        var self = this;
         this.column = params.column;
+
+        this.showingDrafts = ko.observable(false);
+        this.showDrafts = function() {
+            self.showingDrafts(true);
+            self.latestArticles.search();
+        };
+        this.showLive = function() {
+            self.showingDrafts(false);
+            self.latestArticles.search();
+        };
 
         this.latestArticles = new LatestArticles({
             filterTypes: vars.CONST.filterTypes,
-            container: element
+            container: element,
+            showingDrafts: this.showingDrafts
         });
 
         this.latestArticles.search();
         this.latestArticles.startPoller();
 
+        this.subscriptionOnVars = vars.model.switches.subscribe(function (switches) {
+            if (!switches['facia-tool-draft-content']) {
+                self.showingDrafts(false);
+            }
+        });
         this.subscriptionOnArticles = this.latestArticles.articles.subscribe(updateScrollables);
 
         mediator.emit('latest:loaded');
@@ -30,6 +47,7 @@ define([
 
     Latest.prototype.dispose = function () {
         this.subscriptionOnArticles.dispose();
+        this.subscriptionOnVars.dispose();
     };
 
     return Latest;

--- a/facia-tool/test/public/spec/array.spec.js
+++ b/facia-tool/test/public/spec/array.spec.js
@@ -1,0 +1,87 @@
+define([
+    'utils/array'
+], function (array) {
+    describe('Array', function () {
+        it('computes the difference of two lists', function () {
+            var before = [
+                {id: 1, sameAsBefore: true},
+                {id: 2, sameAsBefore: true},
+                {id: 3, sameAsBefore: true},
+                {id: 4, sameAsBefore: true},
+                {id: 5, sameAsBefore: true},
+                {id: 6, sameAsBefore: true}
+            ], after = [
+                {id: 9},
+                {id: 10},
+                {id: 2},
+                {id: 1},
+                {id: 8},
+                {id: 3},
+                {id: 4},
+                {id: 7}
+            ],
+            comparator = function (one, two) {
+                return one.id === two.id;
+            },
+            generator = function (item) {
+                return {
+                    id: item.id,
+                    generated: true
+                };
+            };
+
+            var result = array.combine(after, before, comparator, generator);
+            expect(result).toEqual([
+                {id: 9, generated: true},
+                {id: 10, generated: true},
+                {id: 2, sameAsBefore: true},
+                {id: 1, sameAsBefore: true},
+                {id: 8, generated: true},
+                {id: 3, sameAsBefore: true},
+                {id: 4, sameAsBefore: true},
+                {id: 7, generated: true}
+            ]);
+        });
+
+        it('works even if first is an empty array', function () {
+            var before = [], after = [
+                {id: 1},
+                {id: 2}
+            ],
+            comparator = function (one, two) {
+                return one.id === two.id;
+            },
+            generator = function (item) {
+                return {
+                    id: item.id,
+                    generated: true
+                };
+            };
+
+            var result = array.combine(after, before, comparator, generator);
+            expect(result).toEqual([
+                {id: 1, generated: true},
+                {id: 2, generated: true}
+            ]);
+        });
+
+        it('works even if second is an empty array', function () {
+            var before = [
+                {id: 1},
+                {id: 2}
+            ], after = [],
+            comparator = function (one, two) {
+                return one.id === two.id;
+            },
+            generator = function (item) {
+                return {
+                    id: item.id,
+                    generated: true
+                };
+            };
+
+            var result = array.combine(after, before, comparator, generator);
+            expect(result).toEqual([]);
+        });
+    });
+});

--- a/facia-tool/test/public/spec/array.spec.js
+++ b/facia-tool/test/public/spec/array.spec.js
@@ -1,7 +1,26 @@
 define([
+    'underscore',
     'utils/array'
-], function (array) {
+], function (
+    _,
+    array
+) {
     describe('Array', function () {
+        var comparator = function (one, two) {
+            return one.id === two.id;
+        },
+        generator = function (item) {
+            return {
+                id: item.id,
+                generated: true
+            };
+        },
+        update = function (oldItem, item) {
+            return _.extend({}, oldItem, {
+                updated: oldItem !== item && oldItem.id === item.id
+            });
+        };
+
         it('computes the difference of two lists', function () {
             var before = [
                 {id: 1, sameAsBefore: true},
@@ -20,25 +39,16 @@ define([
                 {id: 4},
                 {id: 7}
             ],
-            comparator = function (one, two) {
-                return one.id === two.id;
-            },
-            generator = function (item) {
-                return {
-                    id: item.id,
-                    generated: true
-                };
-            };
+            result = array.combine(after, before, comparator, generator, update);
 
-            var result = array.combine(after, before, comparator, generator);
             expect(result).toEqual([
                 {id: 9, generated: true},
                 {id: 10, generated: true},
-                {id: 2, sameAsBefore: true},
-                {id: 1, sameAsBefore: true},
+                {id: 2, sameAsBefore: true, updated: true},
+                {id: 1, sameAsBefore: true, updated: true},
                 {id: 8, generated: true},
-                {id: 3, sameAsBefore: true},
-                {id: 4, sameAsBefore: true},
+                {id: 3, sameAsBefore: true, updated: true},
+                {id: 4, sameAsBefore: true, updated: true},
                 {id: 7, generated: true}
             ]);
         });
@@ -48,17 +58,8 @@ define([
                 {id: 1},
                 {id: 2}
             ],
-            comparator = function (one, two) {
-                return one.id === two.id;
-            },
-            generator = function (item) {
-                return {
-                    id: item.id,
-                    generated: true
-                };
-            };
+            result = array.combine(after, before, comparator, generator, update);
 
-            var result = array.combine(after, before, comparator, generator);
             expect(result).toEqual([
                 {id: 1, generated: true},
                 {id: 2, generated: true}
@@ -70,17 +71,8 @@ define([
                 {id: 1},
                 {id: 2}
             ], after = [],
-            comparator = function (one, two) {
-                return one.id === two.id;
-            },
-            generator = function (item) {
-                return {
-                    id: item.id,
-                    generated: true
-                };
-            };
+            result = array.combine(after, before, comparator, generator, update);
 
-            var result = array.combine(after, before, comparator, generator);
             expect(result).toEqual([]);
         });
     });


### PR DESCRIPTION
When polling the search API, facia tool regenerates the entire list of articles in the latest section.
However most of the times nothing changes.

This PR takes advantage of knockout observable and generates new articles only when necessary.

This came up investigating a performance issue.

~~Bonus item, when a new item appers, it flashes for a second, kinda like hack day winner...~~

~~For the moment it's behind a URL switch, I'd like to get some feedback first.~~
