### PR TITLE
add CORS support to quiz service

### DIFF
--- a/diagnostics/app/controllers/QuizzesController.scala
+++ b/diagnostics/app/controllers/QuizzesController.scala
@@ -3,7 +3,7 @@ package controllers
 import common._
 import conf.Switches
 import model.diagnostics.quizzes.Quizzes
-import model.{Cached, NoCache}
+import model.{TinyResponse, Cached, NoCache}
 import play.api.mvc.{Content => _, _}
 
 import scala.concurrent.ExecutionContext.Implicits
@@ -24,7 +24,7 @@ object QuizzesController extends Controller with Logging {
     }
   }
 
-  def update() = Action.async(parse.text) { implicit request =>
+  def update() = Action.async(parse.json) { implicit request =>
     if (Switches.QuizScoresService.isSwitchedOn) {
       Quizzes.update(request.body).map {
         _ =>
@@ -33,6 +33,10 @@ object QuizzesController extends Controller with Logging {
     } else {
       Future.successful(Cached(3600)(NotFound("")))
     }
+  }
+
+  def acceptBeaconOptions = Action { implicit request =>
+    TinyResponse.noContent(Some("POST, OPTIONS"))
   }
 
 }

--- a/diagnostics/app/model/diagnostics/quizzes/Quizzes.scala
+++ b/diagnostics/app/model/diagnostics/quizzes/Quizzes.scala
@@ -8,6 +8,7 @@ import org.json4s.{DefaultFormats, _}
 import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization
 import play.api.Logger
+import play.api.libs.json.{Json, JsValue}
 import shade.memcached.{Codec, Configuration => MemcachedConf, Memcached}
 
 import scala.concurrent.Future
@@ -30,8 +31,8 @@ object Quizzes extends ExecutionContexts {
   lazy val host = Configuration.memcached.host.head
   lazy val memcached = Memcached(MemcachedConf(host), memcachedExecutionContext)
 
-  def update(json: String) = {
-    val quizUpdate = parse(json).extract[QuizUpdate]
+  def update(json: JsValue) = {
+    val quizUpdate = parse(Json.stringify(json)).extract[QuizUpdate]
     for {
       stat <- getResults(quizUpdate.quizId)
       x = addLatest(stat, quizUpdate)

--- a/diagnostics/conf/routes
+++ b/diagnostics/conf/routes
@@ -23,3 +23,4 @@ OPTIONS    /accept-beacon                   controllers.DiagnosticsController.ac
 
 GET        /quiz/results/$quizId<.+>    controllers.QuizzesController.results(quizId)
 POST       /quiz/update                 controllers.QuizzesController.update()
+OPTIONS    /quiz/update                   controllers.DiagnosticsController.acceptBeaconOptions


### PR DESCRIPTION
Temporary quiz scores service worked fine, but it couldn't handle CORS requests.  So adding that, also fixing a bug where it was rejecting content with type application/json.
