### PR TITLE
Navigation Interaction tracking wrapper

### DIFF
--- a/static/public/javascripts/vendor/omniture.js
+++ b/static/public/javascripts/vendor/omniture.js
@@ -84,8 +84,8 @@ function s_doPlugins(s) {
     s.eVar10=s.getDaysSinceLastVisit('s_lv');
 
     /* New/Repeat Status */
-    s.prop16=s.getNewRepeat(365);
-    
+    s.prop16=s.getNewRepeat(30);
+
     // Previous Site section
 	s.prop71 = s.getPreviousValue(s.channel,"s_prev_ch");
 
@@ -276,7 +276,7 @@ s.getNewRepeat=new Function("d","cn",""
     +"=0){s.c_w(cn,ct+'-New',e);return'New';}sval=s.split(cval,'-');if(ct"
     +"-sval[0]<30*60*1000&&sval[1]=='New'){s.c_w(cn,ct+'-New',e);return'N"
     +"ew';}else{s.c_w(cn,ct+'-Repeat',e);return'Repeat';}");
-    
+
 /*
  * Plugin: getPreviousValue_v1.0 - return previous value of designated
  *   variable (requires split utility)

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -77,7 +77,7 @@ define([
     Foresee,
     liveStats,
     mediaListener,
-    Omniture,
+    omniture,
     register,
     ScrollDepth,
     logCss,
@@ -253,7 +253,7 @@ define([
             },
 
             loadAnalytics: function () {
-                new Omniture(window.s).go();
+                omniture.go();
 
                 if (config.switches.ophan) {
                     require('ophan/ng', function (ophan) {

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -29,7 +29,7 @@ define([
     config,
     deferToAnalytics,
     template,
-    Omniture,
+    omniture,
     Component,
     techOrder,
     events,
@@ -38,8 +38,6 @@ define([
     loadingTmpl,
     titlebarTmpl
     ) {
-
-    var omniture = new Omniture(window.s);
 
     function initLoadingSpinner(player) {
         player.loadingSpinner.contentEl().innerHTML = loadingTmpl;

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -31,7 +31,7 @@ define([
      */
     track.getLinkTrackVars = function (extras) {
         extras = extras || [];
-        var linkTrackVars = ['prop6', 'prop19', 'prop75', 'eVar8',  'eVar19', 'eVar31', 'eVar51', 'eVar66' ];
+        var linkTrackVars = ['prop6', 'prop19', 'prop75', 'eVar8',  'eVar19', 'eVar31', 'eVar51', 'eVar66'];
         return ',' + linkTrackVars.concat(extras).join(',');
     };
 

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -3,43 +3,101 @@ define([
     'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/mediator',
-    'common/modules/analytics/omniture'
+    'common/modules/analytics/omniture',
+    'common/modules/identity/api'
 ], function (
     bonzo,
     debounce,
     $,
     mediator,
-    omniture
+    omniture,
+    Id
 ) {
-    var track = {
-        seen: false
+
+    /**
+     * event51: Comment
+     * event72: Engagement event (e.g. recommendation)
+     * eVar65: Only for event72. Type of interaction (any string)
+     * eVar66: User ID of current user
+     * eVar67: User ID of person being acted upon
+     * eVar68: Only for event51. comment || response
+     */
+    var track = {};
+    track.seen = false;
+
+    /**
+     * @param {Array.<string>}
+     * @return {string}
+     */
+    track.getLinkTrackVars = function (extras) {
+        extras = extras || [];
+        var linkTrackVars = ['prop6', 'prop19', 'prop75', 'eVar8',  'eVar19', 'eVar31', 'eVar51', 'eVar66' ];
+        return ',' + linkTrackVars.concat(extras).join(',');
     };
 
-    track.comment = function () {
-        omniture.trackLinkImmediate('comment');
+    track.comment = function (comment) {
+        // Add extra variables for discussion.
+        omniture.populateEventProperties('comment');
+        s.events += ',event51';
+        s.linkTrackVars += this.getLinkTrackVars(['eVar68']);
+        s.linkTrackEvents += ',event51';
+
+        s.eVar66 = Id.getUserFromCookie().id || null;
+        s.eVar68 = comment.replyTo ? 'response' : 'comment';
+        s.eVar67 = comment.replyTo ? comment.replyTo.authorId : null;
+        s.tl(true, 'o', 'comment');
     };
 
-    track.recommend = function () {
-        omniture.trackLinkImmediate('Recommend a comment');
+    track.recommend = function (e) {
+        omniture.populateEventProperties('Recommend a comment');
+        s.events += ',event72';
+        s.linkTrackVars += this.getLinkTrackVars(['eVar65', 'eVar67']);
+        s.linkTrackEvents += ',event72';
+
+        s.eVar65 = 'recommendation';
+        s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
+        s.eVar67 = e.userId;
+        s.tl(true, 'o', 'Recommend a comment');
     };
 
     track.jumpedToComments = function () {
         if (!track.seen) {
-            omniture.trackLinkImmediate('seen jump-to-comments');
+            omniture.populateEventProperties('seen jump-to-comments');
+            s.events += ',event72';
+            s.linkTrackVars += this.getLinkTrackVars(['eVar65']);
+            s.linkTrackEvents += ',event72';
+
+            s.eVar65 = 'seen jump-to-comments';
+            s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
+            s.tl(true, 'o', 'seen jump-to-comments');
             track.seen = true;
         }
     };
 
     track.commentPermalink = function () {
         if (!track.seen) {
-            omniture.trackLinkImmediate('seen comment-permalink');
+            omniture.populateEventProperties('seen comment-permalink');
+            s.events += ',event72';
+            s.linkTrackVars += this.getLinkTrackVars(['eVar65']);
+            s.linkTrackEvents += ',event72';
+
+            s.eVar65 = 'seen comment-permalink';
+            s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
+            s.tl(true, 'o', 'seen comment-permalink');
             track.seen = true;
         }
     };
 
     track.scrolledToComments = function () {
         if (!track.seen) {
-            omniture.trackLinkImmediate('seen scroll-top');
+            omniture.populateEventProperties('seen scroll-top');
+            s.events += ',event72';
+            s.linkTrackVars += this.getLinkTrackVars(['eVar65']);
+            s.linkTrackEvents += ',event72';
+
+            s.eVar65 = 'seen scroll-top';
+            s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
+            s.tl(true, 'o', 'seen scroll-top');
             track.seen = true;
         }
     };

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -3,95 +3,43 @@ define([
     'lodash/functions/debounce',
     'common/utils/$',
     'common/utils/mediator',
-    'common/modules/identity/api'
+    'common/modules/analytics/omniture'
 ], function (
     bonzo,
     debounce,
     $,
     mediator,
-    Id
+    omniture
 ) {
-
-    /**
-     * event51: Comment
-     * event72: Engagement event (e.g. recommendation)
-     * eVar65: Only for event72. Type of interaction (any string)
-     * eVar66: User ID of current user
-     * eVar67: User ID of person being acted upon
-     * eVar68: Only for event51. comment || response
-     */
-    var track = {};
-    track.seen = false;
-
-    /**
-     * @param {Array.<string>}
-     * @return {string}
-     */
-    track.getLinkTrackVars = function (extras) {
-        extras = extras || [];
-        var linkTrackVars = [
-            'events',
-            'prop4', 'prop6', 'prop8', 'prop10', 'prop13',
-            'prop19', 'prop31', 'prop51', 'prop75',
-            'eVar7', 'eVar8',  'eVar19', 'eVar31',
-            'eVar51', 'eVar66'
-        ];
-
-        return linkTrackVars.concat(extras).join(',');
+    var track = {
+        seen: false
     };
 
-    track.comment = function (comment) {
-        s.events = 'event51';
-        s.eVar66 = Id.getUserFromCookie().id || null;
-        s.eVar68 = comment.replyTo ? 'response' : 'comment';
-        s.eVar67 = comment.replyTo ? comment.replyTo.authorId : null;
-        s.linkTrackVars = this.getLinkTrackVars(['eVar68']);
-        s.linkTrackEvents = 'event51';
-        s.tl(true, 'o', 'comment');
+    track.comment = function () {
+        omniture.trackLinkImmediate('comment');
     };
 
-    track.recommend = function (e) {
-        s.events = 'event72';
-        s.eVar65 = 'recommendation';
-        s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
-        s.eVar67 = e.userId;
-        s.linkTrackVars = this.getLinkTrackVars(['eVar65', 'eVar67']);
-        s.linkTrackEvents = 'event72';
-        s.tl(true, 'o', 'Recommend a comment');
+    track.recommend = function () {
+        omniture.trackLinkImmediate('Recommend a comment');
     };
 
     track.jumpedToComments = function () {
         if (!track.seen) {
-            s.events = 'event72';
-            s.eVar65 = 'seen jump-to-comments';
-            s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
-            s.linkTrackVars = this.getLinkTrackVars(['eVar65']);
-            s.linkTrackEvents = 'event72';
-            s.tl(true, 'o', 'seen jump-to-comments');
+            omniture.trackLinkImmediate('seen jump-to-comments');
             track.seen = true;
         }
     };
 
     track.commentPermalink = function () {
         if (!track.seen) {
-            s.events = 'event72';
-            s.eVar65 = 'seen comment-permalink';
-            s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
-            s.linkTrackVars = this.getLinkTrackVars(['eVar65']);
-            s.linkTrackEvents = 'event72';
-            s.tl(true, 'o', 'seen comment-permalink');
+            omniture.trackLinkImmediate('seen comment-permalink');
             track.seen = true;
         }
     };
 
     track.scrolledToComments = function () {
         if (!track.seen) {
-            s.events = 'event72';
-            s.eVar65 = 'seen scroll-top';
-            s.eVar66 = Id.getUserFromCookie() ? Id.getUserFromCookie().id : null;
-            s.linkTrackVars = this.getLinkTrackVars(['eVar65']);
-            s.linkTrackEvents = 'event72';
-            s.tl(true, 'o', 'seen scroll-top');
+            omniture.trackLinkImmediate('seen scroll-top');
             track.seen = true;
         }
     };

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -38,7 +38,7 @@ define([
         this.s = window.s;
         this.pageviewSent = false;
 
-        mediator.on('module:clickstream:interaction', this.trackNonLinkEvent.bind(this));
+        mediator.on('module:clickstream:interaction', this.trackLinkImmediate.bind(this));
 
         mediator.on('module:clickstream:click', this.logTag.bind(this));
 
@@ -119,20 +119,14 @@ define([
         }
     };
 
-    // used where we don't have an element to pass as a tag
-    // eg. keyboard interaction
-    Omniture.prototype.trackNonLinkEvent = function (tagStr) {
-        this.s.linkTrackVars = 'eVar37,events';
-        this.s.linkTrackEvents = 'event37';
-        this.s.events = 'event37';
-        this.s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + tagStr : tagStr;
-        this.s.tl(true, 'o', tagStr);
+    // used where we don't have an element to pass as a tag, eg. keyboard interaction
+    Omniture.prototype.trackLinkImmediate = function (linkName) {
+        // A linkObject of value 'true' means track link with no delay.
+        this.trackLink(true, linkName);
     };
 
     Omniture.prototype.trackLink = function (linkObject, linkName) {
         this.populateEventProperties(linkName);
-
-        // A linkObject of value 'true' means track link with no delay.
         this.s.tl(linkObject, 'o', linkName);
     };
 

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -36,7 +36,10 @@ define([
         this.isEmbed = !!guardian.isEmbed;
         this.s = window.s;
         this.pageviewSent = false;
+        this.addHandlers();
+    }
 
+    Omniture.prototype.addHandlers = function () {
         mediator.on('module:clickstream:interaction', this.trackLinkImmediate.bind(this));
 
         mediator.on('module:clickstream:click', this.logTag.bind(this));
@@ -48,7 +51,7 @@ define([
                 beacon.fire('/count/pva.gif');
             }
         }.bind(this));
-    }
+    };
 
     Omniture.prototype.logView = function () {
         this.s.t();

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -41,11 +41,6 @@ define([
 
         mediator.on('module:clickstream:click', this.logTag.bind(this));
 
-        mediator.on('module:autoupdate:loaded', function () {
-            this.populatePageProperties();
-            this.logUpdate();
-        }.bind(this));
-
         mediator.on('module:analytics:omniture:pageview:sent', function () {
             // Independently log this page view, used for checking we have not broken analytics.
             // We want to exclude off-site embed tracking from this data.
@@ -58,14 +53,6 @@ define([
     Omniture.prototype.logView = function () {
         this.s.t();
         this.confirmPageView();
-    };
-
-    Omniture.prototype.logUpdate = function () {
-        this.s.linkTrackVars = 'events,eVar7';
-        this.s.linkTrackEvents = 'event90';
-        this.s.events = 'event90';
-        this.s.eVar7 = config.page.analyticsName;
-        this.s.tl(true, 'o', 'AutoUpdate Refresh');
     };
 
     Omniture.prototype.generateTrackingImageString = function () {

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -95,23 +95,22 @@ define([
         }
     };
 
-    Omniture.prototype.populateEventProperties = function (tag) {
-        //channel
-        //prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop47,prop51,prop61,prop64,prop65
-        //evar7,evar37,evar38,evar39,evar50
-        this.s.linkTrackVars = 'eVar37,eVar7,prop37,events';
+    Omniture.prototype.populateEventProperties = function (linkName) {
+
+        this.s.linkTrackVars =  'channel,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,'+
+                                'prop51,prop61,prop64,prop65,evar7,evar37,evar38,evar39,evar50,events';
         this.s.linkTrackEvents = 'event37';
         this.s.events = 'event37';
-        this.s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + tag : tag;
+        this.s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + linkName : linkName;
 
         // this allows 'live' Omniture tracking of Navigation Interactions
         this.s.eVar7 = 'D=pageName';
         this.s.prop37 = 'D=v37';
 
-        if (/social/.test(tag)) {
+        if (/social/.test(linkName)) {
             this.s.linkTrackVars   += ',eVar12,prop4,prop9,prop10';
             this.s.linkTrackEvents += ',event16';
-            this.s.eVar12           = tag;
+            this.s.eVar12           = linkName;
             this.s.prop4            = config.page.keywords || '';
             this.s.prop9            = config.page.contentType || '';
             this.s.prop10           = config.page.tones || '';

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -29,317 +29,313 @@ define([
     history,
     id
 ) {
+    var R2_STORAGE_KEY = 's_ni', // DO NOT CHANGE THIS, ITS IS SHARED WITH R2. BAD THINGS WILL HAPPEN!
+        NG_STORAGE_KEY = 'gu.analytics.referrerVars';
 
-    // https://developer.omniture.com/en_US/content_page/sitecatalyst-tagging/c-tagging-overview
-
-    /**
-     * @param Object w 'window' object, used for testing
-     */
-    function Omniture(s, w) {
-
-        var R2_STORAGE_KEY = 's_ni', // DO NOT CHANGE THIS, ITS IS SHARED WITH R2. BAD THINGS WILL HAPPEN!
-            NG_STORAGE_KEY = 'gu.analytics.referrerVars',
-            isEmbed = !!guardian.isEmbed,
-            that = this;
-
-        w = w || {};
-
+    function Omniture() {
+        this.isEmbed = !!guardian.isEmbed;
+        this.s = window.s;
         this.pageviewSent = false;
 
-        this.logView = function () {
-            s.t();
-            this.confirmPageView();
-        };
+        mediator.on('module:clickstream:interaction', this.trackNonLinkEvent.bind(this));
 
-        this.logUpdate = function () {
-            s.linkTrackVars = 'events,eVar7';
-            s.linkTrackEvents = 'event90';
-            s.events = 'event90';
-            s.eVar7 = config.page.analyticsName;
-            s.tl(true, 'o', 'AutoUpdate Refresh');
-        };
-
-        this.generateTrackingImageString = function () {
-            return 's_i_' + window.s_account.split(',').join('_');
-        };
-
-        // Certain pages have specfic channel rules
-        this.getChannel = function () {
-            if (config.page.contentType === 'Network Front') {
-                return 'Network Front';
-            } else if (isEmbed) {
-                return 'Embedded';
-            }
-            return config.page.section || '';
-        };
-
-        this.logTag = function (spec) {
-            var storeObj,
-                delay;
-
-            if (!spec.tag) {
-                return;
-            } else if (spec.sameHost && !spec.samePage) {
-                // Came from a link to a new page on the same host,
-                // so do session storage rather than an omniture track.
-                storeObj = {
-                    pageName: s.pageName,
-                    tag: spec.tag,
-                    time: new Date().getTime()
-                };
-                try { sessionStorage.setItem(R2_STORAGE_KEY, storeObj.tag); } catch (e) {}
-                storage.session.set(NG_STORAGE_KEY, storeObj);
-            } else {
-                that.populateEventProperties(spec.tag);
-                // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
-                delay = spec.samePage ? true : spec.target;
-                s.tl(delay, 'o', spec.tag);
-            }
-        };
-
-        this.populateEventProperties = function (tag) {
-            s.linkTrackVars = 'eVar37,eVar7,prop37,events';
-            s.linkTrackEvents = 'event37';
-            s.events = 'event37';
-            s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + tag : tag;
-
-            // this allows 'live' Omniture tracking of Navigation Interactions
-            s.eVar7 = 'D=pageName';
-            s.prop37 = 'D=v37';
-
-            if (/social/.test(tag)) {
-                s.linkTrackVars   += ',eVar12,prop4,prop9,prop10';
-                s.linkTrackEvents += ',event16';
-                s.eVar12           = tag;
-                s.prop4            = config.page.keywords || '';
-                s.prop9            = config.page.contentType || '';
-                s.prop10           = config.page.tones || '';
-                s.events           = s.apl(s.events, 'event16', ',');
-            }
-        };
-
-        // used where we don't have an element to pass as a tag
-        // eg. keyboard interaction
-        this.trackNonLinkEvent = function (tagStr) {
-            s.linkTrackVars = 'eVar37,events';
-            s.linkTrackEvents = 'event37';
-            s.events = 'event37';
-            s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + tagStr : tagStr;
-            s.tl(true, 'o', tagStr);
-        };
-
-        this.populatePageProperties = function () {
-
-            var d,
-                now      = new Date(),
-                tpA      = s.getTimeParting('n', '+0'),
-                /* Retrieve navigation interaction data */
-                ni       = storage.session.get(NG_STORAGE_KEY),
-                platform = 'frontend',
-                mvt      = ab.makeOmnitureTag(document),
-                // Tag the identity of this user, which is composed of
-                // the omniture visitor id, the ophan browser id, and the frontend-only mvt id.
-                mvtId    = mvtCookie.getMvtFullId();
-
-            // http://www.scribd.com/doc/42029685/15/cookieDomainPeriods
-            s.cookieDomainPeriods = '2';
-
-            s.linkInternalFilters += ',localhost,gucode.co.uk,gucode.com,guardiannews.com,int.gnl,proxylocal.com,theguardian.com';
-
-            s.trackingServer = 'hits.theguardian.com';
-            s.trackingServerSecure = 'hits-secure.theguardian.com';
-
-            s.ce = 'UTF-8';
-            s.pageName  = config.page.analyticsName;
-
-            s.prop1     = config.page.headline || '';
-
-            // eVar1 contains today's date
-            // in the Omniture backend it only ever holds the first
-            // value a user gets, so in effect it is the first time
-            // we saw this user
-            s.eVar1 = now.getFullYear() + '/' +
-                pad(now.getMonth() + 1, 2) + '/' +
-                pad(now.getDate(), 2);
-
-            if (id.getUserFromCookie()) {
-                s.prop2 = 'GUID:' + id.getUserFromCookie().id;
-                s.eVar2 = 'GUID:' + id.getUserFromCookie().id;
-            }
-
-            s.prop3     = config.page.publication || '';
-
-            s.channel   = this.getChannel();
-            s.prop4     = config.page.keywords || '';
-            s.prop6     = config.page.author || '';
-            s.prop7     = config.page.webPublicationDate || '';
-            s.prop8     = config.page.pageCode || '';
-            s.prop9     = config.page.contentType || '';
-            s.prop10    = config.page.tones || '';
-
-            s.prop13    = config.page.series || '';
-
-            // see http://blogs.adobe.com/digitalmarketing/mobile/responsive-web-design-and-web-analytics/
-            s.eVar18    = detect.getBreakpoint();
-            // getting clientWidth causes a reflow, so avoid using if possible
-            s.eVar21    = (window.innerWidth || document.documentElement.clientWidth)
-                        + 'x'
-                        + (window.innerHeight || document.documentElement.clientHeight);
-            s.eVar32    = detect.getOrientation();
-
-            /* Set Time Parting Day and Hour Combination - 0 = GMT */
-            s.prop20    = tpA[2] + ':' + tpA[1];
-            s.eVar20    = 'D=c20';
-
-            s.prop25    = config.page.blogs || '';
-
-            s.prop60    = detect.isFireFoxOSApp() ? 'firefoxosapp' : null;
-
-            s.prop19     = platform;
-            s.eVar19     = platform;
-
-            s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
-            s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
-
-            s.prop47    = config.page.edition || '';
-
-            s.prop51  = mvt;
-            s.eVar51  = mvt;
-
-            s.list3 = map(history.getPopularFiltered(), function (tagTuple) { return tagTuple[1]; }).join(',');
-
-            if (s.prop51) {
-                s.events = s.apl(s.events, 'event58', ',');
-            }
-
-            if (mvtId) {
-                s.eVar60 = mvtId;
-            }
-
-            if (config.page.commentable) {
-                s.events = s.apl(s.events, 'event46', ',');
-            }
-
-            if (config.page.section === 'identity')  {
-                s.prop11 = 'Users';
-                s.prop9 = 'userid';
-                s.eVar27 = config.page.omnitureErrorMessage || '';
-                s.eVar42 = config.page.returnUrl || '';
-                s.hier2 = 'GU/Users/Registration';
-                s.events = s.apl(s.events, config.page.omnitureEvent, ',');
-            }
-
-            s.prop56    = 'Javascript';
-
-            // not all pages have a production office
-            if (config.page.productionOffice) {
-                s.prop64 = config.page.productionOffice;
-            }
-
-            /* Omniture library version */
-            s.prop62    = 'Guardian JS-1.4.1 20140914';
-
-            s.prop63    = detect.getPageSpeed();
-
-            s.prop65    = config.page.headline || '';
-
-            s.prop67    = 'nextgen-served';
-
-            s.prop68    = detect.getConnectionSpeed(w.performance, null, true);
-
-            if (config.page.webPublicationDate) {
-                s.prop30 = 'content';
-            } else {
-                s.prop30 = 'non-content';
-            }
-
-            if (s.getParamValue('INTCMP') !== '') {
-                s.eVar50 = s.getParamValue('INTCMP');
-            }
-            s.eVar50 = s.getValOnce(s.eVar50, 's_intcampaign', 0);
-
-            // the operating system
-            s.eVar58 = navigator.platform || 'unknown';
-
-            // the number of Guardian links inside the body
-            if (config.page.inBodyInternalLinkCount) {
-                s.prop58 = config.page.inBodyInternalLinkCount;
-            }
-
-            // the number of External links inside the body
-            if (config.page.inBodyExternalLinkCount) {
-                s.prop69 = config.page.inBodyExternalLinkCount;
-            }
-
-            if (ni) {
-                d = new Date().getTime();
-                if (d - ni.time < 60 * 1000) { // One minute
-                    s.eVar24 = ni.pageName;
-                    s.eVar37 = ni.tag;
-                    s.events = 'event37';
-
-                    // this allows 'live' Omniture tracking of Navigation Interactions
-                    s.eVar7 = ni.pageName;
-                    s.prop37 = ni.tag;
-                }
-                storage.session.remove(R2_STORAGE_KEY);
-                storage.session.remove(NG_STORAGE_KEY);
-            }
-
-            s.prop75 = config.page.wordCount || 0;
-            s.eVar75 = config.page.wordCount || 0;
-
-            if (isEmbed) {
-                s.eVar11 = s.prop11 = 'Embedded';
-            }
-        };
-
-        this.go = function () {
-            this.populatePageProperties();
-            this.logView();
-            mediator.emit('analytics:ready');
-        };
-
-        this.confirmPageView = function () {
-            // This ensures that the Omniture pageview beacon has successfully loaded
-            // Can be used as a way to prevent other events to fire earlier than the pageview
-            var self = this,
-                checkForPageViewInterval = setInterval(function () {
-                    // s_i_guardiangu-frontend_guardiangu-network is a globally defined Image() object created by Omniture
-                    // It does not sit in the DOM tree, and seems to be the only surefire way
-                    // to check if the intial beacon has been successfully sent
-                    var img = window[self.generateTrackingImageString()];
-                    if (typeof (img) !== 'undefined' && (img.complete === true || img.width + img.height > 0)) {
-                        clearInterval(checkForPageViewInterval);
-
-                        self.pageviewSent = true;
-                        mediator.emit('module:analytics:omniture:pageview:sent');
-                    }
-                }, 250);
-
-            // Give up after 10 seconds
-            setTimeout(function () {
-                clearInterval(checkForPageViewInterval);
-            }, 10000);
-        };
-
-        mediator.on('module:clickstream:interaction', that.trackNonLinkEvent);
-
-        mediator.on('module:clickstream:click', that.logTag);
+        mediator.on('module:clickstream:click', this.logTag.bind(this));
 
         mediator.on('module:autoupdate:loaded', function () {
-            that.populatePageProperties();
-            that.logUpdate();
-        });
+            this.populatePageProperties();
+            this.logUpdate();
+        }.bind(this));
 
         mediator.on('module:analytics:omniture:pageview:sent', function () {
             // Independently log this page view, used for checking we have not broken analytics.
             // We want to exclude off-site embed tracking from this data.
-            if (!isEmbed) { beacon.fire('/count/pva.gif'); }
-        });
-
+            if (!this.isEmbed) {
+                beacon.fire('/count/pva.gif');
+            }
+        }.bind(this));
     }
 
-    return Omniture;
+    Omniture.prototype.logView = function () {
+        this.s.t();
+        this.confirmPageView();
+    };
 
+    Omniture.prototype.logUpdate = function () {
+        this.s.linkTrackVars = 'events,eVar7';
+        this.s.linkTrackEvents = 'event90';
+        this.s.events = 'event90';
+        this.s.eVar7 = config.page.analyticsName;
+        this.s.tl(true, 'o', 'AutoUpdate Refresh');
+    };
+
+    Omniture.prototype.generateTrackingImageString = function () {
+        return 's_i_' + window.s_account.split(',').join('_');
+    };
+
+    // Certain pages have specfic channel rules
+    Omniture.prototype.getChannel = function () {
+        if (config.page.contentType === 'Network Front') {
+            return 'Network Front';
+        } else if (this.isEmbed) {
+            return 'Embedded';
+        }
+        return config.page.section || '';
+    };
+
+    Omniture.prototype.logTag = function (spec) {
+        var storeObj,
+            delay;
+
+        if (!spec.tag) {
+            return;
+        } else if (spec.sameHost && !spec.samePage) {
+            // Came from a link to a new page on the same host,
+            // so do session storage rather than an omniture track.
+            storeObj = {
+                pageName: this.s.pageName,
+                tag: spec.tag,
+                time: new Date().getTime()
+            };
+            try { sessionStorage.setItem(R2_STORAGE_KEY, storeObj.tag); } catch (e) {}
+            storage.session.set(NG_STORAGE_KEY, storeObj);
+        } else {
+            this.populateEventProperties(spec.tag);
+            // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
+            delay = spec.samePage ? true : spec.target;
+            this.s.tl(delay, 'o', spec.tag);
+        }
+    };
+
+    Omniture.prototype.populateEventProperties = function (tag) {
+        this.s.linkTrackVars = 'eVar37,eVar7,prop37,events';
+        this.s.linkTrackEvents = 'event37';
+        this.s.events = 'event37';
+        this.s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + tag : tag;
+
+        // this allows 'live' Omniture tracking of Navigation Interactions
+        this.s.eVar7 = 'D=pageName';
+        this.s.prop37 = 'D=v37';
+
+        if (/social/.test(tag)) {
+            this.s.linkTrackVars   += ',eVar12,prop4,prop9,prop10';
+            this.s.linkTrackEvents += ',event16';
+            this.s.eVar12           = tag;
+            this.s.prop4            = config.page.keywords || '';
+            this.s.prop9            = config.page.contentType || '';
+            this.s.prop10           = config.page.tones || '';
+            this.s.events           = this.s.apl(this.s.events, 'event16', ',');
+        }
+    };
+
+    // used where we don't have an element to pass as a tag
+    // eg. keyboard interaction
+    Omniture.prototype.trackNonLinkEvent = function (tagStr) {
+        this.s.linkTrackVars = 'eVar37,events';
+        this.s.linkTrackEvents = 'event37';
+        this.s.events = 'event37';
+        this.s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + tagStr : tagStr;
+        this.s.tl(true, 'o', tagStr);
+    };
+
+    Omniture.prototype.trackLinkEvent = function (linkObject, linkName) {
+        //channel
+        //prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop47,prop51,prop61,prop64,prop65
+        //evar7,evar37,evar38,evar39,evar50
+
+        // A linkObject of value 'true' means track link with no delay.
+        this.s.tl(linkObject, 'o', linkName);
+    };
+
+    Omniture.prototype.populatePageProperties = function () {
+        var d,
+            now      = new Date(),
+            tpA      = this.s.getTimeParting('n', '+0'),
+            /* Retrieve navigation interaction data */
+            ni       = storage.session.get(NG_STORAGE_KEY),
+            platform = 'frontend',
+            mvt      = ab.makeOmnitureTag(document),
+            // Tag the identity of this user, which is composed of
+            // the omniture visitor id, the ophan browser id, and the frontend-only mvt id.
+            mvtId    = mvtCookie.getMvtFullId();
+
+        // http://www.scribd.com/doc/42029685/15/cookieDomainPeriods
+        this.s.cookieDomainPeriods = '2';
+
+        this.s.linkInternalFilters += ',localhost,gucode.co.uk,gucode.com,guardiannews.com,int.gnl,proxylocal.com,theguardian.com';
+
+        this.s.trackingServer = 'hits.theguardian.com';
+        this.s.trackingServerSecure = 'hits-secure.theguardian.com';
+
+        this.s.ce = 'UTF-8';
+        this.s.pageName  = config.page.analyticsName;
+
+        this.s.prop1     = config.page.headline || '';
+
+        // eVar1 contains today's date
+        // in the Omniture backend it only ever holds the first
+        // value a user gets, so in effect it is the first time
+        // we saw this user
+        this.s.eVar1 = now.getFullYear() + '/' +
+            pad(now.getMonth() + 1, 2) + '/' +
+            pad(now.getDate(), 2);
+
+        if (id.getUserFromCookie()) {
+            this.s.prop2 = 'GUID:' + id.getUserFromCookie().id;
+            this.s.eVar2 = 'GUID:' + id.getUserFromCookie().id;
+        }
+
+        this.s.prop3     = config.page.publication || '';
+
+        this.s.channel   = this.getChannel();
+        this.s.prop4     = config.page.keywords || '';
+        this.s.prop6     = config.page.author || '';
+        this.s.prop7     = config.page.webPublicationDate || '';
+        this.s.prop8     = config.page.pageCode || '';
+        this.s.prop9     = config.page.contentType || '';
+        this.s.prop10    = config.page.tones || '';
+
+        this.s.prop13    = config.page.series || '';
+
+        // see http://blogs.adobe.com/digitalmarketing/mobile/responsive-web-design-and-web-analytics/
+        this.s.eVar18    = detect.getBreakpoint();
+        // getting clientWidth causes a reflow, so avoid using if possible
+        this.s.eVar21    = (window.innerWidth || document.documentElement.clientWidth)
+                    + 'x'
+                    + (window.innerHeight || document.documentElement.clientHeight);
+        this.s.eVar32    = detect.getOrientation();
+
+        /* Set Time Parting Day and Hour Combination - 0 = GMT */
+        this.s.prop20    = tpA[2] + ':' + tpA[1];
+        this.s.eVar20    = 'D=c20';
+
+        this.s.prop25    = config.page.blogs || '';
+
+        this.s.prop60    = detect.isFireFoxOSApp() ? 'firefoxosapp' : null;
+
+        this.s.prop19     = platform;
+        this.s.eVar19     = platform;
+
+        this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
+        this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
+
+        this.s.prop47    = config.page.edition || '';
+
+        this.s.prop51  = mvt;
+        this.s.eVar51  = mvt;
+
+        this.s.list3 = map(history.getPopularFiltered(), function (tagTuple) { return tagTuple[1]; }).join(',');
+
+        if (this.s.prop51) {
+            this.s.events = this.s.apl(this.s.events, 'event58', ',');
+        }
+
+        if (mvtId) {
+            this.s.eVar60 = mvtId;
+        }
+
+        if (config.page.commentable) {
+            this.s.events = this.s.apl(this.s.events, 'event46', ',');
+        }
+
+        if (config.page.section === 'identity')  {
+            this.s.prop11 = 'Users';
+            this.s.prop9 = 'userid';
+            this.s.eVar27 = config.page.omnitureErrorMessage || '';
+            this.s.eVar42 = config.page.returnUrl || '';
+            this.s.hier2 = 'GU/Users/Registration';
+            this.s.events = this.s.apl(this.s.events, config.page.omnitureEvent, ',');
+        }
+
+        this.s.prop56    = 'Javascript';
+
+        // not all pages have a production office
+        if (config.page.productionOffice) {
+            this.s.prop64 = config.page.productionOffice;
+        }
+
+        /* Omniture library version */
+        this.s.prop62    = 'Guardian JS-1.4.1 20140914';
+
+        this.s.prop63    = detect.getPageSpeed();
+
+        this.s.prop65    = config.page.headline || '';
+
+        this.s.prop67    = 'nextgen-served';
+
+        if (config.page.webPublicationDate) {
+            this.s.prop30 = 'content';
+        } else {
+            this.s.prop30 = 'non-content';
+        }
+
+        if (this.s.getParamValue('INTCMP') !== '') {
+            this.s.eVar50 = this.s.getParamValue('INTCMP');
+        }
+        this.s.eVar50 = this.s.getValOnce(this.s.eVar50, 's_intcampaign', 0);
+
+        // the operating system
+        this.s.eVar58 = navigator.platform || 'unknown';
+
+        // the number of Guardian links inside the body
+        if (config.page.inBodyInternalLinkCount) {
+            this.s.prop58 = config.page.inBodyInternalLinkCount;
+        }
+
+        // the number of External links inside the body
+        if (config.page.inBodyExternalLinkCount) {
+            this.s.prop69 = config.page.inBodyExternalLinkCount;
+        }
+
+        if (ni) {
+            d = new Date().getTime();
+            if (d - ni.time < 60 * 1000) { // One minute
+                this.s.eVar24 = ni.pageName;
+                this.s.eVar37 = ni.tag;
+                this.s.events = 'event37';
+
+                // this allows 'live' Omniture tracking of Navigation Interactions
+                this.s.eVar7 = ni.pageName;
+                this.s.prop37 = ni.tag;
+            }
+            storage.session.remove(R2_STORAGE_KEY);
+            storage.session.remove(NG_STORAGE_KEY);
+        }
+
+        this.s.prop75 = config.page.wordCount || 0;
+        this.s.eVar75 = config.page.wordCount || 0;
+
+        if (this.isEmbed) {
+            this.s.eVar11 = this.s.prop11 = 'Embedded';
+        }
+    };
+
+    Omniture.prototype.go = function () {
+        this.populatePageProperties();
+        this.logView();
+        mediator.emit('analytics:ready');
+    };
+
+    Omniture.prototype.confirmPageView = function () {
+        // This ensures that the Omniture pageview beacon has successfully loaded
+        // Can be used as a way to prevent other events to fire earlier than the pageview
+        var checkForPageViewInterval = setInterval(function () {
+                // s_i_guardiangu-frontend_guardiangu-network is a globally defined Image() object created by Omniture
+                // It does not sit in the DOM tree, and seems to be the only surefire way
+                // to check if the intial beacon has been successfully sent
+                var img = window[this.generateTrackingImageString()];
+                if (typeof (img) !== 'undefined' && (img.complete === true || img.width + img.height > 0)) {
+                    clearInterval(checkForPageViewInterval);
+
+                    this.pageviewSent = true;
+                    mediator.emit('module:analytics:omniture:pageview:sent');
+                }
+        }.bind(this), 250);
+
+        // Give up after 10 seconds
+        setTimeout(function () {
+            clearInterval(checkForPageViewInterval);
+        }, 10000);
+    };
+
+    return Omniture;
 });

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -30,8 +30,7 @@ define([
     id
 ) {
     var R2_STORAGE_KEY = 's_ni', // DO NOT CHANGE THIS, ITS IS SHARED WITH R2. BAD THINGS WILL HAPPEN!
-        NG_STORAGE_KEY = 'gu.analytics.referrerVars',
-        omniture = new Omniture();
+        NG_STORAGE_KEY = 'gu.analytics.referrerVars';
 
     function Omniture() {
         this.isEmbed = !!guardian.isEmbed;
@@ -310,5 +309,6 @@ define([
         }, 10000);
     };
 
-    return omniture;
+    // A single Omniture instance for the whole application.
+    return new Omniture();
 });

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -30,7 +30,8 @@ define([
     id
 ) {
     var R2_STORAGE_KEY = 's_ni', // DO NOT CHANGE THIS, ITS IS SHARED WITH R2. BAD THINGS WILL HAPPEN!
-        NG_STORAGE_KEY = 'gu.analytics.referrerVars';
+        NG_STORAGE_KEY = 'gu.analytics.referrerVars',
+        omniture = new Omniture();
 
     function Omniture() {
         this.isEmbed = !!guardian.isEmbed;
@@ -324,5 +325,5 @@ define([
         }, 10000);
     };
 
-    return Omniture;
+    return omniture;
 });

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -76,7 +76,9 @@ define([
 
         if (!spec.tag) {
             return;
-        } else if (spec.sameHost && !spec.samePage) {
+        }
+
+        if (spec.sameHost && !spec.samePage) {
             // Came from a link to a new page on the same host,
             // so do session storage rather than an omniture track.
             storeObj = {
@@ -87,14 +89,16 @@ define([
             try { sessionStorage.setItem(R2_STORAGE_KEY, storeObj.tag); } catch (e) {}
             storage.session.set(NG_STORAGE_KEY, storeObj);
         } else {
-            this.populateEventProperties(spec.tag);
             // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
             delay = spec.samePage ? true : spec.target;
-            this.s.tl(delay, 'o', spec.tag);
+            this.trackLink(delay, spec.tag);
         }
     };
 
     Omniture.prototype.populateEventProperties = function (tag) {
+        //channel
+        //prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop47,prop51,prop61,prop64,prop65
+        //evar7,evar37,evar38,evar39,evar50
         this.s.linkTrackVars = 'eVar37,eVar7,prop37,events';
         this.s.linkTrackEvents = 'event37';
         this.s.events = 'event37';
@@ -125,10 +129,8 @@ define([
         this.s.tl(true, 'o', tagStr);
     };
 
-    Omniture.prototype.trackLinkEvent = function (linkObject, linkName) {
-        //channel
-        //prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop47,prop51,prop61,prop64,prop65
-        //evar7,evar37,evar38,evar39,evar50
+    Omniture.prototype.trackLink = function (linkObject, linkName) {
+        this.populateEventProperties(linkName);
 
         // A linkObject of value 'true' means track link with no delay.
         this.s.tl(linkObject, 'o', linkName);

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -291,16 +291,16 @@ define([
         // This ensures that the Omniture pageview beacon has successfully loaded
         // Can be used as a way to prevent other events to fire earlier than the pageview
         var checkForPageViewInterval = setInterval(function () {
-                // s_i_guardiangu-frontend_guardiangu-network is a globally defined Image() object created by Omniture
-                // It does not sit in the DOM tree, and seems to be the only surefire way
-                // to check if the intial beacon has been successfully sent
-                var img = window[this.generateTrackingImageString()];
-                if (typeof (img) !== 'undefined' && (img.complete === true || img.width + img.height > 0)) {
-                    clearInterval(checkForPageViewInterval);
+            // s_i_guardiangu-frontend_guardiangu-network is a globally defined Image() object created by Omniture
+            // It does not sit in the DOM tree, and seems to be the only surefire way
+            // to check if the intial beacon has been successfully sent
+            var img = window[this.generateTrackingImageString()];
+            if (typeof (img) !== 'undefined' && (img.complete === true || img.width + img.height > 0)) {
+                clearInterval(checkForPageViewInterval);
 
-                    this.pageviewSent = true;
-                    mediator.emit('module:analytics:omniture:pageview:sent');
-                }
+                this.pageviewSent = true;
+                mediator.emit('module:analytics:omniture:pageview:sent');
+            }
         }.bind(this), 250);
 
         // Give up after 10 seconds

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -108,6 +108,13 @@ define([
         // this allows 'live' Omniture tracking of Navigation Interactions
         this.s.eVar7 = 'D=pageName';
         this.s.prop37 = 'D=v37';
+
+        if (/social/.test(linkName)) {
+            s.linkTrackVars   += ',eVar12';
+            s.linkTrackEvents += ',event16';
+            s.events          += ',event16';
+            s.eVar12           = linkName;
+        }
     };
 
     // used where we don't have an element to pass as a tag, eg. keyboard interaction

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -106,16 +106,6 @@ define([
         // this allows 'live' Omniture tracking of Navigation Interactions
         this.s.eVar7 = 'D=pageName';
         this.s.prop37 = 'D=v37';
-
-        if (/social/.test(linkName)) {
-            this.s.linkTrackVars   += ',eVar12,prop4,prop9,prop10';
-            this.s.linkTrackEvents += ',event16';
-            this.s.eVar12           = linkName;
-            this.s.prop4            = config.page.keywords || '';
-            this.s.prop9            = config.page.contentType || '';
-            this.s.prop10           = config.page.tones || '';
-            this.s.events           = this.s.apl(this.s.events, 'event16', ',');
-        }
     };
 
     // used where we don't have an element to pass as a tag, eg. keyboard interaction

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -97,8 +97,8 @@ define([
 
     Omniture.prototype.populateEventProperties = function (linkName) {
 
-        this.s.linkTrackVars =  'channel,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,'+
-                                'prop51,prop61,prop64,prop65,evar7,evar37,evar38,evar39,evar50,events';
+        this.s.linkTrackVars = 'channel,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,' +
+                               'prop51,prop61,prop64,prop65,evar7,evar37,evar38,evar39,evar50,events';
         this.s.linkTrackEvents = 'event37';
         this.s.events = 'event37';
         this.s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + linkName : linkName;

--- a/static/src/javascripts/projects/common/modules/identity/autosignin.js
+++ b/static/src/javascripts/projects/common/modules/identity/autosignin.js
@@ -3,6 +3,7 @@ define([
     'common/utils/ajax',
     'common/utils/config',
     'common/utils/time',
+    'common/modules/analytics/omniture',
     'common/modules/identity/api',
     'common/modules/identity/facebook-authorizer',
     'common/modules/navigation/profile',
@@ -14,6 +15,7 @@ function (
     ajax,
     config,
     time,
+    omniture,
     id,
     FacebookAuthorizer,
     Profile,
@@ -71,10 +73,7 @@ function (
                         });
                         profile.init();
                         new Toggles().init();
-
-                        s.eVar13 = 'facebook auto';
-                        s.linkTrackVars = 'eVar13';
-                        s.tl(this, 'o', 'Social signin auto');
+                        omniture.trackLink(this, 'Social signin auto');
                     }
                 }
             });

--- a/static/src/javascripts/projects/common/modules/identity/autosignin.js
+++ b/static/src/javascripts/projects/common/modules/identity/autosignin.js
@@ -73,7 +73,11 @@ function (
                         });
                         profile.init();
                         new Toggles().init();
-                        omniture.trackLink(this, 'Social signin auto');
+
+                        omniture.populateEventProperties('Social signin auto');
+                        s.eVar13 = 'facebook auto';
+                        s.linkTrackVars += ',eVar13';
+                        s.tl(this, 'o', 'Social signin auto');
                     }
                 }
             });

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -9,6 +9,7 @@ define([
     'common/utils/config',
     'common/utils/storage',
     'common/utils/template',
+    'common/modules/analytics/omniture',
     'common/views/svgs',
     'text!common/views/breaking-news.html'
 ], function (
@@ -22,6 +23,7 @@ define([
     config,
     storage,
     template,
+    omniture,
     svgs,
     alertHtml
 ) {
@@ -130,10 +132,7 @@ define([
                             $breakingNews.removeClass('breaking-news--hidden');
                         });
 
-                        s.eVar36 = message;
-                        s.eVar72 = _.map(alerts, function (article) { return article.headline; }).join(' | ');
-                        s.linkTrackVars = 'eVar36,eVar72';
-                        s.tl(this, 'o', message);
+                        omniture.trackLink(this, message);
                     }, alertDelay);
                 }
             }

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -148,7 +148,6 @@ define([
                         that.view.destroy();
                     } else {
                         that.view.render.call(that, response);
-                        mediator.emit('modules:autoupdate:loaded', response);
                     }
                 }
             );

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -4,14 +4,16 @@ define([
     'common/utils/$',
     'common/utils/_',
     'common/utils/ajax',
-    'common/utils/mediator'
+    'common/utils/mediator',
+    'common/modules/analytics/omniture'
 ], function (
     bean,
     raven,
     $,
     _,
     ajax,
-    mediator
+    mediator,
+    omniture
     ) {
     function SearchTool(options) {
         var $list      = null,
@@ -118,7 +120,7 @@ define([
                 // Send data to whoever is listening
                 mediator.emit('autocomplete:fetch', data);
                 this.setInputValue();
-                this.track(data.city);
+                omniture.trackLinkImmediate('weather location set by user');
                 inputTmp = data.city;
                 $input.blur();
 
@@ -126,15 +128,6 @@ define([
                 setTimeout(this.destroy.bind(this), 50);
 
                 return data;
-            },
-
-            track: function (city) {
-                s.events = 'event100';
-                s.prop22 = city;
-                s.eVar22 = city;
-                s.linkTrackVars = 'prop22,eVar22';
-                s.linkTrackEvents = 'event100';
-                s.tl(true, 'o', 'weather location set by user');
             },
 
             getListOfResults: function (e) {

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -23,6 +23,7 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/utils/template',
+    'common/modules/analytics/omniture',
     'common/modules/user-prefs',
     'facia/modules/onwards/search-tool'
 ], function (
@@ -36,6 +37,7 @@ define([
     detect,
     mediator,
     template,
+    omniture,
     userPrefs,
     SearchTool
     ) {
@@ -99,7 +101,7 @@ define([
                 return this.getWeatherData(config.page.weatherapiurl + '.json')
                     .then(function (response) {
                         this.fetchWeatherData(response);
-                        this.track(response.city);
+                        omniture.trackLinkImmediate(true, 'o', 'weather location set by fastly');
                     }.bind(this))
                     .fail(function (err, msg) {
                         raven.captureException(new Error('Error retrieving city data (' + msg + ')'), {
@@ -128,12 +130,6 @@ define([
         clearLocation: function () {
             userPrefs.remove(prefName);
             searchTool.setInputValue();
-        },
-
-        track: function (city) {
-            s.prop26 = city;
-            s.linkTrackVars = 'prop26';
-            s.tl(true, 'o', 'weather location set by fastly');
         },
 
         fetchForecastData: function (location) {

--- a/static/test/javascripts/helpers/injector.js
+++ b/static/test/javascripts/helpers/injector.js
@@ -12,11 +12,11 @@ define([
 
         return new Promise(function (resolve, reject) {
             r.call(this, deps, function () {
-                var res = cb.apply(this, arguments);
+                cb.apply(this, arguments);
                 resolve();
             }, function () {
-                var res = eb.apply(this, arguments);
-                resolve();
+                eb.apply(this, arguments);
+                reject();
             });
         }.bind(this));
 

--- a/static/test/javascripts/main.js
+++ b/static/test/javascripts/main.js
@@ -9,7 +9,6 @@ requirejs.config({
     // Karma serves files from '/base'
     baseUrl: '/base/static/src/javascripts',
     paths: {
-        bootsraps:    'bootstraps',
         admin:        'projects/admin',
         common:       'projects/common',
         facia:        'projects/facia',
@@ -21,7 +20,6 @@ requirejs.config({
         fastclick:    'components/fastclick/fastclick',
         fastdom:      'components/fastdom/index',
         fence:        'components/fence/fence',
-        imager:       'components/imager.js/container',
         lodash:       'components/lodash-amd',
         picturefill:  'projects/common/utils/picturefill',
         Promise:      'components/native-promise-only/npo.src',
@@ -39,10 +37,6 @@ requirejs.config({
         inlineSvg:    'components/requirejs-inline-svg/inlineSvg'
     },
     shim: {
-        imager: {
-            deps: ['/base/static/src/javascripts/components/imager.js/imager.js'],
-            exports: 'Imager'
-        },
         googletag: {
             exports: 'googletag'
         }

--- a/static/test/javascripts/spec/common/analytics/omniture.spec.js
+++ b/static/test/javascripts/spec/common/analytics/omniture.spec.js
@@ -16,15 +16,10 @@ define([
             'common/utils/config': config,
             'common/utils/mediator': mediator
         })
-        .require(['common/modules/analytics/omniture'], function (Omniture) {
+        .require(['common/modules/analytics/omniture'], function (omniture) {
 
-            describe('Omniture', function () {
-
-                var s,
-                    w = {
-                    performance: { timing: { requestStart: 1, responseEnd: 5000 } },
-                    innerWidth: 500
-                };
+            describe('omniture', function () {
+                var s;
 
                 beforeEach(function () {
                     config.page = {
@@ -39,9 +34,7 @@ define([
                         t: function () {},
                         tl: function () {},
                         apl: function () {},
-                        Util: {
-                            getQueryParam: function () { return 'test'; }
-                        },
+                        Util: { getQueryParam: function () { return 'test'; } },
                         getValOnce: function () { return 'test'; },
                         getTimeParting: function () { return ['4:03PM', '4:00PM', 'Thursday', 'Weekday']; },
                         getParamValue: function() { return ''; }
@@ -49,24 +42,35 @@ define([
                     sinon.spy(s, 't');
                     sinon.spy(s, 'tl');
                     sinon.spy(s, 'apl');
+                    omniture.s = s;
+                    omniture.addHandlers();
                 });
 
                 afterEach(function(){
                     sessionStorage.removeItem('gu.analytics.referrerVars');
+                    mediator.removeEvent('module:clickstream:interaction');
+                    mediator.removeEvent('module:clickstream:click');
+                    mediator.removeEvent('module:analytics:omniture:pageview:sent');
                 });
 
-                it('should record clicks with correct analytics name', function () {
+                it('should track clicks with correct analytics name', function () {
                     s.pageType = 'article';
-                    var o = new Omniture(s);
-                    o.go();
-                    o.populateEventProperties('outer:link');
+                    omniture.go();
+                    omniture.trackLink('link object', 'outer:link');
 
-                    expect(s.linkTrackVars).toBe('eVar37,eVar7,prop37,events');
-                    expect(s.linkTrackEvents).toBe('event37');
-                    expect(s.events).toBe('event37');
                     expect(s.eVar37).toBe('Article:outer:link');
                     expect(s.prop37).toBe('D=v37');
                     expect(s.eVar7).toBe('D=pageName');
+                });
+
+                it('should track clicks with a standardised set of variables', function () {
+                    s.pageType = 'article';
+                    omniture.go();
+                    omniture.trackLink('link object', 'outer:link');
+
+                    expect(s.linkTrackVars).toBe('channel,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,prop51,prop61,prop64,prop65,evar7,evar37,evar38,evar39,evar50,events');
+                    expect(s.linkTrackEvents).toBe('event37');
+                    expect(s.events).toBe('event37');
                 });
 
                 it('should correctly set page properties', function () {
@@ -88,7 +92,7 @@ define([
                         inBodyExternalLinkCount: '0'
                     };
                     s.linkInternalFilters = 'guardian.co.uk,guardiannews.co.uk';
-                    new Omniture(s, w).go();
+                    omniture.go();
 
                     expect(s.linkInternalFilters).toBe('guardian.co.uk,guardiannews.co.uk,localhost,gucode.co.uk,gucode.com,guardiannews.com,int.gnl,proxylocal.com,theguardian.com');
                     expect(s.pageName).toBe('GFE:theworld:a-really-long-title-a-really-long-title-a-really-long-title-a-really-long');
@@ -104,7 +108,6 @@ define([
                     expect(s.prop47).toBe('US');
                     expect(s.prop58).toBe('7');
                     expect(s.prop69).toBe('0');
-                    expect(s.prop68).toBe('low');
                     expect(s.prop56).toBe('Javascript');
                     expect(s.prop30).toBe('content');
                     expect(s.prop19).toBe('frontend');
@@ -118,66 +121,47 @@ define([
 
                 it('should correctly set cookieDomainPeriods for UK edition', function () {
                     s.linkInternalFilters = 'guardian.co.uk,guardiannews.co.uk';
-                    new Omniture(s, w).go();
+                    omniture.go();
 
                     expect(s.cookieDomainPeriods).toBe('2')
                 });
 
                 it('should log a page view event', function () {
-                    new Omniture(s).go();
+                    omniture.go();
 
                     expect(s.t).toHaveBeenCalledOnce();
                 });
 
                 it('should send event46 when a page has comments', function () {
-                    new Omniture(s).go();
+                    omniture.go();
 
                     expect(s.apl).toHaveBeenCalled();
                     expect(s.apl.args[0][1]).toBe('event46');
                 });
 
                 it('should log a clickstream event', function () {
-                    var o         = new Omniture(s),
-                        clickSpec = {
+                    var clickSpec = {
                             target: document.documentElement,
                             samePage: true,
                             sameHost: true,
                             tag: 'something'
                         };
 
-                    o.go();
+                    omniture.go();
                     mediator.emit('module:clickstream:click', clickSpec);
 
                     expect(s.tl).toHaveBeenCalledOnce();
                 });
 
-                it('should send event16 when social button has been clicked', function () {
-                    var o         = new Omniture(s),
-                        clickSpec = {
-                            target: document.documentElement,
-                            samePage: false,
-                            sameHost: false,
-                            tag: 'social | facebook | top'
-                        };
-
-                    o.go();
-                    mediator.emit('module:clickstream:click', clickSpec);
-
-                    expect(s.apl).toHaveBeenCalled();
-                    expect(s.apl.args[1][1]).toBe('event16');
-                });
-
                 it('should make a non-delayed s.tl call for same-page links', function () {
-                    var o                 = new Omniture(s),
-                        el                = document.createElement('a'),
+                    var el                = document.createElement('a'),
                         clickSpecSamePage = {
                             target: el,
                             samePage: true,
                             sameHost: true,
                             tag: 'tag'
                         };
-
-                    o.go();
+                    omniture.go();
                     // same page  (non-delayed s.tl call)
                     mediator.emit('module:clickstream:click', clickSpecSamePage);
 
@@ -185,8 +169,7 @@ define([
                 });
 
                 it('should use local storage for same-host links', function () {
-                    var o         = new Omniture(s),
-                        el        = document.createElement('a'),
+                    var el        = document.createElement('a'),
                         clickSpec = {
                             target: el,
                             samePage: false,
@@ -194,15 +177,14 @@ define([
                             tag: 'tag in localstorage'
                         };
 
-                    o.go();
+                    omniture.go();
                     mediator.emit('module:clickstream:click', clickSpec);
 
                     expect(JSON.parse(sessionStorage.getItem('gu.analytics.referrerVars')).value.tag).toEqual('tag in localstorage')
                 });
 
                 it('should make a delayed s.tl call for other-host links', function () {
-                    var o         = new Omniture(s),
-                        el        = document.createElement('a'),
+                    var el        = document.createElement('a'),
                         clickSpec = {
                             target: el,
                             samePage: false,
@@ -210,7 +192,7 @@ define([
                             tag: 'tag'
                         };
 
-                    o.go();
+                    omniture.go();
                     mediator.emit('module:clickstream:click', clickSpec);
 
                     expect(s.tl.withArgs(el, 'o', 'tag')).toHaveBeenCalledOnce();

--- a/static/test/javascripts/spec/facia/search-tool.spec.js
+++ b/static/test/javascripts/spec/facia/search-tool.spec.js
@@ -94,7 +94,6 @@ define([
 
             it("should push data after click on list item", function() {
                 spyOn(sut, "pushData").and.callThrough();
-                spyOn(sut, "track");
                 spyOn(mocks.store['common/utils/mediator'], "emit");
 
                 $(".js-search-tool-list").html("<li><a class='js-search-tool-link active'></a><a class='js-search-tool-link' data-weather-id='292177' data-weather-city='Ufa'><span></span></a></li>");
@@ -110,13 +109,10 @@ define([
                         'store': 'set'
                     }
                 );
-                expect(sut.track).toHaveBeenCalledWith('Ufa');
                 expect($(".active").length).toEqual(1);
             });
 
             it("should not push data after enter without selecting from the list", function() {
-                spyOn(sut, "track");
-
                 sut.init();
                 $('.js-search-tool-input').val('');
 
@@ -180,7 +176,6 @@ define([
 
             it("should clear after pushing data", function() {
                 spyOn(sut, "destroy");
-                spyOn(sut, "track");
 
                 $(".js-search-tool-list").html('<li><a class="active" data-weather-city="test2"></a></li>');
 

--- a/static/test/javascripts/spec/facia/weather.spec.js
+++ b/static/test/javascripts/spec/facia/weather.spec.js
@@ -96,11 +96,9 @@ define([
                     expect(sut.getUserLocation()).toEqual(result);
                 });
 
-                it("should get the default location and track it", function(done) {
+                it("should get the default location", function(done) {
                     var server = sinon.fakeServer.create(),
                         data = {id: '1', city: "London"};
-
-                    spyOn(sut, "track");
                     spyOn(sut, "fetchWeatherData");
 
                     server.autoRespond = true;
@@ -110,7 +108,6 @@ define([
 
                     sut.getDefaultLocation().then(function () {
                         expect(sut.fetchWeatherData).toHaveBeenCalled();
-                        expect(sut.track).toHaveBeenCalled();
                         done();
                     });
 


### PR DESCRIPTION
An update to the omniture js module which changes what data we track for navigation interaction. The data team are trying to provide a limited, uniform set of variables for navigation analytics. Presumably our events are very hard to report on if each type of event has different variables associated.

For devs, this means we should no longer be freely customising the payload we send to omniture, so no extra props or eVars anymore, with the exception of Video. UPDATE: there are still a couple of exceptions: Autosignin, Social links, Discussion.

The following analytics changes will be made:
- prop68 is now removed
- prop16, get NewRepeat, is now configured to 30 days
- the auto refresh track is no longer used/performed

The following modules have had their custom vars stripped:
- Search tool: removed event100, prop22, evar22
- Weather: removed prop26
- Breaking news: removed evar36, evar72
