### PR TITLE
Add CMP support to FormStack forms

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -24,7 +24,8 @@ object BodyCleaner {
         DropCaps(article.isComment || article.isFeature),
         FigCaptionCleaner,
         RichLinkCleaner,
-        BlockquoteCleaner
+        BlockquoteCleaner,
+        FormStackCleaner
       )
   }
 }

--- a/common/app/views/support/FormStackCleaner.scala
+++ b/common/app/views/support/FormStackCleaner.scala
@@ -1,0 +1,17 @@
+package views.support
+
+import org.jsoup.nodes.{Document, Element}
+
+import scala.collection.JavaConversions._
+
+object FormStackCleaner extends HtmlCleaner {
+  override def clean(document: Document): Document = {
+    val formStackHost: String = "guardiannewsampampmedia.formstack.com"
+
+    document.getElementsByAttributeValueContaining("src", formStackHost).foreach { elem: Element =>
+      elem.addClass("element-formstack")
+    }
+
+    document
+  }
+}

--- a/common/test/views/support/FormStackCleanerTest.scala
+++ b/common/test/views/support/FormStackCleanerTest.scala
@@ -1,0 +1,17 @@
+package views.support
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.{Matchers, FlatSpec}
+
+class FormStackCleanerTest extends FlatSpec with Matchers {
+
+  "FormStackCleaner" should "attach an element-formstack class to formstack iframes" in {
+    val doc = """<html><body><figure><iframe src="https://guardiannewsampampmedia.formstack.com/form" /></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = FormStackCleaner.clean(document)
+
+    result.getElementsByClass("element-formstack") should not be empty
+
+  }
+}

--- a/static/src/javascripts/bootstraps/article.js
+++ b/static/src/javascripts/bootstraps/article.js
@@ -56,8 +56,6 @@ define([
             initFormStack: function () {
                 var allvars = urlutils.getUrlVars();
 
-                console.log("All Vars: "+ allvars);
-
                 if (allvars["CMP"]) {
                     $('.element-formstack').each(function (el) {
                         el.src = el.src + "?CMP=" + allvars["CMP"]

--- a/static/src/javascripts/bootstraps/article.js
+++ b/static/src/javascripts/bootstraps/article.js
@@ -56,9 +56,9 @@ define([
             initFormStack: function () {
                 var allvars = urlutils.getUrlVars();
 
-                if (allvars["CMP"]) {
+                if (allvars.CMP) {
                     $('.element-formstack').each(function (el) {
-                        el.src = el.src + "?CMP=" + allvars["CMP"]
+                        el.src = el.src + '?CMP=' + allvars.CMP;
                     });
                 }
             },

--- a/static/src/javascripts/bootstraps/article.js
+++ b/static/src/javascripts/bootstraps/article.js
@@ -5,6 +5,7 @@ define([
     'common/utils/config',
     'common/utils/detect',
     'common/utils/mediator',
+    'common/utils/url',
     'common/modules/article/rich-links',
     'common/modules/article/open-module',
     'common/modules/article/truncate',
@@ -20,6 +21,7 @@ define([
     config,
     detect,
     mediator,
+    urlutils,
     richLinks,
     openModule,
     truncate,
@@ -51,6 +53,18 @@ define([
                 });
             },
 
+            initFormStack: function () {
+                var allvars = urlutils.getUrlVars();
+
+                console.log("All Vars: "+ allvars);
+
+                if (allvars["CMP"]) {
+                    $('.element-formstack').each(function (el) {
+                        el.src = el.src + "?CMP=" + allvars["CMP"]
+                    });
+                }
+            },
+
             initTruncateAndTwitter: function () {
                 // Ensure that truncation occurs before the tweet upgrading.
                 truncate();
@@ -77,6 +91,7 @@ define([
             modules.initTruncateAndTwitter();
             modules.initRightHandComponent();
             modules.initSelectionSharing();
+            modules.initFormStack();
             richLinks.upgradeRichLinks();
             richLinks.insertTagRichLink();
             openModule.init();


### PR DESCRIPTION
This will enable FormStack users to figure out which campaign referred the user to the FormStack submission. 

CMP is already in use as a campaign tracker param. We just forward the CMP to FormStack forms now .
