### PR TITLE
Putting ads back in the right place on mobile

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -203,20 +203,24 @@
     }
 }
 .ad-slot--container-inline {
+    .ad-slot__content {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        margin: auto;
+    }
     @include mq(tablet) {
         position: relative;
         height: auto;
         margin: 0 $gs-gutter/2;
-
+        width: gs-span(4.5);
+        
         .linkslist-container & {
             position: absolute;
             top: 0;
             right: 0;
         }
-    }
-
-    @include mq(tablet, desktop) {
-        width: gs-span(4.5);
 
         .ad-slot__label {
             padding: 0 $gs-gutter;
@@ -224,17 +228,10 @@
 
         .ad-slot__content {
             top: $mpu-ad-label-height;
+            height: 250px;
         }
     }
 
-    .ad-slot__content {
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        height: 250px;
-        margin: auto;
-    }
 }
 .ad-slot--gallery-inline,
 .ad-slot--liveblog-inline {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -204,10 +204,6 @@
 }
 .ad-slot--container-inline {
     .ad-slot__content {
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        left: 0;
         margin: auto;
     }
     @include mq(tablet) {
@@ -227,6 +223,10 @@
         }
 
         .ad-slot__content {
+            position: absolute;
+            right: 0;
+            bottom: 0;
+            left: 0;
             top: $mpu-ad-label-height;
             height: 250px;
         }


### PR DESCRIPTION
@robertberry @sammorrisdesign 

This fixes the height of the inline MPU in mobile and tablet views, and removes the position absolute that is dumping all the ads at the bottom of the page!

Before;
![screen shot 2015-03-17 at 15 00 54](https://cloud.githubusercontent.com/assets/1303616/6690136/844e5f32-ccb6-11e4-8644-e688c502caac.png)

![screen shot 2015-03-17 at 15 01 11](https://cloud.githubusercontent.com/assets/1303616/6690137/8915d11c-ccb6-11e4-82ad-6e186bfe588d.png)

After;
![screen shot 2015-03-17 at 15 02 45](https://cloud.githubusercontent.com/assets/1303616/6690167/b33c270c-ccb6-11e4-9faa-11c359a71bf5.png)
