### PR TITLE
Do not call `applyMembershipLink` twice

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/register-popup.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/register-popup.js
@@ -59,7 +59,6 @@ define([
                     show();
                     becomeAMember();
                     free();
-                    applyMembershipLink();
 
                     var $popup = $('.js-popup-polly-toynbee-quote', $register),
                         togglePopup = function () {
@@ -84,7 +83,6 @@ define([
                     show();
                     becomeAMember();
                     free();
-                    applyMembershipLink();
 
                     var $popup = $('.js-popup-membership-benefits', $register),
                         togglePopup = function () {


### PR DESCRIPTION
Fixes https://github.com/guardian/frontend/pull/8699#issuecomment-86533764 submitted by @rtley and @akemitakagi
