### PR TITLE
Remove legacy icon class for masterclass fragment

### DIFF
--- a/commercial/app/views/masterClasses/masterClassFragment.scala.html
+++ b/commercial/app/views/masterClasses/masterClassFragment.scala.html
@@ -34,7 +34,7 @@
                 <a class="lineitem__cta button button--primary button--small"
                 href="@clickMacro@masterClass.eventBriteEvent.guardianUrl"
                 data-link-name="merchandising-hybrid-masterclasses-v@{version}_@{date}-class-@masterClass.eventBriteEvent.name-book-now">
-                    Book now@fragments.inlineSvg("arrow-right", "icon", List("i-right", "i-arrow-black-right"))
+                    Book now@fragments.inlineSvg("arrow-right", "icon", List("i-right"))
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Spotted by @austinh7 

Fixes this:
![google chrome](https://cloud.githubusercontent.com/assets/80089/6684883/37203088-cc8d-11e4-97dd-92ec2907fda0.png)
