### PR TITLE
Wrap inline SVG guardian logo in conditional comments to fix IE8 bug

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -77,9 +77,19 @@ to apply any necessary changes to non-shared code there too.
                         <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="logo-wrapper" itemprop="url" data-component="logo">
                             <span class="u-h" itemprop="name">The Guardian</span>
                             @if(metaData.hasSlimHeader) {
-                                @fragments.inlineSvg("guardian-logo-160", "logo")
+                                <!--[if (gt IE 8)&(IEMobile)]><!-->
+                                    @fragments.inlineSvg("guardian-logo-160", "logo")
+                                <!--<![endif]-->
+                                <!--[if (lt IE 9)&(!IEMobile)]>
+                                  <span class="inline-logo inline-guardian-logo-160"></span>
+                                <![endif]-->
                             } else {
-                                @fragments.inlineSvg("guardian-logo-320", "logo")
+                                <!--[if (gt IE 8)&(IEMobile)]><!-->
+                                    @fragments.inlineSvg("guardian-logo-320", "logo")
+                                <!--<![endif]-->
+                                <!--[if (lt IE 9)&(!IEMobile)]>
+                                    <span class="inline-logo inline-guardian-logo-320"></span>
+                                <![endif]-->
                                 <span class="logo__tagline hide-on-mobile">Winner of the Pulitzer prize</span>
                             }
                         </a>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -77,6 +77,7 @@ to apply any necessary changes to non-shared code there too.
                         <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="logo-wrapper" itemprop="url" data-component="logo">
                             <span class="u-h" itemprop="name">The Guardian</span>
                             @if(metaData.hasSlimHeader) {
+                                @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
                                 <!--[if (gt IE 8)&(IEMobile)]><!-->
                                     @fragments.inlineSvg("guardian-logo-160", "logo")
                                 <!--<![endif]-->


### PR DESCRIPTION
This is a semi-temporary hack to fix the IE8 rendering issues (also know as "the blue screen of death").

/cc @michaelwmcnamara @OliverJAsh @rich-nguyen @sndrs 
