### PR TITLE
Refactor styling for article comment counts

### DIFF
--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -61,13 +61,20 @@
         margin: 0;
         position: relative;
         padding-left: 18px;
-        @include mq(leftCol) {
-            padding-left: 15px;
-        }
-        .i {
+
+        .i, .inline-icon {
             position: absolute;
             left: 0;
         }
+
+        @include mq(leftCol) {
+            padding-left: 15px;
+        }
+    }
+
+    .inline-icon {
+        margin: 2px 0 0 -2px;
+        fill: colour(neutral-2);
     }
 
     .commentcount2__value,
@@ -98,14 +105,6 @@
         color: colour(neutral-2);
         .i {
             opacity: .35;
-        }
-    }
-    .commentcount2__heading {
-        @include mq(leftCol) {
-            padding-left: 17px;
-        }
-        .i {
-            top: -1px;
         }
     }
 }

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -68,7 +68,7 @@
         }
 
         @include mq(leftCol) {
-            padding-left: 15px;
+            padding-left: $gs-gutter * .75;
         }
     }
 


### PR DESCRIPTION
Fix's the missing comment count icon within the article meta data.
### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/6802126/b303f494-d225-11e4-9465-c1eeb98d35ec.png)
### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/6802127/b3ff66c6-d225-11e4-8a32-6b5c4e7dd050.png)

/cc @sndrs @mattosborn 
