### PR TITLE
Slim header: only override background on tablet+

### DIFF
--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -19,7 +19,10 @@ $c-guardian-services-action: #ffffff;
 .l-header--is-slim {
     .l-header__inner {
         @include clearfix;
-        background: $c-top-header-background;
+
+        @include mq(tablet) {
+            background: $c-top-header-background;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -17,11 +17,14 @@ $c-guardian-services-action: #ffffff;
 }
 
 .l-header--is-slim {
+    // TODO: Palette?
+    background: darken(colour(guardian-brand), 2%);
+
     .l-header__inner {
         @include clearfix;
 
         @include mq(tablet) {
-            background: $c-top-header-background;
+            background: colour(guardian-brand);
         }
     }
 }

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -14,7 +14,8 @@ $navigation-toggler-width-halffull: 132px;
 $navigation-toggler-width-full: 186px;
 
 $c-navigation-background: mix($c-navigation-base, #ffffff, 80%);
-$c-navigation-background-side-bar: #005182;
+// TODO: Palette?
+$c-navigation-background-side-bar: darken(colour(guardian-brand), 2%);
 
 $c-signposting-action: colour(news-default);
 $c-signposting-background: $c-navigation-base;


### PR DESCRIPTION
The slim header has a darker blue background, but these override is only necessary for tablet+.
