### PR TITLE
Add facebook app links metadata for iOS and Android 

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -405,7 +405,7 @@ object Switches {
 
   val FacebookAppLinksSwitch = Switch("Feature", "facebook-applinks",
     "If this switch is on then shared links on the facebook mobile app will be opened in the native app instead of the mobile browser",
-    safeState = Off, sellByDate = never
+    safeState = Off, sellByDate = new LocalDate(2015, 4, 30)
   )
 
   val IdentityFormstackSwitch = Switch("Feature", "id-formstack",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -403,6 +403,11 @@ object Switches {
     safeState = On, sellByDate = never
   )
 
+  val FacebookAppLinksSwitch = Switch("Feature", "facebook-applinks",
+    "If this switch is on then shared links on the facebook mobile app will be opened in the native app instead of the mobile browser",
+    safeState = Off, sellByDate = never
+  )
+
   val IdentityFormstackSwitch = Switch("Feature", "id-formstack",
     "If this switch is on, formstack forms will be available",
     safeState = Off, sellByDate = never

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -113,3 +113,11 @@
 }
 
 <meta name="google-site-verification" content="LR-FN6c2gIEUoo3k049w1nxyHykmac5ZE3SaUOiKc30" />
+
+@* Metadata to deep-link into native apps from facebook. http://applinks.org/documentation/ *@
+<meta property="al:ios:url" content="theguardian://">
+<meta property="al:ios:app_store_id" content="@Configuration.ios.ukAppId">
+<meta property="al:ios:app_name" content="The Guardian">
+<meta property="al:android:url" content="theguardian://">
+<meta property="al:android:app_name" content="The Guardian">
+<meta property="al:android:package" content="com.guardian">

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -115,7 +115,7 @@
 <meta name="google-site-verification" content="LR-FN6c2gIEUoo3k049w1nxyHykmac5ZE3SaUOiKc30" />
 
 @* Metadata to deep-link into native apps from facebook. http://applinks.org/documentation/ *@
-@if(FacebookAppLinksSwitch.isSwitchedOn && metadata.id = "music/2015/mar/26/frankie-knuckles-house-dance-music-elton-john") {
+@if(Switches.FacebookAppLinksSwitch.isSwitchedOn && item.id == "music/2015/mar/26/frankie-knuckles-house-dance-music-elton-john") {
     <meta property="al:ios:url" content="theguardian://applinks">
     <meta property="al:ios:app_store_id" content="@Configuration.ios.ukAppId">
     <meta property="al:ios:app_name" content="The Guardian">

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -115,9 +115,11 @@
 <meta name="google-site-verification" content="LR-FN6c2gIEUoo3k049w1nxyHykmac5ZE3SaUOiKc30" />
 
 @* Metadata to deep-link into native apps from facebook. http://applinks.org/documentation/ *@
-<meta property="al:ios:url" content="theguardian://">
-<meta property="al:ios:app_store_id" content="@Configuration.ios.ukAppId">
-<meta property="al:ios:app_name" content="The Guardian">
-<meta property="al:android:url" content="theguardian://">
-<meta property="al:android:app_name" content="The Guardian">
-<meta property="al:android:package" content="com.guardian">
+@if(FacebookAppLinksSwitch.isSwitchedOn && metadata.id = "music/2015/mar/26/frankie-knuckles-house-dance-music-elton-john") {
+    <meta property="al:ios:url" content="theguardian://applinks">
+    <meta property="al:ios:app_store_id" content="@Configuration.ios.ukAppId">
+    <meta property="al:ios:app_name" content="The Guardian">
+    <meta property="al:android:url" content="theguardian://applinks">
+    <meta property="al:android:app_name" content="The Guardian">
+    <meta property="al:android:package" content="com.guardian">
+}


### PR DESCRIPTION
This PR adds [App Links](http://applinks.org/documentation/#implementations) metadata to open Guardian Facebook links in the Guardian app on Android and iOS.
