### PR TITLE
Redirect audio content requests which wind up in the wrong place

### DIFF
--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -76,6 +76,7 @@ object InternalRedirect extends implicits.Requests with Logging {
       case a if a.isArticle || a.isLiveBlog => internalRedirect("type/article", a.id)
       case v if v.isVideo => internalRedirect("applications", v.id)
       case g if g.isGallery => internalRedirect("applications", g.id)
+      case a if a.isAudio => internalRedirect("applications", a.id)
       case unsupportedContent =>
         log.info(s"unsupported content: ${unsupportedContent.id}")
         NotFound

--- a/common/test/common/ModelOrResultTest.scala
+++ b/common/test/common/ModelOrResultTest.scala
@@ -21,10 +21,12 @@ class ModelOrResultTest extends FlatSpec with Matchers with ExecutionContexts {
   val articleTag = new Tag("type/article", "type", webTitle = "the title", webUrl = "http://foo.bar", apiUrl = "http://foo.bar")
   val galleryTag = articleTag.copy(id = "type/gallery")
   val videoTag = articleTag.copy(id = "type/video")
+  val audioTag = articleTag.copy(id = "type/audio")
 
   val testArticle = testContent.copy(tags = List(articleTag))
   val testGallery = testContent.copy(tags = List(galleryTag))
   val testVideo = testContent.copy(tags = List(videoTag))
+  val testAudio = testContent.copy(tags = List(audioTag))
 
   val testSection = new Section("water", "Water", "http://foo.bar", "http://foo.bar", Nil)
 
@@ -66,6 +68,17 @@ class ModelOrResultTest extends FlatSpec with Matchers with ExecutionContexts {
     val notFound = Future { ModelOrResult(
         item = None,
         response = stubResponse.copy(content = Some(testGallery))
+      ).right.get
+    }
+
+    status(notFound) should be(200)
+    headers(notFound).apply("X-Accel-Redirect") should be("/applications/the/id")
+  }
+
+  it should "internal redirect to a audio if it has shown up at the wrong server" in {
+    val notFound = Future { ModelOrResult(
+      item = None,
+      response = stubResponse.copy(content = Some(testAudio))
       ).right.get
     }
 


### PR DESCRIPTION
The Careers site is migrating to next gen. It contains several audio
pages with strange urls which fall into this trap.

ie. http://careers.theguardian.com/audio/cvs-tips-explaining-gaps

This additional case line should catch them and send them on their way
to the applications module.
