### PR TITLE
Upgrade pictures when entering the image state

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -318,6 +318,8 @@ define([
 
                 // meta
                 this.$indexEl.text(this.index);
+
+                imagesModule.upgradePictures();
             },
             leave: function () {
                 bean.off(this.$swipeContainer[0], 'click', this.toggleInfo);


### PR DESCRIPTION
For browsers which use picturefill, each image needs the upgrade manually executed. @paperboyo
