### PR TITLE
check if a/b tests can be run from other modules

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -77,7 +77,8 @@ define([
         kruxAbParam = function () {
             var kasTest = ab.getParticipations().KruxAudienceScience;
 
-            return kasTest && kasTest.variant === 'variant';
+            return ab.testCanBeRun('KruxAudienceScience') &&
+                   kasTest && kasTest.variant === 'variant';
         };
 
     return function (opts) {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -4,6 +4,7 @@ define([
     'lodash/collections/forEach',
     'lodash/collections/map',
     'lodash/collections/some',
+    'lodash/collections/find',
     'lodash/objects/assign',
     'lodash/objects/keys',
     'common/utils/_',
@@ -21,6 +22,7 @@ define([
     forEach,
     map,
     some,
+    find,
     assign,
     keys,
     _,
@@ -299,6 +301,22 @@ define([
         getActiveTests: getActiveTests,
         getTestVariant: getTestVariant,
         setTestVariant: setTestVariant,
+
+        /**
+         * check if a test can be run (i.e. is not expired and switched on)
+         *
+         * @param  {string|Object} test   id or test object
+         * @return {Boolean}
+         */
+        testCanBeRun: function (test) {
+            if (typeof test === 'string') {
+                return testCanBeRun(find(TESTS, function (t) {
+                    return t.id === test;
+                }));
+            }
+
+            return test.id && test.expiry && testCanBeRun(test);
+        },
 
         // testing
         reset: function () {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/krux-audience-science.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/krux-audience-science.js
@@ -3,7 +3,7 @@ define(function () {
     return function () {
         this.id = 'KruxAudienceScience';
         this.start = '2015-02-06';
-        this.expiry = '2015-03-06';
+        this.expiry = '2015-05-01';
         this.author = 'Sam Desborough';
         this.description = 'Using Krux rather than Audience Science parameters in DFP ad requests';
         this.audience = 0.04;


### PR DESCRIPTION
We don't currently have a way of checking whether an A/B test can be run (read: its switch is on and it hasn't expired) from outside of the ab module. Some commercial tests need this, so here it is!

@Calanthe 