### PR TITLE
Remified sourcemaps

### DIFF
--- a/grunt-configs/px_to_rem.js
+++ b/grunt-configs/px_to_rem.js
@@ -2,6 +2,7 @@ module.exports = function(grunt, options) {
     return {
         dist: {
             options: {
+                map: true,
                 base: 16,
                 fallback: false // Opera Mini gets its own global.px.css
             },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-karma": "0.10.1",
     "grunt-mkdir": "0.1.2",
     "grunt-pagespeed": "0.3.0",
-    "grunt-px-to-rem": "0.3.1",
+    "grunt-px-to-rem": "0.4.0",
     "grunt-scss-lint": "0.3.3",
     "grunt-shell": "1.1.1",
     "grunt-svgmin": "^2.0.0",


### PR DESCRIPTION
thanks to @walbo adding sourcemap support (https://github.com/walbo/grunt-px-to-rem/issues/10#issuecomment-78169583), we can now have sourcemaps **and** `rem`s:

![screen shot 2015-03-11 at 17 03 09](https://cloud.githubusercontent.com/assets/867233/6601951/83e3f75a-c810-11e4-81ef-367a933e6b98.png)

:grinning: 

/cc @OliverJAsh 
