### PR TITLE
Fix broken quote icon by changing position mechanism

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -23,7 +23,8 @@ object BodyCleaner {
         LiveBlogShareButtons(article),
         DropCaps(article.isComment || article.isFeature),
         FigCaptionCleaner,
-        RichLinkCleaner
+        RichLinkCleaner,
+        BlockquoteCleaner
       )
   }
 }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -36,9 +36,28 @@ object BlockNumberCleaner extends HtmlCleaner {
   }
 }
 
+object BlockquoteCleaner extends HtmlCleaner {
+
+  override def clean(document: Document): Document = {
+    val quotedBlockquotes = document.getElementsByTag("blockquote").filter(_.hasClass("quoted"))
+    val wrapBlockquoteChildren = (blockquoteElement: Element) => {
+      val container = document.createElement("div")
+      container.addClass("quoted__contents")
+      // Get children before mutating
+      val children = blockquoteElement.children()
+      blockquoteElement.prependChild(container)
+      container.insertChildren(0, children)
+    }
+
+    quotedBlockquotes.foreach(wrapBlockquoteChildren)
+    document
+  }
+
+}
+
 case class R2VideoCleaner(article: Article) extends HtmlCleaner {
 
-override def clean(document: Document): Document = {
+  override def clean(document: Document): Document = {
 
     val legacyVideos = document.getElementsByTag("video").filter(_.hasClass("gu-video")).filter(_.parent().tagName() != "figure")
 

--- a/static/src/stylesheets/module/_icons.scss
+++ b/static/src/stylesheets/module/_icons.scss
@@ -33,13 +33,23 @@ blockquote.quoted:before {
 }
 
 // Quotes
-.from-content-api blockquote.quoted:before {
-    content: '';
-    position: absolute;
-    left: 0;
-    @include transform(scale(.8));
-    @include transform-origin(0);
-    @include icon(quote-grey);
+.from-content-api blockquote.quoted {
+    // Clearfix
+    overflow: hidden;
+
+    &:before {
+        content: '';
+        float: left;
+        @include transform(scale(.8));
+        @include transform-origin(0);
+        @include icon(quote-grey);
+    }
+
+    & > .quoted__contents {
+        float: left;
+        // Do not allow text to wrap around blockquote icon
+        overflow: hidden;
+    }
 }
 
 .item--dark .i-comment-light-grey {

--- a/static/src/stylesheets/module/_icons.scss
+++ b/static/src/stylesheets/module/_icons.scss
@@ -46,7 +46,6 @@ blockquote.quoted:before {
     }
 
     & > .quoted__contents {
-        float: left;
         // Do not allow text to wrap around blockquote icon
         overflow: hidden;
     }

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -290,18 +290,9 @@ $block-padding-right: $gs-gutter;
                 }
             }
         }
+
         > blockquote {
             color: colour(neutral-2);
-        }
-
-        > blockquote.quoted:before {
-            left: auto;
-        }
-
-        > blockquote.quoted p:first-child {
-            @include mq(mobileLandscape) {
-                text-indent: $gs-gutter * 1.5;
-            }
         }
 
         /* Media

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -101,7 +101,10 @@
 
     &.quoted {
         color: colour(neutral-2);
-        margin-left: $gs-gutter * 1.5;
+        // Fallback
+        // TODO: Write mixin for this
+        margin-left: initial;
+        margin-left: unset;
     }
 }
 


### PR DESCRIPTION
Fixes #8423

Before the hierachy for a quote was as following:

``` jade
blockquote
  p
  p
```

Now:

``` jade
blockquote
  div
    p
    p
```

The div is needed in order to prevent the contents of the blockquote from wrapping around the pseudo-element.

/cc @rcrphillips 
