### PR TITLE
Adding static layer to scrollable mpu

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
@@ -35,6 +35,8 @@ define([
             clickMacro:       this.params.clickMacro,
             destination:      this.params.destination,
             image:            ScrollableMpu.hasScrollEnabled ? this.params.image : this.params.staticImage,
+            stillImage:       ScrollableMpu.hasScrollEnabled && this.params.stillImage ?
+                '<div class="creative--scrollable-mpu-static-image" style="background-image: url(' + this.params.stillImage + ');"></div>' : '',
             trackingPixelImg: this.params.trackingPixel ?
                 '<img src="' + this.params.trackingPixel + '" width="1" height="1" />' : ''
         };

--- a/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu.html
@@ -2,6 +2,7 @@
     href="{{clickMacro}}{{destination}}"
     target="_new">
     <div class="creative--scrollable-mpu-inner">
+        {{stillImage}}
         <div class="creative--scrollable-mpu-image" style="background-image: url('{{image}}');"></div>
     </div>
 </a>

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -9,15 +9,22 @@
         overflow: hidden;
         position: relative;
     }
-    .creative--scrollable-mpu-image {
+    .creative--scrollable-mpu-image,
+    .creative--scrollable-mpu-static-image {
         display: block;
         height: 100%;
         width: 300px;
         position: absolute;
         top: 0;
         @include box-sizing(border-box);
+    }
+    .creative--scrollable-mpu-image {
         border: 1px solid colour(neutral-5);
-        background: none 0 0 repeat;
+        background: none 0 0 repeat;        
+    }
+    .creative--scrollable-mpu-static-image {
+        z-index: 1;
+        background-repeat: no-repeat;
     }
 }
 


### PR DESCRIPTION
This adds a "static" layer that overlays the scrolling layer on the scrollable MPU ad format. (See Android logo on attached gif.)

![scrolablefixedlayer](https://cloud.githubusercontent.com/assets/1303616/6595845/2f935a6c-c7e6-11e4-9fec-2a4e260d5553.gif)
