### PR TITLE
Immersive mode: hide (rather than remove) footer to prevent breaking header sections nav

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -30,7 +30,8 @@
             ("has-page-skin", metaData.hasPageSkin(edition)),
             ("has-localnav", Navigation.topLevelItem(edition.navigation, metaData).filter(_.links.nonEmpty).nonEmpty),
             ("childrens-books-site", metaData.section == "childrens-books-site"),
-            ("ad-below-nav", adBelowNav)))"
+            ("ad-below-nav", adBelowNav),
+            ("is-immersive", metaData.isImmersive)))"
         itemscope itemtype="http://schema.org/WebPage">
 
         @fragments.message(metaData)
@@ -63,7 +64,7 @@
 
         @body
 
-        @if(!hideUi && !metaData.isImmersive) {
+        @if(!hideUi) {
             @fragments.footer(metaData)
         }
         @fragments.analytics(metaData)

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -41,6 +41,11 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
             display: none;
         }
     }
+
+    .is-immersive & {
+        display: none;
+    }
+
     .control__info {
         display: inline-block;
     }


### PR DESCRIPTION
Without the footer on the page, the header nav cannot populate its sections nav. This change just hides the footer for immersive content, instead of removing it.
