### PR TITLE
Use next gen pagination href instead of r2

### DIFF
--- a/discussion/app/discussion/CommentPage.scala
+++ b/discussion/app/discussion/CommentPage.scala
@@ -6,7 +6,7 @@ import discussion.model.DiscussionComments
 trait CommentPage extends Page {
   val discussionComments: DiscussionComments
 
-  override lazy val url = s"/discussion/$orderBy$id"
+  override lazy val url = s"/discussion$id"
   override val pagination = Some(discussionComments.pagination)
   lazy val discussion = discussionComments.discussion
   lazy val comments = discussionComments.comments
@@ -15,7 +15,6 @@ trait CommentPage extends Page {
   lazy val topLevelCommentCount = discussionComments.topLevelCommentCount
   lazy val commenterCount = discussionComments.commenterCount
   lazy val contentUrl = discussion.webUrl
-  lazy val orderBy = discussionComments.orderBy
   lazy val isClosedForRecommendation = discussion.isClosedForRecommendation
   lazy val switches = discussionComments.switches
   lazy val isLargeDiscussion = commentCount > 1000

--- a/discussion/app/views/fragments/commentPagination.scala.html
+++ b/discussion/app/views/fragments/commentPagination.scala.html
@@ -2,4 +2,13 @@
 
 @import common.SimplePagePaths
 
-@page.pagination.map{ paginate => @fragments.pagination(page.webTitle, paginate, SimplePagePaths(page.url), Some("js-discussion-change-page"), false, Some("Comments")) }
+@page.pagination.map{ paginate =>
+    @fragments.pagination(
+        page.webTitle,
+        paginate,
+        SimplePagePaths(page.url),
+        Some("js-discussion-change-page"),
+        false,
+        Some("Comments")
+    )
+}


### PR DESCRIPTION
the static discussion pages (and the json discussion html) were using pagination hrefs that mapped to r2! This caused static pages to get sent to r2, then redirected back to next gen.
