### PR TITLE
Option button for a front

### DIFF
--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -654,12 +654,17 @@ h1 {
     color: #999;
 }
 
-.collapse-expand-all {
-    position: absolute;
-    right: 34px;
-    bottom: -2px;
-    font-size: 12px;
+.front-controls {
+    position: relative;
     color: #999;
+    font-size: 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.collapse-expand-all {
+    position: relative;
+    right: 34px;
 }
 .collapse-expand-all.expanded .expand,
 .collapse-expand-all .collapse {
@@ -667,6 +672,30 @@ h1 {
 }
 .collapse-expand-all.expanded .collapse {
     display: inline;
+}
+.front-actions {
+    position: relative;
+    left: 17px;
+}
+.front-actions i {
+    margin: 0 4px;
+}
+.floating-controls {
+    position: absolute;
+    z-index: 50;
+}
+.floating-controls.dropdown > ul {
+    margin: 0;
+    padding: 0;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.48), 0 1px 10px rgba(0, 0, 0, 0.24);
+}
+.floating-controls.dropdown > ul > li {
+    padding: 8px 14px;
+    border-bottom: 1px solid #DDD;
+    white-space: nowrap;
+}
+.floating-controls.dropdown > ul > li:last-of-type {
+    border-bottom: none;
 }
 
 .list-header__timings {
@@ -1312,6 +1341,7 @@ button {
     z-index: 2;
     overflow: hidden;
     position: relative;
+    padding-bottom: 10px;
 }
 
 .front-selector select {

--- a/facia-tool/public/js/jspm-config.js
+++ b/facia-tool/public/js/jspm-config.js
@@ -18,6 +18,7 @@ System.config({
     "jquery-mockjax": "npm:jquery-mockjax@1.6.1",
     "jquery-ui": "github:jquery/jquery-ui@1.11.3",
     "knockout": "npm:knockout@3.2.0",
+    "numeral": "npm:numeral@1.5.3",
     "raven-js": "npm:raven-js@1.1.17",
     "sinon": "npm:sinon@1.13.0",
     "text": "github:systemjs/plugin-text@0.0.2",
@@ -119,6 +120,9 @@ System.config({
     },
     "npm:knockout@3.2.0": {
       "process": "github:jspm/nodelibs-process@0.1.1"
+    },
+    "npm:numeral@1.5.3": {
+      "fs": "github:jspm/nodelibs-fs@0.1.1"
     },
     "npm:os-browserify@0.1.2": {
       "os": "github:jspm/nodelibs-os@0.1.0"

--- a/facia-tool/public/js/utils/highcharts.js
+++ b/facia-tool/public/js/utils/highcharts.js
@@ -7,7 +7,7 @@ define([
 ) {
     var Highcharts = highchartsGlobals.Highcharts;
 
-    Highcharts.setOptions({
+    var sparklinesDefaults = {
         chart: {
             renderTo: null,
             backgroundColor: null,
@@ -83,7 +83,11 @@ define([
                 borderColor: 'silver'
             }
         }
-    });
+    };
+
+    Highcharts.CONFIG_DEFAULTS = {
+        sparklines: sparklinesDefaults
+    };
 
     return Highcharts;
 });

--- a/facia-tool/public/js/widgets/fronts.html
+++ b/facia-tool/public/js/widgets/fronts.html
@@ -38,13 +38,32 @@
     <!-- ko ifnot: confirmSendingAlert() -->
         <div class="col__inner front-selector">
             <select data-bind="options: $root.fronts, value: front, optionsCaption: 'choose a front...'"></select>
-            <span class="collapse-expand-all" data-bind="css: {
-                expanded: allExpanded
-            }, click: toggleAll">
-                <span class="expand">expand all <i class="fa fa-chevron-up"></i></span>
-                <span class="collapse">collapse all <i class="fa fa-chevron-down"></i></span>
-            </span>
         </div>
+        <!-- ko if: front -->
+            <div class="front-controls">
+                <span class="front-actions" data-bind="toggleClick: controlsVisible">
+                    <!-- ko if: isControlsVisible -->
+                        <i class="fa fa-ellipsis-v"></i><span data-bind="text: controlsText"></span>
+                        <div class="floating-controls dropdown fadeElement" data-bind="css: {
+                            'dropdown-open': controlsVisible,
+                            'visible': controlsVisible
+                        }">
+                            <ul class="z-depth-2">
+                                <li data-bind="click: setSparklines.bind($data, 1, 10)">Sparklines: 1h</li>
+                                <li data-bind="click: setSparklines.bind($data, 3, 30)">Sparklines: 3h</li>
+                                <li data-bind="click: setSparklines.bind($data, 6, 60)">Sparklines: 6h</li>
+                            </ul>
+                        </div>
+                    <!-- /ko -->
+                </span>
+                <span class="collapse-expand-all" data-bind="css: {
+                    expanded: allExpanded
+                }, click: toggleAll">
+                    <span class="expand">expand all <i class="fa fa-chevron-up"></i></span>
+                    <span class="collapse">collapse all <i class="fa fa-chevron-down"></i></span>
+                </span>
+            </div>
+        <!-- /ko -->
     <!-- /ko -->
 
     <div class="col__inner scrollable collection-container" data-bind="foreach: collections">

--- a/facia-tool/public/js/widgets/fronts.js
+++ b/facia-tool/public/js/widgets/fronts.js
@@ -37,6 +37,7 @@ define([
         this.mode = ko.observable(params.mode || 'draft');
         this.flattenGroups = ko.observable(params.mode === 'treats');
         this.maxArticlesInHistory = this.confirmSendingAlert() ? 20 : 5;
+        this.controlsVisible = ko.observable(false);
 
         this.front.subscribe(this.onFrontChange.bind(this));
         this.mode.subscribe(this.onModeChange.bind(this));
@@ -77,6 +78,11 @@ define([
                 presser.pressDraft(this.front());
             }
         };
+
+        this.isControlsVisible = ko.observable(sparklines.isEnabled());
+        this.controlsText = ko.pureComputed(function () {
+            return 'Sparklines: ' + this.sparklinesOptions().hours + 'h';
+        }, this);
 
         this.ophanPerformances = ko.pureComputed(function () {
             return vars.CONST.ophanFrontBase + encodeURIComponent('/' + this.front());
@@ -139,6 +145,17 @@ define([
         this.refreshRelativeTimes(vars.CONST.pubTimeRefreshMs || 60000);
 
         this.load(frontId);
+
+        this.sparklinesOptions = ko.observable({
+            hours: 1,
+            interval: 10
+        });
+        this.setSparklines = function (hours, interval) {
+            this.sparklinesOptions({
+                hours: hours,
+                interval: interval
+            });
+        };
         sparklines.subscribe(this);
         mediator.emit('front:loaded', this);
     }

--- a/facia-tool/public/package.json
+++ b/facia-tool/public/package.json
@@ -14,6 +14,7 @@
       "jquery-mockjax": "npm:jquery-mockjax@^1.6.1",
       "jquery-ui": "github:jquery/jquery-ui@1.11.3",
       "knockout": "npm:knockout@3.2.0",
+      "numeral": "npm:numeral@1.5.3",
       "raven-js": "npm:raven-js@1.1.17",
       "sinon": "npm:sinon@^1.12.2",
       "text": "0.0.2",

--- a/facia-tool/test/public/mocks/front-widget.js
+++ b/facia-tool/test/public/mocks/front-widget.js
@@ -11,6 +11,7 @@ define([
             front = {
                 front: ko.observable(frontId),
                 collections: ko.observableArray(),
+                sparklinesOptions: ko.observable({}),
                 _collections: {}
             }
         ;

--- a/facia-tool/test/public/spec/sparklines.spec.js
+++ b/facia-tool/test/public/spec/sparklines.spec.js
@@ -290,7 +290,7 @@ define([
                 var afterInterval = _.after(2, function () {
                     mediator.off('mock:histogram', afterInterval);
                     expect(sparklinesTitle('_a')).toBe('500');
-                    expect(sparklinesTitle('_b')).toBe('12345');
+                    expect(sparklinesTitle('_b')).toBe('12,345');
 
                     finishTest();
                 });


### PR DESCRIPTION
Introduce an option button to customize the display of a front. In this PR it's used to change the duration of sparklines.
It can be used in the future to show more options.

And format sparklines values.

It looks like this
![screen shot 2015-03-12 at 12 20 38](https://cloud.githubusercontent.com/assets/680284/6617600/3d546548-c8b2-11e4-850b-5e982a04341d.png)

cc @obrienm  
