### PR TITLE
Refactor breaking news template to use new inline icon

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v2.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v2.js
@@ -75,7 +75,7 @@ define([
             },
             showmorePlus = {
                 showPlus: (this.params.showMoreType === 'plus-only' || this.params.showMoreType === 'plus-and-arrow') ?
-                    '<button class="ad-exp__close-button ad-exp__open">' + svgs('closeCentral') + '</button>' : ''
+                    '<button class="ad-exp__close-button ad-exp__open">' + svgs('closeCentralIcon') + '</button>' : ''
             },
             $expandablev2 = $.create(template(expandableV2Tpl, _.merge(this.params, showmoreArrow, showmorePlus, videoDesktop)));
 

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -89,7 +89,7 @@ define([
                 if (alerts.length) {
                     $breakingNews = $breakingNews || bonzo(qwery('.js-breaking-news-placeholder'));
                     marque36icon = svgs('marque36icon');
-                    closeIcon = svgs('closeCentral');
+                    closeIcon = svgs('closeCentralIcon');
 
                     _.forEach(alerts, function (article) {
                         var el;

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -32,7 +32,8 @@ define([
         maxSimultaneousAlerts = 1,
         $breakingNews,
         $body,
-        marque36icon;
+        marque36icon,
+        closeIcon;
 
     function cleanIDs(articleIds, hiddenIds) {
         var cleanedIDs = {};
@@ -88,11 +89,13 @@ define([
                 if (alerts.length) {
                     $breakingNews = $breakingNews || bonzo(qwery('.js-breaking-news-placeholder'));
                     marque36icon = svgs('marque36icon');
+                    closeIcon = svgs('closeCentral');
 
                     _.forEach(alerts, function (article) {
                         var el;
 
                         article.marque36icon = marque36icon;
+                        article.closeIcon = closeIcon;
                         el = bonzo.create(template(alertHtml, article));
 
                         bean.on($('.js-breaking-news__item__close', el)[0], 'click', function () {

--- a/static/src/javascripts/projects/common/views/breaking-news.html
+++ b/static/src/javascripts/projects/common/views/breaking-news.html
@@ -8,7 +8,7 @@
         <div class="breaking-news__item-options">
             <button class="js-breaking-news__item__close button button--tertiary u-faux-block-link__promote"
                     aria-label="Dismiss"
-                    data-link-name="close button"><i class="i i-close-icon-white-small"></i></button>
+                    data-link-name="close button">{{closeIcon}}</button>
         </div>
     </div>
     <a class="u-faux-block-link__overlay" href="/{{id}}"></a>

--- a/static/src/javascripts/projects/common/views/svgs.js
+++ b/static/src/javascripts/projects/common/views/svgs.js
@@ -27,7 +27,7 @@ define([
     arrowdownicon,
     logoguardian,
     logosoulmates,
-    closeCentral
+    closeCentralIcon
 ) {
     var svgs = {
         commentCount16icon: commentCount16icon,
@@ -40,7 +40,7 @@ define([
         arrowdownicon: arrowdownicon,
         logoguardian: logoguardian,
         logosoulmates: logosoulmates,
-        closeCentral: closeCentral
+        closeCentralIcon: closeCentralIcon
     };
 
     return function (name, classes, title) {

--- a/static/src/stylesheets/module/onward/_breaking-news.scss
+++ b/static/src/stylesheets/module/onward/_breaking-news.scss
@@ -1,4 +1,5 @@
 $breaking-news-icon-width: 36px;
+$breaking-news-close-icon-width: 32px;
 
 .breaking-news {
     z-index: 16777271;
@@ -17,6 +18,9 @@ $breaking-news-icon-width: 36px;
     }
 
     .button {
+        padding: 0;
+        width: $breaking-news-close-icon-width;
+        height: $breaking-news-close-icon-width;
         border-color: #ffffff;
 
         @include mq(tablet) {


### PR DESCRIPTION
### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/6804970/855fc398-d238-11e4-8364-b0b516102b82.png)
### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/6804971/865cae46-d238-11e4-92af-b016211c111c.png)

/cc @sndrs @sturobson
