### PR TITLE
Fix liveblog pulse size

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -93,7 +93,7 @@ $block-padding-right: $gs-gutter;
     display: inline-block;
     position: relative;
     @include border-radius(50%);
-    $size: 0.75em;
+    $size: .75em;
     background-color: #ffffff;
     width: $size;
     height: $size;

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -93,7 +93,7 @@ $block-padding-right: $gs-gutter;
     display: inline-block;
     position: relative;
     @include border-radius(50%);
-    $size: 12px;
+    $size: 0.75em;
     background-color: #ffffff;
     width: $size;
     height: $size;


### PR DESCRIPTION
It now scales to the size of the headline rather than being a fixed size.

Before
![screen shot 2015-03-16 at 15 38 57](https://cloud.githubusercontent.com/assets/1607666/6669788/c4de2588-cbf2-11e4-99d9-9bb39f9165ff.png)

After
![screen shot 2015-03-16 at 15 38 46](https://cloud.githubusercontent.com/assets/1607666/6669789/c4ec6058-cbf2-11e4-8531-e680a3b41369.png)
