### PR TITLE
Revert position for MPU to bottom

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -212,19 +212,9 @@
             top: 0;
             right: 0;
         }
-
-        .ad-slot__content {
-            position: absolute;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            height: 250px;
-            margin: auto;
-        }
     }
 
     @include mq(tablet, desktop) {
-        position: relative;
         width: gs-span(4.5);
 
         .ad-slot__label {


### PR DESCRIPTION
Somebody smarter than me (i.e., @sammorrisdesign) is going to have to make this work on all browsers, as I've given up.

Was seeing problems on latest IE and Mobile IE.
