### PR TITLE
Slim header: fix (hide) close button on mobile

### DIFF
--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -742,14 +742,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     }
 }
 
-.navigation-toggle-label {
-    .l-header--is-slim & {
-        @include mq($until: mobileLandscape) {
-            display: none;
-        }
-    }
-}
-
 .navigation-toggle-label__extra {
     display: none;
 
@@ -779,6 +771,15 @@ $c-navigation-expandable-background: colour(neutral-1);
 }
 .navigation-container--expanded .navigation-toggle-label--close {
     display: inline;
+}
+
+// This must appear last in the cascade
+.navigation-toggle-label {
+    .l-header--is-slim & {
+        @include mq($until: mobileLandscape) {
+            display: none;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
The navigation toggle buttons shows the "close" text when the menu is expanded. This text should be hidden.
