### PR TITLE
Slim header: hide "all" text inside navigation toggle button on smaller viewports

### DIFF
--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -9,7 +9,7 @@ $c-navigation-base: colour(neutral-5);
 
 $navigation-height: $gs-row-height;
 
-$navigation-toggler-width: 44px;
+$navigation-toggler-width: 36px;
 $navigation-toggler-width-halffull: 132px;
 $navigation-toggler-width-full: 186px;
 
@@ -746,6 +746,15 @@ $c-navigation-expandable-background: colour(neutral-1);
         }
     }
 }
+
+.navigation-toggle-label {
+    .l-header--is-slim & {
+        @include mq($until: mobileLandscape) {
+            display: none;
+        }
+    }
+}
+
 .navigation-toggle-label__extra {
     display: none;
 
@@ -800,6 +809,12 @@ $burger-width: 16px;
     vertical-align: top;
     margin: 13px 6px 0 0; // We need to position burger icon to the middle and push text after
     position: relative;
+
+    .l-header--is-slim & {
+        @include mq($until: mobileLandscape) {
+            margin-right: 0;
+        }
+    }
 
     &:before,
     &:after {

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -9,7 +9,7 @@ $c-navigation-base: colour(neutral-5);
 
 $navigation-height: $gs-row-height;
 
-$navigation-toggler-width: 36px;
+$navigation-toggler-width: 44px;
 $navigation-toggler-width-halffull: 132px;
 $navigation-toggler-width-full: 186px;
 
@@ -699,11 +699,11 @@ $c-navigation-expandable-background: colour(neutral-1);
     // TODO: Why is this needed?
     border-left: 2px solid $c-navigation-toggle-shadow;
     outline: none;
+    min-width: $navigation-toggler-width;
 
-    &,
-    // Override breakpoint
+    // Remove redundant min-width and override breakpoint
     .l-header--is-slim & {
-        min-width: $navigation-toggler-width;
+        min-width: 0;
     }
 
     .l-header--is-slim & {


### PR DESCRIPTION
This helps everything fit on one line on smaller devices. As per designs.

Before:
![image](https://cloud.githubusercontent.com/assets/921609/6641148/0d8b2846-c994-11e4-830c-2467173ab169.png)

After:
![image](https://cloud.githubusercontent.com/assets/921609/6641127/e8d55cf6-c993-11e4-917d-fd21bbc0b0b9.png)

Unfortunately, it doesn't quite solve the problem for the most popular viewport width: 320px (iPhone 5 and older):

![image](https://cloud.githubusercontent.com/assets/921609/6641211/5d1465da-c994-11e4-8230-e6ce6869d71b.png)

Perhaps we should make the logo smaller on smaller viewports, to ensure everything fits onto one line? @Pearson82?
