### PR TITLE
Set result set size for search results

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -17,6 +17,7 @@ define([
         var searchLoader,
             enabled,
             gcsUrl,
+            resultSetSize,
             container,
             self = this;
 
@@ -24,6 +25,7 @@ define([
 
             enabled = true;
             gcsUrl = config.page.googleSearchUrl + '?cx=' + config.page.googleSearchId;
+            resultSetSize = config.page.section === 'identity' ? 3 : 10;
 
             searchLoader = _.throttle(function () {
                 self.load();
@@ -80,7 +82,7 @@ define([
                             '<gcse:searchbox></gcse:searchbox>' +
                         '</div>' +
                         '<div class="search-results" data-link-name="search">' +
-                            '<gcse:searchresults></gcse:searchresults>' +
+                            '<gcse:searchresults webSearchResultSetSize="' + resultSetSize + '"></gcse:searchresults>' +
                         '</div>';
                 });
 


### PR DESCRIPTION
Identity pages are short, some are very short. Specify result set size (before we implement the main site header) because 10 results gives us a crazy double-scrollbar scene, hoping to up this to 5 after we've address the very short ones as part of our styling updates across `profile`.
