### PR TITLE
Add data-test-id attributes used by new identity functional tests

### DIFF
--- a/identity/app/views/fragments/registrationError.scala.html
+++ b/identity/app/views/fragments/registrationError.scala.html
@@ -3,7 +3,7 @@
 @for(registrationError <- registrationErrorOpt) {
     @registrationError match {
         case "fbEmail" => {
-            <div class="form__error">We need your email address when you sign in with Facebook. Try again and allow access to your email address or provide it manually below</div>
+            <div class="form__error" data-test-id="facebook-email-error">We need your email address when you sign in with Facebook. Try again and allow access to your email address or provide it manually below</div>
         }
         case _ => {}
     }

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -31,7 +31,7 @@
 
 <div class="identity-wrapper monocolumn-wrapper identity-wrapper--with-membership js-account-profile-forms">
 
-    <h1 class="identity-title">Edit your profile</h1>
+    <h1 class="identity-title" data-test-id="edit-profile-header">Edit your profile</h1>
 
     <div class="tabs u-cf identity-section">
         <ol class="tabs__container js-tabs" id="js-account-profile-tabs" role="tablist" data-is-bound="true">

--- a/identity/app/views/reauthenticate.scala.html
+++ b/identity/app/views/reauthenticate.scala.html
@@ -7,7 +7,7 @@
 @identityMain(page, conf.Switches.all){
 }{
 <div class="identity-wrapper monocolumn-wrapper">
-    <h1 class="identity-title">Confirm your identity</h1>
+    <h1 class="identity-title" data-test-id="reauthentication-header">Confirm your identity</h1>
     <p>Your privacy is important to us. Please re-enter your password to access your personal data.</p>
 
     <form class="form js-signin-form" novalidate action="@idUrlBuilder.buildUrl("/reauthenticate", idRequest)" role="main" method="post">

--- a/static/src/javascripts/projects/common/modules/identity/autosignin.js
+++ b/static/src/javascripts/projects/common/modules/identity/autosignin.js
@@ -84,7 +84,7 @@ function (
         };
 
         this.welcome = function (name) {
-            var msg = '<p class="site-message__message">' +
+            var msg = '<p class="site-message__message" data-test-id="facebook-auto-sign-in-banner">' +
                           'Welcome ' + name + ', you’re signed into the Guardian using Facebook, or ' +
                           '<a data-link-name="fb auto : sign out" href="' + config.page.idUrl + '/signout"/>sign out</a>.' +
                       '</p>';


### PR DESCRIPTION
We are improving our functional tests, but at the moment our identifiers are too ambiguous (relying on CSS classes).

With this change, the elements our tests rely on get unique `data-test-id` attributes.
