### PR TITLE
Re-arrange default football list, create seperate ordering for tables

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -18,9 +18,36 @@ case class TablesPage(
 
 object LeagueTableController extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
 
+    val tableOrder = Seq(
+        "Premier League",
+        "La Liga",
+        "Bundesliga",
+        "Serie A",
+        "Ligue 1",
+        "Championship",
+        "Scottish Premiership",
+        "League One",
+        "League Two",
+        "Scottish Championship",
+        "Scottish League One",
+        "Scottish League Two",
+        "Euro 2016 qualifying",
+        "Champions League qualifying",
+        "Europa League",
+        "Champions League",
+        "FA Cup",
+        "Capital One Cup",
+        "Community Shield",
+        "Scottish Cup",
+        "Scottish League Cup",
+        "International friendlies"
+    )
+
   private def competitions = Competitions().competitions
 
-  private def loadTables: Seq[Table] = competitions.filter(_.hasLeagueTable).map { Table(_) }
+  def sortedCompetitions:Seq[Competition] = tableOrder.map(leagueName => competitions.find(_.fullName == leagueName)).flatten
+
+  private def loadTables: Seq[Table] = sortedCompetitions.filter(_.hasLeagueTable).map { Table(_) }
 
   def renderLeagueTableJson() = renderLeagueTable()
   def renderLeagueTable() = Action { implicit request =>

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -98,6 +98,7 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
   )
 
   val competitionDefinitions = Seq(
+    Competition("500", "/football/championsleague", "Champions League", "Champions League", "European", tableDividers = List(2, 6, 21)),
     Competition("100", "/football/premierleague", "Premier League", "Premier League", "English", showInTeamsList = true, tableDividers = List(4, 5, 17)),
     Competition("650", "/football/laligafootball", "La Liga", "La Liga", "European", showInTeamsList = true, tableDividers = List(4, 6, 17)),
     Competition("625", "/football/bundesligafootball", "Bundesliga", "Bundesliga", "European", showInTeamsList = true, tableDividers = List(3, 4, 6, 15, 16)),
@@ -113,7 +114,6 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
     Competition("751", "/football/euro-2016-qualifiers", "Euro 2016 qualifying", "Euro 2016 qual.", "Internationals"),
     Competition("501", "/football/champions-league-qualifying", "Champions League qualifying", "Champions League qual.", "European"),
     Competition("510", "/football/uefa-europa-league", "Europa League", "Europa League", "European", tableDividers = List(2)),
-    Competition("500", "/football/championsleague", "Champions League", "Champions League", "European", tableDividers = List(2, 6, 21)),
     Competition("300", "/football/fa-cup", "FA Cup", "FA Cup", "English"),
     Competition("301", "/football/capital-one-cup", "Capital One Cup", "Capital One Cup", "English"),
     Competition("400", "/football/community-shield", "Community Shield", "Community Shield", "English", showInTeamsList = true),


### PR DESCRIPTION
This is so that Champions league can sit at the top of the fixtures list but remain low in the tables list. 

TODO:
- Be more explicit of orderings for each view
- Refactor/move ordering lists to the model layer

/cc @rich-nguyen 
