### PR TITLE
save and aggregate quiz results

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -445,6 +445,11 @@ object Switches {
   val IdentityBlockSpamEmails = Switch("Feature", "id-block-spam-emails",
     "If switched on, any new registrations with emails from ae blacklisted domin will be blocked",
     safeState = On, sellByDate = never)
+
+  val QuizScoresService = Switch("Feature", "quiz-scores-service",
+    "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
+    safeState = Off, sellByDate = new LocalDate(2015, 4, 16))
+
   // A/B Tests
 
   val IdentityLogRegistrationsFromTor = Switch("Feature", "id-log-tor-registrations",

--- a/diagnostics/app/controllers/QuizzesController.scala
+++ b/diagnostics/app/controllers/QuizzesController.scala
@@ -1,0 +1,34 @@
+package controllers
+
+import java.net.URLEncoder
+
+import common._
+import model.diagnostics.abtests.AbTests
+import model.diagnostics.analytics.Analytics
+import model.diagnostics.css.Css
+import model.diagnostics.javascript.JavaScript
+import model.diagnostics.quizzes.Quizzes
+import model.{NoCache, TinyResponse}
+import play.api.mvc.{Content => _, _}
+
+import scala.concurrent.ExecutionContext.Implicits
+
+object QuizzesController extends Controller with Logging {
+
+  implicit val ec = Implicits.global
+
+  def results(quizId: String) = Action.async { implicit request =>
+    Quizzes.results(quizId).map {
+      json =>
+        NoCache(Ok(json))
+    }
+  }
+
+  def update() = Action.async(parse.text) { implicit request =>
+    Quizzes.update(request.body).map {
+      _ =>
+        NoCache(Ok(""))
+    }
+  }
+
+}

--- a/diagnostics/app/model/diagnostics/quizzes/Quizzes.scala
+++ b/diagnostics/app/model/diagnostics/quizzes/Quizzes.scala
@@ -4,13 +4,11 @@ import java.text.SimpleDateFormat
 
 import common.ExecutionContexts
 import conf.Configuration
+import org.json4s.{DefaultFormats, _}
 import org.json4s.native.JsonMethods._
-import play.api.Logger
-import shade.memcached.{Configuration => MemcachedConf, Codec, Memcached}
-import org.joda.time.DateTime
-import org.json4s.{DefaultFormats, Extraction}
 import org.json4s.native.Serialization
-import org.json4s._
+import play.api.Logger
+import shade.memcached.{Codec, Configuration => MemcachedConf, Memcached}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration

--- a/diagnostics/app/model/diagnostics/quizzes/Quizzes.scala
+++ b/diagnostics/app/model/diagnostics/quizzes/Quizzes.scala
@@ -1,0 +1,80 @@
+package model.diagnostics.quizzes
+
+import java.text.SimpleDateFormat
+
+import common.ExecutionContexts
+import conf.Configuration
+import org.json4s.native.JsonMethods._
+import play.api.Logger
+import shade.memcached.{Configuration => MemcachedConf, Codec, Memcached}
+import org.joda.time.DateTime
+import org.json4s.{DefaultFormats, Extraction}
+
+import scala.concurrent.Future
+
+object Quizzes extends ExecutionContexts {
+  implicit val formats = new DefaultFormats {
+    override def dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+  } ++ org.json4s.ext.JodaTimeSerializers.all
+
+
+  lazy val host = Configuration.memcached.host.head
+  lazy val memcached = Memcached(MemcachedConf(host), memcachedExecutionContext)
+
+  def update(json: String) = {
+    val quizUpdate = parse(json).extract[QuizUpdate]
+    val oldStats = results(quizUpdate.quizId)
+
+    val x = for {
+      stat <- oldStats
+    } yield {
+      addLatest(stat, quizUpdate)
+    }
+    //memcached.set[QuizUpdate](quizUpdate.quizId, quizUpdate, )
+  }
+
+  private def addLatest(agg: QuizAggregate, upd: QuizUpdate) = {
+    agg.copy()
+  }
+
+  private def addResultsToList(aggList: List[List[Int]], newVals: List[Int]) = {
+    val extendedAgg = aggList ++ Stream.continually(Nil)
+    aggList.zip(newVals).map{ x => incrementByIndex(x._1, x._2) }
+  }
+
+  def incrementByIndex(a: List[Int], b: Int): List[Int] = {
+    // a mght be too short
+    (a, b) match {
+      case (Nil, 0) => List(1)
+      case (x::xs, 0) => x + 1 :: xs
+      case (x::xs, n) => x :: incrementByIndex(xs, b - 1)
+    }
+  }
+
+  def results(quizId: String): Future[QuizAggregate] = {
+    memcached.get[QuizAggregate](quizId).recover {
+      case e: Exception =>
+        Logger.error(e.getMessage)
+        None
+    }
+  }.map(_.getOrElse(QuizAggregate(quizId, Nil, 0)))
+}
+
+case class QuizUpdate (
+  quizId: String,
+  results: List[Int],
+  timeTaken: Long)
+{
+  def toJson = Extraction.decompose(this)
+}
+
+case class QuizAggregate (
+  quizId: String,
+  results: List[List[Int]],
+  timeTaken: Long)
+{
+  def toJson = Extraction.decompose(this)
+  def isCorrect(q: Int) = {
+    results(q) == 1
+  }
+}

--- a/diagnostics/conf/routes
+++ b/diagnostics/conf/routes
@@ -20,3 +20,6 @@ OPTIONS    /css                             controllers.DiagnosticsController.cs
 
 POST       /accept-beacon                   controllers.DiagnosticsController.acceptBeacon
 OPTIONS    /accept-beacon                   controllers.DiagnosticsController.acceptBeaconOptions
+
+GET        /quiz/results/$quizId<.+>    controllers.QuizzesController.results(quizId)
+POST       /quiz/update                 controllers.QuizzesController.update()

--- a/diagnostics/test/quizzes/QuizzesTest.scala
+++ b/diagnostics/test/quizzes/QuizzesTest.scala
@@ -21,12 +21,26 @@ class QuizzesTest extends FlatSpec with Matchers with BeforeAndAfterEach {
     Quizzes.incrementByIndex(List(2, 1), 1) should be(List(2, 2))
   }
 
+  "question Aggregator" should "refuse to add too many answers" in {
+    Quizzes.incrementByIndex(Nil, 6) should be(Nil)
+    Quizzes.incrementByIndex(Nil, 5) should be(List(0, 0, 0, 0, 0, 1))
+  }
+
+  "question Aggregator" should "refuse to add too many answers but preserve existing ones" in {
+    Quizzes.incrementByIndex(List(2, 1), 6) should be(List(2, 1))
+  }
+
   "list Aggregator" should "add to the list" in {
     Quizzes.addResultsToList(List(), List(0, 0)) should be(List(List(1), List(1)))
   }
 
   "list Aggregator" should "do the whole list" in {
     Quizzes.addResultsToList(List(Nil, Nil), List(0, 0)) should be(List(List(1), List(1)))
+  }
+
+  "list Aggregator" should "ignore the trailing answers if there are too many" in {
+    Quizzes.addResultsToList(List(), List.fill(40)(0)) should be(List.fill(40)(List(1)))
+    Quizzes.addResultsToList(List(), List.fill(41)(0)) should be(List.fill(40)(List(1)))
   }
 
 }

--- a/diagnostics/test/quizzes/QuizzesTest.scala
+++ b/diagnostics/test/quizzes/QuizzesTest.scala
@@ -1,0 +1,13 @@
+package quizzes
+
+import model.diagnostics.javascript.Metric
+import model.diagnostics.quizzes.Quizzes
+import org.scalatest.{BeforeAndAfterEach, DoNotDiscover, FlatSpec, Matchers}
+
+@DoNotDiscover class QuizzesTest extends FlatSpec with Matchers with BeforeAndAfterEach {
+
+  "Aggregator" should "add unseen buckets" in {
+    Quizzes.incrementByIndex(Nil, 0) should be(List(1))
+  }
+
+}

--- a/diagnostics/test/quizzes/QuizzesTest.scala
+++ b/diagnostics/test/quizzes/QuizzesTest.scala
@@ -1,10 +1,9 @@
 package quizzes
 
-import model.diagnostics.javascript.Metric
 import model.diagnostics.quizzes.Quizzes
-import org.scalatest.{BeforeAndAfterEach, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 
-class QuizzesTest extends FlatSpec with Matchers with BeforeAndAfterEach {
+class QuizzesTest extends FlatSpec with Matchers {
 
   "question Aggregator" should "add unseen buckets in the first place" in {
     Quizzes.incrementByIndex(Nil, 0) should be(List(1))

--- a/diagnostics/test/quizzes/QuizzesTest.scala
+++ b/diagnostics/test/quizzes/QuizzesTest.scala
@@ -4,10 +4,29 @@ import model.diagnostics.javascript.Metric
 import model.diagnostics.quizzes.Quizzes
 import org.scalatest.{BeforeAndAfterEach, DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class QuizzesTest extends FlatSpec with Matchers with BeforeAndAfterEach {
+class QuizzesTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
-  "Aggregator" should "add unseen buckets" in {
+  "question Aggregator" should "add unseen buckets in the first place" in {
     Quizzes.incrementByIndex(Nil, 0) should be(List(1))
+    Quizzes.incrementByIndex(Nil, 1) should be(List(0, 1))
+  }
+
+  "question Aggregator" should "add unseen buckets once we've got going" in {
+    Quizzes.incrementByIndex(List(2), 1) should be(List(2, 1))
+    Quizzes.incrementByIndex(List(2), 2) should be(List(2, 0, 1))
+  }
+
+  "question Aggregator" should "add to an existing bucket" in {
+    Quizzes.incrementByIndex(List(2, 1), 0) should be(List(3, 1))
+    Quizzes.incrementByIndex(List(2, 1), 1) should be(List(2, 2))
+  }
+
+  "list Aggregator" should "add to the list" in {
+    Quizzes.addResultsToList(List(), List(0, 0)) should be(List(List(1), List(1)))
+  }
+
+  "list Aggregator" should "do the whole list" in {
+    Quizzes.addResultsToList(List(Nil, Nil), List(0, 0)) should be(List(List(1), List(1)))
   }
 
 }


### PR DESCRIPTION
In quizzes we want people to see a comparison of their results against everyone else's as they answer each question.  As such we need a way to collect the data from each user and supply an aggregate.

This endpoint will accept results at the end of the quiz and supply aggregate results at the start so that they can get the info.

note: This will be somewhere else in the long term, possibly ophan.  And we're using memcached on purpose because we're just testing the concept and don't want a datastore lying around afterwards.
Also there is no locking so it will only be approximately right as some users will overwrite each other.

Next step is to write in something to the quiz JS to use this endpoint.

@robertberry @stephanfowler what do you think?
