### PR TITLE
Fix CSS source maps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,7 +72,12 @@ module.exports = function (grunt) {
         }
 
         grunt.task.run(['copy:pxCss']);
-        grunt.task.run(['px_to_rem']);
+        // TODO: Update pixrem to handle source maps
+        // https://github.com/walbo/grunt-px-to-rem/issues/10
+        // Temporarily disabled in dev because pixrem breaks source maps
+        if (! options.isDev) {
+            grunt.task.run(['px_to_rem']);
+        }
 
         if (isOnlyTask(this) && !fullCompile) {
             grunt.task.run('asset_hash');


### PR DESCRIPTION
CSS source maps are currently broken. This was happening because `grunt-px-to-rem` removes the source map annotation (when PostCSS rebuilds the CSS AST). This can be fixed by updating the transitive dependencies. I tried, but it's very fiddly and made even more difficult by the shortsightedness in which the grunt task and its dependencies were authored (as per the entire Node ecosystem, it seems). Oh, hey, Plumber is nice! ;-) https://github.com/plumberjs/plumber

As a quick fix, we can just prevent the task from running in dev—when source maps are in use.

Can I ask why we added the converter in the first place? /cc @phamann

Fixes #8508
