### PR TITLE
kill px-to-rem sourcemaps in prod

### DIFF
--- a/grunt-configs/px_to_rem.js
+++ b/grunt-configs/px_to_rem.js
@@ -2,7 +2,7 @@ module.exports = function(grunt, options) {
     return {
         dist: {
             options: {
-                map: true,
+                map: options.isDev,
                 base: 16,
                 fallback: false // Opera Mini gets its own global.px.css
             },


### PR DESCRIPTION
px-to-rem is inlining a sourcemap in prod, and it def shouldn't be
