### PR TITLE
Rename navigation variable to free up name space for new careers section

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -151,7 +151,7 @@ trait Navigation {
   val savings = SectionLink("money", "savings", "Savings", "/money/savings")
   val borrowing = SectionLink("money", "borrowing", "Borrowing", "/money/debt")
   val insurance = SectionLink("money", "insurance", "Insurance", "/money/insurance")
-  val careers = SectionLink("money", "careers", "Careers", "/money/work-and-careers")
+  val workAndCareers = SectionLink("money", "careers", "Careers", "/money/work-and-careers")
   val consumeraffairs = SectionLink("money", "consumer affairs", "Consumer affairs", "/money/consumer-affairs")
 
   //Life and style

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -50,7 +50,7 @@ object Uk extends Edition(
       NavItem(fashion),
       NavItem(environment, Seq(cities, globalDevelopment)),
       NavItem(technology),
-      NavItem(money, Seq(property, savings, borrowing, careers)),
+      NavItem(money, Seq(property, savings, borrowing, workAndCareers)),
       NavItem(travel, Seq(uktravel, europetravel, usTravel)),
       NavItem(science),
       NavItem(education, Seq(students, teachersNetwork)),
@@ -76,7 +76,7 @@ object Uk extends Edition(
     NavItem(fashion),
     NavItem(environment, Seq(cities, globalDevelopment)),
     NavItem(technology),
-    NavItem(money, Seq(property, savings, borrowing, careers)),
+    NavItem(money, Seq(property, savings, borrowing, workAndCareers)),
     NavItem(travel, Seq(uktravel, europetravel, usTravel))
   )
 }


### PR DESCRIPTION
The val careers currently refers to the Money section work and careers
tag. To match the existing naming convensions I'd like to take val
careers for the new Careers section.
