### PR TITLE
Remove link to "related content"

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -502,14 +502,13 @@ import collection.JavaConversions._
     }
 
     scenario("Progressive related content") {
-      Given("I vist a Guardian article page")
+      Given("I visit a Guardian article page")
       goTo("/technology/askjack/2015/feb/05/how-should-i-upgrade-my-old-hi-fi-in-a-digital-world") { browser =>
         import browser._
 
-        Then("I should see a link to related to related content")
-        val relatedLink = findFirst("[data-test-id=related-content]").findFirst("a")
-        relatedLink.getAttribute("href") should endWith ("/related/technology/askjack/2015/feb/05/how-should-i-upgrade-my-old-hi-fi-in-a-digital-world")
-        relatedLink.getText() should be ("related content >")
+        Then("There should be a placeholder for related content")
+        val relatedLink = findFirst("[data-test-id=related-content]")
+        relatedLink.getText() should be (empty)
       }
     }
 

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -16,8 +16,10 @@
         </aside>
     } else {
         <aside class="@classes.mkString(" ") js-related hide-on-childrens-books-site" role="complementary" data-test-id="related-content">
-        @* TODO progressive enhancement *@
-        @container(Nil, "related content >", "related-content", href = Some(s"related/${content.id}"))
+        @*
+            We are not doing progressive enhancement here. The related content query is expensive and crawlers
+            were having too much fun with the links that used to be here. Also, nobody was actually reading those pages.
+        *@
         </aside>
     }
 }


### PR DESCRIPTION
These pages are not really used (3,700 page views in the entire February).

Unfortunately crawlers seem to like hitting them in bursts which CAPI does not approve of.
