### PR TITLE
Correct behaviour of immersive interactives

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -2,40 +2,51 @@
 @import common.Edition
 @import views.support.TrailCssClasses.articleToneClass
 
-@defining(page.interactive) { interactive =>
-<div class="l-side-margins">
-    <article class="@RenderClasses(
-            Map(
-                "content--advertisement-feature" -> interactive.isAdvertisementFeature,
-                "content--sponsored" -> interactive.isSponsored(Some(Edition(request))),
-                "content--foundation-supported" -> interactive.isFoundationSupported
-            ),
-            "content", "content--interactive", "tonal", s"tonal--${articleToneClass(interactive)}"
-        )"
-        itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
+@if((page.interactive.hideUi && HideInteractiveUi.isSwitchedOn) || page.interactive.isImmersive) {
 
-        @fragments.headDefault(interactive, showBadge = true)
+    @interactiveBodyRaw(page.interactive)
+} else {
+    @interactiveBody(page.interactive)
+}
 
-        <div class="content__main tonal__main tonal__main--@articleToneClass(interactive)">
-            <div class="gs-container u-cf">
-                <div class="content__main-column">
-                    @fragments.contentMeta(interactive, showBadge = false)
-                </div>
-            </div>
-
-            <div class="gs-container" data-test-id="interactive-content-body">
-                <div class="content__main-column content__main-column--interactive">
-                @interactive.body.map { body =>
-                    @HtmlFormat.raw(body)
-                }.getOrElse {
-                    <figure class="interactive" data-interactive="@{conf.Configuration.interactive.url}@{request.path.drop(1)}/boot.js"></figure>
-                }
-                </div>
-            </div>
-        </div>
-    </article>
-
-    @fragments.contentFooter(interactive, page.related)
-
+@interactiveBodyRaw(interactive: model.Interactive) = {
+    @page.interactive.body.map { body =>
+        @HtmlFormat.raw(body)
+    }.getOrElse {
+        <figure class="interactive" data-interactive="@{conf.Configuration.interactive.url}@{request.path.drop(1)}/boot.js"></figure>
     }
-</div>
+}
+
+@interactiveBody(interactive: model.Interactive) {
+    <div class="l-side-margins">
+        <article class="@RenderClasses(
+                Map(
+                    "content--advertisement-feature" -> interactive.isAdvertisementFeature,
+                    "content--sponsored" -> interactive.isSponsored(Some(Edition(request))),
+                    "content--foundation-supported" -> interactive.isFoundationSupported
+                ),
+                "content", "content--interactive", "tonal", s"tonal--${articleToneClass(interactive)}"
+            )"
+            itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
+
+            @fragments.headDefault(interactive, showBadge = true)
+
+            <div class="content__main tonal__main tonal__main--@articleToneClass(interactive)">
+                <div class="gs-container u-cf">
+                    <div class="content__main-column">
+                        @fragments.contentMeta(interactive, showBadge = false)
+                    </div>
+                </div>
+
+                <div class="gs-container" data-test-id="interactive-content-body">
+                    <div class="content__main-column content__main-column--interactive">
+                        @interactiveBodyRaw(interactive)
+                    </div>
+                </div>
+            </div>
+        </article>
+
+        @fragments.contentFooter(interactive, page.related)
+
+    </div>
+}

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -2,14 +2,13 @@
 @import common.Edition
 @import views.support.TrailCssClasses.articleToneClass
 
-@if((page.interactive.hideUi && HideInteractiveUi.isSwitchedOn) || page.interactive.isImmersive) {
-
-    @interactiveBodyRaw(page.interactive)
+@if((page.interactive.hideUi && conf.Switches.HideInteractiveUi.isSwitchedOn) || page.interactive.isImmersive) {
+    @bodyRaw(page.interactive)
 } else {
-    @interactiveBody(page.interactive)
+    @body(page.interactive)
 }
 
-@interactiveBodyRaw(interactive: model.Interactive) = {
+@bodyRaw(interactive: model.Interactive) = {
     @page.interactive.body.map { body =>
         @HtmlFormat.raw(body)
     }.getOrElse {
@@ -17,7 +16,7 @@
     }
 }
 
-@interactiveBody(interactive: model.Interactive) {
+@body(interactive: model.Interactive) = {
     <div class="l-side-margins">
         <article class="@RenderClasses(
                 Map(
@@ -40,7 +39,7 @@
 
                 <div class="gs-container" data-test-id="interactive-content-body">
                     <div class="content__main-column content__main-column--interactive">
-                        @interactiveBodyRaw(interactive)
+                        @bodyRaw(interactive)
                     </div>
                 </div>
             </div>

--- a/applications/app/views/interactive.scala.html
+++ b/applications/app/views/interactive.scala.html
@@ -1,5 +1,5 @@
 @(model: InteractivePage)(implicit request: RequestHeader)
 
-@main(model.interactive){}{
+@main(model.interactive){ }{
     @fragments.interactiveBody(model)
 }

--- a/applications/app/views/interactive.scala.html
+++ b/applications/app/views/interactive.scala.html
@@ -4,7 +4,7 @@
 @defining(model.interactive.hideUi && HideInteractiveUi.isSwitchedOn) { hideUi =>
     @main(model.interactive) { }{
 
-        @if(hideUi) {
+        @if(model.interactive.isImmersive) {
             @model.interactive.body.map { body =>
                 @HtmlFormat.raw(body)
             }

--- a/applications/app/views/interactive.scala.html
+++ b/applications/app/views/interactive.scala.html
@@ -4,7 +4,7 @@
 @defining(model.interactive.hideUi && HideInteractiveUi.isSwitchedOn) { hideUi =>
     @main(model.interactive) { }{
 
-        @if(model.interactive.isImmersive) {
+        @if(hideUi || model.interactive.isImmersive) {
             @model.interactive.body.map { body =>
                 @HtmlFormat.raw(body)
             }

--- a/applications/app/views/interactive.scala.html
+++ b/applications/app/views/interactive.scala.html
@@ -1,16 +1,5 @@
 @(model: InteractivePage)(implicit request: RequestHeader)
-@import conf.Switches.HideInteractiveUi
 
-@defining(model.interactive.hideUi && HideInteractiveUi.isSwitchedOn) { hideUi =>
-    @main(model.interactive) { }{
-
-        @if(hideUi || model.interactive.isImmersive) {
-            @model.interactive.body.map { body =>
-                @HtmlFormat.raw(body)
-            }
-        } else {
-            @fragments.interactiveBody(model)
-        }
-
-    }
+@main(model.interactive){}{
+    @fragments.interactiveBody(model)
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -745,9 +745,10 @@ class Interactive(content: ApiContentWithMeta) extends Content(content) {
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
 
   override lazy val metaData: Map[String, JsValue] = super.metaData + ("contentType" -> JsString(contentType))
-  override lazy val hideUi: Boolean = displayHint.contains("immersive") || body.exists{ b =>
+  override lazy val hideUi: Boolean = body.exists{ b =>
     Jsoup.parseBodyFragment(b).body().getElementsByClass("element-interactive").attr("data-interactive").contains("/visuals-blank-page/")
   }
+  override lazy val isImmersive: Boolean = displayHint.contains("immersive")
 }
 
 object Interactive {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -36,6 +36,7 @@ trait MetaData extends Tags {
   lazy val isFront = false
   lazy val contentType = ""
   lazy val hideUi = false
+  lazy val isImmersive = false
 
   def adUnitSuffix = section
 

--- a/common/app/views/fragments/headDefault.scala.html
+++ b/common/app/views/fragments/headDefault.scala.html
@@ -1,21 +1,23 @@
 @(content: model.Content, showBadge: Boolean = false)(implicit request: RequestHeader)
 
-<header class="content__head u-cf">
-    <div class="gs-container">
-        <div class="content__main-column">
+@if(!content.isImmersive) {
+    <header class="content__head u-cf">
+        <div class="gs-container">
+            <div class="content__main-column">
 
-            @fragments.meta.metaInline(content)
+                @fragments.meta.metaInline(content)
 
-            <h1 class="content__headline js-score" itemprop="headline">@Html(content.headline)</h1>
+                <h1 class="content__headline js-score" itemprop="headline">@Html(content.headline)</h1>
 
-            @if(!content.delegate.isVideo && !content.delegate.isGallery) {
-                @fragments.standfirst(content)
-            }
+                @if(!content.delegate.isVideo && !content.delegate.isGallery) {
+                    @fragments.standfirst(content)
+                }
 
-            @if(showBadge) {
-                @fragments.commercial.badge(content)
-            }
+                @if(showBadge) {
+                    @fragments.commercial.badge(content)
+                }
 
+            </div>
         </div>
-    </div>
-</header>
+    </header>
+}

--- a/common/app/views/fragments/headDefault.scala.html
+++ b/common/app/views/fragments/headDefault.scala.html
@@ -1,23 +1,21 @@
 @(content: model.Content, showBadge: Boolean = false)(implicit request: RequestHeader)
 
-@if(!content.isImmersive) {
-    <header class="content__head u-cf">
-        <div class="gs-container">
-            <div class="content__main-column">
+<header class="content__head u-cf">
+    <div class="gs-container">
+        <div class="content__main-column">
 
-                @fragments.meta.metaInline(content)
+            @fragments.meta.metaInline(content)
 
-                <h1 class="content__headline js-score" itemprop="headline">@Html(content.headline)</h1>
+            <h1 class="content__headline js-score" itemprop="headline">@Html(content.headline)</h1>
 
-                @if(!content.delegate.isVideo && !content.delegate.isGallery) {
-                    @fragments.standfirst(content)
-                }
+            @if(!content.delegate.isVideo && !content.delegate.isGallery) {
+                @fragments.standfirst(content)
+            }
 
-                @if(showBadge) {
-                    @fragments.commercial.badge(content)
-                }
+            @if(showBadge) {
+                @fragments.commercial.badge(content)
+            }
 
-            </div>
         </div>
-    </header>
-}
+    </div>
+</header>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -63,7 +63,7 @@
 
         @body
 
-        @if(!hideUi) {
+        @if(!hideUi && !metaData.isImmersive) {
             @fragments.footer(metaData)
         }
         @fragments.analytics(metaData)


### PR DESCRIPTION
In #8570, @phamann added the ability to _hide all UI_ given the display hint of immersive. We actually mean to only hide content furniture.

Before:
![image](https://cloud.githubusercontent.com/assets/921609/6640095/060ecb42-c98d-11e4-8d59-1a794458cfb0.png)

After:
![image](https://cloud.githubusercontent.com/assets/921609/6640088/ff5eb8a2-c98c-11e4-9442-848c84969c99.png)

Should we also hide the date + share buttons?

/cc @rich-nguyen @andymason @fcage @Pearson82 
