### PR TITLE
remove print analytics switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -336,11 +336,6 @@ object Switches {
     safeState = Off, new LocalDate(2015, 3, 24)
   )
 
-  val Print = Switch("Print analytics", "print",
-    "decide by now whether enough people are printing stuff to care whether they get a good experience",
-    safeState = Off, new LocalDate(2015, 3, 27)
-  )
-
   // Features
   val FixturesAndResultsContainerSwitch = Switch(
     "Feature",


### PR DESCRIPTION
I added tracking to omniture so when people use the print stylesheet we can find out.  You can get to it using event37 and search for print.

It seems to be working fine and shows that in the last week broken down by section:

```
Article:print       86,704   

1.  lifeandstyle        6,692   7.7%

2.  world               5,472   6.3%

3.  commentisfree       3,308   3.8%

4.  books               2,751   3.2%

5.  science             1,896   2.2%

6.  environment         1,701   2.0%

7.  us-news             1,405   1.6%

8.  travel              1,221   1.4%

9.  society             1,128   1.3%

10. economy             1,124   1.3%

11. technology          1,034   1.2%
```

I expect most of the lifeandstyle are sudokus and other puzzles.  In the context of our millions of page views, this probably isn't worth putting a lot of effort into testing and fine tuning.

So I will leave the tracking active and remove the marker switch.
