### PR TITLE
Remove opera mini support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,6 @@ module.exports = function (grunt) {
             grunt.task.run(['replace:cssSourceMaps', 'copy:css']);
         }
 
-        grunt.task.run(['copy:pxCss']);
         grunt.task.run(['px_to_rem']);
 
         if (isOnlyTask(this) && !fullCompile) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('compile:images', ['copy:images', 'shell:spriteGeneration']);
     grunt.registerTask('compile:css', function(fullCompile) {
-        grunt.task.run(['mkdir:css', 'compile:images', 'sass:compile', 'sass:compileStyleguide']);
+        grunt.task.run(['clean:css', 'mkdir:css', 'compile:images', 'sass:compile', 'sass:compileStyleguide']);
 
         if (options.isDev) {
             grunt.task.run(['replace:cssSourceMaps', 'copy:css']);

--- a/common/app/views/fragments/stylesheetsLoad.scala.html
+++ b/common/app/views/fragments/stylesheetsLoad.scala.html
@@ -67,11 +67,4 @@
     @fragments.stylesheetLink("stylesheets/global.css", "global")
 <!--<![endif]-->
 
-@* https://dev.opera.com/articles/opera-mini-and-javascript/#detectingmini *@
-<script>
-if (Object.prototype.toString.call(window.operamini) === "[object OperaMini]") {
-    document.querySelector('link[href$="global.css"]').href = '@Static("stylesheets/global.px.css")';
-}
-</script>
-
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />

--- a/grunt-configs/copy.js
+++ b/grunt-configs/copy.js
@@ -50,10 +50,6 @@ module.exports = function(grunt, options) {
                 dest: options.staticTargetDir + 'stylesheets'
             }]
         },
-        pxCss: {
-            src: [options.staticTargetDir + 'stylesheets/global.css'],
-            dest: options.staticTargetDir + 'stylesheets/global.px.css'
-        },
         images: {
             files: [{
                 expand: true,

--- a/grunt-configs/px_to_rem.js
+++ b/grunt-configs/px_to_rem.js
@@ -4,12 +4,12 @@ module.exports = function(grunt, options) {
             options: {
                 map: options.isDev,
                 base: 16,
-                fallback: false // Opera Mini gets its own global.px.css
+                fallback: false
             },
             files: [{
                 expand: true,
                 cwd: options.staticTargetDir + 'stylesheets/',
-                src: ['*.css', '!old-ie*', '!*.px.css'],
+                src: ['*.css', '!old-ie*'],
                 dest: options.staticTargetDir + 'stylesheets/'
             }]
         }


### PR DESCRIPTION
Opera mini now has [native support](https://dev.opera.com/blog/opera-mini-server-upgrade) for `rem`…
