### PR TITLE
Fix external embed tracking when incorrectly embedded on-site

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -80,9 +80,12 @@
                         ),
                         config: @fragments.javaScriptConfig(video)
                     };
-                    window.s_account = 'guardiangu-thirdpartyapps';
-
                     var docClass = document.documentElement.className;
+
+                    @* Hack to correctly track external embeds which have been incorrectly embedded on theguardian.com *@
+                    var sAccount = (/www\.theguardian\.com/.test(window.parent.location.href)) ? 'guardiangu-frontend,guardiangu-network' : 'guardiangu-thirdpartyapps';
+
+                    window.s_account = sAccount;
 
                     function hasSvgSupport() {
                         var ns = {'svg': 'http://www.w3.org/2000/svg'};

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -82,8 +82,11 @@
                     };
                     var docClass = document.documentElement.className;
 
+                    @* Get iframes parent url: http://www.nczonline.net/blog/2013/04/16/getting-the-url-of-an-iframes-parent/ *@
+                    var parentUrl = (!!window.parent && window.parent !== window) ? document.referrer : '';
+
                     @* Hack to correctly track external embeds which have been incorrectly embedded on theguardian.com *@
-                    var sAccount = (/www\.theguardian\.com/.test(window.parent.location.href)) ? 'guardiangu-frontend,guardiangu-network' : 'guardiangu-thirdpartyapps';
+                    var sAccount = (/www\.theguardian\.com/.test(parentUrl)) ? 'guardiangu-frontend,guardiangu-network' : 'guardiangu-thirdpartyapps';
 
                     window.s_account = sAccount;
 


### PR DESCRIPTION
In certain circumstances our external video player is being embedded within Guardian content. One good example of this is interactives (a genuine use-case).

This has a negative side-effect that the plays get tracked against our off-site omniture suite and not accredited as on-site plays.

This is a temporary hack to solve this problem until we find/build a better solution for the interactive teams to have branded players.

/cc @gklopper @rich-nguyen
