### PR TITLE
URL encode images after validation

### DIFF
--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -804,9 +804,10 @@ define([
         function validateImage (imageSrc, imageSrcWidth, imageSrcHeight, opts) {
             if (imageSrc()) {
                 validateImageSrc(imageSrc(), opts)
-                    .done(function(width, height) {
-                        imageSrcWidth(width);
-                        imageSrcHeight(height);
+                    .done(function(img) {
+                        imageSrc(img.src);
+                        imageSrcWidth(img.width);
+                        imageSrcHeight(img.height);
                     })
                     .fail(function(err) {
                         undefineObservables(imageSrc, imageSrcWidth, imageSrcHeight);

--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -104,10 +104,10 @@ define([
             if (src === this.props.imageUrl()) { return; }
 
             validateImageSrc(src, {minWidth: 120})
-            .done(function(width, height) {
-                self.props.imageUrl(src);
-                self.props.imageWidth(width);
-                self.props.imageHeight(height);
+            .done(function(img) {
+                self.props.imageUrl(img.src);
+                self.props.imageWidth(img.width);
+                self.props.imageHeight(img.height);
                 self.saveProps();
             })
             .fail(function(err) {

--- a/facia-tool/public/js/utils/validate-image-src.js
+++ b/facia-tool/public/js/utils/validate-image-src.js
@@ -52,7 +52,12 @@ define([
                 if (err) {
                     defer.reject(err);
                 } else {
-                    defer.resolve(width, height);
+                    // Get the src again from the img, this makes sure that the URL is encoded properly
+                    defer.resolve({
+                        width: width,
+                        height: height,
+                        src: img.src
+                    });
                 }
             };
             img.src = src;


### PR DESCRIPTION
So that it's a valid URL once it reaches the backend.

Pics or it didn't happen
![screen shot 2015-03-12 at 17 42 27](https://cloud.githubusercontent.com/assets/680284/6624195/a997c5f6-c8df-11e4-8cf1-5fc9656bab28.png)

@robertberry #8577
