### PR TITLE
Add lazy load listener for end slate on lightbox

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -383,7 +383,6 @@ define([
                 this.translateContent(this.$slides.length, 0, 0);
                 this.index = this.images.length + 1;
                 mediator.on('window:resize', this.resize);
-                imagesModule.upgradePictures();
             },
             leave: function () {
                 mediator.off('window:resize', this.resize);
@@ -475,7 +474,7 @@ define([
             this.endslate.componentClass = 'gallery-lightbox__endslate';
             this.endslate.endpoint = '/gallery/most-viewed.json';
             this.endslate.ready = function () {
-                imagesModule.upgradePictures();
+                mediator.emit('module:lightbox-end-slate:loaded');
             }.bind(this);
             this.endslate.prerender = function () {
                 bonzo(this.elem).addClass(this.componentClass);

--- a/static/src/javascripts/projects/common/modules/ui/lazy-load-images.js
+++ b/static/src/javascripts/projects/common/modules/ui/lazy-load-images.js
@@ -73,7 +73,8 @@ define([
             'modules:tonal:loaded',
             'page:media:moreinloaded',
             'page:media:most-viewed-loaded',
-            'module:gallery-most-popular:loaded'
+            'module:gallery-most-popular:loaded',
+            'module:lightbox-end-slate:loaded'
         ], function (event) {
             mediator.on(event, function (context) {
                 attachLazyLoad(qwery('.js-lazy-loaded-image', context));


### PR DESCRIPTION
The lightbox container was doing an images upgrade but should actually have been doing a lazyload.
