### PR TITLE
Fix charts on abtest dashboard

### DIFF
--- a/admin/public/css/abtests.css
+++ b/admin/public/css/abtests.css
@@ -128,6 +128,7 @@
 }
 
 .audience-item__test-label {
+    display: block;
     text-align: center;
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
Makes it look like this:
![screen shot 2015-03-12 at 11 39 43](https://cloud.githubusercontent.com/assets/1607666/6617101/113a599a-c8ad-11e4-9800-786ce266479b.png)
