### PR TITLE
Fix Latency Problem on Commercial Servers

### DIFF
--- a/commercial/app/model/commercial/Keyword.scala
+++ b/commercial/app/model/commercial/Keyword.scala
@@ -1,0 +1,10 @@
+package model.commercial
+
+object Keyword {
+
+  def getIdSuffix(keywordId: String): String = keywordId.split('/').last
+
+  def idSuffixesIntersect(suffixes1: Seq[String], suffixes2: Seq[String]): Boolean = {
+    suffixes1.intersect(suffixes2).nonEmpty
+  }
+}

--- a/commercial/app/model/commercial/jobs/Job.scala
+++ b/commercial/app/model/commercial/jobs/Job.scala
@@ -15,7 +15,7 @@ case class Job(id: Int,
                recruiterLogoUrl: String,
                sectorIds: Seq[Int],
                salaryDescription: String,
-               keywordIds: Seq[String] = Nil) {
+               keywordIdSuffixes: Seq[String] = Nil) {
 
   val shortSalaryDescription = StringUtils.abbreviate(salaryDescription, 25).replace("...", "…")
 

--- a/commercial/app/model/commercial/jobs/JobsAgent.scala
+++ b/commercial/app/model/commercial/jobs/JobsAgent.scala
@@ -7,19 +7,21 @@ object JobsAgent extends MerchandiseAgent[Job] with ExecutionContexts {
 
   def jobsTargetedAt(segment: Segment): Seq[Job] = {
     def defaultJobs = available filter (_.industries.contains("Media"))
-    getTargetedMerchandise(segment, defaultJobs)(job => keywordsMatch(segment, job.keywordIds))
+    getTargetedMerchandise(segment, defaultJobs) { job =>
+      Keyword.idSuffixesIntersect(segment.context.keywords, job.keywordIdSuffixes)
+    }
   }
-  
+
   def specificJobs(jobIdStrings: Seq[String]): Seq[Job] = {
     val jobIds = jobIdStrings map (_.toInt)
     available filter (job => jobIds contains job.id)
   }
 
-  def refresh() {
+  def refresh(): Unit = {
 
     def populateKeywords(jobs: Seq[Job]) = jobs.map { job =>
       val jobKeywordIds = job.sectorIds.flatMap(Industries.forIndustry).distinct
-      job.copy(keywordIds = jobKeywordIds)
+      job.copy(keywordIdSuffixes = jobKeywordIds map Keyword.getIdSuffix)
     }
 
     for {freshJobs <- JobsApi.loadAds()} updateAvailableMerchandise(populateKeywords(freshJobs))

--- a/commercial/app/model/commercial/masterclasses/MasterClass.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClass.scala
@@ -70,21 +70,19 @@ object EventbriteMasterClass {
   }
 }
 
-case class EventbriteMasterClass(
-                                  id: String,
-                                  name: String,
-                                  startDate: DateTime,
-                                  url: String,
-                                  description: String,
-                                  status: String,
-                                  venue: Venue,
-                                  tickets: List[Ticket],
-                                  capacity: Int,
-                                  guardianUrl: String,
-                                  firstParagraph: String = "",
-                                  tags: Seq[String],
-                                  keywordIds: Seq[String] = Nil
-                                  ) {
+case class EventbriteMasterClass(id: String,
+                                 name: String,
+                                 startDate: DateTime,
+                                 url: String,
+                                 description: String,
+                                 status: String,
+                                 venue: Venue,
+                                 tickets: List[Ticket],
+                                 capacity: Int,
+                                 guardianUrl: String,
+                                 firstParagraph: String = "",
+                                 tags: Seq[String],
+                                 keywordIdSuffixes: Seq[String] = Nil) {
 
   def isOpen = { status == "Live" }
 

--- a/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClassAgent.scala
@@ -1,7 +1,7 @@
 package model.commercial.masterclasses
 
 import common.{AkkaAgent, ExecutionContexts, Logging}
-import model.commercial.{Lookup, MerchandiseAgent, Segment, keywordsMatch}
+import model.commercial._
 
 import scala.concurrent.Future
 
@@ -9,7 +9,10 @@ object MasterClassAgent extends MerchandiseAgent[MasterClass] with ExecutionCont
 
   def masterclassesTargetedAt(segment: Segment) = {
     lazy val defaultClasses = available take 4
-    val targeted = available filter (masterclass => keywordsMatch(segment, masterclass.eventBriteEvent.keywordIds))
+    val targeted = available filter { masterclass =>
+      Keyword.idSuffixesIntersect(segment.context.keywords,
+        masterclass.eventBriteEvent.keywordIdSuffixes)
+    }
     val toShow = (targeted ++ defaultClasses) take 4
     toShow sortBy (_.eventBriteEvent.startDate.getMillis)
   }
@@ -41,7 +44,7 @@ object MasterClassAgent extends MerchandiseAgent[MasterClass] with ExecutionCont
     Future.sequence(futureMasterclasses)
   }
 
-  def refresh() {
+  def refresh(): Unit = {
 
     def populateKeywordIds(events: Seq[EventbriteMasterClass]):Seq[EventbriteMasterClass] = {
       val populated = events map { event =>
@@ -57,10 +60,10 @@ object MasterClassAgent extends MerchandiseAgent[MasterClass] with ExecutionCont
             keywordIdsFromTags
           }
         }
-        event.copy(keywordIds = eventKeywordIds)
+        event.copy(keywordIdSuffixes = eventKeywordIds map Keyword.getIdSuffix)
       }
 
-      val unpopulated = populated.filter(_.keywordIds.isEmpty)
+      val unpopulated = populated.filter(_.keywordIdSuffixes.isEmpty)
       if (unpopulated.nonEmpty) {
         val unpopulatedString = unpopulated.map { event =>
           event.name + ": tags(" + event.tags.mkString(", ") + ")"

--- a/commercial/app/model/commercial/package.scala
+++ b/commercial/app/model/commercial/package.scala
@@ -1,19 +1,7 @@
 package model
 
 package object commercial {
-
-  def intersects[T](seq1: Seq[T], seq2: Seq[T]) = !(seq1 intersect seq2).isEmpty
-
   object OptString {
     def apply(s: String): Option[String] = Option(s) filter (_.trim.nonEmpty)
   }
-
-  def lastPart(keywordId: String): String = keywordId.split('/').takeRight(1)(0)
-
-  def lastPart(keywordIds: Seq[String]): Seq[String] = (keywordIds map lastPart).distinct
-
-  def keywordsMatch(segment: Segment, keywordIds: Seq[String]): Boolean = {
-    intersects(segment.context.keywords, lastPart(keywordIds))
-  }
-
 }

--- a/commercial/app/model/commercial/travel/TravelOffer.scala
+++ b/commercial/app/model/commercial/travel/TravelOffer.scala
@@ -8,9 +8,18 @@ import org.joda.time.DateTime
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-case class TravelOffer(id: Int, title: String, offerUrl: String, imageUrl: String, fromPrice: String,
-                       earliestDeparture: DateTime, keywordIds: List[String], countries: List[String], category: String,
-                       tags: List[String], duration: String, position: Int) {
+case class TravelOffer(id: Int,
+                       title: String,
+                       offerUrl: String,
+                       imageUrl: String,
+                       fromPrice: String,
+                       earliestDeparture: DateTime,
+                       keywordIdSuffixes: List[String],
+                       countries: List[String],
+                       category: String,
+                       tags: List[String],
+                       duration: String,
+                       position: Int) {
 
   val durationInWords: String = duration match {
     case "1" => "1 night"

--- a/commercial/test/model/commercial/books/BookTest.scala
+++ b/commercial/test/model/commercial/books/BookTest.scala
@@ -40,7 +40,7 @@ import test.ConfiguredTestSuite
       buyUrl = Some("http://guardianbookshop.staging.lab.co.uk/index.php/in-a-people-house.html"),
       position = Some(222),
       category = Some("Picture books"),
-      keywordIds = Nil
+      keywordIdSuffixes = Nil
     ))
   }
 }


### PR DESCRIPTION
Thread dumps show a lot of time spent doing regex extractions on keyword IDs.

This change makes that unnecessary by only caching the keyword ID suffixes for each merchandising component item, rather than the complete keyword ID which we never use, so that it is no longer necessary to do repeated regexing on every user request.
