### PR TITLE
Run all requireJS tasks concurrently

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,7 +80,7 @@ module.exports = function (grunt) {
 
     });
     grunt.registerTask('compile:js', function(fullCompile) {
-        grunt.task.run(['compile:inlineSvgs', 'requirejs', 'copy:javascript']);
+        grunt.task.run(['compile:inlineSvgs', 'concurrent:requireJS', 'copy:javascript']);
         if (!options.isDev) {
             grunt.task.run('uglify:javascript');
         }

--- a/grunt-configs/concurrent.js
+++ b/grunt-configs/concurrent.js
@@ -1,9 +1,14 @@
 module.exports = function(grunt, options) {
+    var requireJSTargets = grunt.util._.chain(require('./requirejs')(grunt, options)).keys().without('options').map(function(key){
+        return 'requirejs:' + key;
+    }).value();
+
     return {
         options: {
             logConcurrentOutput: true
         },
         compile: ['compile:js:true', 'compile:css:true'],
-        sass: ['sass:old-ie', 'sass:ie9', 'sass:modern']
+        sass: ['sass:old-ie', 'sass:ie9', 'sass:modern'],
+        requireJS: requireJSTargets
     };
 };


### PR DESCRIPTION
knocks about 25-30 secs off `grunt compile:js` on my laptop:

without concurrency:
![screen shot 2015-03-09 at 09 07 22](https://cloud.githubusercontent.com/assets/867233/6552246/e425d650-c63b-11e4-8e3a-673e571c5220.png)

with concurrency:
![screen shot 2015-03-09 at 09 05 47](https://cloud.githubusercontent.com/assets/867233/6552258/f9d1bf8c-c63b-11e4-8ec3-a61914a0bca2.png)
