### PR TITLE
Update width for ima advert

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -94,8 +94,9 @@ define([
         // we have some special autoplay rules, so do not want to depend on 'default' autoplay
         player.guAutoplay = $(el).attr('data-auto-play') === 'true';
 
-        // need to explicitly set the height, as the ima plugin uses it
+        // need to explicitly set the dimensions for the ima plugin.
         player.height(bonzo(player.el()).parent().dim().height);
+        player.width(bonzo(player.el()).parent().dim().width);
 
         if (events.handleInitialMediaError(player)) {
             player.dispose();


### PR DESCRIPTION
Adverts were not reading the correct width, due to video js's width mechanism being overridden.
