### PR TITLE
Add Identity OAuth AB test

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -307,6 +307,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       "googleSearchUrl" -> "http://www.google.co.uk/cse/cse.js",
       "idWebAppUrl" -> id.webappUrl,
       "idApiUrl" -> id.apiRoot,
+      "idOAuthUrl" -> id.oauthUrl,
       "discussionApiRoot" -> discussion.apiRoot,
       ("secureDiscussionApiRoot", discussion.secureApiRoot),
       "discussionApiClientHeader" -> discussion.apiClientHeader,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -451,11 +451,16 @@ object Switches {
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off, sellByDate = new LocalDate(2015, 4, 16))
 
-  // A/B Tests
-
   val IdentityLogRegistrationsFromTor = Switch("Feature", "id-log-tor-registrations",
     "If switched on, any user registrations from a known tor esit node will be logged",
     safeState = On, sellByDate = never)
+
+  // A/B Tests
+
+  val ABIdentitySocialOAuth = Switch("A/B Tests", "ab-id-social-oauth",
+    "Switch to direct users to OAuth social sign-in app.",
+    safeState = Off, sellByDate = new LocalDate(2015, 4, 25)
+  )
 
   val ABAcrossTheCountry = Switch("A/B Tests", "ab-across-the-country",
     "Tests container placement on the US front",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -6,6 +6,7 @@ define([
     'common/utils/storage',
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/high-commercial-component',
+    'common/modules/experiments/tests/identity-social-oauth',
     'common/modules/experiments/tests/krux-audience-science',
     'common/modules/experiments/tests/mt-master',
     'common/modules/experiments/tests/signed-out',
@@ -22,6 +23,7 @@ define([
     store,
     mvtCookie,
     HighCommercialComponent,
+    IdentitySocialOAuth,
     KruxAudienceScience,
     MtMaster,
     SignedOut,
@@ -35,6 +37,7 @@ define([
     var ab,
         TESTS = [
             new HighCommercialComponent(),
+            new IdentitySocialOAuth(),
             new KruxAudienceScience(),
             new MtMaster(),
             new SignedOut(),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
@@ -30,7 +30,7 @@ define([
             {
                 id: 'oauth',
                 test: function () {
-                    $('.social-signin__action').each(function(el) {
+                    $('.social-signin__action').each(function (el) {
                         el.href = el.href.replace(config.page.idWebAppUrl, config.page.idOAuthUrl);
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
@@ -7,7 +7,7 @@ define([
 ) {
     return function () {
         this.id = 'IdSocialOauth';
-        this.start = '2015-03-25';
+        this.start = '2015-03-26';
         this.expiry = '2015-04-25';
         this.author = 'Marc Hibbins';
         this.description = 'Directs social sign-in attempts to the Identity OAuth app, rather than the Webapp.';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
@@ -1,0 +1,41 @@
+define([
+    'common/utils/$',
+    'common/utils/config'
+], function (
+    $,
+    config
+) {
+    return function () {
+        this.id = 'IdSocialOauth';
+        this.start = '2015-03-25';
+        this.expiry = '2015-04-25';
+        this.author = 'Marc Hibbins';
+        this.description = 'Directs social sign-in attempts to the Identity OAuth app, rather than the Webapp.';
+        this.audience = 0.05;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Users authenticated with OAuth';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Retire the old Webapp!';
+
+        this.canRun = function () {
+            return config.page.section === 'identity' && (config.page.pageId === '/signin' || config.page.pageId === '/register');
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () { }
+            },
+            {
+                id: 'oauth',
+                test: function () {
+                    $('.social-signin__action').each(function(el) {
+                        el.href = el.href.replace(config.page.idWebAppUrl, config.page.idOAuthUrl);
+                    });
+                }
+            }
+        ];
+    };
+
+});


### PR DESCRIPTION
Directs social sign-in attempts to the new Identity OAuth app, rather than old the Webapp.
